### PR TITLE
Standardize selection behavior of Groups in SelectionZone

### DIFF
--- a/change/@fluentui-react-8048a73c-6b18-40b3-93bb-2fa00248795b.json
+++ b/change/@fluentui-react-8048a73c-6b18-40b3-93bb-2fa00248795b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support range selection from Group headers",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-33bf3200-95e0-49e3-9e3d-9f77e469da42.json
+++ b/change/@fluentui-utilities-33bf3200-95e0-49e3-9e3d-9f77e469da42.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support range selection from Group headers",
+  "packageName": "@fluentui/utilities",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -7862,7 +7862,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               opacity: 0;
                             }
                         data-is-focusable={true}
-                        onClick={[Function]}
+                        data-selection-index={0}
+                        data-selection-span={2}
                         onKeyUp={[Function]}
                         role="row"
                         style={Object {}}
@@ -8001,7 +8002,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
+                            data-selection-invoke={true}
                             id="GroupHeader5"
+                            onClick={[Function]}
                             role="gridcell"
                           >
                             <span>
@@ -8726,7 +8729,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                               opacity: 0;
                             }
                         data-is-focusable={true}
-                        onClick={[Function]}
+                        data-selection-index={2}
+                        data-selection-span={3}
                         onKeyUp={[Function]}
                         role="row"
                         style={Object {}}
@@ -8865,7 +8869,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   text-overflow: ellipsis;
                                   white-space: nowrap;
                                 }
+                            data-selection-invoke={true}
                             id="GroupHeader7"
+                            onClick={[Function]}
                             role="gridcell"
                           >
                             <span>

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -117,7 +117,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       <div
         className={this._classNames.root}
         style={viewport ? { minWidth: viewport.width } : {}}
-        onClick={this._onHeaderClick}
         role="row"
         aria-level={ariaLevel}
         aria-setsize={ariaSetSize}
@@ -129,6 +128,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         aria-labelledby={group.ariaLabel ? undefined : this._id}
         aria-expanded={!this.state.isCollapsed}
         aria-selected={canSelectGroup ? currentlySelected : undefined}
+        data-selection-index={group.startIndex}
+        data-selection-span={group.count}
       >
         <div className={this._classNames.groupHeaderContainer} role="presentation">
           {isSelectionCheckVisible ? (
@@ -142,7 +143,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
                 aria-checked={currentlySelected}
                 aria-labelledby={`${this._id}-check ${this._id}`}
                 data-selection-toggle={true}
-                onClick={this._onToggleSelectGroupClick}
                 {...selectAllButtonProps}
               >
                 {onRenderCheckbox({ checked: currentlySelected, theme }, onRenderCheckbox)}
@@ -175,7 +175,16 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
             </button>
           </div>
 
-          {onRenderTitle(this.props, this._onRenderTitle)}
+          <div
+            className={this._classNames.title}
+            id={this._id}
+            onClick={this._onHeaderClick}
+            role="gridcell"
+            aria-colspan={this.props.ariaColSpan}
+            data-selection-invoke={true}
+          >
+            {onRenderTitle(this.props, this._onRenderTitle)}
+          </div>
           {isLoadingVisible && <Spinner label={loadingText} />}
         </div>
       </div>
@@ -224,24 +233,11 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     ev.preventDefault();
   };
 
-  private _onToggleSelectGroupClick = (ev: React.MouseEvent<HTMLElement>): void => {
-    const { onToggleSelectGroup, group } = this.props;
-
-    if (onToggleSelectGroup) {
-      onToggleSelectGroup(group!);
-    }
-
-    ev.preventDefault();
-    ev.stopPropagation();
-  };
-
   private _onHeaderClick = (): void => {
-    const { group, onGroupHeaderClick, onToggleSelectGroup } = this.props;
+    const { group, onGroupHeaderClick } = this.props;
 
     if (onGroupHeaderClick) {
       onGroupHeaderClick(group!);
-    } else if (onToggleSelectGroup) {
-      onToggleSelectGroup(group!);
     }
   };
 
@@ -254,14 +250,14 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
   }
 
   private _onRenderTitle = (props: IGroupHeaderProps): JSX.Element | null => {
-    const { group, ariaColSpan } = props;
+    const { group } = props;
 
     if (!group) {
       return null;
     }
 
     return (
-      <div className={this._classNames.title} id={this._id} role="gridcell" aria-colspan={ariaColSpan}>
+      <>
         <span>{group.name}</span>
         {
           // hasMoreData flag is set when grouping is throttled by SPO server which in turn resorts to regular
@@ -273,7 +269,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
           ({group.count}
           {group.hasMoreData && '+'})
         </span>
-      </div>
+      </>
     );
   };
 }

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -324,7 +324,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
             }
           } else {
             if (this.props.isSelectedOnFocus) {
-              this._onItemSurfaceClick(ev, index);
+              this._onItemSurfaceClick('focus', index);
             }
           }
         }
