### PR TITLE
Fix legends selection bugs

### DIFF
--- a/change/@fluentui-react-charting-3475ad9e-70bd-41ba-8508-fb05f00a786f.json
+++ b/change/@fluentui-react-charting-3475ad9e-70bd-41ba-8508-fb05f00a786f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix legends selection bugs",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -101,6 +101,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     super(props);
     this._createSet = memoizeFunction((data: IChartProps) => this._createDataSet(data.lineChartData!));
     this.state = {
+      selectedLegend: '',
       activeLegend: '',
       hoverXValue: '',
       isCalloutVisible: false,
@@ -430,42 +431,32 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     this._chart = this._drawGraph(containerHeight, xAxis, yAxis, xElement!);
   };
 
-  private _onLegendClick(customMessage: string): void {
-    if (this.state.isLegendSelected) {
-      if (this.state.activeLegend === customMessage) {
-        this.setState({
-          isLegendSelected: false,
-          activeLegend: '',
-        });
-      } else {
-        this.setState({
-          activeLegend: customMessage,
-        });
-      }
+  private _onLegendClick(legend: string): void {
+    if (this.state.selectedLegend === legend) {
+      this.setState({
+        isLegendSelected: false,
+        selectedLegend: '',
+      });
     } else {
       this.setState({
-        activeLegend: customMessage,
+        isLegendSelected: true,
+        selectedLegend: legend,
       });
     }
   }
 
-  private _onLegendHover(customMessage: string): void {
-    if (this.state.isLegendSelected === false) {
-      this.setState({
-        activeLegend: customMessage,
-        isLegendHovered: true,
-      });
-    }
+  private _onLegendHover(legend: string): void {
+    this.setState({
+      activeLegend: legend,
+      isLegendHovered: true,
+    });
   }
 
-  private _onLegendLeave(isLegendFocused?: boolean): void {
-    if (!!isLegendFocused || this.state.isLegendSelected === false) {
-      this.setState({
-        activeLegend: '',
-        isLegendHovered: false,
-        isLegendSelected: isLegendFocused ? false : this.state.isLegendSelected,
-      });
-    }
+  private _onLegendLeave(): void {
+    this.setState({
+      activeLegend: '',
+      isLegendHovered: false,
+    });
   }
 
   private _getLegendData = (palette: IPalette, points: ILineChartPoints[]): JSX.Element => {
@@ -493,8 +484,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
         hoverAction: () => {
           this._onLegendHover(singleChartData.legend);
         },
-        onMouseOutAction: (isLegendSelected?: boolean) => {
-          this._onLegendLeave(isLegendSelected);
+        onMouseOutAction: () => {
+          this._onLegendLeave();
         },
       };
 
@@ -518,14 +509,15 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     this.setState({ isCircleClicked: true });
   };
 
-  private _getOpacity = (selectedArea: string): number => {
+  private _getOpacity = (legend: string): number => {
     if (!this._isMultiStackChart) {
       return 0.7;
     } else {
-      let opacity = 0.7;
-      if (this.state.isLegendHovered || this.state.isLegendSelected) {
-        opacity = this.state.activeLegend === selectedArea ? 0.7 : 0.1;
-      }
+      const opacity =
+        this.state.selectedLegend === legend ||
+        (!this.state.isLegendSelected && (!this.state.isLegendHovered || this.state.activeLegend === legend))
+          ? 0.7
+          : 0.1;
       return opacity;
     }
   };
@@ -539,7 +531,10 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
         opacity = 1;
       }
       if (this.state.isLegendHovered || this.state.isLegendSelected) {
-        opacity = this.state.activeLegend === legend ? 0 : 0.1;
+        opacity =
+          this.state.selectedLegend === legend || (!this.state.isLegendSelected && this.state.activeLegend === legend)
+            ? 0
+            : 0.1;
       }
       return opacity;
     }

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -105,8 +105,6 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       activeLegend: '',
       hoverXValue: '',
       isCalloutVisible: false,
-      isLegendSelected: false,
-      isLegendHovered: false,
       refSelected: null,
       YValueHover: [],
       lineXValue: 0,
@@ -434,12 +432,10 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
   private _onLegendClick(legend: string): void {
     if (this.state.selectedLegend === legend) {
       this.setState({
-        isLegendSelected: false,
         selectedLegend: '',
       });
     } else {
       this.setState({
-        isLegendSelected: true,
         selectedLegend: legend,
       });
     }
@@ -448,14 +444,12 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
   private _onLegendHover(legend: string): void {
     this.setState({
       activeLegend: legend,
-      isLegendHovered: true,
     });
   }
 
   private _onLegendLeave(): void {
     this.setState({
       activeLegend: '',
-      isLegendHovered: false,
     });
   }
 
@@ -513,11 +507,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     if (!this._isMultiStackChart) {
       return 0.7;
     } else {
-      const opacity =
-        this.state.selectedLegend === legend ||
-        (!this.state.isLegendSelected && (!this.state.isLegendHovered || this.state.activeLegend === legend))
-          ? 0.7
-          : 0.1;
+      const opacity = this._legendHighlighted(legend) || this._noLegendHighlighted() ? 0.7 : 0.1;
       return opacity;
     }
   };
@@ -530,11 +520,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       if (this.state.isCalloutVisible) {
         opacity = 1;
       }
-      if (this.state.isLegendHovered || this.state.isLegendSelected) {
-        opacity =
-          this.state.selectedLegend === legend || (!this.state.isLegendSelected && this.state.activeLegend === legend)
-            ? 0
-            : 0.1;
+      if (!this._noLegendHighlighted()) {
+        opacity = this._legendHighlighted(legend) ? 0 : 0.1;
       }
       return opacity;
     }
@@ -695,5 +682,15 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _legendHighlighted = (legend: string) => {
+    return (
+      this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -684,12 +684,21 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     });
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legend: string) => {
     return (
       this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -122,7 +122,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 hoverLeaveCallback={this._hoverLeave}
                 uniqText={this._uniqText}
                 onBlurCallback={this._onBlur}
-                activeArc={this._highlightedLegend()}
+                activeArc={this._getHighlightedLegend()}
                 focusedArcId={this.state.focusedArcId || ''}
                 href={this.props.href!}
                 calloutId={this._calloutId}
@@ -272,10 +272,11 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
   };
 
   private _valueInsideDonut(valueInsideDonut: string | number | undefined, data: IChartDataPoint[]) {
-    if (valueInsideDonut !== undefined && this._highlightedLegend() !== '' && !this.state.showHover) {
+    const highlightedLegend = this._getHighlightedLegend();
+    if (valueInsideDonut !== undefined && highlightedLegend !== '' && !this.state.showHover) {
       let legendValue = valueInsideDonut;
       data!.map((point: IChartDataPoint, index: number) => {
-        if (point.legend === this._highlightedLegend()) {
+        if (point.legend === highlightedLegend) {
           legendValue = point.yAxisCalloutData ? point.yAxisCalloutData : point.data!;
         }
         return;
@@ -294,7 +295,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     return localeString?.toString();
   }
 
-  private _highlightedLegend() {
+  private _getHighlightedLegend() {
     if (this.state.selectedLegend !== '') {
       return this.state.selectedLegend;
     }

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -292,6 +292,12 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     return localeString?.toString();
   }
 
+  /**
+   * This function returns
+   * the selected legend if there is one
+   * or the hovered legend if none of the legends is selected.
+   * Note: This won't work in case of multiple legends selection.
+   */
   private _getHighlightedLegend() {
     return this.state.selectedLegend || this.state.activeLegend;
   }

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -204,10 +204,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
             this.setState({ activeLegend: point.legend! });
           },
           onMouseOutAction: () => {
-            this.setState({
-              showHover: false,
-              activeLegend: '',
-            });
+            this.setState({ activeLegend: '' });
           },
         };
         return legend;
@@ -229,7 +226,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     this._currentHoverElement = element;
     this.setState({
       /** Show the callout if highlighted arc is focused and Hide it if unhighlighted arc is focused */
-      showHover: this.state.activeLegend === data.legend || this.state.activeLegend === '',
+      showHover: this.state.selectedLegend === '' || this.state.selectedLegend === data.legend,
       value: data.data!.toString(),
       legend: data.legend,
       color: data.color!,
@@ -247,7 +244,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       this._currentHoverElement = e;
       this.setState({
         /** Show the callout if highlighted arc is hovered and Hide it if unhighlighted arc is hovered */
-        showHover: this.state.activeLegend === data.legend || this.state.activeLegend === '',
+        showHover: this.state.selectedLegend === '' || this.state.selectedLegend === data.legend,
         value: data.data!.toString(),
         legend: data.legend,
         color: data.color!,
@@ -296,9 +293,6 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
   }
 
   private _getHighlightedLegend() {
-    if (this.state.selectedLegend !== '') {
-      return this.state.selectedLegend;
-    }
-    return this.state.activeLegend;
+    return this.state.selectedLegend || this.state.activeLegend;
   }
 }

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -18,7 +18,6 @@ export interface IDonutChartState {
   _height?: number | undefined;
   activeLegend?: string;
   color?: string | undefined;
-  isLegendSelected?: boolean;
   xCalloutValue?: string;
   yCalloutValue?: string;
   focusedArcId?: string;
@@ -61,10 +60,9 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       _height: this.props.height || 200,
       activeLegend: '',
       color: '',
-      isLegendSelected: false,
       xCalloutValue: '',
       yCalloutValue: '',
-      selectedLegend: 'none',
+      selectedLegend: '',
       focusedArcId: '',
     };
     this._hoverCallback = this._hoverCallback.bind(this);
@@ -124,7 +122,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 hoverLeaveCallback={this._hoverLeave}
                 uniqText={this._uniqText}
                 onBlurCallback={this._onBlur}
-                activeArc={this.state.activeLegend}
+                activeArc={this._highlightedLegend()}
                 focusedArcId={this.state.focusedArcId || ''}
                 href={this.props.href!}
                 calloutId={this._calloutId}
@@ -196,22 +194,14 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
           title: point.legend!,
           color: color,
           action: () => {
-            if (this.state.isLegendSelected) {
-              if (this.state.activeLegend !== point.legend || this.state.activeLegend === '') {
-                this.setState({ activeLegend: point.legend!, isLegendSelected: true });
-              } else {
-                this.setState({ activeLegend: point.legend });
-              }
+            if (this.state.selectedLegend === point.legend) {
+              this.setState({ selectedLegend: '' });
             } else {
-              this.setState({ activeLegend: point.legend!, isLegendSelected: true });
+              this.setState({ selectedLegend: point.legend! });
             }
           },
           hoverAction: () => {
-            if (this.state.activeLegend !== point.legend || this.state.activeLegend === '') {
-              this.setState({ activeLegend: point.legend! });
-            } else {
-              this.setState({ activeLegend: point.legend });
-            }
+            this.setState({ activeLegend: point.legend! });
           },
           onMouseOutAction: () => {
             this.setState({
@@ -229,7 +219,6 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
         overflowProps={this.props.legendsOverflowProps}
         focusZonePropsInHoverCard={this.props.focusZonePropsForLegendsInHoverCard}
         overflowText={this.props.legendsOverflowText}
-        selectedLegend={this.state.selectedLegend}
         {...this.props.legendProps}
       />
     );
@@ -283,10 +272,10 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
   };
 
   private _valueInsideDonut(valueInsideDonut: string | number | undefined, data: IChartDataPoint[]) {
-    if (valueInsideDonut !== undefined && this.state.activeLegend !== '' && !this.state.showHover) {
+    if (valueInsideDonut !== undefined && this._highlightedLegend() !== '' && !this.state.showHover) {
       let legendValue = valueInsideDonut;
       data!.map((point: IChartDataPoint, index: number) => {
-        if (point.legend === this.state.activeLegend) {
+        if (point.legend === this._highlightedLegend()) {
           legendValue = point.yAxisCalloutData ? point.yAxisCalloutData : point.data!;
         }
         return;
@@ -303,5 +292,12 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       return data;
     }
     return localeString?.toString();
+  }
+
+  private _highlightedLegend() {
+    if (this.state.selectedLegend !== '') {
+      return this.state.selectedLegend;
+    }
+    return this.state.activeLegend;
   }
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -212,8 +212,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
       : null;
   };
 
-  private _getOpacity = (legend: string): number => {
-    const opacity = this._legendHighlighted(legend) || this._noLegendHighlighted() ? 1 : 0.1;
+  private _getOpacity = (legendTitle: string): string => {
+    const opacity = this._legendHighlighted(legendTitle) || this._noLegendHighlighted() ? '' : '0.1';
     return opacity;
   };
 
@@ -432,21 +432,21 @@ export class GroupedVerticalBarChartBase extends React.Component<
     });
   };
 
-  private _onLegendClick(legend: string): void {
-    if (this.state.selectedLegend === legend) {
+  private _onLegendClick(legendTitle: string): void {
+    if (this.state.selectedLegend === legendTitle) {
       this.setState({
         selectedLegend: '',
       });
     } else {
       this.setState({
-        selectedLegend: legend,
+        selectedLegend: legendTitle,
       });
     }
   }
 
-  private _onLegendHover(legend: string): void {
+  private _onLegendHover(legendTitle: string): void {
     this.setState({
-      activeLegend: legend,
+      activeLegend: legendTitle,
     });
   }
 
@@ -503,9 +503,10 @@ export class GroupedVerticalBarChartBase extends React.Component<
     }
   };
 
-  private _legendHighlighted = (legend: string) => {
+  private _legendHighlighted = (legendTitle: string) => {
     return (
-      this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
+      this.state.selectedLegend === legendTitle ||
+      (this.state.selectedLegend === '' && this.state.activeLegend === legendTitle)
     );
   };
 

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -46,7 +46,6 @@ interface IGVSingleDataPoint {
   [key: string]: IGVDataPoint;
 }
 export interface IGroupedVerticalBarChartState extends IBasestate {
-  titleForHoverCard: string;
   dataPointCalloutProps?: IGVBarChartSeriesPoint;
   callOutAccessibilityData?: IAccessibilityProps;
   calloutLegend: string;
@@ -85,15 +84,14 @@ export class GroupedVerticalBarChartBase extends React.Component<
       color: '',
       dataForHoverCard: 0,
       isCalloutVisible: false,
-      isLegendSelected: false,
-      isLegendHovered: false,
       refSelected: null,
-      titleForHoverCard: '',
+      selectedLegend: '',
       xCalloutValue: '',
       yCalloutValue: '',
       YValueHover: [],
       hoverXValue: '',
       calloutLegend: '',
+      activeLegend: '',
     };
     warnDeprecations(COMPONENT_NAME, props, {
       showYAxisGridLines: 'Dont use this property. Lines are drawn by default',
@@ -214,12 +212,9 @@ export class GroupedVerticalBarChartBase extends React.Component<
       : null;
   };
 
-  private _getOpacity = (legendTitle: string): string => {
-    let shouldHighlight = true;
-    if (this.state.isLegendHovered || this.state.isLegendSelected) {
-      shouldHighlight = this.state.titleForHoverCard === legendTitle;
-    }
-    return shouldHighlight ? '' : '0.1';
+  private _getOpacity = (legend: string): number => {
+    const opacity = this._legendHighlighted(legend) || this._noLegendHighlighted() ? 1 : 0.1;
+    return opacity;
   };
 
   private _onBarHover = (
@@ -234,9 +229,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
       this.setState({
         refSelected: mouseEvent,
         /** Show the callout if highlighted bar is hovered and Hide it if unhighlighted bar is hovered */
-        isCalloutVisible:
-          this.state.isLegendSelected === false ||
-          (this.state.isLegendSelected === true && this.state.titleForHoverCard === pointData.legend),
+        isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === pointData.legend,
         calloutLegend: pointData.legend,
         dataForHoverCard: pointData.data,
         color: pointData.color,
@@ -272,9 +265,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
         this.setState({
           refSelected: obj.refElement,
           /** Show the callout if highlighted bar is focused and Hide it if unhighlighted bar is focused */
-          isCalloutVisible:
-            this.state.isLegendSelected === false ||
-            (this.state.isLegendSelected === true && this.state.titleForHoverCard === pointData.legend),
+          isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === pointData.legend,
           calloutLegend: pointData.legend,
           dataForHoverCard: pointData.data,
           color: pointData.color,
@@ -441,43 +432,28 @@ export class GroupedVerticalBarChartBase extends React.Component<
     });
   };
 
-  private _onLegendClick(customMessage: string): void {
-    if (this.state.isLegendSelected) {
-      if (this.state.titleForHoverCard === customMessage) {
-        this.setState({
-          isLegendSelected: false,
-          titleForHoverCard: customMessage,
-        });
-      } else {
-        this.setState({
-          titleForHoverCard: customMessage,
-        });
-      }
+  private _onLegendClick(legend: string): void {
+    if (this.state.selectedLegend === legend) {
+      this.setState({
+        selectedLegend: '',
+      });
     } else {
       this.setState({
-        isLegendSelected: true,
-        titleForHoverCard: customMessage,
+        selectedLegend: legend,
       });
     }
   }
 
-  private _onLegendHover(customMessage: string): void {
-    if (this.state.isLegendSelected === false) {
-      this.setState({
-        isLegendHovered: true,
-        titleForHoverCard: customMessage,
-      });
-    }
+  private _onLegendHover(legend: string): void {
+    this.setState({
+      activeLegend: legend,
+    });
   }
 
-  private _onLegendLeave(isLegendFocused?: boolean): void {
-    if (!!isLegendFocused || this.state.isLegendSelected === false) {
-      this.setState({
-        isLegendHovered: false,
-        titleForHoverCard: '',
-        isLegendSelected: isLegendFocused ? false : this.state.isLegendSelected,
-      });
-    }
+  private _onLegendLeave(): void {
+    this.setState({
+      activeLegend: '',
+    });
   }
 
   private _getLegendData = (points: IGroupedVerticalBarChartData[], palette: IPalette): JSX.Element => {
@@ -501,8 +477,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
           hoverAction: () => {
             this._onLegendHover(point.legend);
           },
-          onMouseOutAction: (isLegendSelected?: boolean) => {
-            this._onLegendLeave(isLegendSelected);
+          onMouseOutAction: () => {
+            this._onLegendLeave();
           },
         };
 
@@ -525,5 +501,15 @@ export class GroupedVerticalBarChartBase extends React.Component<
       const { yAxisDomainValues: domainValue } = yAxisData;
       this._yMax = Math.max(domainValue[domainValue.length - 1], this.props.yMaxValue || 0);
     }
+  };
+
+  private _legendHighlighted = (legend: string) => {
+    return (
+      this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -503,6 +503,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
     }
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legendTitle: string) => {
     return (
       this.state.selectedLegend === legendTitle ||
@@ -510,6 +516,9 @@ export class GroupedVerticalBarChartBase extends React.Component<
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -248,9 +248,7 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
     this.setState({
       target: this._rectRefArray[id].refElement,
       /** Show the callout if highlighted rectangle is focused and Hide it if unhighlighted rectangle is focused */
-      isCalloutVisible:
-        this.state.isLegendSelected === false ||
-        (this.state.isLegendSelected === true && this.state.activeLegend === data.legend),
+      isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === data.legend,
       calloutYValue: `${data.rectText}`,
       calloutTextColor: this._colorScale(data.value),
       calloutLegend: data.legend,
@@ -268,9 +266,7 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
       this.setState({
         target: this._rectRefArray[id].refElement,
         /** Show the callout if highlighted rectangle is hovered and Hide it if unhighlighted rectangle is hovered */
-        isCalloutVisible:
-          this.state.isLegendSelected === false ||
-          (this.state.isLegendSelected === true && this.state.activeLegend === data.legend),
+        isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === data.legend,
         calloutYValue: `${data.rectText}`,
         calloutTextColor: this._colorScale(data.value),
         calloutLegend: data.legend,

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -658,6 +658,12 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
     });
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legendTitle: string) => {
     return (
       this.state.selectedLegend === legendTitle ||
@@ -665,6 +671,9 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -45,19 +45,9 @@ export interface IHeatMapChartState {
    */
   selectedLegend: string;
   /**
-   * determines if the legend any of the legend is selected or not
-   * @default false
-   */
-  isLegendSelected: boolean;
-  /**
    * contains the hovered legend string
    */
   activeLegend: string;
-  /**
-   * determines if the legend is hovered or not
-   * @default false
-   */
-  isLegendHovered: boolean;
   /**
    * determines wethere to show or hide the callout
    * @default false
@@ -147,9 +137,7 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
     );
     this.state = {
       selectedLegend: '',
-      isLegendSelected: false,
       activeLegend: '',
-      isLegendHovered: false,
       isCalloutVisible: false,
       target: null,
       calloutLegend: '',
@@ -247,12 +235,8 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
     return { x, y };
   };
 
-  private _getOpacity = (legendTitle: string): number => {
-    const opacity =
-      this.state.selectedLegend === legendTitle ||
-      (!this.state.isLegendSelected && (!this.state.isLegendHovered || this.state.activeLegend === legendTitle))
-        ? 1
-        : 0.1;
+  private _getOpacity = (legendTitle: string): string => {
+    const opacity = this._legendHighlighted(legendTitle) || this._noLegendHighlighted() ? '1' : '0.1';
     return opacity;
   };
 
@@ -369,28 +353,22 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
   /**
    * when the legend is hovered we need to highlight
    * all the rectangles which fall under that category
-   * and un-highlight the rest of them, this functionality
-   * should happen only when there no legend Selected
+   * and un-highlight the rest of them
    * @param legendTitle
    */
   private _onLegendHover = (legendTitle: string): void => {
     this.setState({
       activeLegend: legendTitle,
-      isLegendHovered: true,
     });
   };
 
   /**
    * when the mouse is out from the legend , we need
-   * to show the graph in initial mode. isLegendFocused will
-   * be useful at the scenario where mouseout happend for
-   * the legends which are in overflow card
-   * @param isLegendFocused
+   * to show the graph in initial mode.
    */
   private _onLegendLeave = (): void => {
     this.setState({
       activeLegend: '',
-      isLegendHovered: false,
     });
   };
   /**
@@ -402,22 +380,16 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
   private _onLegendClick = (legendTitle: string): void => {
     /**
      * check if the legend is already selceted,
-     * if yes, then check if the consumer has clicked already
-     * seleceted legend if yes un-select the legend, else
-     * set the acitve legend state to legendTitle
-     *
-     * if legend is not alredy selceted, simply set the isLegendSelected to true
-     * and the active legend to the legendTitle of selected legend
+     * if yes, un-select the legend, else
+     * set the selected legend state to legendTitle
      */
     if (this.state.selectedLegend === legendTitle) {
       this.setState({
         selectedLegend: '',
-        isLegendSelected: false,
       });
     } else {
       this.setState({
         selectedLegend: legendTitle,
-        isLegendSelected: true,
       });
     }
   };
@@ -688,5 +660,16 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _legendHighlighted = (legendTitle: string) => {
+    return (
+      this.state.selectedLegend === legendTitle ||
+      (this.state.selectedLegend === '' && this.state.activeLegend === legendTitle)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -237,6 +237,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     // execute similar to "_onClick" and "_onLeave" logic at HoverCard onCardHide event
     const onHoverCardHideHandler = () => {
       this.setState({ isHoverCardVisible: false });
+      /** Unhighlight the focused legend in the hover card */
       const activeOverflowItem = find(legends, (legend: ILegend) => legend.title === this.state.activeLegend);
       if (activeOverflowItem) {
         this.setState({ activeLegend: '' });
@@ -383,15 +384,24 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     let legendColor = color;
     const inSelectedState = this.state.selectedLegend !== '' || this.state.selectedLegends.length > 0;
     if (inSelectedState) {
+      /** if one or more legends are selected */
       if (this.state.selectedLegend === title || this.state.selectedLegends.indexOf(title) > -1) {
+        /** if the given legend (title) is one of the selected legends */
         legendColor = color;
       } else {
+        /** if the given legend is unselected */
         legendColor = palette.white;
       }
     } else {
-      if (this.state.activeLegend === '' || this.state.activeLegend === title) {
+      /** if no legend is selected */
+      if (this.state.activeLegend === title || this.state.activeLegend === '') {
+        /**
+         * if the given legend is hovered
+         * or none of the legends is hovered
+         */
         legendColor = color;
       } else {
+        /** if there is a hovered legend but the given legend is not the one */
         legendColor = palette.white;
       }
     }

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -56,12 +56,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     };
   }
 
-  public componentDidUpdate(prevProps: ILegendsProps) {
-    if (prevProps.selectedLegend !== this.props.selectedLegend) {
-      this.setState({ selectedLegend: this.props.selectedLegend! });
-    }
-  }
-
   public render(): JSX.Element {
     const { theme, className, styles } = this.props;
     this._classNames = getClassNames(styles!, {

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -38,9 +38,7 @@ interface ILegendItem extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 export interface ILegendState {
   selectedLegend: string;
-  selecetedLegendInHoverCard: string;
-  selectedState: boolean;
-  hoverState: boolean;
+  activeLegend: string;
   isHoverCardVisible: boolean;
   selectedLegends: string[];
 }
@@ -51,11 +49,9 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   public constructor(props: ILegendsProps) {
     super(props);
     this.state = {
-      selectedLegend: 'none',
-      selectedState: false,
-      hoverState: false,
+      selectedLegend: '',
+      activeLegend: '',
       isHoverCardVisible: false,
-      selecetedLegendInHoverCard: 'none',
       selectedLegends: [],
     };
   }
@@ -169,12 +165,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     this.setState({
       //check if user selected all legends then empty it get the default behaviour
       selectedLegends: selectedLegends.length === this.props.legends.length ? [] : selectedLegends,
-      // make selectedState to false if none or all the legends selected
-      selectedState:
-        selectedLegends.length === 0 || selectedLegends.length === this.props.legends.length ? false : true,
-      selecetedLegendInHoverCard: this.state.isHoverCardVisible ? legend.title : 'none',
-      selectedLegend: 'none',
-      hoverState: false,
     });
   };
 
@@ -185,17 +175,13 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
    */
 
   private _canSelectOnlySingleLegend = (legend: ILegend): void => {
-    if (this.state.selectedState === true && this.state.selectedLegend === legend.title) {
+    if (this.state.selectedLegend === legend.title) {
       this.setState({
-        selectedState: false,
-        selecetedLegendInHoverCard: this.state.isHoverCardVisible ? legend.title : 'none',
+        selectedLegend: '',
       });
     } else {
       this.setState({
-        hoverState: true,
-        selectedState: true,
         selectedLegend: legend.title,
-        selecetedLegendInHoverCard: this.state.isHoverCardVisible ? legend.title : 'none',
       });
     }
   };
@@ -256,18 +242,14 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const overflowString = overflowText ? overflowText : 'more';
     // execute similar to "_onClick" and "_onLeave" logic at HoverCard onCardHide event
     const onHoverCardHideHandler = () => {
-      const selectedOverflowItem = find(legends, (legend: ILegend) => legend.title === this.state.selectedLegend);
-      this.setState({ isHoverCardVisible: false }, () => {
-        if (selectedOverflowItem) {
-          if (!this.state.selectedState && this.state.hoverState) {
-            this.setState({ hoverState: false, selectedLegend: 'none' }, () => {
-              if (selectedOverflowItem.onMouseOutAction) {
-                selectedOverflowItem.onMouseOutAction(true);
-              }
-            });
-          }
+      this.setState({ isHoverCardVisible: false });
+      const activeOverflowItem = find(legends, (legend: ILegend) => legend.title === this.state.activeLegend);
+      if (activeOverflowItem) {
+        this.setState({ activeLegend: '' });
+        if (activeOverflowItem.onMouseOutAction) {
+          activeOverflowItem.onMouseOutAction();
         }
-      });
+      }
     };
     return (
       <HoverCard
@@ -304,20 +286,16 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   };
 
   private _onHoverOverLegend = (legend: ILegend) => {
-    if (!this.state.selectedState) {
-      if (legend.hoverAction) {
-        this.setState({ hoverState: true, selectedLegend: legend.title });
-        legend.hoverAction();
-      }
+    if (legend.hoverAction) {
+      this.setState({ activeLegend: legend.title });
+      legend.hoverAction();
     }
   };
 
   private _onLeave = (legend: ILegend) => {
-    if (!this.state.selectedState) {
-      if (legend.onMouseOutAction) {
-        this.setState({ hoverState: false, selectedLegend: 'none' });
-        legend.onMouseOutAction();
-      }
+    if (legend.onMouseOutAction) {
+      this.setState({ activeLegend: '' });
+      legend.onMouseOutAction();
     }
   };
 
@@ -406,30 +384,22 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   }
 
   private _getColor(title: string, color: string): string {
-    const { theme, canSelectMultipleLegends = false } = this.props;
+    const { theme } = this.props;
     const { palette } = theme!;
     let legendColor = color;
-    // below if statement  will get executed for the hovered legend.
-    // (which is also the slected legend see fucntion:-_onHoverOverLegend)
-    if (this.state.hoverState && this.state.selectedLegend === title) {
-      legendColor = color;
-    } // below esle if statement will get executed for  the  unselected-legend which is  hovered
-    else if (this.state.hoverState && this.state.selectedLegend !== 'none' && this.state.selectedLegend !== title) {
-      legendColor = palette.white;
-    } // below else if statement will get executed if the legends are in the selected state
-    // this is will only get executed  when we have ability to select multiple legends
-    else if (!!canSelectMultipleLegends && this.state.selectedState && this.state.selectedLegends.indexOf(title) > -1) {
-      legendColor = color;
-    } // below else if statement will get executed when no legend is selected and hovered
-    //(for example:- initial render of legends)
-    else if (
-      (!this.state.selectedState && this.state.selectedLegend === 'none') ||
-      this.state.selectedLegend === title ||
-      this.state.selectedLegends.length <= 0
-    ) {
-      legendColor = color;
+    const inSelectedState = this.state.selectedLegend !== '' || this.state.selectedLegends.length > 0;
+    if (inSelectedState) {
+      if (this.state.selectedLegend === title || this.state.selectedLegends.indexOf(title) > -1) {
+        legendColor = color;
+      } else {
+        legendColor = palette.white;
+      }
     } else {
-      legendColor = palette.white;
+      if (this.state.activeLegend === '' || this.state.activeLegend === title) {
+        legendColor = color;
+      } else {
+        legendColor = palette.white;
+      }
     }
     return legendColor;
   }

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -187,7 +187,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _canSelectOnlySingleLegend = (legend: ILegend): void => {
     if (this.state.selectedState === true && this.state.selectedLegend === legend.title) {
       this.setState({
-        selectedLegend: 'none',
         selectedState: false,
         selecetedLegendInHoverCard: this.state.isHoverCardVisible ? legend.title : 'none',
       });
@@ -257,36 +256,18 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const overflowString = overflowText ? overflowText : 'more';
     // execute similar to "_onClick" and "_onLeave" logic at HoverCard onCardHide event
     const onHoverCardHideHandler = () => {
-      const { canSelectMultipleLegends = false } = this.props;
-      const selectedOverflowItem = find(
-        legends,
-        (legend: ILegend) =>
-          legend.title === this.state.selecetedLegendInHoverCard || legend.title === this.state.selectedLegend,
-      );
-      this.setState(
-        {
-          isHoverCardVisible: false,
-          selecetedLegendInHoverCard: 'none',
-          selectedLegends: [],
-        },
-        () => {
-          if (selectedOverflowItem) {
-            this.setState({ selectedLegend: 'none', selectedState: false }, () => {
-              if (selectedOverflowItem.action && !canSelectMultipleLegends) {
-                selectedOverflowItem.action();
+      const selectedOverflowItem = find(legends, (legend: ILegend) => legend.title === this.state.selectedLegend);
+      this.setState({ isHoverCardVisible: false }, () => {
+        if (selectedOverflowItem) {
+          if (!this.state.selectedState && this.state.hoverState) {
+            this.setState({ hoverState: false, selectedLegend: 'none' }, () => {
+              if (selectedOverflowItem.onMouseOutAction) {
+                selectedOverflowItem.onMouseOutAction(true);
               }
-              if (this.props.onLegendHoverCardLeave && canSelectMultipleLegends) {
-                this.props.onLegendHoverCardLeave();
-              }
-              this.setState({ hoverState: false }, () => {
-                if (selectedOverflowItem.onMouseOutAction) {
-                  selectedOverflowItem.onMouseOutAction(true);
-                }
-              });
             });
           }
-        },
-      );
+        }
+      });
     };
     return (
       <HoverCard

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -1287,12 +1287,21 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     });
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legend: string) => {
     return (
       this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -349,13 +349,10 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
 
   private _handleSingleLegendSelectionAction = (lineChartItem: LineChartDataWithIndex | IColorFillBarsProps) => {
     if (this.state.selectedLegend === lineChartItem.legend) {
-      this.setState({ selectedLegend: '', activeLegend: lineChartItem.legend });
+      this.setState({ selectedLegend: '' });
       this._handleLegendClick(lineChartItem, null);
     } else {
-      this.setState({
-        selectedLegend: lineChartItem.legend,
-        activeLegend: lineChartItem.legend,
-      });
+      this.setState({ selectedLegend: lineChartItem.legend });
       this._handleLegendClick(lineChartItem, lineChartItem.legend);
     }
   };
@@ -578,7 +575,10 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
           this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
 
         const isLegendSelected: boolean =
-          this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
+          this.state.selectedLegend === legendVal ||
+          (this.state.selectedLegend === '' &&
+            (this.state.activeLegend === legendVal || this.state.activeLegend === '')) ||
+          this.state.isSelectedLegend;
 
         const lineData: [number, number][] = [];
         for (let k = 0; k < this._points[i].data.length; k++) {
@@ -684,7 +684,10 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
 
           const isLegendSelected: boolean =
-            this.state.activeLegend === legendVal || this.state.activeLegend === '' || this.state.isSelectedLegend;
+            this.state.selectedLegend === legendVal ||
+            (this.state.selectedLegend === '' &&
+              (this.state.activeLegend === legendVal || this.state.activeLegend === '')) ||
+            this.state.isSelectedLegend;
 
           const currentPointHidden = this._points[i].hideNonActiveDots && activePoint !== circleId;
           pointsForLine.push(
@@ -914,8 +917,9 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         const startX = colorFillBar.data[j].startX;
         const endX = colorFillBar.data[j].endX;
         const opacity =
-          this.state.activeLegend === colorFillBar.legend ||
-          this.state.activeLegend === '' ||
+          this.state.selectedLegend === colorFillBar.legend ||
+          (this.state.selectedLegend === '' &&
+            (this.state.activeLegend === colorFillBar.legend || this.state.activeLegend === '')) ||
           this.state.isSelectedLegend
             ? this._colorFillBarsOpacity
             : 0.1;

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -575,10 +575,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
           this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
 
         const isLegendSelected: boolean =
-          this.state.selectedLegend === legendVal ||
-          (this.state.selectedLegend === '' &&
-            (this.state.activeLegend === legendVal || this.state.activeLegend === '')) ||
-          this.state.isSelectedLegend;
+          this._legendHighlighted(legendVal) || this._noLegendHighlighted() || this.state.isSelectedLegend;
 
         const lineData: [number, number][] = [];
         for (let k = 0; k < this._points[i].data.length; k++) {
@@ -684,10 +681,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             this._points[i].lineOptions?.strokeWidth || this.props.strokeWidth || DEFAULT_LINE_STROKE_SIZE;
 
           const isLegendSelected: boolean =
-            this.state.selectedLegend === legendVal ||
-            (this.state.selectedLegend === '' &&
-              (this.state.activeLegend === legendVal || this.state.activeLegend === '')) ||
-            this.state.isSelectedLegend;
+            this._legendHighlighted(legendVal) || this._noLegendHighlighted() || this.state.isSelectedLegend;
 
           const currentPointHidden = this._points[i].hideNonActiveDots && activePoint !== circleId;
           pointsForLine.push(
@@ -917,10 +911,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         const startX = colorFillBar.data[j].startX;
         const endX = colorFillBar.data[j].endX;
         const opacity =
-          this.state.selectedLegend === colorFillBar.legend ||
-          (this.state.selectedLegend === '' &&
-            (this.state.activeLegend === colorFillBar.legend || this.state.activeLegend === '')) ||
-          this.state.isSelectedLegend
+          this._legendHighlighted(colorFillBar.legend) || this._noLegendHighlighted() || this.state.isSelectedLegend
             ? this._colorFillBarsOpacity
             : 0.1;
         colorFillBars.push(
@@ -1294,5 +1285,15 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       selectedLegendPoints: [],
       isSelectedLegend: false,
     });
+  };
+
+  private _legendHighlighted = (legend: string) => {
+    return (
+      this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -25,14 +25,12 @@ export interface IRefArrayData {
 export interface IMultiStackedBarChartState {
   isCalloutVisible: boolean;
   refArray: IRefArrayData[];
-  selectedLegendTitle: string;
+  selectedLegend: string;
   activeLegend: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   refSelected: any;
   dataForHoverCard: number;
   color: string;
-  isLegendHovered: boolean;
-  isLegendSelected: boolean;
   xCalloutValue?: string;
   yCalloutValue?: string;
   dataPointCalloutProps?: IChartDataPoint;
@@ -56,13 +54,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     this.state = {
       isCalloutVisible: false,
       refArray: [],
-      selectedLegendTitle: '',
+      selectedLegend: '',
       activeLegend: '',
       refSelected: null,
       dataForHoverCard: 0,
       color: '',
-      isLegendHovered: false,
-      isLegendSelected: false,
       xCalloutValue: '',
       yCalloutValue: '',
       calloutLegend: '',
@@ -188,11 +184,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       startingPoint.push(prevPosition);
 
       const styles = this.props.styles;
-      const shouldHighlight =
-        this.state.selectedLegendTitle === point.legend ||
-        (!this.state.isLegendSelected && (!this.state.isLegendHovered || this.state.activeLegend === point.legend))
-          ? true
-          : false;
+      const shouldHighlight = this._legendHighlighted(point.legend!) || this._noLegendHighlighted() ? true : false;
 
       this._classNames = getClassNames(styles!, {
         theme: this.props.theme!,
@@ -283,9 +275,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         this.setState({
           refSelected: obj.refElement,
           /** Show the callout if highlighted bar is focused and Hide it if unhighlighted bar is focused */
-          isCalloutVisible:
-            this.state.isLegendSelected === false ||
-            (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend!),
+          isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === point.legend!,
           calloutLegend: point.legend!,
           dataForHoverCard: pointData,
           color: color,
@@ -315,7 +305,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
 
   private _onHover(legendTitle: string): void {
     this.setState({
-      isLegendHovered: true,
       activeLegend: legendTitle,
     });
   }
@@ -390,22 +379,19 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
   };
 
   private _onClick(legendTitle: string): void {
-    if (this.state.selectedLegendTitle === legendTitle) {
+    if (this.state.selectedLegend === legendTitle) {
       this.setState({
-        isLegendSelected: false,
-        selectedLegendTitle: '',
+        selectedLegend: '',
       });
     } else {
       this.setState({
-        isLegendSelected: true,
-        selectedLegendTitle: legendTitle,
+        selectedLegend: legendTitle,
       });
     }
   }
 
   private _onLeave(): void {
     this.setState({
-      isLegendHovered: false,
       activeLegend: '',
     });
   }
@@ -423,9 +409,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       this.setState({
         refSelected: mouseEvent,
         /** Show the callout if highlighted bar is hovered and Hide it if unhighlighted bar is hovered */
-        isCalloutVisible:
-          this.state.isLegendSelected === false ||
-          (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend!),
+        isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === point.legend!,
         calloutLegend: point.legend!,
         dataForHoverCard: pointData,
         color: color,
@@ -456,5 +440,16 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _legendHighlighted = (legendTitle: string) => {
+    return (
+      this.state.selectedLegend === legendTitle ||
+      (this.state.selectedLegend === '' && this.state.activeLegend === legendTitle)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -442,6 +442,12 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     });
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legendTitle: string) => {
     return (
       this.state.selectedLegend === legendTitle ||
@@ -449,6 +455,9 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -26,6 +26,7 @@ export interface IMultiStackedBarChartState {
   isCalloutVisible: boolean;
   refArray: IRefArrayData[];
   selectedLegendTitle: string;
+  activeLegend: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   refSelected: any;
   dataForHoverCard: number;
@@ -56,6 +57,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       isCalloutVisible: false,
       refArray: [],
       selectedLegendTitle: '',
+      activeLegend: '',
       refSelected: null,
       dataForHoverCard: 0,
       color: '',
@@ -186,10 +188,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       startingPoint.push(prevPosition);
 
       const styles = this.props.styles;
-      let shouldHighlight = true;
-      if (this.state.isLegendHovered || this.state.isLegendSelected) {
-        shouldHighlight = this.state.selectedLegendTitle === point.legend;
-      }
+      const shouldHighlight =
+        this.state.selectedLegendTitle === point.legend ||
+        (!this.state.isLegendSelected && (!this.state.isLegendHovered || this.state.activeLegend === point.legend))
+          ? true
+          : false;
 
       this._classNames = getClassNames(styles!, {
         theme: this.props.theme!,
@@ -310,13 +313,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     });
   };
 
-  private _onHover(customMessage: string): void {
-    if (this.state.isLegendSelected === false) {
-      this.setState({
-        isLegendHovered: true,
-        selectedLegendTitle: customMessage,
-      });
-    }
+  private _onHover(legendTitle: string): void {
+    this.setState({
+      isLegendHovered: true,
+      activeLegend: legendTitle,
+    });
   }
 
   private _getLegendData = (data: IChartProps[], hideRatio: boolean[], palette: IPalette): JSX.Element => {
@@ -344,8 +345,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
               hoverAction: () => {
                 this._onHover(point.legend!);
               },
-              onMouseOutAction: (isLegendSelected?: boolean) => {
-                this._onLeave(isLegendSelected);
+              onMouseOutAction: () => {
+                this._onLeave();
               },
             };
             actions.push(legend);
@@ -369,8 +370,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             hoverAction: () => {
               this._onHover(point.legend!);
             },
-            onMouseOutAction: (isLegendSelected?: boolean) => {
-              this._onLeave(isLegendSelected);
+            onMouseOutAction: () => {
+              this._onLeave();
             },
           };
           actions.push(legend);
@@ -388,34 +389,25 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     );
   };
 
-  private _onClick(customMessage: string): void {
-    if (this.state.isLegendSelected) {
-      if (this.state.selectedLegendTitle === customMessage) {
-        this.setState({
-          isLegendSelected: false,
-          selectedLegendTitle: customMessage,
-        });
-      } else {
-        this.setState({
-          selectedLegendTitle: customMessage,
-        });
-      }
+  private _onClick(legendTitle: string): void {
+    if (this.state.selectedLegendTitle === legendTitle) {
+      this.setState({
+        isLegendSelected: false,
+        selectedLegendTitle: '',
+      });
     } else {
       this.setState({
         isLegendSelected: true,
-        selectedLegendTitle: customMessage,
+        selectedLegendTitle: legendTitle,
       });
     }
   }
 
-  private _onLeave(isLegendFocused?: boolean): void {
-    if (!!isLegendFocused || this.state.isLegendSelected === false) {
-      this.setState({
-        isLegendHovered: false,
-        selectedLegendTitle: '',
-        isLegendSelected: isLegendFocused ? false : this.state.isLegendSelected,
-      });
-    }
+  private _onLeave(): void {
+    this.setState({
+      isLegendHovered: false,
+      activeLegend: '',
+    });
   }
 
   private _onBarHover(

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -12,14 +12,12 @@ import { TooltipHost, TooltipOverflowMode } from '@fluentui/react';
 const getClassNames = classNamesFunction<IStackedBarChartStyleProps, IStackedBarChartStyles>();
 export interface IStackedBarChartState {
   isCalloutVisible: boolean;
-  selectedLegendTitle: string;
+  selectedLegend: string;
   activeLegend: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   refSelected: any;
   dataForHoverCard: number;
   color: string;
-  isLegendHovered: boolean;
-  isLegendSelected: boolean;
   xCalloutValue?: string;
   yCalloutValue?: string;
   dataPointCalloutProps?: IChartDataPoint;
@@ -43,13 +41,11 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     super(props);
     this.state = {
       isCalloutVisible: false,
-      selectedLegendTitle: '',
+      selectedLegend: '',
       activeLegend: '',
       refSelected: null,
       dataForHoverCard: 0,
       color: '',
-      isLegendHovered: false,
-      isLegendSelected: false,
       xCalloutValue: '',
       yCalloutValue: '',
       calloutLegend: '',
@@ -267,11 +263,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       }
       startingPoint.push(prevPosition);
       const styles = this.props.styles;
-      const shouldHighlight =
-        this.state.selectedLegendTitle === point.legend ||
-        (!this.state.isLegendSelected && (!this.state.isLegendHovered || this.state.activeLegend === point.legend))
-          ? true
-          : false;
+      const shouldHighlight = this._legendHighlighted(point.legend!) || this._noLegendHighlighted() ? true : false;
       this._classNames = getClassNames(styles!, {
         theme: this.props.theme!,
         shouldHighlight: shouldHighlight,
@@ -334,9 +326,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         this.setState({
           refSelected: obj.refElement,
           /** Show the callout if highlighted bar is focused and Hide it if unhighlighted bar is focused */
-          isCalloutVisible:
-            this.state.isLegendSelected === false ||
-            (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend!),
+          isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === point.legend!,
           calloutLegend: point.legend!,
           dataForHoverCard: pointData,
           color: color,
@@ -373,29 +363,25 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
   }
 
   private _onClick(legendTitle: string): void {
-    if (this.state.selectedLegendTitle === legendTitle) {
+    if (this.state.selectedLegend === legendTitle) {
       this.setState({
-        isLegendSelected: false,
-        selectedLegendTitle: '',
+        selectedLegend: '',
       });
     } else {
       this.setState({
-        isLegendSelected: true,
-        selectedLegendTitle: legendTitle,
+        selectedLegend: legendTitle,
       });
     }
   }
 
   private _onHover(legendTitle: string): void {
     this.setState({
-      isLegendHovered: true,
       activeLegend: legendTitle,
     });
   }
 
   private _onLeave(): void {
     this.setState({
-      isLegendHovered: false,
       activeLegend: '',
     });
   }
@@ -412,9 +398,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       this.setState({
         refSelected: mouseEvent,
         /** Show the callout if highlighted bar is hovered and Hide it if unhighlighted bar is hovered */
-        isCalloutVisible:
-          this.state.isLegendSelected === false ||
-          (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend!),
+        isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === point.legend!,
         calloutLegend: point.legend!,
         dataForHoverCard: pointData,
         color: color,
@@ -445,5 +429,16 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _legendHighlighted = (legendTitle: string) => {
+    return (
+      this.state.selectedLegend === legendTitle ||
+      (this.state.selectedLegend === '' && this.state.activeLegend === legendTitle)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -431,6 +431,12 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     });
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legendTitle: string) => {
     return (
       this.state.selectedLegend === legendTitle ||
@@ -438,6 +444,9 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -687,6 +687,12 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     }
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legendTitle: string) => {
     return (
       this.state.selectedLegend === legendTitle ||
@@ -694,6 +700,9 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -907,6 +907,12 @@ export class VerticalStackedBarChartBase extends React.Component<
     }
   };
 
+  /**
+   * This function checks if the given legend is highlighted or not.
+   * A legend can be highlighted in 2 ways:
+   * 1. selection: if the user clicks on it
+   * 2. hovering: if there is no selected legend and the user hovers over it
+   */
   private _legendHighlighted = (legendTitle: string) => {
     return (
       this.state.selectedLegend === legendTitle ||
@@ -914,6 +920,9 @@ export class VerticalStackedBarChartBase extends React.Component<
     );
   };
 
+  /**
+   * This function checks if none of the legends is selected or hovered.
+   */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -60,7 +60,6 @@ enum CircleVisbility {
 }
 
 export interface IVerticalStackedBarChartState extends IBasestate {
-  selectedLegendTitle: string;
   dataPointCalloutProps?: IVSChartDataPoint;
   stackCalloutProps?: IVerticalStackedChartProps;
   activeXAxisDataPoint: number | string;
@@ -92,9 +91,8 @@ export class VerticalStackedBarChartBase extends React.Component<
     super(props);
     this.state = {
       isCalloutVisible: false,
-      isLegendSelected: false,
-      isLegendHovered: false,
-      selectedLegendTitle: '',
+      selectedLegend: '',
+      activeLegend: '',
       refSelected: null,
       dataForHoverCard: 0,
       color: '',
@@ -214,7 +212,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     const { isCalloutForStack = false } = this.props;
     let shouldFocusStackOnly: boolean = false;
     if (_isHavingLines) {
-      if (this.state.isLegendSelected) {
+      if (this.state.selectedLegend !== '') {
         shouldFocusStackOnly = false;
       } else {
         shouldFocusStackOnly = true;
@@ -270,7 +268,6 @@ export class VerticalStackedBarChartBase extends React.Component<
     containerHeight: number,
     containerWidth: number,
   ): JSX.Element => {
-    const { isLegendHovered, isLegendSelected, selectedLegendTitle } = this.state;
     const isNumeric = this._xAxisType === XAxisTypes.NumericAxis;
     const { xBarScale } = this._getScales(containerHeight, containerWidth, isNumeric);
     const lineObject: LineObject = this._getFormattedLineData(this.props.data);
@@ -284,10 +281,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const xScaleBandwidthTranslate = isNumeric ? 0 : (xBarScale as any).bandwidth() / 2;
     Object.keys(lineObject).forEach((item: string, index: number) => {
-      let shouldHighlight = true;
-      if (isLegendHovered || isLegendSelected) {
-        shouldHighlight = selectedLegendTitle === item; // item is legend name;
-      }
+      const shouldHighlight = this._legendHighlighted(item) || this._noLegendHighlighted(); // item is legend name
       for (let i = 1; i < lineObject[item].length; i++) {
         const x1 = isNumeric
           ? xScale(lineObject[item][i - 1].xItem.xAxisPoint as number)
@@ -329,11 +323,10 @@ export class VerticalStackedBarChartBase extends React.Component<
             strokeLinecap="round"
             stroke={lineObject[item][i].color}
             transform={`translate(${xScaleBandwidthTranslate}, 0)`}
-            {...(isLegendSelected &&
-              selectedLegendTitle === item && {
-                onMouseOver: this._lineHover.bind(this, lineObject[item][i - 1]),
-                onMouseLeave: this._lineHoverOut,
-              })}
+            {...(this.state.selectedLegend === item && {
+              onMouseOver: this._lineHover.bind(this, lineObject[item][i - 1]),
+              onMouseLeave: this._lineHoverOut,
+            })}
           />,
         );
       }
@@ -351,14 +344,13 @@ export class VerticalStackedBarChartBase extends React.Component<
             }
             cy={yScale(circlePoint.y)}
             onMouseOver={
-              isLegendSelected && selectedLegendTitle === item
+              this.state.selectedLegend === item
                 ? this._lineHover.bind(this, circlePoint)
                 : this._onStackHover.bind(this, circlePoint.xItem)
             }
-            {...(isLegendSelected &&
-              selectedLegendTitle === item && {
-                onMouseLeave: this._lineHoverOut,
-              })}
+            {...(this.state.selectedLegend === item && {
+              onMouseLeave: this._lineHoverOut,
+            })}
             r={this._getCircleVisibilityAndRadius(circlePoint.xItem.xAxisPoint, circlePoint.legend).radius}
             stroke={circlePoint.color}
             fill={this.props.theme!.palette.white}
@@ -382,11 +374,11 @@ export class VerticalStackedBarChartBase extends React.Component<
     xAxispoint: string | number,
     legend: string,
   ): { visibility: CircleVisbility; radius: number } => {
-    const { isLegendSelected, activeXAxisDataPoint, selectedLegendTitle } = this.state;
-    if (isLegendSelected) {
-      if (xAxispoint === activeXAxisDataPoint && legend === selectedLegendTitle) {
+    const { selectedLegend, activeXAxisDataPoint } = this.state;
+    if (selectedLegend !== '') {
+      if (xAxispoint === activeXAxisDataPoint && selectedLegend === legend) {
         return { visibility: CircleVisbility.show, radius: 8 };
-      } else if (legend === selectedLegendTitle) {
+      } else if (selectedLegend === legend) {
         return { visibility: CircleVisbility.show, radius: 0.3 };
       } else {
         return { visibility: CircleVisbility.hide, radius: 0 };
@@ -455,43 +447,28 @@ export class VerticalStackedBarChartBase extends React.Component<
       : null;
   };
 
-  private _onLegendClick(customMessage: string): void {
-    if (this.state.isLegendSelected) {
-      if (this.state.selectedLegendTitle === customMessage) {
-        this.setState({
-          isLegendSelected: false,
-          selectedLegendTitle: customMessage,
-        });
-      } else {
-        this.setState({
-          selectedLegendTitle: customMessage,
-        });
-      }
+  private _onLegendClick(legend: string): void {
+    if (this.state.selectedLegend === legend) {
+      this.setState({
+        selectedLegend: '',
+      });
     } else {
       this.setState({
-        isLegendSelected: true,
-        selectedLegendTitle: customMessage,
+        selectedLegend: legend,
       });
     }
   }
 
-  private _onLegendHover(customMessage: string): void {
-    if (this.state.isLegendSelected === false) {
-      this.setState({
-        isLegendHovered: true,
-        selectedLegendTitle: customMessage,
-      });
-    }
+  private _onLegendHover(legend: string): void {
+    this.setState({
+      activeLegend: legend,
+    });
   }
 
-  private _onLegendLeave(isLegendFocused?: boolean): void {
-    if (!!isLegendFocused || this.state.isLegendSelected === false) {
-      this.setState({
-        isLegendHovered: false,
-        selectedLegendTitle: '',
-        isLegendSelected: isLegendFocused ? false : this.state.isLegendSelected,
-      });
-    }
+  private _onLegendLeave(): void {
+    this.setState({
+      activeLegend: '',
+    });
   }
 
   private _getLegendData(
@@ -521,7 +498,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             this._onLegendClick(point.legend);
           },
           hoverAction: allowHoverOnLegend ? () => this._onLegendHover(point.legend) : undefined,
-          onMouseOutAction: allowHoverOnLegend ? isLegendSelected => this._onLegendLeave(isLegendSelected) : undefined,
+          onMouseOutAction: allowHoverOnLegend ? () => this._onLegendLeave() : undefined,
         };
 
         actions.push(legend);
@@ -538,7 +515,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             this._onLegendClick(point.title);
           },
           hoverAction: allowHoverOnLegend ? () => this._onLegendHover(point.title) : undefined,
-          onMouseOutAction: allowHoverOnLegend ? isLegendSelected => this._onLegendLeave(isLegendSelected) : undefined,
+          onMouseOutAction: allowHoverOnLegend ? () => this._onLegendLeave() : undefined,
         };
         legendsOfLine.push(legend);
       });
@@ -580,9 +557,7 @@ export class VerticalStackedBarChartBase extends React.Component<
          * Show the callout if highlighted bar is focused/hovered
          * and Hide it if unhighlighted bar is focused/hovered
          */
-        isCalloutVisible:
-          this.state.isLegendSelected === false ||
-          (this.state.isLegendSelected === true && this.state.selectedLegendTitle === point.legend),
+        isCalloutVisible: this.state.selectedLegend === '' || this.state.selectedLegend === point.legend,
         calloutLegend: point.legend,
         dataForHoverCard: point.data,
         color,
@@ -741,10 +716,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         const color = point.color ? point.color : this._colors[index];
         const ref: IRefArrayData = {};
 
-        let shouldHighlight = true;
-        if (this.state.isLegendHovered || this.state.isLegendSelected) {
-          shouldHighlight = this.state.selectedLegendTitle === point.legend;
-        }
+        const shouldHighlight = this._legendHighlighted(point.legend) || this._noLegendHighlighted() ? true : false;
         const classNames = getClassNames(this.props.styles!, {
           theme: this.props.theme!,
           shouldHighlight: shouldHighlight,
@@ -933,5 +905,15 @@ export class VerticalStackedBarChartBase extends React.Component<
       const { yAxisDomainValues: domainValue } = yAxisData;
       this._yMax = Math.max(domainValue[domainValue.length - 1], this.props.yMaxValue || 0);
     }
+  };
+
+  private _legendHighlighted = (legend: string) => {
+    return (
+      this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
+    );
+  };
+
+  private _noLegendHighlighted = () => {
+    return this.state.selectedLegend === '' && this.state.activeLegend === '';
   };
 }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -447,21 +447,21 @@ export class VerticalStackedBarChartBase extends React.Component<
       : null;
   };
 
-  private _onLegendClick(legend: string): void {
-    if (this.state.selectedLegend === legend) {
+  private _onLegendClick(legendTitle: string): void {
+    if (this.state.selectedLegend === legendTitle) {
       this.setState({
         selectedLegend: '',
       });
     } else {
       this.setState({
-        selectedLegend: legend,
+        selectedLegend: legendTitle,
       });
     }
   }
 
-  private _onLegendHover(legend: string): void {
+  private _onLegendHover(legendTitle: string): void {
     this.setState({
-      activeLegend: legend,
+      activeLegend: legendTitle,
     });
   }
 
@@ -907,9 +907,10 @@ export class VerticalStackedBarChartBase extends React.Component<
     }
   };
 
-  private _legendHighlighted = (legend: string) => {
+  private _legendHighlighted = (legendTitle: string) => {
     return (
-      this.state.selectedLegend === legend || (this.state.selectedLegend === '' && this.state.activeLegend === legend)
+      this.state.selectedLegend === legendTitle ||
+      (this.state.selectedLegend === '' && this.state.activeLegend === legendTitle)
     );
   };
 


### PR DESCRIPTION
## Current Behavior

- Legend selection gets lost after hovering out of the overflow callout
- Legend states in chart components don't stay in sync with the Legends component. For example, in case of multiple legend selection, wrong element gets highlighted when mouse hasn't left the last deselected legend
  - Three states (selectedLegend, isLegendSelected, isLegendHovered) keep track of selection and hovering on legends together

## New Behavior

- Legends selection remains even after hovering out of the overflow callout
- Legend states in chart components and the Legends component stay in sync
  - Two states (selectedLegend, activeLegend) keep track of selection and hovering on legends separately