### PR TITLE
fix: Make focus rects visible inside of ContextualMenu

### DIFF
--- a/change/@fluentui-react-999e7752-4c0d-4b7b-97c5-c0938466f097.json
+++ b/change/@fluentui-react-999e7752-4c0d-4b7b-97c5-c0938466f097.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make focus rects visible inside of ContextualMenu",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -20,6 +20,7 @@ import {
   memoizeFunction,
   getPropsWithDefaults,
   getDocument,
+  FocusRects,
 } from '../../Utilities';
 import { hasSubmenu, getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
 import { Callout } from '../../Callout';
@@ -1295,6 +1296,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
                   : null}
                 {submenuProps && onRenderSubMenu(submenuProps, onDefaultRenderSubMenu)}
               </div>
+              <FocusRects />
             </Callout>
           )}
         </MenuContext.Consumer>


### PR DESCRIPTION
## Current Behavior

The behavior of focus rects was modified by #24025 and #24150. Those moved the focus listeners from the `window` to the `Fabric` and `Portal` root elements. This now requires focus listeners to be registered on each root element, instead of just once on the window.

Focus rects require at least one element to register the listeners by either calling `useFocusRects` or rendering a `<FocusRects />`. This is currently handled by BaseButton and a handful of other components that use focus rects. However, nothing inside of a ContextualMenu does this registering. It had previously been relying on the button that opened the menu to do the registration, but that no longer works because the menu items are inside a Layer.

## New Behavior

Add a `<FocusRects />` node to ContextualMenuBase, to register for focus rects within the ContextualMenu's Layer.

## Related Issue(s)

* Fixes #24233