### PR TITLE
chore(react-aria): `useARIAButton` folder

### DIFF
--- a/change/@fluentui-react-aria-4b79e85a-b5bc-45ce-802e-9ea17f31184c.json
+++ b/change/@fluentui-react-aria-4b79e85a-b5bc-45ce-802e-9ea17f31184c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: re-organize useARIAButton into its own folder",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-aria/src/hooks/index.ts
+++ b/packages/react-components/react-aria/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useARIAButton';

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/index.ts
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/index.ts
@@ -1,0 +1,3 @@
+export * from './useARIAButtonProps';
+export * from './useARIAButtonShorthand';
+export * from './types';

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/types.ts
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/types.ts
@@ -1,0 +1,57 @@
+import type { ExtractSlotProps, Slot } from '@fluentui/react-utilities';
+import * as React from 'react';
+
+export type ARIAButtonType = 'button' | 'a' | 'div';
+
+/**
+ * Props expected by `useARIAButtonProps` hooks
+ */
+export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = React.PropsWithRef<
+  JSX.IntrinsicElements[Type]
+> & {
+  disabled?: boolean;
+  /**
+   * When set, allows the button to be focusable even when it has been disabled.
+   * This is used in scenarios where it is important to keep a consistent tab order
+   * for screen reader and keyboard users. The primary example of this
+   * pattern is when the disabled button is in a menu or a commandbar and is seldom used for standalone buttons.
+   *
+   * @default false
+   */
+  disabledFocusable?: boolean;
+};
+
+export type ARIAButtonSlotProps<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = ExtractSlotProps<
+  Slot<'button', AlternateAs>
+> &
+  Pick<ARIAButtonProps<ARIAButtonType>, 'disabled' | 'disabledFocusable'>;
+
+/**
+ * @internal
+ * Props that will be modified internally by `useARIAButtonProps` by each case.
+ * This typing is to ensure a well specified return value for `useARIAbButtonProps`
+ */
+export type ARIAButtonAlteredProps<Type extends ARIAButtonType> =
+  | (Type extends 'button'
+      ? Pick<
+          JSX.IntrinsicElements['button'],
+          'onClick' | 'onKeyDown' | 'onKeyUp' | 'disabled' | 'aria-disabled' | 'tabIndex'
+        >
+      : never)
+  | (Type extends 'a'
+      ? Pick<
+          JSX.IntrinsicElements['a'],
+          'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role' | 'href'
+        >
+      : never)
+  | (Type extends 'div'
+      ? Pick<JSX.IntrinsicElements['div'], 'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role'>
+      : never);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
+
+/**
+ * Merge of props provided by the user and props provided internally.
+ */
+export type ARIAButtonResultProps<Type extends ARIAButtonType, Props> = Props &
+  UnionToIntersection<ARIAButtonAlteredProps<Type>>;

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButton.stories.tsx
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButton.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useARIAButtonShorthand } from './useARIAButton';
-import type { ARIAButtonSlotProps } from './useARIAButton';
+import { useARIAButtonShorthand } from '../useARIAButton';
+import type { ARIAButtonSlotProps } from '../useARIAButton';
 import { getSlots } from '@fluentui/react-components';
 import type { ComponentState, Slot } from '@fluentui/react-components';
 

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonProps.test.tsx
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonProps.test.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { useARIAButtonShorthand, useARIAButtonProps, ARIAButtonProps, ARIAButtonSlotProps } from './useARIAButton';
+import { useARIAButtonProps } from './useARIAButtonProps';
 import { renderHook } from '@testing-library/react-hooks';
 import { fireEvent, render } from '@testing-library/react';
 import { getSlots, Slot, ComponentProps } from '@fluentui/react-utilities';
