### PR TITLE
docs(RFC): Update File Organization Convention for v9 RFC to address other issue

### DIFF
--- a/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
+++ b/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
@@ -22,16 +22,14 @@ The proposed folder organization can be seen below:
 |- stories/
   |- assets/
   |- {componentName}/ //story files
-|- e2e/ //cypress tests files
-  |- assets/
-  |- e2e tests
 |- src/
   |- components/
-    |- {ComponentName}/ //implementation and unit test files
+    |- {ComponentName}/ //implementation, unit and cypress test files
       |- index.ts
       |- {ComponentName}.tsx
       |- {ComponentName}.types.ts
       |- {ComponentName}.test.tsx
+      |- {ComponentName}.e2e.tsx
       |- render{ComponentName}.tsx
       |- use{ComponentName}.tsx
       |- use{ComponentName}Styles.ts
@@ -51,7 +49,11 @@ package.json
 README.md
 ```
 
-We're already following this convention when it comes to e2e so most of the work will be extracting stories out of the `src` folder and moving those to the root of the package. The asset files will also need to be moved to the appropriate `assets` subfolder. The `.npmignore` file will then be updated to ignore any asset files and files living within the documentation folder. Also, the old `common/` folder which caused confusion and unexpected linting errors will now be replaced with a more robust `testing/` subfolder within the `src` folder to house the conformance testing factory and any mock testing files to be used in multiple tests within a package.
+We will be extracting stories out of the `src` folder and moving those to the root of the package within a `stories/` subfolder. The asset files will also need to be moved to the appropriate `assets` subfolder. The `.npmignore` file will then be updated to ignore any asset files and files living within the documentation folder.
+
+Also, the old `common/` folder which caused confusion and unexpected linting errors will now be replaced with a more robust `testing/` subfolder within the `src` folder to house the conformance testing factory and any mock or utility testing files to be used in multiple tests within a package.
+
+The final change will be removing the `e2e/` subfolder and collocating all cypress tests with the implementation and jest test files. The motivation for this is because we use cypress to test components on a real browser and not as a true e2e solution. Nx also collocates those cypress files like standard jest files so having them together provides more consistency.
 
 ## Pros and Cons
 

--- a/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
+++ b/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
@@ -29,7 +29,7 @@ The proposed folder organization can be seen below:
       |- {ComponentName}.tsx
       |- {ComponentName}.types.ts
       |- {ComponentName}.test.tsx
-      |- {ComponentName}.e2e.tsx
+      |- {ComponentName}.cy.tsx
       |- render{ComponentName}.tsx
       |- use{ComponentName}.tsx
       |- use{ComponentName}Styles.ts

--- a/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
+++ b/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
@@ -40,6 +40,7 @@ The proposed folder organization can be seen below:
   |- testing/
     |- index.ts
     |- isConformant.ts
+    |- some-testing-utility.ts
     |- your-mock-test.mock.ts //mock testing files to be used in multiple tests within package
   |- index.ts
   |- {componentName}.ts

--- a/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
+++ b/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
@@ -54,7 +54,7 @@ We will be extracting stories out of the `src` folder and moving those to the ro
 
 Also, the old `common/` folder which caused confusion and unexpected linting errors will now be replaced with a more robust `testing/` subfolder within the `src` folder to house the conformance testing factory and any mock or utility testing files to be used in multiple tests within a package.
 
-The final change will be removing the `e2e/` subfolder and collocating all cypress tests with the implementation and jest test files. The motivation for this is because we use cypress to test components on a real browser and not as a true e2e solution. Nx also collocates those cypress files like standard jest files so having them together provides more consistency.
+The final change will be removing the `e2e/` subfolder and collocating all cypress tests with the implementation and jest test files. The motivation for this is that we use cypress to test components on a real browser and not as a true e2e solution so calling it e2e is a bit misleading. Nx also collocates those cypress files with standard jest files so having them together from the get go provides more consistency.
 
 ## Pros and Cons
 

--- a/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
+++ b/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
@@ -54,7 +54,7 @@ We will be extracting stories out of the `src` folder and moving those to the ro
 
 Also, the old `common/` folder which caused confusion and unexpected linting errors will now be replaced with a more robust `testing/` subfolder within the `src` folder to house the conformance testing factory and any mock or utility testing files to be used in multiple tests within a package.
 
-The final change will be removing the `e2e/` subfolder and collocating all cypress tests with the implementation and jest test files. The motivation for this is that we use cypress to test components on a real browser and not as a true e2e solution so calling it e2e is a bit misleading. Nx also collocates those cypress files with standard jest files so having them together from the get go provides more consistency.
+The final change will be removing the `e2e/` subfolder and collocating all cypress component tests with the implementation and jest test files. The motivation for this is that we use cypress to test components on a real browser and not as a true e2e solution so calling it e2e is a bit misleading. Nx also collocates those cypress component test files with standard jest files so having them together from the get go provides more consistency.
 
 ## Pros and Cons
 

--- a/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
+++ b/rfcs/shared/build-system/07-standard-package-structure-for-v9.md
@@ -22,12 +22,27 @@ The proposed folder organization can be seen below:
 |- stories/
   |- assets/
   |- {componentName}/ //story files
-|- e2e/
+|- e2e/ //cypress tests files
   |- assets/
   |- e2e tests
 |- src/
-  |- common/
-  |- components/ //implementation and test files
+  |- components/
+    |- {ComponentName}/ //implementation and unit test files
+      |- index.ts
+      |- {ComponentName}.tsx
+      |- {ComponentName}.types.ts
+      |- {ComponentName}.test.tsx
+      |- render{ComponentName}.tsx
+      |- use{ComponentName}.tsx
+      |- use{ComponentName}Styles.ts
+  |- utils/ //shared implementation or utility files
+    |- index.ts
+    |- shared-component-types.types.ts
+    |- some-function-or-hook.ts
+  |- testing/
+    |- index.ts
+    |- isConformant.ts
+    |- your-mock-test.mock.ts //mock testing files to be used in multiple tests within package
   |- index.ts
   |- {componentName}.ts
 CHANGELOG.json
@@ -36,7 +51,7 @@ package.json
 README.md
 ```
 
