### PR TITLE
fix: add type=button to button slots in react-link, react-accordion, and react-tabs

### DIFF
--- a/change/@fluentui-react-accordion-786c1a81-7dfb-41b9-8bea-5ada800bd5f0.json
+++ b/change/@fluentui-react-accordion-786c1a81-7dfb-41b9-8bea-5ada800bd5f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add type=button to button slot",
+  "packageName": "@fluentui/react-accordion",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-748580a8-f10f-41b6-bf28-b2b3653c74d4.json
+++ b/change/@fluentui-react-link-748580a8-f10f-41b6-bf28-b2b3653c74d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add type=button when rendered as a button",
+  "packageName": "@fluentui/react-link",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-047ce97a-764d-44ff-a59b-ed7caf3e3b99.json
+++ b/change/@fluentui-react-tabs-047ce97a-764d-44ff-a59b-ed7caf3e3b99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add type=button to root slot ",
+  "packageName": "@fluentui/react-tabs",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`AccordionHeader renders a default state 1`] = `
     className="fui-AccordionHeader__button"
     disabled={false}
     onClick={[Function]}
+    type="button"
   >
     <span
       aria-hidden={true}

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
@@ -47,6 +47,7 @@ export const useAccordionHeader_unstable = (
       disabled,
       disabledFocusable,
       'aria-expanded': open,
+      type: 'button',
     },
   });
 

--- a/packages/react-components/react-link/src/components/Link/useLink.ts
+++ b/packages/react-components/react-link/src/components/Link/useLink.ts
@@ -14,6 +14,7 @@ export const useLink_unstable = (
 ): LinkState => {
   const { appearance = 'default', disabled = false, disabledFocusable = false, inline = false } = props;
   const as = props.as || (props.href ? 'a' : 'button');
+  const type = as === 'button' ? 'button' : undefined;
 
   const state: LinkState = {
     // Props passed at the top-level
@@ -29,6 +30,7 @@ export const useLink_unstable = (
 
     root: getNativeElementProps(as, {
       ref,
+      type,
       ...props,
       as,
     }),

--- a/packages/react-components/react-tabs/src/components/Tab/__snapshots__/Tab.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/Tab/__snapshots__/Tab.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Tab renders correctly 1`] = `
     class="fui-Tab"
     role="tab"
     style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+    type="button"
     value="1"
   >
     <span
@@ -24,6 +25,7 @@ exports[`Tab renders correctly when disabled 1`] = `
     class="fui-Tab"
     disabled=""
     role="tab"
+    type="button"
     value="1"
   >
     <span
@@ -42,6 +44,7 @@ exports[`Tab renders default correctly with icon slotted 1`] = `
     class="fui-Tab"
     role="tab"
     style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+    type="button"
     value="1"
   >
     <span
@@ -78,6 +81,7 @@ exports[`Tab renders small size and vertical correctly with icon slotted 1`] = `
     class="fui-Tab"
     role="tab"
     style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+    type="button"
     value="1"
   >
     <span
@@ -114,6 +118,7 @@ exports[`Tab renders small size correctly with icon slotted 1`] = `
     class="fui-Tab"
     role="tab"
     style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+    type="button"
     value="1"
   >
     <span
@@ -150,6 +155,7 @@ exports[`Tab renders subtle appearance correctly with icon slotted 1`] = `
     class="fui-Tab"
     role="tab"
     style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+    type="button"
     value="1"
   >
     <span
@@ -186,6 +192,7 @@ exports[`Tab renders vertical correctly with icon slotted 1`] = `
     class="fui-Tab"
     role="tab"
     style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+    type="button"
     value="1"
   >
     <span

--- a/packages/react-components/react-tabs/src/components/Tab/useTab.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTab.ts
@@ -52,6 +52,7 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
     root: getNativeElementProps('button', {
       ref: useMergedRefs(ref, innerRef),
       role: 'tab',
+      type: 'button',
       // aria-selected undefined indicates it is not selectable
       // according to https://www.w3.org/TR/wai-aria-1.1/#aria-selected
       'aria-selected': disabled ? undefined : `${selected}`,

--- a/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`TabList renders tabs when disabled 1`] = `
       class="fui-Tab"
       disabled=""
       role="tab"
+      type="button"
       value="1"
     >
       <span
@@ -23,6 +24,7 @@ exports[`TabList renders tabs when disabled 1`] = `
       class="fui-Tab"
       disabled=""
       role="tab"
+      type="button"
       value="2"
     >
       <span
@@ -35,6 +37,7 @@ exports[`TabList renders tabs when disabled 1`] = `
       class="fui-Tab"
       disabled=""
       role="tab"
+      type="button"
       value="3"
     >
       <span
@@ -59,6 +62,7 @@ exports[`TabList renders tabs with default selected tab 1`] = `
       class="fui-Tab"
       role="tab"
       style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+      type="button"
       value="1"
     >
       <span
@@ -72,6 +76,7 @@ exports[`TabList renders tabs with default selected tab 1`] = `
       class="fui-Tab"
       role="tab"
       style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+      type="button"
       value="2"
     >
       <span
@@ -85,6 +90,7 @@ exports[`TabList renders tabs with default selected tab 1`] = `
       class="fui-Tab"
       role="tab"
       style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+      type="button"
       value="3"
     >
       <span
@@ -119,6 +125,7 @@ exports[`TabList renders with tabs 1`] = `
       class="fui-Tab"
       role="tab"
       style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+      type="button"
       value="1"
     >
       <span
@@ -132,6 +139,7 @@ exports[`TabList renders with tabs 1`] = `
       class="fui-Tab"
       role="tab"
       style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+      type="button"
       value="2"
     >
       <span
@@ -145,6 +153,7 @@ exports[`TabList renders with tabs 1`] = `
       class="fui-Tab"
       role="tab"
       style="--fui-Tab__indicator--offset: 0px; --fui-Tab__indicator--scale: 1;"
+      type="button"
       value="3"
     >
       <span


### PR DESCRIPTION
Related to #23334, I noticed that the accordion buttons were submitting a form when nested within one.

This PR adds `type="button"` by default to all button slots in `react-components` that don't already have `type` defined.