### PR TITLE
Added exports for ContextualMenu getItemStyles and getItemClassNames to v8

### DIFF
--- a/change/@fluentui-react-7370dc1e-3d86-49b6-9e76-0a971d251bfa.json
+++ b/change/@fluentui-react-7370dc1e-3d86-49b6-9e76-0a971d251bfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added exports for ContextualMenu getItemStyles and getItemClassNames",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1719,6 +1719,14 @@ export function getColorFromRGBA(rgba: IRGB): IColor;
 // @public
 export function getColorFromString(inputColor: string): IColor | undefined;
 
+// Warning: (ae-internal-missing-underscore) The name "getContextualMenuItemClassNames" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal @deprecated (undocumented)
+export const getContextualMenuItemClassNames: (theme: ITheme, disabled: boolean, expanded: boolean, checked: boolean, isAnchorLink: boolean, knownIcon: boolean, itemClassName?: string | undefined, dividerClassName?: string | undefined, iconClassName?: string | undefined, subMenuClassName?: string | undefined, primaryDisabled?: boolean | undefined, className?: string | undefined) => IContextualMenuItemStyles;
+
+// @public
+export const getContextualMenuItemStyles: (props: IContextualMenuItemStyleProps) => IContextualMenuItemStyles;
+
 // @public (undocumented)
 export function getContrastRatio(color1: IColor, color2: IColor): number;
 

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1725,6 +1725,12 @@ export function getColorFromRGBA(rgba: IRGB): IColor;
 // @public
 export function getColorFromString(inputColor: string): IColor | undefined;
 
+// @public (undocumented)
+export const getCommandBarStyles: (props: ICommandBarStyleProps) => ICommandBarStyles;
+
+// @public (undocumented)
+export const getCommandButtonStyles: (customStyles: IButtonStyles | undefined) => IButtonStyles;
+
 // Warning: (ae-internal-missing-underscore) The name "getContextualMenuItemClassNames" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal @deprecated (undocumented)
@@ -1732,12 +1738,6 @@ export const getContextualMenuItemClassNames: (theme: ITheme, disabled: boolean,
 
 // @public
 export const getContextualMenuItemStyles: (props: IContextualMenuItemStyleProps) => IContextualMenuItemStyles;
-
-// @public (undocumented)
-export const getCommandBarStyles: (props: ICommandBarStyleProps) => ICommandBarStyles;
-
-// @public (undocumented)
-export const getCommandButtonStyles: (customStyles: IButtonStyles | undefined) => IButtonStyles;
 
 // @public (undocumented)
 export function getContrastRatio(color1: IColor, color2: IColor): number;

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -235,7 +235,7 @@ export const getItemClassNames = memoizeFunction(
  * the getStyles API, but invokes memoized className generator function with
  * primitive values.
  *
- * @param props the ContextualMenuItem style props used to generate its styles.
+ * @param props - the ContextualMenuItem style props used to generate its styles.
  */
 export const getItemStyles = (props: IContextualMenuItemStyleProps): IContextualMenuItemStyles => {
   const {

--- a/packages/react/src/components/ContextualMenu/index.ts
+++ b/packages/react/src/components/ContextualMenu/index.ts
@@ -5,5 +5,10 @@ export * from './ContextualMenuItem';
 export * from './ContextualMenuItem.base';
 export * from './ContextualMenuItem.types';
 export { getMenuItemStyles } from './ContextualMenu.cnstyles';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  getItemClassNames as getContextualMenuItemClassNames,
+  getItemStyles as getContextualMenuItemStyles,
+} from './ContextualMenu.classNames';
 // eslint-disable-next-line deprecation/deprecation
 export type { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level export of ContextualMenu getItemStyles as getContextualMenuItemStyles
- added top-level export of ContextualMenu getItemClassNames as getContextualMenuItemClassNames

## Issues
Updates #24454

To be cherry picked to 7.0 branch.