### PR TITLE
Fix check:affected-package scoping

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar --pr)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/docs --pr)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -133,7 +133,7 @@ jobs:
         condition: eq(variables['isPR'], 'true')
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/docs)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -182,7 +182,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react --pr)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests --pr)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -192,7 +192,7 @@ jobs:
         condition: eq(variables['isPR'], 'true')
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -241,7 +241,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components --pr)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests-react-components --pr)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -251,7 +251,7 @@ jobs:
         condition: eq(variables['isPR'], 'true')
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests-react-components)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

``check:affected-package`` was using workspaces that included components not tested by the screener, so sometimes a stoybook build would be created even though there was no need for it.

## New Behavior

``check:affected-package`` is using the appropriate workspace for each screener so that the scoped building is correct.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
