### PR TITLE
Add baseUrl to proxy payload

### DIFF
--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -46,6 +46,8 @@ async function scheduleScreenerBuild(
     pullRequest: buildInfo.pullRequest,
   };
 
+  console.log(screenerConfig.baseUrl);
+
   const response = await fetch(environment.screener.proxyUri.replace('ci', 'runner'), {
     method: 'post',
     headers: {

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -36,7 +36,6 @@ async function scheduleScreenerBuild(
 
     baseBranch: screenerConfig.baseBranch,
     projectRepo: screenerConfig.projectRepo,
-    baseUrl: screenerConfig.baseUrl,
 
     alwaysAcceptBaseBranch: screenerConfig.alwaysAcceptBaseBranch,
     diffOptions: screenerConfig.diffOptions,
@@ -54,6 +53,7 @@ async function scheduleScreenerBuild(
     },
     body: JSON.stringify({
       payload: payload,
+      baseUrl: screenerConfig.baseUrl,
     }),
   });
 

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -36,6 +36,7 @@ async function scheduleScreenerBuild(
 
     baseBranch: screenerConfig.baseBranch,
     projectRepo: screenerConfig.projectRepo,
+    baseUrl: screenerConfig.baseUrl,
 
     alwaysAcceptBaseBranch: screenerConfig.alwaysAcceptBaseBranch,
     diffOptions: screenerConfig.diffOptions,

--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -46,8 +46,6 @@ async function scheduleScreenerBuild(
     pullRequest: buildInfo.pullRequest,
   };
 
-  console.log(screenerConfig.baseUrl);
-
   const response = await fetch(environment.screener.proxyUri.replace('ci', 'runner'), {
     method: 'post',
     headers: {
@@ -64,7 +62,7 @@ async function scheduleScreenerBuild(
   }
 
   if (response.status !== 201 && response.status !== 200) {
-    throw new Error(`Call to proxy failed: ${response.status}`);
+    throw new Error(`Call to proxy failed: ${response.status} , url: ${screenerConfig.baseUrl}`);
   }
   //conclusion of the screener run
   return response.json() as ScheduleScreenerBuildResponse;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The screener proxy is checking if a test app has been deployed by making a GET request to the base URL where the test build should be uploaded to. If the response is OK, the screener test runs, if the response is PAGE NOT FOUND, the screener test is skipped. 

The payload that the CI is sending to the proxy does not contain that base URL, so currently there is some parsing done to the `states` field of the payload in order to get that URL, but it is not a sustainable way of getting it.

## New Behavior

Since the CI has the base URL, it can just send it to the proxy as another field of the payload, and then the proxy can use it directly.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24401 
