### PR TITLE
[v8] fix: Add check for FocusRectsProvider providerRef being undefined

### DIFF
--- a/change/@fluentui-utilities-fb8931ea-afab-44af-af7e-729cb3a2f647.json
+++ b/change/@fluentui-utilities-fb8931ea-afab-44af-af7e-729cb3a2f647.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add check for FocusRectsProvider providerRef being undefined",
+  "packageName": "@fluentui/utilities",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -108,7 +108,7 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
     let onPointerDown: (ev: PointerEvent) => void;
     let onKeyDown: (ev: KeyboardEvent) => void;
     let onKeyUp: (ev: KeyboardEvent) => void;
-    if (context?.providerRef.current) {
+    if (context?.providerRef?.current) {
       el = context.providerRef.current;
       const callbacks = setCallbackMap(context);
       onMouseDown = callbacks.onMouseDown;


### PR DESCRIPTION
## Current Behavior

PR #24340 modified FocusRectsContext so that the providerRef should never be undefined (the entire context is undefined if there is none). However, #24616 indicates that in some cases, providerRef can get set to undefined.

It is unclear where or how it is getting set to undefined, but perhaps one of the places that uses FocusRectsProvider can get into a bad state and/or is casting away undefined somewhere.

## New Behavior

Add a check that the `providerRef` is not undefined before trying to use it.

## Related Issue(s)

* Fixes #24616