@@ -404,7 +404,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
         if (this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME)) {
           if (!isSelectionDisabled) {
             if (this._isShiftPressed) {
-              this._onItemSurfaceClick(ev, index, span);
+              this._onItemSurfaceClick('click', index, span);
             } else {
               this._onToggleClick(ev, index, span);
             }
@@ -423,7 +423,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
           break;
         } else if (target === itemRoot) {
           if (!isSelectionDisabled) {
-            this._onItemSurfaceClick(ev, index, span);
+            this._onItemSurfaceClick('click', index, span);
           }
           break;
         } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
@@ -678,7 +678,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     }
   }
 
-  private _onItemSurfaceClick(ev: React.SyntheticEvent<HTMLElement>, index: number, span?: number): void {
+  private _onItemSurfaceClick(type: 'focus' | 'click', index: number, span?: number): void {
     const { selection, toggleWithoutModifierPressed } = this.props;
     const isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
 
@@ -691,7 +691,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
         } else {
           selection.selectToIndex(index, !isToggleModifierPressed);
         }
-      } else if (isToggleModifierPressed || toggleWithoutModifierPressed) {
+      } else if (type === 'click' && (isToggleModifierPressed || toggleWithoutModifierPressed)) {
         if (span !== undefined) {
           selection.toggleRangeSelected(index, span);
         } else {

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -33,6 +33,7 @@ import type { ISelection, IObjectWithKey } from './interfaces';
 
 const SELECTION_DISABLED_ATTRIBUTE_NAME = 'data-selection-disabled';
 const SELECTION_INDEX_ATTRIBUTE_NAME = 'data-selection-index';
+const SELECTION_SPAN_ATTRIBUTE_NAME = 'data-selection-span';
 const SELECTION_TOGGLE_ATTRIBUTE_NAME = 'data-selection-toggle';
 const SELECTION_INVOKE_ATTRIBUTE_NAME = 'data-selection-invoke';
 const SELECTION_INVOKE_TOUCH_ATTRIBUTE_NAME = 'data-selection-touch-invoke';
@@ -311,17 +312,20 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
 
       if (!isToggle && itemRoot) {
         const index = this._getItemIndex(itemRoot);
+        const span = this._getItemSpan(itemRoot);
 
-        if (isToggleModifierPressed) {
-          // set anchor only.
-          selection.setIndexSelected(index, selection.isIndexSelected(index), true);
-          if (this.props.enterModalOnTouch && this._isTouch && selection.setModal) {
-            selection.setModal(true);
-            this._setIsTouch(false);
-          }
-        } else {
-          if (this.props.isSelectedOnFocus) {
-            this._onItemSurfaceClick(ev, index);
+        if (span === undefined) {
+          if (isToggleModifierPressed) {
+            // set anchor only.
+            selection.setIndexSelected(index, selection.isIndexSelected(index), true);
+            if (this.props.enterModalOnTouch && this._isTouch && selection.setModal) {
+              selection.setModal(true);
+              this._setIsTouch(false);
+            }
+          } else {
+            if (this.props.isSelectedOnFocus) {
+              this._onItemSurfaceClick(ev, index);
+            }
           }
         }
       }
@@ -332,6 +336,8 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
 
   private _onMouseDown = (ev: React.MouseEvent<HTMLElement>): void => {
     this._updateModifiers(ev);
+
+    const { toggleWithoutModifierPressed } = this.props;
 
     let target = ev.target as HTMLElement;
     const itemRoot = this._findItemRoot(target);
@@ -354,9 +360,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
           !this._isShiftPressed &&
           !this._isCtrlPressed &&
           !this._isMetaPressed &&
-          !this.props.toggleWithoutModifierPressed
+          !toggleWithoutModifierPressed
         ) {
-          this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
+          this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot), this._getItemSpan(itemRoot));
+
           break;
         } else if (
           this.props.disableAutoSelectOnInputElements &&
@@ -392,13 +399,14 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
         break;
       } else if (itemRoot) {
         const index = this._getItemIndex(itemRoot);
+        const span = this._getItemSpan(itemRoot);
 
         if (this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME)) {
           if (!isSelectionDisabled) {
             if (this._isShiftPressed) {
-              this._onItemSurfaceClick(ev, index);
+              this._onItemSurfaceClick(ev, index, span);
             } else {
-              this._onToggleClick(ev, index);
+              this._onToggleClick(ev, index, span);
             }
           }
           break;
@@ -408,12 +416,14 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
             this._hasAttribute(target, SELECTION_INVOKE_TOUCH_ATTRIBUTE_NAME)) ||
           this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)
         ) {
-          // Items should be invokable even if selection is disabled.
-          this._onInvokeClick(ev, index);
+          if (span === undefined) {
+            // Items should be invokable even if selection is disabled.
+            this._onInvokeClick(ev, index);
+          }
           break;
         } else if (target === itemRoot) {
           if (!isSelectionDisabled) {
-            this._onItemSurfaceClick(ev, index);
+            this._onItemSurfaceClick(ev, index, span);
           }
           break;
         } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
