### PR TITLE
FocusZone: Add ability to bypass hidden elements

### DIFF
--- a/change/@fluentui-react-de587d83-1c46-488b-9d1e-e1dd10739fb1.json
+++ b/change/@fluentui-react-de587d83-1c46-488b-9d1e-e1dd10739fb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "FocusZone: enable focus to be able to bypass hidden elements",
+  "packageName": "@fluentui/react",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-ec8c78ab-cee2-4700-b82d-5ed2aef1fd4b.json
+++ b/change/@fluentui-react-focus-ec8c78ab-cee2-4700-b82d-5ed2aef1fd4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "FocusZone: enable focus to be able to bypass hidden elements",
+  "packageName": "@fluentui/react-focus",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-7b6dc27b-e41a-4cdc-9041-ba28da7a3401.json
+++ b/change/@fluentui-utilities-7b6dc27b-e41a-4cdc-9041-ba28da7a3401.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "FocusZone: enable focus to be able to bypass hidden elements",
+  "packageName": "@fluentui/utilities",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react-focus/FocusZone/FocusZone.Disabled.Example.tsx
+++ b/packages/react-examples/src/react-focus/FocusZone/FocusZone.Disabled.Example.tsx
@@ -9,14 +9,11 @@ const textFieldStyles: Partial<ITextFieldStyles> = { root: { width: 200 } };
 
 export const FocusZoneDisabledExample: React.FunctionComponent = () => {
   const tokens = { childrenGap: 20 };
-  const fzRef = React.useRef<FocusZone>(null);
   return (
     <Stack tokens={tokens} horizontalAlign="start">
-      {/* <FocusZone direction={FocusZoneDirection.horizontal} componentRef={ref => (fzRef.current = ref || undefined)}> */}
-      <FocusZone direction={FocusZoneDirection.horizontal} ref={fzRef}>
+      <FocusZone direction={FocusZoneDirection.horizontal}>
         <Stack tokens={tokens} horizontal verticalAlign="center">
           <span>Enabled FocusZone: </span>
-          <DefaultButton style={{ visibility: 'hidden' }}>Button 0</DefaultButton>
           <DefaultButton>Button 1</DefaultButton>
           <DefaultButton>Button 2</DefaultButton>
           <TextField placeholder="FocusZone TextField" styles={textFieldStyles} ariaLabel="FocusZone TextField" />
@@ -32,10 +29,6 @@ export const FocusZoneDisabledExample: React.FunctionComponent = () => {
         </Stack>
       </FocusZone>
       <TextField placeholder="Tabbable Element 2" ariaLabel="Tabbable Element 2" />
-      <DefaultButton onClick={() => fzRef.current?.focus(true)}>Set Focus to the first Focus Zone - OLD</DefaultButton>
-      <DefaultButton onClick={() => fzRef.current?.focus(true, true)}>
-        Set Focus to the first Focus Zone - Bypass hidden
-      </DefaultButton>
     </Stack>
   );
 };

--- a/packages/react-examples/src/react-focus/FocusZone/FocusZone.Disabled.Example.tsx
+++ b/packages/react-examples/src/react-focus/FocusZone/FocusZone.Disabled.Example.tsx
@@ -9,11 +9,14 @@ const textFieldStyles: Partial<ITextFieldStyles> = { root: { width: 200 } };
 
 export const FocusZoneDisabledExample: React.FunctionComponent = () => {
   const tokens = { childrenGap: 20 };
+  const fzRef = React.useRef<FocusZone>(null);
   return (
     <Stack tokens={tokens} horizontalAlign="start">
-      <FocusZone direction={FocusZoneDirection.horizontal}>
+      {/* <FocusZone direction={FocusZoneDirection.horizontal} componentRef={ref => (fzRef.current = ref || undefined)}> */}
+      <FocusZone direction={FocusZoneDirection.horizontal} ref={fzRef}>
         <Stack tokens={tokens} horizontal verticalAlign="center">
           <span>Enabled FocusZone: </span>
+          <DefaultButton style={{ visibility: 'hidden' }}>Button 0</DefaultButton>
           <DefaultButton>Button 1</DefaultButton>
           <DefaultButton>Button 2</DefaultButton>
           <TextField placeholder="FocusZone TextField" styles={textFieldStyles} ariaLabel="FocusZone TextField" />
@@ -29,6 +32,10 @@ export const FocusZoneDisabledExample: React.FunctionComponent = () => {
         </Stack>
       </FocusZone>
       <TextField placeholder="Tabbable Element 2" ariaLabel="Tabbable Element 2" />
+      <DefaultButton onClick={() => fzRef.current?.focus(true)}>Set Focus to the first Focus Zone - OLD</DefaultButton>
+      <DefaultButton onClick={() => fzRef.current?.focus(true, true)}>
+        Set Focus to the first Focus Zone - Bypass hidden
+      </DefaultButton>
     </Stack>
   );
 };

--- a/packages/react-focus/etc/react-focus.api.md
+++ b/packages/react-focus/etc/react-focus.api.md
@@ -23,7 +23,7 @@ export class FocusZone extends React_2.Component<IFocusZoneProps> implements IFo
     get defaultFocusElement(): HTMLElement | null;
     // (undocumented)
     static defaultProps: IFocusZoneProps;
-    focus(forceIntoFirstElement?: boolean): boolean;
+    focus(forceIntoFirstElement?: boolean, bypassHiddenElements?: boolean): boolean;
     focusElement(element: HTMLElement, forceAlignment?: boolean): boolean;
     focusLast(): boolean;
     static getOuterZones(): number;
@@ -52,7 +52,7 @@ export type FocusZoneTabbableElements = typeof FocusZoneTabbableElements[keyof t
 
 // @public
 export interface IFocusZone {
-    focus(forceIntoFirstElement?: boolean): boolean;
+    focus(forceIntoFirstElement?: boolean, bypassHiddenElements?: boolean): boolean;
     focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;
     focusLast(): boolean;
     setFocusAlignment(point: Point): void;

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -23,6 +23,7 @@ import {
   portalContainsElement,
   findScrollableParent,
   createMergedRef,
+  isElementVisibleAndNotHidden,
 } from '@fluentui/utilities';
 import { mergeStyles } from '@fluentui/merge-styles';
 import { getTheme } from '@fluentui/style-utilities';
@@ -337,9 +338,10 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
    * Sets focus to the first tabbable item in the zone.
    * @param forceIntoFirstElement - If true, focus will be forced into the first element, even
    * if focus is already in the focus zone.
+   * @param bypassHiddenElements - If true, focus will be not be set on hidden elements.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  public focus(forceIntoFirstElement: boolean = false): boolean {
+  public focus(forceIntoFirstElement: boolean = false, bypassHiddenElements: boolean = false): boolean {
     if (this._root.current) {
       if (
         !forceIntoFirstElement &&
@@ -359,14 +361,27 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         !forceIntoFirstElement &&
         this._activeElement &&
         elementContains(this._root.current, this._activeElement) &&
-        isElementTabbable(this._activeElement)
+        isElementTabbable(this._activeElement) &&
+        (!bypassHiddenElements || isElementVisibleAndNotHidden(this._activeElement))
       ) {
         this._activeElement.focus();
         return true;
       } else {
         const firstChild = this._root.current.firstChild as HTMLElement;
 
-        return this.focusElement(getNextElement(this._root.current, firstChild, true) as HTMLElement);
+        return this.focusElement(
+          getNextElement(
+            this._root.current,
+            firstChild,
+            true,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            bypassHiddenElements,
+          ) as HTMLElement,
+        );
       }
     }
     return false;

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -10,9 +10,10 @@ export interface IFocusZone {
    * Sets focus to the first tabbable item in the zone.
    * @param forceIntoFirstElement - If true, focus will be forced into the first element, even
    * if focus is already in the focus zone.
+   * @param bypassHiddenElements - If true, focus will be not be set on hidden elements.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  focus(forceIntoFirstElement?: boolean): boolean;
+  focus(forceIntoFirstElement?: boolean, bypassHiddenElements?: boolean): boolean;
 
   /**
    * Sets focus to the last tabbable item in the zone.

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -7057,7 +7057,7 @@ export interface IOnRenderComboBoxLabelProps {
 
 // @public (undocumented)
 export interface IOverflowSet {
-    focus(forceIntoFirstElement?: boolean): boolean;
+    focus(forceIntoFirstElement?: boolean, bypassHiddenElements?: boolean): boolean;
     focusElement(childElement?: HTMLElement): boolean;
 }
 

--- a/packages/react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -12,10 +12,10 @@ const useComponentRef = (props: IOverflowSetProps, divContainer: React.RefObject
   React.useImperativeHandle(
     props.componentRef,
     (): IOverflowSet => ({
-      focus: (): boolean => {
+      focus: (_forceIntoFirstElement?: boolean, bypassHiddenElements?: boolean): boolean => {
         let focusSucceeded = false;
         if (divContainer.current) {
-          focusSucceeded = focusFirstChild(divContainer.current);
+          focusSucceeded = focusFirstChild(divContainer.current, bypassHiddenElements);
         }
         return focusSucceeded;
       },

--- a/packages/react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/react/src/components/OverflowSet/OverflowSet.types.ts
@@ -10,10 +10,11 @@ export interface IOverflowSet {
   /**
    * Sets focus to the first tabbable item in the zone.
    * @param forceIntoFirstElement - If true, focus will be forced into the first element, even if
+   * @param bypassHiddenElements - If true, focus will be not be set on hidden elements.
    * focus is already in the focus zone.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  focus(forceIntoFirstElement?: boolean): boolean;
+  focus(forceIntoFirstElement?: boolean, bypassHiddenElements?: boolean): boolean;
 
   /**
    * Sets focus to a specific child element within the zone. This can be used in conjunction with

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -294,7 +294,7 @@ export function focusAsync(element: HTMLElement | {
 } | undefined | null): void;
 
 // @public
-export function focusFirstChild(rootElement: HTMLElement): boolean;
+export function focusFirstChild(rootElement: HTMLElement, bypassHiddenElements?: boolean): boolean;
 
 // @public
 export const FocusRects: React_2.FunctionComponent<{
@@ -358,7 +358,7 @@ export function getNativeElementProps<TAttributes extends React_2.HTMLAttributes
 export function getNativeProps<T extends Record<string, any>>(props: Record<string, any>, allowedPropNames: string[] | Record<string, number>, excludedPropNames?: string[]): T;
 
 // @public
-export function getNextElement(rootElement: HTMLElement, currentElement: HTMLElement | null, checkNode?: boolean, suppressParentTraversal?: boolean, suppressChildTraversal?: boolean, includeElementsInFocusZones?: boolean, allowFocusRoot?: boolean, tabbable?: boolean): HTMLElement | null;
+export function getNextElement(rootElement: HTMLElement, currentElement: HTMLElement | null, checkNode?: boolean, suppressParentTraversal?: boolean, suppressChildTraversal?: boolean, includeElementsInFocusZones?: boolean, allowFocusRoot?: boolean, tabbable?: boolean, bypassHiddenElements?: boolean): HTMLElement | null;
 
 export { getParent }
 

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -110,10 +110,21 @@ export function getLastTabbable(
  *
  * @public
  * @param rootElement - Element to start the search for a focusable child.
+ * @param bypassHiddenElements - If true, focus will be not be set on hidden elements.
  * @returns True if focus was set, false if it was not.
  */
-export function focusFirstChild(rootElement: HTMLElement): boolean {
-  let element: HTMLElement | null = getNextElement(rootElement, rootElement, true, false, false, true);
+export function focusFirstChild(rootElement: HTMLElement, bypassHiddenElements?: boolean): boolean {
+  let element: HTMLElement | null = getNextElement(
+    rootElement,
+    rootElement,
+    true,
+    false,
+    false,
+    true,
+    undefined,
+    undefined,
+    bypassHiddenElements,
+  );
 
   if (element) {
     focusAsync(element);
@@ -261,12 +272,15 @@ export function getNextElement(
   includeElementsInFocusZones?: boolean,
   allowFocusRoot?: boolean,
   tabbable?: boolean,
+  bypassHiddenElements?: boolean,
 ): HTMLElement | null {
   if (!currentElement || (currentElement === rootElement && suppressChildTraversal && !allowFocusRoot)) {
     return null;
   }
 
-  let isCurrentElementVisible = isElementVisible(currentElement);
+  const checkElementVisibility = bypassHiddenElements ? isElementVisibleAndNotHidden : isElementVisible;
+
+  let isCurrentElementVisible = checkElementVisibility(currentElement);
 
   // Check the current node, if it's not the first traversal.
   if (checkNode && isCurrentElementVisible && isElementTabbable(currentElement, tabbable)) {
@@ -288,6 +302,7 @@ export function getNextElement(
       includeElementsInFocusZones,
       allowFocusRoot,
       tabbable,
+      bypassHiddenElements,
     );
 
     if (childMatch) {
@@ -309,6 +324,7 @@ export function getNextElement(
     includeElementsInFocusZones,
     allowFocusRoot,
     tabbable,
+    bypassHiddenElements,
   );
 
   if (siblingMatch) {
@@ -325,6 +341,7 @@ export function getNextElement(
       includeElementsInFocusZones,
       allowFocusRoot,
       tabbable,
+      bypassHiddenElements,
     );
   }
 


### PR DESCRIPTION
## Current Behavior
If a FocusZone contains a hidden element (especially if it's the first element), `focus` doesn't move as expected

## New Behavior
With this PR you can pass `bypassHiddenElements` into `FocusZone.focus` and `Overflow.focus` so that focus gets set as expected
