### PR TITLE
Remove downloaded artifact file after using it

### DIFF
--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -94,6 +94,10 @@ jobs:
           echo "$line" >> $GITHUB_ENV
           done < "$input_file"
 
+      - name: Delete environment file
+        run: |
+          rm environment
+
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.1
@@ -158,6 +162,10 @@ jobs:
           echo "$line" >> $GITHUB_ENV
           done < "$input_file"
 
+      - name: Delete environment file
+        run: |
+          rm environment
+
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.1
@@ -219,6 +227,10 @@ jobs:
           do
           echo "$line" >> $GITHUB_ENV
           done < "$input_file"
+
+      - name: Delete environment file
+        run: |
+          rm environment
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The `environment` file used to define environment variables for each job used to make `lage` assume the whole workspace has been affected when it is not the case.

## New Behavior

The `environment` file is deleted when it is no longer needed so that the `lage` command can return an accurate result.

Adresses build scoping issue after merging PR #24466 
