### PR TITLE
Update to UIFabric (v7 Branch) to pick up latest filetype icon system.

### DIFF
--- a/change/@uifabric-file-type-icons-7846cc28-5e45-4d9c-ac7b-1eda9989ae23.json
+++ b/change/@uifabric-file-type-icons-7846cc28-5e45-4d9c-ac7b-1eda9989ae23.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update to UIFabric (v7 Branch) to pick up latest filetype icon system. Here's the changes:",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-file-type-icons-7846cc28-5e45-4d9c-ac7b-1eda9989ae23.json
+++ b/change/@uifabric-file-type-icons-7846cc28-5e45-4d9c-ac7b-1eda9989ae23.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Update to UIFabric (v7 Branch) to pick up latest filetype icon system. Here's the changes:",
+  "comment": "Update to UIFabric (v7 Branch) to pick up latest filetype icon system. Here's the changes: - New icontype 'loop' to align to the brand (keeping 'fluid' around since it's still referenced). - Renaming the KFM folders (currently un-referenced) so their names are correct. - Cleanup of video, stream, audio icons to align to one brand. - Replacing the icon-generation pipeline from Adobe Illustrator to Figma. - Adding 20x1.5 and 64 sized icons that were previously missing (thanks to new Figma workflow!)",
   "packageName": "@uifabric/file-type-icons",
   "email": "caperez@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -271,14 +271,11 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   exe: {
     extensions: ['application', 'appref-ms', 'apk', 'app', 'appx', 'exe', 'ipa', 'msi', 'xap'],
   },
+  favoritesfolder: {},
   folder: {},
   font: {
     extensions: ['ttf', 'otf', 'woff'],
   },
-  loop: {
-    extensions: ['fluid', 'loop'],
-  },
-  favoritesfolder: {},
   form: {},
   genericfile: {},
   html: {
@@ -286,6 +283,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   ipynb: {
     extensions: ['nnb', 'ipynb'],
+  },
+  loop: {
+    extensions: ['fluid', 'loop'],
   },
   link: {
     extensions: ['lnk', 'link', 'url', 'website', 'webloc'],

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -258,7 +258,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   desktopfolder: {},
   docset: {},
-  documentfolder: {},
+  documentsfolder: {},
   docx: {
     extensions: ['doc', 'docm', 'docx', 'docb'],
   },
@@ -275,9 +275,10 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   font: {
     extensions: ['ttf', 'otf', 'woff'],
   },
-  fluid: {
+  loop: {
     extensions: ['fluid', 'loop'],
   },
+  favoritesfolder: {},
   form: {},
   genericfile: {},
   html: {
@@ -414,7 +415,6 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   spreadsheet: {
     extensions: ['odc', 'ods', 'gsheet', 'numbers', 'tsv'],
   },
-  stream: {},
   rtf: {
     extensions: ['epub', 'gdoc', 'odt', 'rtf', 'wri', 'pages'],
   },

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220309.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220801.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220801.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220803.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Update to UIFabric (v7 Branch) to pick up latest filetype icon system. 

- New icontype 'loop' to align to the brand (keeping 'fluid' around since it's still referenced). 
- Renaming the KFM folders (currently un-referenced) so their names are correct. 
- Cleanup of video, stream, audio icons to align to one brand. 
- Replacing the icon-generation pipeline from Adobe Illustrator to Figma. 
- Adding 20x1.5 and 64 sized icons that were previously missing (thanks to new Figma workflow!)",

## Checks
- yarn change was run with these update notes added to package comments
- changes tested with experiments/storyboard/filetypeicons
- package consumers using the methods described in [readme.md](https://github.com/microsoft/fluentui/tree/7.0/packages/file-type-icons#readme) will pick up new/correct icons with no issues
- Cherry pick of #24190 