### PR TITLE
task: Fix Common style copy task in @fluentui/react

### DIFF
--- a/change/@fluentui-react-af1de3e4-31d3-4136-8809-9f8abd9d90f6.json
+++ b/change/@fluentui-react-af1de3e4-31d3-4136-8809-9f8abd9d90f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "task: fix precopy in react in include files from the correct folder",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/config/pre-copy.json
+++ b/packages/react/config/pre-copy.json
@@ -2,14 +2,14 @@
   "copyTo": {
     "dist/sass": [
       "office-ui-fabric-core/dist/sass/**/*",
-      "@fluentui/common-styles/src/common/_highContrast.scss",
-      "@fluentui/common-styles/src/common/_i18n.scss",
-      "@fluentui/common-styles/src/common/_semanticSlots.scss",
-      "@fluentui/common-styles/src/common/_themeOverrides.scss",
-      "@fluentui/common-styles/src/common/_legacyThemePalette.scss",
-      "@fluentui/common-styles/src/common/_effects.scss",
-      "@fluentui/common-styles/src/common/_themeVariables.scss",
-      "@fluentui/common-styles/src/common/ThemingSass.scss"
+      "@fluentui/common-styles/src/_highContrast.scss",
+      "@fluentui/common-styles/src/_i18n.scss",
+      "@fluentui/common-styles/src/_semanticSlots.scss",
+      "@fluentui/common-styles/src/_themeOverrides.scss",
+      "@fluentui/common-styles/src/_legacyThemePalette.scss",
+      "@fluentui/common-styles/src/_effects.scss",
+      "@fluentui/common-styles/src/_themeVariables.scss",
+      "@fluentui/common-styles/src/ThemingSass.scss"
     ],
     "dist/css": ["office-ui-fabric-core/dist/css/**/*"]
   }


### PR DESCRIPTION
Looks like this bug has been here for a couple years now https://github.com/microsoft/fluentui/pull/15543

When we started pulling sass files from common-styles, we left `src/common` in the path, when it should just be `src`. This fix will make the common styles again ship with our react bundle, and not force people to install common-styles to get access to these sass files.