### PR TITLE
Easy choice group option props

### DIFF
--- a/change/@fluentui-react-ca0880b1-2d51-40a5-ba98-0c357f33a91f.json
+++ b/change/@fluentui-react-ca0880b1-2d51-40a5-ba98-0c357f33a91f.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Allow IChoiceGroupOption in callback signatures",
+  "comment": "feat: Allow IChoiceGroupOption in callback signatures",
   "packageName": "@fluentui/react",
   "email": "gcox@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-ca0880b1-2d51-40a5-ba98-0c357f33a91f.json
+++ b/change/@fluentui-react-ca0880b1-2d51-40a5-ba98-0c357f33a91f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow IChoiceGroupOption in callback signatures",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3247,8 +3247,8 @@ export interface IChoiceGroupOption extends Omit<React_2.InputHTMLAttributes<HTM
     imageSrc?: string;
     key: string;
     labelId?: string;
-    onRenderField?: IRenderFunction<IChoiceGroupOptionProps>;
-    onRenderLabel?: IRenderFunction<IChoiceGroupOptionProps>;
+    onRenderField?: IRenderFunction<IChoiceGroupOption | IChoiceGroupOptionProps>;
+    onRenderLabel?: IRenderFunction<IChoiceGroupOption | IChoiceGroupOptionProps>;
     selectedImageSrc?: string;
     styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
     text: string;
@@ -3263,9 +3263,9 @@ export interface IChoiceGroupOptionProps extends Omit<IChoiceGroupOption, 'key'>
     itemKey: string;
     key?: string;
     name?: string;
-    onBlur?: (ev?: React_2.FocusEvent<HTMLElement>, props?: IChoiceGroupOptionProps) => void;
-    onChange?: (evt?: React_2.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void;
-    onFocus?: (ev?: React_2.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void | undefined;
+    onBlur?: (ev?: React_2.FocusEvent<HTMLElement>, props?: IChoiceGroupOption | IChoiceGroupOptionProps) => void;
+    onChange?: (evt?: React_2.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption | IChoiceGroupOptionProps) => void;
+    onFocus?: (ev?: React_2.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption | IChoiceGroupOptionProps) => void | undefined;
     required?: boolean;
     theme?: ITheme;
 }

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -96,12 +96,12 @@ export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLE
   /**
    * Used to customize option rendering.
    */
-  onRenderField?: IRenderFunction<IChoiceGroupOptionProps>;
+  onRenderField?: IRenderFunction<IChoiceGroupOption | IChoiceGroupOptionProps>;
 
   /**
    * Used to customize label rendering.
    */
-  onRenderLabel?: IRenderFunction<IChoiceGroupOptionProps>;
+  onRenderLabel?: IRenderFunction<IChoiceGroupOption | IChoiceGroupOptionProps>;
 
   /**
    * Props for an icon to display with this option.

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -32,20 +32,23 @@ export interface IChoiceGroupOptionProps extends Omit<IChoiceGroupOption, 'key'>
   /**
    * Callback for the ChoiceGroup creating the option to be notified when the choice has been changed.
    */
-  onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void;
+  onChange?: (
+    evt?: React.FormEvent<HTMLElement | HTMLInputElement>,
+    props?: IChoiceGroupOption | IChoiceGroupOptionProps,
+  ) => void;
 
   /**
    * Callback for the ChoiceGroup creating the option to be notified when the choice has received focus.
    */
   onFocus?: (
     ev?: React.FocusEvent<HTMLElement | HTMLInputElement>,
-    props?: IChoiceGroupOptionProps,
+    props?: IChoiceGroupOption | IChoiceGroupOptionProps,
   ) => void | undefined;
 
   /**
    * Callback for the ChoiceGroup creating the option to be notified when the choice has lost focus.
    */
-  onBlur?: (ev?: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOptionProps) => void;
+  onBlur?: (ev?: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOption | IChoiceGroupOptionProps) => void;
 
   /**
    * Indicates if the ChoiceGroupOption should appear focused, visually


### PR DESCRIPTION
## Issue
ODSP upgrade to v8 requires hundreds of updates to render callbacks in ChoiceGroup because of the creation of the IChoiceGroupOptionProps.  This extends IChoiceGroupOption.  This change allows existing callbacks that take IChoiceGroupOption to continue to work without having to manually update the typing.
 
## Changes
- Added IChoiceGroupOption as a parameter type in render callbacks for ChoiceGroup.  