### PR TITLE
feat(react-theme): Add bold font weight

### DIFF
--- a/change/@fluentui-react-text-01530fa1-545f-4a94-a9fb-00fa2be3dc3b.json
+++ b/change/@fluentui-react-text-01530fa1-545f-4a94-a9fb-00fa2be3dc3b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add Body2",
+  "comment": "feat: Add Body2",
   "packageName": "@fluentui/react-text",
   "email": "miroslav.stastny@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-text-01530fa1-545f-4a94-a9fb-00fa2be3dc3b.json
+++ b/change/@fluentui-react-text-01530fa1-545f-4a94-a9fb-00fa2be3dc3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Body2",
+  "packageName": "@fluentui/react-text",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-bdcdae2f-8e92-4d18-b7da-d8336334caa6.json
+++ b/change/@fluentui-react-theme-bdcdae2f-8e92-4d18-b7da-d8336334caa6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add fontWeightBold, add Body2, fix font weight for *Stronger typography",
+  "comment": "feat: Add fontWeightBold, add Body2, fix font weight for *Stronger typography",
   "packageName": "@fluentui/react-theme",
   "email": "miroslav.stastny@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-theme-bdcdae2f-8e92-4d18-b7da-d8336334caa6.json
+++ b/change/@fluentui-react-theme-bdcdae2f-8e92-4d18-b7da-d8336334caa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add fontWeightBold, add Body2, fix font weight for *Stronger typography",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-sass-7ddd5d89-4d81-49e6-b347-a1f779b7dbf0.json
+++ b/change/@fluentui-react-theme-sass-7ddd5d89-4d81-49e6-b347-a1f779b7dbf0.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add fontWeightBold",
+  "comment": "feat: Add fontWeightBold",
   "packageName": "@fluentui/react-theme-sass",
   "email": "miroslav.stastny@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-theme-sass-7ddd5d89-4d81-49e6-b347-a1f779b7dbf0.json
+++ b/change/@fluentui-react-theme-sass-7ddd5d89-4d81-49e6-b347-a1f779b7dbf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add fontWeightBold",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-text/etc/react-text.api.md
+++ b/packages/react-components/react-text/etc/react-text.api.md
@@ -74,7 +74,7 @@ export type TextProps = ComponentProps<TextSlots> & {
     strikethrough?: boolean;
     truncate?: boolean;
     underline?: boolean;
-    weight?: 'regular' | 'medium' | 'semibold';
+    weight?: 'regular' | 'medium' | 'semibold' | 'bold';
     wrap?: boolean;
 };
 

