### PR TITLE
fix: v8 Dropdown no longer sets incorrect and unnecessary aria-activedescendant

### DIFF
--- a/change/@fluentui-react-2a9784d7-e2d3-40b7-93ae-e6b94ca7e231.json
+++ b/change/@fluentui-react-2a9784d7-e2d3-40b7-93ae-e6b94ca7e231.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Dropdown no longer sets incorrect and unnecessary aria-activedescendant",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -332,11 +332,6 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     const disabled = this._isDisabled();
 
     const errorMessageId = id + '-errorMessage';
-    const ariaActiveDescendant = disabled
-      ? undefined
-      : isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0
-      ? this._listId + selectedIndices[0]
-      : undefined;
 
     this._classNames = getClassNames(propStyles, {
       theme,
@@ -373,7 +368,6 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
           aria-label={ariaLabel}
           aria-labelledby={label && !ariaLabel ? mergeAriaAttributeValues(this._labelId, this._optionId) : undefined}
           aria-describedby={hasErrorMessage ? this._id + '-errorMessage' : undefined}
-          aria-activedescendant={ariaActiveDescendant}
           aria-required={required}
           aria-disabled={disabled}
           aria-controls={isOpen ? this._listId : undefined}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -869,7 +869,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
       class="ms-Dropdown-container"
     >
       <div
-        aria-activedescendant="Dropdown0-list1"
         aria-controls="Dropdown0-list"
         aria-expanded="true"
         aria-haspopup="listbox"
@@ -1224,7 +1223,6 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
       class="ms-Dropdown-container"
     >
       <div
-        aria-activedescendant="Dropdown0-list1"
         aria-controls="Dropdown0-list"
         aria-expanded="true"
         aria-haspopup="listbox"


### PR DESCRIPTION
The v8 Dropdown uses keyboard focus to move between options when the popup is open, but still sets `aria-activedescendant` on the trigger. The attribute currently serves no use, since the trigger does not have focus when the popup is open.

Because `activedescendant` is based on an internally generated `id`, rendering custom options that do not receive the internal `id` results in an automated a11y test failure. This PR removes the attribute entirely to fix that issue and simplify the component.