### PR TITLE
fix: react-menu blur handlers are not called on close

### DIFF
--- a/change/@fluentui-react-menu-edd8fa90-6d20-4644-80c1-a84589c039ee.json
+++ b/change/@fluentui-react-menu-edd8fa90-6d20-4644-80c1-a84589c039ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: focus change on close occurs before menu popup is removed, so blur events occur on menu items",
+  "packageName": "@fluentui/react-menu",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/e2e/Menu.e2e.tsx
+++ b/packages/react-components/react-menu/e2e/Menu.e2e.tsx
@@ -74,6 +74,35 @@ describe('MenuTrigger', () => {
       .should('not.exist');
   });
 
+  it('should trigger focus and blur events when opening and closing', () => {
+    const onFocus = cy.stub().as('focus');
+    const onBlur = cy.stub().as('blur');
+
+    mount(
+      <Menu>
+        <MenuTrigger>
+          <button>Menu</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem onFocus={onFocus} onBlur={onBlur}>
+              Item
+            </MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    cy.get(menuTriggerSelector)
+      .click()
+      .get('@focus')
+      .should('have.been.calledOnce')
+      .get(menuItemSelector)
+      .type('{esc}')
+      .get('@blur')
+      .should('have.been.calledOnce');
+  });
+
   (['ArrowDown', 'Enter', 'Space'] as const).forEach(key => {
     it(`should open menu with ${key} and focus first menuitem`, () => {
       mount(

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -132,9 +132,6 @@ const useMenuOpenState = (
   const parentSetOpen = useMenuContext_unstable(context => context.setOpen);
   const onOpenChange: MenuState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
 
-  const shouldHandleKeyboardRef = React.useRef(false);
-  const shouldHandleTabRef = React.useRef(false);
-  const pressedShiftRef = React.useRef(false);
   const setOpenTimeout = React.useRef(0);
   const enteringTriggerRef = React.useRef(false);
 
@@ -164,22 +161,26 @@ const useMenuOpenState = (
   const trySetOpen = useEventCallback((e: MenuOpenEvents, data: MenuOpenChangeData) => {
     const event = e instanceof CustomEvent && e.type === MENU_ENTER_EVENT ? e.detail.nativeEvent : e;
     onOpenChange?.(event, { ...data });
+    let shouldHandleKeyboard = false;
+    let shouldHandleTab = false;
+    let pressedShift = false;
+
     if (data.open && e.type === 'contextmenu') {
       state.setContextTarget(e as React.MouseEvent);
     }
 
     if (data.keyboard) {
-      shouldHandleKeyboardRef.current = true;
-      shouldHandleTabRef.current = (e as React.KeyboardEvent).key === 'Tab';
-      pressedShiftRef.current = (e as React.KeyboardEvent).shiftKey;
+      shouldHandleKeyboard = true;
+      shouldHandleTab = (e as React.KeyboardEvent).key === 'Tab';
+      pressedShift = (e as React.KeyboardEvent).shiftKey;
     }
 
     if (!data.open) {
       state.setContextTarget(undefined);
 
-      if (shouldHandleKeyboardRef.current) {
-        if (shouldHandleTabRef.current && !state.isSubmenu) {
-          pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
+      if (shouldHandleKeyboard) {
+        if (shouldHandleTab && !state.isSubmenu) {
+          pressedShift ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
         } else {
           state.triggerRef.current?.focus();
         }
@@ -262,11 +263,7 @@ const useMenuOpenState = (
     if (open) {
       focusFirst();
     }
-
-    shouldHandleKeyboardRef.current = false;
-    shouldHandleTabRef.current = false;
-    pressedShiftRef.current = false;
-  }, [state.triggerRef, state.isSubmenu, open, focusFirst, focusAfterMenuTrigger, focusBeforeMenuTrigger]);
+  }, [open, focusFirst]);
 
   return [open ?? false, setOpen] as const;
 };

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Tab } from '@fluentui/keyboard-keys';
 import { usePositioningMouseTarget, usePositioning, resolvePositioningShorthand } from '@fluentui/react-positioning';
 import {
   useControllableState,
@@ -171,7 +172,7 @@ const useMenuOpenState = (
 
     if (data.keyboard) {
       shouldHandleKeyboard = true;
-      shouldHandleTab = (e as React.KeyboardEvent).key === 'Tab';
+      shouldHandleTab = (e as React.KeyboardEvent).key === Tab;
       pressedShift = (e as React.KeyboardEvent).shiftKey;
     }
 
@@ -180,7 +181,11 @@ const useMenuOpenState = (
 
       if (shouldHandleKeyboard) {
         if (shouldHandleTab && !state.isSubmenu) {
-          pressedShift ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
+          if (pressedShift) {
+            focusBeforeMenuTrigger();
+          } else {
+            focusAfterMenuTrigger();
+          }
         } else {
           state.triggerRef.current?.focus();
         }


### PR DESCRIPTION
Fixes #24546

Blur handlers on menu items were not being called on close, since focus updates happened in a `useEffect`. I moved the focus change for the closed state out of the `useEffect`, while keeping the focus change for the open state in the `useEffect`.