### PR TITLE
fix(react-theme): Swap Background1 and Foreground1 in HC color palette

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
@@ -8,7 +8,7 @@ import { TestWrapperDecoratorNoAnimation } from '../utilities/TestWrapperDecorat
 // or photo. This wrapper ensures a dark background so the Spinners
 // are consistently visible.
 const InvertedWrapper: React.FC = ({ children }) => {
-  return <div style={{ background: tokens.colorPaletteBerryForeground1, padding: '10px' }}>{children}</div>;
+  return <div style={{ background: tokens.colorBrandBackgroundStatic, padding: '10px' }}>{children}</div>;
 };
 
 storiesOf('Spinner converged', module)

--- a/change/@fluentui-react-theme-98ccbaf6-2736-430a-b1d6-8a28818a2bc4.json
+++ b/change/@fluentui-react-theme-98ccbaf6-2736-430a-b1d6-8a28818a2bc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Swap Background1 and Foreground1 in HC color palette",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinner/src/stories/Spinner/SpinnerAppearance.stories.tsx
+++ b/packages/react-components/react-spinner/src/stories/Spinner/SpinnerAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Spinner } from '@fluentui/react-components';
+import { makeStyles, shorthands, Spinner, tokens } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -9,7 +9,7 @@ const useStyles = makeStyles({
   // Inverted Spinners are meant as overlays (e.g., over an image or similar)
   // so give it a solid, dark background so it is visible in all themes.
   invertedWrapper: {
-    backgroundColor: '#af33a1',
+    backgroundColor: tokens.colorBrandBackgroundStatic,
   },
 });
 

--- a/packages/react-components/react-theme/src/alias/highContrastColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/highContrastColorPalette.ts
@@ -1,19 +1,19 @@
-import { hcHighlight, white, black } from '../global/colors';
+import { hcHighlight, hcCanvas, hcCanvasText } from '../global/colors';
 import { statusSharedColorNames, personaSharedColorNames } from '../sharedColorNames';
 import { ColorPaletteTokens, PersonaColorPaletteTokens, StatusColorPaletteTokens } from '../types';
 
 const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor) => {
   const color = sharedColor.slice(0, 1).toUpperCase() + sharedColor.slice(1);
   const sharedColorTokens = {
-    [`colorPalette${color}Background1`]: white,
-    [`colorPalette${color}Background2`]: black,
-    [`colorPalette${color}Background3`]: white,
-    [`colorPalette${color}Foreground1`]: black,
-    [`colorPalette${color}Foreground2`]: white,
-    [`colorPalette${color}Foreground3`]: white,
+    [`colorPalette${color}Background1`]: hcCanvas,
+    [`colorPalette${color}Background2`]: hcCanvas,
+    [`colorPalette${color}Background3`]: hcCanvasText,
+    [`colorPalette${color}Foreground1`]: hcCanvasText,
+    [`colorPalette${color}Foreground2`]: hcCanvasText,
+    [`colorPalette${color}Foreground3`]: hcCanvasText,
     [`colorPalette${color}BorderActive`]: hcHighlight,
-    [`colorPalette${color}Border1`]: white,
-    [`colorPalette${color}Border2`]: white,
+    [`colorPalette${color}Border1`]: hcCanvasText,
+    [`colorPalette${color}Border2`]: hcCanvasText,
   };
 
   return { ...acc, ...sharedColorTokens };
@@ -22,8 +22,8 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
   const color = sharedColor.slice(0, 1).toUpperCase() + sharedColor.slice(1);
   const sharedColorTokens = {
-    [`colorPalette${color}Background2`]: black,
-    [`colorPalette${color}Foreground2`]: white,
+    [`colorPalette${color}Background2`]: hcCanvas,
+    [`colorPalette${color}Foreground2`]: hcCanvasText,
     [`colorPalette${color}BorderActive`]: hcHighlight,
   };
 

--- a/packages/react-components/react-theme/src/alias/lightColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/lightColorPalette.ts
@@ -19,6 +19,9 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
   return { ...acc, ...sharedColorTokens };
 }, {} as StatusColorPaletteTokens);
 
+// one-off patch for yellow
+statusColorPaletteTokens.colorPaletteYellowForeground1 = statusSharedColors.yellow.shade30;
+
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
   const color = sharedColor.slice(0, 1).toUpperCase() + sharedColor.slice(1);
   const sharedColorTokens = {


### PR DESCRIPTION
## Current Behavior

1. `colorPalette*Background1` was **white** in High Contrast
2. `colorPalette*Foreground1` was **black** in High Contrast
3. `colorPalette*` colors used hardcoded **white** and **black** instead of **hcCanvas** and **hcCanvasText** in High Contrast
4. `colorPalette*Foreground1` used **Shade 10** for all Status shared colors in Light Theme

## New Behavior

1. `colorPalette*Background1` is **hcCanvas** (resolves to black in default windows HC theme) in High Contrast
2. `colorPalette*Foreground1` is **hcCanvasText** (resolves to white in default windows HC theme) in High Contrast
3. `colorPalette*` colors now use **hcCanvas**, **hcCanvasTest** or **hcHighlight** instead of *white* and *black* for all status and persona Color Palette colors
4. `colorPaletteYellowForeground1` uses **Shade 30** in Light Theme, all other Status shared colors remained unchanged, using **Shade 10**

## Related Issue(s)

Fixes #24256
