### PR TITLE
Tag Picker: fix select all and delete

### DIFF
--- a/change/@fluentui-react-a918e551-6867-4583-be9e-dedfa8d6b135.json
+++ b/change/@fluentui-react-a918e551-6867-4583-be9e-dedfa8d6b135.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Resolved ref issue causing tag items to not be selectable or deletable. Fixed styles to show selection without focus",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Pickers/TagPicker.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/TagPicker.Basic.Example.tsx
@@ -89,7 +89,6 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
         onResolveSuggestions={filterSuggestedTags}
         getTextFromItem={getTextFromItem}
         pickerSuggestionsProps={pickerSuggestionsProps}
-        itemLimit={2}
         disabled={tagPicker}
         inputProps={{
           ...inputProps,
@@ -108,7 +107,6 @@ export const TagPickerBasicExample: React.FunctionComponent = () => {
         onItemSelected={onItemSelected}
         getTextFromItem={getTextFromItem}
         pickerSuggestionsProps={pickerSuggestionsProps}
-        itemLimit={2}
         disabled={tagPicker}
         inputProps={{
           ...inputProps,

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -10981,7 +10981,6 @@ export const TagPicker: React_2.FunctionComponent<ITagPickerProps>;
 
 // @public (undocumented)
 export class TagPickerBase extends BasePicker<ITag, ITagPickerProps> {
-    constructor(props: ITagPickerProps);
     // (undocumented)
     static defaultProps: {
         onRenderItem: (props: ITagItemProps) => JSX.Element;

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -53,12 +53,6 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
               },
             disabled && { background: palette.neutralLighter },
           ],
-          ':focus-within': [
-            !disabled && {
-              background: palette.themePrimary,
-              color: palette.white,
-            },
-          ],
           [HighContrastSelector]: {
             border: `1px solid ${!selected ? 'WindowText' : 'WindowFrame'}`,
           },
@@ -71,7 +65,14 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
           },
         },
       },
-      selected && !disabled && [classNames.isSelected],
+      selected &&
+        !disabled && [
+          classNames.isSelected,
+          {
+            background: palette.themePrimary,
+            color: palette.white,
+          },
+        ],
       className,
     ],
     text: [
@@ -103,6 +104,11 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
           ? `${effects.roundedCorner2} 0 0 ${effects.roundedCorner2}`
           : `0 ${effects.roundedCorner2} ${effects.roundedCorner2} 0`,
         selectors: {
+          [`.${classNames.isSelected} &`]: {
+            // selected but not focused, assume color and bg of parent
+            color: 'inherit',
+            background: 'transparent',
+          },
           ':hover': {
             background: palette.neutralQuaternaryAlt,
             color: palette.neutralPrimary,

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -104,16 +104,11 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
           ? `${effects.roundedCorner2} 0 0 ${effects.roundedCorner2}`
           : `0 ${effects.roundedCorner2} ${effects.roundedCorner2} 0`,
         selectors: {
-          [`.${classNames.isSelected} &`]: {
-            // selected but not focused, assume color and bg of parent
-            color: 'inherit',
-            background: 'transparent',
-          },
           ':hover': {
             background: palette.neutralQuaternaryAlt,
             color: palette.neutralPrimary,
           },
-          ':focus': {
+          [`.${classNames.isSelected} &, :focus`]: {
             color: palette.white,
             background: palette.themePrimary,
           },

--- a/packages/react/src/components/pickers/TagPicker/TagPicker.tsx
+++ b/packages/react/src/components/pickers/TagPicker/TagPicker.tsx
@@ -15,10 +15,6 @@ export class TagPickerBase extends BasePicker<ITag, ITagPickerProps> {
     onRenderItem: (props: ITagItemProps) => <TagItem {...props}>{props.item.name}</TagItem>,
     onRenderSuggestionsItem: (props: ITag) => <TagItemSuggestion>{props.name}</TagItemSuggestion>,
   };
-
-  constructor(props: ITagPickerProps) {
-    super(props);
-  }
 }
 
 export const TagPicker = styled<ITagPickerProps, IBasePickerStyleProps, IBasePickerStyles>(

--- a/packages/react/src/components/pickers/TagPicker/TagPicker.tsx
+++ b/packages/react/src/components/pickers/TagPicker/TagPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled, initializeComponentRef } from '../../../Utilities';
+import { styled } from '../../../Utilities';
 import { BasePicker } from '../BasePicker';
 import { getStyles } from '../BasePicker.styles';
 import { TagItem } from './TagItem';
@@ -18,7 +18,6 @@ export class TagPickerBase extends BasePicker<ITag, ITagPickerProps> {
 
   constructor(props: ITagPickerProps) {
     super(props);
-    initializeComponentRef(this);
   }
 }
 

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -51,10 +51,6 @@ exports[`TagItem accepts title override 1`] = `
       &:hover .ms-TagItem-close {
         color: #323130;
       }
-      &:focus-within {
-        background: #0078d4;
-        color: #ffffff;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border: 1px solid WindowText;
       }
@@ -151,6 +147,10 @@ exports[`TagItem accepts title override 1`] = `
         }
         &:active {
           background-color: #005a9e;
+          color: #ffffff;
+        }
+        .is-selected & {
+          background: #0078d4;
           color: #ffffff;
         }
         &:focus:hover {
@@ -276,10 +276,6 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
       &:hover .ms-TagItem-close {
         color: #323130;
       }
-      &:focus-within {
-        background: #0078d4;
-        color: #ffffff;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border: 1px solid WindowText;
       }
@@ -400,6 +396,10 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
         }
         &:active {
           background-color: #005a9e;
+          color: #ffffff;
+        }
+        .is-selected & {
+          background: #0078d4;
           color: #ffffff;
         }
         &:focus:hover {
@@ -525,10 +525,6 @@ exports[`TagItem renders correctly 1`] = `
       &:hover .ms-TagItem-close {
         color: #323130;
       }
-      &:focus-within {
-        background: #0078d4;
-        color: #ffffff;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border: 1px solid WindowText;
       }
@@ -625,6 +621,10 @@ exports[`TagItem renders correctly 1`] = `
         }
         &:active {
           background-color: #005a9e;
+          color: #ffffff;
+        }
+        .is-selected & {
+          background: #0078d4;
           color: #ffffff;
         }
         &:focus:hover {

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -128,10 +128,6 @@ exports[`TagPicker renders correctly 1`] = `
               &:hover .ms-TagItem-close {
                 color: #323130;
               }
-              &:focus-within {
-                background: #0078d4;
-                color: #ffffff;
-              }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
@@ -228,6 +224,10 @@ exports[`TagPicker renders correctly 1`] = `
                 }
                 &:active {
                   background-color: #005a9e;
+                  color: #ffffff;
+                }
+                .is-selected & {
+                  background: #0078d4;
                   color: #ffffff;
                 }
                 &:focus:hover {
@@ -521,10 +521,6 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
               &:hover .ms-TagItem-close {
                 color: #323130;
               }
-              &:focus-within {
-                background: #0078d4;
-                color: #ffffff;
-              }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 border: 1px solid WindowText;
               }
@@ -621,6 +617,10 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                 }
                 &:active {
                   background-color: #005a9e;
+                  color: #ffffff;
+                }
+                .is-selected & {
+                  background: #0078d4;
                   color: #ffffff;
                 }
                 &:focus:hover {


### PR DESCRIPTION
This PR starts to address the issues in #24314, fixing a bug that broke ctrl+a selection, and 'del' key deletion. This PR also fixes the styles so that they are properly driven from the is-selected class, and are applied to all items when ctrl + a is pressed.

After this PR I'll come back and look at adding click to select, which will be a bit more complicated and more of a feature add. 