### PR TITLE
docs(v8): usage of placeholder images now link to correct https protocol

### DIFF
--- a/packages/react-examples/src/react/Announced/Announced.LazyLoading.Example.tsx
+++ b/packages/react-examples/src/react/Announced/Announced.LazyLoading.Example.tsx
@@ -48,7 +48,7 @@ export const AnnouncedLazyLoadingExample = () => {
     const width = 100;
     const height = 100;
     return createArray(PHOTO_COUNT, () => ({
-      url: `http://via.placeholder.com/${width}x${height}`,
+      url: `https://via.placeholder.com/${width}x${height}`,
       width,
       height,
     }));

--- a/packages/react-examples/src/react/Image/Image.Center.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Center.Example.tsx
@@ -21,7 +21,7 @@ export const ImageCenterExample = () => {
       <p>This image is larger than the frame, so all sides are cropped to center the image.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/800x300"
+        src="https://via.placeholder.com/800x300"
         alt='Example of the image fit value "center" on an image larger than the frame.'
       />
       <p>
@@ -30,7 +30,7 @@ export const ImageCenterExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/100x100"
+        src="https://via.placeholder.com/100x100"
         alt='Example of the image fit value "center" on an image smaller than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/Image/Image.CenterContain.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.CenterContain.Example.tsx
@@ -22,32 +22,32 @@ export const ImageCenterContainExample = () => {
       <p>This image is smaller than the frame, so it's centered and rendered at its natural size.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/100x150"
+        src="https://via.placeholder.com/100x150"
         alt='Example of the image fit value "centerContain" on an image smaller than the frame.'
       />
       <p>This image is wider than the frame, so it's contained.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/300x100"
+        src="https://via.placeholder.com/300x100"
         alt='Example of the image fit value "centerContain" on an image wider than the frame.'
       />
       <p>This image is taller than the frame, so it's contained.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/100x300"
+        src="https://via.placeholder.com/100x300"
         alt='Example of the image fit value "centerContain" on an image taller than the frame.'
       />
       <p>These images are taller and wider than the frame, so they are contained.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/400x500"
+        src="https://via.placeholder.com/400x500"
         alt='Example of the image fit value "centerContain" on an image taller and wider than the frame.'
       />
       <br />
       <br />
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/500x400"
+        src="https://via.placeholder.com/500x400"
         alt='Example of the image fit value "centerContain" on an image taller and wider than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/Image/Image.CenterCover.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.CenterCover.Example.tsx
@@ -22,7 +22,7 @@ export const ImageCenterCoverExample = () => {
       <p>This image is smaller than the frame, so it's centered and rendered at its natural size.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/100x150"
+        src="https://via.placeholder.com/100x150"
         alt='Example of the image fit value "centerCover" on an image smaller than the frame.'
       />
       <p>
@@ -31,7 +31,7 @@ export const ImageCenterCoverExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/300x100"
+        src="https://via.placeholder.com/300x100"
         alt='Example of the image fit value "centerCover" on an image wider than the frame.'
       />
       <p>
@@ -40,20 +40,20 @@ export const ImageCenterCoverExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/100x300"
+        src="https://via.placeholder.com/100x300"
         alt='Example of the image fit value "centerCover" on an image taller than the frame.'
       />
       <p>These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/400x500"
+        src="https://via.placeholder.com/400x500"
         alt='Example of the image fit value "centerCover" on an image taller and wider than the frame.'
       />
       <br />
       <br />
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/500x400"
+        src="https://via.placeholder.com/500x400"
         alt='Example of the image fit value "centerCover" on an image taller and wider than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/Image/Image.Contain.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Contain.Example.tsx
@@ -5,7 +5,7 @@ import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
 // Normally specifying them inline would be fine.
 const imageProps: IImageProps = {
   imageFit: ImageFit.contain,
-  src: 'http://via.placeholder.com/700x300',
+  src: 'https://via.placeholder.com/700x300',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.Cover.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Cover.Example.tsx
@@ -5,7 +5,7 @@ import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
 // Normally specifying them inline would be fine.
 const imageProps: IImageProps = {
   imageFit: ImageFit.cover,
-  src: 'http://via.placeholder.com/500x500',
+  src: 'https://via.placeholder.com/600x600',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.Default.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Default.Example.tsx
@@ -4,7 +4,7 @@ import { Image, IImageProps } from '@fluentui/react/lib/Image';
 // These props are defined up here so they can easily be applied to multiple Images.
 // Normally specifying them inline would be fine.
 const imageProps: Partial<IImageProps> = {
-  src: 'http://via.placeholder.com/350x150',
+  src: 'https://via.placeholder.com/350x150',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.MaximizeFrame.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.MaximizeFrame.Example.tsx
@@ -6,7 +6,7 @@ import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
 const imageProps: IImageProps = {
   maximizeFrame: true,
   imageFit: ImageFit.cover,
-  src: 'http://via.placeholder.com/500x500',
+  src: 'https://via.placeholder.com/600x600',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.None.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.None.Example.tsx
@@ -21,7 +21,7 @@ export const ImageNoneExample = () => {
       <p>This image is larger than the frame, so it's cropped to fit and positioned at the upper left.</p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/500x250"
+        src="https://via.placeholder.com/500x250"
         alt='Example of the image fit value "none" on an image larger than the frame.'
       />
       <p>
@@ -30,7 +30,7 @@ export const ImageNoneExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="http://via.placeholder.com/100x100"
+        src="https://via.placeholder.com/100x100"
         alt='Example of the image fit value "none" on an image smaller than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/MarqueeSelection/MarqueeSelection.Basic.Example.tsx
+++ b/packages/react-examples/src/react/MarqueeSelection/MarqueeSelection.Basic.Example.tsx
@@ -15,7 +15,7 @@ const PHOTOS: IPhoto[] = createArray(250, (index: number) => {
   const randomWidth = 50 + Math.floor(Math.random() * 150);
   return {
     key: index,
-    url: `http://via.placeholder.com/${randomWidth}x100`,
+    url: `https://via.placeholder.com/${randomWidth}x100`,
     width: randomWidth,
     height: 100,
   };

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.Illustration.Example.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.Illustration.Example.tsx
@@ -4,7 +4,7 @@ import { DefaultButton, IButtonProps } from '@fluentui/react/lib/Button';
 import { TeachingBubble } from '@fluentui/react/lib/TeachingBubble';
 import { useBoolean, useId } from '@fluentui/react-hooks';
 
-const exampleImageProps: IImageProps = { src: 'http://via.placeholder.com/364x180', alt: 'Example placeholder image' };
+const exampleImageProps: IImageProps = { src: 'https://via.placeholder.com/364x180', alt: 'Example placeholder image' };
 
 const examplePrimaryButtonProps: IButtonProps = {
   children: 'Try it out',

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx
@@ -9,7 +9,7 @@ const examplePrimaryButtonProps: IButtonProps = {
   children: 'Try it out',
 };
 
-const exampleImageProps: IImageProps = { src: 'http://via.placeholder.com/154x220', alt: 'Example placeholder image' };
+const exampleImageProps: IImageProps = { src: 'https://via.placeholder.com/154x220', alt: 'Example placeholder image' };
 
 const CalloutProps = { directionalHint: DirectionalHint.bottomCenter };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Placeholder images dont render:
![image](https://user-images.githubusercontent.com/8649804/186277676-77639f0c-62f0-4203-bc5a-e8b8f55f506e.png)


## New Behavior
- now linked to the correct source using https, placeholder images now render: 
<!-- This is the behavior we should expect with the changes in this PR -->
![image](https://user-images.githubusercontent.com/8649804/186277742-e7c449d8-6963-4f41-8da5-c8dab1471ccc.png)

