### PR TITLE
Enable CI to call screener proxy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,6 @@ jobs:
 
       - script: yarn workspace @fluentui/docs vr:test
         displayName: Start @fluentui/react-northstar VR Test
-        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -222,7 +221,6 @@ jobs:
       - script: |
           yarn workspace @fluentui/vr-tests screener
         displayName: Start @fluentui/react VR Test
-        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)
@@ -282,7 +280,6 @@ jobs:
       - script: |
           yarn workspace @fluentui/vr-tests-react-components screener
         displayName: Start @fluentui/react-components VR Test
-        condition: ne(variables['skipScreener'], 'true')
         env:
           SCREENER_ENDPOINT: $(screenerApiUri)
           SCREENER_PROXY_ENDPOINT: $(screenerProxyUri)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Screener start steps were conditioned by the ``skipScreener`` variable even though they should always run in order to be able to cancel unnecessary checks.

## New Behavior

Screener start steps are no longer conditioned and always run.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
