### PR TITLE
Update to UIFabric (master branch) to pick up latest filetype icon system.

### DIFF
--- a/change/@fluentui-react-file-type-icons-c69416e0-f17b-4199-b094-11b74b50462e.json
+++ b/change/@fluentui-react-file-type-icons-c69416e0-f17b-4199-b094-11b74b50462e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Filetype Icon Update for Fluent. Here's the corresponding patch notes from the CDN: - New icontype 'loop' to align to the brand (keeping 'fluid' around since it's still referenced). - Renaming the KFM folders (currently un-referenced) so their names are correct. - Cleanup of video, stream, audio icons to align to one brand. - Replacing the icon-generation pipeline from Adobe Illustrator to Figma. - Adding 20x1.5 and 64 sized icons that were previously missing (thanks to new Figma workflow!)",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/react-file-type-icons/src/FileTypeIconMap.ts
@@ -258,7 +258,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   desktopfolder: {},
   docset: {},
-  documentfolder: {},
+  documentsfolder: {},
   docx: {
     extensions: ['doc', 'docm', 'docx', 'docb'],
   },
@@ -271,12 +271,10 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   exe: {
     extensions: ['application', 'appref-ms', 'apk', 'app', 'appx', 'exe', 'ipa', 'msi', 'xap'],
   },
+  favoritesfolder: {},
   folder: {},
   font: {
     extensions: ['ttf', 'otf', 'woff'],
-  },
-  fluid: {
-    extensions: ['fluid', 'loop'],
   },
   form: {},
   genericfile: {},
@@ -291,6 +289,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   linkedfolder: {},
   listitem: {},
+  loop: {
+    extensions: ['fluid', 'loop'],
+  },
   officescript: {
     extensions: ['osts'],
   },
@@ -414,7 +415,6 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   spreadsheet: {
     extensions: ['odc', 'ods', 'gsheet', 'numbers', 'tsv'],
   },
-  stream: {},
   rtf: {
     extensions: ['epub', 'gdoc', 'odt', 'rtf', 'wri', 'pages'],
   },

--- a/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
@@ -6,7 +6,7 @@ import type { IIconOptions } from '@fluentui/style-utilities';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220801.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220803.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {

--- a/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/react-file-type-icons/src/initializeFileTypeIcons.tsx
@@ -6,7 +6,7 @@ import type { IIconOptions } from '@fluentui/style-utilities';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220309.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20220801.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Update to UIFabric (master branch) to pick up latest filetype icon system. 

- New icontype 'loop' to align to the brand (keeping 'fluid' around since it's still referenced). 
- Renaming the KFM folders (currently un-referenced) so their names are correct. 
- Cleanup of video, stream, audio icons to align to one brand. 
- Replacing the icon-generation pipeline from Adobe Illustrator to Figma. 
- Adding 20x1.5 and 64 sized icons that were previously missing (thanks to new Figma workflow!)",

## Checks
- yarn change was run with these update notes added to package comments
- changes tested with experiments/storyboard/filetypeicons
- package consumers using the methods described in [readme.md](https://github.com/microsoft/fluentui/tree/master/packages/react-file-type-icons#readme) will pick up new/correct icons with no issues
- Also deployed to v7 : #24188