-We're already following this convention when it comes to e2e so most of the work will be extracting stories out of the `src` folder and moving those to the root of the package. The asset files will also need to be moved to the appropriate `assets` subfolder. And finally, the `.npmignore` file will then be updated to ignore any asset files and files living within the documentation folder.
+We're already following this convention when it comes to e2e so most of the work will be extracting stories out of the `src` folder and moving those to the root of the package. The asset files will also need to be moved to the appropriate `assets` subfolder. The `.npmignore` file will then be updated to ignore any asset files and files living within the documentation folder. Also, the old `common/` folder which caused confusion and unexpected linting errors will now be replaced with a more robust `testing/` subfolder within the `src` folder to house the conformance testing factory and any mock testing files to be used in multiple tests within a package.
 
 ## Pros and Cons
 
@@ -53,3 +68,4 @@ We're already following this convention when it comes to e2e so most of the work
 ## Open Issues
 
 - [#22289](https://github.com/microsoft/fluentui/issues/22289)
+- [#23976](https://github.com/microsoft/fluentui/issues/23976)


### PR DESCRIPTION
## Changes
- Updates **File Organization Convention for v9 Packages** RFC to reflect removal of [problematic ](https://github.com/microsoft/fluentui/issues/23976) `common/` folder and adds proposed replacement for it. Also provides a more detailed outline of how the `components/`, `utils/` and new `testing/` subfolders should be structured.
- Also adds an update to remove the `e2e/` subfolder in favor of collocating cypress tests with the implementation and unit/jest files.

[PREVIEW](https://github.com/microsoft/fluentui/pull/24543/files?short_path=aa0c69f#diff-aa0c69ffcf1e796ffc7b69168e9575f60caaa35981660d6ebb2b8d8e64ff1d19)


Follow-up to https://github.com/microsoft/fluentui/pull/24332#discussion_r952720485
Part of https://github.com/microsoft/fluentui/issues/24129