### PR TITLE
fix(v8): changefiles for broken v8 published packages 

### DIFF
--- a/change/@fluentui-codemods-3b4d10b6-376f-4297-9712-fbd4faa4c1b7.json
+++ b/change/@fluentui-codemods-3b4d10b6-376f-4297-9712-fbd4faa4c1b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/codemods",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-e6041f8c-08c7-4d69-8cb8-cda821f4ddf1.json
+++ b/change/@fluentui-foundation-legacy-e6041f8c-08c7-4d69-8cb8-cda821f4ddf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-01e57943-3375-4a3f-b608-62678cd1b074.json
+++ b/change/@fluentui-react-conformance-01e57943-3375-4a3f-b608-62678cd1b074.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/react-conformance",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-file-type-icons-cb0dbcf1-2894-466d-bab9-dab6be1ee6b1.json
+++ b/change/@fluentui-react-file-type-icons-cb0dbcf1-2894-466d-bab9-dab6be1ee6b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-a16e89c1-2a3d-475b-87fd-16a40cf17dad.json
+++ b/change/@fluentui-react-hooks-a16e89c1-2a3d-475b-87fd-16a40cf17dad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/react-hooks",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-style-utilities-f13327df-aad4-4091-9865-c8b6733404b9.json
+++ b/change/@fluentui-style-utilities-f13327df-aad4-4091-9865-c8b6733404b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/style-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-theme-59d6527e-c54c-4728-bf44-42bf8880df2e.json
+++ b/change/@fluentui-theme-59d6527e-c54c-4728-bf44-42bf8880df2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fixes broken publish.",
+  "packageName": "@fluentui/theme",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Changes

- The v8 packages below are still in a broken state even after the latest v8 release. This is most likely caused by the publishing issues yesterday and while `@fluentui/react`'s publish was fixed and a new one was successfully released - the packages below were left in a broken state because they don't depend on `@fluentui/react`. This PR generates changefiles for the below packages to kick off a new publish with beachball.

```
@fluentui/codemods
@fluentui/react-conformance
@fluentui/react-file-type-icons
@fluentui/react-hooks
@fluentui/style-utilities
@fluentui/theme
@fluentui/foundation-legacy
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
