### PR TITLE
update background color for appearance stories and vr tests

### DIFF
--- a/apps/public-docsite-v9/src/shims/ThemeShim/v9ThemeShim.ts
+++ b/apps/public-docsite-v9/src/shims/ThemeShim/v9ThemeShim.ts
@@ -58,6 +58,7 @@ const mapAliasColors = (palette: IPalette, inverted: boolean): ColorTokens => {
     colorNeutralForegroundInvertedLinkHover: palette.white,
     colorNeutralForegroundInvertedLinkPressed: palette.white,
     colorNeutralForegroundInvertedLinkSelected: palette.white,
+    colorNeutralForegroundInverted2: palette.white,
     colorBrandForegroundInverted: palette.themeSecondary,
     colorBrandForegroundInvertedHover: palette.themeTertiary,
     colorBrandForegroundInvertedPressed: palette.themeSecondary,

--- a/change/@fluentui-react-theme-49e830f4-b491-4b83-a28a-2f0df72b97d7.json
+++ b/change/@fluentui-react-theme-49e830f4-b491-4b83-a28a-2f0df72b97d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update color neutral background inverted color in teams dark",
+  "packageName": "@fluentui/react-theme",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-sass-fcd4b7d2-32f5-494a-9bb6-4f79893cd6cf.json
+++ b/change/@fluentui-react-theme-sass-fcd4b7d2-32f5-494a-9bb6-4f79893cd6cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add color neutral foreground inverted 2 token",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxAppearance.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxAppearance.stories.tsx
@@ -22,13 +22,13 @@ const useStyles = makeStyles({
   },
   // filledLighter and filledDarker appearances depend on particular background colors
   filledLighter: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxAppearance.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxAppearance.stories.tsx
@@ -24,13 +24,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
 });

--- a/packages/react-components/react-input/src/stories/Input/InputAppearance.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputAppearance.stories.tsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
 });

--- a/packages/react-components/react-input/src/stories/Input/InputAppearance.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputAppearance.stories.tsx
@@ -14,13 +14,13 @@ const useStyles = makeStyles({
     ...shorthands.padding(tokens.spacingHorizontalMNudge),
   },
   filledLighter: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },

--- a/packages/react-components/react-select/src/stories/Select/SelectAppearance.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectAppearance.stories.tsx
@@ -19,13 +19,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
 });

--- a/packages/react-components/react-select/src/stories/Select/SelectAppearance.stories.tsx
+++ b/packages/react-components/react-select/src/stories/Select/SelectAppearance.stories.tsx
@@ -17,13 +17,13 @@ const useStyles = makeStyles({
   },
 
   filledLighter: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },

--- a/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
@@ -18,13 +18,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInvertedStatic,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInvertedStatic,
     },
   },
 });

--- a/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles({
   },
 
   filledLighter: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },

--- a/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
@@ -18,13 +18,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInvertedStatic,
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInvertedStatic,
+      color: tokens.colorNeutralForegroundInverted,
     },
   },
 });

--- a/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
+++ b/packages/react-components/react-spinbutton/src/stories/SpinButton/SpinButtonAppearance.stories.tsx
@@ -18,13 +18,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
 });

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaAppearance.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaAppearance.stories.tsx
@@ -21,13 +21,13 @@ const useStyles = makeStyles({
   filledLighter: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
   filledDarker: {
     backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
-      color: tokens.colorNeutralForegroundInverted,
+      color: tokens.colorNeutralForegroundInverted2,
     },
   },
 });

