### PR TITLE
feat(ChatMessage): Add alternative 'v2' comfy layout

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `GlobeIcon` and `ArrowSyncIcon` @notandrew ([#23683](https://github.com/microsoft/fluentui/pull/23683))
 - Add size 'medium-large' to `Avatar` @yuanboxue-amber ([#23787](https://github.com/microsoft/fluentui/pull/23787))
 - Allow freeform to better support time picker scenario for `Dropdown` @jurokapsiar ([#23949](https://github.com/microsoft/fluentui/pull/23949))
+- Add a new comfy layout variation for `ChatMessage` @davezuko ([#23974](https://github.com/microsoft/fluentui/pull/23974))
 
 ### Fixes
 - Updating `Chat Message`'s `actionMenu` to use shadow8 @notandrew ([#23100](https://github.com/microsoft/fluentui/pull/23100))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Features
+
+- Add a new comfy layout variation for `ChatMessage` @davezuko ([#23974](https://github.com/microsoft/fluentui/pull/23974))
+
 ### Fixes
 - Allow React 17 in `peerDependencies` of all packages and bump react-is to 17 @TristanWatanabe ([#24356](https://github.com/microsoft/fluentui/pull/24356))
 - Fix `FocusTrapZone` to always remove `aria-hidden` on portal wrapper @yuanboxue-amber ([#24414](https://github.com/microsoft/fluentui/pull/24414))
@@ -32,7 +36,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `GlobeIcon` and `ArrowSyncIcon` @notandrew ([#23683](https://github.com/microsoft/fluentui/pull/23683))
 - Add size 'medium-large' to `Avatar` @yuanboxue-amber ([#23787](https://github.com/microsoft/fluentui/pull/23787))
 - Allow freeform to better support time picker scenario for `Dropdown` @jurokapsiar ([#23949](https://github.com/microsoft/fluentui/pull/23949))
-- Add a new comfy layout variation for `ChatMessage` @davezuko ([#23974](https://github.com/microsoft/fluentui/pull/23974))
 
 ### Fixes
 - Updating `Chat Message`'s `actionMenu` to use shadow8 @notandrew ([#23100](https://github.com/microsoft/fluentui/pull/23100))

--- a/packages/fluentui/docs/src/components/ComponentPlayground/ComponentPlaygroundSnippet.tsx
+++ b/packages/fluentui/docs/src/components/ComponentPlayground/ComponentPlaygroundSnippet.tsx
@@ -11,7 +11,6 @@ type ComponentPlaygroundSnippetProps = {
  */
 const ComponentPlaygroundSnippet: React.FunctionComponent<ComponentPlaygroundSnippetProps> = props => {
   const { element, component, ...rest } = props;
-  return null;
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof component === 'function' && !!component.prototype?.isReactComponent) {

--- a/packages/fluentui/docs/src/components/ComponentPlayground/ComponentPlaygroundSnippet.tsx
+++ b/packages/fluentui/docs/src/components/ComponentPlayground/ComponentPlaygroundSnippet.tsx
@@ -11,6 +11,7 @@ type ComponentPlaygroundSnippetProps = {
  */
 const ComponentPlaygroundSnippet: React.FunctionComponent<ComponentPlaygroundSnippetProps> = props => {
   const { element, component, ...rest } = props;
+  return null;
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof component === 'function' && !!component.prototype?.isReactComponent) {

--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -72,6 +72,11 @@ const prototypesTreeItems: TreeProps['items'] = [
     public: true,
   },
   {
+    id: 'chatRefresh',
+    title: { content: 'Chat Refresh', as: NavLink, to: '/prototype-chat-refresh' },
+    public: true,
+  },
+  {
     id: 'customscrollbar',
     title: { content: 'Custom Scrollbar', as: NavLink, to: '/prototype-custom-scrollbar' },
     public: true,

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { AcceptIcon, TranslationIcon } from '@fluentui/react-icons-northstar';
 import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/react-northstar';
 
@@ -13,20 +12,7 @@ const items: ShorthandCollection<ChatItemProps> = [
         status={{ color: 'green', icon: <AcceptIcon /> }}
       />
     ),
-    message: (
-      <Chat.Message
-        v2
-        content="Hello"
-        author="Robin Counts"
-        timestamp="10:15 PM"
-        details={
-          <>
-            Edited <TranslationIcon size="small" />
-          </>
-        }
-        timestampTooltip="Yesterday, 10:15 PM"
-      />
-    ),
+    message: <Chat.Message v2 content="Hello" author="Robin Counts" timestamp="10:15 PM" />,
     key: 'message-id-1',
   },
   {
@@ -36,7 +22,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     message: (
       <Chat.Message
         v2
-        content="Hi"
+        content="Hi! How are you doing?"
         author="Tim Deboer"
         timestamp="10:15 PM"
         details={
@@ -45,27 +31,9 @@ const items: ShorthandCollection<ChatItemProps> = [
           </>
         }
         mine
-        timestampTooltip="Yesterday, 10:15 PM"
       />
     ),
     key: 'message-id-2',
-  },
-  {
-    v2: true,
-    attached: 'bottom',
-    contentPosition: 'end',
-    message: (
-      <Chat.Message
-        v2
-        author="Tim Deboer"
-        content="How are you doing?"
-        details={<>Edited</>}
-        mine
-        timestamp="10:16 PM"
-        timestampTooltip="Yesterday, 10:16 PM"
-      />
-    ),
-    key: 'message-id-3',
   },
 ];
 

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
@@ -14,6 +14,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
     message: (
       <Chat.Message
+        v2
         content="Hello"
         author="Robin Counts"
         timestamp="10:15 PM"
@@ -22,9 +23,7 @@ const items: ShorthandCollection<ChatItemProps> = [
             Edited <TranslationIcon size="small" />
           </>
         }
-        v2={{
-          timestampTooltip: 'Yesterday, 10:15 PM',
-        }}
+        timestampTooltip="Yesterday, 10:15 PM"
       />
     ),
     key: 'message-id-1',
@@ -34,6 +33,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     contentPosition: 'end',
     message: (
       <Chat.Message
+        v2
         content="Hi"
         author="Tim Deboer"
         timestamp="10:15 PM"
@@ -43,9 +43,7 @@ const items: ShorthandCollection<ChatItemProps> = [
           </>
         }
         mine
-        v2={{
-          timestampTooltip: 'Yesterday, 10:15 PM',
-        }}
+        timestampTooltip="Yesterday, 10:15 PM"
       />
     ),
     key: 'message-id-2',
@@ -55,14 +53,13 @@ const items: ShorthandCollection<ChatItemProps> = [
     contentPosition: 'end',
     message: (
       <Chat.Message
+        v2
         author="Tim Deboer"
         content="How are you doing?"
         details={<>Edited</>}
         mine
         timestamp="10:16 PM"
-        v2={{
-          timestampTooltip: 'Yesterday, 10:16 PM',
-        }}
+        timestampTooltip="Yesterday, 10:16 PM"
       />
     ),
     key: 'message-id-3',

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
@@ -5,6 +5,7 @@ import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/reac
 
 const items: ShorthandCollection<ChatItemProps> = [
   {
+    v2: true,
     contentPosition: 'start',
     gutter: (
       <Avatar
@@ -29,6 +30,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     key: 'message-id-1',
   },
   {
+    v2: true,
     attached: 'top',
     contentPosition: 'end',
     message: (
@@ -49,6 +51,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     key: 'message-id-2',
   },
   {
+    v2: true,
     attached: 'bottom',
     contentPosition: 'end',
     message: (

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyV2.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+import { AcceptIcon, TranslationIcon } from '@fluentui/react-icons-northstar';
+import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/react-northstar';
+
+const items: ShorthandCollection<ChatItemProps> = [
+  {
+    contentPosition: 'start',
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobinCounts.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
+    message: (
+      <Chat.Message
+        content="Hello"
+        author="Robin Counts"
+        timestamp="10:15 PM"
+        details={
+          <>
+            Edited <TranslationIcon size="small" />
+          </>
+        }
+        v2={{
+          timestampTooltip: 'Yesterday, 10:15 PM',
+        }}
+      />
+    ),
+    key: 'message-id-1',
+  },
+  {
+    attached: 'top',
+    contentPosition: 'end',
+    message: (
+      <Chat.Message
+        content="Hi"
+        author="Tim Deboer"
+        timestamp="10:15 PM"
+        details={
+          <>
+            Edited <TranslationIcon size="small" />
+          </>
+        }
+        mine
+        v2={{
+          timestampTooltip: 'Yesterday, 10:15 PM',
+        }}
+      />
+    ),
+    key: 'message-id-2',
+  },
+  {
+    attached: 'bottom',
+    contentPosition: 'end',
+    message: (
+      <Chat.Message
+        author="Tim Deboer"
+        content="How are you doing?"
+        details={<>Edited</>}
+        mine
+        timestamp="10:16 PM"
+        v2={{
+          timestampTooltip: 'Yesterday, 10:16 PM',
+        }}
+      />
+    ),
+    key: 'message-id-3',
+  },
+];
+
+const ChatExampleComfyV2 = () => <Chat items={items} />;
+
+export default ChatExampleComfyV2;

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/index.tsx
@@ -30,6 +30,11 @@ const Types = () => (
       description="A Chat message may contained Edited and/or Translated."
       examplePath="components/Chat/Types/ChatExampleDetails"
     />
+    <ComponentExample
+      title="V2 Layout"
+      description="A chat can render with an alternative layout."
+      examplePath="components/Chat/Types/ChatExampleComfyV2"
+    />
   </ExampleSection>
 );
 

--- a/packages/fluentui/docs/src/routes.tsx
+++ b/packages/fluentui/docs/src/routes.tsx
@@ -40,6 +40,7 @@ import {
   ChatMessagesPrototype,
   ChatPanePrototype,
   CompactChatPrototype,
+  ChatRefreshPrototype,
   CopyToClipboardPrototype,
   CustomScrollbarPrototype,
   CustomToolbarPrototype,
@@ -110,6 +111,7 @@ const Routes = () => (
                 <Route exact path="/prototype-chat-pane" component={ChatPanePrototype} />
                 <Route exact path="/prototype-chat-messages" component={ChatMessagesPrototype} />
                 <Route exact path="/prototype-compact-chat" component={CompactChatPrototype} />
+                <Route exact path="/prototype-chat-refresh" component={ChatRefreshPrototype} />
                 <Route exact path="/prototype-custom-scrollbar" component={CustomScrollbarPrototype} />
                 <Route exact path="/prototype-custom-toolbar" component={CustomToolbarPrototype} />
                 <Route exact path="/prototype-async-shorthand" component={AsyncShorthandPrototype} />

--- a/packages/fluentui/react-northstar-prototypes/src/index.ts
+++ b/packages/fluentui/react-northstar-prototypes/src/index.ts
@@ -10,6 +10,9 @@ export const ChatMessagesPrototype = React.lazy(
 export const CompactChatPrototype = React.lazy(
   () => import(/* webpackChunkName: "prototypes" */ './prototypes/compactChat'),
 );
+export const ChatRefreshPrototype = React.lazy(
+  () => import(/* webpackChunkName: "prototypes" */ './prototypes/chatRefresh'),
+);
 export const AsyncShorthandPrototype = React.lazy(
   () => import(/* webpackChunkName: "prototypes" */ './prototypes/AsyncShorthand'),
 );

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshSimple.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshSimple.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { AcceptIcon, TranslationIcon } from '@fluentui/react-icons-northstar';
+import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/react-northstar';
+
+const items: ShorthandCollection<ChatItemProps> = [
+  {
+    v2: true,
+    contentPosition: 'start',
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobinCounts.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
+    message: (
+      <Chat.Message
+        v2
+        content="Hello"
+        author="Robin Counts"
+        timestamp="10:15 PM"
+        details={
+          <>
+            Edited <TranslationIcon size="small" />
+          </>
+        }
+      />
+    ),
+    key: 'message-id-1',
+  },
+  {
+    v2: true,
+    attached: 'top',
+    contentPosition: 'end',
+    message: (
+      <Chat.Message
+        v2
+        mine
+        content="Hi"
+        author="Tim Deboer"
+        timestamp="10:15 PM"
+        details={
+          <>
+            Edited <TranslationIcon size="small" />
+          </>
+        }
+      />
+    ),
+    key: 'message-id-2',
+  },
+];
+
+export const ChatRefreshSimple = () => <Chat items={items} />;

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshSimple.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshSimple.tsx
@@ -29,7 +29,6 @@ const items: ShorthandCollection<ChatItemProps> = [
   },
   {
     v2: true,
-    attached: 'top',
     contentPosition: 'end',
     message: (
       <Chat.Message

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshStressTest.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshStressTest.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { AcceptIcon } from '@fluentui/react-icons-northstar';
+import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/react-northstar';
+
+const items: ShorthandCollection<ChatItemProps> = [
+  {
+    v2: true,
+    contentPosition: 'start',
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobinCounts.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
+    message: (
+      <Chat.Message
+        v2
+        content={`This is a really long message. It has a lot of content so that we can see how a chat message looks when it has a lot of content. You get the point? Lots of content to test lots of content. Here's even more content on top of the already long amount of content that we already had. This is a really long message. It has a lot of content so that we can see how a chat message looks when it has a lot of content. You get the point? Lots of content to test lots of content. Here's even more content on top of the already long amount of content that we already had. This is a really long message. It has a lot of content so that we can see how a chat message looks when it has a lot of content. You get the point? Lots of content to test lots of content. Here's even more content on top of the already long amount of content that we already had.`}
+        author="Tim Deboer"
+        timestamp="10:15 PM"
+      />
+    ),
+    key: 'message-id-2',
+  },
+  {
+    v2: true,
+    contentPosition: 'end',
+    message: (
+      <Chat.Message
+        v2
+        mine
+        content={`contentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespace`}
+        author="Tim Deboer"
+        timestamp="10:15 PM"
+      />
+    ),
+    key: 'message-id-2',
+  },
+];
+
+export const ChatRefreshStressTest = () => <Chat items={items} />;

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshTimestampTooltip.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshTimestampTooltip.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { AcceptIcon } from '@fluentui/react-icons-northstar';
+import { Avatar, Chat, ChatItemProps, ShorthandCollection, Tooltip } from '@fluentui/react-northstar';
+
+const items: ShorthandCollection<ChatItemProps> = [
+  {
+    v2: true,
+    contentPosition: 'start',
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobinCounts.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
+    message: (
+      <Chat.Message
+        v2
+        content="Hello"
+        author="Robin Counts"
+        timestamp={{
+          content: '10:15 PM',
+          children: (Component, props) => (
+            <Tooltip content="Yesterday at 10:15 PM" trigger={<Component {...props} />} />
+          ),
+        }}
+      />
+    ),
+    key: 'message-id-1',
+  },
+];
+
+export const ChatRefreshTimestampTooltip = () => <Chat items={items} />;

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/index.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ComponentPrototype, PrototypeSection } from '../Prototypes';
 import { ChatRefreshSimple } from './ChatRefreshSimple';
 import { ChatRefreshTimestampTooltip } from './ChatRefreshTimestampTooltip';
+import { ChatRefreshStressTest } from './ChatRefreshStressTest';
 
 export default () => (
   <PrototypeSection title="Chat Refresh">
@@ -13,6 +14,9 @@ export default () => (
       description="Message tooltip can be modified to render a tooltip on hover."
     >
       <ChatRefreshTimestampTooltip />
+    </ComponentPrototype>
+    <ComponentPrototype title="Stress Test" description="Testing uncommon messages.">
+      <ChatRefreshStressTest />
     </ComponentPrototype>
   </PrototypeSection>
 );

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/index.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/index.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { ComponentPrototype, PrototypeSection } from '../Prototypes';
+import { ChatRefreshSimple } from './ChatRefreshSimple';
+import { ChatRefreshTimestampTooltip } from './ChatRefreshTimestampTooltip';
+
+export default () => (
+  <PrototypeSection title="Chat Refresh">
+    <ComponentPrototype title="Simple" description="Message metadata sits outside the bubble.">
+      <ChatRefreshSimple />
+    </ComponentPrototype>
+    <ComponentPrototype
+      title="Timestamp Tooltip"
+      description="Message tooltip can be modified to render a tooltip on hover."
+    >
+      <ChatRefreshTimestampTooltip />
+    </ComponentPrototype>
+  </PrototypeSection>
+);

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
@@ -60,7 +60,7 @@ export interface ChatItemProps extends UIComponentProps, ChildrenComponentProps 
   v2?: boolean;
 }
 
-export type ChatItemStylesProps = Pick<ChatItemProps, 'attached' | 'contentPosition' | 'density'>;
+export type ChatItemStylesProps = Pick<ChatItemProps, 'attached' | 'contentPosition' | 'density' | 'v2'>;
 
 /**
  * A ChatItem is container for single entity in Chat (e.g. message, notification, etc).

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
@@ -55,6 +55,9 @@ export interface ChatItemProps extends UIComponentProps, ChildrenComponentProps 
 
   /** Chat items can have a message. */
   message?: ShorthandValue<BoxProps>;
+
+  /** Opts into the V2 layout. */
+  v2?: boolean;
 }
 
 export type ChatItemStylesProps = Pick<ChatItemProps, 'attached' | 'contentPosition' | 'density'>;
@@ -88,6 +91,7 @@ export const ChatItem = (React.forwardRef<HTMLLIElement, ChatItemProps>((inputPr
     message,
     styles,
     variables,
+    v2,
   } = props;
 
   const getA11Props = useAccessibility(accessibility, {
@@ -97,6 +101,7 @@ export const ChatItem = (React.forwardRef<HTMLLIElement, ChatItemProps>((inputPr
   const { classes, styles: resolvedStyles } = useStyles<ChatItemStylesProps>(ChatItem.displayName, {
     className: chatItemClassName,
     mapPropsToStyles: () => ({
+      v2,
       attached,
       contentPosition,
       density,
@@ -169,6 +174,7 @@ ChatItem.propTypes = {
   density: PropTypes.oneOf<ChatDensity>(['comfy', 'compact']),
   gutter: customPropTypes.itemShorthand,
   message: customPropTypes.itemShorthand,
+  v2: PropTypes.bool,
 };
 ChatItem.handledProps = Object.keys(ChatItem.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -204,6 +204,9 @@ export interface ChatMessageProps
 
   /** More refined version of the original `timestamp` property that guarantees certain fields exist. */
   timestampTooltip?: string;
+
+  /** Optional override for the content in the message header. */
+  headerContent?: React.ReactNode;
 }
 
 export type ChatMessageStylesProps = Pick<ChatMessageProps, 'attached' | 'badgePosition' | 'density' | 'mine'> & {
@@ -299,6 +302,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
     customizeBubbleElement,
     timestampTooltip,
     bubbleInset,
+    headerContent,
   } = props;
 
   const isV2Enabled = v2 && density === 'comfy';
@@ -602,7 +606,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
     const headerElement = createShorthand(ChatMessageHeader, header || {}, {
       overrideProps: () => ({
         styles: resolvedStyles.header,
-        content: (
+        content: headerContent || (
           <>
             {authorElement}
             {infoLabel}
@@ -790,6 +794,7 @@ ChatMessage.propTypes = {
   unstable_overflow: PropTypes.bool,
   failed: PropTypes.bool,
   importantLabel: PropTypes.node,
+  headerContent: PropTypes.node,
   infoLabel: PropTypes.node,
   customizeBubbleElement: PropTypes.func,
   bubbleInset: PropTypes.node,

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -187,7 +187,7 @@ export interface ChatMessageProps
   failed?: boolean;
 
   /** Label that describes message importance. */
-  importantLabel?: React.ReactNode;
+  importanceLabel?: React.ReactNode;
 
   /** Additional label slot for message importance, scheduled messages, etc. */
   infoLabel?: React.ReactNode;
@@ -298,7 +298,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
     variables,
     v2,
     infoLabel,
-    importantLabel,
+    importanceLabel,
     customizeBubbleElement,
     timestampTooltip,
     bubbleInset,
@@ -610,7 +610,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
           <>
             {authorElement}
             {infoLabel}
-            {importantLabel}
+            {importanceLabel}
             {detailsElement}
           </>
         ),
@@ -793,7 +793,7 @@ ChatMessage.propTypes = {
   timestamp: customPropTypes.itemShorthand,
   unstable_overflow: PropTypes.bool,
   failed: PropTypes.bool,
-  importantLabel: PropTypes.node,
+  importanceLabel: PropTypes.node,
   headerContent: PropTypes.node,
   infoLabel: PropTypes.node,
   customizeBubbleElement: PropTypes.func,

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -124,6 +124,9 @@ export interface ChatMessageProps
   /** A message can have a custom header. */
   header?: ShorthandValue<ChatMessageHeaderProps>;
 
+  /** Optional slot for inserting content into the default header. */
+  headerContent?: React.ReactNode;
+
   /** Indicates whether message belongs to the current user. */
   mine?: boolean;
 
@@ -183,11 +186,11 @@ export interface ChatMessageProps
   /** Opts into the V2 layout. */
   v2?: boolean;
 
-  /** Indicates whether the message is in a failure state. */
+  /** Indicates whether the message is in a failed state. */
   failed?: boolean;
 
-  /** Optional override for the content in the message header. */
-  headerContent?: React.ReactNode;
+  /** A message can span the full width of its container. */
+  fullWidth?: boolean;
 
   /** A message can have a custom body element. */
   body?: ShorthandValue<BoxProps>;
@@ -195,13 +198,13 @@ export interface ChatMessageProps
   /** A message can have a custom bubble element. */
   bubble?: ShorthandValue<BoxProps>;
 
-  /** A message can have a custom bubble inset element, which sits next to the bubble. */
+  /** A message can have a custom bubble inset element which sits next to the bubble. */
   bubbleInset?: ShorthandValue<BoxProps>;
 
-  /** Optional override for the content in the message header. */
+  /** Optional override for the content in the default bubble inset. */
   bubbleInsetContent?: React.ReactNode;
 
-  /** More refined version of the original `timestamp` property that guarantees certain fields exist. */
+  /** The timestamp can render a tooltip to display more detailed information. */
   timestampTooltip?: string;
 }
 
@@ -209,7 +212,9 @@ export type ChatMessageStylesProps = Pick<ChatMessageProps, 'attached' | 'badgeP
   hasBadge: boolean;
   hasHeaderReactionGroup: boolean;
   hasReactions: boolean;
-  isV2Enabled: boolean;
+  v2: boolean;
+  failed: boolean;
+  fullWidth: boolean;
 
   // focused, hasActionMenu and showActionMenu controls the visibility of action menu
   focused: boolean;
@@ -293,6 +298,8 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
     unstable_overflow: overflow,
     variables,
     v2,
+    failed,
+    fullWidth,
     bubble,
     body,
     timestampTooltip,
@@ -391,7 +398,9 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
       mine,
       showActionMenu,
       hasReactions: !!reactionGroup,
-      isV2Enabled,
+      failed,
+      fullWidth,
+      v2,
     }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -777,7 +786,9 @@ ChatMessage.propTypes = {
   readStatus: customPropTypes.itemShorthand,
   timestamp: customPropTypes.itemShorthand,
   unstable_overflow: PropTypes.bool,
+  v2: PropTypes.bool,
   failed: PropTypes.bool,
+  fullWidth: PropTypes.bool,
   headerContent: PropTypes.node,
   body: customPropTypes.itemShorthand,
   bubble: customPropTypes.itemShorthand,

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -203,7 +203,7 @@ interface ChatMessageV2Props {
    * This is required for external, platform-specific implementations that need to
    * wrap the bubble in order to inject animations et al.
    */
-  customizeBubble?(element: React.ReactNode): React.ReactNode;
+  customizeBubbleElement?(element: React.ReactElement): React.ReactElement;
 
   /** Slot for elements that sit next to the message bubble. */
   bubbleInset?: React.ReactNode;
@@ -642,8 +642,8 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
         }),
       },
     );
-    if (v2.customizeBubble) {
-      bubbleElement = v2.customizeBubble(bubbleElement);
+    if (v2.customizeBubbleElement) {
+      bubbleElement = v2.customizeBubbleElement(bubbleElement);
     }
 
     const timestampElement = (
@@ -793,7 +793,7 @@ ChatMessage.propTypes = {
     failed: PropTypes.bool,
     importantLabel: PropTypes.node,
     infoLabel: PropTypes.node,
-    customizeBubble: PropTypes.func,
+    customizeBubbleElement: PropTypes.func,
     bubbleInset: PropTypes.node,
     timestampTooltip: PropTypes.string,
   }),

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -61,7 +61,6 @@ import { PortalInner } from '../Portal/PortalInner';
 import { Reaction, ReactionProps } from '../Reaction/Reaction';
 import { ReactionGroupProps } from '../Reaction/ReactionGroup';
 import { Text, TextProps } from '../Text/Text';
-import { Tooltip } from '../Tooltip/Tooltip';
 import { useChatContextSelectors } from './chatContext';
 import { ChatDensity } from './chatDensity';
 import { ChatItemContext } from './chatItemContext';
@@ -203,9 +202,6 @@ export interface ChatMessageProps
 
   /** Optional override for the content in the default bubble inset. */
   bubbleInsetContent?: React.ReactNode;
-
-  /** The timestamp can render a tooltip to display more detailed information. */
-  timestampTooltip?: string;
 }
 
 export type ChatMessageStylesProps = Pick<ChatMessageProps, 'attached' | 'badgePosition' | 'density' | 'mine'> & {
@@ -302,7 +298,6 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
     fullWidth,
     bubble,
     body,
-    timestampTooltip,
     bubbleInset,
     bubbleInsetContent,
     headerContent,
@@ -647,20 +642,6 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
       }),
     });
 
-    const timestampElement = (
-      <Tooltip
-        content={timestampTooltip}
-        trigger={Text.create(timestamp, {
-          defaultProps: () => ({
-            size: 'small',
-            styles: resolvedStyles.timestamp,
-            timestamp: true,
-            className: chatMessageSlotClassNames.timestamp,
-          }),
-        })}
-      />
-    );
-
     const bubbleInsetElement = Box.create(bubbleInset || {}, {
       defaultProps: () => ({
         as: 'span',
@@ -794,7 +775,6 @@ ChatMessage.propTypes = {
   bubble: customPropTypes.itemShorthand,
   bubbleInset: customPropTypes.itemShorthand,
   bubbleInsetContent: PropTypes.node,
-  timestampTooltip: PropTypes.string,
 };
 
 ChatMessage.handledProps = Object.keys(ChatMessage.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -189,7 +189,7 @@ export interface ChatMessageProps
   /** Label that describes message importance. */
   importanceLabel?: React.ReactNode;
 
-  /** Additional label slot for message importance, scheduled messages, etc. */
+  /** Additional label slot for message details, such as a scheduled message label. */
   infoLabel?: React.ReactNode;
 
   /**

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -180,15 +180,9 @@ export interface ChatMessageProps
   /** Positions an actionMenu slot in "fixed" mode. */
   unstable_overflow?: boolean;
 
-  /**
-   * Properties that are only available to the v2 (refresh) version of
-   * ChatMessage because they only have an effect there. Enabling this property
-   * will opt into the new layout.
-   */
-  v2?: ChatMessageV2Props;
-}
+  /** Opts into the V2 layout. */
+  v2?: boolean;
 
-interface ChatMessageV2Props {
   /** Indicates whether the message is in a failure state. */
   failed?: boolean;
 
@@ -300,9 +294,14 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
     unstable_overflow: overflow,
     variables,
     v2,
+    infoLabel,
+    importantLabel,
+    customizeBubbleElement,
+    timestampTooltip,
+    bubbleInset,
   } = props;
 
-  const isV2Enabled = !!v2 && density === 'comfy';
+  const isV2Enabled = v2 && density === 'comfy';
 
   const [actionMenuOptions, positioningProps] = partitionPopperPropsFromShorthand(props.actionMenu);
   const [actionMenu, inlineActionMenu, controlledShowActionMenu] = partitionActionMenuPropsFromShorthand(
@@ -606,8 +605,8 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
         content: (
           <>
             {authorElement}
-            {v2.infoLabel}
-            {v2.importantLabel}
+            {infoLabel}
+            {importantLabel}
             {detailsElement}
           </>
         ),
@@ -642,13 +641,13 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
         }),
       },
     );
-    if (v2.customizeBubbleElement) {
-      bubbleElement = v2.customizeBubbleElement(bubbleElement);
+    if (customizeBubbleElement) {
+      bubbleElement = customizeBubbleElement(bubbleElement);
     }
 
     const timestampElement = (
       <Tooltip
-        content={v2.timestampTooltip}
+        content={timestampTooltip}
         trigger={Text.create(timestamp, {
           defaultProps: () => ({
             size: 'small',
@@ -660,7 +659,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
       />
     );
 
-    const bubbleInset = Box.create(
+    const bubbleInsetElement = Box.create(
       { as: 'span' },
       {
         defaultProps: () => ({
@@ -671,7 +670,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
           content: (
             <>
               {badgeElement}
-              {v2.bubbleInset}
+              {bubbleInset}
               {timestampElement}
             </>
           ),
@@ -691,7 +690,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
           content: (
             <>
               {bubbleElement}
-              {bubbleInset}
+              {bubbleInsetElement}
             </>
           ),
         }),
@@ -789,14 +788,12 @@ ChatMessage.propTypes = {
   readStatus: customPropTypes.itemShorthand,
   timestamp: customPropTypes.itemShorthand,
   unstable_overflow: PropTypes.bool,
-  v2: PropTypes.shape({
-    failed: PropTypes.bool,
-    importantLabel: PropTypes.node,
-    infoLabel: PropTypes.node,
-    customizeBubbleElement: PropTypes.func,
-    bubbleInset: PropTypes.node,
-    timestampTooltip: PropTypes.string,
-  }),
+  failed: PropTypes.bool,
+  importantLabel: PropTypes.node,
+  infoLabel: PropTypes.node,
+  customizeBubbleElement: PropTypes.func,
+  bubbleInset: PropTypes.node,
+  timestampTooltip: PropTypes.string,
 };
 
 ChatMessage.handledProps = Object.keys(ChatMessage.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemStylesComfy.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemStylesComfy.ts
@@ -16,7 +16,7 @@ export const chatItemStylesComfy: ComponentSlotStylesPrepared<ChatItemStylesProp
   }),
 
   gutter: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    marginTop: v.gutterMargin,
+    marginTop: p.v2 ? v.gutterMarginComfyV2 : v.gutterMargin,
     [p.contentPosition === 'end' ? 'right' : 'left']: 0,
   }),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatItemVariables.ts
@@ -3,6 +3,7 @@ import { pxToRem } from '../../../../utils';
 export interface ChatItemVariables {
   gutterMargin: string;
   gutterMarginCompact: string;
+  gutterMarginComfyV2: string;
   margin: string;
   messageMargin: string;
   messageMarginCompact: string;
@@ -12,6 +13,7 @@ export interface ChatItemVariables {
 export const chatItemVariables = (): ChatItemVariables => ({
   gutterMargin: pxToRem(10),
   gutterMarginCompact: pxToRem(2),
+  gutterMarginComfyV2: pxToRem(22),
   margin: pxToRem(8),
   messageMargin: pxToRem(40),
   messageMarginCompact: pxToRem(56),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -7,6 +7,7 @@ import { pxToRem } from '../../../../utils';
 import { getBorderFocusStyles } from '../../getBorderFocusStyles';
 import { chatMessageStylesComfy } from './chatMessageStylesComfy';
 import { chatMessageStylesCompact } from './chatMessageStylesCompact';
+import { chatMessageStylesComfyV2 } from './chatMessageStylesComfyV2';
 import { ChatMessageVariables } from './chatMessageVariables';
 
 const displayActionMenu = (overlayZIndex: ICSSInJSStyle['zIndex']): ICSSInJSStyle => ({
@@ -27,7 +28,13 @@ const chatMessageDensityStyles: Record<
   compact: chatMessageStylesCompact,
 };
 
-const getChatMessageDensityStyles = (density: ChatDensity = defaultChatDensity) => chatMessageDensityStyles[density];
+const getChatMessageVariantStyles = (props: ChatMessageStylesProps) => {
+  if (props.isV2Enabled) {
+    return chatMessageStylesComfyV2;
+  }
+  const density = props.density || defaultChatDensity;
+  return chatMessageDensityStyles[density];
+};
 
 export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesProps, ChatMessageVariables> = {
   root: (componentStyleFunctionParam): ICSSInJSStyle => {
@@ -36,6 +43,10 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
       variables: v,
       theme: { siteVariables },
     } = componentStyleFunctionParam;
+
+    if (p.v2 && p.density === 'comfy') {
+      return chatMessageStylesComfyV2.root(componentStyleFunctionParam);
+    }
     return {
       borderRadius: v.borderRadius,
       display: 'inline-block',
@@ -59,11 +70,12 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
           }),
         }),
 
-      ...getChatMessageDensityStyles(p.density).root?.(componentStyleFunctionParam),
+      ...getChatMessageVariantStyles(p).root?.(componentStyleFunctionParam),
     };
   },
 
-  actionMenu: ({ props: p, variables: v }): ICSSInJSStyle => {
+  actionMenu: (componentStyleFunctionParam): ICSSInJSStyle => {
+    const { props: p, variables: v } = componentStyleFunctionParam;
     const defaultShowActionMenu = p.hasActionMenu && (p.focused || p.showActionMenu);
     const showActionMenu = isNil(v.showActionMenu) ? defaultShowActionMenu : v.showActionMenu;
 
@@ -80,24 +92,25 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
       opacity: 0,
       width: 0,
       ...(showActionMenu && displayActionMenu(v.overlayZIndex)),
+      ...getChatMessageVariantStyles(p).actionMenu?.(componentStyleFunctionParam),
     };
   },
 
   author: (componentStyleFunctionParam): ICSSInJSStyle => {
     const { props: p } = componentStyleFunctionParam;
-    return getChatMessageDensityStyles(p.density).author?.(componentStyleFunctionParam);
+    return getChatMessageVariantStyles(p).author?.(componentStyleFunctionParam);
   },
 
   compactBody: (componentStyleFunctionParam): ICSSInJSStyle => {
     const { props: p } = componentStyleFunctionParam;
-    return getChatMessageDensityStyles(p.density).compactBody?.(componentStyleFunctionParam);
+    return getChatMessageVariantStyles(p).compactBody?.(componentStyleFunctionParam);
   },
 
   timestamp: (componentStyleFunctionParam): ICSSInJSStyle => {
     const { props: p } = componentStyleFunctionParam;
     return {
       display: 'inline-block',
-      ...getChatMessageDensityStyles(p.density).timestamp?.(componentStyleFunctionParam),
+      ...getChatMessageVariantStyles(p).timestamp?.(componentStyleFunctionParam),
     };
   },
 
@@ -113,7 +126,7 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
           textDecoration: 'underline',
         },
       },
-      ...getChatMessageDensityStyles(p.density).content?.(componentStyleFunctionParam),
+      ...getChatMessageVariantStyles(p).content?.(componentStyleFunctionParam),
     };
   },
 
@@ -129,12 +142,26 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
       width: 'auto',
       zIndex: v.zIndex,
       '& > :first-child': { display: 'inline-flex' },
-      ...getChatMessageDensityStyles(p.density).badge?.(componentStyleFunctionParam),
+      ...getChatMessageVariantStyles(p).badge?.(componentStyleFunctionParam),
+    };
+  },
+
+  body: (componentStyleFunctionParam): ICSSInJSStyle => {
+    const { props: p } = componentStyleFunctionParam;
+    return {
+      ...getChatMessageVariantStyles(p).body?.(componentStyleFunctionParam),
+    };
+  },
+
+  bubble: (componentStyleFunctionParam): ICSSInJSStyle => {
+    const { props: p } = componentStyleFunctionParam;
+    return {
+      ...getChatMessageVariantStyles(p).bubble?.(componentStyleFunctionParam),
     };
   },
 
   reactionGroup: (componentStyleFunctionParam): ICSSInJSStyle => {
     const { props: p } = componentStyleFunctionParam;
-    return getChatMessageDensityStyles(p.density).reactionGroup?.(componentStyleFunctionParam);
+    return getChatMessageVariantStyles(p).reactionGroup?.(componentStyleFunctionParam);
   },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -160,6 +160,13 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
     };
   },
 
+  bubbleInset: (componentStyleFunctionParam): ICSSInJSStyle => {
+    const { props: p } = componentStyleFunctionParam;
+    return {
+      ...getChatMessageVariantStyles(p).bubbleInset?.(componentStyleFunctionParam),
+    };
+  },
+
   reactionGroup: (componentStyleFunctionParam): ICSSInJSStyle => {
     const { props: p } = componentStyleFunctionParam;
     return getChatMessageVariantStyles(p).reactionGroup?.(componentStyleFunctionParam);

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -29,10 +29,10 @@ const chatMessageDensityStyles: Record<
 };
 
 const getChatMessageVariantStyles = (props: ChatMessageStylesProps) => {
-  if (props.isV2Enabled) {
+  const density = props.density || defaultChatDensity;
+  if (props.v2 && density === 'comfy') {
     return chatMessageStylesComfyV2;
   }
-  const density = props.density || defaultChatDensity;
   return chatMessageDensityStyles[density];
 };
 
@@ -44,7 +44,7 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
       theme: { siteVariables },
     } = componentStyleFunctionParam;
 
-    if (p.isV2Enabled && p.density === 'comfy') {
+    if (p.v2 && p.density === 'comfy') {
       return chatMessageStylesComfyV2.root(componentStyleFunctionParam);
     }
     return {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStyles.ts
@@ -44,7 +44,7 @@ export const chatMessageStyles: ComponentSlotStylesPrepared<ChatMessageStylesPro
       theme: { siteVariables },
     } = componentStyleFunctionParam;
 
-    if (p.v2 && p.density === 'comfy') {
+    if (p.isV2Enabled && p.density === 'comfy') {
       return chatMessageStylesComfyV2.root(componentStyleFunctionParam);
     }
     return {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -161,11 +161,11 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
     position: 'absolute',
     top: pxToRem(10),
     display: 'flex',
+    paddingTop: 0,
+    paddingBottom: 0,
     // use padding instead of margin so that the bubble container's :hover
     // styles still apply when mousing over the gap between the container
     // and bubble-inset.
-    paddingTop: 0,
-    paddingBottom: 0,
     paddingLeft: v.isNarrow ? pxToRem(2.5) : pxToRem(5),
     paddingRight: v.isNarrow ? pxToRem(2.5) : pxToRem(5),
     ...(p.mine ? { right: '100%', flexDirection: 'row-reverse' } : { left: '100%' }),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -67,7 +67,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
       display: 'none',
       whiteSpace: 'nowrap',
     };
-    if (v.v2_isNarrow) {
+    if (v.isNarrow) {
       styles.fontSize = '1rem';
       styles.marginTop = pxToRem(3);
       styles.marginLeft = pxToRem(2.5);
@@ -80,12 +80,12 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
   body: ({ props: p, variables: v }): ICSSInJSStyle => ({
     position: 'relative',
     maxWidth: '100%',
-    ...(v.v2_isFullWidth && {
+    ...(v.isFullWidth && {
       width: '100%',
     }),
 
     ...(!p.mine &&
-      v.v2_isNarrow && {
+      v.isNarrow && {
         marginRight: pxToRem(16),
       }),
   }),
@@ -107,7 +107,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
         backgroundAttachment: 'fixed',
       }),
 
-      ...(v.v2_isFailed && {
+      ...(v.isFailed && {
         backgroundImage: 'none',
         backgroundColor: theme.siteVariables.colorScheme.red.background1,
         border: `1px solid ${theme.siteVariables.colorScheme.red.border}`,
@@ -166,8 +166,8 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
     // and bubble-inset.
     paddingTop: 0,
     paddingBottom: 0,
-    paddingLeft: v.v2_isNarrow ? pxToRem(2.5) : pxToRem(5),
-    paddingRight: v.v2_isNarrow ? pxToRem(2.5) : pxToRem(5),
+    paddingLeft: v.isNarrow ? pxToRem(2.5) : pxToRem(5),
+    paddingRight: v.isNarrow ? pxToRem(2.5) : pxToRem(5),
     ...(p.mine ? { right: '100%', flexDirection: 'row-reverse' } : { left: '100%' }),
   }),
 
@@ -182,7 +182,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
       '&:hover': { textDecorationStyle: 'double' },
       '&:focus': { textDecorationStyle: 'double' },
     },
-    ...(v.v2_isFailed && {
+    ...(v.isFailed && {
       color: theme.siteVariables.colorScheme.default.foreground,
     }),
   }),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -21,8 +21,8 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
     });
 
     // Fixes the bubble focus border rendering on top of the user avatar
-    delete borderFocusStyles[':focus-visible'][':before'].zIndex;
-    delete borderFocusStyles[':focus-visible'][':after'].zIndex;
+    delete (borderFocusStyles[':focus-visible'][':before'] as ICSSInJSStyle).zIndex;
+    delete (borderFocusStyles[':focus-visible'][':after'] as ICSSInJSStyle).zIndex;
 
     return {
       display: 'flex',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -67,7 +67,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
       display: 'none',
       whiteSpace: 'nowrap',
     };
-    if (v.isNarrow) {
+    if (v.hasReducedHorizontalSpace) {
       styles.fontSize = '1rem';
       styles.marginTop = pxToRem(3);
       styles.marginLeft = pxToRem(2.5);
@@ -80,12 +80,12 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
   body: ({ props: p, variables: v }): ICSSInJSStyle => ({
     position: 'relative',
     maxWidth: '100%',
-    ...(v.isFullWidth && {
+    ...(p.fullWidth && {
       width: '100%',
     }),
 
     ...(!p.mine &&
-      v.isNarrow && {
+      v.hasReducedHorizontalSpace && {
         marginRight: pxToRem(16),
       }),
   }),
@@ -107,7 +107,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
         backgroundAttachment: 'fixed',
       }),
 
-      ...(v.isFailed && {
+      ...(p.failed && {
         backgroundImage: 'none',
         backgroundColor: theme.siteVariables.colorScheme.red.background1,
         border: `1px solid ${theme.siteVariables.colorScheme.red.border}`,
@@ -166,8 +166,8 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
     // use padding instead of margin so that the bubble container's :hover
     // styles still apply when mousing over the gap between the container
     // and bubble-inset.
-    paddingLeft: v.isNarrow ? pxToRem(2.5) : pxToRem(5),
-    paddingRight: v.isNarrow ? pxToRem(2.5) : pxToRem(5),
+    paddingLeft: v.hasReducedHorizontalSpace ? pxToRem(2.5) : pxToRem(5),
+    paddingRight: v.hasReducedHorizontalSpace ? pxToRem(2.5) : pxToRem(5),
     ...(p.mine ? { right: '100%', flexDirection: 'row-reverse' } : { left: '100%' }),
   }),
 
@@ -182,7 +182,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
       '&:hover': { textDecorationStyle: 'double' },
       '&:focus': { textDecorationStyle: 'double' },
     },
-    ...(v.isFailed && {
+    ...(p.failed && {
       color: theme.siteVariables.colorScheme.default.foreground,
     }),
   }),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -158,10 +158,6 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
   },
 
   bubbleInset: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    // position: 'absolute',
-    // top: pxToRem(10),
-    // paddingTop: 0,
-
     display: 'flex',
     paddingTop: pxToRem(10),
     paddingBottom: 0,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -31,14 +31,10 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
       outline: 'none',
 
       [`&:focus-visible .${chatMessageSlotClassNames.timestamp}`]: {
-        display: 'block',
+        opacity: 1,
       },
 
       [`&:focus-visible .${chatMessageSlotClassNames.bubble}`]: borderFocusStyles[':focus-visible'],
-
-      [`& .bubble-inset:hover .${chatMessageSlotClassNames.timestamp}`]: {
-        display: 'block',
-      },
     };
   },
 
@@ -64,8 +60,10 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
 
   timestamp: ({ variables: v }): ICSSInJSStyle => {
     const styles: ICSSInJSStyle = {
-      display: 'none',
+      display: 'inline-block',
+      alignSelf: 'self-start',
       whiteSpace: 'nowrap',
+      opacity: 0,
     };
     if (v.hasReducedHorizontalSpace) {
       styles.fontSize = '1rem';
@@ -78,6 +76,8 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
   },
 
   body: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    display: 'flex',
+    flexDirection: p.mine ? 'row-reverse' : 'row',
     position: 'relative',
     maxWidth: '100%',
     ...(p.fullWidth && {
@@ -138,7 +138,7 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
         }),
 
       [`&:hover + .${chatMessageSlotClassNames.bubbleInset} .${chatMessageSlotClassNames.timestamp}`]: {
-        display: 'block',
+        opacity: 1,
       },
 
       ...(p.attached === true &&
@@ -158,10 +158,12 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
   },
 
   bubbleInset: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    position: 'absolute',
-    top: pxToRem(10),
+    // position: 'absolute',
+    // top: pxToRem(10),
+    // paddingTop: 0,
+
     display: 'flex',
-    paddingTop: 0,
+    paddingTop: pxToRem(10),
     paddingBottom: 0,
     // use padding instead of margin so that the bubble container's :hover
     // styles still apply when mousing over the gap between the container
@@ -169,6 +171,10 @@ export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageSt
     paddingLeft: v.hasReducedHorizontalSpace ? pxToRem(2.5) : pxToRem(5),
     paddingRight: v.hasReducedHorizontalSpace ? pxToRem(2.5) : pxToRem(5),
     ...(p.mine ? { right: '100%', flexDirection: 'row-reverse' } : { left: '100%' }),
+
+    [`&:hover .${chatMessageSlotClassNames.timestamp}`]: {
+      opacity: 1,
+    },
   }),
 
   content: ({ props: p, variables: v, theme }): ICSSInJSStyle => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageStylesComfyV2.ts
@@ -1,0 +1,227 @@
+import { isNil } from 'lodash';
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { getBorderFocusStyles } from '../../getBorderFocusStyles';
+import { chatMessageSlotClassNames, ChatMessageStylesProps } from '../../../../components/Chat/ChatMessage';
+import { pxToRem } from '../../../../utils';
+import { screenReaderContainerStyles } from '../../../../utils/accessibility/Styles/accessibilityStyles';
+import { ChatMessageVariables } from './chatMessageVariables';
+
+const displayActionMenu = (overlayZIndex: ICSSInJSStyle['zIndex']): ICSSInJSStyle => ({
+  zIndex: overlayZIndex!,
+  overflow: 'visible',
+  opacity: 1,
+  width: 'auto',
+});
+
+export const chatMessageStylesComfyV2: ComponentSlotStylesPrepared<ChatMessageStylesProps, ChatMessageVariables> = {
+  root: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
+    const borderFocusStyles = getBorderFocusStyles({
+      borderRadius: 'inherit',
+      variables: theme.siteVariables,
+    });
+
+    // Fixes the bubble focus border rendering on top of the user avatar
+    delete borderFocusStyles[':focus-visible'][':before'].zIndex;
+    delete borderFocusStyles[':focus-visible'][':after'].zIndex;
+
+    return {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: p.mine ? 'flex-end' : 'flex-start',
+      outline: 'none',
+
+      [`&:focus-visible .${chatMessageSlotClassNames.timestamp}`]: {
+        display: 'block',
+      },
+
+      [`&:focus-visible .${chatMessageSlotClassNames.bubble}`]: borderFocusStyles[':focus-visible'],
+
+      [`& .bubble-inset:hover .${chatMessageSlotClassNames.timestamp}`]: {
+        display: 'block',
+      },
+    };
+  },
+
+  header: ({ props: p, theme }): ICSSInJSStyle => ({
+    display: 'flex',
+    width: '100%',
+    justifyContent: p.mine ? 'flex-end' : 'start',
+    gap: pxToRem(8),
+    '& > div': {
+      paddingTop: pxToRem(8),
+    },
+    color: theme.siteVariables.colorScheme.default.foreground2,
+  }),
+
+  author: ({ props: p }): ICSSInJSStyle => ({
+    ...((p.mine || p.attached === 'bottom' || p.attached === true) && (screenReaderContainerStyles as ICSSInJSStyle)),
+    fontWeight: 400,
+    marginBottom: pxToRem(2),
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  }),
+
+  timestamp: ({ variables: v }): ICSSInJSStyle => {
+    const styles: ICSSInJSStyle = {
+      display: 'none',
+      whiteSpace: 'nowrap',
+    };
+    if (v.v2_isNarrow) {
+      styles.fontSize = '1rem';
+      styles.marginTop = pxToRem(3);
+      styles.marginLeft = pxToRem(2.5);
+      styles.marginRight = pxToRem(2.5);
+      styles.marginBottom = 0;
+    }
+    return styles;
+  },
+
+  body: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    position: 'relative',
+    maxWidth: '100%',
+    ...(v.v2_isFullWidth && {
+      width: '100%',
+    }),
+
+    ...(!p.mine &&
+      v.v2_isNarrow && {
+        marginRight: pxToRem(16),
+      }),
+  }),
+
+  bubble: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
+    return {
+      position: 'relative',
+      border: v.border,
+      borderRadius: pxToRem(6),
+      paddingLeft: pxToRem(16),
+      paddingRight: pxToRem(16),
+      paddingTop: pxToRem(8),
+      paddingBottom: p.hasReactions ? pxToRem(10) : pxToRem(8),
+
+      backgroundColor: p.mine ? `var(--chat-bubble-bg-mine, ${v.backgroundColorMine})` : v.backgroundColor,
+
+      ...(p.mine && {
+        backgroundImage: `var(--chat-bubble-bg-mine)`,
+        backgroundAttachment: 'fixed',
+      }),
+
+      ...(v.v2_isFailed && {
+        backgroundImage: 'none',
+        backgroundColor: theme.siteVariables.colorScheme.red.background1,
+        border: `1px solid ${theme.siteVariables.colorScheme.red.border}`,
+      }),
+
+      ...((v.hasMention || v.isImportant) && {
+        [`& .${chatMessageSlotClassNames.bar}`]: {
+          backgroundColor: v.hasMention ? v.hasMentionColor : v.isImportantColor,
+          position: 'absolute',
+
+          borderBottomLeftRadius: 'inherit',
+          borderTopLeftRadius: 'inherit',
+          height: '100%',
+          left: '0',
+          top: '0',
+          width: pxToRem(3),
+        },
+      }),
+
+      ...(isNil(v.showActionMenu) &&
+        p.hasActionMenu && {
+          ':hover': {
+            [`& > .${chatMessageSlotClassNames.actionMenu}`]: displayActionMenu(v.overlayZIndex),
+          },
+          ...(p.showActionMenu && {
+            [`& .${chatMessageSlotClassNames.actionMenu}`]: displayActionMenu(v.overlayZIndex),
+          }),
+        }),
+
+      [`&:hover + .${chatMessageSlotClassNames.bubbleInset} .${chatMessageSlotClassNames.timestamp}`]: {
+        display: 'block',
+      },
+
+      ...(p.attached === true &&
+        !v.isImportant && {
+          [p.mine ? 'borderTopRightRadius' : 'borderTopLeftRadius']: 0,
+          [p.mine ? 'borderBottomRightRadius' : 'borderBottomLeftRadius']: 0,
+        }),
+      ...(p.attached === 'top' &&
+        !v.isImportant && {
+          [p.mine ? 'borderBottomRightRadius' : 'borderBottomLeftRadius']: 0,
+        }),
+      ...(p.attached === 'bottom' &&
+        !v.isImportant && {
+          [p.mine ? 'borderTopRightRadius' : 'borderTopLeftRadius']: 0,
+        }),
+    };
+  },
+
+  bubbleInset: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    position: 'absolute',
+    top: pxToRem(10),
+    display: 'flex',
+    // use padding instead of margin so that the bubble container's :hover
+    // styles still apply when mousing over the gap between the container
+    // and bubble-inset.
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingLeft: v.v2_isNarrow ? pxToRem(2.5) : pxToRem(5),
+    paddingRight: v.v2_isNarrow ? pxToRem(2.5) : pxToRem(5),
+    ...(p.mine ? { right: '100%', flexDirection: 'row-reverse' } : { left: '100%' }),
+  }),
+
+  content: ({ props: p, variables: v, theme }): ICSSInJSStyle => ({
+    color: p.mine ? `var(--chat-bubble-fg-mine, ${v.contentColor})` : v.contentColor,
+    wordBreak: 'break-word',
+    wordWrap: 'break-word',
+    '& a': {
+      color: 'inherit',
+      textDecoration: 'underline',
+      wordBreak: 'break-all',
+      '&:hover': { textDecorationStyle: 'double' },
+      '&:focus': { textDecorationStyle: 'double' },
+    },
+    ...(v.v2_isFailed && {
+      color: theme.siteVariables.colorScheme.default.foreground,
+    }),
+  }),
+
+  badge: ({ props: p, variables: v }): ICSSInJSStyle => {
+    const styles: ICSSInJSStyle = {
+      position: 'relative',
+      top: pxToRem(-5),
+      width: pxToRem(25),
+      height: pxToRem(25),
+      backgroundColor: 'none',
+      color: v.isImportantColor,
+      zIndex: v.zIndex,
+      '& > :first-child': {
+        display: 'inline-flex',
+        margin: '0 auto',
+      },
+    };
+    if (p.mine) {
+      styles.marginRight = pxToRem(-5);
+    } else {
+      styles.marginLeft = pxToRem(-5);
+    }
+    return styles;
+  },
+
+  reactionGroup: ({ props: p }): ICSSInJSStyle => {
+    const styles: ICSSInJSStyle = {
+      position: 'relative',
+      display: 'flex',
+      mraginTop: pxToRem(2),
+      zIndex: 1,
+    };
+    if (p.mine) {
+      styles.float = 'right';
+      styles.marginRight = pxToRem(-4);
+    } else {
+      styles.float = 'left';
+    }
+    return styles;
+  },
+};

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -37,9 +37,7 @@ export interface ChatMessageVariables {
   reactionGroupMarginLeft: string;
   showActionMenu?: boolean;
   zIndex: number;
-  isFailed: boolean;
-  isNarrow: boolean;
-  isFullWidth: boolean;
+  hasReducedHorizontalSpace: boolean;
 }
 
 export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
@@ -79,7 +77,5 @@ export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
   reactionGroupMarginLeft: pxToRem(12),
   showActionMenu: undefined,
   zIndex: siteVars.zIndexes.foreground,
-  isFailed: false,
-  isNarrow: false,
-  isFullWidth: false,
+  hasReducedHorizontalSpace: false,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -37,6 +37,10 @@ export interface ChatMessageVariables {
   reactionGroupMarginLeft: string;
   showActionMenu?: boolean;
   zIndex: number;
+  // these properties are prefixed because they only affect the v2 layout.
+  v2_isFailed: boolean;
+  v2_isNarrow: boolean;
+  v2_isFullWidth: boolean;
 }
 
 export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
@@ -76,4 +80,7 @@ export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
   reactionGroupMarginLeft: pxToRem(12),
   showActionMenu: undefined,
   zIndex: siteVars.zIndexes.foreground,
+  v2_isFailed: false,
+  v2_isNarrow: false,
+  v2_isFullWidth: false,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Chat/chatMessageVariables.ts
@@ -37,10 +37,9 @@ export interface ChatMessageVariables {
   reactionGroupMarginLeft: string;
   showActionMenu?: boolean;
   zIndex: number;
-  // these properties are prefixed because they only affect the v2 layout.
-  v2_isFailed: boolean;
-  v2_isNarrow: boolean;
-  v2_isFullWidth: boolean;
+  isFailed: boolean;
+  isNarrow: boolean;
+  isFullWidth: boolean;
 }
 
 export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
@@ -80,7 +79,7 @@ export const chatMessageVariables = (siteVars): ChatMessageVariables => ({
   reactionGroupMarginLeft: pxToRem(12),
   showActionMenu: undefined,
   zIndex: siteVars.zIndexes.foreground,
-  v2_isFailed: false,
-  v2_isNarrow: false,
-  v2_isFullWidth: false,
+  isFailed: false,
+  isNarrow: false,
+  isFullWidth: false,
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally

PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

**NOTE**: Recreating this PR because of a CI issue that may be caused by the original PR pointing to a remote repository. I'll close the other one if this works.

## Current Behavior

We currently have two different layouts for ChatMessage: comfy and compact.

![image](https://user-images.githubusercontent.com/6439050/179882363-027cbf0c-8573-444c-b366-839d737defe4.png)

## New Behavior

This introduces a new variation on the ChatMessage comfy layout. It is enabled by passing the `v2` property to `ChatMessage`. We have tried to use the existing ChatMessage interface as much as possible, but did have to add a few properties specific to the new layout to achieve the desired result. These properties are namespaced in such a way that it's clear that they only apply to when the v2 layout is enabled.

- **Existing usage of ChatMessage remains unchanged.**
- Metadata sits outside of the bubble (e.g. author, edited state).
- Timestamp shows on hover and focus states (still accessible via screen reader).
- Updated placement of badges (e.g. importance, at-mention).

![MicrosoftTeams-image](https://user-images.githubusercontent.com/6439050/179882699-f9d0076e-f62b-46e4-9200-fa376eb4e3db.png)
