### PR TITLE
chore: Bump tabster to 2.1.2

### DIFF
--- a/change/@fluentui-react-tabster-8d97f222-b315-470d-88a0-50ab3e3b69fe.json
+++ b/change/@fluentui-react-tabster-8d97f222-b315-470d-88a0-50ab3e3b69fe.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Bumps keyborg to 1.1.1 and removes deep import for KeyborgCallback",
+  "comment": "fix: Bumps tabster to 2.1.2 and removes deep import for KeyborgCallback",
   "packageName": "@fluentui/react-tabster",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-tabster-8d97f222-b315-470d-88a0-50ab3e3b69fe.json
+++ b/change/@fluentui-react-tabster-8d97f222-b315-470d-88a0-50ab3e3b69fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Bumps keyborg to 1.1.1 and removes deep import for KeyborgCallback",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.2",
-    "keyborg": "^1.1.0",
+    "keyborg": "^1.1.1",
     "tabster": "^2.1.0",
     "tslib": "^2.1.0"
   },

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -35,8 +35,8 @@
     "@fluentui/react-shared-contexts": "^9.0.0",
     "@fluentui/react-theme": "^9.0.0",
     "@fluentui/react-utilities": "^9.0.2",
-    "keyborg": "^1.1.1",
-    "tabster": "^2.1.0",
+    "keyborg": "^1.2.1",
+    "tabster": "^2.1.2",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-tabster/src/hooks/useKeyboardNavAttribute.ts
+++ b/packages/react-components/react-tabster/src/hooks/useKeyboardNavAttribute.ts
@@ -2,7 +2,7 @@ import { createKeyborg } from 'keyborg';
 import { useEffect, useMemo, useRef } from 'react';
 import { KEYBOARD_NAV_ATTRIBUTE } from '../focus/constants';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import type { KeyborgCallback } from 'keyborg/dist/Keyborg';
+import type { KeyborgCallback } from 'keyborg';
 import type { RefObject } from 'react';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -17616,10 +17616,10 @@ karma@^6.3.0:
     ua-parser-js "^0.7.30"
     yargs "^16.1.1"
 
-keyborg@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.1.0.tgz#f6886a90b4ec1f4c5272326213110f6d9e831d0e"
-  integrity sha512-AmEH/if+1TG1MkDT4UOAG8ZKTTO2IwJBXq20crsLD3QhMsRivL6OpxZSTBrnbGAsn/QeH/+YIgDCXcNvLSe/Yw==
+keyborg@^1.1.0, keyborg@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.2.1.tgz#0503719c9b2791d8e4f1a00f7eae7e29327416fa"
+  integrity sha512-PXjcJb7d4ecncFnJgq1TzLBx38+LbTPDpbwNCXebMzp3xaZeG//7ydWpISouBVyjRtJFuIvpIryme4U2dYGUEg==
 
 keyv@3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17616,7 +17616,7 @@ karma@^6.3.0:
     ua-parser-js "^0.7.30"
     yargs "^16.1.1"
 
-keyborg@^1.1.0, keyborg@^1.1.1:
+keyborg@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.2.1.tgz#0503719c9b2791d8e4f1a00f7eae7e29327416fa"
   integrity sha512-PXjcJb7d4ecncFnJgq1TzLBx38+LbTPDpbwNCXebMzp3xaZeG//7ydWpISouBVyjRtJFuIvpIryme4U2dYGUEg==
@@ -24849,12 +24849,12 @@ table@^6.0.4:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-2.1.0.tgz#ac0ae66ec5213b66e4fea14f271ae741bb72e877"
-  integrity sha512-yhPV56ILc2vuXiXDIUwWPP5L9SSG8Gz1QsbDcJ4kglEyDMZsD8boHOekmqp8LGS6PCWoisFucgyU2qtaEIna6w==
+tabster@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-2.1.2.tgz#9d2d50cae2fbb3ee8ff98b207183e1814ead953c"
+  integrity sha512-wBA0gEtohhp/VKRQr9rgYRJa29cygefhyZQqhmAQSIdHQ/sQ5mv8nRH42z0wt0CtKf2iXJmclpaEbRDdCdWnHA==
   dependencies:
-    keyborg "^1.1.0"
+    keyborg "^1.2.1"
     tslib "^2.3.1"
 
 tapable@^1.0.0, tapable@^1.1.3:


### PR DESCRIPTION
Bumps tabster to 2.1.2 and keyborg to 1.2.1

Fixes #20892
