### PR TITLE
chore: Add possibility to run locally-cloned token-pipeline

### DIFF
--- a/scripts/token-pipeline.ts
+++ b/scripts/token-pipeline.ts
@@ -36,9 +36,14 @@ function runPipeline(theme: typeof themes[number], pipelineDir: string, outDir: 
 
   // https://github.com/microsoft/fluentui-token-pipeline
   execSync(
-    `npx transform-tokens --platform react --in src/global.json --in src/${_.kebabCase(
-      theme,
-    )}.json --out ${outDir}/${theme}`,
+    [
+      'npx',
+      'transform-tokens',
+      '--platform react',
+      '--in src/global.json',
+      `--in src/${_.kebabCase(theme)}.json`,
+      `--out ${outDir}/${theme}`,
+    ].join(' '),
     `Generate tokens for theme:${theme}`,
     pipelineDir,
   );

--- a/scripts/token-pipeline.ts
+++ b/scripts/token-pipeline.ts
@@ -49,22 +49,30 @@ function runPipeline(theme: typeof themes[number], pipelineDir: string, outDir: 
   );
 }
 
-const tokenPipeline = () => {
+function setupDesignTokensRepo(options: { argv: typeof argv }) {
   const tmpDir = createTempDir('theme');
-  let pipelineDir = path.join(tmpDir, 'fluentui-design-tokens');
 
-  if (typeof argv.designTokensRepo === 'string') {
-    console.log(`Using local copy of design-tokens from ${argv.designTokensRepo}`);
-    pipelineDir = argv.designTokensRepo;
-  } else {
-    // clone repo, install deps
-    execSync(
-      'git clone --depth 1 https://github.com/microsoft/fluentui-design-tokens.git',
-      'Clone design tokens repo',
-      tmpDir,
-    );
-    execSync('npm install', 'Install dependencies', pipelineDir);
+  if (options.argv['design-tokens-repo']) {
+    const pipelineDir = options.argv['design-tokens-repo'];
+    console.log(`Using local copy of design-tokens from ${pipelineDir}`);
+
+    return { pipelineDir, tmpDir };
   }
+
+  // clone repo, install deps
+  execSync(
+    'git clone --depth 1 https://github.com/microsoft/fluentui-design-tokens.git',
+    'Clone design tokens repo',
+    tmpDir,
+  );
+  const pipelineDir = path.join(tmpDir, 'fluentui-design-tokens');
+  execSync('npm install', 'Install dependencies', pipelineDir);
+
+  return { pipelineDir, tmpDir };
+}
+
+const tokenPipeline = () => {
+  const { pipelineDir, tmpDir } = setupDesignTokensRepo({ argv });
 
   themes.forEach(theme => {
     runPipeline(theme, pipelineDir, tmpDir);

--- a/scripts/token-pipeline.ts
+++ b/scripts/token-pipeline.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import * as fs from 'fs-extra';
 import * as _ from 'lodash';
+import * as yargs from 'yargs';
 
 import { findGitRoot } from './monorepo';
 import execSync from './exec-sync';
@@ -9,14 +10,22 @@ import { createTempDir } from './projects-test';
 const themes = ['light', 'dark', 'teamsDark', 'highContrast'] as const;
 const repoRoot = findGitRoot();
 
+const argv = yargs
+  .option('design-tokens-repo', {
+    describe: 'Instead of cloning microsoft/fluentui-design-tokens use a local copy of the repo',
+    type: 'string',
+  })
+  .version(false)
+  .help().argv;
+
 function getGeneratedFiles(tmpDir: string) {
   return [
     {
-      src: path.join(tmpDir, 'light/react/global-colors.ts'), // the same global colors are generated for all theme, just use light
+      src: path.join(tmpDir, 'light/global-colors.ts'), // the same global colors are generated for all theme, just use light
       dest: path.join(repoRoot, 'packages/react-components/react-theme/src/global/colors.ts'),
     },
     ...themes.map(theme => ({
-      src: path.join(tmpDir, `${theme}/react/alias-colors.ts`),
+      src: path.join(tmpDir, `${theme}/alias-colors.ts`),
       dest: path.join(repoRoot, `packages/react-components/react-theme/src/alias/${theme}Color.ts`),
     })),
   ];
@@ -27,24 +36,33 @@ function runPipeline(theme: typeof themes[number], pipelineDir: string, outDir: 
 
   // https://github.com/microsoft/fluentui-token-pipeline
   execSync(
-    `npx transform-tokens --in src/global.json --in src/${_.kebabCase(theme)}.json --out ${outDir}/${theme}`,
+    `npx transform-tokens --platform react --in src/global.json --in src/${_.kebabCase(
+      theme,
+    )}.json --out ${outDir}/${theme}`,
     `Generate tokens for theme:${theme}`,
     pipelineDir,
   );
 }
 
-export const tokenPipeline = () => {
+const tokenPipeline = () => {
   const tmpDir = createTempDir('theme');
+  let pipelineDir = path.join(tmpDir, 'fluentui-design-tokens');
 
-  execSync(
-    'git clone --depth 1 https://github.com/microsoft/fluentui-design-tokens.git',
-    'Clone design tokens repo',
-    tmpDir,
-  );
-  execSync('npm install', 'Install dependencies', path.join(tmpDir, 'fluentui-design-tokens'));
+  if (typeof argv.designTokensRepo === 'string') {
+    console.log(`Using local copy of design-tokens from ${argv.designTokensRepo}`);
+    pipelineDir = argv.designTokensRepo;
+  } else {
+    // clone repo, install deps
+    execSync(
+      'git clone --depth 1 https://github.com/microsoft/fluentui-design-tokens.git',
+      'Clone design tokens repo',
+      tmpDir,
+    );
+    execSync('npm install', 'Install dependencies', pipelineDir);
+  }
 
   themes.forEach(theme => {
-    runPipeline(theme, path.join(tmpDir, 'fluentui-design-tokens'), tmpDir);
+    runPipeline(theme, pipelineDir, tmpDir);
   });
 
   getGeneratedFiles(tmpDir).forEach(file => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

To update tokens in `react-theme` an engineer runs `yarn token-pipeline`. The script always clones the repo.
This is problematic when you are debugging the pipeline.

## New Behavior

If `--design-tokens-repo=<path>` argument is passed to the script, it now uses the local copy of the repo instead of cloning it.

## Related Issue(s)

Related to #24161
