### PR TITLE
feat: Remove inferred row state and add `rowEnhancer` option

### DIFF
--- a/change/@fluentui-react-table-78287e07-9d21-47ab-9ae1-efca3ecc54d5.json
+++ b/change/@fluentui-react-table-78287e07-9d21-47ab-9ae1-efca3ecc54d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Remove inferred row state and add `rowEnhancer` option",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -63,12 +63,8 @@ export type RowId = string | number;
 
 // @public (undocumented)
 export interface RowState<TItem> {
-    deSelectRow: () => void;
     item: TItem;
     rowId: RowId;
-    selected: boolean;
-    selectRow: () => void;
-    toggleSelect: () => void;
 }
 
 // @public (undocumented)
@@ -76,6 +72,7 @@ export interface SelectionState {
     allRowsSelected: boolean;
     clearSelection: () => void;
     deSelectRow: (rowId: RowId) => void;
+    isRowSelected: (rowId: RowId) => boolean;
     selectedRows: RowId[];
     selectRow: (rowId: RowId) => void;
     someRowsSelected: boolean;
@@ -303,7 +300,7 @@ export type TableSlots = {
 export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'> & TableContextValue;
 
 // @public (undocumented)
-export function useTable<TItem>(options: UseTableOptions<TItem>): TableState_2<TItem>;
+export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TItem>>(options: UseTableOptions<TItem, TRowState>): TableState_2<TItem, TRowState>;
 
 // @public
 export const useTable_unstable: (props: TableProps, ref: React_2.Ref<HTMLElement>) => TableState;
@@ -342,13 +339,15 @@ export const useTableHeaderCellStyles_unstable: (state: TableHeaderCellState) =>
 export const useTableHeaderStyles_unstable: (state: TableHeaderState) => TableHeaderState;
 
 // @public (undocumented)
-export interface UseTableOptions<TItem> {
+export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowState<TItem>> {
     // (undocumented)
     columns: ColumnDefinition<TItem>[];
     // (undocumented)
     getRowId?: (item: TItem) => RowId;
     // (undocumented)
     items: TItem[];
+    // (undocumented)
+    rowEnhancer?: RowEnhancer<TItem, TRowState>;
     // (undocumented)
     selectionMode?: 'single' | 'multiselect';
 }

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -85,7 +85,7 @@ export type SortDirection = 'ascending' | 'descending';
 
 // @public (undocumented)
 export interface SortState {
-    headerSortProps: (columnId: ColumnId) => TableHeaderCellProps;
+    getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
     setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
     sortColumn: ColumnId | undefined;
     sortDirection: SortDirection;

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -11,7 +11,7 @@ export interface ColumnDefinition<TItem> {
 
 export type RowEnhancer<TItem, TRowState extends RowState<TItem> = RowState<TItem>> = (
   row: RowState<TItem>,
-  state: { selection: SelectionStateInternal; sort: SortStateInternal<TItem> },
+  state: { selection: SelectionState; sort: SortState },
 ) => TRowState;
 
 export interface SortStateInternal<TItem> {

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -1,5 +1,4 @@
 import { SortDirection } from '../components/Table/Table.types';
-import { TableHeaderCellProps } from '../components/TableHeaderCell/TableHeaderCell.types';
 
 export type RowId = string | number;
 export type ColumnId = string | number;
@@ -20,7 +19,7 @@ export interface SortStateInternal<TItem> {
   sortColumn: ColumnId | undefined;
   setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
   toggleColumnSort: (columnId: ColumnId) => void;
-  headerSortProps: (columnId: ColumnId) => TableHeaderCellProps;
+  getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
   /**
    * Returns a sorted **shallow** copy of original items
    */
@@ -65,9 +64,10 @@ export interface SortState {
    */
   toggleColumnSort: (columnId: ColumnId) => void;
   /**
-   * Returns props for @see TableHeaderCell to display sort state correctly
+   * Returns the sort direction if a column is sorted,
+   * returns undefined if the column is not sorted
    */
-  headerSortProps: (columnId: ColumnId) => TableHeaderCellProps;
+  getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
 }
 
 export interface SelectionState {

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -10,6 +10,11 @@ export interface ColumnDefinition<TItem> {
   compare?: (a: TItem, b: TItem) => number;
 }
 
+export type RowEnhancer<TItem, TRowState extends RowState<TItem> = RowState<TItem>> = (
+  row: RowState<TItem>,
+  state: { selection: SelectionStateInternal; sort: SortStateInternal<TItem> },
+) => TRowState;
+
 export interface SortStateInternal<TItem> {
   sortDirection: SortDirection;
   sortColumn: ColumnId | undefined;
@@ -22,11 +27,12 @@ export interface SortStateInternal<TItem> {
   sort: (items: TItem[]) => TItem[];
 }
 
-export interface UseTableOptions<TItem> {
+export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowState<TItem>> {
   columns: ColumnDefinition<TItem>[];
   items: TItem[];
   selectionMode?: 'single' | 'multiselect';
   getRowId?: (item: TItem) => RowId;
+  rowEnhancer?: RowEnhancer<TItem, TRowState>;
 }
 
 export interface SelectionStateInternal {
@@ -35,6 +41,7 @@ export interface SelectionStateInternal {
   selectRow: (rowId: RowId) => void;
   toggleSelectAllRows: () => void;
   toggleRowSelect: (rowId: RowId) => void;
+  isRowSelected: (rowId: RowId) => boolean;
   selectedRows: Set<RowId>;
   allRowsSelected: boolean;
   someRowsSelected: boolean;
@@ -96,6 +103,11 @@ export interface SelectionState {
    * Whether some rows are selected
    */
   someRowsSelected: boolean;
+
+  /**
+   * Checks if a given rowId is selected
+   */
+  isRowSelected: (rowId: RowId) => boolean;
 }
 
 export interface RowState<TItem> {
@@ -104,32 +116,16 @@ export interface RowState<TItem> {
    */
   item: TItem;
   /**
-   * Toggle the selection of the row
-   */
-  toggleSelect: () => void;
-  /**
-   * Selects the row
-   */
-  selectRow: () => void;
-  /**
-   * De-selects the row
-   */
-  deSelectRow: () => void;
-  /**
-   * Whether the row is selected
-   */
-  selected: boolean;
-  /**
    * The row id, defaults to index position in the collection
    */
   rowId: RowId;
 }
 
-export interface TableState<TItem> {
+export interface TableState<TItem, TRowState extends RowState<TItem> = RowState<TItem>> {
   /**
    * The row data for rendering
    */
-  rows: RowState<TItem>[];
+  rows: TRowState[];
   /**
    * State and actions to manage row selection
    */

--- a/packages/react-components/react-table/src/hooks/useMultipleSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useMultipleSelection.ts
@@ -62,7 +62,15 @@ export function useMultipleSelection<TItem>(items: TItem[], getRowId: GetRowIdIn
     setSelected(new Set<RowId>());
   }, []);
 
+  const isRowSelected: SelectionStateInternal['isRowSelected'] = React.useCallback(
+    (rowId: RowId) => {
+      return selected.has(rowId);
+    },
+    [selected],
+  );
+
   return {
+    isRowSelected,
     clearSelection,
     deSelectRow,
     selectRow,

--- a/packages/react-components/react-table/src/hooks/useSingleSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSingleSelection.ts
@@ -11,7 +11,15 @@ export function useSingleSelection(): SelectionStateInternal {
     setSelected(undefined);
   }, []);
 
+  const isRowSelected: SelectionStateInternal['isRowSelected'] = React.useCallback(
+    (rowId: RowId) => {
+      return selected === rowId;
+    },
+    [selected],
+  );
+
   return {
+    isRowSelected,
     deSelectRow: clearSelection,
     clearSelection,
     selectRow: toggleRowSelect,

--- a/packages/react-components/react-table/src/hooks/useSort.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import * as React from 'react';
 import { ColumnDefinition } from './types';
 import { useSort } from './useSort';
 
@@ -107,47 +106,27 @@ describe('useSort', () => {
     });
   });
 
-  describe('headerSortProps', () => {
-    it('should return props for column id', () => {
-      const columnDefinition: ColumnDefinition<{}>[] = [{ columnId: 1 }];
-
-      const { result } = renderHook(() => useSort(columnDefinition));
-      expect(result.current.headerSortProps(1)).toBeDefined();
-    });
-
-    it('should return onClick that toggles sort', () => {
-      const columnDefinition: ColumnDefinition<{}>[] = [{ columnId: 1 }];
+  describe('getSortDirection', () => {
+    it('should return sort direction for the sorted column', () => {
+      const columnDefinition: ColumnDefinition<{ value: number }>[] = [{ columnId: 1 }];
 
       const { result } = renderHook(() => useSort(columnDefinition));
       act(() => {
-        result.current.headerSortProps(1).onClick?.(({} as unknown) as React.MouseEvent<HTMLTableCellElement>);
+        result.current.setColumnSort(1, 'descending');
       });
-      expect(result.current.sortColumn).toBe(1);
-      expect(result.current.sortDirection).toBe('ascending');
+
+      expect(result.current.getSortDirection(1)).toEqual('descending');
     });
 
-    it('should return undefined sort direction for unsorted column', () => {
-      const columnDefinition: ColumnDefinition<{}>[] = [{ columnId: 1 }, { columnId: 2 }];
+    it('should return undefined for unsorted column', () => {
+      const columnDefinition: ColumnDefinition<{ value: number }>[] = [{ columnId: 1 }, { columnId: 2 }];
 
       const { result } = renderHook(() => useSort(columnDefinition));
       act(() => {
-        result.current.toggleColumnSort(1);
+        result.current.setColumnSort(1, 'descending');
       });
 
-      const headerProps = result.current.headerSortProps(2);
-      expect(headerProps.sortDirection).toBe(undefined);
-    });
-
-    it('should return sort direction for sorted column', () => {
-      const columnDefinition: ColumnDefinition<{}>[] = [{ columnId: 1 }, { columnId: 2 }];
-
-      const { result } = renderHook(() => useSort(columnDefinition));
-      act(() => {
-        result.current.toggleColumnSort(1);
-      });
-
-      const headerProps = result.current.headerSortProps(1);
-      expect(headerProps.sortDirection).toBe('ascending');
+      expect(result.current.getSortDirection(2)).toBeUndefined();
     });
   });
 });

--- a/packages/react-components/react-table/src/hooks/useSort.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.ts
@@ -38,15 +38,16 @@ export function useSort<TItem>(columns: ColumnDefinition<TItem>[]): SortStateInt
       return sortColumnDef.compare(a, b) * mod;
     });
 
+  const getSortDirection: SortStateInternal<TItem>['getSortDirection'] = (columnId: ColumnId) => {
+    return sortColumn === columnId ? sortDirection : undefined;
+  };
+
   return {
     sortColumn,
     sortDirection,
     sort,
     setColumnSort,
     toggleColumnSort,
-    headerSortProps: (columnId: ColumnId) => ({
-      sortDirection: sortColumn === columnId ? sortDirection : undefined,
-      onClick: () => toggleColumnSort(columnId),
-    }),
+    getSortDirection,
   };
 }

--- a/packages/react-components/react-table/src/hooks/useTable.test.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.test.ts
@@ -54,6 +54,7 @@ describe('useTable', () => {
         "allRowsSelected": false,
         "clearSelection": [Function],
         "deSelectRow": [Function],
+        "isRowSelected": [Function],
         "selectRow": [Function],
         "selectedRows": Array [],
         "someRowsSelected": false,
@@ -82,8 +83,38 @@ describe('useTable', () => {
     `);
   });
 
+  describe('rowEnhancer', () => {
+    it('should enahnce rows', () => {
+      const { result } = renderHook(() =>
+        useTable({
+          columns: [{ columnId: 1 }],
+          items: [{}, {}, {}],
+          rowEnhancer: row => ({ ...row, foo: 'bar' }),
+        }),
+      );
+
+      expect(result.current.rows.map(row => row.foo)).toEqual(['bar', 'bar', 'bar']);
+    });
+
+    it('should have access to state', () => {
+      const { result } = renderHook(() =>
+        useTable({
+          columns: [{ columnId: 1 }],
+          items: [{}, {}, {}],
+          rowEnhancer: (row, { selection }) => ({ ...row, selectRow: () => selection.selectRow(row.rowId) }),
+        }),
+      );
+
+      act(() => {
+        result.current.rows[1].selectRow();
+      });
+
+      expect(result.current.selection.isRowSelected(1));
+    });
+  });
+
   describe('rows', () => {
-    it('should have selectRow action', () => {
+    it('should return position index as rowId by default', () => {
       const { result } = renderHook(() =>
         useTable({
           columns: [{ columnId: 1 }],
@@ -91,80 +122,30 @@ describe('useTable', () => {
         }),
       );
 
-      act(() => {
-        result.current.rows[1].selectRow();
-      });
-
-      expect(result.current.selection.selectedRows.length).toBe(1);
-      expect(result.current.selection.selectedRows[0]).toBe(1);
+      expect(result.current.rows.map(row => row.rowId)).toEqual([0, 1, 2]);
     });
 
-    it('should have deSelectRow action', () => {
+    it('should return original items', () => {
       const { result } = renderHook(() =>
         useTable({
           columns: [{ columnId: 1 }],
-          items: [{}, {}, {}],
+          items: [{ value: 1 }, { value: 2 }, { value: 3 }],
         }),
       );
 
-      act(() => {
-        result.current.rows[1].selectRow();
-      });
-
-      act(() => {
-        result.current.rows[1].deSelectRow();
-      });
-
-      expect(result.current.selection.selectedRows.length).toBe(0);
+      expect(result.current.rows.map(row => row.item)).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
     });
 
-    it('should have toggleSelect action', () => {
+    it('should use custom rowId', () => {
       const { result } = renderHook(() =>
         useTable({
           columns: [{ columnId: 1 }],
-          items: [{}, {}, {}],
-        }),
-      );
-
-      act(() => {
-        result.current.rows[1].toggleSelect();
-      });
-
-      expect(result.current.selection.selectedRows.length).toBe(1);
-      expect(result.current.selection.selectedRows[0]).toBe(1);
-
-      act(() => {
-        result.current.rows[1].toggleSelect();
-      });
-
-      expect(result.current.selection.selectedRows.length).toBe(0);
-    });
-
-    it('should have selected status of item', () => {
-      const { result } = renderHook(() =>
-        useTable({
-          columns: [{ columnId: 1 }],
-          items: [{}, {}, {}],
-        }),
-      );
-
-      act(() => {
-        result.current.rows[1].selectRow();
-      });
-
-      expect(result.current.rows[1].selected).toBe(true);
-    });
-
-    it('should use getRowId', () => {
-      const { result } = renderHook(() =>
-        useTable({
-          columns: [{ columnId: 1 }],
-          items: [{ value: 'a' }],
+          items: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
           getRowId: item => item.value,
         }),
       );
 
-      expect(result.current.rows[0].rowId).toBe('a');
+      expect(result.current.rows.map(row => row.rowId)).toEqual(['a', 'b', 'c']);
     });
   });
 });

--- a/packages/react-components/react-table/src/hooks/useTable.test.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.test.ts
@@ -74,7 +74,7 @@ describe('useTable', () => {
 
     expect(result.current.sort).toMatchInlineSnapshot(`
       Object {
-        "headerSortProps": [Function],
+        "getSortDirection": [Function],
         "setColumnSort": [Function],
         "sortColumn": undefined,
         "sortDirection": "ascending",

--- a/packages/react-components/react-table/src/hooks/useTable.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.ts
@@ -16,7 +16,7 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
 
   const getRowId = React.useCallback((item: TItem, index: number) => getUserRowId(item) ?? index, [getUserRowId]);
   const sortState = useSort(columns);
-  const { sortColumn, sortDirection, toggleColumnSort, setColumnSort, headerSortProps, sort } = sortState;
+  const { sortColumn, sortDirection, toggleColumnSort, setColumnSort, getSortDirection, sort } = sortState;
 
   const selectionState = useSelection(selectionMode, baseItems, getRowId);
   const {
@@ -63,7 +63,7 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
       sortDirection,
       setColumnSort,
       toggleColumnSort,
-      headerSortProps,
+      getSortDirection,
     },
   };
 }

--- a/packages/react-components/react-table/src/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/MultipleSelect.stories.tsx
@@ -96,8 +96,16 @@ const columns: ColumnDefinition<Item>[] = [
 export const MultipleSelect = () => {
   const {
     rows,
-    selection: { someRowsSelected, allRowsSelected, toggleSelectAllRows },
-  } = useTable({ columns, items });
+    selection: { allRowsSelected, someRowsSelected, toggleSelectAllRows },
+  } = useTable({
+    columns,
+    items,
+    rowEnhancer: (row, { selection }) => ({
+      ...row,
+      toggleSelect: () => selection.toggleRowSelect(row.rowId),
+      selected: selection.isRowSelected(row.rowId),
+    }),
+  });
 
   return (
     <Table sortable>
@@ -114,7 +122,7 @@ export const MultipleSelect = () => {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {rows.map(({ item, toggleSelect, selected }) => (
+        {rows.map(({ item, selected, toggleSelect }) => (
           <TableRow key={item.file.label} onClick={toggleSelect} aria-selected={selected}>
             <TableSelectionCell checked={selected} />
             <TableCell media={item.file.icon}>{item.file.label}</TableCell>

--- a/packages/react-components/react-table/src/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SingleSelect.stories.tsx
@@ -93,8 +93,17 @@ const columns: ColumnDefinition<Item>[] = [
   },
 ];
 
-export const Selection = () => {
-  const { rows } = useTable({ columns, items, selectionMode: 'single' });
+export const SingleSelect = () => {
+  const { rows } = useTable({
+    columns,
+    items,
+    selectionMode: 'single',
+    rowEnhancer: (row, { selection }) => ({
+      ...row,
+      selected: selection.isRowSelected(row.rowId),
+      toggleSelect: () => selection.toggleRowSelect(row.rowId),
+    }),
+  });
 
   return (
     <Table sortable>

--- a/packages/react-components/react-table/src/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/Sort.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell } from '../..';
-import { useTable, ColumnDefinition } from '../../hooks';
+import { useTable, ColumnDefinition, ColumnId } from '../../hooks';
 
 type FileCell = {
   label: string;
@@ -108,8 +108,13 @@ const columns: ColumnDefinition<Item>[] = [
 export const Sort = () => {
   const {
     rows,
-    sort: { headerSortProps },
+    sort: { getSortDirection, toggleColumnSort },
   } = useTable({ columns, items });
+
+  const headerSortProps = (columnId: ColumnId) => () => ({
+    onClick: () => toggleColumnSort(columnId),
+    sortDirection: getSortDirection(columnId),
+  });
 
   return (
     <Table sortable>

--- a/packages/react-components/react-table/src/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/index.stories.tsx
@@ -8,6 +8,7 @@ export { SizeSmall } from './SizeSmall.stories';
 export { SizeSmaller } from './SizeSmaller.stories';
 export { NonNativeElements } from './NonNativeElements.stories';
 export { MultipleSelect } from './MultipleSelect.stories';
+export { SingleSelect } from './SingleSelect.stories';
 
 export default {
   title: 'Preview Components/Table',


### PR DESCRIPTION
A lot of the row state was actually inferred from other state. This
creates an unnecessary coupling between the selection state and the
actual render data.

To impreove this, this PR adds the `rowEnhancer` concept. This allows
users to 'enhance' their rows with extra functionality or data with
access to the table state. The enhancer runs during the creation of
`rows` which means the user does not need to unnecessarily iterate over
the return of `useTable` again.

Also makes it easier to split up the different substates in the future

Addresses #24226
