### PR TITLE
fix(react-theme): Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted

### DIFF
--- a/apps/public-docsite-v9/src/shims/ThemeShim/v9ThemeShim.ts
+++ b/apps/public-docsite-v9/src/shims/ThemeShim/v9ThemeShim.ts
@@ -53,7 +53,7 @@ const mapAliasColors = (palette: IPalette, inverted: boolean): ColorTokens => {
     colorNeutralForegroundInvertedPressed: palette.white,
     colorNeutralForegroundInvertedSelected: palette.white,
     colorNeutralForegroundOnBrand: palette.white,
-    colorNeutralForegroundInvertedStatic: palette.white,
+    colorNeutralForegroundStaticInverted: palette.white,
     colorNeutralForegroundInvertedLink: palette.white,
     colorNeutralForegroundInvertedLinkHover: palette.white,
     colorNeutralForegroundInvertedLinkPressed: palette.white,

--- a/change/@fluentui-react-avatar-bbc12538-d128-45e3-9f9b-302829fede9d.json
+++ b/change/@fluentui-react-avatar-bbc12538-d128-45e3-9f9b-302829fede9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-avatar",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-749f0a23-1986-4a17-899d-be7ef2db5724.json
+++ b/change/@fluentui-react-badge-749f0a23-1986-4a17-899d-be7ef2db5724.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-badge",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-38cb556a-cc08-471a-8aeb-878b78bbbbcd.json
+++ b/change/@fluentui-react-popover-38cb556a-cc08-471a-8aeb-878b78bbbbcd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-popover",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-3631728e-701e-46a0-a6b5-41fb4785a921.json
+++ b/change/@fluentui-react-spinner-3631728e-701e-46a0-a6b5-41fb4785a921.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-spinner",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-591d6c0f-d093-4b79-ae3e-067b74c7c0d0.json
+++ b/change/@fluentui-react-theme-591d6c0f-d093-4b79-ae3e-067b74c7c0d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-sass-8ca8c7e8-cbe6-4104-b893-1de751254302.json
+++ b/change/@fluentui-react-theme-sass-8ca8c7e8-cbe6-4104-b893-1de751254302.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-f76bb687-2740-4cb7-a9be-63917260000f.json
+++ b/change/@fluentui-react-tooltip-f76bb687-2740-4cb7-a9be-63917260000f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Rename colorNeutralForegroundInvertedStatic token to colorNeutralForegroundStaticInverted",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -254,7 +254,7 @@ const useColorStyles = makeStyles({
     backgroundColor: tokens.colorNeutralBackground6,
   },
   brand: {
-    color: tokens.colorNeutralForegroundInvertedStatic,
+    color: tokens.colorNeutralForegroundStaticInverted,
     backgroundColor: tokens.colorBrandBackgroundStatic,
   },
   'dark-red': {

--- a/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -155,7 +155,7 @@ const useRootStyles = makeStyles({
     color: tokens.colorPaletteDarkOrangeForeground3,
   },
   'ghost-subtle': {
-    color: tokens.colorNeutralForegroundInvertedStatic,
+    color: tokens.colorNeutralForegroundStaticInverted,
   },
   'ghost-success': {
     color: tokens.colorPaletteGreenForeground3,
@@ -187,7 +187,7 @@ const useRootStyles = makeStyles({
     color: tokens.colorPaletteDarkOrangeForeground3,
   },
   'outline-subtle': {
-    color: tokens.colorNeutralForegroundInvertedStatic,
+    color: tokens.colorNeutralForegroundStaticInverted,
   },
   'outline-success': {
     color: tokens.colorPaletteGreenForeground2,

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -28,7 +28,7 @@ const useStyles = makeStyles({
 
   inverted: {
     backgroundColor: tokens.colorNeutralBackgroundStatic,
-    color: tokens.colorNeutralForegroundInvertedStatic,
+    color: tokens.colorNeutralForegroundStaticInverted,
   },
 
   brand: {

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.ts
@@ -255,7 +255,7 @@ const useTrackStyles = makeStyles({
 const useLabelStyles = makeStyles({
   // style for label
   inverted: {
-    color: tokens.colorNeutralForegroundInvertedStatic,
+    color: tokens.colorNeutralForegroundStaticInverted,
   },
 
   primary: {}, // no change

--- a/packages/react-components/react-theme-sass/sass/colorTokens.scss
+++ b/packages/react-components/react-theme-sass/sass/colorTokens.scss
@@ -38,7 +38,7 @@ $colorNeutralForegroundInvertedHover: var(--colorNeutralForegroundInvertedHover)
 $colorNeutralForegroundInvertedPressed: var(--colorNeutralForegroundInvertedPressed);
 $colorNeutralForegroundInvertedSelected: var(--colorNeutralForegroundInvertedSelected);
 $colorNeutralForegroundOnBrand: var(--colorNeutralForegroundOnBrand);
-$colorNeutralForegroundInvertedStatic: var(--colorNeutralForegroundInvertedStatic);
+$colorNeutralForegroundStaticInverted: var(--colorNeutralForegroundStaticInverted);
 $colorNeutralForegroundInvertedLink: var(--colorNeutralForegroundInvertedLink);
 $colorNeutralForegroundInvertedLinkHover: var(--colorNeutralForegroundInvertedLinkHover);
 $colorNeutralForegroundInvertedLinkPressed: var(--colorNeutralForegroundInvertedLinkPressed);

--- a/packages/react-components/react-theme/etc/react-theme.api.md
+++ b/packages/react-components/react-theme/etc/react-theme.api.md
@@ -170,7 +170,7 @@ export type ColorTokens = {
     colorNeutralForegroundInvertedPressed: string;
     colorNeutralForegroundInvertedSelected: string;
     colorNeutralForegroundOnBrand: string;
-    colorNeutralForegroundInvertedStatic: string;
+    colorNeutralForegroundStaticInverted: string;
     colorNeutralForegroundInvertedLink: string;
     colorNeutralForegroundInvertedLinkHover: string;
     colorNeutralForegroundInvertedLinkPressed: string;

--- a/packages/react-components/react-theme/src/alias/darkColor.ts
+++ b/packages/react-components/react-theme/src/alias/darkColor.ts
@@ -40,7 +40,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorBrandForeground1: brand[100], // #2899f5 Global.Color.Brand.100
   colorBrandForeground2: brand[110], // #3aa0f3 Global.Color.Brand.110
   colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
-  colorNeutralForegroundInvertedStatic: white, // #ffffff Global.Color.White
+  colorNeutralForegroundStaticInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInverted: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedHover: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedPressed: grey[14], // #242424 Global.Color.Grey.14

--- a/packages/react-components/react-theme/src/alias/highContrastColor.ts
+++ b/packages/react-components/react-theme/src/alias/highContrastColor.ts
@@ -50,7 +50,7 @@ export const generateColorTokens = (): ColorTokens => ({
   colorBrandForeground1: hcCanvasText, // CanvasText Global.Color.hcCanvasText
   colorBrandForeground2: hcButtonText, // ButtonText Global.Color.hcButtonText
   colorNeutralForeground1Static: hcCanvas, // Canvas Global.Color.hcCanvas
-  colorNeutralForegroundInvertedStatic: hcCanvasText, // CanvasText Global.Color.hcCanvasText
+  colorNeutralForegroundStaticInverted: hcCanvasText, // CanvasText Global.Color.hcCanvasText
   colorNeutralForegroundInverted: hcHighlightText, // HighlightText Global.Color.hcHighlightText
   colorNeutralForegroundInvertedHover: hcHighlightText, // HighlightText Global.Color.hcHighlightText
   colorNeutralForegroundInvertedPressed: hcHighlightText, // HighlightText Global.Color.hcHighlightText

--- a/packages/react-components/react-theme/src/alias/lightColor.ts
+++ b/packages/react-components/react-theme/src/alias/lightColor.ts
@@ -40,7 +40,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorBrandForeground1: brand[80], // #0078d4 Global.Color.Brand.80
   colorBrandForeground2: brand[70], // #106ebe Global.Color.Brand.70
   colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
-  colorNeutralForegroundInvertedStatic: white, // #ffffff Global.Color.White
+  colorNeutralForegroundStaticInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedHover: white, // #ffffff Global.Color.White
   colorNeutralForegroundInvertedPressed: white, // #ffffff Global.Color.White

--- a/packages/react-components/react-theme/src/alias/teamsDarkColor.ts
+++ b/packages/react-components/react-theme/src/alias/teamsDarkColor.ts
@@ -40,7 +40,7 @@ export const generateColorTokens = (brand: BrandVariants): ColorTokens => ({
   colorBrandForeground1: brand[100], // #2899f5 Global.Color.Brand.100
   colorBrandForeground2: brand[120], // #6cb8f6 Global.Color.Brand.120
   colorNeutralForeground1Static: grey[14], // #242424 Global.Color.Grey.14
-  colorNeutralForegroundInvertedStatic: white, // #ffffff Global.Color.White
+  colorNeutralForegroundStaticInverted: white, // #ffffff Global.Color.White
   colorNeutralForegroundInverted: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedHover: grey[14], // #242424 Global.Color.Grey.14
   colorNeutralForegroundInvertedPressed: grey[14], // #242424 Global.Color.Grey.14

--- a/packages/react-components/react-theme/src/tokens.ts
+++ b/packages/react-components/react-theme/src/tokens.ts
@@ -38,7 +38,7 @@ export const tokens: Record<keyof Theme, string> = {
   colorNeutralForegroundInvertedHover: 'var(--colorNeutralForegroundInvertedHover)',
   colorNeutralForegroundInvertedPressed: 'var(--colorNeutralForegroundInvertedPressed)',
   colorNeutralForegroundInvertedSelected: 'var(--colorNeutralForegroundInvertedSelected)',
-  colorNeutralForegroundInvertedStatic: 'var(--colorNeutralForegroundInvertedStatic)',
+  colorNeutralForegroundStaticInverted: 'var(--colorNeutralForegroundStaticInverted)',
   colorNeutralForegroundInvertedLink: 'var(--colorNeutralForegroundInvertedLink)',
   colorNeutralForegroundInvertedLinkHover: 'var(--colorNeutralForegroundInvertedLinkHover)',
   colorNeutralForegroundInvertedLinkPressed: 'var(--colorNeutralForegroundInvertedLinkPressed)',

--- a/packages/react-components/react-theme/src/types.ts
+++ b/packages/react-components/react-theme/src/types.ts
@@ -44,7 +44,7 @@ export type ColorTokens = {
   colorNeutralForegroundInvertedPressed: string;
   colorNeutralForegroundInvertedSelected: string;
   colorNeutralForegroundOnBrand: string;
-  colorNeutralForegroundInvertedStatic: string;
+  colorNeutralForegroundStaticInverted: string;
   colorNeutralForegroundInvertedLink: string;
   colorNeutralForegroundInvertedLinkHover: string;
   colorNeutralForegroundInvertedLinkPressed: string;

--- a/packages/react-components/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/useTooltipStyles.ts
@@ -40,7 +40,7 @@ const useStyles = makeStyles({
 
   inverted: {
     backgroundColor: tokens.colorNeutralBackgroundStatic,
-    color: tokens.colorNeutralForegroundInvertedStatic,
+    color: tokens.colorNeutralForegroundStaticInverted,
   },
 
   arrow: createArrowStyles({ arrowHeight }),


### PR DESCRIPTION
## New Behavior

Rename `colorNeutralForegroundInvertedStatic` token to `colorNeutralForegroundStaticInverted` in order to match design spec.

<img width="1347" alt="image" src="https://user-images.githubusercontent.com/9615899/187689861-6a354e57-6901-4642-a279-c2abb60d7123.png">

### NOT a breaking change
Theoretically this would be a breaking change, but since the token was added in #24027 no FUI version has been released.
cc @spmonahan