### PR TITLE
Export ButtonGlobalClassNames

### DIFF
--- a/change/@fluentui-react-81ba3c6c-fe16-4767-bd80-1557c3a93c01.json
+++ b/change/@fluentui-react-81ba3c6c-fe16-4767-bd80-1557c3a93c01.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: export ButtonGlobalClassNames from classnames file",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -871,6 +871,19 @@ export class Button extends React_2.Component<IButtonProps, {}> {
 }
 
 // @public (undocumented)
+export const ButtonGlobalClassNames: {
+    msButton: string;
+    msButtonHasMenu: string;
+    msButtonIcon: string;
+    msButtonMenuIcon: string;
+    msButtonLabel: string;
+    msButtonDescription: string;
+    msButtonScreenReaderText: string;
+    msButtonFlexContainer: string;
+    msButtonTextContainer: string;
+};
+
+// @public (undocumented)
 export const ButtonGrid: React_2.FunctionComponent<IButtonGridProps>;
 
 // @public (undocumented)

--- a/packages/react/src/components/Button/index.ts
+++ b/packages/react/src/components/Button/index.ts
@@ -10,4 +10,5 @@ export * from './MessageBarButton/MessageBarButton';
 export * from './PrimaryButton/PrimaryButton';
 export * from './IconButton/IconButton';
 export * from './SplitButton/SplitButton.classNames';
+export { ButtonGlobalClassNames } from './BaseButton.classNames';
 export type { IButtonClassNames } from './BaseButton.classNames';


### PR DESCRIPTION
fixes #24623

this was from a random discussion request back in may, but seeing as we explicitly do this in v9, it seems a welcome change for anyone using the v8 button.