### PR TITLE
feat: add popupProps to Callout

### DIFF
--- a/change/@fluentui-react-b6625e07-abc9-46fd-a63c-bc28f8aab0ef.json
+++ b/change/@fluentui-react-b6625e07-abc9-46fd-a63c-bc28f8aab0ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add popupProps to Callout",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3102,6 +3102,7 @@ export interface ICalloutProps extends React_2.HTMLAttributes<HTMLDivElement>, R
     onPositioned?: (positions?: ICalloutPositionedInfo) => void;
     onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
     onScroll?: () => void;
+    popupProps?: IPopupProps;
     preventDismissOnEvent?: (ev: Event | React_2.FocusEvent | React_2.KeyboardEvent | React_2.MouseEvent) => boolean;
     // @deprecated
     preventDismissOnLostFocus?: boolean;

--- a/packages/react/src/components/Callout/Callout.test.tsx
+++ b/packages/react/src/components/Callout/Callout.test.tsx
@@ -186,6 +186,19 @@ describe('Callout', () => {
     );
   });
 
+  it('passes popupProps through to Popup', () => {
+    const { getByRole } = render(
+      <div>
+        <Callout doNotLayer role="dialog" popupProps={{ 'aria-modal': 'true' }}>
+          content
+        </Callout>
+      </div>,
+    );
+
+    const popup = getByRole('dialog');
+    expect(popup.getAttribute('aria-modal')).toEqual('true');
+  });
+
   // This behavior could be changed in the future
   it('does not hide siblings (currently)', () => {
     const { getByText, getByTestId } = render(

--- a/packages/react/src/components/Callout/Callout.types.ts
+++ b/packages/react/src/components/Callout/Callout.types.ts
@@ -4,6 +4,7 @@ import type { IStyle, ITheme } from '../../Styling';
 import type { IRectangle, IStyleFunctionOrObject } from '../../Utilities';
 import type { ICalloutPositionedInfo } from '../../Positioning';
 import type { ILayerProps } from '../../Layer';
+import type { IPopupProps } from '../../Popup';
 import type { Target } from '@fluentui/react-hooks';
 import type { IPopupRestoreFocusParams } from '../../Popup';
 
@@ -182,6 +183,11 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
    * Optional props to pass to the Layer component hosting the callout.
    */
   layerProps?: ILayerProps;
+
+  /**
+   * Optional props to pass the Popup component that the panel uses.
+   */
+  popupProps?: IPopupProps;
 
   /**
    * Optional callback that is called once the callout has been correctly positioned.

--- a/packages/react/src/components/Callout/Callout.types.ts
+++ b/packages/react/src/components/Callout/Callout.types.ts
@@ -185,7 +185,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, Rea
   layerProps?: ILayerProps;
 
   /**
-   * Optional props to pass the Popup component that the panel uses.
+   * Optional props to pass the Popup component that the callout uses.
    */
   popupProps?: IPopupProps;
 

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -421,6 +421,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       target,
       hidden,
       onLayerMounted,
+      popupProps,
     } = props;
 
     const hostElement = React.useRef<HTMLDivElement>(null);
@@ -522,6 +523,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
             onScroll={onScroll}
             shouldRestoreFocus={shouldRestoreFocus}
             style={overflowStyle}
+            {...popupProps}
           >
             {children}
           </Popup>


### PR DESCRIPTION
Fixes [14807](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14807)

Adding a `popupProps` prop to Callout allows authors to pass through props directly to the underlying `Popup` element, which allows for e.g. making a modal Callout (the original request).

Panel also uses `popupProps` and Callout already has `layerProps`, so this should be consistent with existing patterns.