### PR TITLE
chore: Scope screener builds by vr-test project

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar --pr)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/docs --pr)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -133,7 +133,7 @@ jobs:
         condition: eq(variables['isPR'], 'true')
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/docs)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -182,7 +182,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react --pr)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests --pr)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -192,7 +192,7 @@ jobs:
         condition: eq(variables['isPR'], 'true')
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -241,7 +241,7 @@ jobs:
         displayName: yarn
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components --pr)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests-react-components --pr)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"
@@ -251,7 +251,7 @@ jobs:
         condition: eq(variables['isPR'], 'true')
 
       - script: |
-          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components)
+          packageAffected=$(yarn --silent check:affected-package --packages @fluentui/vr-tests-react-components)
           if [[ $packageAffected == false ]]; then
             echo "##vso[task.setvariable variable=skipScreener]true"
             echo "Should skip screener"


### PR DESCRIPTION
Currently the builds are scoped by the published package, which can lead to some edge cases:

* vr-test package is not affected -> builds anyway
* published package is not affected but the vr-test package is