### PR TITLE
Added export of GroupedListUtilities in v8

### DIFF
--- a/change/@fluentui-react-125a9967-6b56-48b1-825d-6cbc7fbcc823.json
+++ b/change/@fluentui-react-125a9967-6b56-48b1-825d-6cbc7fbcc823.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added exports of GroupedList utils in v8",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1793,6 +1793,9 @@ export function getFullColorString(color: IColor): string;
 
 export { getGlobalClassNames }
 
+// @public
+export const GetGroupCount: (groups: IGroup[] | undefined) => number;
+
 export { getHighContrastNoAdjustStyle }
 
 export { getIcon }

--- a/packages/react/src/GroupedList.ts
+++ b/packages/react/src/GroupedList.ts
@@ -1,1 +1,2 @@
 export * from './components/GroupedList/index';
+export * from './utilities/groupedList/GroupedListUtility';


### PR DESCRIPTION
To better support removing deep imports in ODSP.

## Changes
- added top-level exports of GroupedListUtilities to GroupedList

## Issues
Updates #24506