### PR TITLE
fix(FocusTrapZone): aria-hidden on FocusTrapZone's parent is not removed when there's multiple FTZ

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Fix `FocusTrapZone` to always remove `aria-hidden` on portal wrapper @yuanboxue-amber ([#24414](https://github.com/microsoft/fluentui/pull/24414))
+
 <!--------------------------------[ v0.64.0 ]------------------------------- -->
 ## [v0.64.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.64.0) (2022-08-10)
 [Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-northstar_v0.63.1..@fluentui/react-northstar_v0.64.0)

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusTrapZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusTrapZone.tsx
@@ -294,12 +294,14 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
 
     if (!lastActiveFocusTrap) {
       this._showContentInAccessibilityTree();
-    } else if (
-      lastActiveFocusTrap._root.current &&
-      lastActiveFocusTrap._root.current.hasAttribute(HIDDEN_FROM_ACC_TREE)
-    ) {
-      lastActiveFocusTrap._root.current.removeAttribute(HIDDEN_FROM_ACC_TREE);
-      lastActiveFocusTrap._root.current.removeAttribute('aria-hidden');
+    } else if (lastActiveFocusTrap._root.current) {
+      let element = lastActiveFocusTrap._root.current;
+      // aria hidden attributes are added to direct children of body. It can be the focusTrapZone root itself, or its parent
+      while (element.parentElement && element.parentElement !== doc?.body) {
+        element = element.parentElement;
+      }
+      element.removeAttribute(HIDDEN_FROM_ACC_TREE);
+      element.removeAttribute('aria-hidden');
     }
   };
 

--- a/packages/fluentui/react-bindings/test/FocusZone/FocusTrapZone-test.tsx
+++ b/packages/fluentui/react-bindings/test/FocusZone/FocusTrapZone-test.tsx
@@ -733,4 +733,64 @@ describe('FocusTrapZone', () => {
       removeTestContainer();
     });
   });
+
+  describe('multiple FocusZone mount/unmount', () => {
+    it('remove aria-hidden from the 1st focusZone when the 2nd focusZone unmount', () => {
+      const { testContainer, removeTestContainer } = createTestContainer();
+      const TestComponent = () => {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <>
+            {ReactDOM.createPortal(
+              <>
+                {open && (
+                  <FocusTrapZone id="zone2">
+                    <button>zone2 button</button>
+                  </FocusTrapZone>
+                )}
+              </>,
+              document.body,
+            )}
+            {ReactDOM.createPortal(
+              <div id="zone1-wrapper">
+                <FocusTrapZone id="zone1">
+                  <button>zone1 button</button>
+                </FocusTrapZone>
+              </div>,
+              document.body,
+            )}
+
+            <button id="unmount-zone2-button" onClick={() => setOpen(false)}>
+              button
+            </button>
+          </>
+        );
+      };
+      ReactTestUtils.act(() => {
+        ReactDOM.render(<TestComponent />, testContainer);
+      });
+
+      // initially both focusZone are mounted
+      let zone1Wrapper = document.body.querySelector('#zone1-wrapper') as HTMLElement;
+      expect(zone1Wrapper).toBeDefined();
+      expect(zone1Wrapper.getAttribute('aria-hidden')).toBe('true');
+
+      const zone2 = document.body.querySelector('#zone2') as HTMLElement;
+      expect(zone2).toBeDefined();
+      expect(zone2.getAttribute('aria-hidden')).toBe('true');
+
+      // unmount zone2
+      const unmountButton = testContainer.querySelector('#unmount-zone2-button') as HTMLElement;
+      expect(unmountButton).toBeDefined();
+      ReactTestUtils.Simulate.click(unmountButton);
+
+      // expect zone1 is mounted, but it's wrapper's aria-hidden attribute is removed
+      zone1Wrapper = document.body.querySelector('#zone1-wrapper') as HTMLElement;
+      expect(zone1Wrapper).toBeDefined();
+      expect(zone1Wrapper.getAttribute('aria-hidden')).toBeFalsy();
+
+      removeTestContainer();
+    });
+  });
 });


### PR DESCRIPTION
## tl;dr
FocusTrapZone adds aria-hidden to only direct children of body. But when it's time to remove aria-hidden, it only tries to remove aria-hidden on FocusTrapZone element itself, even though it is not always a direct children of body. In this case the aria-hidden on the parent element is never removed.
This PR checks for parent element of FocusTrapZone and remove aria-hidden

## A long and painful story of how I came to this problem 🥲:
Try: https://codesandbox.io/s/confident-rosalind-dhi2gy?file=/example.tsx

1. click on the button to open popup, notice a dialog is opened at the same time
2. dismiss dialog by clicking on 'cancel' button
3. hit 'tab' key and focus should go inside the first button 'grid-item-0' in Popup content.
4. try to navigate by right arrow key. The expected behavior is that focus move to 'grid-item-1', but the actual behavior is focus does not move.

Now there's one thing that makes arrow navigation starts to work:
After dismissing Dialog, open browser devtools, find the outer most wrapper of the popup content. It should be an element with className 'ui-provider', and attribute `aria-hidden="true" data-is-hidden-from-acc-tree="true"`. Removing `aria-hidden="true"` will make arrow navigation starts to work:

https://user-images.githubusercontent.com/28751745/185427650-c29b545c-045b-4758-b90c-0c7431ad536e.mov

This happens because the arrow navigation here is done by tabster mover. And it won't work when there's a 'aria-hidden' element in the parent of the mover element.

To sum it up, the `aria-hidden` on Popup wrapper div should go away when dialog is dismissed. But it wasn't.

Here's a more abstract example with just FocusTrapZone: https://codesandbox.io/s/distracted-panna-uwihrz?file=/example.tsx
Note that when click on 'button', focus zone2 unmounts. And inspecting zone1 shows that the wrapper element in zone1 still has aria-hidden=true.


 
