### PR TITLE
Fix artifact downloading race condition

### DIFF
--- a/.github/workflows/screener-run.yml
+++ b/.github/workflows/screener-run.yml
@@ -30,7 +30,7 @@ jobs:
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: ${{context.payload.workflow_run.id}},
 
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
@@ -42,14 +42,14 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          run_id: context.payload.workflow_run.id
+          run_id: ${{context.payload.workflow_run.id}}
           name: env-artifact
 
       - name: Download N* storybook artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          run_id: context.payload.workflow_run.id
+          run_id: ${{context.payload.workflow_run.id}}
           name: northstar-artifact
           # downloads artifact to where it would be 'built'
           path: packages/fluentui/docs/dist
@@ -107,7 +107,7 @@ jobs:
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: ${{context.payload.workflow_run.id}},
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "screener-artifact"
@@ -118,14 +118,14 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          run_id: context.payload.workflow_run.id
+          run_id: ${{context.payload.workflow_run.id}}
           name: env-artifact
 
       - name: Download screener storybook artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          run_id: context.payload.workflow_run.id
+          run_id: ${{context.payload.workflow_run.id}}
           name: screener-artifact
           path: apps/vr-tests/dist/storybook
         if: ${{ env.IS_ARTIFACT_PRESENT == 'true' }}
@@ -181,7 +181,7 @@ jobs:
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: ${{context.payload.workflow_run.id}},
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "vnext-artifact"
@@ -192,14 +192,14 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          run_id: context.payload.workflow_run.id
+          run_id: ${{context.payload.workflow_run.id}}
           name: env-artifact
 
       - name: Download VNext storybook artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          run_id: context.payload.workflow_run.id
+          run_id: ${{context.payload.workflow_run.id}}
           name: vnext-artifact
           path: apps/vr-tests-react-components/dist/storybook
         if: ${{ env.IS_ARTIFACT_PRESENT == 'true' }}

--- a/.github/workflows/screener-run.yml
+++ b/.github/workflows/screener-run.yml
@@ -42,14 +42,14 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          workflow_conclusion: success
+          run_id: context.payload.workflow_run.id
           name: env-artifact
 
       - name: Download N* storybook artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          workflow_conclusion: success
+          run_id: context.payload.workflow_run.id
           name: northstar-artifact
           # downloads artifact to where it would be 'built'
           path: packages/fluentui/docs/dist
@@ -118,14 +118,14 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          workflow_conclusion: success
+          run_id: context.payload.workflow_run.id
           name: env-artifact
 
       - name: Download screener storybook artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          workflow_conclusion: success
+          run_id: context.payload.workflow_run.id
           name: screener-artifact
           path: apps/vr-tests/dist/storybook
         if: ${{ env.IS_ARTIFACT_PRESENT == 'true' }}
@@ -192,14 +192,14 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          workflow_conclusion: success
+          run_id: context.payload.workflow_run.id
           name: env-artifact
 
       - name: Download VNext storybook artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: screener-build.yml
-          workflow_conclusion: success
+          run_id: context.payload.workflow_run.id
           name: vnext-artifact
           path: apps/vr-tests-react-components/dist/storybook
         if: ${{ env.IS_ARTIFACT_PRESENT == 'true' }}

--- a/.github/workflows/screener-run.yml
+++ b/.github/workflows/screener-run.yml
@@ -30,7 +30,7 @@ jobs:
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{context.payload.workflow_run.id}},
+               run_id: context.payload.workflow_run.id,
 
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
@@ -107,7 +107,7 @@ jobs:
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{context.payload.workflow_run.id}},
+               run_id: context.payload.workflow_run.id,
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "screener-artifact"
@@ -181,7 +181,7 @@ jobs:
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{context.payload.workflow_run.id}},
+               run_id: context.payload.workflow_run.id,
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "vnext-artifact"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

If multiple PRs are pushed at the same time, `screener-run.yml` for all of them is likely to download the last artifact that was uploaded, the other ones being ignored. This race condition may cause build failures for the involved PRs.

## New Behavior

The action used to download artifacts uses the run ID of the `screener-build.yml` workflow in order to download the artifact associated with the current build.

