### PR TITLE
fix(Breadcrumb): overflowbutton focus outline now visible in HCM

### DIFF
--- a/change/@fluentui-react-9389c81c-3bf8-4fd7-a465-31fd4a677c80.json
+++ b/change/@fluentui-react-9389c81c-3bf8-4fd7-a465-31fd4a677c80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Breadcrumb): overflowbutton focus outline now visible in HCM.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-9389c81c-3bf8-4fd7-a465-31fd4a677c80.json
+++ b/change/@fluentui-react-9389c81c-3bf8-4fd7-a465-31fd4a677c80.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(Breadcrumb): overflowbutton focus outline now visible in HCM.",
+  "comment": "fix: Breadcrumb overflowbutton focus outline now visible in HCM.",
   "packageName": "@fluentui/react",
   "email": "tristan.watanabe@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.styles.ts
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.styles.ts
@@ -93,6 +93,13 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
     fontWeight: itemTextFontWeight,
   };
 
+  const overflowButtonHighContrastFocus = {
+    left: 1,
+    right: 1,
+    top: 1,
+    bottom: 1,
+  };
+
   return {
     root: [
       classNames.root,
@@ -167,7 +174,7 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
 
     overflowButton: [
       classNames.overflowButton,
-      getFocusStyle(theme),
+      getFocusStyle(theme, { highContrastStyle: overflowButtonHighContrastFocus }),
       SingleLineTextStyle,
       {
         fontSize: overflowButtonFontSize,

--- a/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -111,11 +111,11 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                         z-index: 1;
                       }
                       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        bottom: -2px;
-                        left: -2px;
+                        bottom: 1px;
+                        left: 1px;
                         outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
+                        right: 1px;
+                        top: 1px;
                       }
                       &:active > span {
                         left: 0px;
@@ -1344,11 +1344,11 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         z-index: 1;
                       }
                       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        bottom: -2px;
-                        left: -2px;
+                        bottom: 1px;
+                        left: 1px;
                         outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
+                        right: 1px;
+                        top: 1px;
                       }
                       &:active > span {
                         left: 0px;
@@ -1557,11 +1557,11 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         z-index: 1;
                       }
                       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        bottom: -2px;
-                        left: -2px;
+                        bottom: 1px;
+                        left: 1px;
                         outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
+                        right: 1px;
+                        top: 1px;
                       }
                       &:active > span {
                         left: 0px;
@@ -1770,11 +1770,11 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         z-index: 1;
                       }
                       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        bottom: -2px;
-                        left: -2px;
+                        bottom: 1px;
+                        left: 1px;
                         outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
+                        right: 1px;
+                        top: 1px;
                       }
                       &:active > span {
                         left: 0px;
@@ -2271,11 +2271,11 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         z-index: 1;
                       }
                       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        bottom: -2px;
-                        left: -2px;
+                        bottom: 1px;
+                        left: 1px;
                         outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
+                        right: 1px;
+                        top: 1px;
                       }
                       &:active > span {
                         left: 0px;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Focus outline on the overflowButton is not visible in high contrast mode.

![image](https://user-images.githubusercontent.com/8649804/182941559-9c11658c-83a3-4a07-8e8c-4e75af6836a9.png)


## New Behavior
- Changed `inset` to `1px` to make outline visible and to match `inset` of `Breadcrumb` items. Focus outline is now visible in high contrast mode. 

![image](https://user-images.githubusercontent.com/8649804/182941802-e643a436-1b4b-45b0-bad7-4798d1a8419d.png)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23745
