### PR TITLE
fix(create-component): Remove start script check from create-component so a recently created package shows up in the list of packages.

### DIFF
--- a/scripts/create-component/create-component.ts
+++ b/scripts/create-component/create-component.ts
@@ -19,7 +19,6 @@ const convergedComponentPackages = Object.entries(getAllPackageInfo())
       isConvergedPackage(info.packageJson) &&
       pkgName.startsWith('@fluentui/react-') &&
       info.packagePath.startsWith('packages') &&
-      !!info.packageJson.scripts?.start &&
       !!info.packageJson.dependencies?.['@fluentui/react-utilities'],
   )
   .map(([packageName]) => packageName);


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

After creating a package with `create-package` and then using `create-component`, the recently created package won't show up. This is due to the create package removing the start script.

## New Behavior

To avoid this when filtering the packages from `getAllPackageInfo()`, the check for the start script is removed.

