### PR TITLE
chore: bump lage to fix dep tree resolution issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "jju": "1.4.0",
     "json-schema": "0.4.0",
     "just-scripts": "1.8.2",
-    "lage": "1.1.3",
+    "lage": "1.7.4",
     "lerna": "^3.21.0",
     "lint-staged": "10.2.10",
     "loader-utils": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,6 +2208,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@lage-run/logger@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@lage-run/logger/-/logger-1.1.1.tgz#250b3e237b100d48f95ead2fb95fb07f9297b947"
+  integrity sha512-8ZWHKCnnOYdLlLS2sSrMRZ4PM3oY5uqc2JN1RptSaKg8tR8g6ITMRmJ04/J4OqqiXiWVv2vozGt9pgxJLI2i7A==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -3616,21 +3621,6 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@rushstack/node-core-library@3.35.2":
-  version "3.35.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.35.2.tgz#21ca879b5051a5ebafa952fafcd648a07a142bcb"
-  integrity sha512-SPd0uG7mwsf3E30np9afCUhtaM1SBpibrbxOXPz82KWV6SQiPUtXeQfhXq9mSnGxOb3WLWoSDe7AFxQNex3+kQ==
-  dependencies:
-    "@types/node" "10.17.13"
-    colors "~1.2.1"
-    fs-extra "~7.0.1"
-    import-lazy "~4.0.0"
-    jju "~1.4.0"
-    resolve "~1.17.0"
-    semver "~7.3.0"
-    timsort "~0.3.0"
-    z-schema "~3.18.3"
-
 "@rushstack/node-core-library@3.39.0":
   version "3.39.0"
   resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.39.0.tgz#38928946d15ae89b773386cf97433d0d1ec83b93"
@@ -3661,12 +3651,27 @@
     timsort "~0.3.0"
     z-schema "~5.0.2"
 
-"@rushstack/package-deps-hash@^2.4.48":
-  version "2.4.110"
-  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-2.4.110.tgz#e1016af0d1bf3a03f44ab79fcde0057b58c82ebd"
-  integrity sha512-6PJaruKZJ7xCcs80F5yv9fedsZIvB5iSpWG7mkXLeMDVEJVM5vqyHs22YbqVb5UeALA3Q2Dyzaj++QIDng2DVQ==
+"@rushstack/node-core-library@3.50.1":
+  version "3.50.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.50.1.tgz#d4aa4602460f29bbf0662052969b65129384da23"
+  integrity sha512-9d2xE7E9yQEBS6brTptdP8cslt6iL5+UnkY2lRxQQ4Q/jlXtsrWCCJCxwr56W/eJEe9YT/yHR4mMn5QY64Ps2w==
   dependencies:
-    "@rushstack/node-core-library" "3.35.2"
+    "@types/node" "12.20.24"
+    colors "~1.2.1"
+    fs-extra "~7.0.1"
+    import-lazy "~4.0.0"
+    jju "~1.4.0"
+    resolve "~1.17.0"
+    semver "~7.3.0"
+    timsort "~0.3.0"
+    z-schema "~5.0.2"
+
+"@rushstack/package-deps-hash@^3.2.4":
+  version "3.2.40"
+  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-3.2.40.tgz#0f14076694e65bd85de39bfcd83afb00483e0dae"
+  integrity sha512-0nnhbWrYE8mdEZXYXY9wOGEMFW3VtZ7+vgh6CJeyY95MDqjz6Alx2PpAHM1T53TNDV/LNFagwl0AzivfJnjhCw==
+  dependencies:
+    "@rushstack/node-core-library" "3.50.1"
 
 "@rushstack/package-deps-hash@^3.2.5":
   version "3.2.5"
@@ -6435,6 +6440,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.1.tgz#b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
   integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
 
+"@xmldom/xmldom@^0.8.0":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.2.tgz#b695ff674e8216efa632a3d36ad51ae9843380c0"
+  integrity sha512-+R0juSseERyoPvnBQ/cZih6bpF7IpCXlWbHRoCRzYzqpz6gWHOgf8o4MOEf6KBVuOyqU+gCNLkCWVIJAro8XyQ==
+
 "@xstate/react@1.0.0-rc.3":
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.0.0-rc.3.tgz#a5974c651849604636fd9ed4a371f8fac538b8d6"
@@ -7786,42 +7796,43 @@ bach@^1.0.0, bach@^1.2.0:
     async-settle "^1.0.0"
     now-and-later "^2.0.0"
 