--- a/packages/react-components/react-textarea/src/stories/Textarea/TextareaAppearance.stories.tsx
+++ b/packages/react-components/react-textarea/src/stories/Textarea/TextareaAppearance.stories.tsx
@@ -19,13 +19,13 @@ const useStyles = makeStyles({
     },
   },
   filledLighter: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },
   },
   filledDarker: {
-    backgroundColor: tokens.colorPaletteBerryForeground1,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
     '> label': {
       color: tokens.colorNeutralForegroundInverted,
     },

--- a/packages/react-components/react-theme-sass/sass/colorTokens.scss
+++ b/packages/react-components/react-theme-sass/sass/colorTokens.scss
@@ -37,6 +37,7 @@ $colorNeutralForegroundInverted: var(--colorNeutralForegroundInverted);
 $colorNeutralForegroundInvertedHover: var(--colorNeutralForegroundInvertedHover);
 $colorNeutralForegroundInvertedPressed: var(--colorNeutralForegroundInvertedPressed);
 $colorNeutralForegroundInvertedSelected: var(--colorNeutralForegroundInvertedSelected);
+$colorNeutralForegroundInverted2: var(--colorNeutralForegroundInverted2);
 $colorNeutralForegroundOnBrand: var(--colorNeutralForegroundOnBrand);
 $colorNeutralForegroundStaticInverted: var(--colorNeutralForegroundStaticInverted);
 $colorNeutralForegroundInvertedLink: var(--colorNeutralForegroundInvertedLink);

--- a/packages/react-components/react-theme/etc/react-theme.api.md
+++ b/packages/react-components/react-theme/etc/react-theme.api.md
@@ -169,6 +169,7 @@ export type ColorTokens = {
     colorNeutralForegroundInvertedHover: string;
     colorNeutralForegroundInvertedPressed: string;
     colorNeutralForegroundInvertedSelected: string;
+    colorNeutralForegroundInverted2: string;
     colorNeutralForegroundOnBrand: string;
     colorNeutralForegroundStaticInverted: string;
     colorNeutralForegroundInvertedLink: string;

--- a/packages/react-components/react-theme/src/alias/darkColor.ts
+++ b/packages/react-components/react-theme/src/alias/darkColor.ts
@@ -45,6 +45,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorNeutralForegroundInvertedHover: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedPressed: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedSelected: grey[14], // #242424 Global.Color.Grey.14
+  colorNeutralForegroundInverted2: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundOnBrand: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedLink: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedLinkHover: white, // #ffffff Global.Color.White

--- a/packages/react-components/react-theme/src/alias/highContrastColor.ts
+++ b/packages/react-components/react-theme/src/alias/highContrastColor.ts
@@ -51,10 +51,11 @@ export const generateColorTokens = (): ColorTokens => ({
   colorBrandForeground2: hcButtonText, // ButtonText Global.Color.hcButtonText
   colorNeutralForeground1Static: hcCanvas, // Canvas Global.Color.hcCanvas
   colorNeutralForegroundStaticInverted: hcCanvasText, // CanvasText Global.Color.hcCanvasText
-  colorNeutralForegroundInverted: hcCanvasText, // CanvasText Global.Color.hcCanvasText
-  colorNeutralForegroundInvertedHover: hcCanvasText, // CanvasText Global.Color.hcCanvasText
-  colorNeutralForegroundInvertedPressed: hcCanvasText, // CanvasText Global.Color.hcCanvasText
-  colorNeutralForegroundInvertedSelected: hcCanvasText, // CanvasText Global.Color.hcCanvasText
+  colorNeutralForegroundInverted: hcHighlightText, // HighlightText Global.Color.hcHighlightText
+  colorNeutralForegroundInvertedHover: hcHighlightText, // HighlightText Global.Color.hcHighlightText
+  colorNeutralForegroundInvertedPressed: hcHighlightText, // HighlightText Global.Color.hcHighlightText
+  colorNeutralForegroundInvertedSelected: hcHighlightText, // HighlightText Global.Color.hcHighlightText
+  colorNeutralForegroundInverted2: hcCanvasText, // CanvasText Global.Color.hcCanvasText
   colorNeutralForegroundOnBrand: hcButtonText, // ButtonText Global.Color.hcButtonText
   colorNeutralForegroundInvertedLink: hcHyperlink, // LinkText Global.Color.hcHyperlink
   colorNeutralForegroundInvertedLinkHover: hcHyperlink, // LinkText Global.Color.hcHyperlink

--- a/packages/react-components/react-theme/src/alias/highContrastColor.ts
+++ b/packages/react-components/react-theme/src/alias/highContrastColor.ts
@@ -51,10 +51,10 @@ export const generateColorTokens = (): ColorTokens => ({
   colorBrandForeground2: hcButtonText, // ButtonText Global.Color.hcButtonText
   colorNeutralForeground1Static: hcCanvas, // Canvas Global.Color.hcCanvas
   colorNeutralForegroundStaticInverted: hcCanvasText, // CanvasText Global.Color.hcCanvasText
-  colorNeutralForegroundInverted: hcHighlightText, // HighlightText Global.Color.hcHighlightText
-  colorNeutralForegroundInvertedHover: hcHighlightText, // HighlightText Global.Color.hcHighlightText
-  colorNeutralForegroundInvertedPressed: hcHighlightText, // HighlightText Global.Color.hcHighlightText
-  colorNeutralForegroundInvertedSelected: hcHighlightText, // HighlightText Global.Color.hcHighlightText
+  colorNeutralForegroundInverted: hcCanvasText, // CanvasText Global.Color.hcCanvasText
+  colorNeutralForegroundInvertedHover: hcCanvasText, // CanvasText Global.Color.hcCanvasText
+  colorNeutralForegroundInvertedPressed: hcCanvasText, // CanvasText Global.Color.hcCanvasText
+  colorNeutralForegroundInvertedSelected: hcCanvasText, // CanvasText Global.Color.hcCanvasText
   colorNeutralForegroundOnBrand: hcButtonText, // ButtonText Global.Color.hcButtonText
   colorNeutralForegroundInvertedLink: hcHyperlink, // LinkText Global.Color.hcHyperlink
   colorNeutralForegroundInvertedLinkHover: hcHyperlink, // LinkText Global.Color.hcHyperlink

--- a/packages/react-components/react-theme/src/alias/lightColor.ts
+++ b/packages/react-components/react-theme/src/alias/lightColor.ts
@@ -45,6 +45,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorNeutralForegroundInvertedHover: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedPressed: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedSelected: white, // #ffffff Global.Color.White
+  colorNeutralForegroundInverted2: white, // #ffffff Global.Color.White
   colorNeutralForegroundOnBrand: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedLink: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedLinkHover: white, // #ffffff Global.Color.White

--- a/packages/react-components/react-theme/src/alias/teamsDarkColor.ts
+++ b/packages/react-components/react-theme/src/alias/teamsDarkColor.ts
@@ -45,6 +45,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorNeutralForegroundInvertedHover: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedPressed: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedSelected: grey[14], // #242424 Global.Color.Grey.14
+  colorNeutralForegroundInverted2: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundOnBrand: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedLink: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedLinkHover: white, // #ffffff Global.Color.White

--- a/packages/react-components/react-theme/src/tokens.ts
+++ b/packages/react-components/react-theme/src/tokens.ts
@@ -38,6 +38,7 @@ export const tokens: Record<keyof Theme, string> = {
   colorNeutralForegroundInvertedHover: 'var(--colorNeutralForegroundInvertedHover)',
   colorNeutralForegroundInvertedPressed: 'var(--colorNeutralForegroundInvertedPressed)',
   colorNeutralForegroundInvertedSelected: 'var(--colorNeutralForegroundInvertedSelected)',
+  colorNeutralForegroundInverted2: 'var(--colorNeutralForegroundInverted2)',
   colorNeutralForegroundStaticInverted: 'var(--colorNeutralForegroundStaticInverted)',
   colorNeutralForegroundInvertedLink: 'var(--colorNeutralForegroundInvertedLink)',
   colorNeutralForegroundInvertedLinkHover: 'var(--colorNeutralForegroundInvertedLinkHover)',

--- a/packages/react-components/react-theme/src/types.ts
+++ b/packages/react-components/react-theme/src/types.ts
@@ -43,6 +43,7 @@ export type ColorTokens = {
   colorNeutralForegroundInvertedHover: string;
   colorNeutralForegroundInvertedPressed: string;
   colorNeutralForegroundInvertedSelected: string;
+  colorNeutralForegroundInverted2: string;
   colorNeutralForegroundOnBrand: string;
   colorNeutralForegroundStaticInverted: string;
   colorNeutralForegroundInvertedLink: string;


### PR DESCRIPTION
## Current Behavior

"Appearance" stories and one VR test use a foreground color for backgrounds. This was done to achieve sufficient color contrast to meet WCAG guidance.

## New Behavior

All instances now use a background color and still meet WCAG guidance.

## Related Issue(s)

Fixes #24328
