### PR TITLE
fix(docsite): add build time script to fix the website title from Web…

### DIFF
--- a/apps/public-docsite-v9/.storybook/fix-title.js
+++ b/apps/public-docsite-v9/.storybook/fix-title.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+try {
+  const args = process.argv.slice(2);
+  const [title, distPath] = args;
+
+  console.log(`Rewriting index.html document title to ${title}.`);
+
+  const filePath = `${distPath}/storybook/index.html`;
+  const document = fs.readFileSync(path.resolve(__dirname, filePath), 'utf8');
+  const output = document.replace(/<title>.*<\/title>/, `<title>${title}</title>`);
+
+  fs.writeFileSync(path.resolve(__dirname, filePath), output);
+  console.log('Title rewrite complete.');
+} catch (error) {
+  console.log('Title rewrite failed.');
+  console.error(error);
+  process.exit(1);
+}

--- a/apps/public-docsite-v9/.storybook/fix-title.js
+++ b/apps/public-docsite-v9/.storybook/fix-title.js
@@ -1,17 +1,28 @@
 const fs = require('fs');
 const path = require('path');
 
+function fixTitle(filePath, title) {
+  const htmlDocumentPath = path.resolve(__dirname, filePath);
+  const htmlDocument = fs.readFileSync(htmlDocumentPath, 'utf-8');
+  const updatedHtmlDocument = htmlDocument.replace(/<title>.*<\/title>/, `<title>${title}</title>`);
+
+  fs.writeFileSync(htmlDocumentPath, updatedHtmlDocument);
+}
+
 try {
   const args = process.argv.slice(2);
   const [title, distPath] = args;
 
+  const storybookDistPath = `${distPath}/storybook`;
+  const indexPath = `${storybookDistPath}/index.html`;
+  const iframePath = `${storybookDistPath}/iframe.html`;
+
   console.log(`Rewriting index.html document title to ${title}.`);
+  fixTitle(indexPath, title);
 
-  const filePath = `${distPath}/storybook/index.html`;
-  const document = fs.readFileSync(path.resolve(__dirname, filePath), 'utf8');
-  const output = document.replace(/<title>.*<\/title>/, `<title>${title}</title>`);
+  console.log(`Rewriting iframe.html document title to ${title}.`);
+  fixTitle(iframePath, title);
 
-  fs.writeFileSync(path.resolve(__dirname, filePath), output);
   console.log('Title rewrite complete.');
 } catch (error) {
   console.log('Title rewrite failed.');

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -5,7 +5,7 @@
   "description": "A collection of examples demonstrating how to upgrade from v8 to v9",
   "scripts": {
     "build": "just-scripts build",
-    "build-storybook": "build-storybook -o ./dist/storybook --docs",
+    "build-storybook": "build-storybook -o ./dist/storybook --docs && node ./.storybook/fix-title.js 'Fluent UI React v9' ../dist",
     "chromatic:branch": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook",
     "chromatic": "npx chromatic@6.4.3 --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes --build-script-name build-storybook --branch-name microsoft:master",
     "clean": "just-scripts clean",


### PR DESCRIPTION
## Current Behavior

The current [website](https://react.fluentui.dev/) default title is "Webpack App":

![image](https://user-images.githubusercontent.com/97875118/183944301-cf9ca9bc-3a64-4c86-a982-52db6ef151b1.png)

There is currently no option in Storybook to add a custom title, as [the last comment in this issue specifies](https://github.com/storybookjs/storybook/issues/812).

## New Behavior

The current fix involves running a script after the `build-storybook` command finishes running which changes the `<title>` tag value to the desired one.
