### PR TITLE
Update "screener-build.yml" to include lage's output

### DIFF
--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -116,7 +116,7 @@ jobs:
 
       - run: |
           yarn lage info --since origin/master
-        name: Debug lage
+        name: Log affected packages (debug)
         if: ${{startsWith(github.ref, 'refs/pull/')}}
 
       - name: Log environment variables (Linux)
@@ -180,7 +180,7 @@ jobs:
 
       - run: |
           yarn lage info --since origin/master
-        name: Debug lage
+        name: Log affected packages (debug)
         if: ${{startsWith(github.ref, 'refs/pull/')}}
 
       - name: Log environment variables (Linux)
@@ -241,7 +241,7 @@ jobs:
 
       - run: |
           yarn lage info --since origin/master
-        name: Debug lage
+        name: Log affected packages (debug)
         if: ${{startsWith(github.ref, 'refs/pull/')}}
 
       - name: Log environment variables (Linux)

--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -114,6 +114,11 @@ jobs:
           fi
         name: Check if northstar packages were affected
 
+      - run: |
+          yarn lage info --since origin/master
+        name: Debug lage
+        if: ${{startsWith(github.ref, 'refs/pull/')}}
+
       - name: Log environment variables (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -173,6 +178,11 @@ jobs:
           fi
         name: Check if v8 packages were affected
 
+      - run: |
+          yarn lage info --since origin/master
+        name: Debug lage
+        if: ${{startsWith(github.ref, 'refs/pull/')}}
+
       - name: Log environment variables (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -228,6 +238,11 @@ jobs:
             echo "Should NOT skip screener"
           fi
         name: Check if v9 packages were affected
+
+      - run: |
+          yarn lage info --since origin/master
+        name: Debug lage
+        if: ${{startsWith(github.ref, 'refs/pull/')}}
 
       - name: Log environment variables (Linux)
         if: runner.os == 'Linux'

--- a/packages/react-components/babel-preset-global-context/src/index.ts
+++ b/packages/react-components/babel-preset-global-context/src/index.ts
@@ -5,3 +5,4 @@ export default function preset() {
     plugins: [[transformPlugin]],
   };
 }
+//add comment

--- a/packages/react-components/babel-preset-global-context/src/index.ts
+++ b/packages/react-components/babel-preset-global-context/src/index.ts
@@ -5,4 +5,3 @@ export default function preset() {
     plugins: [[transformPlugin]],
   };
 }
-//add comment


### PR DESCRIPTION
## Current Behavior

Temporarily logging `lage` output for debugging purposes (understand if affected packages check works properly). Locally it works as expected:

```sh
$ yarn check:affected-package --packages @fluentui/vr-tests --pr=true
false
```

For an example change:

```sh
$ yarn lage info --since origin/master
info {
info   "command": [],
info   "scope": [
info     "@fluentui/react-alert",
info     "@fluentui/theme-designer",
info     "@fluentui/react-components",
info     "@fluentui/react-portal-compat",
info     "@fluentui/ts-minbar-test-react-components",
info     "@fluentui/stress-test",
info     "@fluentui/ssr-tests-v9",
info     "@fluentui/public-docsite-v9"
info   ],
info   "packageTasks": []
info }
```