### PR TITLE
Enable screener proxy to scope and update checks

### DIFF
--- a/scripts/gulp/tasks/screener.ts
+++ b/scripts/gulp/tasks/screener.ts
@@ -2,8 +2,8 @@ import { task, series } from 'gulp';
 import { argv } from 'yargs';
 
 import config from '../../config';
-import { getAffectedPackages, getAllPackageInfo, getNthCommit } from '../../monorepo';
-import { screenerRunner, cancelScreenerRun } from '../../screener/screener.runner';
+import { getAllPackageInfo } from '../../monorepo';
+import { screenerRunner } from '../../screener/screener.runner';
 
 const { paths } = config;
 
@@ -37,35 +37,9 @@ task('screener:runner', cb => {
       });
 
   const screenerConfig = require(screenerConfigPath);
-  let affectedPackages = new Set<string>();
-  const isPrBuild = process.env.BUILD_SOURCEBRANCH && process.env.BUILD_SOURCEBRANCH.includes('refs/pull');
 
-  if (isPrBuild) {
-    affectedPackages = getAffectedPackages();
-  } else {
-    // master CI build,
-    const previousMasterCommit = getNthCommit();
-    affectedPackages = getAffectedPackages(previousMasterCommit);
-  }
-
-  debugAffectedGraph(affectedPackages);
-
-  if (!affectedPackages.has(docsPackageName)) {
-    handlePromiseExit(cancelScreenerRun(screenerConfig, 'skipped'));
-  } else {
-    handlePromiseExit(screenerRunner(screenerConfig));
-  }
+  handlePromiseExit(screenerRunner(screenerConfig));
 });
-
-/**
- * Outputs debug output for the affected packages graph
- * @param affectedPackages  - set of affected packages
- */
-function debugAffectedGraph(affectedPackages: Set<string>) {
-  console.log('affected package tree');
-  console.log(Array.from(affectedPackages.values()));
-}
-
 // ----------------------------------------
 // Default
 // ----------------------------------------

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -56,7 +56,7 @@ async function scheduleScreenerBuild(
   if (response.status !== 201 && response.status !== 200) {
     throw new Error(`Call to proxy failed: ${response.status}`);
   }
-  //conclusion of screener run triggered by the proxy
+  //conclusion of the screener run triggered by the proxy
   return response.json().then(conclusion => conclusion);
 }
 

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -56,7 +56,7 @@ async function scheduleScreenerBuild(
   if (response.status !== 201 && response.status !== 200) {
     throw new Error(`Call to proxy failed: ${response.status}`);
   }
-  //conclusion of the screener run triggered by the proxy
+  //conclusion of the screener run
   return response.json().then(conclusion => conclusion);
 }
 

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -56,7 +56,7 @@ async function scheduleScreenerBuild(
   if (response.status !== 201 && response.status !== 200) {
     throw new Error(`Call to proxy failed: ${response.status}`);
   }
-
+  //conclusion of screener run triggered by the proxy
   return response.json().then(conclusion => conclusion);
 }
 

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -49,10 +49,12 @@ async function scheduleScreenerBuild(
     }),
   });
 
-  let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
+  if (response.status === 200) {
+    console.log('Skipping screener check');
+  }
 
   if (response.status !== 201 && response.status !== 200) {
-    throw new Error(`[PR #${prNumber}]: Call to proxy failed: ${response.status}`);
+    throw new Error(`Call to proxy failed: ${response.status}`);
   }
   //conclusion of screener run triggered by the proxy
   return response.json().then(conclusion => conclusion);
@@ -63,8 +65,6 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
   const commit = process.env.SYSTEM_PULLREQUEST_SOURCECOMMITID;
   // https://github.com/screener-io/screener-runner/blob/2a8291fb1b0219c96c8428ea6644678b0763a1a1/src/ci.js#L101
   let branchName = process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH || process.env.BUILD_SOURCEBRANCHNAME;
