### PR TITLE
chore(react-avatar): AvatarGroup context cleanup

### DIFF
--- a/change/@fluentui-react-avatar-553b43fa-6ccc-4d4b-a6e7-81b0e3803e07.json
+++ b/change/@fluentui-react-avatar-553b43fa-6ccc-4d4b-a6e7-81b0e3803e07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Cleaning up use of AvatarGroup context.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
-import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
+import { AvatarGroupProvider } from '../../contexts/AvatarGroupContext';
 import type { AvatarGroupState, AvatarGroupSlots, AvatarGroupContextValues } from './AvatarGroup.types';
 
 /**
@@ -10,8 +10,8 @@ export const renderAvatarGroup_unstable = (state: AvatarGroupState, contextValue
   const { slots, slotProps } = getSlots<AvatarGroupSlots>(state);
 
   return (
-    <AvatarGroupContext.Provider value={contextValues.avatarGroup}>
+    <AvatarGroupProvider value={contextValues.avatarGroup}>
       <slots.root {...slotProps.root} />
-    </AvatarGroupContext.Provider>
+    </AvatarGroupProvider>
   );
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AvatarGroupContext } from '../../contexts/AvatarGroupContext';
+import { AvatarGroupProvider } from '../../contexts/AvatarGroupContext';
 import { AvatarGroupContextValues } from '../AvatarGroup/AvatarGroup.types';
 import { getSlots } from '@fluentui/react-utilities';
 import { PopoverProps, PopoverTrigger } from '@fluentui/react-popover';
@@ -23,9 +23,9 @@ export const renderAvatarGroupPopover_unstable = (
         </slots.tooltip>
       </PopoverTrigger>
       <slots.popoverSurface {...slotProps.popoverSurface}>
-        <AvatarGroupContext.Provider value={contextValues.avatarGroup}>
+        <AvatarGroupProvider value={contextValues.avatarGroup}>
           <slots.content {...slotProps.content} />
-        </AvatarGroupContext.Provider>
+        </AvatarGroupProvider>
       </slots.popoverSurface>
     </slots.root>
   );

--- a/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.ts
+++ b/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.ts
@@ -3,7 +3,7 @@ import type { Context } from '@fluentui/react-context-selector';
 import type { AvatarGroupContextValue } from '../AvatarGroup';
 
 /**
- * AvatarGroupContext is provided by AvatarGroup and AvatarGroupOverflo. It's consumed by AvatarGroupItem to determine
+ * AvatarGroupContext is provided by AvatarGroup and AvatarGroupPopover. It's consumed by AvatarGroupItem to determine
  * default values of some props.
  */
 export const AvatarGroupContext: Context<AvatarGroupContextValue> = createContext<AvatarGroupContextValue | undefined>(

--- a/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.ts
+++ b/packages/react-components/react-avatar/src/contexts/AvatarGroupContext.ts
@@ -3,7 +3,7 @@ import type { Context } from '@fluentui/react-context-selector';
 import type { AvatarGroupContextValue } from '../AvatarGroup';
 
 /**
- * AvatarGroupContext is provided by AvatarGroup, and is consumed by AvatarGroupItem to determine
+ * AvatarGroupContext is provided by AvatarGroup and AvatarGroupOverflo. It's consumed by AvatarGroupItem to determine
  * default values of some props.
  */
 export const AvatarGroupContext: Context<AvatarGroupContextValue> = createContext<AvatarGroupContextValue | undefined>(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

AvatarGroup and AvatarGroupPopover use AvatarGroup's context as follows: `AvatarGroupContext.Provider`

## New Behavior

AvatarGroup and AvatarGroupPopover now use AvatarGroup's context as it should by importing `AvatarGroupProvider`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24447 
