### PR TITLE
Scope storybooks builds

### DIFF
--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -21,9 +21,9 @@ jobs:
         displayName: yarn
 
       - script: |
-          NorthstarAffected=$(yarn --silent check:affected-package --@fluentui/react-northstar)
-          V8Affected=$(yarn --silent check:affected-package --@fluentui/react)
-          ReactComponentsAffected=$(yarn --silent check:affected-package --@fluentui/react-components)
+          NorthstarAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar --pr)
+          V8Affected=$(yarn --silent check:affected-package --packages @fluentui/react --pr)
+          ReactComponentsAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components --pr)
           if [[ $NorthstarAffected == true ]]; then
             echo "##vso[task.setvariable variable=NorthstarPackageAffected;isOutput=true]true"
           fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,13 +123,35 @@ jobs:
         displayName: yarn
 
       - script: |
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar --pr)
+          if [[ $packageAffected == false ]]; then
+            echo "##vso[task.setvariable variable=skipScreener]true"
+            echo "Should skip screener"
+          fi
+        name: PackagesAffected
+        displayName: Check if northstar packages were affected
+        condition: eq(variables['isPR'], 'true')
+
+      - script: |
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar)
+          if [[ $packageAffected == false ]]; then
+            echo "##vso[task.setvariable variable=skipScreener]true"
+            echo "Should skip screener"
+          fi
+        name: PackagesAffected
+        displayName: Check if northstar packages were affected
+        condition: eq(variables['isPR'], 'false')
+
+      - script: |
           yarn workspace @fluentui/docs vr:build
         displayName: build FUI N* VR Test
+        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_BUILD: 1
 
       - task: AzureUpload@2
         displayName: Upload N* VR test site
+        condition: ne(variables['skipScreener'], 'true')
         inputs:
           azureSubscription: $(azureSubscription)
           BlobPrefix: $(deployBasePath)/react-northstar-screener
@@ -140,6 +162,7 @@ jobs:
 
       - script: yarn workspace @fluentui/docs vr:test
         displayName: Start @fluentui/react-northstar VR Test
+        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -160,11 +183,33 @@ jobs:
         displayName: yarn
 
       - script: |
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react --pr)
+          if [[ $packageAffected == false ]]; then
+            echo "##vso[task.setvariable variable=skipScreener]true"
+            echo "Should skip screener"
+          fi
+        name: PackagesAffected
+        displayName: Check if v8 packages were affected
+        condition: eq(variables['isPR'], 'true')
+
+      - script: |
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react)
+          if [[ $packageAffected == false ]]; then
+            echo "##vso[task.setvariable variable=skipScreener]true"
+            echo "Should skip screener"
+          fi
+        name: PackagesAffected
+        displayName: Check if v8 packages were affected
+        condition: eq(variables['isPR'], 'false')
+
+      - script: |
           yarn workspace @fluentui/vr-tests screener:build
         displayName: build vr-tests storybook
+        condition: ne(variables['skipScreener'], 'true')
 
       - task: AzureUpload@2
         displayName: Upload @fluentui/react VR test site
+        condition: ne(variables['skipScreener'], 'true')
         inputs:
           azureSubscription: $(azureSubscription)
           BlobPrefix: $(deployBasePath)/react-screener
@@ -177,6 +222,7 @@ jobs:
       - script: |
           yarn workspace @fluentui/vr-tests screener
         displayName: Start @fluentui/react VR Test
+        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -197,11 +243,33 @@ jobs:
         displayName: yarn
 
       - script: |
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components --pr)
+          if [[ $packageAffected == false ]]; then
+            echo "##vso[task.setvariable variable=skipScreener]true"
+            echo "Should skip screener"
+          fi
+        name: PackagesAffected
+        displayName: Check if v9 packages were affected
+        condition: eq(variables['isPR'], 'true')
+
+      - script: |
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components)
+          if [[ $packageAffected == false ]]; then
+            echo "##vso[task.setvariable variable=skipScreener]true"
+            echo "Should skip screener"
+          fi
+        name: PackagesAffected
+        displayName: Check if v9 packages were affected
+        condition: eq(variables['isPR'], 'false')
+
+      - script: |
           yarn workspace @fluentui/vr-tests-react-components screener:build
         displayName: build vr-tests-react-components storybook