-backfill-cache@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/backfill-cache/-/backfill-cache-5.3.0.tgz#7cd14b13f558f66c61a84464b0e2308e168fdf86"
-  integrity sha512-OnOojS2b14b5oEGoawhJKM94kDCNQmSL60DXdFpxYWjLv9aaZhqStN4ortQmySprNpQAM3aNHJretCBQZ+eNhA==
+backfill-cache@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/backfill-cache/-/backfill-cache-5.6.1.tgz#904e4c7cfb75a7de994a284a48fa48f96144408c"
+  integrity sha512-BaVakWMiCR/varXPE00QFqyfoWSikIIZMqNGt1JQEJ+MgkBBq4oHu4a3L2o1/u7IMOxKFXkz8sNXM+wyNSfAuA==
   dependencies:
     "@azure/storage-blob" "12.1.2"
-    "@rushstack/package-deps-hash" "^2.4.48"
-    backfill-config "^6.2.0"
+    "@rushstack/package-deps-hash" "^3.2.4"
+    backfill-config "^6.3.0"
     backfill-logger "^5.1.3"
     execa "^4.0.0"
     find-up "^5.0.0"
     fs-extra "^8.1.0"
     globby "^11.0.0"
+    p-limit "^3.0.0"
     tar-fs "^2.1.0"
 
-backfill-config@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/backfill-config/-/backfill-config-6.2.0.tgz#63b9685f22ebdf7a276747663224efc432acd31a"
-  integrity sha512-58prL8+DigOWePEkF+rWRFtcHmaxBjTvmadFZbF/NE8+N3KruYKpXliIlSVs0NT9raqOC8E8gBoHWIV0QuB8rw==
+backfill-config@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/backfill-config/-/backfill-config-6.3.0.tgz#bd95115fa7c446162ada80324b9bc820fb9fa9e3"
+  integrity sha512-4Pvqe4SIthHmlJi1yEyh8ThdZCh9SbNcf12Dx1TNkLii6um3Ez1P1rruPNQGW8jFtLb5kOWWkTnXPj6OXewXSA==
   dependencies:
     backfill-logger "^5.1.3"
     find-up "^5.0.0"
     fs-extra "^8.1.0"
     pkg-dir "^4.2.0"
 
-backfill-hasher@^6.2.6:
-  version "6.2.6"
-  resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.2.6.tgz#751466f9413f94f10965c2e5fd682197d3eecd24"
-  integrity sha512-Gf8uMlTaCi+8GQwE1Zh9hOxzTFpSXK3ZBVu3/6pFnn4Esd0GjlQsISmEdOS8KE97UfHl0sbhk26a92FFQ0GuHw==
+backfill-hasher@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.4.1.tgz#bb10a8a0688ce75a502aa3c6f0461e7b70f52479"
+  integrity sha512-ZiIo77UCBgTnojK9+4DQVEn9yeJQn2+KW9gh22coS45I3pNqAHflxALIyfIosQwz7Fos/peGj8iuWHw2Ieuurg==
   dependencies:
-    "@rushstack/package-deps-hash" "^2.4.48"
-    backfill-config "^6.2.0"
+    "@rushstack/package-deps-hash" "^3.2.4"
+    backfill-config "^6.3.0"
     backfill-logger "^5.1.3"
     find-up "^5.0.0"
     fs-extra "^8.1.0"
-    workspace-tools "^0.15.0"
+    workspace-tools "^0.18.2"
 
 backfill-logger@^5.1.3:
   version "5.1.3"
@@ -7840,15 +7851,15 @@ backfill-utils-dotenv@^5.1.1:
     dotenv "^8.1.0"
     find-up "^5.0.0"
 
-backfill@^6.1.10:
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/backfill/-/backfill-6.1.10.tgz#502c4d2574f6c7191ca607f100e17e31fbeee4c8"
-  integrity sha512-C7GEAdhhlg2yZ6Xb5yBsgUTaZdpM0htfxKRTYT6oma/D6FzsvZywfwdA/IgwPnsRv7+0DAC+FEe+l3mA13UOAA==
+backfill@^6.1.20:
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/backfill/-/backfill-6.1.20.tgz#7e7e5a41024d72d5cf26d479faa0c20557b53f32"
+  integrity sha512-sD4DPugvZodbgNTfDc6so3VXIjpyY4e+5S/+wDXsjc6I/tEtT+pu7U/WxLGajMXsvusU3wM7wqgtGHZhxvSrIw==
   dependencies:
     anymatch "^3.0.3"
