### PR TITLE
chore(react-dialog): removes aria-label from stories

### DIFF
--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogAlert.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogAlert.stories.tsx
@@ -9,7 +9,7 @@ export const AlertDialog = () => {
       <DialogTrigger>
         <Button>Open Alert dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Alert dialog title</DialogTitle>
         <DialogBody>
           This dialog cannot be dismissed by clicking on the backdrop nor by pressing Escape. Close button should be

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogChangeFocus.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogChangeFocus.stories.tsx
@@ -15,7 +15,7 @@ export const CustomFocusedElementOnOpen = () => {
       <DialogTrigger>
         <Button>Open dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
         <DialogBody>This dialog focus on the second button instead of the first</DialogBody>
         <DialogActions position="start">

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogControllingOpenAndClose.stories.tsx
@@ -10,7 +10,7 @@ export const ControllingOpenAndClose = () => {
       <DialogTrigger>
         <Button>Open dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
         <DialogBody>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque est

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogDefault.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogDefault.stories.tsx
@@ -8,7 +8,7 @@ export const Default = () => {
       <DialogTrigger>
         <Button>Open dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
         <DialogBody>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque est

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogNested.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogNested.stories.tsx
@@ -6,7 +6,7 @@ export const Nested = () => {
   return (
     <Dialog>
       <DialogTrigger>
-        <Button>Open dialog</Button>
+        <Button>Open nested dialog</Button>
       </DialogTrigger>
       <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
@@ -17,7 +17,7 @@ export const Nested = () => {
             </DialogTrigger>
             <DialogSurface>
               <DialogTitle>Inner dialog title</DialogTitle>
-              <DialogBody>⚠️ just because you can doesn't mean you should have nested dialogs ⚠️</DialogBody>
+              <DialogBody>⛔️ just because you can doesn't mean you should have nested dialogs ⛔️</DialogBody>
               <DialogActions>
                 <DialogTrigger>
                   <Button appearance="primary">Close</Button>

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogNoFocusableElement.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogNoFocusableElement.stories.tsx
@@ -12,7 +12,7 @@ export const NoFocusableElement = () => {
         <DialogSurface>
           <DialogTitle>Dialog Title</DialogTitle>
           <DialogBody>
-            <p>⚠️A Dialog without focusable elements is not recommended!⚠️</p>
+            <p>⛔️ A Dialog without focusable elements is not recommended! ⛔️</p>
             <p>Escape key and backdrop click still works to ensure this modal can be closed</p>
           </DialogBody>
         </DialogSurface>
@@ -24,8 +24,8 @@ export const NoFocusableElement = () => {
         <DialogSurface>
           <DialogTitle closeButton={null}>Dialog Title</DialogTitle>
           <DialogBody>
-            <p>⚠️A Dialog without focusable elements is not recommended!⚠️</p>
-            <p>Escape key still works to ensure this modal can be closed</p>
+            <p>⛔️ A Dialog without focusable elements is not recommended! ⛔️</p>
+            <p>⛔️ Escape key doesn't work, you're trapped! ⛔️</p>
           </DialogBody>
         </DialogSurface>
       </Dialog>

--- a/packages/react-components/react-dialog/src/stories/Dialog/DialogScrollingLongContent.stories.tsx
+++ b/packages/react-components/react-dialog/src/stories/Dialog/DialogScrollingLongContent.stories.tsx
@@ -8,7 +8,7 @@ export const ScrollingLongContent = () => {
       <DialogTrigger>
         <Button>Open dialog</Button>
       </DialogTrigger>
-      <DialogSurface aria-label="label">
+      <DialogSurface>
         <DialogTitle>Dialog title</DialogTitle>
         <DialogBody>
           <p>


### PR DESCRIPTION

## Current Behavior

`aria-label` has been added on most `DialogSurface` stories since `tabster` didn't support `aria-labelledby` attribute (which is used internally by `DialogSurface`) as a valid description.

### Extra

Modifies some content from `DialogBody`

## New Behavior

removes `aria-label` since newest version of `tabster` supports `aria-labelledby` attribute.

