### PR TITLE
docs(v8): replace placeholder images with assets from CDN

### DIFF
--- a/packages/react-examples/src/react/Announced/Announced.LazyLoading.Example.tsx
+++ b/packages/react-examples/src/react/Announced/Announced.LazyLoading.Example.tsx
@@ -48,7 +48,7 @@ export const AnnouncedLazyLoadingExample = () => {
     const width = 100;
     const height = 100;
     return createArray(PHOTO_COUNT, () => ({
-      url: `https://via.placeholder.com/${width}x${height}`,
+      url: `https://fabricweb.azureedge.net/fabric-website/placeholders/${width}x${height}.png`,
       width,
       height,
     }));

--- a/packages/react-examples/src/react/Image/Image.Center.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Center.Example.tsx
@@ -21,7 +21,7 @@ export const ImageCenterExample = () => {
       <p>This image is larger than the frame, so all sides are cropped to center the image.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/800x300"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/800x300.png"
         alt='Example of the image fit value "center" on an image larger than the frame.'
       />
       <p>
@@ -30,7 +30,7 @@ export const ImageCenterExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/100x100"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/100x100.png"
         alt='Example of the image fit value "center" on an image smaller than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/Image/Image.CenterContain.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.CenterContain.Example.tsx
@@ -22,32 +22,32 @@ export const ImageCenterContainExample = () => {
       <p>This image is smaller than the frame, so it's centered and rendered at its natural size.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/100x150"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/100x150.png"
         alt='Example of the image fit value "centerContain" on an image smaller than the frame.'
       />
       <p>This image is wider than the frame, so it's contained.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/300x100"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/300x100.png"
         alt='Example of the image fit value "centerContain" on an image wider than the frame.'
       />
       <p>This image is taller than the frame, so it's contained.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/100x300"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/100x300.png"
         alt='Example of the image fit value "centerContain" on an image taller than the frame.'
       />
       <p>These images are taller and wider than the frame, so they are contained.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/400x500"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/400x500.png"
         alt='Example of the image fit value "centerContain" on an image taller and wider than the frame.'
       />
       <br />
       <br />
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/500x400"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/500x400.png"
         alt='Example of the image fit value "centerContain" on an image taller and wider than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/Image/Image.CenterCover.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.CenterCover.Example.tsx
@@ -22,7 +22,7 @@ export const ImageCenterCoverExample = () => {
       <p>This image is smaller than the frame, so it's centered and rendered at its natural size.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/100x150"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/100x150.png"
         alt='Example of the image fit value "centerCover" on an image smaller than the frame.'
       />
       <p>
@@ -31,7 +31,7 @@ export const ImageCenterCoverExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/300x100"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/300x100.png"
         alt='Example of the image fit value "centerCover" on an image wider than the frame.'
       />
       <p>
@@ -40,20 +40,20 @@ export const ImageCenterCoverExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/100x300"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/100x300.png"
         alt='Example of the image fit value "centerCover" on an image taller than the frame.'
       />
       <p>These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/400x500"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/400x500.png"
         alt='Example of the image fit value "centerCover" on an image taller and wider than the frame.'
       />
       <br />
       <br />
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/500x400"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/500x400.png"
         alt='Example of the image fit value "centerCover" on an image taller and wider than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/Image/Image.Contain.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Contain.Example.tsx
@@ -5,7 +5,7 @@ import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
 // Normally specifying them inline would be fine.
 const imageProps: IImageProps = {
   imageFit: ImageFit.contain,
-  src: 'https://via.placeholder.com/700x300',
+  src: 'https://fabricweb.azureedge.net/fabric-website/placeholders/700x300.png',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.Cover.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Cover.Example.tsx
@@ -5,7 +5,7 @@ import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
 // Normally specifying them inline would be fine.
 const imageProps: IImageProps = {
   imageFit: ImageFit.cover,
-  src: 'https://via.placeholder.com/600x600',
+  src: 'https://fabricweb.azureedge.net/fabric-website/placeholders/500x500.png',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.Default.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Default.Example.tsx
@@ -4,7 +4,7 @@ import { Image, IImageProps } from '@fluentui/react/lib/Image';
 // These props are defined up here so they can easily be applied to multiple Images.
 // Normally specifying them inline would be fine.
 const imageProps: Partial<IImageProps> = {
-  src: 'https://via.placeholder.com/350x150',
+  src: 'https://fabricweb.azureedge.net/fabric-website/placeholders/350x150.png',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.MaximizeFrame.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.MaximizeFrame.Example.tsx
@@ -6,7 +6,7 @@ import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
 const imageProps: IImageProps = {
   maximizeFrame: true,
   imageFit: ImageFit.cover,
-  src: 'https://via.placeholder.com/600x600',
+  src: 'https://fabricweb.azureedge.net/fabric-website/placeholders/500x500.png',
   // Show a border around the image (just for demonstration purposes)
   styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
 };

--- a/packages/react-examples/src/react/Image/Image.None.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.None.Example.tsx
@@ -21,7 +21,7 @@ export const ImageNoneExample = () => {
       <p>This image is larger than the frame, so it's cropped to fit and positioned at the upper left.</p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/500x250"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/500x250.png"
         alt='Example of the image fit value "none" on an image larger than the frame.'
       />
       <p>
@@ -30,7 +30,7 @@ export const ImageNoneExample = () => {
       </p>
       <Image
         {...imageProps}
-        src="https://via.placeholder.com/100x100"
+        src="https://fabricweb.azureedge.net/fabric-website/placeholders/100x100.png"
         alt='Example of the image fit value "none" on an image smaller than the frame.'
       />
     </div>

--- a/packages/react-examples/src/react/MarqueeSelection/MarqueeSelection.Basic.Example.tsx
+++ b/packages/react-examples/src/react/MarqueeSelection/MarqueeSelection.Basic.Example.tsx
@@ -15,7 +15,7 @@ const PHOTOS: IPhoto[] = createArray(250, (index: number) => {
   const randomWidth = 50 + Math.floor(Math.random() * 150);
   return {
     key: index,
-    url: `https://via.placeholder.com/${randomWidth}x100`,
+    url: `https://fabricweb.azureedge.net/fabric-website/placeholders/${randomWidth}x100.png`,
     width: randomWidth,
     height: 100,
   };

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.Illustration.Example.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.Illustration.Example.tsx
@@ -4,7 +4,10 @@ import { DefaultButton, IButtonProps } from '@fluentui/react/lib/Button';
 import { TeachingBubble } from '@fluentui/react/lib/TeachingBubble';
 import { useBoolean, useId } from '@fluentui/react-hooks';
 
-const exampleImageProps: IImageProps = { src: 'https://via.placeholder.com/364x180', alt: 'Example placeholder image' };
+const exampleImageProps: IImageProps = {
+  src: 'https://fabricweb.azureedge.net/fabric-website/placeholders/364x180.png',
+  alt: 'Example placeholder image',
+};
 
 const examplePrimaryButtonProps: IButtonProps = {
   children: 'Try it out',

--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.WideIllustration.Example.tsx
@@ -9,7 +9,10 @@ const examplePrimaryButtonProps: IButtonProps = {
   children: 'Try it out',
 };
 
-const exampleImageProps: IImageProps = { src: 'https://via.placeholder.com/154x220', alt: 'Example placeholder image' };
+const exampleImageProps: IImageProps = {
+  src: 'https://fabricweb.azureedge.net/fabric-website/placeholders/154x220.png',
+  alt: 'Example placeholder image',
+};
 
 const CalloutProps = { directionalHint: DirectionalHint.bottomCenter };
 


### PR DESCRIPTION
## Changes
- placeholder.com assets not loading (see [here](https://developer.microsoft.com/en-us/fluentui#/controls/web/image)) when viewed through docsite so this PR replaces them with image assets served from our CDN storage.


Follow up to #24489

Fixes #24301