### PR TITLE
docs: add proportional example for DetailsList to docs

### DIFF
--- a/apps/public-docsite-resources/src/AppDefinition.tsx
+++ b/apps/public-docsite-resources/src/AppDefinition.tsx
@@ -224,6 +224,13 @@ export const AppDefinition: IAppDefinition = {
               name: 'DetailsList - Keyboard Overrides',
               url: '#/examples/detailslist/keyboardoverrides',
             },
+            {
+              component: require<any>('./components/pages/DetailsList/DetailsListProportionalColumnsPage')
+                .DetailsListProportionalColumnsPage,
+              key: 'DetailsList - Proportional Columns',
+              name: 'DetailsList - Proportional Columns',
+              url: '#/examples/detailslist/proportionalcolumns',
+            },
           ],
         },
         {

--- a/apps/public-docsite-resources/src/components/pages/DetailsList/DetailsListProportionalColumnsPage.tsx
+++ b/apps/public-docsite-resources/src/components/pages/DetailsList/DetailsListProportionalColumnsPage.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { DemoPage } from '../../DemoPage';
+import { DetailsListProportionalColumnsProps } from '@fluentui/react-examples/lib/react/DetailsList/DetailsList.doc';
+
+export const DetailsListProportionalColumnsPage = (props: { isHeaderVisible: boolean }) => (
+  <DemoPage {...{ ...DetailsListProportionalColumnsProps, ...props }} />
+);

--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -67,6 +67,7 @@ export const categories: { Other?: ICategory; [name: string]: ICategory } = {
         DragDrop: { title: 'Drag & Drop', url: 'draganddrop' },
         NavigatingFocus: { title: 'Inner Navigation', url: 'innernavigation' },
         Shimmer: {},
+        ProportionalColumns: { title: 'Proportional Columns', url: 'proportionalcolumns' },
       },
     },
     GroupedList: {},

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListProportionalColumnsPage.doc.ts
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListProportionalColumnsPage.doc.ts
@@ -1,0 +1,10 @@
+import { TFabricPlatformPageProps } from '../../../interfaces/Platforms';
+import { DetailsListProportionalColumnsProps as ExternalProps } from '@fluentui/react-examples/lib/react/DetailsList/DetailsList.doc';
+
+export const DetailsListProportionalColumnsPageProps: TFabricPlatformPageProps = {
+  web: {
+    ...(ExternalProps as any),
+    title: 'DetailsList - Proportional Columns',
+    isFeedbackVisible: false,
+  },
+};

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListProportionalColumnsPage.tsx
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListProportionalColumnsPage.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
+import { DetailsListProportionalColumnsPageProps } from './DetailsListProportionalColumnsPage.doc';
+
+export const DetailsListProportionalColumnsPage: React.FunctionComponent<IControlsPageProps> = props => {
+  return <ControlsAreaPage {...props} {...DetailsListProportionalColumnsPageProps[props.platform]} />;
+};

--- a/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
@@ -24,7 +24,7 @@ import { DetailsListAdvancedExample } from './DetailsList.Advanced.Example';
 const DetailsListAdvancedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx') as string;
 
 import { DetailsListProportionalColumnsExample } from './DetailsList.ProportionalColumns.Example';
-const DetailsListProportionalColumnsCode = require('!raw-loader!@fluentui/react-examples/src/react/DetailsList/DetailsList.ProportionalColumns.Example.tsx') as string;
+const DetailsListProportionalColumnsCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.ProportionalColumns.Example.tsx') as string;
 
 import { DetailsListGroupedExample } from './DetailsList.Grouped.Example';
 const DetailsListGroupedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx') as string;


### PR DESCRIPTION
## Current Behavior

We have `DetailsList.ProportionalColumns.Example.tsx`, but it's not visible in docs.

## New Behavior

We have `DetailsList.ProportionalColumns.Example.tsx` and it's **visible** in docs.

## Related Issue(s)

Related to #23786.
