### PR TITLE
Added exports for GroupedListUtilities in v7

### DIFF
--- a/change/office-ui-fabric-react-57c82b0b-3fee-4424-914c-f6433971e342.json
+++ b/change/office-ui-fabric-react-57c82b0b-3fee-4424-914c-f6433971e342.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added exports for GroupedList utilities in v7",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1387,6 +1387,9 @@ export const getFontIcon: (iconName: string, className?: string | undefined, ari
 // @public
 export function getFullColorString(color: IColor): string;
 
+// @public
+export const GetGroupCount: (groups: IGroup[] | undefined) => number;
+
 // @public (undocumented)
 export const getIconContent: (iconName?: string | undefined) => IIconContent | null;
 

--- a/packages/office-ui-fabric-react/src/GroupedList.ts
+++ b/packages/office-ui-fabric-react/src/GroupedList.ts
@@ -1,1 +1,2 @@
 export * from './components/GroupedList/index';
+export * from './utilities/groupedList/GroupedListUtility';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level exports of GroupedListUtilities to GroupedList

## Issues
Fixes #24506