### PR TITLE
Change file to bump version

### DIFF
--- a/change/@uifabric-icons-8a46a4cc-b4ee-402f-94e1-514ba647f024.json
+++ b/change/@uifabric-icons-8a46a4cc-b4ee-402f-94e1-514ba647f024.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Bumping version to match font-icons-mdl2",
+  "packageName": "@uifabric/icons",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
We want uifabric/icons and fluentui/font-icons-mdl2 on the same version so we can then beachball sync them in v7.

This bumps the version of icons to 7.8.0 which should match font-icons-mdl2

Updated #24393 