### PR TITLE
feat: use browser `:focus-visible` if supported

### DIFF
--- a/change/@fluentui-react-tabster-8d4667d2-30a7-4c68-bbcc-7b6331016905.json
+++ b/change/@fluentui-react-tabster-8d4667d2-30a7-4c68-bbcc-7b6331016905.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: use browser `:focus-visible` if supported",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -67,10 +67,14 @@ export const useFocusFinders: () => {
     findPrevFocusable: (currentElement: HTMLElement, options?: Pick<Types.FindNextProps, 'container'>) => HTMLElement | null | undefined;
 };
 
-// @public (undocumented)
+// Warning: (ae-internal-missing-underscore) The name "useFocusVisible" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
 export function useFocusVisible<TElement extends HTMLElement = HTMLElement>(): React_2.RefObject<TElement>;
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "useFocusWithin" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export function useFocusWithin<TElement extends HTMLElement = HTMLElement>(): React_2.RefObject<TElement>;
 
 // @public

--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -28,6 +28,8 @@ export const createCustomFocusIndicatorStyle = (
     [`:global(.fui-FluentProvider)`]: {
       [`& .${FOCUS_VISIBLE_CLASS}`]: style,
     },
+
+    ':focus-visible': style,
   }),
   ...(selector === 'focus-within' && {
     [`:global(.fui-FluentProvider)`]: {

--- a/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
@@ -20,8 +20,7 @@ type HTMLElementWithFocusVisibleScope = {
 } & HTMLElement;
 
 export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () => void {
-  if (alreadyInScope(scope)) {
-    // Focus visible polyfill already applied at this scope
+  if (alreadyInScope(scope) || browserSupportsFocusVisible()) {
     return () => undefined;
   }
 
@@ -102,4 +101,8 @@ function alreadyInScope(el: HTMLElement | null | undefined): boolean {
   }
 
   return alreadyInScope(el?.parentElement);
+}
+
+function browserSupportsFocusVisible() {
+  return CSS.supports('selector(:focus-visible)');
 }

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { canUseDOM } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { applyFocusVisiblePolyfill } from '../focus/focusVisiblePolyfill';
 
@@ -7,7 +8,7 @@ export function useFocusVisible<TElement extends HTMLElement = HTMLElement>() {
   const scopeRef = React.useRef<TElement>(null);
 
   React.useEffect(() => {
-    if (targetDocument?.defaultView && scopeRef.current) {
+    if (targetDocument?.defaultView && scopeRef.current && canUseDOM()) {
       return applyFocusVisiblePolyfill(scopeRef.current, targetDocument.defaultView);
     }
   }, [scopeRef, targetDocument]);

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
@@ -11,7 +11,7 @@ export function useFocusVisible<TElement extends HTMLElement = HTMLElement>() {
   const scopeRef = React.useRef<TElement>(null);
 
   React.useEffect(() => {
-    if (targetDocument?.defaultView && scopeRef.current && canUseDOM()) {
+    if (targetDocument?.defaultView && scopeRef.current) {
       return applyFocusVisiblePolyfill(scopeRef.current, targetDocument.defaultView);
     }
   }, [scopeRef, targetDocument]);

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { canUseDOM } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { applyFocusVisiblePolyfill } from '../focus/focusVisiblePolyfill';
 

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
@@ -3,6 +3,10 @@ import { canUseDOM } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { applyFocusVisiblePolyfill } from '../focus/focusVisiblePolyfill';
 
+/**
+ * @internal
+ * @returns ref to the container element whose children have `:focus-visible` styles
+ */
 export function useFocusVisible<TElement extends HTMLElement = HTMLElement>() {
   const { targetDocument } = useFluent();
   const scopeRef = React.useRef<TElement>(null);

--- a/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
@@ -4,6 +4,7 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import { applyFocusWithinPolyfill } from '../focus/focusWithinPolyfill';
 
 /**
+ * @internal
  * A ponyfill that allows `:focus-within` to support visibility based on keyboard/mouse navigation
  * like `:focus-visible` https://github.com/WICG/focus-visible/issues/151
  * @returns ref to the element that uses `:focus-within` styles

--- a/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { canUseDOM } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { applyFocusWithinPolyfill } from '../focus/focusWithinPolyfill';
 
@@ -12,7 +13,7 @@ export function useFocusWithin<TElement extends HTMLElement = HTMLElement>() {
   const elementRef = React.useRef<TElement>(null);
 
   React.useEffect(() => {
-    if (targetDocument?.defaultView && elementRef.current) {
+    if (targetDocument?.defaultView && elementRef.current && canUseDOM()) {
       return applyFocusWithinPolyfill(elementRef.current, targetDocument.defaultView);
     }
   }, [elementRef, targetDocument]);

--- a/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
@@ -13,7 +13,7 @@ export function useFocusWithin<TElement extends HTMLElement = HTMLElement>() {
   const elementRef = React.useRef<TElement>(null);
 
   React.useEffect(() => {
-    if (targetDocument?.defaultView && elementRef.current && canUseDOM()) {
+    if (targetDocument?.defaultView && elementRef.current) {
       return applyFocusWithinPolyfill(elementRef.current, targetDocument.defaultView);
     }
   }, [elementRef, targetDocument]);

--- a/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusWithin.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { canUseDOM } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { applyFocusWithinPolyfill } from '../focus/focusWithinPolyfill';
 


### PR DESCRIPTION
## Current Behavior

v9 `:focus-visible` ponyfill will always be used

## New Behavior

Both native `:focus-visible` and ponyfill styles are written to DOM, but if the ponyfill is never applied, its styles will never be used because there is no selector

### `:focus-visible` native

> Changes to `:focus-visible`  will not trigger `:focus-within`

| time elapsed | fast reject count | match attempts |match count |
| - | - | - | - |
| 116 | 0 | 783 | 265 |

### `:focus-visible` ponyfill 🦄

| time elapsed | fast reject count | match attempts |match count |
| - | - | - | - |
| 377 | 0 | 1484 | 364 |

### `:focus-visible` Improvement in %
| time elapsed | fast reject count | match attempts | match count |
| - | - | - | - |
| 69.2% | 0% | 47.2% | 27.2% |

## Related Issue(s)

Addresses #24183