+        condition: ne(variables['skipScreener'], 'true')
 
       - task: AzureUpload@2
         displayName: Upload @fluentui/react-components VR test site
+        condition: ne(variables['skipScreener'], 'true')
         inputs:
           azureSubscription: $(azureSubscription)
           BlobPrefix: $(deployBasePath)/react-components-screener
@@ -214,6 +282,7 @@ jobs:
       - script: |
           yarn workspace @fluentui/vr-tests-react-components screener
         displayName: Start @fluentui/react-components VR Test
+        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ jobs:
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
           fi
-        name: PackagesAffected
+        name: PackagesAffectedPR
         displayName: Check if northstar packages were affected
         condition: eq(variables['isPR'], 'true')
 
@@ -188,7 +188,7 @@ jobs:
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
           fi
-        name: PackagesAffected
+        name: PackagesAffectedPR
         displayName: Check if v8 packages were affected
         condition: eq(variables['isPR'], 'true')
 
@@ -248,7 +248,7 @@ jobs:
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
           fi
-        name: PackagesAffected
+        name: PackagesAffectedPR
         displayName: Check if v9 packages were affected
         condition: eq(variables['isPR'], 'true')
 

--- a/scripts/monorepo/checkIfPackagesAffected.js
+++ b/scripts/monorepo/checkIfPackagesAffected.js
@@ -1,11 +1,36 @@
 const getAffectedPackages = require('./getAffectedPackages');
+const yargs = require('yargs');
 
-const packagesToCheck = process.argv.filter(pkg => pkg.startsWith('--')).map(pkg => pkg.substring(2));
+const args = yargs
+  .option('packages', {
+    alias: 'p',
+    type: 'array',
+    description: 'Package to check modified files from',
+    demandOption: true,
+  })
+  .option('pr', {
+    alias: 'r',
+    type: 'boolean',
+    description: 'During PR build compares to origin/master, in CI build compares to last commit',
+    default: false,
+  })
+  .scriptName('bundle-size')
+  .version(false).argv;
 
-const isPackageAffected = packagesToCheck => {
-  const affectedPackages = getAffectedPackages();
+const isPackageAffected = () => {
+  const { packages, pr } = args;
 
-  for (const pkg of packagesToCheck) {
+  let affectedPackages = new Set();
+
+  if (pr) {
+    affectedPackages = getAffectedPackages();
+  } else {
+    // master CI build,
+    const previousMasterCommit = getNthCommit();
+    affectedPackages = getAffectedPackages(previousMasterCommit);
+  }
+
+  for (const pkg of packages) {
     if (affectedPackages.has(pkg)) {
       return true;
     }
@@ -17,4 +42,4 @@ const isPackageAffected = packagesToCheck => {
  * In order for pipeline to capture and save the return value from a node script,
  * the output needs to be printed.
  */
-console.log(isPackageAffected(packagesToCheck));
+console.log(isPackageAffected());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Storybooks builds are not scoped so they are built even when a screener test should be skipped.

``check:affected-package`` cannot tell the difference between PR and master builds, so pushes to the master branch are always skipped as the comparing is done with origin/maste. ``check:affected-package`` will always return ``false`` in master.

## New Behavior

Improved ``check:affected-package`` command by using an argument parser and adding an argument for PR builds.
This command is used for scoping storybooks builds.

Example:

```shell
 yarn --silent check:affected-package --packages @fluentui/react --pr
```

Checks if  fluentui/react PR build packages are affected. (checks by comparing against origin/master)

```shell
 yarn --silent check:affected-package --packages @fluentui/react 
```

Checks if fluentui/react push to master build packages are affected. (it checks by comparing against the last commit to master)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23905 
