### PR TITLE
fix: Combobox and Dropdown hover/active borders and padding style fixes

### DIFF
--- a/change/@fluentui-react-combobox-0da3aa7d-1f93-4987-932b-52aaaf1e8f38.json
+++ b/change/@fluentui-react-combobox-0da3aa7d-1f93-4987-932b-52aaaf1e8f38.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Combobox and Dropdown hover/active border colors and padding styles",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
@@ -11,6 +11,14 @@ export const comboboxClassNames: SlotClassNames<ComboboxSlots> = {
   listbox: 'fui-Combobox__listbox',
 };
 
+// Matches internal heights for Select and Input, but there are no theme variables for these
+// field heights are 2px less than other controls, since the border is on the parent element.
+const fieldHeights = {
+  small: '22px',
+  medium: '30px',
+  large: '38px',
+};
+
 /**
  * Styles for Combobox
  */
@@ -139,18 +147,21 @@ const useInputStyles = makeStyles({
   // size variants
   small: {
     fontSize: tokens.fontSizeBase200,
+    height: fieldHeights.small,
     lineHeight: tokens.lineHeightBase200,
-    ...shorthands.padding('3px', 0, '3px', `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`),
+    ...shorthands.padding(0, 0, 0, `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`),
   },
   medium: {
     fontSize: tokens.fontSizeBase300,
+    height: fieldHeights.medium,
     lineHeight: tokens.lineHeightBase300,
-    ...shorthands.padding('5px', 0, '5px', `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`),
+    ...shorthands.padding(0, 0, 0, `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`),
   },
   large: {
     fontSize: tokens.fontSizeBase400,
+    height: fieldHeights.large,
     lineHeight: tokens.lineHeightBase400,
-    ...shorthands.padding('7px', 0, '7px', `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalSNudge})`),
+    ...shorthands.padding(0, 0, 0, `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalSNudge})`),
   },
 });
 

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
     display: 'inline-grid',
     gridTemplateColumns: '1fr auto',
     justifyContent: 'space-between',
-    minWidth: '160px',
+    minWidth: '250px',
     position: 'relative',
 
     // windows high contrast mode focus indicator
