### PR TITLE
fix(react-avatar): Set aria-hidden to AvatarGroupItem's label

### DIFF
--- a/change/@fluentui-react-avatar-79855439-3adf-4e84-a434-f95911b3655b.json
+++ b/change/@fluentui-react-avatar-79855439-3adf-4e84-a434-f95911b3655b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Set aria-hidden to AvatarGroupItem's label.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -60,6 +60,7 @@ export const useAvatarGroupItem_unstable = (
     overflowLabel: resolveShorthand(props.overflowLabel, {
       required: true,
       defaultProps: {
+        'aria-hidden': true,
         children: props.name,
       },
     }),

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -60,6 +60,7 @@ export const useAvatarGroupItem_unstable = (
     overflowLabel: resolveShorthand(props.overflowLabel, {
       required: true,
       defaultProps: {
+        // Avatar already has its aria-label set to the name, this will prevent the name to be read twice.
         'aria-hidden': true,
         children: props.name,
       },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Screen readers read both the Avatar's aria-label and the label in the AvatarGroupItem. 

## New Behavior

To avoid this, the label will be hidden and only the Avatar's label will be read.

## Related Issue(s)

#23773