### PR TITLE
Update Suggestions loading aria for extended Picker loading

### DIFF
--- a/change/@fluentui-react-3e54cdb6-be6b-43cf-98cc-d9af921c2afe.json
+++ b/change/@fluentui-react-3e54cdb6-be6b-43cf-98cc-d9af921c2afe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Suggestions loading aria for extended Picker loading",
+  "packageName": "@fluentui/react",
+  "email": "daneuber@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2320,6 +2320,8 @@ export interface IBasePickerState<T> {
     // (undocumented)
     suggestedDisplayValue?: string;
     // (undocumented)
+    suggestionsExtendedLoading?: boolean;
+    // (undocumented)
     suggestionsLoading?: boolean;
     // (undocumented)
     suggestionsVisible?: boolean;
@@ -8832,6 +8834,7 @@ export interface ISuggestionsProps<T> extends IReactProps<any> {
     componentRef?: IRefObject<ISuggestions<T>>;
     createGenericItem?: () => void;
     forceResolveText?: string;
+    isExtendedLoading?: boolean;
     isLoading?: boolean;
     isMostRecentlyUsedVisible?: boolean;
     isResultsFooterVisible?: boolean;

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -947,7 +947,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
 
   /** If suggestions are still loading after a predefined amount of time, set state to show user alert */
   private _startLoadTimer() {
-    setTimeout(() => {
+    this._async.setTimeout(() => {
       if (this.state.suggestionsLoading) {
         this.setState({ suggestionsExtendedLoading: true });
       }

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -32,6 +32,8 @@ import type { IPickerItemProps } from './PickerItem.types';
 
 const legacyStyles: any = stylesImport;
 
+const EXTENDED_LOAD_TIME = 3000;
+
 export interface IBasePickerState<T> {
   items?: any;
   suggestedDisplayValue?: string;
@@ -41,6 +43,7 @@ export interface IBasePickerState<T> {
   isMostRecentlyUsedVisible?: boolean;
   suggestionsVisible?: boolean;
   suggestionsLoading?: boolean;
+  suggestionsExtendedLoading?: boolean;
   isResultsFooterVisible?: boolean;
   selectedIndices?: number[];
   selectionRemoved?: T;
@@ -364,6 +367,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
           onGetMoreResults={this.onGetMoreResults}
           moreSuggestionsAvailable={this.state.moreSuggestionsAvailable}
           isLoading={this.state.suggestionsLoading}
+          isExtendedLoading={this.state.suggestionsExtendedLoading}
           isSearching={this.state.isSearching}
           isMostRecentlyUsedVisible={this.state.isMostRecentlyUsedVisible}
           isResultsFooterVisible={this.state.isResultsFooterVisible}
@@ -475,6 +479,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
       this.setState({
         suggestionsLoading: true,
       });
+      this._startLoadTimer();
 
       // Clear suggestions
       this.suggestionStore.updateSuggestions([]);
@@ -515,7 +520,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
         suggestedDisplayValue: itemValue,
         suggestionsVisible: this._getShowSuggestions(),
       },
-      () => this.setState({ suggestionsLoading: false }),
+      () => this.setState({ suggestionsLoading: false, suggestionsExtendedLoading: false }),
     );
   }
 
@@ -940,6 +945,15 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
     );
   }
 
+  /** If suggestions are still loading after a predefined amount of time, set state to show user alert */
+  private _startLoadTimer() {
+    setTimeout(() => {
+      if (this.state.suggestionsLoading) {
+        this.setState({ suggestionsExtendedLoading: true });
+      }
+    }, EXTENDED_LOAD_TIME);
+  }
+
   /**
    * Takes in the current updated value and either resolves it with the new suggestions
    * or if updated value is undefined then it clears out currently suggested items
@@ -952,6 +966,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
       if (this.state.suggestionsLoading) {
         this.setState({
           suggestionsLoading: false,
+          suggestionsExtendedLoading: false,
         });
       }
     }

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -368,7 +368,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       if (noResultsFoundText) {
         return noResultsFoundText;
       }
-    } else if (isExtendedLoading) {
+    } else if (isLoading && isExtendedLoading) {
       return loadingText || '';
     }
     return '';

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -351,7 +351,16 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
   }
 
   private _getAlertText = () => {
-    const { isLoading, isSearching, suggestions, suggestionsAvailableAlertText, noResultsFoundText } = this.props;
+    const {
+      isLoading,
+      isSearching,
+      suggestions,
+      suggestionsAvailableAlertText,
+      noResultsFoundText,
+      isExtendedLoading,
+      loadingText,
+    } = this.props;
+
     if (!isLoading && !isSearching) {
       if (suggestions.length > 0) {
         return suggestionsAvailableAlertText || '';
@@ -359,6 +368,8 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
       if (noResultsFoundText) {
         return noResultsFoundText;
       }
+    } else if (isExtendedLoading) {
+      return loadingText || '';
     }
     return '';
   };

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -146,6 +146,11 @@ export interface ISuggestionsProps<T> extends IReactProps<any> {
   isLoading?: boolean;
 
   /**
+   * Used to indicate whether or not the suggestions are taking an extended amount of time to load.
+   */
+  isExtendedLoading?: boolean;
+
+  /**
    * Used to indicate whether or not the component is searching for more results.
    */
   isSearching?: boolean;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ X] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
"Loading" (or, the host-provided loadingText property in Suggestions) is not announced by screenreaders even when fetching suggestions takes a long amount of time. There's no screenreader feedback to users that loading is occurring during this period, and no announcement that anything happened at all until results are generated.

## New Behavior
If loading takes longer than 3000ms, announce the loadingText so screenreader users know action is ongoing.
This could also be used in the future if an extendedLoadingText is added so something like "Loading.." -> "Still loading.." might be announced later on.

To test, I used the changes in PR and also locally changed PeoplePicker.Normal.Example.tsx to increase timeout/resolvedelay, then built. Using NVDA we now see the 'loading' announcement:
```
People Picker combo box expanded has auto complete editable blank
Loading
People Picker Suggestions available
```
![image](https://user-images.githubusercontent.com/22989057/183008435-cad37166-bb85-4cc6-9dc6-a7bd82d4a639.png)

## Related Issue(s)
(internal)

Fixes #
