### PR TITLE
Exported getActivityItemStyles and getActivityItemClassNames

### DIFF
--- a/change/office-ui-fabric-react-8650d6f5-6f73-47d2-a18d-401f14b6c50f.json
+++ b/change/office-ui-fabric-react-8650d6f5-6f73-47d2-a18d-401f14b6c50f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exported getActivityItemStyles and getActivityItemClassNames",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1320,6 +1320,12 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
 export const FontIcon: React.FunctionComponent<IFontIconProps>;
 
 // @public (undocumented)
+export const getActivityItemClassNames: (styles: IActivityItemStyles, className: string, activityPersonas: IPersonaProps[], isCompact: boolean) => IActivityItemClassNames;
+
+// @public (undocumented)
+export const getActivityItemStyles: (theme?: ITheme, customStyles?: IActivityItemStyles | undefined, animateBeaconSignal?: boolean | undefined, beaconColorOne?: string | undefined, beaconColorTwo?: string | undefined, isCompact?: boolean | undefined) => IActivityItemStyles;
+
+// @public (undocumented)
 export function getAllSelectedOptions(options: ISelectableOption[], selectedIndices: number[]): ISelectableOption[];
 
 // @public
@@ -1524,6 +1530,28 @@ export interface IAccessiblePopupProps {
     forceFocusInsideTrap?: boolean;
     ignoreExternalFocusing?: boolean;
     isClickableOutsideFocusTrap?: boolean;
+}
+
+// @public (undocumented)
+export interface IActivityItemClassNames {
+    // (undocumented)
+    activityContent?: string;
+    // (undocumented)
+    activityPersona?: string;
+    // (undocumented)
+    activityText?: string;
+    // (undocumented)
+    activityTypeIcon?: string;
+    // (undocumented)
+    commentText?: string;
+    // (undocumented)
+    personaContainer?: string;
+    // (undocumented)
+    pulsingBeacon?: string;
+    // (undocumented)
+    root?: string;
+    // (undocumented)
+    timeStamp?: string;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/index.ts
@@ -1,2 +1,5 @@
+export { getStyles as getActivityItemStyles } from './ActivityItem.styles';
+export { IActivityItemClassNames, getClassNames as getActivityItemClassNames } from './ActivityItem.classNames';
+
 export * from './ActivityItem';
 export * from './ActivityItem.types';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level export of ActivityItem getStyles as getActivityItemStyles
- added top-level export of ActivityItem getClassNames as getActivityItemClassNames
- added top-level export of IActivityItemClassNames type

## Issues
Fixes #24452