### PR TITLE
fix: react-combobox rename onSelect to onOptionSelect to avoid native event conflict

### DIFF
--- a/change/@fluentui-react-combobox-dcf36678-5acd-424c-89de-aa1363dd9e9d.json
+++ b/change/@fluentui-react-combobox-dcf36678-5acd-424c-89de-aa1363dd9e9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: react-combobox change onSelect to onOptionSelect to avoid conflicts with native onSelect",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/Spec.md
+++ b/packages/react-components/react-combobox/Spec.md
@@ -143,9 +143,9 @@ Combobox in v9 allows both controlled and uncontrolled selection, as do the corr
 | -------------------- | ------------------- | ------------------- | ------------------ | -------------------- | ------------ |
 | Initial selection    | initialSelectedKeys | defaultSelectedKeys | defaultSelectedKey | defaultSelectedItems | defaultValue |
 | Controlled selection | selectedKeys        | selectedKey         | selectedKey        | selectedItems        | value        |
-| Callback             | onSelect            | onChange            | onChange           | onChange             | onChange     |
+| Callback             | onOptionSelect      | onChange            | onChange           | onChange             | onChange     |
 
-The reason to move to `onSelect` over `onChange` in the v9 Combobox is because the editable Combobox uses an `<input>` element as its primary slot. Using `onSelect` allows the input to retain it's built-in `onChange` event. This could be revisited if we want to override `onChange` to handle both input value changes and selection changes.
+The reason to move to `onOptionSelect` over `onChange` in the v9 Combobox is because the editable Combobox uses an `<input>` element as its primary slot. Using `onOptionSelect` allows the input to retain it's built-in `onChange` event.
 
 ## Sample Code
 
@@ -344,7 +344,7 @@ type SimpleComboboxProps = {
   onOpenChange?(event: OpenEvents, data: OnOpenChangeData): void;
 
   /* Callback when an option is selected */
-  onSelect?(event: SelectionEvents, optionKey: string): void;
+  onOptionSelect?(event: SelectionEvents, optionKey: string): void;
 };
 ```
 
@@ -367,7 +367,7 @@ type SimpleListboxProps = {
   selectedKeys?: string[];
 
   /* Callback when an option is selected */
-  onSelect?(event: SelectionEvents, optionKey: string): void;
+  onOptionSelect?(event: SelectionEvents, optionKey: string): void;
 };
 ```
 

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -406,6 +406,53 @@ describe('Combobox', () => {
     expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Red');
   });
 
+  it('calls onOptionSelect with correct data for single-select', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole, getByText } = render(
+      <Combobox value="Red" onOptionSelect={onOptionSelect}>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    userEvent.click(getByRole('combobox'));
+    userEvent.click(getByText('Green'));
+
+    expect(onOptionSelect).toHaveBeenCalledTimes(1);
+    expect(onOptionSelect).toHaveBeenCalledWith(expect.anything(), {
+      optionValue: 'Green',
+      selectedOptions: ['Green'],
+    });
+  });
+
+  it('calls onOptionSelect with correct data for multi-select', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole, getByText } = render(
+      <Combobox value="Red" onOptionSelect={onOptionSelect} multiselect>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    userEvent.click(getByRole('combobox'));
+    userEvent.click(getByText('Green'));
+    userEvent.click(getByText('Blue'));
+
+    expect(onOptionSelect).toHaveBeenCalledTimes(2);
+    expect(onOptionSelect).toHaveBeenNthCalledWith(1, expect.anything(), {
+      optionValue: 'Green',
+      selectedOptions: ['Green'],
+    });
+    expect(onOptionSelect).toHaveBeenNthCalledWith(2, expect.anything(), {
+      optionValue: 'Blue',
+      selectedOptions: ['Green', 'Blue'],
+    });
+  });
+
   /* Active option */
   it('should set active option on click', () => {
     const { getByTestId } = render(

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -46,7 +46,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
-    excludedPropNames: ['children', 'size'],
+    excludedPropNames: ['children', 'size', 'onOptionSelect'],
   });
 
   const triggerRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -46,7 +46,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
-    excludedPropNames: ['children', 'size', 'onOptionSelect'],
+    excludedPropNames: ['children', 'size'],
   });
 
   const triggerRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -323,6 +323,53 @@ describe('Dropdown', () => {
     expect(getByText('Blue').getAttribute('aria-selected')).toEqual('false');
   });
 
