### PR TITLE
Added exports from Layer notification for v7

### DIFF
--- a/change/office-ui-fabric-react-e8c0506d-254b-4a43-9ea7-0fcbf01c98c2.json
+++ b/change/office-ui-fabric-react-e8c0506d-254b-4a43-9ea7-0fcbf01c98c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added exports from Layer",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1386,6 +1386,18 @@ export const getIconContent: (iconName?: string | undefined) => IIconContent | n
 export function getInitialResponsiveMode(): ResponsiveMode;
 
 // @public
+export function getLayerCount(hostId: string): number;
+
+// @public
+export function getLayerHost(hostId: string): ILayerHost | undefined;
+
+// @public
+export function getLayerHostSelector(): string | undefined;
+
+// @public (undocumented)
+export const getLayerStyles: (props: ILayerStyleProps) => ILayerStyles;
+
+// @public
 export function getMaxHeight(target: Element | MouseEvent | Point | Rectangle, targetEdge: DirectionalHint, gapSpace?: number, bounds?: IRectangle, coverTarget?: boolean): number;
 
 // @public
@@ -5723,6 +5735,19 @@ export type ILayerBaseState = {
     layerElement?: HTMLElement;
 };
 
+// @public
+export interface ILayerHost {
+    hostId: string;
+    notifyLayersChanged(): void;
+    rootRef: React.RefObject<HTMLDivElement | null>;
+}
+
+// @public (undocumented)
+export interface ILayerHostProps extends React.HTMLAttributes<HTMLElement> {
+    componentRef?: IRefObject<ILayerHost>;
+    id?: string;
+}
+
 // @public (undocumented)
 export interface ILayerProps extends React.HTMLAttributes<HTMLDivElement | LayerBase> {
     className?: string;
@@ -8824,9 +8849,6 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     render(): React.ReactNode;
     }
 
-// Warning: (ae-forgotten-export) The symbol "ILayerHostProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ILayerHost" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export class LayerHost extends React.Component<ILayerHostProps> implements ILayerHost {
     constructor(props: ILayerHostProps);
@@ -9056,6 +9078,9 @@ export class NormalPeoplePickerBase extends BasePeoplePicker {
         createGenericItem: typeof createGenericItem;
     };
 }
+
+// @public
+export function notifyHostChanged(id: string): void;
 
 // @public @deprecated (undocumented)
 export type OnChangeCallback = IChoiceGroupOptionProps['onChange'];
@@ -9522,6 +9547,12 @@ export enum RectangleEdge {
     top = 1
 }
 
+// @public
+export function registerLayer(hostId: string, callback: () => void): void;
+
+// @public
+export function registerLayerHost(hostId: string, layerHost: ILayerHost): void;
+
 // @public (undocumented)
 export const ResizeGroup: typeof ResizeGroupBase;
 
@@ -9747,6 +9778,9 @@ export const SeparatorBase: React.FunctionComponent<ISeparatorProps>;
 
 // @public
 export function sequencesToID(keySequences: string[]): string;
+
+// @public
+export function setLayerHostSelector(selector?: string): void;
 
 // @public
 export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): void;
@@ -10393,6 +10427,12 @@ export function transitionKeysAreEqual(key1: IKeytipTransitionKey, key2: IKeytip
 
 // @public
 export function transitionKeysContain(keys: IKeytipTransitionKey[], key: IKeytipTransitionKey): boolean;
+
+// @public
+export function unregisterLayer(hostId: string, callback: () => void): void;
+
+// @public
+export function unregisterLayerHost(hostId: string, layerHost: ILayerHost): void;
 
 // @public
 export function updateA(color: IColor, a: number): IColor;

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.notification.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.notification.ts
@@ -7,8 +7,8 @@ let _defaultHostSelector: string | undefined;
 
 /**
  * Register a layer for a given host id
- * @param hostId Id of the layer host
- * @param layer Layer instance
+ * @param hostId - Id of the layer host
+ * @param layer - Layer instance
  */
 export function registerLayer(hostId: string, callback: () => void) {
   if (!_layersByHostId[hostId]) {
@@ -28,8 +28,8 @@ export function registerLayer(hostId: string, callback: () => void) {
 
 /**
  * Unregister a layer for a given host id
- * @param hostId Id of the layer host
- * @param layer Layer instance
+ * @param hostId - Id of the layer host
+ * @param layer - Layer instance
  */
 export function unregisterLayer(hostId: string, callback: () => void) {
   const layers = _layersByHostId[hostId];
@@ -56,7 +56,7 @@ export function unregisterLayer(hostId: string, callback: () => void) {
 
 /**
  * Gets the number of layers currently registered with a host id.
- * @param hostId Id of the layer host.
+ * @param hostId - Id of the layer host.
  * @returns The number of layers currently registered with the host.
  */
 export function getLayerCount(hostId: string): number {
@@ -67,7 +67,7 @@ export function getLayerCount(hostId: string): number {
 
 /**
  * Gets the Layer Host instance associated with a hostId, if applicable.
- * @param hostId
+ * @param hostId - Id of the layer host.
  * @returns A component ref for the associated layer host.
  */
 export function getLayerHost(hostId: string): ILayerHost | undefined {
@@ -78,8 +78,8 @@ export function getLayerHost(hostId: string): ILayerHost | undefined {
 
 /**
  * Registers a Layer Host with an associated hostId.
- * @param hostId Id of the layer host
- * @param layerHost layer host instance
+ * @param hostId - Id of the layer host
+ * @param layerHost - layer host instance
  */
 export function registerLayerHost(hostId: string, layerHost: ILayerHost): void {
   const layerHosts = _layerHostsById[hostId] || (_layerHostsById[hostId] = []);
@@ -93,8 +93,8 @@ export function registerLayerHost(hostId: string, layerHost: ILayerHost): void {
 
 /**
  * Unregisters a Layer Host from the associated hostId.
- * @param hostId Id of the layer host
- * @param layerHost layer host instance
+ * @param hostId - Id of the layer host
+ * @param layerHost - layer host instance
  */
 export function unregisterLayerHost(hostId: string, layerHost: ILayerHost): void {
   const layerHosts = _layerHostsById[hostId];
@@ -118,7 +118,7 @@ export function unregisterLayerHost(hostId: string, layerHost: ILayerHost): void
  */
 export function notifyHostChanged(id: string) {
   if (_layersByHostId[id]) {
-    _layersByHostId[id].forEach((callback) => callback());
+    _layersByHostId[id].forEach(callback => callback());
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/Layer/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/index.ts
@@ -2,3 +2,16 @@ export * from './Layer';
 export * from './Layer.base';
 export * from './Layer.types';
 export * from './LayerHost';
+export * from './LayerHost.types';
+export {
+  getDefaultTarget as getLayerHostSelector,
+  getLayerCount,
+  getLayerHost,
+  notifyHostChanged,
+  registerLayer,
+  registerLayerHost,
+  setDefaultTarget as setLayerHostSelector,
+  unregisterLayer,
+  unregisterLayerHost,
+} from './Layer.notification';
+export { getStyles as getLayerStyles } from './Layer.styles';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level export of Layer notification methods
- added top-level export of Layer getStyles as getLayerStyles

## Issues
Fixes #24456