### PR TITLE
[v8] fix: update setFocusVisibility to get providers from context if one is not provided

### DIFF
--- a/change/@fluentui-utilities-d6d8cab0-dc25-4cd5-9acd-69af34090b2f.json
+++ b/change/@fluentui-utilities-d6d8cab0-dc25-4cd5-9acd-69af34090b2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "setFocusVisibility: get providers from FocusRectsContext if one wasn't provided",
+  "packageName": "@fluentui/utilities",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/setFocusVisibility.ts
+++ b/packages/utilities/src/setFocusVisibility.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { getWindow } from './dom/getWindow';
+import { FocusRectsContext } from './useFocusRects';
 export const IsFocusVisibleClassName = 'ms-Fabric--isFocusVisible';
 export const IsFocusHiddenClassName = 'ms-Fabric--isFocusHidden';
 
@@ -30,8 +31,10 @@ export function setFocusVisibility(
   target?: Element,
   registeredProviders?: React.RefObject<HTMLElement>[],
 ): void {
-  if (registeredProviders) {
-    registeredProviders.forEach(ref => updateClassList(ref.current, enabled));
+  const context = React.useContext(FocusRectsContext);
+  const providers = registeredProviders || (context?.providerRef && [context?.providerRef]);
+  if (providers) {
+    providers.forEach(ref => updateClassList(ref.current, enabled));
   } else {
     updateClassList(getWindow(target)?.document.body, enabled);
   }


### PR DESCRIPTION
## Current Behavior
When `setFocusVisibility` is called, if `registeredProviders` is not provided (which is the case `BaseButton.focus`, `ChoiceGroup.focus`, etc), the classname will be written to the body, even if the component is inside of a `FocusRectsProvider`

## New Behavior
This PR adds logic to `setFocusVisibility` to attempt to get `FocusRectsContext.providerRef` if `registeredProviders` isn't provided. This will allow callers of `setFocusVisibility` to default to using the current `providerRef` instead of 1) either having to explicitly pass the `providerRef` and 2) keeps the components from changing the classname on the body if it is inside of a provider already
