### PR TITLE
fix: react-combobox Dropdown moves active option based on typed characters

### DIFF
--- a/change/@fluentui-react-combobox-03bbe68a-a87b-4349-99eb-17bf3c7df044.json
+++ b/change/@fluentui-react-combobox-03bbe68a-a87b-4349-99eb-17bf3c7df044.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: typing moves active option in Dropdown",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Dropdown } from './Dropdown';
 import { Option } from '../Option/index';
 import { isConformant } from '../../common/isConformant';
@@ -422,5 +423,82 @@ describe('Dropdown', () => {
 
     fireEvent.keyDown(combobox, { key: 'ArrowUp' });
     expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Green').id);
+  });
+
+  it('should move to first matching active option by typing a matching string', () => {
+    const { getByRole, getByText } = render(
+      <Dropdown>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Groot</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    const combobox = getByRole('combobox');
+
+    userEvent.type(combobox, 'gr');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Green').id);
+  });
+
+  it('should clear active option when typing a string with no matches', () => {
+    const { getByRole, getByText } = render(
+      <Dropdown>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    const combobox = getByRole('combobox');
+
+    userEvent.click(combobox);
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Red').id);
+
+    userEvent.keyboard('t');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toBeFalsy();
+  });
+
+  it('should cycle through options by repeating the same letter', () => {
+    const { getByRole, getByText } = render(
+      <Dropdown open>
+        <Option>Cat</Option>
+        <Option>Dog</Option>
+        <Option>Dolphin</Option>
+        <Option>Duck</Option>
+        <Option>Horse</Option>
+      </Dropdown>,
+    );
+
+    const combobox = getByRole('combobox');
+
+    userEvent.type(combobox, 'dd');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Dolphin').id);
+
+    userEvent.type(combobox, 'dd');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Dog').id);
+  });
+
+  it('should not move active option when typing a matching string', () => {
+    const { getByRole, getByText } = render(
+      <Dropdown>
+        <Option>Red</Option>
+        <Option>Redder</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    const combobox = getByRole('combobox');
+
+    userEvent.tab();
+    userEvent.keyboard('red');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Red').id);
   });
 });

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
-import { getPartitionedNativeProps, mergeCallbacks, resolveShorthand } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, mergeCallbacks, resolveShorthand, useTimeout } from '@fluentui/react-utilities';
 import { getDropdownActionFromKey } from '../../utils/dropdownKeyActions';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
 import { useTriggerListboxSlots } from '../../utils/useTriggerListboxSlots';
@@ -31,7 +31,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
 
   // jump to matching option based on typing
   const searchString = React.useRef('');
-  const keyTimeoutRef = React.useRef<number>();
+  const [setKeyTimeout, clearKeyTimeout] = useTimeout();
 
   const getNextMatchingOption = (): OptionValue | undefined => {
     // first check for matches for the full searchString
@@ -71,16 +71,13 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
 
   const onTriggerKeyDown = (ev: React.KeyboardEvent<HTMLButtonElement>) => {
     // clear timeout, if it exists
-    if (keyTimeoutRef.current) {
-      window.clearTimeout(keyTimeoutRef.current);
-      keyTimeoutRef.current = undefined;
-    }
+    clearKeyTimeout();
 
     // if the key was a char key, update search string
     if (getDropdownActionFromKey(ev) === 'Type') {
       // update search string
       searchString.current += ev.key.toLowerCase();
-      keyTimeoutRef.current = setTimeout(() => {
+      setKeyTimeout(() => {
         searchString.current = '';
       }, 500);
 

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
@@ -71,6 +71,10 @@ const useStyles = makeStyles({
 
   listbox: {},
 
+  listboxCollapsed: {
+    display: 'none',
+  },
+
   button: {
     alignItems: 'center',
     backgroundColor: tokens.colorTransparentBackground,
@@ -160,7 +164,7 @@ const useIconStyles = makeStyles({
  * Apply styling to the Dropdown slots based on the state
  */
 export const useDropdownStyles_unstable = (state: DropdownState): DropdownState => {
-  const { appearance, placeholderVisible, size } = state;
+  const { appearance, open, placeholderVisible, size } = state;
   const styles = useStyles();
   const iconStyles = useIconStyles();
 
@@ -175,7 +179,12 @@ export const useDropdownStyles_unstable = (state: DropdownState): DropdownState 
   );
 
   if (state.listbox) {
-    state.listbox.className = mergeClasses(dropdownClassNames.listbox, styles.listbox, state.listbox.className);
+    state.listbox.className = mergeClasses(
+      dropdownClassNames.listbox,
+      styles.listbox,
+      !open && styles.listboxCollapsed,
+      state.listbox.className,
+    );
   }
 
   if (state.expandIcon) {

--- a/packages/react-components/react-combobox/src/stories/Dropdown/DropdownDefault.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Dropdown/DropdownDefault.stories.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
 
 export const Default = (props: Partial<DropdownProps>) => {
   const dropdownId = useId('dropdown-default');
-  const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const options = ['Cat', 'Caterpiller', 'Corgi', 'Chupacabra', 'Dog', 'Ferret', 'Fish', 'Fox', 'Hamster', 'Snake'];
   const styles = useStyles();
   return (
     <div className={styles.root}>


### PR DESCRIPTION
Similar to Combobox, Dropdown also moves the currently highlighted option to match typed characters. It follows a slightly different matching schema than combobox, and also doesn't need to have any value-related logic.

The desired behavior for Dropdown is:
- typing the same letter repeatedly cycles through options starting with that letter (e.g. "cc" would move first to cat, then chupacabra)
- typing a series of different letters moves to an option that matches the entire typed string (with a 500ms no-typing timeout to reset)
- typing a letter or series of letters that has no matches will clear the active option. Using arrow keys afterwards will begin again at the top.
- typing causes the dropdown to open

Dropdown now also renders the listbox when collapsed but focused, so if a user types a letter when the dropdown is closed, it will immediately move to the matching option when it opens.