### PR TITLE
fix(devops): docsite publish workflow check job output fix

### DIFF
--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ contains(github.event.head_commit.message, 'applying package updates') || github.event_name == 'workflow_dispatch' }}
 
     outputs:
-      status: ${{ steps.verify-react-components-changed.outputs.any_changed }}
+      status: ${{ steps.verify-react-components-changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The current `check` job in the docsite-publish workflow doesn't return `true` when doing a manual trigger, except the times when `react-components/package.json` is also changed.

## New Behavior

This PR adds an "or" condition to the `check` job as well to make sure that manual releases go through every time.