+import { ARIAButtonProps, ARIAButtonSlotProps } from './types';
+import { useARIAButtonShorthand } from './useARIAButtonShorthand';
 
 const TestButton = (props: ComponentProps<{ root: Slot<ARIAButtonSlotProps> }>) => {
   const { slots, slotProps } = getSlots<{ root: Slot<ARIAButtonSlotProps> }>({
@@ -156,26 +158,5 @@ describe('useARIAButton', () => {
     const { getByRole } = render(<TestButton as={type} onClick={handleClick} aria-disabled />);
     fireEvent.click(getByRole('button'));
     expect(handleClick).toBeCalledTimes(0);
-  });
-});
-
-describe('useARIAButtonShorthands', () => {
-  it('should return shorthands', () => {
-    const {
-      result: { current: buttonShorthand },
-    } = renderHook(() => useARIAButtonShorthand({ as: 'button' }));
-    expect(buttonShorthand.as).toBe('button');
-    const {
-      result: { current: buttonShorthand2 },
-    } = renderHook(() => useARIAButtonShorthand({ as: undefined }));
-    expect(buttonShorthand2.as).toBe(undefined);
-    const {
-      result: { current: acnhorShorthand },
-    } = renderHook(() => useARIAButtonShorthand({ as: 'a' }));
-    expect(acnhorShorthand.as).toBe('a');
-    const {
-      result: { current: divShorthand },
-    } = renderHook(() => useARIAButtonShorthand({ as: 'div' }));
-    expect(divShorthand.as).toBe('div');
   });
 });

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonProps.ts
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonProps.ts
@@ -1,62 +1,6 @@
 import { Enter, Space } from '@fluentui/keyboard-keys';
-import { resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
-import type { ExtractSlotProps, ResolveShorthandFunction, Slot } from '@fluentui/react-utilities';
-import * as React from 'react';
-
-export type ARIAButtonType = 'button' | 'a' | 'div';
-
-/**
- * Props expected by `useARIAButtonProps` hooks
- */
-export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = React.PropsWithRef<
-  JSX.IntrinsicElements[Type]
-> & {
-  disabled?: boolean;
-  /**
-   * When set, allows the button to be focusable even when it has been disabled.
-   * This is used in scenarios where it is important to keep a consistent tab order
-   * for screen reader and keyboard users. The primary example of this
-   * pattern is when the disabled button is in a menu or a commandbar and is seldom used for standalone buttons.
-   *
-   * @default false
-   */
-  disabledFocusable?: boolean;
-};
-
-export type ARIAButtonSlotProps<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = ExtractSlotProps<
-  Slot<'button', AlternateAs>
-> &
-  Pick<ARIAButtonProps<ARIAButtonType>, 'disabled' | 'disabledFocusable'>;
-
-/**
- * @internal
- * Props that will be modified internally by `useARIAButtonProps` by each case.
- * This typing is to ensure a well specified return value for `useARIAbButtonProps`
- */
-type ARIAButtonAlteredProps<Type extends ARIAButtonType> =
-  | (Type extends 'button'
-      ? Pick<
-          JSX.IntrinsicElements['button'],
-          'onClick' | 'onKeyDown' | 'onKeyUp' | 'disabled' | 'aria-disabled' | 'tabIndex'
-        >
-      : never)
-  | (Type extends 'a'
-      ? Pick<
-          JSX.IntrinsicElements['a'],
-          'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role' | 'href'
-        >
-      : never)
-  | (Type extends 'div'
-      ? Pick<JSX.IntrinsicElements['div'], 'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role'>
-      : never);
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
-
-/**
- * Merge of props provided by the user and props provided internally.
- */
-export type ARIAButtonResultProps<Type extends ARIAButtonType, Props> = Props &
-  UnionToIntersection<ARIAButtonAlteredProps<Type>>;
+import { useEventCallback } from '@fluentui/react-utilities';
+import type { ARIAButtonProps, ARIAButtonResultProps, ARIAButtonType } from './types';
 
 /**
  * @internal
@@ -199,18 +143,3 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
     return resultProps;
   }
 }
-
-/**
- * @internal
- *
- * This function expects to receive a slot, if `as` property is not desired use `useARIAButtonProps` instead
- *
- * Button keyboard handling, role, disabled and tabIndex implementation that ensures ARIA spec
- * for multiple scenarios of shorthand properties. Ensuring 1st rule of ARIA for cases
- * where no attribute addition is required.
- */
-export const useARIAButtonShorthand: ResolveShorthandFunction<ARIAButtonSlotProps> = (slot, options) => {
-  const shorthand = resolveShorthand(slot, options);
-  const shorthandARIAButton = useARIAButtonProps<ARIAButtonType, ARIAButtonProps>(shorthand?.as ?? 'button', shorthand);
-  return shorthand && shorthandARIAButton;
-};

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonShorthand.test.tsx
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonShorthand.test.tsx
@@ -1,0 +1,23 @@
+import { useARIAButtonShorthand } from './useARIAButtonShorthand';
+import { renderHook } from '@testing-library/react-hooks';
+
+describe('useARIAButtonShorthands', () => {
+  it('should return shorthands', () => {
+    const {
+      result: { current: buttonShorthand },
+    } = renderHook(() => useARIAButtonShorthand({ as: 'button' }));
+    expect(buttonShorthand.as).toBe('button');
+    const {
+      result: { current: buttonShorthand2 },
+    } = renderHook(() => useARIAButtonShorthand({ as: undefined }));
+    expect(buttonShorthand2.as).toBe(undefined);
+    const {
+      result: { current: anchorShorthand },
+    } = renderHook(() => useARIAButtonShorthand({ as: 'a' }));
+    expect(anchorShorthand.as).toBe('a');
+    const {
+      result: { current: divShorthand },
+    } = renderHook(() => useARIAButtonShorthand({ as: 'div' }));
+    expect(divShorthand.as).toBe('div');
+  });
+});

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonShorthand.ts
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonShorthand.ts
@@ -1,0 +1,19 @@
+import { resolveShorthand } from '@fluentui/react-utilities';
+import { useARIAButtonProps } from './useARIAButtonProps';
+import type { ResolveShorthandFunction } from '@fluentui/react-utilities';
+import type { ARIAButtonProps, ARIAButtonSlotProps, ARIAButtonType } from './types';
+
+/**
+ * @internal
+ *
+ * This function expects to receive a slot, if `as` property is not desired use `useARIAButtonProps` instead
+ *
+ * Button keyboard handling, role, disabled and tabIndex implementation that ensures ARIA spec
+ * for multiple scenarios of shorthand properties. Ensuring 1st rule of ARIA for cases
+ * where no attribute addition is required.
+ */
+export const useARIAButtonShorthand: ResolveShorthandFunction<ARIAButtonSlotProps> = (slot, options) => {
+  const shorthand = resolveShorthand(slot, options);
+  const shorthandARIAButton = useARIAButtonProps<ARIAButtonType, ARIAButtonProps>(shorthand?.as ?? 'button', shorthand);
+  return shorthand && shorthandARIAButton;
+};

--- a/packages/react-components/react-aria/src/index.ts
+++ b/packages/react-components/react-aria/src/index.ts
@@ -1,2 +1,7 @@
-export { useARIAButtonShorthand, useARIAButtonProps } from './hooks/index';
-export type { ARIAButtonSlotProps, ARIAButtonProps, ARIAButtonResultProps, ARIAButtonType } from './hooks/index';
+export { useARIAButtonShorthand, useARIAButtonProps } from './hooks/useARIAButton/index';
+export type {
+  ARIAButtonSlotProps,
+  ARIAButtonProps,
+  ARIAButtonResultProps,
+  ARIAButtonType,
+} from './hooks/useARIAButton/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Organizes folder structure for `useARIAButton` into a single folder, to open space for more hooks.

## Before

<img width="280" alt="image" src="https://user-images.githubusercontent.com/5483269/185885145-ac1aa7d9-64b2-4066-84d0-2853f590ee45.png">

## After

<img width="303" alt="image" src="https://user-images.githubusercontent.com/5483269/185885279-0dbc7256-68f0-443b-a6a5-b704792c799d.png">
