### PR TITLE
Add field to proxy request body

### DIFF
--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -53,6 +53,7 @@ async function scheduleScreenerBuild(
     },
     body: JSON.stringify({
       payload: payload,
+      isArtifactPresent: environment.screener.isArtifactPresent,
     }),
   });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

In order to check if a screener test should be skipped or not, the proxy sends a GET request to the blob storage address where test apps should be deployed and checks whether the response is 200(test app deployed) or 404(test app not deployed). However, test apps from previous build will still be accessible from the same address for builds that have not uploaded test apps so the response would still be 200 instead of 404. 

## New Behavior

The proxy receives, besides the payload used for calling the screener API, the status of the test app artifact through another field of the request body: `isArtifactPresent`, so that the proxy can instantly decide if a screener check should be skipped or not without the need for any additional requests. 

Addresses #24466 
