### PR TITLE
Create FileTypeIcon.tsx

### DIFF
--- a/packages/react-file-type-icons/src/FileTypeIcon.tsx
+++ b/packages/react-file-type-icons/src/FileTypeIcon.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react';
+import { DEFAULT_BASE_URL } from './initializeFileTypeIcons';
+import { FileIconType } from './FileIconType';
+import type { FileTypeIconSize } from './getFileTypeIconProps';
+import {
+  getFileTypeIconNameFromExtensionOrType,
+  getFileTypeIconSuffix,
+  DEFAULT_ICON_SIZE
+} from './getFileTypeIconProps';
+import {
+    makeStyles,
+    shorthands
+} from '@fluentui/react-components';
+
+const useStyles = (size: FileTypeIconSize) => makeStyles({
+    root: {
+        display: 'inline-block',
+        width: `${size}px`,
+        ...shorthands.overflow('hidden'),
+        fontWeight: 'normal',
+        fontStyle: 'normal'
+    }
+})();
+
+export const FileTypeIcon = memo(({
+    size = DEFAULT_ICON_SIZE,
+    ...props
+}: { fileName: string; size?: FileTypeIconSize; }) => {
+    const styles = useStyles(size);
+    const baseUrl = DEFAULT_BASE_URL;
+    const baseSuffix = getFileTypeIconSuffix(size, 'svg'); // eg: 96_3x_svg or 96_png
+    const suffixArray = baseSuffix.split('_'); // eg: ['96', '3x', 'svg']
+    const fileNameSplit = props.fileName.split('.');
+    const baseIconName = fileNameSplit.length > 1 ? getFileTypeIconNameFromExtensionOrType(fileNameSplit[fileNameSplit.length - 1], undefined) : getFileTypeIconNameFromExtensionOrType(undefined, FileIconType.genericFile); // eg: docx
+    
+    if (suffixArray.length === 3) {
+        /** suffix is of type 96_3x_svg  - it has a pixel ratio > 1*/
+        return <i className={styles.root}><img src={`${baseUrl}${size}_${suffixArray[1]}/${baseIconName}.${suffixArray[2]}`} height="100%" width="100%" alt={baseIconName} /></i>;
+    } 
+    /** suffix is of type 96_svg  - it has a pixel ratio of 1*/
+    return <i className={styles.root}><img src={`${baseUrl}${size}/${baseIconName}.${suffixArray[1]}`} alt={baseIconName} /></i>;
+});


### PR DESCRIPTION
When using version 9 of Fluent UI. (@fluentui/react-components).
This simple component is very useful.

I cannot create this component in my project because of missing exports needed: DEFAULT_BASE_URL, getFileTypeIconNameFromExtensionOrType, getFileTypeIconSuffix.

I currently manually add those exports so that my project works. Like this:

export { initializeFileTypeIcons, DEFAULT_BASE_URL } from './initializeFileTypeIcons';
export { getFileTypeIconProps, getFileTypeIconNameFromExtensionOrType, getFileTypeIconSuffix } from './getFileTypeIconProps';
export { FileIconType } from './FileIconType';
export { FileTypeIconMap } from './FileTypeIconMap';
export { getFileTypeIconAsHTMLString } from './getFileTypeIconAsHTMLString';
import './version';
export type { FileTypeIconSize, IFileTypeIconOptions, ImageFileType } from './getFileTypeIconProps';



I suggest adding this component or adding the missing exports.

Thanks

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
