### PR TITLE
fix: react-textarea uses semantic high contrast border color when disabled

### DIFF
--- a/change/@fluentui-react-textarea-c2525ad6-b2de-4fae-a3d9-f5b2fe05fab1.json
+++ b/change/@fluentui-react-textarea-c2525ad6-b2de-4fae-a3d9-f5b2fe05fab1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: disabled textarea uses semantic contrast theme border color",
+  "packageName": "@fluentui/react-textarea",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -37,6 +37,9 @@ const useRootStyles = makeStyles({
         color: tokens.colorNeutralForegroundDisabled,
       },
     },
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('GrayText'),
+    },
   },
 
   interactive: {


### PR DESCRIPTION
Quick fix for react-textarea -- since the border color style is on the root rather than the `<textarea>` element, it needs an explicit high contrast style for the disabled state.