### PR TITLE
feat(react-18-tests-v9): Add cypress setup to enable writing cypress tests

### DIFF
--- a/apps/react-18-tests-v9/cypress.config.ts
+++ b/apps/react-18-tests-v9/cypress.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '@fluentui/scripts/cypress/cypress.config';
+
+export default baseConfig;

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -11,7 +11,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start": "webpack-dev-server --mode=development --config=webpack.config.js",
-    "e2e": "cypress run --component",
     "e2e:local": "cypress open --component"
   },
   "devDependencies": {

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -10,7 +10,9 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start": "webpack-dev-server --mode=development --config=webpack.config.js"
+    "start": "webpack-dev-server --mode=development --config=webpack.config.js",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/apps/react-18-tests-v9/tsconfig.cy.json
+++ b/apps/react-18-tests-v9/tsconfig.cy.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "isolatedModules": false,
+    "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
+    "lib": ["ES2019", "dom"]
+  },
+  "include": ["./src/**/*.e2e.ts", "./src/**/*.e2e.tsx"]
+}

--- a/apps/react-18-tests-v9/tsconfig.json
+++ b/apps/react-18-tests-v9/tsconfig.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.cy.json"
     }
   ]
 }


### PR DESCRIPTION
## Changes
- Adds cypress setup which will enable writing cypress tests in this package. 
  - cypress test files must have `.e2e.` in its filename.