-    backfill-cache "^5.3.0"
-    backfill-config "^6.2.0"
-    backfill-hasher "^6.2.6"
+    backfill-cache "^5.6.1"
+    backfill-config "^6.3.0"
+    backfill-hasher "^6.4.1"
     backfill-logger "^5.1.3"
     backfill-utils-dotenv "^5.1.1"
     chokidar "^3.2.1"
@@ -17699,15 +17710,17 @@ ky@^0.12.0:
   resolved "https://registry.yarnpkg.com/ky/-/ky-0.12.0.tgz#c05be95e6745ba422a6d2cc8ae964164962279f9"
   integrity sha512-t9b7v3V2fGwAcQnnDDQwKQGF55eWrf4pwi1RN08Fy8b/9GEwV7Ea0xQiaSW6ZbeghBHIwl8kgnla4vVo9seepQ==
 
-lage@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-1.1.3.tgz#1b1ab7c0e512fa9f5f34d1b5e612b1ed4ea1fe3f"
-  integrity sha512-oBvFHWh4N066lkH9hJgmBB3jJIqn021h6HtI0QRaEFiDSsWPSpV5Jc0niJRIuKuS1rIjoARh1+ihCYqXt7a66w==
+lage@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-1.7.4.tgz#eb08dee0206a29c203b772cb4a5aac78bb396687"
+  integrity sha512-sdFC6z9XFMX4ex4bxrGO5bA/bF54X57l5frXEeXdB2y08bqwmSiDUecQMvzn3q7lxgQ7KL0DewN5au2+PTGNjw==
   dependencies:
+    "@lage-run/logger" "*"
+    "@xmldom/xmldom" "^0.8.0"
     abort-controller "^3.0.0"
-    backfill "^6.1.10"
-    backfill-cache "^5.3.0"
-    backfill-config "^6.2.0"
+    backfill "^6.1.20"
+    backfill-cache "^5.6.1"
+    backfill-config "^6.3.0"
     backfill-logger "^5.1.3"
     bullmq "^1.50.2"
     chalk "^4.0.0"
@@ -17720,7 +17733,7 @@ lage@1.1.3:
     p-graph "^1.1.1"
     p-limit "^3.1.0"
     p-profiler "^0.2.1"
-    workspace-tools "^0.16.2"
+    workspace-tools "^0.23.0"
     yargs-parser "^18.1.3"
 
 language-subtag-registry@~0.3.2:
@@ -20433,19 +20446,19 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.0, p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-limit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
   integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
   dependencies:
     p-try "^2.0.0"
-
-p-limit@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -27040,7 +27053,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-workspace-tools@0.18.4, workspace-tools@^0.15.0, workspace-tools@^0.16.2:
+workspace-tools@0.18.4, workspace-tools@^0.16.2, workspace-tools@^0.18.2, workspace-tools@^0.23.0:
   version "0.18.4"
   resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.18.4.tgz#a59ca6dc864d07aafc06a9ff4a9ff093456b8765"
   integrity sha512-ZdhlB4NEC3uJ4eW7snyHKOfzMC00HXWO2QbIU3aY8XBdtE+VrU2ajv+oxDUIZfCLD4Wlk3ltWaPt4Jk6IC9bMA==


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

We are running into lage execution issues.

Looks like the dependency chain is being incorrectly resolved which leads to undeterministic failures of pipelines

**Example:**

1. If i run `yarn lage build --since origin/master` on local machine, it will explode on `ssr-tests` `build`

<img width="1779" alt="image" src="https://user-images.githubusercontent.com/1223799/185166529-04c4bd27-585d-4b75-8a85-696f233aa045.png">


2. if i run `yarn lage build --to @fluentui/ssr-tests`  it will pass the build

<img width="846" alt="image" src="https://user-images.githubusercontent.com/1223799/185167032-f4be0fb0-3290-4edd-bf7b-4dc33920e89d.png">

3. if I turn off cache `yarn lage build --since origin/master --no-cache`  it will explode on different error.... 


## New Behavior

we use latest `lage`

`yarn lage build --since origin/master --no-cache`  passed

## Related

- https://github.com/microsoft/fluentui/pull/24279
