### PR TITLE
feat(react-aria): Starts treating `aria-disabled` as `disabledFocusable`

### DIFF
--- a/change/@fluentui-react-aria-736d949d-2d8b-40f4-bbc4-31b8cb27f318.json
+++ b/change/@fluentui-react-aria-736d949d-2d8b-40f4-bbc4-31b8cb27f318.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: treats aria-disabled as disabled state on useARIAButtonProps",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -10,7 +10,7 @@ import type { ResolveShorthandFunction } from '@fluentui/react-utilities';
 import type { Slot } from '@fluentui/react-utilities';
 
 // @public (undocumented)
-export type ARIAButtonProps<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = React_2.PropsWithRef<JSX.IntrinsicElements[NonNullable<ARIAButtonSlotProps<AlternateAs>['as']>]> & Pick<ARIAButtonSlotProps<AlternateAs>, 'disabled' | 'disabledFocusable'>;
+export type ARIAButtonProps<Type extends 'a' | 'div' | 'button' = 'a' | 'div' | 'button'> = React_2.PropsWithRef<JSX.IntrinsicElements[Type]> & Pick<ARIAButtonSlotProps, 'disabled' | 'disabledFocusable'>;
 
 // @public (undocumented)
 export type ARIAButtonSlotProps<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = ExtractSlotProps<Slot<'button', AlternateAs>> & {

--- a/packages/react-components/react-aria/src/hooks/useARIAButton.test.tsx
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { useARIAButtonShorthand, useARIAButtonProps, ARIAButtonProps } from './useARIAButton';
+import { useARIAButtonShorthand, useARIAButtonProps, ARIAButtonProps, ARIAButtonSlotProps } from './useARIAButton';
 import { renderHook } from '@testing-library/react-hooks';
 import { fireEvent, render } from '@testing-library/react';
-import { ARIAButtonSlotProps } from '../../dist/types';
 import { getSlots, Slot, ComponentProps } from '@fluentui/react-utilities';
 
 const TestButton = (props: ComponentProps<{ root: Slot<ARIAButtonSlotProps> }>) => {

--- a/packages/react-components/react-aria/src/hooks/useARIAButton.test.tsx
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton.test.tsx
@@ -1,5 +1,17 @@
+import * as React from 'react';
 import { useARIAButtonShorthand, useARIAButtonProps, ARIAButtonProps } from './useARIAButton';
 import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render } from '@testing-library/react';
+import { ARIAButtonSlotProps } from '../../dist/types';
+import { getSlots, Slot, ComponentProps } from '@fluentui/react-utilities';
+
+const TestButton = (props: ComponentProps<{ root: Slot<ARIAButtonSlotProps> }>) => {
+  const { slots, slotProps } = getSlots<{ root: Slot<ARIAButtonSlotProps> }>({
+    components: { root: 'button' },
+    root: useARIAButtonShorthand(props, { required: true }),
+  });
+  return <slots.root {...slotProps.root} />;
+};
 
 describe('useARIAButton', () => {
   describe('<button>', () => {
@@ -21,7 +33,7 @@ describe('useARIAButton', () => {
       expect(current).toEqual(
         expect.objectContaining<ARIAButtonProps>({
           'aria-disabled': undefined,
-          onClick: handle,
+          onClick: expect.any(Function),
           onKeyDown: handle,
           onKeyUp: handle,
         }),
@@ -81,7 +93,7 @@ describe('useARIAButton', () => {
       expect(current).not.toHaveProperty('disabledFocusable');
       expect(current).toEqual(
         expect.objectContaining<ARIAButtonProps>({
-          'aria-disabled': false,
+          'aria-disabled': undefined,
           role: 'button',
           tabIndex: 0,
           onClick: expect.any(Function),
@@ -139,6 +151,12 @@ describe('useARIAButton', () => {
         }),
       );
     });
+  });
+  it.each(['button', 'div', 'a'] as const)('should not be possible to click %p when aria-disabled is true', type => {
+    const handleClick = jest.fn();
+    const { getByRole } = render(<TestButton as={type} onClick={handleClick} aria-disabled />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toBeCalledTimes(0);
   });
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Right now, `useARIAButtonProps` ignores `aria-disabled` value in favor of `disabled` or `disabledFocusable`

```ts
  if (type === 'button' || type === undefined) {
    return {
      ...rest,
      'aria-disabled': disabledFocusable ? true : undefined, // 🚨
    } ;
  }

```

## New Behavior

Instead of ignoring `aria-disabled`, it should be treated as if `disabledFocusable=true` has been passed, making the element focusable but still not emitting any click events.

```ts

  if (type === 'button' || type === undefined) {
    return {
      ...rest,
      disabled: disabled && !disabledFocusable,
      'aria-disabled': disabledFocusable ? true : ariaDisabled, // ✅
    };
  }

```

