### PR TITLE
fix(react-theme): Change colorBrandForeground2 mapping in teamsDark theme

### DIFF
--- a/change/@fluentui-react-theme-91dd6ff2-c7b2-4e68-a3f4-75deb8832093.json
+++ b/change/@fluentui-react-theme-91dd6ff2-c7b2-4e68-a3f4-75deb8832093.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Change colorBrandForeground2 mapping in teamsDark theme",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-theme/src/alias/teamsDarkColor.ts
+++ b/packages/react-components/react-theme/src/alias/teamsDarkColor.ts
@@ -35,7 +35,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorCompoundBrandForeground1Hover: brand[110], // #3aa0f3 Global.Color.Brand.110
   colorCompoundBrandForeground1Pressed: brand[90], // #1890f1 Global.Color.Brand.90
   colorBrandForeground1: brand[100], // #2899f5 Global.Color.Brand.100
-  colorBrandForeground2: brand[110], // #3aa0f3 Global.Color.Brand.110
+  colorBrandForeground2: brand[120], // #6cb8f6 Global.Color.Brand.120
   colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInverted: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedHover: grey[14], // #242424 Global.Color.Grey.14


### PR DESCRIPTION


## Current Behavior

In teamsDarkTheme `colorBrandForeground2` was mapped to `brand[110]`.
When used together `colorBrandBackground2` (which is the case in `<Badge appearance="tinted" />`) this resulted in insufficient contrast ratio of 4.17

## New Behavior

In teamsDarkTheme `colorBrandForeground2` is now mapped to `brand[120]`. The contrast ration for tinted `Badge` increased to 5.33

## Related Issue(s)

Fixes #23898
