### PR TITLE
@fluentui/react: Adding TextField style file to export map

### DIFF
--- a/change/@fluentui-react-3a375dde-2393-4e0c-84a9-8550ee6e33d1.json
+++ b/change/@fluentui-react-3a375dde-2393-4e0c-84a9-8550ee6e33d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "@fluentui/react: Adding TextField style file to export map",
+  "packageName": "@fluentui/react",
+  "email": "gasramirez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -974,6 +974,11 @@
       "import": "./lib/TextField.js",
       "require": "./lib-commonjs/TextField.js"
     },
+    "./lib/components/TextField/TextField.styles": {
+      "types": "./lib/components/TextField/TextField.styles.d.ts",
+      "import": "./lib/components/TextField/TextField.styles.js",
+      "require": "./lib-commonjs/components/TextField/TextField.styles.js"
+    },
     "./lib/Theme": {
       "types": "./lib/Theme.d.ts",
       "import": "./lib/Theme.js",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
When trying to use `getStyles` on TextField, the method cannot be accessed because the styles file is not exported.

## New Behavior
TextField `getStyles` is accessible.

## Related Issue(s)
This PR is related to #22161.
