### PR TITLE
fix: Scope keydown event listener so that it is added to the FocusZone itself instead of the window

### DIFF
--- a/change/@fluentui-react-focus-2af33127-ad63-49d2-8928-82bed1ce64d2.json
+++ b/change/@fluentui-react-focus-2af33127-ad63-49d2-8928-82bed1ce64d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Scope keydown event listener so that it is added to the FocusZone itself instead of the window.",
+  "packageName": "@fluentui/react-focus",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-focus/src/components/FocusZone/FocusZone.EventHandler.test.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.EventHandler.test.tsx
@@ -3,9 +3,6 @@ import { fireEvent, render } from '@testing-library/react';
 import { KeyCodes } from '@fluentui/utilities';
 import { FocusZone } from './FocusZone';
 
-// HEADS UP: this test is intentionally in a separate file aside from the rest of FocusZone tests
-// As it is testing ref counting on a global `window` object it would interfere with other FocusZone tests
-// which use ReactTestUtils.renderIntoDocument() which renders FocusZone into a detached DOM node and never unmounts.
 describe('FocusZone keydown event handler', () => {
   let originalOnKeyDownCapture: (ev: KeyboardEvent) => void;
   const mockOnKeyDownCapture = jest.fn();

--- a/packages/react-focus/src/components/FocusZone/FocusZone.EventHandler.test.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.EventHandler.test.tsx
@@ -1,92 +1,145 @@
-import * as ReactDOM from 'react-dom';
 import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { KeyCodes } from '@fluentui/utilities';
 import { FocusZone } from './FocusZone';
-
-type EventHandler = {
-  listener: EventListenerOrEventListenerObject;
-  options?: boolean | AddEventListenerOptions;
-};
-
-function optionsEqual(
-  a: boolean | AddEventListenerOptions | undefined,
-  b: boolean | AddEventListenerOptions | undefined,
-) {
-  if (typeof a !== 'object' || typeof b !== 'object') {
-    return a === b;
-  }
-
-  return a.once === b.once && a.passive === b.passive && a.capture === b.capture;
-}
-
-function handlersEqual(a: EventHandler, b: EventHandler) {
-  return a.listener === b.listener && optionsEqual(a.options, b.options);
-}
 
 // HEADS UP: this test is intentionally in a separate file aside from the rest of FocusZone tests
 // As it is testing ref counting on a global `window` object it would interfere with other FocusZone tests
 // which use ReactTestUtils.renderIntoDocument() which renders FocusZone into a detached DOM node and never unmounts.
 describe('FocusZone keydown event handler', () => {
-  let host: HTMLElement;
-  let keydownEventHandlers: EventHandler[];
+  let originalOnKeyDownCapture: (ev: KeyboardEvent) => void;
+  const mockOnKeyDownCapture = jest.fn();
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    originalOnKeyDownCapture = (FocusZone as any)._onKeyDownCapture;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (FocusZone as any)._onKeyDownCapture = mockOnKeyDownCapture;
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (FocusZone as any)._onKeyDownCapture = originalOnKeyDownCapture;
+  });
 
   beforeEach(() => {
-    host = document.createElement('div');
-    keydownEventHandlers = [];
-
-    window.addEventListener = jest.fn((type, listener, options) => {
-      if (type === 'keydown') {
-        const eventListener = { listener, options };
-        if (!keydownEventHandlers.some(item => handlersEqual(item, eventListener))) {
-          keydownEventHandlers.push(eventListener);
-        }
-      }
-    });
-
-    window.removeEventListener = jest.fn((type, listener, options) => {
-      if (type === 'keydown') {
-        const eventListener = { listener, options };
-        const index = keydownEventHandlers.findIndex(item => handlersEqual(item, eventListener));
-        if (index >= 0) {
-          keydownEventHandlers.splice(index, 1);
-        }
-      }
-    });
+    mockOnKeyDownCapture.mockReset();
   });
 
   it('is added on mount/removed on unmount', () => {
-    ReactDOM.render(<FocusZone />, host);
-    expect(keydownEventHandlers.length).toBe(1);
+    const { getAllByRole, rerender } = render(
+      <div>
+        <FocusZone>
+          <button />
+        </FocusZone>
+        <button />
+      </div>,
+    );
 
-    ReactDOM.unmountComponentAtNode(host);
-    expect(keydownEventHandlers.length).toBe(0);
+    let buttons = getAllByRole('button');
+    expect(buttons.length).toBe(2);
+
+    fireEvent.keyDown(buttons[0], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <div>
+        <button />
+      </div>,
+    );
+
+    buttons = getAllByRole('button');
+    expect(buttons.length).toBe(1);
+
+    fireEvent.keyDown(buttons[0], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not triggered when the keydown event happens outside of the focus zone', () => {
+    const { getAllByRole } = render(
+      <div>
+        <FocusZone>
+          <button />
+        </FocusZone>
+        <button />
+      </div>,
+    );
+
+    const buttons = getAllByRole('button');
+    expect(buttons.length).toBe(2);
+
+    fireEvent.keyDown(buttons[1], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(0);
   });
 
   it('is added only once for nested focus zones', () => {
-    ReactDOM.render(
+    const { getAllByRole, rerender } = render(
       <div>
         <FocusZone>
-          <FocusZone />
+          <FocusZone>
+            <button />
+          </FocusZone>
         </FocusZone>
+        <button />
       </div>,
-      host,
     );
-    expect(keydownEventHandlers.length).toBe(1);
 
-    ReactDOM.unmountComponentAtNode(host);
-    expect(keydownEventHandlers.length).toBe(0);
+    let buttons = getAllByRole('button');
+    expect(buttons.length).toBe(2);
+
+    fireEvent.keyDown(buttons[0], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <div>
+        <button />
+      </div>,
+    );
+
+    buttons = getAllByRole('button');
+    expect(buttons.length).toBe(1);
+
+    fireEvent.keyDown(buttons[0], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(1);
   });
 
-  it('is added only once for sibling focus zones', () => {
-    ReactDOM.render(
+  it('is added once for each outer focus zone and called once for each one', () => {
+    const { getAllByRole, rerender } = render(
       <div>
-        <FocusZone />
-        <FocusZone />
+        <FocusZone>
+          <FocusZone>
+            <button />
+          </FocusZone>
+        </FocusZone>
+        <FocusZone>
+          <button />
+        </FocusZone>
+        <button />
       </div>,
-      host,
     );
-    expect(keydownEventHandlers.length).toBe(1);
 
-    ReactDOM.unmountComponentAtNode(host);
-    expect(keydownEventHandlers.length).toBe(0);
+    let buttons = getAllByRole('button');
+    expect(buttons.length).toBe(3);
+
+    fireEvent.keyDown(buttons[0], { which: KeyCodes.tab });
+    fireEvent.keyDown(buttons[1], { which: KeyCodes.tab });
+    fireEvent.keyDown(buttons[2], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(2);
+
+    rerender(
+      <div>
+        <FocusZone>
+          <button />
+        </FocusZone>
+        <button />
+      </div>,
+    );
+
+    buttons = getAllByRole('button');
+    expect(buttons.length).toBe(2);
+
+    fireEvent.keyDown(buttons[0], { which: KeyCodes.tab });
+    fireEvent.keyDown(buttons[1], { which: KeyCodes.tab });
+    expect(mockOnKeyDownCapture).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -21,7 +21,6 @@ import {
   shouldWrapFocus,
   warnDeprecations,
   portalContainsElement,
-  getWindow,
   findScrollableParent,
   createMergedRef,
 } from '@fluentui/utilities';
@@ -147,8 +146,6 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   private _shouldRaiseClicksOnEnter: boolean;
   private _shouldRaiseClicksOnSpace: boolean;
 
-  private _windowElement: Window | undefined;
-
   /** Used for testing purposes only. */
   public static getOuterZones(): number {
     return _outerZones.size;
@@ -201,7 +198,6 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     _allInstances[this._id] = this;
 
     if (root) {
-      this._windowElement = getWindow(root);
       let parentElement = getParent(root, ALLOW_VIRTUAL_ELEMENTS);
 
       while (parentElement && parentElement !== this._getDocument().body && parentElement.nodeType === 1) {
@@ -215,9 +211,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       if (!this._isInnerZone) {
         _outerZones.add(this);
 
-        if (this._windowElement && _outerZones.size === 1) {
-          this._windowElement.addEventListener('keydown', FocusZone._onKeyDownCapture, true);
-        }
+        this._root.current && this._root.current.addEventListener('keydown', FocusZone._onKeyDownCapture, true);
       }
 
       this._root.current && this._root.current.addEventListener('blur', this._onBlur, true);
@@ -282,10 +276,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     if (!this._isInnerZone) {
       _outerZones.delete(this);
 
-      // If this is the last outer zone, remove the keydown listener.
-      if (this._windowElement && _outerZones.size === 0) {
-        this._windowElement.removeEventListener('keydown', FocusZone._onKeyDownCapture, true);
-      }
+      this._root.current && this._root.current.removeEventListener('keydown', FocusZone._onKeyDownCapture, true);
     }
 
     if (this._root.current) {


### PR DESCRIPTION
## Current Behavior

`FocusZone` currently attaches an event listener on keydown to the window, so that whenever the `tab` key is pressed all outer `FocusZone's` indexes are updated (an outer `FocusZone` is a `FocusZone` that is not within another one). This ensures tab indexes are always correct, but can cause a big performance dip since the keydown function is called even on elements that are not within `FocusZones`.

## New Behavior

This PR fixes the issue described above by attaching the listeners to the `FocusZone` elements instead of the window. This means that there is the potential of more event listeners being on the page (one per outer `FocusZone` vs one for the window), but scopes the listeners to be called only when the event happens within one of these `FocusZones`. This has a performance benefit because indexes are now updated only in the scope of `FocusZones`, so tabbing on any element outside of them doesn't incur this cost. It is also safe because indexes shouldn't need to be updated if interacting with something outside of a `FocusZone` either way.

## Related Issue(s)

Fixes #23785

A further improvement is left out of this PR but suggested in #24174.