+  it('calls onOptionSelect with correct data for single-select', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole, getByText } = render(
+      <Dropdown value="Red" onOptionSelect={onOptionSelect}>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    userEvent.click(getByRole('combobox'));
+    userEvent.click(getByText('Green'));
+
+    expect(onOptionSelect).toHaveBeenCalledTimes(1);
+    expect(onOptionSelect).toHaveBeenCalledWith(expect.anything(), {
+      optionValue: 'Green',
+      selectedOptions: ['Green'],
+    });
+  });
+
+  it('calls onOptionSelect with correct data for multi-select', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole, getByText } = render(
+      <Dropdown value="Red" onOptionSelect={onOptionSelect} multiselect>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    userEvent.click(getByRole('combobox'));
+    userEvent.click(getByText('Green'));
+    userEvent.click(getByText('Blue'));
+
+    expect(onOptionSelect).toHaveBeenCalledTimes(2);
+    expect(onOptionSelect).toHaveBeenNthCalledWith(1, expect.anything(), {
+      optionValue: 'Green',
+      selectedOptions: ['Green'],
+    });
+    expect(onOptionSelect).toHaveBeenNthCalledWith(2, expect.anything(), {
+      optionValue: 'Blue',
+      selectedOptions: ['Green', 'Blue'],
+    });
+  });
+
   it('stays open on click for multiselect', () => {
     const { getByText, getByRole } = render(
       <Dropdown defaultOpen multiselect>

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
@@ -206,10 +206,10 @@ describe('Listbox', () => {
   });
 
   it('should fire onChange when an option is selected', () => {
-    const onSelect = jest.fn();
+    const onOptionSelect = jest.fn();
 
     const { getByText } = render(
-      <Listbox onSelect={onSelect}>
+      <Listbox onOptionSelect={onOptionSelect}>
         <Option>Red</Option>
         <Option>Green</Option>
         <Option>Blue</Option>
@@ -218,15 +218,15 @@ describe('Listbox', () => {
 
     fireEvent.click(getByText('Red'));
 
-    expect(onSelect).toHaveBeenCalled();
-    expect(onSelect.mock.calls[0][1]).toEqual({ optionValue: 'Red', selectedOptions: ['Red'] });
+    expect(onOptionSelect).toHaveBeenCalled();
+    expect(onOptionSelect.mock.calls[0][1]).toEqual({ optionValue: 'Red', selectedOptions: ['Red'] });
   });
 
   it('should not change selection with selectedOptions', () => {
-    const onSelect = jest.fn();
+    const onOptionSelect = jest.fn();
 
     const { getByText } = render(
-      <Listbox onSelect={onSelect} selectedOptions={['Green']}>
+      <Listbox onOptionSelect={onOptionSelect} selectedOptions={['Green']}>
         <Option>Red</Option>
         <Option>Green</Option>
         <Option>Blue</Option>
@@ -238,15 +238,15 @@ describe('Listbox', () => {
     fireEvent.click(option);
 
     expect(option.getAttribute('aria-selected')).toEqual('false');
-    expect(onSelect).toHaveBeenCalled();
-    expect(onSelect.mock.calls[0][1]).toEqual({ optionValue: 'Red', selectedOptions: ['Red'] });
+    expect(onOptionSelect).toHaveBeenCalled();
+    expect(onOptionSelect.mock.calls[0][1]).toEqual({ optionValue: 'Red', selectedOptions: ['Red'] });
   });
 
   it('should select option with the enter key', () => {
-    const onSelect = jest.fn();
+    const onOptionSelect = jest.fn();
 
     const { getByTestId } = render(
-      <Listbox data-testid="listbox" onSelect={onSelect}>
+      <Listbox data-testid="listbox" onOptionSelect={onOptionSelect}>
         <Option data-testid="red">Red</Option>
         <Option>Green</Option>
         <Option>Blue</Option>
@@ -258,14 +258,14 @@ describe('Listbox', () => {
     fireEvent.keyDown(listbox, { key: 'Enter' });
 
     expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(onSelect).toHaveBeenCalled();
+    expect(onOptionSelect).toHaveBeenCalled();
   });
 
   it('should select option with the space key', () => {
-    const onSelect = jest.fn();
+    const onOptionSelect = jest.fn();
 
     const { getByTestId } = render(
-      <Listbox data-testid="listbox" onSelect={onSelect}>
+      <Listbox data-testid="listbox" onOptionSelect={onOptionSelect}>
         <Option data-testid="red">Red</Option>
         <Option>Green</Option>
         <Option>Blue</Option>
@@ -277,6 +277,6 @@ describe('Listbox', () => {
     fireEvent.keyDown(listbox, { key: ' ' });
 
     expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(onSelect).toHaveBeenCalled();
+    expect(onOptionSelect).toHaveBeenCalled();
   });
 });

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -62,7 +62,7 @@ export type ComboboxBaseProps = SelectionProps & {
 
   /**
    * The value displayed by the Combobox.
-   * Use this with `onSelect` to directly control the displayed value string
+   * Use this with `onOptionSelect` to directly control the displayed value string
    */
   value?: string;
 };

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -14,7 +14,7 @@ export type SelectionProps = {
   multiselect?: boolean;
 
   /* Callback when an option is selected */
-  onOptionSelect?: (event: SelectionEvents, data: OptionSelectData) => void;
+  onOptionSelect?: (event: SelectionEvents, data: OptionOnSelectData) => void;
 
   /**
    * An array of selected option keys.
@@ -36,7 +36,7 @@ export type SelectionValue = {
  * Data for the onOptionSelect callback.
  * `optionValue` will be undefined if the multiple options are modified at once.
  */
-export type OptionSelectData = { optionValue: string | undefined; selectedOptions: string[] };
+export type OptionOnSelectData = { optionValue: string | undefined; selectedOptions: string[] };
 
 /* Possible event types for onOptionSelect */
 export type SelectionEvents =

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -14,11 +14,11 @@ export type SelectionProps = {
   multiselect?: boolean;
 
   /* Callback when an option is selected */
-  onSelect?(event: SelectionEvents, data: OnSelectData): void;
+  onOptionSelect?: (event: SelectionEvents, data: OptionSelectData) => void;
 
   /**
    * An array of selected option keys.
-   * Use this with `onSelect` to directly control the selected option(s)
+   * Use this with `onOptionSelect` to directly control the selected option(s)
    */
   selectedOptions?: string[];
 };
@@ -33,12 +33,12 @@ export type SelectionValue = {
 };
 
 /*
- * Data for the onSelect callback.
+ * Data for the onOptionSelect callback.
  * `optionValue` will be undefined if the multiple options are modified at once.
  */
-export type OnSelectData = { optionValue: string | undefined; selectedOptions: string[] };
+export type OptionSelectData = { optionValue: string | undefined; selectedOptions: string[] };
 
-/* Possible event types for onSelect */
+/* Possible event types for onOptionSelect */
 export type SelectionEvents =
   | React.ChangeEvent<HTMLElement>
   | React.KeyboardEvent<HTMLElement>

--- a/packages/react-components/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-components/react-combobox/src/utils/useSelection.ts
@@ -3,7 +3,7 @@ import { OptionValue } from './OptionCollection.types';
 import { SelectionEvents, SelectionProps, SelectionValue } from './Selection.types';
 
 export const useSelection = (props: SelectionProps): SelectionValue => {
-  const { defaultSelectedOptions, multiselect, onSelect } = props;
+  const { defaultSelectedOptions, multiselect, onOptionSelect } = props;
 
   const [selectedOptions, setSelectedOptions] = useControllableState({
     state: props.selectedOptions,
@@ -33,12 +33,12 @@ export const useSelection = (props: SelectionProps): SelectionValue => {
     }
 
     setSelectedOptions(newSelection);
-    onSelect?.(event, { optionValue: option.value, selectedOptions: newSelection });
+    onOptionSelect?.(event, { optionValue: option.value, selectedOptions: newSelection });
   };
 
   const clearSelection = (event: SelectionEvents) => {
     setSelectedOptions([]);
-    onSelect?.(event, { optionValue: undefined, selectedOptions: [] });
+    onOptionSelect?.(event, { optionValue: undefined, selectedOptions: [] });
   };
 
   return { clearSelection, selectOption, selectedOptions };


### PR DESCRIPTION
Fixes #24537
Fixes #24539

The `onSelect` event was causing type issues and getting called multiple times on Combobox because it overlaps with the native `onSelect` event.

This PR changes the prop name to `onOptionSelect`, and adds tests to combobox/dropdown in addition to the listbox tests.