### PR TITLE
fix(List): solve stale props problem with getPageSpecification

### DIFF
--- a/change/@fluentui-react-6701599d-0685-4f2a-8f1e-0f9b843ebef3.json
+++ b/change/@fluentui-react-6701599d-0685-4f2a-8f1e-0f9b843ebef3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(List): solve stale props problem with getPageSpecification",
+  "packageName": "@fluentui/react",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -1,3 +1,4 @@
+import { render } from '@testing-library/react';
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
@@ -216,6 +217,21 @@ describe('List', () => {
       const rows = wrapper.find('.ms-List-cell');
 
       expect(rows).toHaveLength(100);
+    });
+  });
+
+  describe('getPageSpecification', () => {
+    it('calls an actual reference for getPageSpecification', () => {
+      const getPageSpecificationA = jest.fn().mockImplementation(() => ({}));
+      const getPageSpecificationB = jest.fn().mockImplementation(() => ({}));
+
+      const { rerender } = render(<List getPageSpecification={getPageSpecificationA} items={mockData(5)} />);
+
+      jest.clearAllMocks();
+      rerender(<List getPageSpecification={getPageSpecificationB} items={mockData(5)} />);
+
+      expect(getPageSpecificationA).toHaveBeenCalledTimes(0);
+      expect(getPageSpecificationB).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -224,7 +224,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
     let itemsPerPage = 1;
     for (let itemIndex = startIndex; itemIndex < endIndex; itemIndex += itemsPerPage) {
-      const pageSpecification = this._getPageSpecification(itemIndex, allowedRect);
+      const pageSpecification = this._getPageSpecification(this.props, itemIndex, allowedRect);
 
       const pageHeight = pageSpecification.height;
       itemsPerPage = pageSpecification.itemCount;
@@ -884,7 +884,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     const allowedRect = this._allowedRect;
 
     for (let itemIndex = startIndex!; itemIndex < endIndex; itemIndex += itemsPerPage) {
-      const pageSpecification = this._getPageSpecification(itemIndex, allowedRect);
+      const pageSpecification = this._getPageSpecification(props, itemIndex, allowedRect);
       const pageHeight = pageSpecification.height;
       const pageData = pageSpecification.data;
       const key = pageSpecification.key;
@@ -982,6 +982,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   }
 
   private _getPageSpecification(
+    props: IListProps,
     itemIndex: number,
     visibleRect: IRectangle,
   ): {
@@ -991,7 +992,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     data?: any;
     key?: string;
   } {
-    const { getPageSpecification } = this.props;
+    const { getPageSpecification } = props;
+
     if (getPageSpecification) {
       const pageData = getPageSpecification(itemIndex, visibleRect);
 


### PR DESCRIPTION
## Current Behavior

`List` component has stale props issue and uses invalid references of `getPageSpecification()`, check https://github.com/microsoft/fluentui/issues/20319#issuecomment-1209366179 for more details.

## New Behavior

This PR fixes an issue to use proper reference of `getPageSpecification` from actual `props`.

## Related Issue(s)

Fixes #20319.
