### PR TITLE
feat(Pivot): add overflowButtonAs prop

### DIFF
--- a/change/@fluentui-react-8eaa0012-dc28-494f-a9c8-41bbb8f24c1a.json
+++ b/change/@fluentui-react-8eaa0012-dc28-494f-a9c8-41bbb8f24c1a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add overflowButtonAs prop to Pivot component",
+  "comment": "feat(Pivot): add overflowButtonAs prop to allow overflow button customization.",
   "packageName": "@fluentui/react",
   "email": "alina.o.zaieva@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-8eaa0012-dc28-494f-a9c8-41bbb8f24c1a.json
+++ b/change/@fluentui-react-8eaa0012-dc28-494f-a9c8-41bbb8f24c1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add overflowButtonAs prop to Pivot component",
+  "packageName": "@fluentui/react",
+  "email": "alinazaieva@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-8eaa0012-dc28-494f-a9c8-41bbb8f24c1a.json
+++ b/change/@fluentui-react-8eaa0012-dc28-494f-a9c8-41bbb8f24c1a.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add overflowButtonAs prop to Pivot component",
   "packageName": "@fluentui/react",
-  "email": "alinazaieva@microsoft.com",
+  "email": "alina.o.zaieva@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -7547,6 +7547,7 @@ export interface IPivotProps extends React_2.HTMLAttributes<HTMLDivElement>, Rea
     onLinkClick?: (item?: PivotItem, ev?: React_2.MouseEvent<HTMLElement>) => void;
     overflowAriaLabel?: string;
     overflowBehavior?: 'none' | 'menu';
+    overflowButtonAs?: IComponentAs<IButtonProps>;
     selectedKey?: string | null;
     styles?: IStyleFunctionOrObject<IPivotStyleProps, IPivotStyles>;
     theme?: ITheme;

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -70,7 +70,16 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
 
     const [selectedKey, setSelectedKey] = useControllableValue(props.selectedKey, props.defaultSelectedKey);
 
-    const { componentRef, theme, linkSize, linkFormat, overflowBehavior, overflowAriaLabel, focusZoneProps } = props;
+    const {
+      componentRef,
+      theme,
+      linkSize,
+      linkFormat,
+      overflowBehavior,
+      overflowAriaLabel,
+      focusZoneProps,
+      overflowButtonAs,
+    } = props;
 
     let classNames: { [key in keyof IPivotStyles]: string };
     const nameProps = {
@@ -269,6 +278,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       pinnedIndex: renderedSelectedIndex,
     });
 
+    const OverflowButton = overflowButtonAs ? overflowButtonAs : CommandButton;
     return (
       <div ref={ref} {...divProps}>
         <FocusZone
@@ -281,7 +291,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
         >
           {items}
           {overflowBehavior === 'menu' && (
-            <CommandButton
+            <OverflowButton
               className={css(classNames.link, classNames.overflowMenuButton)}
               elementRef={overflowMenuButtonRef}
               componentRef={overflowMenuButtonComponentRef}

--- a/packages/react/src/components/Pivot/Pivot.types.ts
+++ b/packages/react/src/components/Pivot/Pivot.types.ts
@@ -3,6 +3,8 @@ import { PivotItem } from './PivotItem';
 import type { IStyle, ITheme } from '@fluentui/style-utilities';
 import type { IStyleFunctionOrObject } from '@fluentui/utilities';
 import type { IFocusZoneProps } from '../../FocusZone';
+import type { IComponentAs } from '../../Utilities';
+import type { IButtonProps } from '../../Button';
 
 /**
  * {@docCategory Pivot}
@@ -81,6 +83,11 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React
    * @default none
    */
   overflowBehavior?: 'none' | 'menu';
+
+  /**
+   * Custom component for the overflow button.
+   */
+  overflowButtonAs?: IComponentAs<IButtonProps>;
 
   /**
    * Whether to skip rendering the tabpanel with the content of the selected tab.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
Not applicable, this is a new functionality.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
* `oveflowButtonAs` prop is added to `Pivot` component
* When `overflow` is set to `menu` and `overflowButtonAs` is provided, the component will be used for rendering overflow button instead of default `CommandButton`

Usage example: setting custom label and icon for the overflow button
<img width="732" alt="image" src="https://user-images.githubusercontent.com/70098623/182582223-0a9cf53f-719a-4dae-8201-e09c15508435.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Implements #24001 
