### PR TITLE
Website fabric core

### DIFF
--- a/apps/public-docsite/src/root.tsx
+++ b/apps/public-docsite/src/root.tsx
@@ -36,7 +36,7 @@ registerIcons({
   },
 });
 
-const skipToMain = document.getElementById('uhfSkipToMain') as HTMLAnchorElement;
+const skipToMain = document.querySelector('[href="#mainContent"]') as HTMLAnchorElement;
 if (skipToMain) {
   // This link points to #mainContent by default, which would be interpreted as a route in our app.
   // Handle focusing the main content manually instead.

--- a/apps/public-docsite/src/utilities/createSite.tsx
+++ b/apps/public-docsite/src/utilities/createSite.tsx
@@ -33,11 +33,9 @@ if (window.__siteConfig?.baseCDNUrl) {
 
 initializeIcons();
 
-const corePackageVersion: string = require<any>('office-ui-fabric-core/package.json').version;
+// blog storage is now immutable, so new versions of fabric-core will be at a new url based on the build number
 addCSSToHeader(
-  'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' +
-    corePackageVersion +
-    '/css/fabric.min.css',
+  'https://res-1.cdn.office.net/files/fabric-cdn-prod_20220825.001/office-ui-fabric-core/11.0.1/css/fabric.min.css',
 );
 
 let rootElement: HTMLElement;

--- a/change/@fluentui-public-docsite-setup-fead5804-7705-4646-842d-5bfbf4fd7a28.json
+++ b/change/@fluentui-public-docsite-setup-fead5804-7705-4646-842d-5bfbf4fd7a28.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update fabric core URL and change selector for back to top button",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/public-docsite-setup/index.html
+++ b/packages/public-docsite-setup/index.html
@@ -66,7 +66,7 @@
 
   <body>
     <!-- Copied from UHF site -->
-    <a id="uhfSkipToMain" class="m-skip-to-main" href="#mainContent" tabindex="0">Skip to main content</a>
+    <a class="m-skip-to-main" href="#mainContent" tabindex="0">Skip to main content</a>
     <div id="main">
       <div class="loading">
         <img


### PR DESCRIPTION
Addresses a couple issues found in #24610

Now that the CDN is immutable, each deploy has a unique URL, so core we can't just add 11.0.1 to the old core URL and get the new version...we need to update the entire URL with the build number. Fortunately, core doesn't rev all that often.

Secondly, it seems the ID that used to be on the 'back to top' button has been removed, so I updated the selector to something that SHOULD be static. 