-
-  let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
   // remove prefix if exists
   if (branchName.indexOf('refs/heads/') === 0) {
     branchName = branchName.replace('refs/heads/', '');
@@ -80,8 +80,8 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
   });
 
   if (screenerRun.conclusion === 'skipped') {
-    console.log(`[PR #${prNumber}]: Screener test skipped.`);
+    console.log('Screener test skipped.');
   } else if (screenerRun.conclusion === 'in_progress') {
-    console.log(`[PR #${prNumber}]: Screener test in progress.`);
+    console.log('Screener test in progress.');
   }
 }

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { ScreenerProxyPayload, ScreenerRunnerConfig } from './screener.types';
+import { ScreenerRunnerConfig } from './screener.types';
 
 const environment = {
   screener: {
@@ -45,31 +45,19 @@ async function scheduleScreenerBuild(
     },
     body: JSON.stringify({
       payload: payload,
+      screenerConfiguration: screenerConfig,
     }),
   });
 
   if (response.status === 200) {
     console.log('Skipping screener check');
-    return undefined;
   }
 
-  if (response.status !== 201) {
+  if (response.status !== 201 && response.status !== 200) {
     throw new Error(`Call to proxy failed: ${response.status}`);
   }
 
-  return response.json().then(url => url);
-}
-
-async function notifyIntegration(payload: ScreenerProxyPayload) {
-  const fetchResponse = await fetch(environment.screener.proxyUri, {
-    method: 'post',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-
-  if (fetchResponse.status !== 200) {
-    throw new Error(`Notify integration failed: ${fetchResponse.status}`);
-  }
+  return response.json().then(conclusion => conclusion);
 }
 
 export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
@@ -82,7 +70,7 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
     branchName = branchName.replace('refs/heads/', '');
   }
 
-  const checkUrl = await scheduleScreenerBuild(screenerConfig, {
+  const screenerRun = await scheduleScreenerBuild(screenerConfig, {
     build: process.env.BUILD_BUILDID,
     branchName,
     commit,
@@ -91,35 +79,9 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
       : undefined,
   });
 
-  if (checkUrl === undefined) {
-    await cancelScreenerRun(screenerConfig, 'skipped');
-  } else
-    await notifyIntegration({
-      commit,
-      url: checkUrl.url,
-      status: 'in_progress',
-      project: screenerConfig.projectRepo,
-      branch: branchName,
-    });
-}
-
-export async function cancelScreenerRun(
-  screenerConfig: ScreenerRunnerConfig,
-  conclusion: ScreenerProxyPayload['conclusion'] = 'cancelled',
-) {
-  // https://github.com/microsoft/azure-pipelines-tasks/issues/9801
-  const commit = process.env.SYSTEM_PULLREQUEST_SOURCECOMMITID;
-  // https://github.com/screener-io/screener-runner/blob/2a8291fb1b0219c96c8428ea6644678b0763a1a1/src/ci.js#L101
-  let branchName = process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH || process.env.BUILD_SOURCEBRANCHNAME;
-
-  await notifyIntegration({
-    commit,
-    url: 'https://screener.io/',
-    status: 'completed',
-    project: screenerConfig.projectRepo,
-    conclusion,
-    branch: branchName,
-  });
-
-  console.log(`cancelled screener run ${screenerConfig.projectRepo}`);
+  if (screenerRun.conclusion === 'skipped') {
+    console.log('Screener test skipped.');
+  } else if (screenerRun.conclusion === 'in_progress') {
+    console.log('Screener test in progress.');
+  }
 }

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -48,6 +48,11 @@ async function scheduleScreenerBuild(
     }),
   });
 
+  if (response.status === 200) {
+    console.log('Skipping screener check');
+    return undefined;
+  }
+
   if (response.status !== 201) {
     throw new Error(`Call to proxy failed: ${response.status}`);
   }
@@ -86,13 +91,16 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
       : undefined,
   });
 
-  await notifyIntegration({
-    commit,
-    url: checkUrl.url,
-    status: 'in_progress',
-    project: screenerConfig.projectRepo,
-    branch: branchName,
-  });
+  if (checkUrl === undefined) {
+    await cancelScreenerRun(screenerConfig, 'skipped');
+  } else
+    await notifyIntegration({
+      commit,
+      url: checkUrl.url,
+      status: 'in_progress',
+      project: screenerConfig.projectRepo,
+      branch: branchName,
+    });
 }
 
 export async function cancelScreenerRun(

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -56,7 +56,7 @@ async function scheduleScreenerBuild(
   if (response.status !== 201) {
     throw new Error(`Call to proxy failed: ${response.status}`);
   }
-  //checkUrl
+
   return response.json().then(url => url);
 }
 

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -50,9 +50,6 @@ async function scheduleScreenerBuild(
   });
 
   let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
