### PR TITLE
chore(eslint-plugin): bump eslint-plugin-jest

### DIFF
--- a/change/@fluentui-eslint-plugin-cd9f4918-88db-4d1d-a24b-786c888a5c71.json
+++ b/change/@fluentui-eslint-plugin-cd9f4918-88db-4d1d-a24b-786c888a5c71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(eslint-plugin): bump eslint-plugin-jest",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "stjust@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "eslint-plugin-deprecation": "1.2.1",
     "eslint-plugin-es": "4.1.0",
     "eslint-plugin-import": "2.25.4",
-    "eslint-plugin-jest": "23.20.0",
+    "eslint-plugin-jest": "25.7.0",
     "eslint-plugin-jsdoc": "^36.0.7",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-react": "7.26.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -22,7 +22,7 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-deprecation": "^1.2.1",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^23.13.2",
+    "eslint-plugin-jest": "^25.7.0",
     "eslint-plugin-jsdoc": "^36.0.7",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5904,7 +5904,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^2.5.0", "@typescript-eslint/experimental-utils@^4.22.0", "@typescript-eslint/experimental-utils@^5.0.0":
+"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0", "@typescript-eslint/experimental-utils@^4.22.0", "@typescript-eslint/experimental-utils@^5.0.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
   integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
@@ -11871,17 +11871,10 @@ eslint-plugin-import@2.25.4, eslint-plugin-import@^2.22.1:
     resolve "^1.20.0"
     tsconfig-paths "^3.12.0"
 
-eslint-plugin-jest@23.20.0, eslint-plugin-jest@^23.13.2:
-  version "23.20.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz#e1d69c75f639e99d836642453c4e75ed22da4099"
-  integrity sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "^2.5.0"
-
-eslint-plugin-jest@^25.0.0:
-  version "25.2.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz#bb9f6a0bd1fd524ffb0b8b7a159cd70a58a1a793"
-  integrity sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==
+eslint-plugin-jest@25.7.0, eslint-plugin-jest@^25.0.0, eslint-plugin-jest@^25.7.0:
+  version "25.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz#ff4ac97520b53a96187bad9c9814e7d00de09a6a"
+  integrity sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==
   dependencies:
     "@typescript-eslint/experimental-utils" "^5.0.0"
 


### PR DESCRIPTION
This version is compatible with eslint 8 to unblock future eslint upgrade.

Breaking changes in this plugin remove support for node versions that @fluentui/eslint-plugin already did not support. There are also a couple renamed rules which do not appear to be used anywhere in fluentui. 

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
Partially addresses #23048.