### PR TITLE
feat(react-builder): Load state from URL

### DIFF
--- a/packages/fluentui/react-builder/src/components/Builder.tsx
+++ b/packages/fluentui/react-builder/src/components/Builder.tsx
@@ -39,6 +39,7 @@ export type BuilderProps = {
   onSourceCodeError: (code: any, error: any) => void;
   onSwitchTab?: (tab: any) => void;
   onSwitchToStore: () => void;
+  onLoadFromUrl: () => void;
   selectedComponent: JSONTreeElement;
   selectedComponentAccessibilityErrors: AccessibilityError[];
   selectedComponentInfo: ComponentInfo;
@@ -87,6 +88,7 @@ export const Builder: React.FunctionComponent<BuilderProps> = (props: BuilderPro
         showJSONTree={props.showJSONTree}
         state={props.state}
         onSwitchToStore={props.onSwitchToStore}
+        onLoadFromUrl={props.onLoadFromUrl}
       />
 
       <ComponentPropertiesPanel

--- a/packages/fluentui/react-builder/src/components/CanvasWindow.tsx
+++ b/packages/fluentui/react-builder/src/components/CanvasWindow.tsx
@@ -1,9 +1,9 @@
-import { CodeSandboxExporter, CodeSandboxState, renderElementToJSX } from '@fluentui/docs-components';
+import { CodeSandboxExporter, CodeSandboxState } from '@fluentui/docs-components';
 import { FilesCodeIcon, AcceptIcon } from '@fluentui/react-icons-northstar';
 import { Button, Text } from '@fluentui/react-northstar';
 import * as React from 'react';
 import { AccessibilityError } from '../accessibility/types';
-import { getCodeSandboxInfo, renderJSONTreeToJSXElement } from '../config';
+import { getCodeSandboxInfo } from '../config';
 import { useMode } from '../hooks/useMode';
 import { DesignerState } from '../state/state';
 import { BrowserWindow } from './BrowserWindow';
@@ -33,15 +33,13 @@ export type CanvasWindowProps = {
   onSourceCodeError: (code: any, error: any) => void;
   onSelectComponent: (jsonTreeElement: any) => void;
   onSwitchToStore: () => void;
+  onLoadFromUrl: () => void;
 };
 
 export const CanvasWindow: React.FunctionComponent<CanvasWindowProps> = (props: CanvasWindowProps) => {
   const HEADER_HEIGHT = '3rem';
   const [headerMessage, setHeaderMessage] = React.useState('');
-  const codeSandboxData = getCodeSandboxInfo(
-    props.state.jsonTree,
-    renderElementToJSX(renderJSONTreeToJSXElement(props.state.jsonTree)),
-  );
+  const codeSandboxData = getCodeSandboxInfo(props.state.jsonTree, props.state.code);
   const [{ mode }] = useMode();
 
   const CodeEditor = React.lazy(async () => {

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -60,6 +60,15 @@ export const Designer: React.FunctionComponent = () => {
     }
   }, [dispatch]);
 
+  const handleLoadFromUrl = React.useCallback(() => {
+    /* eslint-disable-next-line no-alert */
+    if (confirm('Lose your changes?')) {
+      /* eslint-disable-next-line no-alert */
+      const url = window.prompt('Paste URL');
+      dispatch({ type: 'LOAD_FROM_URL', url });
+    }
+  }, [dispatch]);
+
   const handleShowCodeChange = React.useCallback(
     showCode => {
       dispatch({ type: 'SHOW_CODE', show: showCode });
@@ -378,6 +387,7 @@ export const Designer: React.FunctionComponent = () => {
         canUndo={state.history.length > 0}
         canRedo={state.redo.length > 0}
         onReset={handleReset}
+        onLoadFromUrl={handleLoadFromUrl}
         onModeChange={setMode}
         showCode={showCode}
         showJSONTree={showJSONTree}
@@ -413,6 +423,7 @@ export const Designer: React.FunctionComponent = () => {
         onSourceCodeError={handleSourceCodeError}
         onSwitchTab={handleSwitchTab}
         onSwitchToStore={handleSwitchToStore}
+        onLoadFromUrl={handleLoadFromUrl}
         selectedComponent={selectedComponent}
         selectedComponentAccessibilityErrors={selectedComponentAccessibilityErrors}
         selectedComponentInfo={selectedComponentInfo}

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -13,6 +13,7 @@ import {
   CodeSnippetIcon,
   OpenOutsideIcon,
   TrashCanIcon,
+  CallControlPresentNewIcon,
   UndoIcon,
   RedoIcon,
   TranslationIcon,
@@ -25,6 +26,7 @@ export type ToolbarProps = {
   canUndo: boolean;
   onModeChange: (mode: DesignerMode) => void;
   onReset: () => void;
+  onLoadFromUrl: () => void;
   onUndo: () => void;
   onRedo: () => void;
   onShowCodeChange: (showCode: boolean) => void;
@@ -44,6 +46,7 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
   canUndo,
   onModeChange,
   onReset,
+  onLoadFromUrl,
   onUndo,
   onRedo,
   onShowCodeChange,
@@ -142,6 +145,14 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
             {
               key: 'divider-2',
               kind: 'divider',
+            },
+            {
+              icon: <CallControlPresentNewIcon outline={true} />,
+              key: 'load-from-url',
+              title: 'Load from URL',
+              onClick: () => {
+                onLoadFromUrl();
+              },
             },
             {
               icon: <TrashCanIcon outline={true} />,

--- a/packages/fluentui/react-builder/src/state/state.ts
+++ b/packages/fluentui/react-builder/src/state/state.ts
@@ -50,6 +50,7 @@ export type DesignerAction =
   | { type: 'ENABLE_VIRTUAL_CURSOR'; enabledVirtualCursor: boolean }
   | { type: 'SWITCH_TO_STORE' }
   | { type: 'RESET_STORE' }
+  | { type: 'LOAD_FROM_URL'; url: string }
   | { type: 'SHOW_CODE'; show: boolean }
   | { type: 'SWITCH_TAB'; tab: string }
   | { type: 'SOURCE_CODE_CHANGE'; code: string; jsonTree: JSONTreeElement }
@@ -193,6 +194,17 @@ export const stateReducer: Reducer<DesignerState, DesignerAction> = (draftState,
 
     case 'SWITCH_TO_STORE':
       draftState.jsonTree = readTreeFromStore() || getDefaultJSONTree();
+      draftState.jsonTreeOrigin = 'store';
+      treeChanged = true;
+      break;
+
+    case 'LOAD_FROM_URL':
+      draftState.code = '';
+      draftState.selectedJSONTreeElementUuid = null;
+      draftState.selectedComponentInfo = null;
+      draftState.codeError = null;
+
+      draftState.jsonTree = readTreeFromURL(action.url) || getDefaultJSONTree();
       draftState.jsonTreeOrigin = 'store';
       treeChanged = true;
       break;


### PR DESCRIPTION
Allows to load builder state from a shared url:
- created by "Share" button
- created by "Popout window" button

<img width="268" alt="image" src="https://user-images.githubusercontent.com/13742664/182082765-76c3d53a-1463-4d73-9802-71b91260145a.png">
