### PR TITLE
bugfix(Combobox): update useMergedEventCallbacks to mergeCallbacks

### DIFF
--- a/change/@fluentui-react-combobox-d1f4333e-0e57-4809-ad40-86df3bf5e61c.json
+++ b/change/@fluentui-react-combobox-d1f4333e-0e57-4809-ad40-86df3bf5e61c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "bugfix: update useMergedEventCallbacks to mergeCallbacks",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -3,7 +3,8 @@ import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
 import {
   getPartitionedNativeProps,
   resolveShorthand,
-  useMergedEventCallbacks,
+  mergeCallbacks,
+  useEventCallback,
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
@@ -77,16 +78,20 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
 
   /* handle open/close + focus change when clicking expandIcon */
   const { onMouseDown: onIconMouseDown, onClick: onIconClick } = state.expandIcon || {};
-  const onExpandIconMouseDown = useMergedEventCallbacks(onIconMouseDown, () => {
-    // do not dismiss on blur when clicking the icon
-    baseState.ignoreNextBlur.current = true;
-  });
+  const onExpandIconMouseDown = useEventCallback(
+    mergeCallbacks(onIconMouseDown, () => {
+      // do not dismiss on blur when clicking the icon
+      baseState.ignoreNextBlur.current = true;
+    }),
+  );
 
-  const onExpandIconClick = useMergedEventCallbacks(onIconClick, (event: React.MouseEvent<HTMLSpanElement>) => {
-    // open and set focus
-    state.setOpen(event, !state.open);
-    triggerRef.current?.focus();
-  });
+  const onExpandIconClick = useEventCallback(
+    mergeCallbacks(onIconClick, (event: React.MouseEvent<HTMLSpanElement>) => {
+      // open and set focus
+      state.setOpen(event, !state.open);
+      triggerRef.current?.focus();
+    }),
+  );
 
   if (state.expandIcon) {
     state.expandIcon.onMouseDown = onExpandIconMouseDown;


### PR DESCRIPTION
## Current Behavior

`master` is broken as `useCombobox` uses `useMergedEventCallbacks` hook that was removed in #24152:

![image](https://user-images.githubusercontent.com/14183168/183851963-5fa424c9-be60-4a10-9515-37eba1cb13d8.png)

## New Behavior

`master` is green, CI is passing.