### PR TITLE
Opening a <Menu> inside an iframe causes parent window to scroll to top in certain conditions

### DIFF
--- a/change/@fluentui-react-menu-52783ac6-9d80-4a95-8c2c-56d3264cefe3.json
+++ b/change/@fluentui-react-menu-52783ac6-9d80-4a95-8c2c-56d3264cefe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue causing the parent page to be scrolled to top when opening a <MenuPopover> if the storybooks are embedded in an iframe that doesn't have scrollbars",
+  "packageName": "@fluentui/react-menu",
+  "email": "radu.groza@bistone.eu",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -236,7 +236,12 @@ const useMenuOpenState = (
   const { findFirstFocusable, findNextFocusable, findPrevFocusable } = useFocusFinders();
   const focusFirst = React.useCallback(() => {
     const firstFocusable = findFirstFocusable(state.menuPopoverRef.current);
-    firstFocusable?.focus();
+    if (firstFocusable) {
+      // For some reason, directly focusing the element here causes a nasty issue when opening the menu
+      // while inside an iframe with no scrollbars: the parent frame will be automatically scrolled to top
+      // focusing the menu item on the next repaint seems to fix the issue
+      requestAnimationFrame(() => firstFocusable.focus());
+    }
   }, [findFirstFocusable, state.menuPopoverRef]);
 
   const focusAfterMenuTrigger = React.useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [-] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
Issue replicates here: https://codepen.io/radugroza/pen/ZExaLEw
When a `<Menu>` is opened in an embedded iframe with no scrollbars (iframe height big enough to fit all content), the parent page is auto-scrolled to top (if previously scrolled).

## New Behavior
The parent frame doesn't get scrolled when opening the menu

## Related Issue(s)

Fixes #
