### PR TITLE
fix: Making PopoverSurface focusable, moving Overflow aria-label to PopoverSurface, and moving content styles to PopoverSurface

### DIFF
--- a/change/@fluentui-react-avatar-6c6ac0d8-779b-4863-b199-95916a602eab.json
+++ b/change/@fluentui-react-avatar-6c6ac0d8-779b-4863-b199-95916a602eab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Making PopoverSurface focusable, moving Overflow aria-label to PopoverSurface, and moving content styles to PopoverSurface.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/e2e/AvatarGroup.e2e.tsx
+++ b/packages/react-components/react-avatar/e2e/AvatarGroup.e2e.tsx
@@ -14,7 +14,7 @@ describe('AvatarGroup', () => {
   describe('AvatarGroupOverflow', () => {
     beforeEach(() => {
       mount(
-        <AvatarGroupPopover content={{ id: 'content-id' }}>
+        <AvatarGroupPopover popoverSurface={{ id: 'surface-id' }}>
           <AvatarGroupItem name="Allan Munger" />
           <AvatarGroupItem name="Daisy Phillips" />
           <AvatarGroupItem name="Robert Tolbert" />
@@ -25,7 +25,7 @@ describe('AvatarGroup', () => {
 
     it('opens popover and focuses on the content', () => {
       cy.get(overflowTriggerSelector).realClick();
-      cy.get('#content-id').should('have.focus');
+      cy.get('#surface-id').should('have.focus');
     });
   });
 });

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -77,14 +77,16 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
     content: resolveShorthand(props.content, {
       required: true,
       defaultProps: {
-        'aria-label': 'Overflow',
         children: children,
         role: 'list',
-        tabIndex: 0,
       },
     }),
     popoverSurface: resolveShorthand(props.popoverSurface, {
       required: true,
+      defaultProps: {
+        'aria-label': 'Overflow',
+        tabIndex: 0,
+      },
     }),
     tooltip: resolveShorthand(props.tooltip, {
       required: true,

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -78,7 +78,6 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
       required: true,
       defaultProps: {
         children: children,
-        role: 'list',
       },
     }),
     popoverSurface: resolveShorthand(props.popoverSurface, {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -78,6 +78,7 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
       required: true,
       defaultProps: {
         children: children,
+        role: 'list',
       },
     }),
     popoverSurface: resolveShorthand(props.popoverSurface, {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
@@ -20,12 +20,8 @@ export const avatarGroupPopoverClassNames: SlotClassNames<AvatarGroupPopoverSlot
 const useContentStyles = makeStyles({
   base: {
     listStyleType: 'none',
-    maxHeight: '220px',
     ...shorthands.margin('0'),
-    minHeight: '80px',
-    ...shorthands.overflow('hidden', 'scroll'),
-    ...shorthands.padding(tokens.spacingHorizontalS),
-    width: '220px',
+    ...shorthands.padding('0'),
   },
 });
 
@@ -34,7 +30,11 @@ const useContentStyles = makeStyles({
  */
 const usePopoverSurfaceStyles = makeStyles({
   base: {
-    ...shorthands.padding(0),
+    maxHeight: '220px',
+    minHeight: '80px',
+    ...shorthands.overflow('hidden', 'scroll'),
+    ...shorthands.padding(tokens.spacingHorizontalS),
+    width: '220px',
   },
 });
 

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
@@ -33,7 +33,7 @@ const usePopoverSurfaceStyles = makeStyles({
     maxHeight: '220px',
     minHeight: '80px',
     ...shorthands.overflow('hidden', 'scroll'),
-    ...shorthands.padding(tokens.spacingHorizontalS),
+    ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalS),
     width: '220px',
   },
 });


### PR DESCRIPTION


## Current Behavior

Currently Content has most of the styles needed for the Popover Surface, this brings problems with screen readers:
* aria-modal doesn't have an aria-label.
* aria-label is in a `<ul>` therefore there are some listbox problems in Windows where the screen reader mode is changed to forms mode.
* As a side effect, the styles to handle overflow are in the wrong element.

## New Behavior

Makes PopoverSurface focusable, moves Overflow aria-label to PopoverSurface, and moves content styles to PopoverSurface. This fixes the accessibility issues mentioned above.

## Related Issue(s)

#23773 
