### PR TITLE
react-theme-sass dev-depends on react-theme

### DIFF
--- a/change/@fluentui-react-theme-sass-85b0f325-84a3-4866-ac55-5ed7015886e7.json
+++ b/change/@fluentui-react-theme-sass-85b0f325-84a3-4866-ac55-5ed7015886e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "react-theme-sass dev-depends on react-theme",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-theme-sass/package.json
+++ b/packages/react-components/react-theme-sass/package.json
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/react-theme": "^9.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
## Current Behavior

`react-theme-sass` does not depend on `react-theme`
That is correct code-wise, the problem is with `lage` which does not consider `react-theme-sass` being affected by changes in `react-theme`. This happened in #24027.

## New Behavior

`react-theme-sass` has dev dependency on `react-theme`
Whenever `react-theme` changes, CI runs build and tests for `react-theme-sass`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Part of #24161
