### PR TITLE
Bug 5118 For a hybrid graph, include 2px outline for the line graph

### DIFF
--- a/change/@fluentui-react-charting-bbc541d0-79af-4a9b-81e3-3c81dd0e8b88.json
+++ b/change/@fluentui-react-charting-bbc541d0-79af-4a9b-81e3-3c81dd0e8b88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bug 5118 For a hybrid graph including a 2px outline for line graph",
+  "packageName": "@fluentui/react-charting",
+  "email": "ankityadav@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -53,6 +53,8 @@ export interface IVerticalBarChartState extends IBasestate {
 
 type ColorScale = (_p?: number) => string;
 
+const LINE_BORDER_WIDTH: number = 4;
+
 export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps, IVerticalBarChartState> {
   private _points: IVerticalBarChartDataPoint[];
   private _barWidth: number;
@@ -196,15 +198,28 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     if (this.state.isLegendHovered || this.state.isLegendSelected) {
       shouldHighlight = this.state.selectedLegendTitle === lineLegendText;
     }
+
     const line = (
-      <path
-        opacity={shouldHighlight ? 1 : 0.4}
-        d={linePath(lineData)!}
-        fill={'none'}
-        strokeWidth={3}
-        stroke={lineLegendColor}
-      />
+      <>
+        <path
+          opacity={shouldHighlight ? 1 : 0.4}
+          d={linePath(lineData)!}
+          fill="transparent"
+          strokeLinecap="square"
+          strokeWidth={3 + LINE_BORDER_WIDTH}
+          stroke={theme!.palette.white}
+        />
+        <path
+          opacity={shouldHighlight ? 1 : 0.4}
+          d={linePath(lineData)!}
+          fill="transparent"
+          strokeLinecap="square"
+          strokeWidth={3}
+          stroke={lineLegendColor}
+        />
+      </>
     );
+
     const dots: React.ReactNode[] = lineData.map(
       (item: { x: number | string; y: number; point: IVerticalBarChartDataPoint; index: number }, index: number) => {
         return (

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -204,7 +204,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     if (lineBorderWidth > 0) {
       line.push(
         <path
-          opacity={shouldHighlight ? 1 : 0.4}
+          opacity={shouldHighlight ? 1 : 0.1}
           d={linePath(lineData)!}
           fill="transparent"
           strokeLinecap="square"
@@ -215,7 +215,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     }
     line.push(
       <path
-        opacity={shouldHighlight ? 1 : 0.4}
+        opacity={shouldHighlight ? 1 : 0.1}
         d={linePath(lineData)!}
         fill="transparent"
         strokeLinecap="square"

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -181,7 +181,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     const { data, lineLegendColor = theme!.palette.yellow, lineLegendText } = this.props;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const lineData: Array<any> = [];
-    const bordersForLine: JSX.Element[] = [];
+    const line: JSX.Element[] = [];
     data &&
       data.forEach((item: IVerticalBarChartDataPoint, index: number) => {
         if (item.lineData && item.lineData.y) {
@@ -202,7 +202,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
       : 0;
 
     if (lineBorderWidth > 0) {
-      bordersForLine.push(
+      line.push(
         <path
           opacity={shouldHighlight ? 1 : 0.4}
           d={linePath(lineData)!}
@@ -213,7 +213,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
         />,
       );
     }
-    bordersForLine.push(
+    line.push(
       <path
         opacity={shouldHighlight ? 1 : 0.4}
         d={linePath(lineData)!}
@@ -246,7 +246,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
 
     return (
       <>
-        {bordersForLine}
+        {line}
         {dots}
       </>
     );

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -53,8 +53,6 @@ export interface IVerticalBarChartState extends IBasestate {
 
 type ColorScale = (_p?: number) => string;
 
-const LINE_BORDER_WIDTH: number = 4;
-
 export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps, IVerticalBarChartState> {
   private _points: IVerticalBarChartDataPoint[];
   private _barWidth: number;
@@ -183,6 +181,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     const { data, lineLegendColor = theme!.palette.yellow, lineLegendText } = this.props;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const lineData: Array<any> = [];
+    const bordersForLine: JSX.Element[] = [];
     data &&
       data.forEach((item: IVerticalBarChartDataPoint, index: number) => {
         if (item.lineData && item.lineData.y) {
@@ -198,26 +197,31 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     if (this.state.isLegendHovered || this.state.isLegendSelected) {
       shouldHighlight = this.state.selectedLegendTitle === lineLegendText;
     }
+    const lineBorderWidth = this.props.lineOptions?.lineBorderWidth
+      ? Number.parseFloat(this.props.lineOptions!.lineBorderWidth!.toString())
+      : 0;
 
-    const line = (
-      <>
+    if (lineBorderWidth > 0) {
+      bordersForLine.push(
         <path
           opacity={shouldHighlight ? 1 : 0.4}
           d={linePath(lineData)!}
           fill="transparent"
           strokeLinecap="square"
-          strokeWidth={3 + LINE_BORDER_WIDTH}
+          strokeWidth={3 + lineBorderWidth * 2}
           stroke={theme!.palette.white}
-        />
-        <path
-          opacity={shouldHighlight ? 1 : 0.4}
-          d={linePath(lineData)!}
-          fill="transparent"
-          strokeLinecap="square"
-          strokeWidth={3}
-          stroke={lineLegendColor}
-        />
-      </>
+        />,
+      );
+    }
+    bordersForLine.push(
+      <path
+        opacity={shouldHighlight ? 1 : 0.4}
+        d={linePath(lineData)!}
+        fill="transparent"
+        strokeLinecap="square"
+        strokeWidth={3}
+        stroke={lineLegendColor}
+      />,
     );
 
     const dots: React.ReactNode[] = lineData.map(
@@ -242,7 +246,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
 
     return (
       <>
-        {line}
+        {bordersForLine}
         {dots}
       </>
     );

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.types.ts
@@ -6,6 +6,7 @@ import {
   ICartesianChartStyles,
   IVerticalBarChartDataPoint,
 } from '../../index';
+import { ILineChartLineOptions } from '../../types/index';
 
 export interface IVerticalBarChartProps extends ICartesianChartProps {
   /**
@@ -67,6 +68,11 @@ export interface IVerticalBarChartProps extends ICartesianChartProps {
    * it's padding between bar's or lines in the graph
    */
   xAxisPadding?: number;
+
+  /**
+   * options for the line drawn
+   */
+  lineOptions?: ILineChartLineOptions;
 }
 
 export interface IVerticalBarChartStyleProps extends ICartesianChartStyleProps {

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -273,7 +273,12 @@ export class VerticalStackedBarChartBase extends React.Component<
     const { xBarScale } = this._getScales(containerHeight, containerWidth, isNumeric);
     const lineObject: LineObject = this._getFormattedLineData(this.props.data);
     const lines: React.ReactNode[] = [];
+    const borderForLines: React.ReactNode[] = [];
     const dots: React.ReactNode[] = [];
+    const { theme } = this.props;
+    const lineBorderWidth = this.props.lineOptions?.lineBorderWidth
+      ? Number.parseFloat(this.props.lineOptions!.lineBorderWidth!.toString())
+      : 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const xScaleBandwidthTranslate = isNumeric ? 0 : (xBarScale as any).bandwidth() / 2;
     Object.keys(lineObject).forEach((item: string, index: number) => {
@@ -292,6 +297,29 @@ export class VerticalStackedBarChartBase extends React.Component<
           : // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (xBarScale as any)(lineObject[item][i].xItem.xAxisPoint as string) + this._additionalSpace;
         const y2 = yScale(lineObject[item][i].y);
+
+        if (lineBorderWidth > 0) {
+          borderForLines.push(
+            <line
+              key={`${index}-${i}-line`}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              opacity={shouldHighlight ? 1 : 0.1}
+              strokeWidth={3 + lineBorderWidth * 2}
+              fill="transparent"
+              strokeLinecap="round"
+              stroke={theme!.palette.white}
+              transform={`translate(${xScaleBandwidthTranslate}, 0)`}
+              {...(isLegendSelected &&
+                selectedLegendTitle === item && {
+                  onMouseOver: this._lineHover.bind(this, lineObject[item][i - 1]),
+                  onMouseLeave: this._lineHoverOut,
+                })}
+            />,
+          );
+        }
         lines.push(
           <line
             key={`${index}-${i}-line`}
@@ -301,6 +329,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             y2={y2}
             opacity={shouldHighlight ? 1 : 0.1}
             strokeWidth={3}
+            strokeLinecap="round"
             stroke={lineObject[item][i].color}
             transform={`translate(${xScaleBandwidthTranslate}, 0)`}
             {...(isLegendSelected &&
@@ -345,6 +374,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     });
     return (
       <>
+        {borderForLines}
         {lines}
         {dots}
       </>

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -301,7 +301,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         if (lineBorderWidth > 0) {
           borderForLines.push(
             <line
-              key={`${index}-${i}-line`}
+              key={`${index}-${i}-BorderLine`}
               x1={x1}
               y1={y1}
               x2={x2}
@@ -312,11 +312,6 @@ export class VerticalStackedBarChartBase extends React.Component<
               strokeLinecap="round"
               stroke={theme!.palette.white}
               transform={`translate(${xScaleBandwidthTranslate}, 0)`}
-              {...(isLegendSelected &&
-                selectedLegendTitle === item && {
-                  onMouseOver: this._lineHover.bind(this, lineObject[item][i - 1]),
-                  onMouseLeave: this._lineHoverOut,
-                })}
             />,
           );
         }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -6,6 +6,7 @@ import {
   ICartesianChartProps,
   ICartesianChartStyleProps,
   ICartesianChartStyles,
+  ILineChartLineOptions,
   IVerticalStackedChartProps,
   IVSChartDataPoint,
 } from '../../index';
@@ -106,6 +107,11 @@ export interface IVerticalStackedBarChartProps extends ICartesianChartProps {
    * it's padding between bar's or lines in the graph
    */
   xAxisPadding?: number;
+
+  /**
+   * options for the line drawn
+   */
+  lineOptions?: ILineChartLineOptions;
 }
 
 export interface IVerticalStackedBarChartStyleProps extends ICartesianChartStyleProps {}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { VerticalBarChart, IVerticalBarChartProps, IVerticalBarChartDataPoint } from '@fluentui/react-charting';
+import {
+  VerticalBarChart,
+  IVerticalBarChartProps,
+  IVerticalBarChartDataPoint,
+  ILineChartLineOptions,
+} from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { IRenderFunction } from '@fluentui/react/lib/Utilities';
 import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
@@ -142,6 +147,9 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
         },
       },
     ];
+
+    const lineOptions: ILineChartLineOptions = { lineBorderWidth: '2' };
+
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
 
     return (
@@ -183,6 +191,7 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
             height={this.state.height}
             lineLegendText={'just line'}
             lineLegendColor={'brown'}
+            lineOptions={lineOptions}
             {...(this.state.isCalloutselected && {
               onRenderCalloutPerDataPoint: (
                 props: IVerticalBarChartDataPoint,

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { IVSChartDataPoint, IVerticalStackedChartProps, VerticalStackedBarChart } from '@fluentui/react-charting';
+import {
+  IVSChartDataPoint,
+  IVerticalStackedChartProps,
+  VerticalStackedBarChart,
+  ILineChartLineOptions,
+} from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
 
@@ -188,6 +193,8 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
       },
     ];
 
+    const lineOptions: ILineChartLineOptions = { lineBorderWidth: '2' };
+
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
 
     return (
@@ -236,6 +243,7 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
             data={data}
             height={this.state.height}
             width={this.state.width}
+            lineOptions={lineOptions}
             legendProps={{
               allowFocusOnLegends: true,
             }}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Callout.Example.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { VerticalStackedBarChart, IVSChartDataPoint, IVerticalStackedChartProps } from '@fluentui/react-charting';
+import {
+  VerticalStackedBarChart,
+  IVSChartDataPoint,
+  IVerticalStackedChartProps,
+  ILineChartLineOptions,
+} from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { DirectionalHint } from '@fluentui/react';
 import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
@@ -185,6 +190,8 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
       },
     ];
 
+    const lineOptions: ILineChartLineOptions = { lineBorderWidth: '2' };
+
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
 
     return (
@@ -239,6 +246,7 @@ export class VerticalStackedBarChartCalloutExample extends React.Component<{}, I
             height={this.state.height}
             width={this.state.width}
             yAxisTickCount={10}
+            lineOptions={lineOptions}
             isCalloutForStack={
               this.state.selectedCallout === 'MultiCallout' || this.state.selectedCallout === 'MultiCustomCallout'
             }

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { IVSChartDataPoint, IVerticalStackedChartProps, VerticalStackedBarChart } from '@fluentui/react-charting';
+import {
+  IVSChartDataPoint,
+  IVerticalStackedChartProps,
+  VerticalStackedBarChart,
+  ILineChartLineOptions,
+} from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
 
@@ -152,6 +157,8 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
       },
     ];
 
+    const lineOptions: ILineChartLineOptions = { lineBorderWidth: '2' };
+
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
 
     return (
@@ -199,6 +206,7 @@ export class VerticalStackedBarChartCustomAccessibilityExample extends React.Com
             data={data}
             height={this.state.height}
             width={this.state.width}
+            lineOptions={lineOptions}
             legendProps={{
               allowFocusOnLegends: true,
             }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x ] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x ] You've run `yarn change` locally


PR flow tips:
* [x ] Try to start with a Draft PR
* [ x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
![VerticalBarChartHybridBefore](https://user-images.githubusercontent.com/103660888/182313566-171aaf92-5dce-4b6a-8f6e-5f610a1ab723.png)
![VerticalStackedBarBefore](https://user-images.githubusercontent.com/103660888/183015080-2235c5db-9d04-4928-8d30-baa81ec23490.png)


<!-- This is the behavior we have today -->

## New Behavior
![VerticalBarChartHybridAfter2](https://user-images.githubusercontent.com/103660888/183061423-3d874974-c77d-4fc1-aed0-fd937c546ecc.png)

![VerticalStackedBarAfter](https://user-images.githubusercontent.com/103660888/183015120-ca535de7-e580-4e37-993d-dcf603f3d0d6.png)
![VerticalStackedBarAfter2](https://user-images.githubusercontent.com/103660888/183015138-da6d274e-0ba1-4898-955a-f39dc5bb85e9.png)



<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
