### PR TITLE
Export detailslist styles

### DIFF
--- a/change/office-ui-fabric-react-1d21c8fd-c529-4278-962a-9d9a8e7a098d.json
+++ b/change/office-ui-fabric-react-1d21c8fd-c529-4278-962a-9d9a8e7a098d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added getStyles exports for details list components",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -905,6 +905,9 @@ export class DefaultButton extends React.Component<IButtonProps, {}> {
 // @public (undocumented)
 export type DefaultProps = Required<Pick<ISpinButtonProps, 'step' | 'min' | 'max' | 'disabled' | 'labelPosition' | 'label' | 'incrementButtonIcon' | 'decrementButtonIcon'>>;
 
+// @public (undocumented)
+export const DetailsColumn: React.FunctionComponent<IDetailsColumnProps>;
+
 // @public
 export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     constructor(props: IDetailsColumnProps);
@@ -1350,6 +1353,18 @@ export function getColorFromString(inputColor: string): IColor | undefined;
 export function getContrastRatio(color1: IColor, color2: IColor): number;
 
 // @public (undocumented)
+export const getDetailsColumnStyles: (props: IDetailsColumnStyleProps) => IDetailsColumnStyles;
+
+// @public (undocumented)
+export const getDetailsHeaderStyles: (props: IDetailsHeaderStyleProps) => IDetailsHeaderStyles;
+
+// @public (undocumented)
+export const getDetailsListStyles: (props: IDetailsListStyleProps) => IDetailsListStyles;
+
+// @public (undocumented)
+export const getDetailsRowCheckStyles: (props: IDetailsRowCheckStyleProps) => IDetailsRowCheckStyles;
+
+// @public (undocumented)
 export const getDetailsRowStyles: (props: IDetailsRowStyleProps) => IDetailsRowStyles;
 
 // @public
@@ -1397,6 +1412,9 @@ export function getResponsiveMode(currentWindow: Window | undefined): Responsive
 
 // @public
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
+
+// @public (undocumented)
+export const getShimmeredDetailsListStyles: (props: Required<Pick<import("./ShimmeredDetailsList.types").IShimmeredDetailsListProps, "theme">>) => IShimmeredDetailsListStyles;
 
 // @public (undocumented)
 export const getSplitButtonClassNames: (styles: IButtonStyles, disabled: boolean, expanded: boolean, checked: boolean, primaryDisabled?: boolean | undefined) => ISplitButtonClassNames;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -15,5 +15,12 @@ export * from './DetailsRowCheck.types';
 export * from './DetailsRowFields';
 export * from './DetailsRowFields.types';
 export * from './DetailsFooter.types';
+export * from './DetailsColumn';
 export * from './DetailsColumn.base';
 export * from './DetailsColumn.types';
+
+export { getStyles as getDetailsColumnStyles } from './DetailsColumn.styles';
+export { getStyles as getDetailsHeaderStyles } from './DetailsHeader.styles';
+export { getStyles as getDetailsListStyles } from './DetailsList.styles';
+export { getStyles as getDetailsRowCheckStyles } from './DetailsRowCheck.styles';
+export { getStyles as getShimmeredDetailsListStyles } from './ShimmeredDetailsList.styles';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

This change was done previously in v8, but differently because implicit exports were disabled. https://github.com/GeoffCoxMSFT/fluentui/commit/f43f5fa45ce881e096177e26f54072a7a2a562d5

## Changes
- added top-level export of DetailsColumn getStyles as getDetailsColumnStyles
- added top-level export of DetailsHeader getStyles as getDetailsHeaderStyles
- added top-level export of DetailsList getStyles as getDetailsListStyles
- added top-level export of DetailsRow getStyles as getDetailsRowCheckStyles
- added top-level export of ShimmeredDetailsList getStyles as getShimmeredDetailsListStyles


## Issues
Fixes #24455