### PR TITLE
docs(v8): Modal examples now target header to allow text selection when draggable

### DIFF
--- a/packages/react-examples/src/react/Modal/Modal.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Modal/Modal.Basic.Example.tsx
@@ -25,6 +25,7 @@ export const ModalBasicExample: React.FunctionComponent = () => {
       closeMenuItemText: 'Close',
       menu: ContextualMenu,
       keepInBounds,
+      dragHandleSelector: '.ms-Modal-scrollableContent > div:first-child',
     }),
     [keepInBounds],
   );

--- a/packages/react-examples/src/react/Modal/Modal.Modeless.Example.tsx
+++ b/packages/react-examples/src/react/Modal/Modal.Modeless.Example.tsx
@@ -16,6 +16,7 @@ const dragOptions: IDragOptions = {
   moveMenuItemText: 'Move',
   closeMenuItemText: 'Close',
   menu: ContextualMenu,
+  dragHandleSelector: '.ms-Modal-scrollableContent > div:first-child',
 };
 const cancelIcon: IIconProps = { iconName: 'Cancel' };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
- v8 draggable modal example does not allow for text selection of the body when draggable.

<!-- This is the behavior we have today -->

## New Behavior
- demonstrates how to use the `dragHandleSelector` option to allow custom click targeting of the `Modal` header which enables users to select text when the Modal draggable 

https://user-images.githubusercontent.com/8649804/186278654-73b16d2a-5657-4951-994d-be2b8958c197.mp4


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24469