-  if (response.status === 200) {
-    console.log(`[PR #${prNumber}]: Skipping screener check`);
-  }
 
   if (response.status !== 201 && response.status !== 200) {
     throw new Error(`[PR #${prNumber}]: Call to proxy failed: ${response.status}`);

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -49,12 +49,13 @@ async function scheduleScreenerBuild(
     }),
   });
 
+  let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
   if (response.status === 200) {
-    console.log('Skipping screener check');
+    console.log(`[PR #${prNumber}]: Skipping screener check`);
   }
 
   if (response.status !== 201 && response.status !== 200) {
-    throw new Error(`Call to proxy failed: ${response.status}`);
+    throw new Error(`[PR #${prNumber}]: Call to proxy failed: ${response.status}`);
   }
   //conclusion of screener run triggered by the proxy
   return response.json().then(conclusion => conclusion);
@@ -65,6 +66,8 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
   const commit = process.env.SYSTEM_PULLREQUEST_SOURCECOMMITID;
   // https://github.com/screener-io/screener-runner/blob/2a8291fb1b0219c96c8428ea6644678b0763a1a1/src/ci.js#L101
   let branchName = process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH || process.env.BUILD_SOURCEBRANCHNAME;
+
+  let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
   // remove prefix if exists
   if (branchName.indexOf('refs/heads/') === 0) {
     branchName = branchName.replace('refs/heads/', '');
@@ -80,8 +83,8 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
   });
 
   if (screenerRun.conclusion === 'skipped') {
-    console.log('Screener test skipped.');
+    console.log(`[PR #${prNumber}]: Screener test skipped.`);
   } else if (screenerRun.conclusion === 'in_progress') {
-    console.log('Screener test in progress.');
+    console.log(`[PR #${prNumber}]: Screener test in progress.`);
   }
 }

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -11,8 +11,7 @@ import { getStorybook } from '@storybook/react';
 export async function screener() {
   const screenerConfigPath = path.resolve(process.cwd(), './screener.config.js');
   const screenerConfig: ScreenerRunnerConfig = require(screenerConfigPath);
-  let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
-  console.log(`[PR #${prNumber}]: screener config for run`);
+  console.log('screener config for run');
   console.log(JSON.stringify(screenerConfig, null, 2));
 
   try {

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -11,7 +11,8 @@ import { getStorybook } from '@storybook/react';
 export async function screener() {
   const screenerConfigPath = path.resolve(process.cwd(), './screener.config.js');
   const screenerConfig: ScreenerRunnerConfig = require(screenerConfigPath);
-  console.log('screener config for run');
+  let prNumber = process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
+  console.log(`[PR #${prNumber}]: screener config for run`);
   console.log(JSON.stringify(screenerConfig, null, 2));
 
   try {

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -20,7 +20,7 @@ export async function screener() {
     screenerConfig.states = screenerStates;
     await screenerRunner(screenerConfig);
   } catch (err) {
-    console.error('failed to run screener task');
+    console.error(`[PR #${prNumber}]: `, 'failed to run screener task');
     console.error(err);
     // screener-storybook internally starts a puppeteer instance that only closes on process exist
     process.exit(1);

--- a/scripts/tasks/screener.ts
+++ b/scripts/tasks/screener.ts
@@ -20,7 +20,7 @@ export async function screener() {
     screenerConfig.states = screenerStates;
     await screenerRunner(screenerConfig);
   } catch (err) {
-    console.error(`[PR #${prNumber}]: `, 'failed to run screener task');
+    console.error('failed to run screener task');
     console.error(err);
     // screener-storybook internally starts a puppeteer instance that only closes on process exist
     process.exit(1);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

CI scopes storybook builds and calls the proxy to update the checks status.

## New Behavior

CI no longer scopes storybook builds as the scoping is done by the screener proxy, which is also the one directly updating all of the checks statuses.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Addresses #24305 
