### PR TITLE
Bump react icons mdl2 branded

### DIFF
--- a/change/@fluentui-react-icons-mdl2-branded-25b2fc8e-4556-4dbd-a789-183e427bcbf1.json
+++ b/change/@fluentui-react-icons-mdl2-branded-25b2fc8e-4556-4dbd-a789-183e427bcbf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update package.json from react 17 to 18",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-icons-mdl2-branded/package.json
+++ b/packages/react-icons-mdl2-branded/package.json
@@ -30,10 +30,10 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
-    "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "@types/react": ">=16.8.0 <18.0.0",
+    "@types/react-dom": ">=16.8.0 <18.0.0",
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The `react-icons-mdl2-branded` package has a dependency requirement for max react 17. This is preventing max bar to ts 18

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Updates the max to react 18

Fixes #22895
