### PR TITLE
Jspurlin/modal insert first fix

### DIFF
--- a/change/@fluentui-react-e11548c5-f93a-4e6b-a334-f39f2bf5d9c0.json
+++ b/change/@fluentui-react-e11548c5-f93a-4e6b-a334-f39f2bf5d9c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Modal: respect insertFirst if passed in",
+  "packageName": "@fluentui/react",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-e11548c5-f93a-4e6b-a334-f39f2bf5d9c0.json
+++ b/change/@fluentui-react-e11548c5-f93a-4e6b-a334-f39f2bf5d9c0.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Modal: respect insertFirst if passed in",
+  "comment": "fix: Respect insertFirst in Modal if passed in",
   "packageName": "@fluentui/react",
   "email": "jspurlin@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/Modal/Modal.base.tsx
+++ b/packages/react/src/components/Modal/Modal.base.tsx
@@ -183,7 +183,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
       eventBubblingEnabled: false,
       ...layerProps,
       onLayerDidMount: layerProps && layerProps.onLayerDidMount ? layerProps.onLayerDidMount : onLayerDidMount,
-      insertFirst: isModeless,
+      insertFirst: layerProps?.insertFirst || isModeless,
       className: classNames.layer,
     };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
Modal does not respect insertFirst if passed in on the layerProps

## New Behavior
Modal will now respect the insertFirst prop if explicitly passed in


Fixes #
https://github.com/microsoft/fluentui/issues/24527