### PR TITLE
v7 fix: remove explicit readonly semantics from Calendar grid in office-ui-fabric-react package

### DIFF
--- a/change/office-ui-fabric-react-6392d55f-1850-4bee-b31c-a0ff57e7c83f.json
+++ b/change/office-ui-fabric-react-6392d55f-1850-4bee-b31c-a0ff57e7c83f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: v7 fabric port: remove explicit readonly semantics from Calendar grid",
+  "packageName": "office-ui-fabric-react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -240,7 +240,6 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
         <FocusZone>
           <table
             className={css('ms-DatePicker-table', styles.table)}
-            aria-readonly="true"
             aria-multiselectable="false"
             aria-labelledby={monthAndYearId}
             aria-activedescendant={activeDescendantId}

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -119,7 +119,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                 aria-activedescendant="DatePickerDay-active0"
                 aria-labelledby="DatePickerDay-monthAndYear2"
                 aria-multiselectable="false"
-                aria-readonly="true"
                 className="ms-DatePicker-table"
                 role="grid"
               >


### PR DESCRIPTION
Slowly making this fix in every single version of Calendar 😅

Here's the PR for the same fix in the date-time package: https://github.com/microsoft/fluentui/pull/23990
here's the original PR in v8: https://github.com/microsoft/fluentui/pull/20324

This is the same fix, but in the office-ui-fabric-react Calendar component.