### PR TITLE
Exported getCommandBarStyles

### DIFF
--- a/change/office-ui-fabric-react-dc2fbcb8-eb8e-4741-965b-17e26b616682.json
+++ b/change/office-ui-fabric-react-dc2fbcb8-eb8e-4741-965b-17e26b616682.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export getCommandBarStyles and getCommandButtonStyles",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1341,6 +1341,12 @@ export function getColorFromRGBA(rgba: IRGB): IColor;
 export function getColorFromString(inputColor: string): IColor | undefined;
 
 // @public (undocumented)
+export const getCommandBarStyles: (props: ICommandBarStyleProps) => ICommandBarStyles;
+
+// @public (undocumented)
+export const getCommandButtonStyles: (customStyles: IButtonStyles | undefined) => IButtonStyles;
+
+// @public (undocumented)
 export function getContrastRatio(color1: IColor, color2: IColor): number;
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/CommandBar/index.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/index.ts
@@ -1,3 +1,5 @@
+export { getStyles as getCommandBarStyles, getCommandButtonStyles } from './CommandBar.styles';
+
 export * from './CommandBar';
 export * from './CommandBar.base';
 export * from './CommandBar.types';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level export of CommandBar getStyles as getCommandBarStyles
- added top-level export getCommandButtonStyles

## Issues
Fixes #24453