### PR TITLE
ci: enable yarn install caching for all GH action workflows

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 14.18.1
 
       - uses: actions/github-script@v6
         with:
@@ -34,9 +34,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 14.18.1
 
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -83,19 +83,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.18.1
-
       - name: Log environment variables (Linux)
         if: runner.os == 'Linux'
         run: |
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: yarn (install packages)
-        run: ./yarn-ci.sh
-        shell: bash
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.1
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: build FUI N* VR Test
         run: yarn workspace @fluentui/docs vr:build
@@ -117,19 +117,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.18.1
-
       - name: Log environment variables (Linux)
         if: runner.os == 'Linux'
         run: |
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: yarn (install packages)
-        run: ./yarn-ci.sh
-        shell: bash
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.1
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: build vr-tests storybook
         run: yarn workspace @fluentui/vr-tests screener:build
@@ -149,19 +149,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.18.1
-
       - name: Log environment variables (Linux)
         if: runner.os == 'Linux'
         run: |
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: yarn (install packages)
-        run: ./yarn-ci.sh
-        shell: bash
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.18.1
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: build vr-tests-react-components storybook
         run: yarn workspace @fluentui/vr-tests-react-components screener:build

--- a/.github/workflows/screener-run.yml
+++ b/.github/workflows/screener-run.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.1
+          cache: 'yarn'
 
       - name: Download environment variables artifact
         uses: dawidd6/action-download-artifact@v2
@@ -55,9 +56,8 @@ jobs:
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: yarn (install packages)
-        run: ./yarn-ci.sh
-        shell: bash
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Upload N* VR test site
         uses: azure/CLI@v1
@@ -85,6 +85,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.1
+          cache: 'yarn'
 
       - name: Download environment variables artifact
         uses: dawidd6/action-download-artifact@v2
@@ -114,9 +115,8 @@ jobs:
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: yarn (install packages)
-        run: ./yarn-ci.sh
-        shell: bash
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Upload @fluentui/react VR test site
         uses: azure/CLI@v1
@@ -144,6 +144,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.1
+          cache: 'yarn'
 
       - name: Download environment variables artifact
         uses: dawidd6/action-download-artifact@v2
@@ -174,9 +175,8 @@ jobs:
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: yarn (install packages)
-        run: ./yarn-ci.sh
-        shell: bash
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Upload @fluentui/react-components VR test site
         uses: azure/CLI@v1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- we use custom yarn wrapper for installation
- we don't use caching

## New Behavior

- all GH action workflows now use `yarn` directly with [caching enabled](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows https://github.com/microsoft/fluentui/pull/24106/files#r932168118
