### PR TITLE
Remove check for commit existence and make it optional

### DIFF
--- a/scripts/screener/screener.runner.ts
+++ b/scripts/screener/screener.runner.ts
@@ -27,7 +27,7 @@ async function scheduleScreenerBuild(
   buildInfo: {
     build: string;
     branchName: string;
-    commit: string;
+    commit?: string;
     pullRequest?: string;
   },
 ): Promise<ScheduleScreenerBuildResponse> {
@@ -78,9 +78,6 @@ export async function screenerRunner(screenerConfig: ScreenerRunnerConfig) {
   // https://github.com/screener-io/screener-runner/blob/2a8291fb1b0219c96c8428ea6644678b0763a1a1/src/ci.js#L101
   let branchName = process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH || process.env.BUILD_SOURCEBRANCHNAME;
 
-  if (!commit) {
-    throw new Error('SYSTEM_PULLREQUEST_SOURCECOMMITID env variable doesnt exist');
-  }
   if (!branchName) {
     throw new Error('SYSTEM_PULLREQUEST_SOURCEBRANCH or BUILD_SOURCEBRANCHNAME env variable doesnt exist');
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Check for existence of  environment variable `SYSTEM_PULLREQUEST_SOURCECOMMITID` in `screener.runner.ts` would break screener checks for master builds due to the `SYSTEM_PULLREQUEST_SOURCECOMMITID` environment variable not exsiting in such case.

## New Behavior

Check has been removed and `commit` has become an optional argument for the `scheduleScreenerBuild` function.

Reverting change from PR #24345 @Hotell 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