--- a/packages/react-components/react-text/src/components/Text/Text.test.tsx
+++ b/packages/react-components/react-text/src/components/Text/Text.test.tsx
@@ -145,6 +145,7 @@ describe('Text', () => {
     ['regular', 'Regular'],
     ['medium', 'Medium'],
     ['semibold', 'Semibold'],
+    ['bold', 'Bold'],
   ] as const)('applies %s weight', (input, expectedValue) => {
     const { getByText } = render(<Text weight={input}>Test</Text>);
 

--- a/packages/react-components/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-components/react-text/src/components/Text/Text.types.ts
@@ -73,7 +73,7 @@ export type TextProps = ComponentProps<TextSlots> & {
    *
    * @default regular
    */
-  weight?: 'regular' | 'medium' | 'semibold';
+  weight?: 'regular' | 'medium' | 'semibold' | 'bold';
 
   /**
    * Wraps the text content on white spaces.

--- a/packages/react-components/react-text/src/components/Text/useTextStyles.ts
+++ b/packages/react-components/react-text/src/components/Text/useTextStyles.ts
@@ -92,6 +92,9 @@ const useStyles = makeStyles({
   weightSemibold: {
     fontWeight: tokens.fontWeightSemibold,
   },
+  weightBold: {
+    fontWeight: tokens.fontWeightBold,
+  },
   alignCenter: {
     textAlign: 'center',
   },
@@ -132,6 +135,7 @@ export const useTextStyles_unstable = (state: TextState): TextState => {
     state.font === 'numeric' && styles.numeric,
     state.weight === 'medium' && styles.weightMedium,
     state.weight === 'semibold' && styles.weightSemibold,
+    state.weight === 'bold' && styles.weightBold,
     state.align === 'center' && styles.alignCenter,
     state.align === 'end' && styles.alignEnd,
     state.align === 'justify' && styles.alignJustify,

--- a/packages/react-components/react-theme-sass/sass/fontTokens.scss
+++ b/packages/react-components/react-theme-sass/sass/fontTokens.scss
@@ -23,6 +23,7 @@ $lineHeightHero1000: var(--lineHeightHero1000);
 $fontWeightRegular: var(--fontWeightRegular);
 $fontWeightMedium: var(--fontWeightMedium);
 $fontWeightSemibold: var(--fontWeightSemibold);
+$fontWeightBold: var(--fontWeightBold);
 
 $fontFamilyBase: var(--fontFamilyBase);
 $fontFamilyMonospace: var(--fontFamilyMonospace);

--- a/packages/react-components/react-theme/etc/react-theme.api.md
+++ b/packages/react-components/react-theme/etc/react-theme.api.md
@@ -338,6 +338,7 @@ export type FontWeightTokens = {
     fontWeightRegular: number;
     fontWeightMedium: number;
     fontWeightSemibold: number;
+    fontWeightBold: number;
 };
 
 // @public (undocumented)
@@ -446,6 +447,7 @@ export type TypographyStyles = {
     body1: TypographyStyle;
     body1Strong: TypographyStyle;
     body1Stronger: TypographyStyle;
+    body2: TypographyStyle;
     caption1: TypographyStyle;
     caption1Strong: TypographyStyle;
     caption1Stronger: TypographyStyle;

--- a/packages/react-components/react-theme/src/global/fonts.ts
+++ b/packages/react-components/react-theme/src/global/fonts.ts
@@ -32,6 +32,7 @@ export const fontWeights: FontWeightTokens = {
   fontWeightRegular: 400,
   fontWeightMedium: 500,
   fontWeightSemibold: 600,
+  fontWeightBold: 700,
 };
 
 export const fontFamilies: FontFamilyTokens = {

--- a/packages/react-components/react-theme/src/global/typographyStyles.ts
+++ b/packages/react-components/react-theme/src/global/typographyStyles.ts
@@ -20,8 +20,14 @@ export const typographyStyles: TypographyStyles = {
   body1Stronger: {
     fontFamily: tokens.fontFamilyBase,
     fontSize: tokens.fontSizeBase300,
-    fontWeight: tokens.fontWeightMedium,
+    fontWeight: tokens.fontWeightBold,
     lineHeight: tokens.lineHeightBase300,
+  },
+  body2: {
+    fontFamily: tokens.fontFamilyBase,
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightSemibold,
+    lineHeight: tokens.lineHeightBase400,
   },
   caption1: {
     fontFamily: tokens.fontFamilyBase,
@@ -38,7 +44,7 @@ export const typographyStyles: TypographyStyles = {
   caption1Stronger: {
     fontFamily: tokens.fontFamilyBase,
     fontSize: tokens.fontSizeBase200,
-    fontWeight: tokens.fontWeightMedium,
+    fontWeight: tokens.fontWeightBold,
     lineHeight: tokens.lineHeightBase200,
   },
   caption2: {
@@ -68,7 +74,7 @@ export const typographyStyles: TypographyStyles = {
   subtitle2Stronger: {
     fontFamily: tokens.fontFamilyBase,
     fontSize: tokens.fontSizeBase400,
-    fontWeight: tokens.fontWeightMedium,
+    fontWeight: tokens.fontWeightBold,
     lineHeight: tokens.lineHeightBase400,
   },
   title1: {

--- a/packages/react-components/react-theme/src/tokens.ts
+++ b/packages/react-components/react-theme/src/tokens.ts
@@ -395,6 +395,7 @@ export const tokens: Record<keyof Theme, string> = {
   fontWeightRegular: 'var(--fontWeightRegular)',
   fontWeightMedium: 'var(--fontWeightMedium)',
   fontWeightSemibold: 'var(--fontWeightSemibold)',
+  fontWeightBold: 'var(--fontWeightBold)',
 
   // Line height tokens
   lineHeightBase100: 'var(--lineHeightBase100)',

--- a/packages/react-components/react-theme/src/types.ts
+++ b/packages/react-components/react-theme/src/types.ts
@@ -505,6 +505,7 @@ export type FontWeightTokens = {
   fontWeightRegular: number;
   fontWeightMedium: number;
   fontWeightSemibold: number;
+  fontWeightBold: number;
 };
 
 export type FontFamilyTokens = {
@@ -544,6 +545,7 @@ export type TypographyStyles = {
   body1: TypographyStyle;
   body1Strong: TypographyStyle;
   body1Stronger: TypographyStyle;
+  body2: TypographyStyle;
   caption1: TypographyStyle;
   caption1Strong: TypographyStyle;
   caption1Stronger: TypographyStyle;


### PR DESCRIPTION
## Current Behavior

- there was no `fontWeightBold` token in react-theme
- there was no `Body2` in Typography
- all Stronger Typography variants used `fontWeightMedium`

## New Behavior

Add `fontWeightBold` token to react theme
<img width="348" alt="image" src="https://user-images.githubusercontent.com/9615899/184865456-26b0c4ac-d175-4d47-8be2-47db6fe6bfa6.png">

Add `bold` as a valid option of `weight` prop in `Text`.

Update typography to use `fontWeightBold` in all Stronger variants
<img width="370" alt="image" src="https://user-images.githubusercontent.com/9615899/184865764-bb7eafa4-4cc7-41bc-815c-90de2f7a0b64.png">
<img width="394" alt="image" src="https://user-images.githubusercontent.com/9615899/184865795-698b8977-3027-4d0a-a97d-0fe7d68a16c6.png">
<img width="389" alt="image" src="https://user-images.githubusercontent.com/9615899/184865821-60a3bc6a-561c-4328-a87d-28c2f65b121f.png">

Add `Body2` to Typography and also as a component to `react-text`
<img width="385" alt="image" src="https://user-images.githubusercontent.com/9615899/184866143-2a101c86-596f-4330-a6fe-bf9c06e36ae6.png">

