### PR TITLE
chore(react-avatar): Change content to render as ul and list item to render as li

### DIFF
--- a/change/@fluentui-react-avatar-0a844534-f651-4b66-92c0-f9b1352ec334.json
+++ b/change/@fluentui-react-avatar-0a844534-f651-4b66-92c0-f9b1352ec334.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Change content to render as ul and list item to render as li.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -54,7 +54,7 @@ export type AvatarGroupItemProps = Omit<ComponentProps<Partial<AvatarGroupItemSl
 
 // @public (undocumented)
 export type AvatarGroupItemSlots = {
-    root: NonNullable<Slot<'div'>>;
+    root: NonNullable<Slot<'div', 'li'>>;
     avatar: NonNullable<Slot<typeof Avatar>>;
     overflowLabel: NonNullable<Slot<'span'>>;
 };
@@ -83,7 +83,7 @@ export type AvatarGroupPopoverProps = Omit<ComponentProps<Partial<AvatarGroupPop
 export type AvatarGroupPopoverSlots = {
     root: NonNullable<Slot<PopoverProps>>;
     triggerButton: NonNullable<Slot<'button'>>;
-    content: NonNullable<Slot<'div'>>;
+    content: NonNullable<Slot<'ul'>>;
     popoverSurface: NonNullable<Slot<typeof PopoverSurface>>;
     tooltip: NonNullable<Slot<TooltipProps>>;
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.test.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.test.tsx
@@ -40,14 +40,4 @@ describe('AvatarGroupItem', () => {
 
     expect(screen.getByTestId(testId).textContent).toBe('Test Label');
   });
-
-  it('sets role to listitem when context provides true for isOverflow', () => {
-    render(
-      <AvatarGroupContext.Provider value={{ isOverflow: true }}>
-        <AvatarGroupItem name="Katri Athokas" />
-      </AvatarGroupContext.Provider>,
-    );
-
-    expect(screen.getByRole('listitem').textContent).toBe('KAKatri Athokas');
-  });
 });

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/AvatarGroupItem.types.ts
@@ -3,7 +3,7 @@ import type { Avatar, AvatarSizes } from '../../Avatar';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type AvatarGroupItemSlots = {
-  root: NonNullable<Slot<'div'>>;
+  root: NonNullable<Slot<'div', 'li'>>;
 
   /**
    * Avatar that represents a person or entity.

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -37,7 +37,7 @@ export const useAvatarGroupItem_unstable = (
     layout,
     size,
     components: {
-      root: groupIsOverflow ? 'div' : 'li',
+      root: groupIsOverflow ? 'li' : 'div',
       avatar: Avatar,
       overflowLabel: 'span',
     },

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -37,7 +37,7 @@ export const useAvatarGroupItem_unstable = (
     layout,
     size,
     components: {
-      root: 'div',
+      root: groupIsOverflow ? 'div' : 'li',
       avatar: Avatar,
       overflowLabel: 'span',
     },
@@ -46,7 +46,6 @@ export const useAvatarGroupItem_unstable = (
       defaultProps: {
         style,
         className,
-        role: groupIsOverflow ? 'listitem' : undefined,
       },
     }),
     avatar: resolveShorthand(props.avatar, {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
@@ -16,7 +16,7 @@ export type AvatarGroupPopoverSlots = {
   /**
    * List that contains the overflowed AvatarGroupItems.
    */
-  content: NonNullable<Slot<'div'>>;
+  content: NonNullable<Slot<'ul'>>;
 
   /**
    * PopoverSurface that contains the content.

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -55,7 +55,7 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
     components: {
       root: Popover,
       triggerButton: 'button',
-      content: 'div',
+      content: 'ul',
       popoverSurface: PopoverSurface,
       tooltip: Tooltip,
     },

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
@@ -19,7 +19,9 @@ export const avatarGroupPopoverClassNames: SlotClassNames<AvatarGroupPopoverSlot
  */
 const useContentStyles = makeStyles({
   base: {
+    listStyleType: 'none',
     maxHeight: '220px',
+    ...shorthands.margin('0'),
     minHeight: '80px',
     ...shorthands.overflow('hidden', 'scroll'),
     ...shorthands.padding(tokens.spacingHorizontalS),


### PR DESCRIPTION
## Current Behavior

Content is rendered as a `<div>` and a role `list` is given to it. AvatarGroupItem is rendered as a `<div>` and a role `listitem` is given to it when rendered inside content.

## New Behavior

Content is rendered as `<ul>` and AvatarGroupItem as a `<li>` when rendered inside content.

## Related Issue(s)

Fixes #24239 
