### PR TITLE
chore(react-dialog): renames `overlay` slot to `backdrop`

### DIFF
--- a/change/@fluentui-react-dialog-7e208240-ef01-4ecb-861e-2693b939b990.json
+++ b/change/@fluentui-react-dialog-7e208240-ef01-4ecb-861e-2693b939b990.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: renames overlay slot to backdrop",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/Spec.md
+++ b/packages/react-components/react-dialog/Spec.md
@@ -86,11 +86,11 @@ The root level component serves as an interface for interaction with all possibl
 type DialogSlots = {
   /**
    * Dimmed background of dialog.
-   * The default overlay is rendered as a `<div>` with styling.
-   * This slot expects a `<div>` element which will replace the default overlay.
-   * The overlay should have `aria-hidden="true"`.
+   * The default backdrop is rendered as a `<div>` with styling.
+   * This slot expects a `<div>` element which will replace the default backdrop.
+   * The backdrop should have `aria-hidden="true"`.
    */
-  overlay?: Slot<'div'>;
+  backdrop?: Slot<'div'>;
   /**
    * The root element of the Dialog right after Portal.
    */
@@ -131,7 +131,7 @@ type DialogOpenChangeData = {
   /**
    * The event source of the callback invocation
    */
-  type: 'escapeKeyDown' | 'overlayClick' | 'triggerClick';
+  type: 'escapeKeyDown' | 'backdropClick' | 'triggerClick';
   /**
    * The next value for the internal state of the dialog
    */
@@ -238,7 +238,7 @@ const dialog = <Dialog>
 <!-- expected DOM output  -->
 <button aria-haspopup="true" class="fui-button">Open Dialog</button>
 <!-- ... portal ... -->
-<div aria-hidden="true" class="fui-dialog-overlay"></div>
+<div aria-hidden="true" class="fui-dialog-backdrop"></div>
 <div aria-modal="true" role="dialog" class="fui-dialog-content">This is as basic as it gets</div>
 ```
 
@@ -271,7 +271,7 @@ const dialog = <Dialog type="alert">
 ```html
 <button aria-haspopup="true" class="fui-button">Open Dialog</button>
 <!-- ... portal ... -->
-<div aria-hidden="true" class="fui-dialog-overlay"></div>
+<div aria-hidden="true" class="fui-dialog-backdrop"></div>
 <div
   aria-describedby="fui-dialog-body-id"
   aria-labelledby="fui-dialog-title-id"
@@ -333,7 +333,7 @@ const CustomDialog = () => {
 ```html
 <button aria-haspopup="true" class="fui-button">Open Dialog</button>
 <!-- ... portal ... -->
-<div aria-hidden="true" class="fui-dialog-overlay"></div>
+<div aria-hidden="true" class="fui-dialog-backdrop"></div>
 <div
   aria-describedby="fui-dialog-body-id"
   aria-labelledby="fui-dialog-title-id"

--- a/packages/react-components/react-dialog/e2e/selectors.ts
+++ b/packages/react-components/react-dialog/e2e/selectors.ts
@@ -1,6 +1,6 @@
 import { dialogClassNames, dialogSurfaceClassNames, dialogTitleClassNames } from '@fluentui/react-dialog';
 
-export const dialogOverlaySelector = `.${dialogClassNames.overlay}`;
+export const dialogBackdropSelector = `.${dialogClassNames.backdrop}`;
 export const dialogSurfaceSelector = `.${dialogSurfaceClassNames.root}`;
 export const dialogTriggerOpenSelector = `[aria-haspopup="dialog"]`;
 export const dialogTriggerCloseSelector = `#close-btn`;

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -78,7 +78,7 @@ export type DialogOpenChangeData = {
     open: boolean;
     event: KeyboardEvent;
 } | {
-    type: 'overlayClick';
+    type: 'backdropClick';
     open: boolean;
     event: React_2.MouseEvent;
 } | {
@@ -101,7 +101,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
 
 // @public (undocumented)
 export type DialogSlots = {
-    overlay?: Slot<'div'>;
+    backdrop?: Slot<'div'>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -5,11 +5,11 @@ import type { DialogContextValue, DialogSurfaceContextValue } from '../../contex
 export type DialogSlots = {
   /**
    * Dimmed background of dialog.
-   * The default overlay is rendered as a `<div>` with styling.
-   * This slot expects a `<div>` element which will replace the default overlay.
-   * The overlay should have `aria-hidden="true"`.
+   * The default backdrop is rendered as a `<div>` with styling.
+   * This slot expects a `<div>` element which will replace the default backdrop.
+   * The backdrop should have `aria-hidden="true"`.
    */
-  overlay?: Slot<'div'>;
+  backdrop?: Slot<'div'>;
 };
 
 export type DialogOpenChangeEvent = React.KeyboardEvent | React.MouseEvent | KeyboardEvent;
@@ -20,7 +20,7 @@ export type DialogOpenChangeData =
    * document escape keydown defers from internal escape keydown events because of the synthetic event API
    */
   | { type: 'documentEscapeKeyDown'; open: boolean; event: KeyboardEvent }
-  | { type: 'overlayClick'; open: boolean; event: React.MouseEvent }
+  | { type: 'backdropClick'; open: boolean; event: React.MouseEvent }
   | { type: 'triggerClick'; open: boolean; event: React.MouseEvent };
 
 export type DialogModalType = 'modal' | 'non-modal' | 'alert';

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -17,7 +17,7 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
         {trigger}
         {open && (
           <Portal>
-            {slots.overlay && <slots.overlay {...slotProps.overlay} />}
+            {slots.backdrop && <slots.backdrop {...slotProps.backdrop} />}
             {content}
           </Portal>
         )}

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -15,7 +15,7 @@ import type { DialogProps, DialogState, DialogModalType, DialogOpenChangeData } 
  * @param props - props from this instance of Dialog
  */
 export const useDialog_unstable = (props: DialogProps): DialogState => {
-  const { children, overlay, modalType = 'modal', onOpenChange } = props;
+  const { children, backdrop, modalType = 'modal', onOpenChange } = props;
 
   const [trigger, content] = childrenToTriggerAndContent(children);
 
@@ -25,7 +25,7 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     initialState: false,
   });
 
-  const overlayShorthand = resolveShorthand(overlay, {
+  const backdropShorthand = resolveShorthand(backdrop, {
     required: modalType !== 'non-modal',
     defaultProps: {
       'aria-hidden': 'true',
@@ -54,20 +54,20 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     requestOpenChange,
   });
 
-  const handleOverLayClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    overlayShorthand?.onClick?.(event);
-    if (isOverlayClickDismiss(event, modalType)) {
-      requestOpenChange({ event, open: false, type: 'overlayClick' });
+  const handlebackdropClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    backdropShorthand?.onClick?.(event);
+    if (isbackdropClickDismiss(event, modalType)) {
+      requestOpenChange({ event, open: false, type: 'backdropClick' });
     }
   });
 
   return {
     components: {
-      overlay: 'div',
+      backdrop: 'div',
     },
-    overlay: overlayShorthand && {
-      ...overlayShorthand,
-      onClick: handleOverLayClick,
+    backdrop: backdropShorthand && {
+      ...backdropShorthand,
+      onClick: handlebackdropClick,
     },
     open,
     modalType,
@@ -111,9 +111,9 @@ function childrenToTriggerAndContent(
 }
 
 /**
- * Checks is click event is a proper Overlay click dismiss
+ * Checks is click event is a proper backdrop click dismiss
  */
-function isOverlayClickDismiss(event: React.MouseEvent, type: DialogModalType): boolean {
+function isbackdropClickDismiss(event: React.MouseEvent, type: DialogModalType): boolean {
   const isDefaultPrevented = normalizeDefaultPrevented(event);
   return type === 'modal' && !isDefaultPrevented();
 }

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogStyles.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogStyles.ts
@@ -5,18 +5,18 @@ import { DialogContext } from '../../contexts/dialogContext';
 import type { DialogSlots, DialogState } from './Dialog.types';
 
 export const dialogClassNames: SlotClassNames<DialogSlots> = {
-  overlay: 'fui-Dialog__overlay',
+  backdrop: 'fui-Dialog__backdrop',
 };
 /**
  * Styles for the root slot
  */
 const useStyles = makeStyles({
-  overlay: {
+  backdrop: {
     position: 'fixed',
     backgroundColor: 'rgba(0, 0, 0, 0.4)',
     ...shorthands.inset('0px'),
   },
-  nestedDialogOverlay: {
+  nestedDialogBackdrop: {
     backgroundColor: 'transparent',
   },
 });
@@ -28,12 +28,12 @@ export const useDialogStyles_unstable = (state: DialogState): DialogState => {
   const styles = useStyles();
   const isNestedDialog = useHasParentContext(DialogContext);
 
-  if (state.overlay) {
-    state.overlay.className = mergeClasses(
-      dialogClassNames.overlay,
-      styles.overlay,
-      isNestedDialog && styles.nestedDialogOverlay,
-      state.overlay.className,
+  if (state.backdrop) {
+    state.backdrop.className = mergeClasses(
+      dialogClassNames.backdrop,
+      styles.backdrop,
+      isNestedDialog && styles.nestedDialogBackdrop,
+      state.backdrop.className,
     );
   }
 

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogAlert.md
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogAlert.md
@@ -1,3 +1,3 @@
 An `alert` Dialog is a modal dialog that interrupts the user's workflow to communicate an important message and acquire a response. Examples include action confirmation prompts and error message confirmations. The `alert` Dialog role enables assistive technologies and browsers to distinguish alert dialogs from other dialogs so they have the option of giving alert dialogs special treatment, such as playing a system alert sound.
 
-By default clicking on `overlay` and pressing `Escape` will not dismiss an `alert` Dialog.
+By default clicking on `backdrop` and pressing `Escape` will not dismiss an `alert` Dialog.

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogAlert.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogAlert.stories.tsx
@@ -12,7 +12,7 @@ export const AlertDialog = () => {
       <DialogSurface aria-label="label">
         <DialogTitle>Alert dialog title</DialogTitle>
         <DialogBody>
-          This dialog cannot be dismissed by clicking on the overlay nor by pressing Escape. Close button should be
+          This dialog cannot be dismissed by clicking on the backdrop nor by pressing Escape. Close button should be
           pressed to dismiss this Alert
         </DialogBody>
         <DialogActions>

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogBestPractices.md
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogBestPractices.md
@@ -7,7 +7,7 @@
 
 - Dialog boxes consist of a header (`DialogTitle`), body (`DialogBody`), and footer (`DialogActions`).
 - Validate that people’s entries are acceptable before closing the dialog. Show an inline validation error near the field they must correct.
-- Modal dialogs should be used very sparingly—only when it’s critical that people make a choice or provide information before they can proceed. Thee dialogs are generally used for irreversible or potentially destructive tasks. They’re typically paired with an overlay without a light dismiss.
+- Modal dialogs should be used very sparingly—only when it’s critical that people make a choice or provide information before they can proceed. Thee dialogs are generally used for irreversible or potentially destructive tasks. They’re typically paired with an backdrop without a light dismiss.
 - `DialogSurface` by default has `aria-describedby="dialog-body-id"`, which might not be ideal with complex `DialogBody`, on those scenarios, it is recommended to set `aria-describedby={null}`
 
 ### Don't

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogNoFocusableElement.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogNoFocusableElement.stories.tsx
@@ -13,7 +13,7 @@ export const NoFocusableElement = () => {
           <DialogTitle>Dialog Title</DialogTitle>
           <DialogBody>
             <p>⚠️A Dialog without focusable elements is not recommended!⚠️</p>
-            <p>Escape key and overlay click still works to ensure this modal can be closed</p>
+            <p>Escape key and backdrop click still works to ensure this modal can be closed</p>
           </DialogBody>
         </DialogSurface>
       </Dialog>

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogNonModal.md
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogNonModal.md
@@ -1,4 +1,4 @@
-A `non-modal` Dialog by default presents no `overlay`, allowing elements outside of the Dialog to be interacted with (unless `DialogSurface` `noTrapFocus` property is provided).
+A `non-modal` Dialog by default presents no `backdrop`, allowing elements outside of the Dialog to be interacted with (unless `DialogSurface` `noTrapFocus` property is provided).
 
 `DialogTitle` compound componet will present by default a `closeButton`.
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The background dimmed effect presented on a `modal` or `alert` `Dialog` is called `overlay` per design spec

## New Behavior

Renames `overlay` in favor of [backdrop](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop), which is the name used by native [dialog](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) element
