### PR TITLE
Export activity item styles v8

### DIFF
--- a/change/@fluentui-react-06abbff8-7902-4a49-bdff-476e15c6e4fe.json
+++ b/change/@fluentui-react-06abbff8-7902-4a49-bdff-476e15c6e4fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exported getActivityItemStyles and getActivityItemClassNaes",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1691,6 +1691,12 @@ export { format }
 export { formProperties }
 
 // @public (undocumented)
+export const getActivityItemClassNames: (styles: IActivityItemStyles, className: string, activityPersonas: Array<IPersonaProps>, isCompact: boolean) => IActivityItemClassNames;
+
+// @public (undocumented)
+export const getActivityItemStyles: (theme?: ITheme, customStyles?: IActivityItemStyles | undefined, animateBeaconSignal?: IActivityItemProps['animateBeaconSignal'], beaconColorOne?: IActivityItemProps['beaconColorOne'], beaconColorTwo?: IActivityItemProps['beaconColorTwo'], isCompact?: IActivityItemProps['isCompact']) => IActivityItemStyles;
+
+// @public (undocumented)
 export function getAllSelectedOptions(options: ISelectableOption[], selectedIndices: number[]): ISelectableOption[];
 
 // @public
@@ -2037,6 +2043,28 @@ export interface IAccessiblePopupProps {
     // @deprecated (undocumented)
     ignoreExternalFocusing?: boolean;
     isClickableOutsideFocusTrap?: boolean;
+}
+
+// @public (undocumented)
+export interface IActivityItemClassNames {
+    // (undocumented)
+    activityContent?: string;
+    // (undocumented)
+    activityPersona?: string;
+    // (undocumented)
+    activityText?: string;
+    // (undocumented)
+    activityTypeIcon?: string;
+    // (undocumented)
+    commentText?: string;
+    // (undocumented)
+    personaContainer?: string;
+    // (undocumented)
+    pulsingBeacon?: string;
+    // (undocumented)
+    root?: string;
+    // (undocumented)
+    timeStamp?: string;
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/ActivityItem/index.ts
+++ b/packages/react/src/components/ActivityItem/index.ts
@@ -1,2 +1,6 @@
+export { getStyles as getActivityItemStyles } from './ActivityItem.styles';
+export { getClassNames as getActivityItemClassNames } from './ActivityItem.classNames';
+export type { IActivityItemClassNames } from './ActivityItem.classNames';
+
 export * from './ActivityItem';
 export * from './ActivityItem.types';


### PR DESCRIPTION
Same change from v7 from https://github.com/microsoft/fluentui/pull/24473 but in v8.
This change cannot be easily cherry-picked from master to 7.0 as it is in different files and the type export is different.