### PR TITLE
fix(devops): change main branch name with master

### DIFF
--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -4,10 +4,10 @@ name: 'Docsite publish'
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
     branches:
-      - main
+      - master
 
 jobs:
   check:
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        name: Checkout [main]
+        name: Checkout [master]
 
       - name: Verify react-compoenents has changed
         uses: tj-actions/changed-files@v23.1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Current branch for `push` and `workflow_dispatch` events is `main` instead of `master`.

## New Behavior

Replaced `main` branch with `master`.
