### PR TITLE
fix(react-input): Remove box-shadow from Input filled appearances

### DIFF
--- a/change/@fluentui-react-input-b6dae232-bb04-4dcd-90b6-eb9272f009fe.json
+++ b/change/@fluentui-react-input-b6dae232-bb04-4dcd-90b6-eb9272f009fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove box-shadow from input.",
+  "packageName": "@fluentui/react-input",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-b6dae232-bb04-4dcd-90b6-eb9272f009fe.json
+++ b/change/@fluentui-react-input-b6dae232-bb04-4dcd-90b6-eb9272f009fe.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Remove box-shadow from input.",
+  "comment": "fix: Remove box-shadow from filled appearances.",
   "packageName": "@fluentui/react-input",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -144,7 +144,6 @@ const useRootStyles = makeStyles({
     '::after': shorthands.borderRadius(0), // remove rounded corners from focus underline
   },
   filled: {
-    boxShadow: tokens.shadow2, // optional shadow for filled appearances
     ...shorthands.border('1px', 'solid', tokens.colorTransparentStroke),
   },
   filledInteractive: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Input has a box-shadow in filled appearances.

![image](https://user-images.githubusercontent.com/5953191/186278546-c23cba81-3904-4a47-8804-d6dffae7c68d.png)
Note: I've removed the contrasting background and made the label black to differentiate the before and after.

## New Behavior

Input does not have a box-shadow in filled appearances.

![image](https://user-images.githubusercontent.com/5953191/186278425-36e72c1c-9719-4e03-a59c-ad7ff1a8f18b.png)
Note: I've removed the contrasting background and made the label black to differentiate the before and after.

Note: this is the only input control that has this box-shadow, here's a list of the files that have a box-shadow:

![image](https://user-images.githubusercontent.com/5953191/186278250-d489e223-23c0-4172-9ad3-2b30f80e09d0.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24076
