### PR TITLE
feat: Make sorting more primitive

### DIFF
--- a/change/@fluentui-react-table-a321ce69-1698-45df-a2fd-96bf52ee9084.json
+++ b/change/@fluentui-react-table-a321ce69-1698-45df-a2fd-96bf52ee9084.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Make sorting more primitive",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -36,6 +36,9 @@ export const renderTableHeaderCell_unstable: (state: TableHeaderCellState) => JS
 // @public
 export const renderTableRow_unstable: (state: TableRowState) => JSX.Element;
 
+// @public (undocumented)
+export type SortDirection = 'ascending' | 'descending';
+
 // @public
 export const Table: ForwardRefComponent<TableProps>;
 
@@ -93,9 +96,6 @@ export const TableContextProvider: Provider<TableContextValue | undefined> & FC<
 export type TableContextValue = {
     size: 'small' | 'smaller' | 'medium';
     noNativeElements: boolean;
-    requestSortColumnChange: (e: React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement>, columnKey: string) => void;
-    sortColumn: string | undefined;
-    sortDirection: SortDirection;
     sortable: boolean;
 };
 
@@ -118,7 +118,7 @@ export const tableHeaderCellClassNames: SlotClassNames<TableHeaderCellSlots>;
 
 // @public
 export type TableHeaderCellProps = ComponentProps<Partial<TableHeaderCellSlots>> & {
-    columnKey: string;
+    sortDirection?: SortDirection;
 };
 
 // @public (undocumented)
@@ -187,7 +187,7 @@ export type TableSlots = {
 };
 
 // @public
-export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'> & Pick<TableContextValue, 'sortable' | 'sortColumn' | 'sortDirection' | 'requestSortColumnChange'>;
+export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'> & TableContextValue;
 
 // @public
 export const useTable_unstable: (props: TableProps, ref: React_2.Ref<HTMLElement>) => TableState;

--- a/packages/react-components/react-table/src/components/Table/Table.test.tsx
+++ b/packages/react-components/react-table/src/components/Table/Table.test.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Table } from './Table';
 import { isConformant } from '../../common/isConformant';
 import { TableProps } from './Table.types';
 import { TableRow } from '../TableRow/TableRow';
 import { TableCell } from '../TableCell/TableCell';
 import { TableBody } from '../TableBody/TableBody';
