### PR TITLE
CI/CD v9 docsite deploy action

### DIFF
--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -1,0 +1,55 @@
+# Workflow name
+name: 'Docsite publish'
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.head_commit.message, 'applying package updates') || github.event_name == 'workflow_dispatch' }}
+
+    outputs:
+      status: ${{ steps.verify-react-components-changed.outputs.any_changed }}
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout [main]
+
+      - name: Verify react-compoenents has changed
+        uses: tj-actions/changed-files@v23.1
+        id: verify-react-components-changed
+        with:
+          files: |
+            packages/react-components/react-components/package.json
+  deploy:
+    runs-on: ubuntu-latest
+    needs: check
+    if: needs.check.outputs.status == 'true'
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.1
+          cache: 'yarn'
+
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+
+      - name: Build dependencies
+        run: yarn build --to @fluentui/public-docsite-v9
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          workingDir: apps/public-docsite-v9
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## Current Behavior

All docsite Chromatic deployments have to be done manually right now.

## New Behavior

This PR adds a Github Action to automate Chromatic deployments or trigger them manually from the Actions tab.

## Related issues 

Addresses https://github.com/microsoft/fluentui/issues/24165