### PR TITLE
feat(useTable): support default states and onChange callbacks

### DIFF
--- a/change/@fluentui-react-table-00d8a67c-191a-44ae-889b-f1e36cd54fb0.json
+++ b/change/@fluentui-react-table-00d8a67c-191a-44ae-889b-f1e36cd54fb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(useTable): support default states and onChange callbacks",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -349,7 +349,9 @@ export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowS
     // (undocumented)
     rowEnhancer?: RowEnhancer<TItem, TRowState>;
     // (undocumented)
-    selectionMode?: SelectionMode_2;
+    selection?: UseTableSelectionOptions;
+    // (undocumented)
+    sort?: UseTableSortOptions;
 }
 
 // @public

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -37,12 +37,12 @@ export interface UseTableSelectionOptions {
   /**
    * Sets the default selected rows on mount
    */
-  defaultSelectedRows?: Set<RowId>;
+  defaultSelectedRows?: RowId[];
   /**
    * Called whenever the selected rows changes, can be useful
    * to forward to higher state in userland
    */
-  onRowSelectionChange?: (selectedRows: Set<RowId>) => void;
+  onRowSelectionChange?: (selectedRows: RowId[]) => void;
 }
 
 export interface UseTableSortOptions {

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -15,6 +15,11 @@ export type RowEnhancer<TItem, TRowState extends RowState<TItem> = RowState<TIte
   state: { selection: SelectionState; sort: SortState },
 ) => TRowState;
 