-import { TableHeader } from '../TableHeader/TableHeader';
-import { TableHeaderCell } from '../TableHeaderCell/TableHeaderCell';
 
 describe('Table', () => {
   isConformant({
@@ -41,106 +39,5 @@ describe('Table', () => {
       </Table>,
     );
     expect(container).toMatchSnapshot();
-  });
-
-  it('should call onSortColumnChange when column is clicked', () => {
-    const columnKey = 'test';
-    const spy = jest.fn();
-    const { getByRole } = render(
-      <Table noNativeElements onSortColumnChange={spy}>
-        <TableBody>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-            </TableRow>
-          </TableHeader>
-        </TableBody>
-      </Table>,
-    );
-
-    fireEvent.click(getByRole('button'));
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(expect.anything(), {
-      sortState: { sortColumn: columnKey, sortDirection: 'ascending' },
-    });
-  });
-
-  it('should use defaultSortState on mount', () => {
-    const columnKey = 'test';
-    const { getByRole } = render(
-      <Table noNativeElements defaultSortState={{ sortColumn: columnKey, sortDirection: 'descending' }}>
-        <TableBody>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-            </TableRow>
-          </TableHeader>
-        </TableBody>
-      </Table>,
-    );
-
-    expect(getByRole('columnheader').getAttribute('aria-sort')).toEqual('descending');
-  });
-
-  it('should not use defaultSortState after mount', () => {
-    const columnKey = 'test';
-    const { getByRole, rerender } = render(
-      <Table noNativeElements defaultSortState={{ sortColumn: columnKey, sortDirection: 'descending' }}>
-        <TableBody>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-            </TableRow>
-          </TableHeader>
-        </TableBody>
-      </Table>,
-    );
-
-    expect(getByRole('columnheader').getAttribute('aria-sort')).toEqual('descending');
-
-    rerender(
-      <Table noNativeElements defaultSortState={{ sortColumn: columnKey, sortDirection: 'ascending' }}>
-        <TableBody>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-            </TableRow>
-          </TableHeader>
-        </TableBody>
-      </Table>,
-    );
-
-    expect(getByRole('columnheader').getAttribute('aria-sort')).toEqual('descending');
-  });
-
-  it('should use sortState to control sorting', () => {
-    const columnKey = 'test';
-    const { getByRole, rerender } = render(
-      <Table noNativeElements sortState={{ sortColumn: columnKey, sortDirection: 'descending' }}>
-        <TableBody>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-            </TableRow>
-          </TableHeader>
-        </TableBody>
-      </Table>,
-    );
-
-    expect(getByRole('columnheader').getAttribute('aria-sort')).toEqual('descending');
-
-    rerender(
-      <Table noNativeElements sortState={{ sortColumn: columnKey, sortDirection: 'ascending' }}>
-        <TableBody>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-            </TableRow>
-          </TableHeader>
-        </TableBody>
-      </Table>,
-    );
-
-    expect(getByRole('columnheader').getAttribute('aria-sort')).toEqual('ascending');
   });
 });

--- a/packages/react-components/react-table/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/src/components/Table/Table.types.ts
@@ -10,15 +10,6 @@ export type TableContextValue = {
 
   noNativeElements: boolean;
 
-  requestSortColumnChange: (
-    e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-    columnKey: string,
-  ) => void;
-
-  sortColumn: string | undefined;
-
-  sortDirection: SortDirection;
-
   sortable: boolean;
 };
 
@@ -54,4 +45,4 @@ export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextV
  */
 export type TableState = ComponentState<TableSlots> &
   Pick<Required<TableProps>, 'size' | 'noNativeElements'> &
-  Pick<TableContextValue, 'sortable' | 'sortColumn' | 'sortDirection' | 'requestSortColumnChange'>;
+  TableContextValue;

--- a/packages/react-components/react-table/src/components/Table/useTable.ts
+++ b/packages/react-components/react-table/src/components/Table/useTable.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps, useControllableState, useEventCallback } from '@fluentui/react-utilities';
-import type { SortDirection, TableContextValue, TableProps, TableState } from './Table.types';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { TableProps, TableState } from './Table.types';
 
 /**
  * Create the state required to render Table.
@@ -13,36 +13,6 @@ import type { SortDirection, TableContextValue, TableProps, TableState } from '.
  */
 export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>): TableState => {
   const rootComponent = props.as ?? props.noNativeElements ? 'div' : 'table';
-  const sortable =
-    !!props.onSortColumnChange ||
-    !!props.sortColumn ||
-    !!props.sortDirection ||
-    !!props.sortState ||
-    !!props.defaultSortState;
-
-  const [sortState, setSortState] = useControllableState<NonNullable<TableProps['sortState']>>({
-    initialState: {
-      sortColumn: undefined,
-      sortDirection: 'ascending',
-    },
-    defaultState: props.defaultSortState,
-    state: props.sortState,
-  });
-
-  const requestSortColumnChange: TableContextValue['requestSortColumnChange'] = useEventCallback((e, columnKey) => {
-    const newState = {
-      sortColumn: columnKey,
-      sortDirection: 'ascending' as SortDirection,
-    };
-    setSortState(s => {
-      if (s.sortColumn === columnKey) {
-        newState.sortDirection = s.sortDirection === 'ascending' ? 'descending' : 'ascending';
-      }
-
-      props.onSortColumnChange?.(e, { sortState: newState });
-      return newState;
-    });
-  });
 
   return {
     components: {
@@ -55,8 +25,6 @@ export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>
     }),
     size: props.size ?? 'medium',
     noNativeElements: props.noNativeElements ?? false,
-    sortable,
-    requestSortColumnChange,
-    ...sortState,
+    sortable: props.sortable ?? false,
   };
 };

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
@@ -14,10 +14,10 @@ describe('useTableContextValues', () => {
       Object {
         "table": Object {
           "noNativeElements": false,
-          "requestSortColumnChange": [Function],
+          "requestSortColumnChange": undefined,
           "size": "medium",
           "sortColumn": undefined,
-          "sortDirection": "ascending",
+          "sortDirection": undefined,
           "sortable": false,
         },
       }

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.test.ts
@@ -14,10 +14,7 @@ describe('useTableContextValues', () => {
       Object {
         "table": Object {
           "noNativeElements": false,
-          "requestSortColumnChange": undefined,
           "size": "medium",
-          "sortColumn": undefined,
-          "sortDirection": undefined,
           "sortable": false,
         },
       }

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
@@ -1,15 +1,12 @@
 import { TableContextValues, TableState } from './Table.types';
 
 export function useTableContextValues_unstable(state: TableState): TableContextValues {
-  const { size, noNativeElements, sortable, sortColumn, sortDirection, requestSortColumnChange } = state;
+  const { size, noNativeElements, sortable } = state;
 
   return {
     table: {
       noNativeElements,
-      requestSortColumnChange,
       size,
-      sortColumn,
-      sortDirection,
       sortable,
     },
   };

--- a/packages/react-components/react-table/src/components/TableHeaderCell/TableHeaderCell.test.tsx
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/TableHeaderCell.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { TableHeaderCell } from './TableHeaderCell';
 import { isConformant } from '../../common/isConformant';
 import { TableHeaderCellProps } from './TableHeaderCell.types';
@@ -30,7 +30,7 @@ describe('TableHeaderCell', () => {
   });
 
   it('renders a default state', () => {
-    const result = render(<TableHeaderCell columnKey="test">Default TableHeaderCell</TableHeaderCell>, {
+    const result = render(<TableHeaderCell>Default TableHeaderCell</TableHeaderCell>, {
       container: tr,
     });
     expect(result.container).toMatchSnapshot();
@@ -39,7 +39,7 @@ describe('TableHeaderCell', () => {
   it('renders as div if `noNativeElements` is set', () => {
     const { container } = render(
       <TableContextProvider value={{ ...tableContextDefaultValue, noNativeElements: true }}>
-        <TableHeaderCell columnKey={'test'}>Cell</TableHeaderCell>
+        <TableHeaderCell>Cell</TableHeaderCell>
       </TableContextProvider>,
     );
     expect(container.firstElementChild?.tagName).toEqual('DIV');
@@ -47,34 +47,27 @@ describe('TableHeaderCell', () => {
   });
 
   it('should render sortIcon when sortable is true and the header cell is sorted', () => {
-    const columnKey = 'test';
     const { container } = render(
-      <TableContextProvider
-        value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: true, sortColumn: columnKey }}
-      >
-        <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
+      <TableContextProvider value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: true }}>
+        <TableHeaderCell sortDirection="ascending">Cell</TableHeaderCell>
       </TableContextProvider>,
     );
     expect(container.querySelector('svg')).not.toBe(null);
   });
 
   it('should not render sortIcon when the header cell is not sorted', () => {
-    const columnKey = 'test';
     const { container } = render(
-      <TableContextProvider
-        value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: true, sortColumn: 'sorted' }}
-      >
-        <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
+      <TableContextProvider value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: true }}>
+        <TableHeaderCell>Cell</TableHeaderCell>
       </TableContextProvider>,
     );
     expect(container.querySelector('svg')).toBe(null);
   });
 
   it('should not have interactive button when not sortable', () => {
-    const columnKey = 'test';
     const { container } = render(
       <TableContextProvider value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: false }}>
-        <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
+        <TableHeaderCell>Cell</TableHeaderCell>
       </TableContextProvider>,
     );
 
@@ -86,18 +79,15 @@ describe('TableHeaderCell', () => {
   it.each<SortDirection>(['ascending', 'descending'])(
     'should render aria-sort according to sortDirection',
     sortDirection => {
-      const columnKey = 'test';
       const { getByRole } = render(
         <TableContextProvider
           value={{
             ...tableContextDefaultValue,
             noNativeElements: true,
             sortable: true,
-            sortColumn: columnKey,
-            sortDirection,
           }}
         >
-          <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
+          <TableHeaderCell sortDirection={sortDirection}>Cell</TableHeaderCell>
         </TableContextProvider>,
       );
       expect(getByRole('columnheader').getAttribute('aria-sort')).toEqual(sortDirection);
@@ -105,53 +95,17 @@ describe('TableHeaderCell', () => {
   );
 
   it('should not render aria-sort when column is not sorted', () => {
-    const columnKey = 'test';
     const { getByRole } = render(
       <TableContextProvider
         value={{
           ...tableContextDefaultValue,
           noNativeElements: true,
           sortable: true,
-          sortColumn: 'other',
-          sortDirection: 'ascending',
         }}
       >
-        <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
+        <TableHeaderCell>Cell</TableHeaderCell>
       </TableContextProvider>,
     );
     expect(getByRole('columnheader').hasAttribute('aria-sort')).toBe(false);
-  });
-
-  it('should should call requestSortColumnChange when header is clicked', () => {
-    const columnKey = 'test';
-    const spy = jest.fn();
-    const { getByRole } = render(
-      <TableContextProvider
-        value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: true, requestSortColumnChange: spy }}
-      >
-        <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-      </TableContextProvider>,
-    );
-
-    fireEvent.click(getByRole('button'));
-
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(expect.anything(), columnKey);
-  });
-
-  it('should should not call requestSortColumnChange when non-sortable header is clicked', () => {
-    const columnKey = 'test';
-    const spy = jest.fn();
-    const { getByRole } = render(
-      <TableContextProvider
-        value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: false, requestSortColumnChange: spy }}
-      >
-        <TableHeaderCell columnKey={columnKey}>Cell</TableHeaderCell>
-      </TableContextProvider>,
-    );
-
-    fireEvent.click(getByRole('presentation'));
-
-    expect(spy).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/react-components/react-table/src/components/TableHeaderCell/TableHeaderCell.types.ts
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/TableHeaderCell.types.ts
@@ -1,5 +1,6 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
+import { SortDirection } from '../Table/Table.types';
 
 export type TableHeaderCellSlots = {
   root: Slot<'th', 'div'>;
@@ -16,10 +17,7 @@ export type TableHeaderCellSlots = {
  * TableHeaderCell Props
  */
 export type TableHeaderCellProps = ComponentProps<Partial<TableHeaderCellSlots>> & {
-  /**
-   * Key that uniquely identifies the column
-   */
-  columnKey: string;
+  sortDirection?: SortDirection;
 };
 
 /**

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
@@ -4,7 +4,11 @@ import { ArrowUpRegular, ArrowDownRegular } from '@fluentui/react-icons';
 import type { TableHeaderCellProps, TableHeaderCellState } from './TableHeaderCell.types';
 import { useTableContext } from '../../contexts/tableContext';
 import { useARIAButtonShorthand } from '@fluentui/react-aria';
-import { useEventCallback } from '@fluentui/react-utilities';
+
+const sortIcons = {
+  ascending: <ArrowUpRegular />,
+  descending: <ArrowDownRegular />,
+};
 
 /**
  * Create the state required to render TableHeaderCell.
@@ -21,13 +25,6 @@ export const useTableHeaderCell_unstable = (
 ): TableHeaderCellState => {
   const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
   const sortable = useTableContext(ctx => ctx.sortable);
-  const isSorted = useTableContext(ctx => ctx.sortColumn === props.columnKey);
-  const sortDirection = useTableContext(ctx => ctx.sortDirection);
-  const requestSortColumnChange = useTableContext(ctx => ctx.requestSortColumnChange);
-
-  const onClick = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
-    requestSortColumnChange(e, props.columnKey);
-  });
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'th';
   return {
@@ -39,12 +36,12 @@ export const useTableHeaderCell_unstable = (
     root: getNativeElementProps(rootComponent, {
       ref,
       role: rootComponent === 'div' ? 'columnheader' : undefined,
-      'aria-sort': isSorted ? sortDirection : undefined,
+      'aria-sort': props.sortDirection,
       ...props,
     }),
     sortIcon: resolveShorthand(props.sortIcon, {
-      required: sortable && isSorted,
-      defaultProps: { children: sortDirection === 'ascending' ? <ArrowUpRegular /> : <ArrowDownRegular /> },
+      required: !!props.sortDirection,
+      defaultProps: { children: props.sortDirection ? sortIcons[props.sortDirection] : undefined },
     }),
     button: useARIAButtonShorthand(props.button, {
       required: true,
@@ -55,7 +52,6 @@ export const useTableHeaderCell_unstable = (
         ...(sortable && {
           role: undefined,
           tabIndex: undefined,
-          onClick,
         }),
       },
     }),

--- a/packages/react-components/react-table/src/contexts/tableContext.ts
+++ b/packages/react-components/react-table/src/contexts/tableContext.ts
@@ -6,10 +6,7 @@ const tableContext = createContext<TableContextValue | undefined>(undefined);
 export const tableContextDefaultValue: TableContextValue = {
   size: 'medium',
   noNativeElements: false,
-  sortColumn: undefined,
-  sortDirection: 'ascending',
   sortable: false,
-  requestSortColumnChange: () => undefined,
 };
 
 export const TableContextProvider = tableContext.Provider;

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -36,7 +36,7 @@ export {
   useTable_unstable,
   renderTable_unstable,
 } from './Table';
-export type { TableProps, TableSlots, TableState, TableContextValue, TableContextValues } from './Table';
+export type { TableProps, TableSlots, TableState, TableContextValue, TableContextValues, SortDirection } from './Table';
 
 export {
   TableHeader,

--- a/packages/react-components/react-table/src/stories/Table/Default.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/Default.stories.tsx
@@ -63,9 +63,7 @@ export const Default = () => {
       <TableHeader>
         <TableRow>
           {columns.map(column => (
-            <TableHeaderCell key={column.columnKey} columnKey={column.columnKey}>
-              {column.label}
-            </TableHeaderCell>
+            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
           ))}
         </TableRow>
       </TableHeader>

--- a/packages/react-components/react-table/src/stories/Table/NonNativeElements.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/NonNativeElements.stories.tsx
@@ -63,9 +63,7 @@ export const NonNativeElements = () => {
       <TableHeader>
         <TableRow>
           {columns.map(column => (
-            <TableHeaderCell columnKey={column.columnKey} key={column.columnKey}>
-              {column.label}
-            </TableHeaderCell>
+            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
           ))}
         </TableRow>
       </TableHeader>

--- a/packages/react-components/react-table/src/stories/Table/SizeSmall.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SizeSmall.stories.tsx
@@ -63,9 +63,7 @@ export const SizeSmall = () => {
       <TableHeader>
         <TableRow>
           {columns.map(column => (
-            <TableHeaderCell columnKey={column.columnKey} key={column.columnKey}>
-              {column.label}
-            </TableHeaderCell>
+            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
           ))}
         </TableRow>
       </TableHeader>

--- a/packages/react-components/react-table/src/stories/Table/SizeSmaller.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SizeSmaller.stories.tsx
@@ -63,9 +63,7 @@ export const SizeSmaller = () => {
       <TableHeader>
         <TableRow>
           {columns.map(column => (
-            <TableHeaderCell columnKey={column.columnKey} key={column.columnKey}>
-              {column.label}
-            </TableHeaderCell>
+            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
           ))}
         </TableRow>
       </TableHeader>

--- a/packages/react-components/react-table/src/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/Sort.stories.tsx
@@ -9,8 +9,7 @@ import {
   Video16Regular as VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell } from '../..';
-import { SortState } from '../../components/Table/Table.types';
+import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell, SortDirection } from '../..';
 
 type FileCell = {
   label: string;
@@ -100,10 +99,13 @@ const columns: Record<string, { label: string; compare: (a: unknown, b: unknown)
 };
 
 export const Sort = () => {
-  const [sortState, setSortState] = React.useState<SortState>({ sortColumn: 'file', sortDirection: 'ascending' });
+  const [sortState, setSortState] = React.useState<{ sortColumn: string; sortDirection: SortDirection }>({
+    sortColumn: 'file',
+    sortDirection: 'ascending',
+  });
+  const { sortColumn, sortDirection } = sortState;
 
   const sortedItems = items.slice().sort((a, b) => {
-    const { sortColumn, sortDirection } = sortState;
     if (!sortColumn) {
       return 1;
     }
@@ -113,12 +115,30 @@ export const Sort = () => {
     return columns[columnKey].compare(a[columnKey], b[columnKey]) * mod;
   });
 
+  const onHeaderCellClick = (columnKey: string) => () => {
+    setSortState(s => {
+      const newState = { ...s, sortDirection: 'ascending' as SortDirection };
+
+      if (s.sortColumn === columnKey) {
+        newState.sortDirection = s.sortDirection === 'ascending' ? 'descending' : 'ascending';
+      } else {
+        newState.sortColumn = columnKey;
+      }
+
+      return newState;
+    });
+  };
+
   return (
-    <Table onSortColumnChange={(_, data) => setSortState(data.sortState)} defaultSortState={sortState}>
+    <Table>
       <TableHeader>
         <TableRow>
-          {(Object.keys(columns) as (keyof typeof columns)[]).map(columnKey => (
-            <TableHeaderCell key={columnKey} columnKey={columnKey}>
+          {Object.keys(columns).map(columnKey => (
+            <TableHeaderCell
+              key={columnKey}
+              onClick={onHeaderCellClick(columnKey)}
+              sortDirection={sortColumn === columnKey ? sortDirection : undefined}
+            >
               {columns[columnKey].label}
             </TableHeaderCell>
           ))}


### PR DESCRIPTION
Removes `sortState` and associated props from `Table`. This will be
reserved for the future `DataGrid`-like component in order to keep
the `Table` as primitive as possible for the moment.

Addresses #23983 
