### PR TITLE
Fix grouped list derived state from props

### DIFF
--- a/change/@fluentui-react-28f94bba-caa9-4aac-81af-6cf0d0cd592d.json
+++ b/change/@fluentui-react-28f94bba-caa9-4aac-81af-6cf0d0cd592d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add items prop to state to fix issue 23135",
+  "packageName": "@fluentui/react",
+  "email": "tonyhallett74@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-28f94bba-caa9-4aac-81af-6cf0d0cd592d.json
+++ b/change/@fluentui-react-28f94bba-caa9-4aac-81af-6cf0d0cd592d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "add items prop to state to fix issue 23135",
+  "comment": "fix: add items prop to state to fix issue 23135",
   "packageName": "@fluentui/react",
   "email": "tonyhallett74@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -1725,13 +1725,13 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                             >
                               <div>
                                 <div>
-                                  D1
+                                  A1
                                 </div>
                                 <div>
-                                  E1
+                                  B1
                                 </div>
                                 <div>
-                                  F1
+                                  C1
                                 </div>
                               </div>
                             </div>
@@ -1743,13 +1743,13 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                             >
                               <div>
                                 <div>
-                                  D2
+                                  A2
                                 </div>
                                 <div>
-                                  E2
+                                  B2
                                 </div>
                                 <div>
-                                  F2
+                                  C2
                                 </div>
                               </div>
                             </div>
@@ -1804,13 +1804,13 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                             >
                               <div>
                                 <div>
-                                  D3
+                                  A3
                                 </div>
                                 <div>
-                                  E3
+                                  B3
                                 </div>
                                 <div>
-                                  F3
+                                  C3
                                 </div>
                               </div>
                             </div>
@@ -1822,13 +1822,13 @@ exports[`DetailsList handles updates to items and groups 4`] = `
                             >
                               <div>
                                 <div>
-                                  D4
+                                  A4
                                 </div>
                                 <div>
-                                  E4
+                                  B4
                                 </div>
                                 <div>
-                                  F4
+                                  C4
                                 </div>
                               </div>
                             </div>

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -77,17 +77,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       shouldForceUpdates = true;
     }
 
-    if (groups !== previousState.groups) {
-      nextState = {
-        ...nextState,
-        groups,
-      };
-    }
-
-    if (selectionMode !== previousState.selectionMode || compact !== previousState.compact) {
-      shouldForceUpdates = true;
-    }
-
     if (shouldForceUpdates) {
       nextState = {
         ...nextState,

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -57,6 +57,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       compact,
       groups,
       listProps,
+      items,
     };
 
     let shouldForceUpdates = false;

--- a/packages/react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.test.tsx
@@ -329,9 +329,13 @@ describe('GroupedList', () => {
     }
 
     const wrapper = mount(<GroupedList items={initialItems} groups={_groups} onRenderCell={_onRenderCell} />);
-    wrapper.setProps({ items: nextItems });
-    wrapper.setProps({ items: initialItems });
+    expect(wrapper.contains(<div id="rendered-item-initial" />)).toEqual(true);
 
+    wrapper.setProps({ items: nextItems });
+    expect(wrapper.contains(<div id="rendered-item-changed" />)).toEqual(true);
+    expect(wrapper.contains(<div id="rendered-item-initial" />)).toEqual(false);
+
+    wrapper.setProps({ items: initialItems });
     expect(wrapper.contains(<div id="rendered-item-initial" />)).toEqual(true);
   });
 });

--- a/packages/react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.test.tsx
@@ -307,4 +307,31 @@ describe('GroupedList', () => {
     expect(onRenderCheckboxMock).toHaveBeenCalledTimes(1);
     expect(onRenderCheckboxMock.mock.calls[0][0]).toEqual({ checked: false, theme: getTheme() });
   });
+
+  it('re-renders when items change back to the initial items', () => {
+    const initialItems: Array<{ key: string }> = [{ key: 'initial' }];
+    const nextItems: Array<{ key: string }> = [{ key: 'changed' }];
+    const _groups: Array<IGroup> = [
+      {
+        count: 1,
+        hasMoreData: true,
+        isCollapsed: false,
+        key: 'group0',
+        name: 'group 0',
+        startIndex: 0,
+        level: 0,
+      },
+    ];
+
+    function _onRenderCell(nestingDepth: number, item: { key: string }, itemIndex: number): JSX.Element {
+      const id = `rendered-item-${item.key}`;
+      return <div id={id} />;
+    }
+
+    const wrapper = mount(<GroupedList items={initialItems} groups={_groups} onRenderCell={_onRenderCell} />);
+    wrapper.setProps({ items: nextItems });
+    wrapper.setProps({ items: initialItems });
+
+    expect(wrapper.contains(<div id="rendered-item-initial" />)).toEqual(true);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Grouped list can show old items

## New Behavior

Grouped list does not show old items

## Related Issue(s)

Fixes #23135
