### PR TITLE
Chromatic deployment using yarn command

### DIFF
--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -56,7 +56,6 @@ jobs:
         run: yarn build --to @fluentui/public-docsite-v9
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        with:
-          workingDir: apps/public-docsite-v9
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: yarn workspace @fluentui/public-docsite-v9 chromatic
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The current Chromatic deployment pipeline fails because of the Chromatic Github Action.

## New Behavior

Based on multiple tests, none of the specified action parameters seemed to fix the job, so going with the normal chromatic publish command fixes the pipeline and makes it easier for us to adapt it in the future.
