### PR TITLE
Bump uifabric/charting to match minor version of fluentui/react-charting

### DIFF
--- a/change/@uifabric-charting-807e2156-2cf8-4462-8115-bda3e4dfbabd.json
+++ b/change/@uifabric-charting-807e2156-2cf8-4462-8115-bda3e4dfbabd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Bump charting to match fluentui/react-charting minor version",
+  "packageName": "@uifabric/charting",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -31,7 +31,7 @@ export interface IRefArrayData {
 
 export interface IMargins {
   /**
-   * left margin for the chart.
+   * Left margin for the chart.
    */
   left?: number;
   /**


### PR DESCRIPTION
fluentui/react-charting got 1 minor bump ahead of uifabric/charting when it was created. that version was already published, so we need to pull charting forward a minor version. Then we can fix the grouping between the two and bump 1 of them to get them in sync