@@ -548,6 +558,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     // If a key was pressed within an item, we should treat "enters" as invokes and "space" as toggle
     if (itemRoot) {
       const index = this._getItemIndex(itemRoot);
+      const span = this._getItemSpan(itemRoot);
 
       while (target !== this._root.current) {
         if (this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME)) {
@@ -555,10 +566,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
           // so we can no-op for any keydowns in this case.
           break;
         } else if (this._shouldAutoSelect(target)) {
-          if (!isSelectionDisabled) {
+          if (!isSelectionDisabled && span === undefined) {
             // If the event went to an element which should trigger auto-select, select it and then let
             // the default behavior kick in.
-            this._onInvokeMouseDown(ev, index);
+            this._onInvokeMouseDown(ev, index, span);
           }
           break;
         } else if (
@@ -570,14 +581,16 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
         } else if (target === itemRoot) {
           // eslint-disable-next-line deprecation/deprecation
           if (ev.which === KeyCodes.enter) {
-            // Items should be invokable even if selection is disabled.
-            this._onInvokeClick(ev, index);
-            ev.preventDefault();
+            if (span === undefined) {
+              // Items should be invokable even if selection is disabled.
+              this._onInvokeClick(ev, index);
+              ev.preventDefault();
+            }
             return;
             // eslint-disable-next-line deprecation/deprecation
           } else if (ev.which === KeyCodes.space) {
             if (!isSelectionDisabled) {
-              this._onToggleClick(ev, index);
+              this._onToggleClick(ev, index, span);
             }
             ev.preventDefault();
             return;
@@ -602,30 +615,45 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     }
   }
 
-  private _onToggleClick(ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, index: number): void {
+  private _onToggleClick(
+    ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    index: number,
+    span?: number,
+  ): void {
     const { selection } = this.props;
 
     const selectionMode = this._getSelectionMode();
 
     selection.setChangeEvents(false);
 
-    if (this.props.enterModalOnTouch && this._isTouch && !selection.isIndexSelected(index) && selection.setModal) {
+    if (
+      this.props.enterModalOnTouch &&
+      this._isTouch &&
+      (span !== undefined ? !selection.isRangeSelected(index, span) : !selection.isIndexSelected(index)) &&
+      selection.setModal
+    ) {
       selection.setModal(true);
       this._setIsTouch(false);
     }
 
     if (selectionMode === SelectionMode.multiple) {
-      selection.toggleIndexSelected(index);
+      if (span !== undefined) {
+        selection.toggleRangeSelected(index, span);
+      } else {
+        selection.toggleIndexSelected(index);
+      }
     } else if (selectionMode === SelectionMode.single) {
-      const isSelected = selection.isIndexSelected(index);
-      const isModal = selection.isModal && selection.isModal();
-      selection.setAllSelected(false);
-      selection.setIndexSelected(index, !isSelected, true);
-      if (isModal && selection.setModal) {
-        // Since the above call to setAllSelected(false) clears modal state,
-        // restore it. This occurs because the SelectionMode of the Selection
-        // may differ from the SelectionZone.
-        selection.setModal(true);
+      if (span === undefined || span === 1) {
+        const isSelected = selection.isIndexSelected(index);
+        const isModal = selection.isModal && selection.isModal();
+        selection.setAllSelected(false);
+        selection.setIndexSelected(index, !isSelected, true);
+        if (isModal && selection.setModal) {
+          // Since the above call to setAllSelected(false) clears modal state,
+          // restore it. This occurs because the SelectionMode of the Selection
+          // may differ from the SelectionZone.
+          selection.setModal(true);
+        }
       }
     } else {
       selection.setChangeEvents(true);
@@ -650,7 +678,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     }
   }
 
-  private _onItemSurfaceClick(ev: React.SyntheticEvent<HTMLElement>, index: number): void {
+  private _onItemSurfaceClick(ev: React.SyntheticEvent<HTMLElement>, index: number, span?: number): void {
     const { selection, toggleWithoutModifierPressed } = this.props;
     const isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
 
@@ -658,29 +686,44 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
 
     if (selectionMode === SelectionMode.multiple) {
       if (this._isShiftPressed && !this._isTabPressed) {
-        selection.selectToIndex(index, !isToggleModifierPressed);
+        if (span !== undefined) {
+          selection.selectToRange(index, span, !isToggleModifierPressed);
+        } else {
+          selection.selectToIndex(index, !isToggleModifierPressed);
+        }
       } else if (isToggleModifierPressed || toggleWithoutModifierPressed) {
-        selection.toggleIndexSelected(index);
+        if (span !== undefined) {
+          selection.toggleRangeSelected(index, span);
+        } else {
+          selection.toggleIndexSelected(index);
+        }
       } else {
-        this._clearAndSelectIndex(index);
+        this._clearAndSelectIndex(index, span);
       }
     } else if (selectionMode === SelectionMode.single) {
-      this._clearAndSelectIndex(index);
+      this._clearAndSelectIndex(index, span);
     }
   }
 
   private _onInvokeMouseDown(
     ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
     index: number,
+    span?: number,
   ): void {
     const { selection } = this.props;
 
-    // Only do work if item is not selected.
-    if (selection.isIndexSelected(index)) {
-      return;
+    if (span !== undefined) {
+      if (selection.isRangeSelected(index, span)) {
+        return;
+      }
+    } else {
+      // Only do work if item is not selected.
+      if (selection.isIndexSelected(index)) {
+        return;
+      }
     }
 
-    this._clearAndSelectIndex(index);
+    this._clearAndSelectIndex(index, span);
   }
 
   /**
@@ -708,15 +751,20 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     }
   }
 
-  private _clearAndSelectIndex(index: number): void {
+  private _clearAndSelectIndex(index: number, span?: number): void {
     const { selection, selectionClearedOnSurfaceClick = true } = this.props;
-    const isAlreadySingleSelected = selection.getSelectedCount() === 1 && selection.isIndexSelected(index);
+    const isAlreadySingleSelected =
+      (span === undefined || span === 1) && selection.getSelectedCount() === 1 && selection.isIndexSelected(index);
 
     if (!isAlreadySingleSelected && selectionClearedOnSurfaceClick) {
       const isModal = selection.isModal && selection.isModal();
       selection.setChangeEvents(false);
       selection.setAllSelected(false);
-      selection.setIndexSelected(index, true, true);
+      if (span !== undefined) {
+        selection.setRangeSelected(index, span, true, true);
+      } else {
+        selection.setIndexSelected(index, true, true);
+      }
       if (isModal || (this.props.enterModalOnTouch && this._isTouch)) {
         if (selection.setModal) {
           selection.setModal(true);
@@ -765,7 +813,19 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
   }
 
   private _getItemIndex(itemRoot: HTMLElement): number {
-    return Number(itemRoot.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME));
+    const indexValue = itemRoot.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME);
+
+    return Number(indexValue);
+  }
+
+  private _getItemSpan(itemRoot: HTMLElement): number | undefined {
+    const spanValue = itemRoot.getAttribute(SELECTION_SPAN_ATTRIBUTE_NAME);
+
+    if (typeof spanValue === 'string') {
+      return Number(spanValue);
+    }
+
+    return undefined;
   }
 
   private _shouldAutoSelect(element: HTMLElement): boolean {

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -813,19 +813,15 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
   }
 
   private _getItemIndex(itemRoot: HTMLElement): number {
-    const indexValue = itemRoot.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME);
+    const indexValue = parseInt(itemRoot.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME) ?? '', 10);
 
-    return Number(indexValue);
+    return isNaN(indexValue) ? -1 : indexValue;
   }
 
   private _getItemSpan(itemRoot: HTMLElement): number | undefined {
-    const spanValue = itemRoot.getAttribute(SELECTION_SPAN_ATTRIBUTE_NAME);
+    const spanValue = parseInt(itemRoot.getAttribute(SELECTION_SPAN_ATTRIBUTE_NAME) ?? '', 10);
 
-    if (typeof spanValue === 'string') {
-      return Number(spanValue);
-    }
-
-    return undefined;
+    return isNaN(spanValue) ? undefined : spanValue;
   }
 
   private _shouldAutoSelect(element: HTMLElement): boolean {

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -736,6 +736,8 @@ export interface ISelection<TItem = IObjectWithKey> {
     // (undocumented)
     selectToKey(key: string, clearSelection?: boolean): void;
     // (undocumented)
+    selectToRange(index: number, count: number, clearSelection?: boolean): void;
+    // (undocumented)
     setAllSelected(isAllSelected: boolean): void;
     // (undocumented)
     setChangeEvents(isEnabled: boolean, suppressChange?: boolean): void;
@@ -747,6 +749,8 @@ export interface ISelection<TItem = IObjectWithKey> {
     setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)
     setModal?(isModal: boolean): void;
+    // (undocumented)
+    setRangeSelected(fromIndex: number, count: number, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)
     toggleAllSelected(): void;
     // (undocumented)
@@ -1112,6 +1116,8 @@ class Selection_2<TItem = IObjectWithKey> implements ISelection<TItem> {
     // (undocumented)
     selectToKey(key: string, clearSelection?: boolean): void;
     // (undocumented)
+    selectToRange(fromIndex: number, count: number, clearSelection?: boolean): void;
+    // (undocumented)
     setAllSelected(isAllSelected: boolean): void;
     // (undocumented)
     setChangeEvents(isEnabled: boolean, suppressChange?: boolean): void;
@@ -1122,6 +1128,8 @@ class Selection_2<TItem = IObjectWithKey> implements ISelection<TItem> {
     setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)
     setModal(isModal: boolean): void;
+    // (undocumented)
+    setRangeSelected(fromIndex: number, count: number, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)
     toggleAllSelected(): void;
     // (undocumented)

--- a/packages/utilities/src/selection/Selection.types.ts
+++ b/packages/utilities/src/selection/Selection.types.ts
@@ -55,6 +55,7 @@ export interface ISelection<TItem = IObjectWithKey> {
   setAllSelected(isAllSelected: boolean): void;
   setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void;
   setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean): void;
+  setRangeSelected(fromIndex: number, count: number, isSelected: boolean, shouldAnchor: boolean): void;
 
   setModal?(isModal: boolean): void; // TODO make non-optional on next breaking change
 
@@ -62,6 +63,7 @@ export interface ISelection<TItem = IObjectWithKey> {
 
   selectToKey(key: string, clearSelection?: boolean): void;
   selectToIndex(index: number, clearSelection?: boolean): void;
+  selectToRange(index: number, count: number, clearSelection?: boolean): void;
 
   // Toggle helpers.
 


### PR DESCRIPTION
## Current Behavior

The `SelectionZone` component currently only handles the concept of single-item selection when the user clicks on items or uses the Space key. Grouped Lists support whole-group selection, but this behavior is handled special by the Group Header using custom click-handling logic. On the plus side, this kept the SelectionZone logic modular, but on the negative side the selection behavior of Groups has never been consistent.

Notably:
1. Focusing the whole group header element and hitting Space does nothing.
2. Clicking in the white-space of a group header tries to 'invoke' the group and provides no affordance to select it.

## New Behavior

Updated `SelectionZone` so that it checks for a new `data-selection-span` attribute applied to the same elements as `data-selection-index`, and updated Group Headers to add `data-selection-index` and `data-selection-span`. The `index` is set to the start index of the group and the `span` is set to the size of the group.

Most of the event-handling logic in `SelectionZone` now will treat an event on a group header as a 'range' event, applying to all elements within the span of the group:
1. Clicking on the toggle zone of a Group Header toggles selection of the whole group
2. Hitting Space while the Group Header is focused, or clicking the white-space in a Group Header will set all items in the group as selected.
3. Arrowing up and down within the list still avoids setting focus to the Group, preserving existing behavior
4. Clicking on the Title of the group still invokes the group rather than setting it as selected, *if* the event handler stops propagation.

Added utility methods to `Selection` to handle setting a whole range as selected or deselected, in addition to its `toggleRangeSelected` method.