### PR TITLE
fix: Make use parent FocusRectsContext so that only the outermost Fabric/ThemeProvider element in a tree is the only one being targetted by focus visibility classnames and event listeners

### DIFF
--- a/change/@fluentui-react-ae3f44c5-89bf-414c-b72a-151eb8a61a3f.json
+++ b/change/@fluentui-react-ae3f44c5-89bf-414c-b72a-151eb8a61a3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make use parent FocusRectsContext so that only the outermost Fabric/ThemeProvider element in a tree is the only one being targetted by focus visibility classnames and event listeners.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-430d2bb7-3bb6-4645-9783-824b5d0cc25a.json
+++ b/change/@fluentui-utilities-430d2bb7-3bb6-4645-9783-824b5d0cc25a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Updating description in comments of useFocusRects function.",
+  "packageName": "@fluentui/utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react/src/components/Fabric/Fabric.base.tsx
@@ -6,7 +6,6 @@ import {
   getNativeProps,
   getRTL,
   memoizeFunction,
-  useFocusRects,
   Customizer,
   FocusRectsContext,
   FocusRectsProvider,

--- a/packages/react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react/src/components/Fabric/Fabric.base.tsx
@@ -8,14 +8,15 @@ import {
   memoizeFunction,
   useFocusRects,
   Customizer,
+  FocusRectsContext,
   FocusRectsProvider,
-  IFocusRectsContext,
 } from '../../Utilities';
 import { createTheme } from '../../Styling';
 import { useMergedRefs } from '@fluentui/react-hooks';
 import type { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric.types';
 import type { IProcessedStyleSet } from '@fluentui/merge-styles';
 import type { ITheme } from '../../Styling';
+import type { IFocusRectsContext } from '../../Utilities';
 
 const getClassNames = classNamesFunction<IFabricStyleProps, IFabricStyles>();
 const getFabricTheme = memoizeFunction((theme?: ITheme, isRTL?: boolean) => createTheme({ ...theme, rtl: isRTL }));
@@ -47,7 +48,6 @@ export const FabricBase: React.FunctionComponent<IFabricProps> = React.forwardRe
 
     const rootElement = React.useRef<HTMLDivElement>(null);
     useApplyThemeToBody(applyThemeToBody, classNames, rootElement);
-    useFocusRects(rootElement);
 
     return <>{useRenderedContent(props, classNames, rootElement, ref)}</>;
   },
@@ -65,11 +65,12 @@ function useRenderedContent(
 
   const { rootDir, needsTheme } = getDir(props);
 
+  const { providerRef: parentProviderRef } = React.useContext(FocusRectsContext);
   const focusRectsContext = React.useMemo<IFocusRectsContext>(
     () => ({
-      providerRef: rootElement,
+      providerRef: parentProviderRef ?? rootElement,
     }),
-    [rootElement],
+    [parentProviderRef, rootElement],
   );
 
   let renderedContent = (

--- a/packages/react/src/utilities/ThemeProvider/useThemeProviderState.tsx
+++ b/packages/react/src/utilities/ThemeProvider/useThemeProviderState.tsx
@@ -1,7 +1,7 @@
 import { mergeThemes } from '@fluentui/theme';
 import * as React from 'react';
 import { useTheme } from './useTheme';
-import { getId } from '@fluentui/utilities';
+import { getId, FocusRectsContext } from '@fluentui/utilities';
 import type { PartialTheme, Theme } from '@fluentui/theme';
 import type { ThemeProviderState } from './ThemeProvider.types';
 import type { ICustomizerContext, IFocusRectsContext } from '@fluentui/utilities';
@@ -52,11 +52,12 @@ export const useThemeProviderState = (draftState: ThemeProviderState) => {
     [theme],
   );
 
+  const { providerRef: parentProviderRef } = React.useContext(FocusRectsContext);
   draftState.focusRectsContext = React.useMemo<IFocusRectsContext>(
     () => ({
-      providerRef: draftState.ref,
+      providerRef: parentProviderRef ?? draftState.ref,
     }),
-    [draftState.ref],
+    [draftState.ref, parentProviderRef],
   );
 
   if (draftState.theme.rtl !== parentTheme.rtl) {

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -56,9 +56,9 @@ export const FocusRectsProvider = FocusRectsContext.Provider;
 /**
  * Initializes the logic which:
  *
- * 1. Subscribes keydown and mousedown events. (It will only do it once for the current element of the FocusRectsContext
- *    providerRef or once per window if no such element is provided via context, so it's safe to call this method
- *    multiple times.)
+ * 1. Subscribes keydown, keyup, mousedown and pointerdown events. (It will only do it once for the current element of
+ *    the FocusRectsContext providerRef or once per window if no such element is provided via context, so it's safe to
+ *    call this method multiple times.)
  * 2. When the user presses triggers a keydown or keyup event via directional keyboard keys, adds the
  *    'ms-Fabric--isFocusVisible' classname to the current element of the FocusRectsContext providerRef or the document
  *    body if no such element is provided via context, and removes the 'ms-Fabric-isFocusHidden' classname.

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -56,14 +56,15 @@ export const FocusRectsProvider = FocusRectsContext.Provider;
 /**
  * Initializes the logic which:
  *
- * 1. Subscribes keydown and mousedown events. (It will only do it once for the outmost ThemeProvider/Fabric element in
- *    a tree or once per window if no such element exists in the tree, so it's safe to call this method multiple times.)
- * 2. When the user presses directional keyboard keys, adds the 'ms-Fabric--isFocusVisible' classname to the
- *    ThemeProvider/Fabric element or the document body if no such element exists in the tree, and removes the
- *    'ms-Fabric-isFocusHidden' classname.
- * 3. When the user clicks a mouse button, adds the 'ms-Fabric-isFocusHidden' classname to the ThemeProvider/Fabric
- *    element or the document body if no such element exists in the tree, and removes the 'ms-Fabric--isFocusVisible'
- *    classname.
+ * 1. Subscribes keydown and mousedown events. (It will only do it once for the current element of the FocusRectsContext
+ *    providerRef or once per window if no such element is provided via context, so it's safe to call this method
+ *    multiple times.)
+ * 2. When the user presses triggers a keydown or keyup event via directional keyboard keys, adds the
+ *    'ms-Fabric--isFocusVisible' classname to the current element of the FocusRectsContext providerRef or the document
+ *    body if no such element is provided via context, and removes the 'ms-Fabric-isFocusHidden' classname.
+ * 3. When the user triggers a mousedown or pointerdown event, adds the 'ms-Fabric-isFocusHidden' classname to the
+ *    current element of the FocusRectsContext providerRef or the document body if no such element is provided via
+ *    context, and removes the 'ms-Fabric--isFocusVisible' classname.
  *
  * This logic allows components on the page to conditionally render focus treatments based on
  * the existence of global classnames, which simplifies logic overall.

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -56,12 +56,14 @@ export const FocusRectsProvider = FocusRectsContext.Provider;
 /**
  * Initializes the logic which:
  *
- * 1. Subscribes keydown and mousedown events. (It will only do it once per window,
- *    so it's safe to call this method multiple times.)
- * 2. When the user presses directional keyboard keys, adds the 'ms-Fabric--isFocusVisible' classname
- *    to the document body, removes the 'ms-Fabric-isFocusHidden' classname.
- * 3. When the user clicks a mouse button, adds the 'ms-Fabric-isFocusHidden' classname to the
- *    document body, removes the 'ms-Fabric--isFocusVisible' classname.
+ * 1. Subscribes keydown and mousedown events. (It will only do it once for the outmost ThemeProvider/Fabric element in
+ *    a tree or once per window if no such element exists in the tree, so it's safe to call this method multiple times.)
+ * 2. When the user presses directional keyboard keys, adds the 'ms-Fabric--isFocusVisible' classname to the
+ *    ThemeProvider/Fabric element or the document body if no such element exists in the tree, and removes the
+ *    'ms-Fabric-isFocusHidden' classname.
+ * 3. When the user clicks a mouse button, adds the 'ms-Fabric-isFocusHidden' classname to the ThemeProvider/Fabric
+ *    element or the document body if no such element exists in the tree, and removes the 'ms-Fabric--isFocusVisible'
+ *    classname.
  *
  * This logic allows components on the page to conditionally render focus treatments based on
  * the existence of global classnames, which simplifies logic overall.
@@ -96,6 +98,14 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
       onKeyDown = _onKeyDown;
       onKeyUp = _onKeyUp;
     }
+
+    // If the providerRef from context is defined but the current value is null, then it means that a ref has been
+    // provided to context bu the element it refers to has not been resolved yet. We abort operations here in those
+    // scenarios to ensure that we do not erroneously attach event listeners to the window while we wait for the ref to
+    // resolve.
+    // if (providerRef && providerRef.current === null) {
+    //   return;
+    // }
 
     let count = setMountCounters(el, 1);
     if (count <= 1) {

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -99,14 +99,6 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
       onKeyUp = _onKeyUp;
     }
 
-    // If the providerRef from context is defined but the current value is null, then it means that a ref has been
-    // provided to context bu the element it refers to has not been resolved yet. We abort operations here in those
-    // scenarios to ensure that we do not erroneously attach event listeners to the window while we wait for the ref to
-    // resolve.
-    // if (providerRef && providerRef.current === null) {
-    //   return;
-    // }
-
     let count = setMountCounters(el, 1);
     if (count <= 1) {
       el.addEventListener('mousedown', onMouseDown, true);


### PR DESCRIPTION
## PR Description 

This PR is a follow up to #24025 and #24110.

This PR does a couple of things:
- It updates the `Fabric` and `ThemeProvider` components so that, if any of them have another parent that is already a provider, the focus visibility classnames and event listeners only hook up to the outermost one in the tree.
- It removes the `useFocusRects` call from the `Fabric` component. This component does not have any focusable elements so it does not need the function. Additionally, if the component was the outermost provider of the `FocusRectsContext` value, it was causing the listeners to be attached to the window and the classnames to be attached to the document body. This no longer happens with that change.
- It updates the description of the `useFocusRects` function to indicate how it now first looks to see if a `ref` to an element to attach classnames and event listeners has been provided via context, defaulting to the window and document body if none was provided.

Below is a before and after of the changes with now only the outermost `Fabric` or `ThemeProvider` element in the tree being the target of the focus visibility classnames and event listeners. There are six "groups" in those examples:
1. Only one `Fabric` component at the top of the tree with 2 buttons as its descendants.
2. Only one `ThemeProvider` component at the top of the tree with 2 buttons as its descendants.
3. One `Fabric` component at the top of the tree, with a button as a descendant at the same level of another `Fabric` component, which has another 2 buttons as its descendants.
4. One `ThemeProvider` component at the top of the tree, with a button as a descendant at the same level of another `ThemeProvider` component, which has another 2 buttons as its descendants.
5. One `ThemeProvider` component at the top of the tree, with a button as a descendant at the same level of another `Fabric` component, which has another 2 buttons as its descendants.
6. One `Fabric` component at the top of the tree, with a button as a descendant at the same level of another `ThemeProvider` component, which has another 2 buttons as its descendants.

You'll see that when using more than one `Fabric`/`ThemeProvider` component at different levels in the tree hierarchy, before each of them used to be targets of the classnames and event listeners, while only the outermost one is the target of them after these changes.

__Before:__
![Before1](https://user-images.githubusercontent.com/7798177/181826963-be347d72-ad02-4ac4-b599-16ed3be9dab7.gif)

__After:__
![After](https://user-images.githubusercontent.com/7798177/181826654-4b194940-94ab-4e6b-b934-cdfffe8074b1.gif)