### PR TITLE
fix: remove misleading instructions from aria-label in examples

### DIFF
--- a/packages/react-examples/src/react/CommandBar/CommandBar.ButtonAs.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.ButtonAs.Example.tsx
@@ -72,7 +72,6 @@ export const CommandBarButtonAsExample: React.FunctionComponent = () => {
       items={_items}
       overflowItems={_overflowItems}
       farItems={_farItems}
-      ariaLabel="Use left and right arrow keys to navigate between commands"
     />
   );
 };

--- a/packages/react-examples/src/react/CommandBar/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.CommandBarButtonAs.Example.tsx
@@ -89,13 +89,7 @@ const IndividualCommandBarButtonAsExample: React.FunctionComponent<IIndividualCo
     ];
   }, [onDismissCoachmark, isCoachmarkVisible]);
 
-  return (
-    <CommandBar
-      overflowButtonProps={overflowButtonProps}
-      items={items}
-      ariaLabel="Use left and right arrow keys to navigate between commands"
-    />
-  );
+  return <CommandBar overflowButtonProps={overflowButtonProps} items={items} />;
 };
 
 export const IndividualCommandBarButtonAsExampleWrapper: React.FunctionComponent = () => {

--- a/packages/react-examples/src/react/CommandBar/CommandBar.SplitDisabled.Example.tsx
+++ b/packages/react-examples/src/react/CommandBar/CommandBar.SplitDisabled.Example.tsx
@@ -7,11 +7,7 @@ const overflowButtonProps: IButtonProps = { ariaLabel: 'More commands' };
 export const CommandBarSplitDisabledExample: React.FunctionComponent = () => {
   return (
     <div>
-      <CommandBar
-        items={_items}
-        overflowButtonProps={overflowButtonProps}
-        ariaLabel="Use left and right arrow keys to navigate between commands"
-      />
+      <CommandBar items={_items} overflowButtonProps={overflowButtonProps} />
     </div>
   );
 };

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Checkmarks.Example.tsx
@@ -77,7 +77,6 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
           isChecked: selection[keys[5]],
           split: true,
           onClick: onToggleSelect,
-          ariaLabel: 'Split Button. Click to check/uncheck. Press right arrow key to open submenu.',
         },
         {
           key: keys[8],
@@ -109,7 +108,6 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
           split: true,
           onClick: onToggleSelect,
           disabled: true,
-          ariaLabel: 'Split Button. Click to check/uncheck. Press right arrow key to open submenu.',
         },
         {
           key: keys[11],
@@ -140,7 +138,6 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
           isChecked: selection[keys[11]],
           split: true,
           onClick: onToggleSelect,
-          ariaLabel: 'Split Button Left Menu. Click to check/uncheck. Press right arrow key to open submenu.',
         },
         {
           key: keys[12],
@@ -161,7 +158,6 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
           name: 'Split Button Disabled Primary',
           split: true,
           primaryDisabled: true,
-          ariaLabel: 'Split Button Disabled Primary. Click to check/uncheck. Press right arrow key to open submenu.',
         },
         {
           key: keys[13],

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Customization.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Customization.Example.tsx
@@ -23,7 +23,6 @@ export const ContextualMenuCustomizationExample: React.FunctionComponent = () =>
       {
         key: 'charm',
         text: 'Charm',
-        ariaLabel: 'Charm. Press enter, space or right arrow keys to open submenu.',
         subMenuProps: {
           focusZoneProps: { direction: FocusZoneDirection.bidirectional },
           items: [
@@ -48,7 +47,6 @@ export const ContextualMenuCustomizationExample: React.FunctionComponent = () =>
       {
         key: 'categories',
         text: 'Categorize',
-        ariaLabel: 'Categorize. Press enter, space or right arrow keys to open submenu.',
         subMenuProps: {
           items: [
             {

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -19,7 +19,6 @@ export const ContextualMenuCustomizationWithNoWrapExample: React.FunctionCompone
         key: 'charm',
         text: 'Charm',
         className: 'Charm-List',
-        ariaLabel: 'Charm. Press enter, space or right arrow keys to open submenu.',
         subMenuProps: {
           focusZoneProps: {
             direction: FocusZoneDirection.bidirectional,
@@ -48,7 +47,6 @@ export const ContextualMenuCustomizationWithNoWrapExample: React.FunctionCompone
       {
         key: 'categories',
         text: 'Categorize',
-        ariaLabel: 'Categorize. Press enter, space or right arrow keys to open submenu.',
         subMenuProps: {
           items: [
             {

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Header.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Header.Example.tsx
@@ -31,7 +31,6 @@ export const ContextualMenuHeaderExample: React.FunctionComponent = () => {
           ],
         },
         text: 'Sharing',
-        ariaLabel: 'Sharing. Press enter, space or right arrow keys to open submenu.',
       },
       {
         key: 'navigation',

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.ScreenReader.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.ScreenReader.Example.tsx
@@ -20,7 +20,6 @@ export const ContextualMenuScreenReaderExample: React.FunctionComponent = () => 
       href: 'https://bing.com',
       text: 'New',
       target: '_blank',
-      ariaLabel: 'New. Press enter or right arrow keys to open submenu.',
       ariaDescription: 'Additional information about new item',
     },
     {
@@ -42,7 +41,6 @@ export const ContextualMenuScreenReaderExample: React.FunctionComponent = () => 
         ],
       },
       text: 'Share',
-      ariaLabel: 'Share. Press enter, space or right arrow keys to open submenu.',
       ariaDescription: 'Additional information about share item',
     },
     {
@@ -66,7 +64,6 @@ export const ContextualMenuScreenReaderExample: React.FunctionComponent = () => 
         ],
       },
       text: 'Share w/ Split',
-      ariaLabel: 'Share w/ Split. Press enter or space keys to trigger action. Press right arrow key to open submenu.',
       ariaDescription: 'Additional information about share split item',
     },
   ];

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Submenu.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.Submenu.Example.tsx
@@ -60,7 +60,6 @@ const menuItems: IContextualMenuItem[] = [
     href: 'https://bing.com',
     text: 'New',
     target: '_blank',
-    ariaLabel: 'New. Press enter or right arrow keys to open submenu.',
   },
   {
     key: 'share',
@@ -81,7 +80,6 @@ const menuItems: IContextualMenuItem[] = [
       ],
     },
     text: 'Share',
-    ariaLabel: 'Share. Press enter, space or right arrow keys to open submenu.',
   },
   {
     key: 'shareSplit',
@@ -104,6 +102,5 @@ const menuItems: IContextualMenuItem[] = [
       ],
     },
     text: 'Share w/ Split',
-    ariaLabel: 'Share w/ Split. Press enter or space keys to trigger action. Press right arrow key to open submenu.',
   },
 ];


### PR DESCRIPTION
No issue, but a partner request --

We currently have docsite examples of CommandBar and ContextualMenu that include interaction-specific `aria-label` values that specify arrow key and mouse usage. Those aren't recommended, since they are not always accurate to different types of screen reader usage, so this PR removes them.

Apparently having them in our docs examples was causing the strings to get re-added in downstream products, even after they were removed 😅.