### PR TITLE
fix(devops): add required inputs for workflow_dispatch event on docsi…

### DIFF
--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: The SHA-1 hash referring to the commit to check.
+        description: The SHA-1 hash referring to the commit which will be used for publishing.
         required: true
       ref:
         description: The head branch associated with the pull request.

--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - master
   workflow_dispatch:
-    branches:
-      - master
+    inputs:
+      sha:
+        description: The SHA-1 hash referring to the commit to check.
+        required: true
+      ref:
+        description: The head branch associated with the pull request.
+        required: true
 
 jobs:
   check:

--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
   workflow_dispatch:
+    # both inputs are required by chromaui/action
+    # https://github.com/chromaui/action#triggering-from-workflow_dispatch
     inputs:
       sha:
         description: The SHA-1 hash referring to the commit which will be used for publishing.


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The Chromatic Github Action requires 2 inputs when doing a manual release(workflow_dispatch). These are currently not specified.

## New Behavior

The missing inputs are added.