+export interface SortColumnState {
+  sortDirection: SortDirection;
+  sortColumn: ColumnId | undefined;
+}
+
 export interface SortStateInternal<TItem> {
   sortDirection: SortDirection;
   sortColumn: ColumnId | undefined;
@@ -27,12 +32,39 @@ export interface SortStateInternal<TItem> {
   sort: (items: TItem[]) => TItem[];
 }
 
+export interface UseTableSelectionOptions {
+  selectionMode?: SelectionMode;
+  /**
+   * Sets the default selected rows on mount
+   */
+  defaultSelectedRows?: Set<RowId>;
+  /**
+   * Called whenever the selected rows changes, can be useful
+   * to forward to higher state in userland
+   */
+  onRowSelectionChange?: (selectedRows: Set<RowId>) => void;
+}
+
+export interface UseTableSortOptions {
+  /**
+   * Sets the default sort state on mount
+   */
+  defaultSortColumn?: SortColumnState;
+
+  /**
+   * Called whenever the sort state changes, can be useful to forward to higher
+   * state in userland.
+   */
+  onSortColumnChange?: (state: SortColumnState) => void;
+}
+
 export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowState<TItem>> {
   columns: ColumnDefinition<TItem>[];
   items: TItem[];
-  selectionMode?: SelectionMode;
   getRowId?: (item: TItem) => RowId;
   rowEnhancer?: RowEnhancer<TItem, TRowState>;
+  selection?: UseTableSelectionOptions;
+  sort?: UseTableSortOptions;
 }
 
 export interface SelectionStateInternal {

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -20,7 +20,7 @@ describe('useSelection', () => {
 
     it('should set default selected rows', () => {
       const { result } = renderHook(() =>
-        useSelection({ selectionMode: 'multiselect', items, getRowId, defaultSelectedRows: new Set([1, 2]) }),
+        useSelection({ selectionMode: 'multiselect', items, getRowId, defaultSelectedRows: [1, 2] }),
       );
 
       expect(Array.from(result.current.selectedRows)).toEqual([1, 2]);
@@ -226,7 +226,7 @@ describe('useSelection', () => {
   describe('single select', () => {
     it('should set default selected row', () => {
       const { result } = renderHook(() =>
-        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: new Set([1]) }),
+        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: [1] }),
       );
 
       expect(Array.from(result.current.selectedRows)).toEqual([1]);
@@ -248,7 +248,7 @@ describe('useSelection', () => {
 
     it('should throw error when defaultSelectedRows has a length greater than 1', () => {
       const { result } = renderHook(() =>
-        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: new Set([1, 2]) }),
+        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: [1, 2] }),
       );
 
       expect(result.error).toMatchInlineSnapshot(
@@ -260,7 +260,7 @@ describe('useSelection', () => {
       const nodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
       const { result } = renderHook(() =>
-        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: new Set([1, 2]) }),
+        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: [1, 2] }),
       );
 
       expect(result.error).toBeUndefined();

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -37,7 +37,7 @@ describe('useSelection', () => {
       });
 
       expect(onRowSelectionChange).toHaveBeenCalledTimes(1);
-      expect(onRowSelectionChange).toHaveBeenCalledWith(new Set([0, 1, 2, 3]));
+      expect(onRowSelectionChange).toHaveBeenCalledWith([0, 1, 2, 3]);
     });
 
     describe('toggleAllRows', () => {
@@ -243,7 +243,7 @@ describe('useSelection', () => {
       });
 
       expect(onRowSelectionChange).toHaveBeenCalledTimes(1);
-      expect(onRowSelectionChange).toHaveBeenCalledWith(new Set([1]));
+      expect(onRowSelectionChange).toHaveBeenCalledWith([1]);
     });
 
     it('should throw error when defaultSelectedRows has a length greater than 1', () => {

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -8,7 +8,9 @@ describe('useSelection', () => {
 
   describe('multiselect', () => {
     it('should use custom row id', () => {
-      const { result } = renderHook(() => useSelection('multiselect', items, (item: { value: string }) => item.value));
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'multiselect', items, getRowId: (item: { value: string }) => item.value }),
+      );
       act(() => {
         result.current.toggleAllRows();
       });
@@ -16,9 +18,31 @@ describe('useSelection', () => {
       expect(Array.from(result.current.selectedRows)).toEqual(items.map(item => item.value));
     });
 
+    it('should set default selected rows', () => {
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'multiselect', items, getRowId, defaultSelectedRows: new Set([1, 2]) }),
+      );
+
+      expect(Array.from(result.current.selectedRows)).toEqual([1, 2]);
+    });
+
+    it('should call onRowSelectionChange with selected rows', () => {
+      const onRowSelectionChange = jest.fn();
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'multiselect', items, getRowId, onRowSelectionChange }),
+      );
+
+      act(() => {
+        result.current.toggleAllRows();
+      });
+
+      expect(onRowSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onRowSelectionChange).toHaveBeenCalledWith(new Set([0, 1, 2, 3]));
+    });
+
     describe('toggleAllRows', () => {
       it('should select all rows', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -28,7 +52,7 @@ describe('useSelection', () => {
       });
 
       it('should deselect all rows', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -43,7 +67,7 @@ describe('useSelection', () => {
     });
     describe('clearRows', () => {
       it('should clear selection', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -58,7 +82,7 @@ describe('useSelection', () => {
 
     describe('selectRow', () => {
       it('should select row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -68,7 +92,7 @@ describe('useSelection', () => {
       });
 
       it('should select multiple rows', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -86,7 +110,7 @@ describe('useSelection', () => {
 
     describe('deselectRow', () => {
       it('should make row unselected', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -102,7 +126,7 @@ describe('useSelection', () => {
 
     describe('toggleRow', () => {
       it('should select unselected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -113,7 +137,7 @@ describe('useSelection', () => {
       });
 
       it('should deselect selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -128,7 +152,7 @@ describe('useSelection', () => {
       });
 
       it('should select another unselected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -146,7 +170,7 @@ describe('useSelection', () => {
 
     describe('allRowsSelected', () => {
       it('should return true if all rows are selected', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -156,14 +180,14 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.allRowsSelected).toBe(false);
       });
 
       it('should return false if not all rows are selected', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -180,7 +204,7 @@ describe('useSelection', () => {
 
     describe('someRowsSelected', () => {
       it('should return true if there is a selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -191,7 +215,7 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.someRowsSelected).toBe(false);
@@ -200,9 +224,53 @@ describe('useSelection', () => {
   });
 
   describe('single select', () => {
+    it('should set default selected row', () => {
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: new Set([1]) }),
+      );
+
+      expect(Array.from(result.current.selectedRows)).toEqual([1]);
+    });
+
+    it('should call onRowSelectionChange with selected row', () => {
+      const onRowSelectionChange = jest.fn();
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'single', items, getRowId, onRowSelectionChange }),
+      );
+
+      act(() => {
+        result.current.selectRow(1);
+      });
+
+      expect(onRowSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onRowSelectionChange).toHaveBeenCalledWith(new Set([1]));
+    });
+
+    it('should throw error when defaultSelectedRows has a length greater than 1', () => {
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: new Set([1, 2]) }),
+      );
+
+      expect(result.error).toMatchInlineSnapshot(
+        `[Error: [react-table]: \`defaultSelectedItems\` should not have more than 1 element]`,
+      );
+    });
+
+    it('should not throw error when defaultSelectedRows has a length greater than 1 during production', () => {
+      const nodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      const { result } = renderHook(() =>
+        useSelection({ selectionMode: 'single', items, getRowId, defaultSelectedRows: new Set([1, 2]) }),
+      );
+
+      expect(result.error).toBeUndefined();
+
+      process.env.NODE_ENV = nodeEnv;
+    });
+
     describe('toggleAllRows', () => {
       it('should throw when not in production', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         expect(result.current.toggleAllRows).toThrowErrorMatchingInlineSnapshot(
           `"[react-table]: \`toggleAllItems\` should not be used in single selection mode"`,
@@ -211,7 +279,7 @@ describe('useSelection', () => {
 
       it('should be a noop in production', () => {
         const nodeEnv = (process.env.NODE_ENV = 'production');
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         result.current.toggleAllRows;
         expect(result.current.selectedRows.size).toBe(0);
@@ -221,7 +289,7 @@ describe('useSelection', () => {
     });
     describe('clearRows', () => {
       it('should clear selection', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -236,7 +304,7 @@ describe('useSelection', () => {
 
     describe('selectRow', () => {
       it('should select row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -246,7 +314,7 @@ describe('useSelection', () => {
       });
 
       it('should select another row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -263,7 +331,7 @@ describe('useSelection', () => {
 
     describe('deselectRow', () => {
       it('should make row unselected', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -279,7 +347,7 @@ describe('useSelection', () => {
 
     describe('toggleRow', () => {
       it('should select unselected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -290,7 +358,7 @@ describe('useSelection', () => {
       });
 
       it('should deselect selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -305,7 +373,7 @@ describe('useSelection', () => {
       });
 
       it('should select another unselected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -323,7 +391,7 @@ describe('useSelection', () => {
 
     describe('allRowsSelected', () => {
       it('should return true if there is a selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -334,7 +402,7 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.allRowsSelected).toBe(false);
@@ -343,7 +411,7 @@ describe('useSelection', () => {
 
     describe('someRowsSelected', () => {
       it('should return true if there is a selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -354,7 +422,7 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.someRowsSelected).toBe(false);

--- a/packages/react-components/react-table/src/hooks/useSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.ts
@@ -8,7 +8,7 @@ interface UseSelectionOptions<TItem> {
   items: TItem[];
   getRowId: GetRowIdInternal<TItem>;
   onRowSelectionChange?: UseTableSelectionOptions['onRowSelectionChange'];
-  defaultSelectedRows?: Set<RowId>;
+  defaultSelectedRows?: RowId[];
 }
 
 export function useSelection<TItem>(options: UseSelectionOptions<TItem>): SelectionStateInternal {
@@ -20,10 +20,10 @@ export function useSelection<TItem>(options: UseSelectionOptions<TItem>): Select
     createSelectionManager({
       mode: selectionMode,
       onSelectionChange: selectedItems => {
-        onRowSelectionChange(selectedItems);
+        onRowSelectionChange(Array.from(selectedItems));
         rerender();
       },
-      defaultSelectedItems: defaultSelectedRows,
+      defaultSelectedItems: new Set(defaultSelectedRows),
     }),
   );
 
@@ -33,10 +33,10 @@ export function useSelection<TItem>(options: UseSelectionOptions<TItem>): Select
         createSelectionManager({
           mode: selectionMode,
           onSelectionChange: selectedItems => {
-            onRowSelectionChange(selectedItems);
+            onRowSelectionChange(Array.from(selectedItems));
             rerender();
           },
-          defaultSelectedItems: defaultSelectedRows,
+          defaultSelectedItems: new Set(defaultSelectedRows),
         }),
       );
     }

--- a/packages/react-components/react-table/src/hooks/useSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.ts
@@ -1,38 +1,70 @@
 import * as React from 'react';
 import { useEventCallback, usePrevious } from '@fluentui/react-utilities';
 import { createSelectionManager } from './selectionManager';
-import { GetRowIdInternal, RowId, SelectionMode, SelectionStateInternal } from './types';
+import { GetRowIdInternal, RowId, SelectionMode, SelectionStateInternal, UseTableSelectionOptions } from './types';
 
-export function useSelection<TItem>(
-  selectionMode: SelectionMode,
-  items: TItem[],
-  getRowId: GetRowIdInternal<TItem>,
-): SelectionStateInternal {
+interface UseSelectionOptions<TItem> {
+  selectionMode: SelectionMode;
+  items: TItem[];
+  getRowId: GetRowIdInternal<TItem>;
+  onRowSelectionChange?: UseTableSelectionOptions['onRowSelectionChange'];
+  defaultSelectedRows?: Set<RowId>;
+}
+
+export function useSelection<TItem>(options: UseSelectionOptions<TItem>): SelectionStateInternal {
+  const { selectionMode, items, getRowId, onRowSelectionChange = () => undefined, defaultSelectedRows } = options;
+
   const prevSelectionMode = usePrevious(selectionMode);
-  const [selected, setSelected] = React.useState(() => new Set<RowId>());
+  const [_, rerender] = React.useReducer(x => x + 1, 0);
   const [selectionManager, setSelectionManager] = React.useState(() =>
-    createSelectionManager(selectionMode, setSelected),
+    createSelectionManager({
+      mode: selectionMode,
+      onSelectionChange: selectedItems => {
+        onRowSelectionChange(selectedItems);
+        rerender();
+      },
+      defaultSelectedItems: defaultSelectedRows,
+    }),
   );
 
   React.useEffect(() => {
     if (prevSelectionMode !== selectionMode) {
-      setSelectionManager(createSelectionManager(selectionMode, setSelected));
+      setSelectionManager(
+        createSelectionManager({
+          mode: selectionMode,
+          onSelectionChange: selectedItems => {
+            onRowSelectionChange(selectedItems);
+            rerender();
+          },
+          defaultSelectedItems: defaultSelectedRows,
+        }),
+      );
     }
-  }, [selectionMode, prevSelectionMode]);
+  }, [selectionMode, prevSelectionMode, defaultSelectedRows, onRowSelectionChange]);
+
+  const {
+    selectItem,
+    selectedItems,
+    toggleAllItems,
+    toggleItem,
+    clearItems,
+    deselectItem,
+    isSelected,
+  } = selectionManager;
 
   const toggleAllRows: SelectionStateInternal['toggleAllRows'] = useEventCallback(() => {
-    selectionManager.toggleAllItems(items.map((item, i) => getRowId(item, i)));
+    toggleAllItems(items.map((item, i) => getRowId(item, i)));
   });
 
   return {
-    someRowsSelected: selected.size > 0,
-    allRowsSelected: selectionMode === 'single' ? selected.size > 0 : selected.size === items.length,
-    selectedRows: selected,
-    toggleRow: selectionManager.toggleItem,
+    someRowsSelected: selectedItems().size > 0,
+    allRowsSelected: selectionMode === 'single' ? selectedItems().size > 0 : selectedItems().size === items.length,
+    selectedRows: selectedItems(),
+    toggleRow: toggleItem,
     toggleAllRows,
-    clearRows: selectionManager.clearItems,
-    deselectRow: selectionManager.deselectItem,
-    selectRow: selectionManager.selectItem,
-    isRowSelected: selectionManager.isSelected,
+    clearRows: clearItems,
+    deselectRow: deselectItem,
+    selectRow: selectItem,
+    isRowSelected: isSelected,
   };
 }

--- a/packages/react-components/react-table/src/hooks/useSort.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.test.ts
@@ -3,6 +3,29 @@ import { ColumnDefinition } from './types';
 import { useSort } from './useSort';
 
 describe('useSort', () => {
+  it('should set default sort column', () => {
+    const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+    const { result } = renderHook(() =>
+      useSort(columnDefinition, jest.fn(), { sortColumn: 2, sortDirection: 'descending' }),
+    );
+
+    expect(result.current.sortColumn).toBe(2);
+    expect(result.current.sortDirection).toBe('descending');
+  });
+
+  it('should call onSortColumnChange when sort state changes', () => {
+    const onSortColumnChange = jest.fn();
+    const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+    const { result } = renderHook(() => useSort(columnDefinition, onSortColumnChange));
+
+    act(() => {
+      result.current.setColumnSort(3, 'descending');
+    });
+
+    expect(onSortColumnChange).toHaveBeenCalledTimes(1);
+    expect(onSortColumnChange).toHaveBeenCalledWith({ sortColumn: 3, sortDirection: 'descending' });
+  });
+
   describe('toggleColumnSort', () => {
     it('should sort a new column in ascending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];

--- a/packages/react-components/react-table/src/hooks/useSort.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.ts
@@ -1,12 +1,17 @@
 import * as React from 'react';
-import { SortDirection } from '../components/Table/Table.types';
-import type { ColumnDefinition, ColumnId, SortStateInternal } from './types';
+import { ColumnDefinition, ColumnId, SortColumnState, SortStateInternal, UseTableSortOptions } from './types';
 
-export function useSort<TItem>(columns: ColumnDefinition<TItem>[]): SortStateInternal<TItem> {
-  const [sorted, setSorted] = React.useState({
-    sortDirection: 'ascending' as SortDirection,
-    sortColumn: undefined as ColumnId | undefined,
-  });
+export function useSort<TItem>(
+  columns: ColumnDefinition<TItem>[],
+  onSortColumnChange: UseTableSortOptions['onSortColumnChange'] = () => undefined,
+  defaultSortColumn?: UseTableSortOptions['defaultSortColumn'],
+): SortStateInternal<TItem> {
+  const [sorted, setSorted] = React.useState<SortColumnState>(
+    defaultSortColumn ?? {
+      sortDirection: 'ascending' as const,
+      sortColumn: undefined,
+    },
+  );
 
   const { sortColumn, sortDirection } = sorted;
 
@@ -19,11 +24,13 @@ export function useSort<TItem>(columns: ColumnDefinition<TItem>[]): SortStateInt
         newState.sortDirection = 'ascending';
       }
 
+      onSortColumnChange(newState);
       return newState;
     });
   };
 
   const setColumnSort: SortStateInternal<TItem>['setColumnSort'] = (nextSortColumn, nextSortDirection) => {
+    onSortColumnChange({ sortColumn: nextSortColumn, sortDirection: nextSortDirection });
     setSorted({ sortColumn: nextSortColumn, sortDirection: nextSortDirection });
   };
 

--- a/packages/react-components/react-table/src/hooks/useTable.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.ts
@@ -10,12 +10,17 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
     items: baseItems,
     columns,
     getRowId: getUserRowId = () => undefined,
-    selectionMode = 'multiselect',
+    selection: { selectionMode = 'multiselect', onRowSelectionChange, defaultSelectedRows } = {},
+    sort: { defaultSortColumn, onSortColumnChange } = {},
     rowEnhancer = (row: RowState<TItem>) => row as TRowState,
   } = options;
 
   const getRowId = React.useCallback((item: TItem, index: number) => getUserRowId(item) ?? index, [getUserRowId]);
-  const { sortColumn, sortDirection, toggleColumnSort, setColumnSort, getSortDirection, sort } = useSort(columns);
+  const { sortColumn, sortDirection, toggleColumnSort, setColumnSort, getSortDirection, sort } = useSort(
+    columns,
+    onSortColumnChange,
+    defaultSortColumn,
+  );
   const sortState: SortState = React.useMemo(
     () => ({
       sortColumn,
@@ -37,7 +42,7 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
     someRowsSelected,
     selectRow,
     deselectRow,
-  } = useSelection(selectionMode, baseItems, getRowId);
+  } = useSelection({ selectionMode, items: baseItems, getRowId, onRowSelectionChange, defaultSelectedRows });
 
   const selectionState: SelectionState = React.useMemo(
     () => ({

--- a/packages/react-components/react-table/src/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/MultipleSelect.stories.tsx
@@ -100,6 +100,9 @@ export const MultipleSelect = () => {
   } = useTable({
     columns,
     items,
+    selection: {
+      defaultSelectedRows: new Set([1]),
+    },
     rowEnhancer: (row, { selection }) => ({
       ...row,
       toggle: () => selection.toggleRow(row.rowId),

--- a/packages/react-components/react-table/src/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SingleSelect.stories.tsx
@@ -97,7 +97,10 @@ export const SingleSelect = () => {
   const { rows } = useTable({
     columns,
     items,
-    selectionMode: 'single',
+    selection: {
+      selectionMode: 'single',
+      defaultSelectedRows: new Set([1]),
+    },
     rowEnhancer: (row, { selection }) => ({
       ...row,
       selected: selection.isRowSelected(row.rowId),

--- a/packages/react-components/react-table/src/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/Sort.stories.tsx
@@ -109,10 +109,12 @@ export const Sort = () => {
   const {
     rows,
     sort: { getSortDirection, toggleColumnSort },
-  } = useTable({ columns, items });
+  } = useTable({ columns, items, sort: { defaultSortColumn: { sortColumn: 'file', sortDirection: 'ascending' } } });
 
-  const headerSortProps = (columnId: ColumnId) => () => ({
-    onClick: () => toggleColumnSort(columnId),
+  const headerSortProps = (columnId: ColumnId) => ({
+    onClick: () => {
+      toggleColumnSort(columnId);
+    },
     sortDirection: getSortDirection(columnId),
   });
 


### PR DESCRIPTION
After some deliberation, there should be no 'autocontrol' support for features
of the `useTable` hook. The hook is intended to be used standalone so
simple providing default state values on mount and change callbacks
should be enough to allow it to integrate with apps' own state
management.

```ts
const [selectedRows, setSelectedRows] = React.useState([1, 2])

const {
    rows,
  } = useTable({
    columns,
    items,
    selection: {
      onRowSelectionChange: setSelectedRows,
      defaultSelectedRows: selectedRows,
    },
});
```

Addresses #24226
