### PR TITLE
fix(react-18-tests-v9): extend correct tsconfig.json

### DIFF
--- a/apps/react-18-tests-v9/tsconfig.cy.json
+++ b/apps/react-18-tests-v9/tsconfig.cy.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
     "isolatedModules": false,


### PR DESCRIPTION
## Changes
- now correctly extends the root package `tsconfig.json` file instead of the monorepo one for the `tsconfig.cy.json` file