### PR TITLE
Export layer notification methods in v8

### DIFF
--- a/change/@fluentui-react-7043e19d-280f-4044-a4f6-4b85b0cde742.json
+++ b/change/@fluentui-react-7043e19d-280f-4044-a4f6-4b85b0cde742.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added layer notification exports",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1810,6 +1810,18 @@ export { getLastFocusable }
 export { getLastTabbable }
 
 // @public
+export function getLayerCount(hostId: string): number;
+
+// @public
+export function getLayerHost(hostId: string): ILayerHost | undefined;
+
+// @public
+export function getLayerHostSelector(): string | undefined;
+
+// @public (undocumented)
+export const getLayerStyles: (props: ILayerStyleProps) => ILayerStyles;
+
+// @public
 export function getMaxHeight(target: Element | MouseEvent | Point | Rectangle, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
 
 // @public
@@ -9887,6 +9899,9 @@ export class NormalPeoplePickerBase extends BasePeoplePicker {
     };
 }
 
+// @public
+export function notifyHostChanged(id: string): void;
+
 export { noWrap }
 
 export { nullRender }
@@ -10299,6 +10314,12 @@ export { registerDefaultFontFaces }
 export { registerIconAlias }
 
 export { registerIcons }
+
+// @public
+export function registerLayer(hostId: string, callback: () => void): void;
+
+// @public
+export function registerLayerHost(hostId: string, layerHost: ILayerHost): void;
 
 export { registerOnThemeChangeCallback }
 
@@ -11185,6 +11206,12 @@ export { trProperties }
 export { unhoistMethods }
 
 export { unregisterIcons }
+
+// @public
+export function unregisterLayer(hostId: string, callback: () => void): void;
+
+// @public
+export function unregisterLayerHost(hostId: string, layerHost: ILayerHost): void;
 
 // @public
 export function updateA(color: IColor, a: number): IColor;

--- a/packages/react/src/components/Layer/Layer.notification.ts
+++ b/packages/react/src/components/Layer/Layer.notification.ts
@@ -8,8 +8,8 @@ let _defaultHostSelector: string | undefined = `#${defaultHostId}`;
 
 /**
  * Register a layer for a given host id
- * @param hostId Id of the layer host
- * @param layer Layer instance
+ * @param hostId - Id of the layer host
+ * @param layer - Layer instance
  */
 export function registerLayer(hostId: string, callback: () => void) {
   if (!_layersByHostId[hostId]) {
@@ -29,8 +29,8 @@ export function registerLayer(hostId: string, callback: () => void) {
 
 /**
  * Unregister a layer for a given host id
- * @param hostId Id of the layer host
- * @param layer Layer instance
+ * @param hostId - Id of the layer host
+ * @param layer - Layer instance
  */
 export function unregisterLayer(hostId: string, callback: () => void) {
   const layers = _layersByHostId[hostId];
@@ -57,7 +57,7 @@ export function unregisterLayer(hostId: string, callback: () => void) {
 
 /**
  * Gets the number of layers currently registered with a host id.
- * @param hostId Id of the layer host.
+ * @param hostId - Id of the layer host.
  * @returns The number of layers currently registered with the host.
  */
 export function getLayerCount(hostId: string): number {
@@ -68,7 +68,7 @@ export function getLayerCount(hostId: string): number {
 
 /**
  * Gets the Layer Host instance associated with a hostId, if applicable.
- * @param hostId
+ * @param hostId - Id of the layer host
  * @returns A component ref for the associated layer host.
  */
 export function getLayerHost(hostId: string): ILayerHost | undefined {
@@ -79,8 +79,8 @@ export function getLayerHost(hostId: string): ILayerHost | undefined {
 
 /**
  * Registers a Layer Host with an associated hostId.
- * @param hostId Id of the layer host
- * @param layerHost layer host instance
+ * @param hostId - Id of the layer host
+ * @param layerHost - layer host instance
  */
 export function registerLayerHost(hostId: string, layerHost: ILayerHost): void {
   const layerHosts = _layerHostsById[hostId] || (_layerHostsById[hostId] = []);
@@ -94,8 +94,8 @@ export function registerLayerHost(hostId: string, layerHost: ILayerHost): void {
 
 /**
  * Unregisters a Layer Host from the associated hostId.
- * @param hostId Id of the layer host
- * @param layerHost layer host instance
+ * @param hostId - Id of the layer host
+ * @param layerHost - layer host instance
  */
 export function unregisterLayerHost(hostId: string, layerHost: ILayerHost): void {
   const layerHosts = _layerHostsById[hostId];

--- a/packages/react/src/components/Layer/index.ts
+++ b/packages/react/src/components/Layer/index.ts
@@ -3,4 +3,17 @@ export * from './Layer.base';
 export * from './Layer.types';
 export * from './LayerHost';
 export * from './LayerHost.types';
-export { createDefaultLayerHost, cleanupDefaultLayerHost, setDefaultTarget as setLayerHostSelector } from './Layer.notification';
+export {
+  createDefaultLayerHost,
+  cleanupDefaultLayerHost,
+  getDefaultTarget as getLayerHostSelector,
+  getLayerCount,
+  getLayerHost,
+  notifyHostChanged,
+  registerLayer,
+  registerLayerHost,
+  setDefaultTarget as setLayerHostSelector,
+  unregisterLayer,
+  unregisterLayerHost,
+} from './Layer.notification';
+export { getStyles as getLayerStyles } from './Layer.styles';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level export of Layer notification methods
- added top-level export of Layer getStyles as getLayerStyles

## Issues
Updates #24456