@@ -45,7 +45,7 @@ const useStyles = makeStyles({
       height: `max(2px, ${tokens.borderRadiusMedium})`,
       borderBottomLeftRadius: tokens.borderRadiusMedium,
       borderBottomRightRadius: tokens.borderRadiusMedium,
-      ...shorthands.borderBottom('2px', 'solid', tokens.colorCompoundBrandStroke),
+      ...shorthands.borderBottom(tokens.strokeWidthThick, 'solid', tokens.colorCompoundBrandStroke),
       clipPath: 'inset(calc(100% - 2px) 0 0 0)',
       transform: 'scaleX(0)',
       transitionProperty: 'transform',
@@ -94,12 +94,22 @@ const useStyles = makeStyles({
   // appearance variants
   outline: {
     backgroundColor: tokens.colorNeutralBackground1,
-    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke1),
     borderBottomColor: tokens.colorNeutralStrokeAccessible,
+
+    '&:hover': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
+      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+    },
+
+    '&:active': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+    },
   },
   underline: {
     backgroundColor: tokens.colorTransparentBackground,
-    ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStrokeAccessible),
+    ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStrokeAccessible),
     ...shorthands.borderRadius(0),
   },
   'filled-lighter': {
@@ -130,17 +140,17 @@ const useInputStyles = makeStyles({
   small: {
     fontSize: tokens.fontSizeBase200,
     lineHeight: tokens.lineHeightBase200,
-    ...shorthands.padding('3px', 0, '3px', tokens.spacingHorizontalSNudge),
+    ...shorthands.padding('3px', 0, '3px', `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`),
   },
   medium: {
     fontSize: tokens.fontSizeBase300,
     lineHeight: tokens.lineHeightBase300,
-    ...shorthands.padding('5px', 0, '5px', tokens.spacingHorizontalMNudge),
+    ...shorthands.padding('5px', 0, '5px', `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`),
   },
   large: {
     fontSize: tokens.fontSizeBase400,
     lineHeight: tokens.lineHeightBase400,
-    ...shorthands.padding('7px', 0, '7px', tokens.spacingHorizontalM),
+    ...shorthands.padding('7px', 0, '7px', `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalSNudge})`),
   },
 });
 
@@ -161,12 +171,15 @@ const useIconStyles = makeStyles({
   // icon size variants
   small: {
     fontSize: iconSizes.small,
+    marginLeft: tokens.spacingHorizontalXXS,
   },
   medium: {
     fontSize: iconSizes.medium,
+    marginLeft: tokens.spacingHorizontalXXS,
   },
   large: {
     fontSize: iconSizes.large,
+    marginLeft: tokens.spacingHorizontalSNudge,
   },
 });
 

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     boxSizing: 'border-box',
     display: 'inline-block',
-    minWidth: '160px',
+    minWidth: '250px',
     position: 'relative',
 
     // windows high contrast mode focus indicator
@@ -38,10 +38,10 @@ const useStyles = makeStyles({
       left: '-1px',
       bottom: '-1px',
       right: '-1px',
-      height: `max(2px, ${tokens.borderRadiusMedium})`,
+      height: `max(${tokens.strokeWidthThick}, ${tokens.borderRadiusMedium})`,
       borderBottomLeftRadius: tokens.borderRadiusMedium,
       borderBottomRightRadius: tokens.borderRadiusMedium,
-      ...shorthands.borderBottom('2px', 'solid', tokens.colorCompoundBrandStroke),
+      ...shorthands.borderBottom(tokens.strokeWidthThick, 'solid', tokens.colorCompoundBrandStroke),
       clipPath: 'inset(calc(100% - 2px) 0 0 0)',
       transform: 'scaleX(0)',
       transitionProperty: 'transform',
@@ -77,6 +77,7 @@ const useStyles = makeStyles({
     ...shorthands.border('0'),
     boxSizing: 'border-box',
     columnGap: tokens.spacingHorizontalXXS,
+    cursor: 'pointer',
     display: 'grid',
     fontFamily: tokens.fontFamilyBase,
     gridTemplateColumns: '1fr auto',
@@ -97,29 +98,54 @@ const useStyles = makeStyles({
   small: {
     fontSize: tokens.fontSizeBase200,
     lineHeight: tokens.lineHeightBase200,
-    ...shorthands.padding('3px', tokens.spacingHorizontalSNudge),
+    ...shorthands.padding(
+      '3px',
+      tokens.spacingHorizontalSNudge,
+      '3px',
+      `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`,
+    ),
   },
   medium: {
     fontSize: tokens.fontSizeBase300,
     lineHeight: tokens.lineHeightBase300,
-    ...shorthands.padding('5px', tokens.spacingHorizontalMNudge),
+    ...shorthands.padding(
+      '5px',
+      tokens.spacingHorizontalMNudge,
+      '5px',
+      `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`,
+    ),
   },
   large: {
     columnGap: tokens.spacingHorizontalSNudge,
     fontSize: tokens.fontSizeBase400,
     lineHeight: tokens.lineHeightBase400,
-    ...shorthands.padding('7px', tokens.spacingHorizontalM),
+    ...shorthands.padding(
+      '7px',
+      tokens.spacingHorizontalM,
+      '7px',
+      `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalSNudge})`,
+    ),
   },
 
   // appearance variants
   outline: {
     backgroundColor: tokens.colorNeutralBackground1,
-    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke1),
     borderBottomColor: tokens.colorNeutralStrokeAccessible,
+
+    '&:hover': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
+      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+    },
+
+    '&:active': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+    },
   },
   underline: {
     backgroundColor: tokens.colorTransparentBackground,
-    ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStrokeAccessible),
+    ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStrokeAccessible),
     ...shorthands.borderRadius(0),
   },
   'filled-lighter': {
@@ -147,12 +173,15 @@ const useIconStyles = makeStyles({
   // icon size variants
   small: {
     fontSize: iconSizes.small,
+    marginLeft: tokens.spacingHorizontalXXS,
   },
   medium: {
     fontSize: iconSizes.medium,
+    marginLeft: tokens.spacingHorizontalXXS,
   },
   large: {
     fontSize: iconSizes.large,
+    marginLeft: tokens.spacingHorizontalSNudge,
   },
 });
 


### PR DESCRIPTION
Resolves part of #23926

- Fixes the hover/active border colors for the outline style
- Fixes inner content padding for the Dropdown button and Combobox input
- Updates `minWidth` so both Dropdown and Combobox are the same width by default
- Updates borders to use tokens for width