### PR TITLE
fix(create-component): Update use{{componentName}}Styles to use classnames object

### DIFF
--- a/scripts/create-component/plop-templates/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
+++ b/scripts/create-component/plop-templates/src/components/{{componentName}}/use{{componentName}}Styles.ts.hbs
@@ -25,7 +25,7 @@ const useStyles = makeStyles({
  */
 export const use{{componentName}}Styles_unstable = (state: {{componentName}}State): {{componentName}}State => {
   const styles = useStyles();
-  state.root.className = mergeClasses({{componentNames.propertyName}}ClassName, styles.root, state.root.className);
+  state.root.className = mergeClasses({{componentNames.propertyName}}ClassNames.root, styles.root, state.root.className);
 
   // TODO Add class names to slots, for example:
   // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When using `create-component` the `use{{ComponentName}}Styles` template uses the old static classname instead of the new classnames object.

## New Behavior

`create-component` now uses the new classnames object.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#23494 
