### PR TITLE
chore(vr-tests-v9): enable type-checking and use raw binaries within …

### DIFF
--- a/apps/vr-tests-react-components/.storybook/main.js
+++ b/apps/vr-tests-react-components/.storybook/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
-module.exports = {
+module.exports = /** @type {import('../../../.storybook/main').StorybookBaseConfig} */ ({
   stories: ['../src/**/*.stories.tsx'],
   core: {
     builder: 'webpack5',
@@ -20,20 +20,22 @@ module.exports = {
       config.resolve.plugins ? config.resolve.plugins.push(tsPaths) : (config.resolve.plugins = [tsPaths]);
     }
 
-    config.module.rules.unshift({
-      test: /\.(ts|tsx)$/,
-      use: [
-        {
-          loader: '@griffel/webpack-loader',
-          options: {
-            babelOptions: {
-              presets: ['@babel/preset-typescript'],
+    if (config.module) {
+      config.module.rules?.unshift({
+        test: /\.(ts|tsx)$/,
+        use: [
+          {
+            loader: '@griffel/webpack-loader',
+            options: {
+              babelOptions: {
+                presets: ['@babel/preset-typescript'],
+              },
             },
           },
-        },
-      ],
-    });
+        ],
+      });
+    }
 
     return config;
   },
-};
+});

--- a/apps/vr-tests-react-components/.storybook/preview.js
+++ b/apps/vr-tests-react-components/.storybook/preview.js
@@ -1,4 +1,3 @@
-// @ts-check
 import * as React from 'react';
 import { setAddon } from '@storybook/react';
 import { webLightTheme, teamsHighContrastTheme, webDarkTheme } from '@fluentui/react-theme';
@@ -25,11 +24,11 @@ setAddon({
    * @this {import('../src/utilities/types').ExtendedStoryApi}
    */
   addStory(storyName, storyFn, config = {}) {
-    this.add(storyName, context => {
+    this.add(storyName, (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
       return <FluentProvider theme={webLightTheme}>{storyFn(context)}</FluentProvider>;
     });
     if (config.includeRtl) {
-      this.add(storyName + ' - RTL', context => {
+      this.add(storyName + ' - RTL', (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
         return (
           <FluentProvider theme={webLightTheme} dir="rtl">
             {storyFn(context)}
@@ -38,12 +37,14 @@ setAddon({
       });
     }
     if (config.includeDarkMode) {
-      this.add(storyName + ' - Dark Mode', context => {
+      this.add(storyName + ' - Dark Mode', (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
         return <FluentProvider theme={webDarkTheme}>{storyFn(context)}</FluentProvider>;
       });
     }
     if (config.includeHighContrast) {
-      this.add(storyName + ' - High Contrast', context => {
+      this.add(storyName + ' - High Contrast', (
+        /** @type {import('../src/utilities/types').StoryContext} */ context,
+      ) => {
         return <FluentProvider theme={teamsHighContrastTheme}>{storyFn(context)}</FluentProvider>;
       });
     }

--- a/apps/vr-tests-react-components/just.config.ts
+++ b/apps/vr-tests-react-components/just.config.ts
@@ -1,5 +1,3 @@
-import { preset, task } from '@fluentui/scripts';
+import { preset } from '@fluentui/scripts';
 
 preset();
-
-task('build', 'build:node-lib').cached();

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "description": "Visual regression tests for @fluentui/react-components",
   "scripts": {
-    "build": "just-scripts build",
+    "build": "build-storybook -o dist/storybook",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
+    "format": "prettier . -w --ignore-path ../../.prettierignore",
     "lint": "just-scripts lint",
     "screener": "just-scripts screener",
-    "screener:build": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts storybook:build",
-    "start": "just-scripts dev:storybook"
+    "screener:build": "yarn build",
+    "start": "start-storybook",
+    "type-check": "tsc"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*"

--- a/apps/vr-tests-react-components/screener.config.js
+++ b/apps/vr-tests-react-components/screener.config.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 const cp = require('child_process');
 
 function getCurrentHash() {

--- a/apps/vr-tests-react-components/src/utilities/types.ts
+++ b/apps/vr-tests-react-components/src/utilities/types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StoryApi, StoryName, LegacyStoryFn, ClientApiReturnFn } from '@storybook/addons';
+import type { StoryApi, StoryName, LegacyStoryFn, ClientApiReturnFn } from '@storybook/addons';
 
 /** Extra parameters provided by our addon (see `.storybook/preview.js`) */
 export interface AddStoryConfig {
@@ -14,6 +14,7 @@ export interface AddStoryConfig {
 export type ExtendedStoryFnReturnType = React.ReactElement<unknown>;
 
 export type ExtendedStoryFn = LegacyStoryFn<ExtendedStoryFnReturnType>;
+export type StoryContext = Parameters<ExtendedStoryFn>[0];
 
 export interface ExtendedStoryApi extends StoryApi<ExtendedStoryFnReturnType> {
   addStory: (storyName: StoryName, storyFn: ExtendedStoryFn, config?: AddStoryConfig) => ExtendedStoryApi;

--- a/apps/vr-tests-react-components/tsconfig.json
+++ b/apps/vr-tests-react-components/tsconfig.json
@@ -1,22 +1,18 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es5",
-    "outDir": "lib",
+    "target": "ES2019",
     "module": "commonjs",
-    "jsx": "react",
-    "declaration": true,
-    "sourceMap": true,
+    "outDir": "lib",
     "noEmit": true,
+    "jsx": "react",
+    "allowJs": true,
+    "checkJs": true,
+    "sourceMap": true,
     "experimentalDecorators": true,
     "noUnusedLocals": true,
-    "forceConsistentCasingInFileNames": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "moduleResolution": "node",
     "preserveConstEnums": true,
-    "skipLibCheck": true,
-    "types": ["webpack-env", "@storybook/react", "screener-storybook"]
+    "types": ["screener-storybook", "node"]
   },
-  "include": ["src"]
+  "include": ["./src", "./.storybook/*", "screener.config.js"]
 }


### PR DESCRIPTION
…npm scripts

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- v9 vr tests setup uses deprecated tools from v8
- improper type checking setup

## New Behavior

- v9 vr tests use raw binaries 
- full type checking setup

## Related Issue(s)


