### PR TITLE
change charting to private until we determine if the package is needed

### DIFF
--- a/change/@fluentui-react-charting-4c86-4bd5-a049-6766a22dfcf7.json
+++ b/change/@fluentui-react-charting-4c86-4bd5-a049-6766a22dfcf7.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Adding @fluentui/react-charting package to alias @fluentui/charting",
-  "packageName": "@fluentui/react-charting",
-  "email": "mgodbolt@microsoft.com",
-  "dependentChangeType": "minor"
-}

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -2,6 +2,7 @@
   "name": "@fluentui/react-charting",
   "version": "4.21.10",
   "description": "Experimental React charting components for building experiences for Microsoft 365.",
+  "private": "true",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
I decided to investigate npm aliasing to solve the ODSP upgrade issue. So until we decide if this package should be published i'm setting the package to private and removing the change file