### PR TITLE
fix: export ToolbarButton

### DIFF
--- a/change/@fluentui-react-components-847b38fb-34c3-40b2-b8d4-4c53b3027acc.json
+++ b/change/@fluentui-react-components-847b38fb-34c3-40b2-b8d4-4c53b3027acc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export ToolbarButton",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -201,6 +201,7 @@ import { TableSelectionCellState } from '@fluentui/react-table';
 import { TableSlots } from '@fluentui/react-table';
 import { TableState } from '@fluentui/react-table';
 import { Toolbar } from '@fluentui/react-toolbar';
+import { ToolbarButton } from '@fluentui/react-toolbar';
 import { ToolbarButtonProps } from '@fluentui/react-toolbar';
 import { ToolbarButtonState } from '@fluentui/react-toolbar';
 import { toolbarClassNames } from '@fluentui/react-toolbar';
@@ -671,6 +672,8 @@ export { TableSlots }
 export { TableState }
 
 export { Toolbar }
+
+export { ToolbarButton }
 
 export { ToolbarButtonProps }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -128,6 +128,7 @@ export type { SelectProps, SelectSlots, SelectState } from '@fluentui/react-sele
 
 export {
   Toolbar,
+  ToolbarButton,
   ToolbarDivider,
   ToolbarToggleButton,
   renderToolbar_unstable,


### PR DESCRIPTION
## Current Behavior

`ToolbarButton` is not re-exported, but used in examples (stories).

## New Behavior

`ToolbarButton` is re-exported.

## Related Issue(s)

Fixes #24015.
