### PR TITLE
chore(public-docsite-v9): adds `Dialog` components to Poster metadata

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Poster/metadata.ts
+++ b/apps/public-docsite-v9/src/Concepts/Poster/metadata.ts
@@ -139,7 +139,14 @@ export const libraryInfo: LibraryInfo = {
         {
           name: 'react-dialog',
           newColumn: true,
-          codeItems: [{ name: 'Dialog', componentType: 'component' }],
+          codeItems: [
+            { name: 'Dialog', componentType: 'component' },
+            { name: 'DialogTrigger', componentType: 'component' },
+            { name: 'DialogSurface', componentType: 'component' },
+            { name: 'DialogTitle', componentType: 'component' },
+            { name: 'DialogBody', componentType: 'component' },
+            { name: 'DialogActions', componentType: 'component' },
+          ],
         },
         {
           name: 'react-popover',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently only `Dialog` component is present on Poster

![image](https://user-images.githubusercontent.com/5483269/187448958-a12d1989-2dd5-452a-8c95-7c4189267d8f.png)


## New Behavior

Adds compound components from `Dialog` as it's becoming more stable, including:

1. Dialog
2. DialogTrigger
3. DialogSurface
4. DialogTitle
5. DialogBody
6. DialogActions

