### PR TITLE
Cherry pick fix line order in line chart as per legends

### DIFF
--- a/change/@uifabric-charting-6d7a4b95-c260-49c4-ab19-ef3c2ae1013b.json
+++ b/change/@uifabric-charting-6d7a4b95-c260-49c4-ab19-ef3c2ae1013b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update line chart legend order",
+  "packageName": "@uifabric/charting",
+  "email": "atishay.jain@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -487,7 +487,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     } else {
       this._points = this._injectIndexPropertyInLineChartData(this.props.data.lineChartData);
     }
-    for (let i = 0; i < this._points.length; i++) {
+    for (let i = this._points.length - 1; i >= 0; i--) {
       const linesForLine: JSX.Element[] = [];
       const bordersForLine: JSX.Element[] = [];
       const pointsForLine: JSX.Element[] = [];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Order of lines in line chart is not correct. The last line in order of legend appears on top of other lines.

## New Behavior

Lines appear in same order as that of legends. Lines in beginning of legend are on top of subsequent lines in the legend.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
