### PR TITLE
Fix typos in webpack integration instructions

### DIFF
--- a/change/@fluentui-web-components-30e8b3f3-0f3e-4922-bcae-5737d66d0f0c.json
+++ b/change/@fluentui-web-components-30e8b3f3-0f3e-4922-bcae-5737d66d0f0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix typos in webpack integration instructions",
+  "packageName": "@fluentui/web-components",
+  "email": "aelkholy248@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/src/_docs/integrations/webpack.stories.mdx
+++ b/packages/web-components/src/_docs/integrations/webpack.stories.mdx
@@ -87,7 +87,6 @@ module.exports = function(env, { mode }) {
       app: ['./src/main.ts']
     },
     output: {
-      filename: 'bundle.js'
       filename: 'bundle.js',
       publicPath:'/'
     },
@@ -163,9 +162,9 @@ With all the basic pieces in place, let's run our app in dev mode with `npm run 
 First, open your `src/main.ts` file and add the following code:
 
 ```ts
-import { provideFluentDesignSystem, fastCard, fastButton } from '@fluentui/web-components';
+import { provideFluentDesignSystem, fluentCard, fluentButton } from '@fluentui/web-components';
 
-provideFluentDesignSystem().register(fastCard(), fastButton());
+provideFluentDesignSystem().register(fluentCard(), fluentButton());
 ```
 
 This code uses the Fluent Design System to register the `<fluent-card>` and `<fluent-button>` components. Once you save, the dev server will rebuild and refresh your browser. However, you still won't see anything. To get some UI showing up, we need to write some HTML that uses our components. Replace the contents of the `<body>` in your `index.html` file with the following markup:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Some typos in the webpack integration instructions.

## New Behavior

1- Removed extra filename entry in webpack.config.js
2- Import fluentCard and fluentButton instead of fastCard and fastButton respectively
