### PR TITLE
fix(react-18-tests-v8): remove type-check command to fix CI issue

### DIFF
--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "build": "just-scripts build",
     "type-check": "tsc -b",
     "lint": "just-scripts lint",
     "test": "just-scripts test",

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@fluentui/react": "^8.93.0",
+    "@fluentui/react-hooks": "^8.6.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tslib": "^2.1.0"

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -5,15 +5,15 @@
   "private": true,
   "scripts": {
     "build": "just-scripts build",
-    "type-check": "tsc -b",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
     "start": "webpack-dev-server --mode=development --config=webpack.config.js",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component"
+    "type-check": "tsc -b"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
@@ -23,7 +23,7 @@
     "swc-loader": "^0.2.3"
   },
   "dependencies": {
-    "@fluentui/react": "^8.93.0",
+    "@fluentui/react": "^8.93.1",
     "@fluentui/react-hooks": "^8.6.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@fluentui/react": "^8.93.1",
-    "@fluentui/react-hooks": "^8.6.9",
+    "@fluentui/react-hooks": "^8.6.10",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tslib": "^2.1.0"

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -13,7 +13,7 @@
     "test": "just-scripts test",
     "just": "just-scripts",
     "start": "webpack-dev-server --mode=development --config=webpack.config.js",
-    "type-check": "tsc -b"
+    "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
@@ -23,8 +23,8 @@
     "swc-loader": "^0.2.3"
   },
   "dependencies": {
-    "@fluentui/react": "^8.93.1",
-    "@fluentui/react-hooks": "^8.6.10",
+    "@fluentui/react": "8.93.1",
+    "@fluentui/react-hooks": "8.6.10",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tslib": "^2.1.0"

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -12,8 +12,7 @@
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",
-    "start": "webpack-dev-server --mode=development --config=webpack.config.js",
-    "type-check": "tsc -b tsconfig.json"
+    "start": "webpack-dev-server --mode=development --config=webpack.config.js"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@fluentui/react": "^8.93.0",
-    "@fluentui/react-hooks": "^8.6.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tslib": "^2.1.0"

--- a/apps/react-18-tests-v8/src/components/ContextualMenu/ContextualMenuExample.tsx
+++ b/apps/react-18-tests-v8/src/components/ContextualMenu/ContextualMenuExample.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
 import {
   ContextualMenuItemType,
+  css,
+  DefaultButton,
   DirectionalHint,
-  IContextualMenuProps,
+  FocusZoneDirection,
+  IconButton,
   IContextualMenuItem,
-} from '@fluentui/react/lib/ContextualMenu';
-import { DefaultButton, IconButton } from '@fluentui/react/lib/Button';
-import { FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
-import { mergeStyleSets } from '@fluentui/react/lib/Styling';
-import { css } from '@fluentui/react/lib/Utilities';
-import { useConst } from '@fluentui/react-hooks';
+  mergeStyleSets,
+} from '@fluentui/react';
 
 export const ContextualMenuExample: React.FunctionComponent = () => {
-  const menuProps = useConst<IContextualMenuProps>(() => ({
+  const menuProps = {
     shouldFocusOnMount: true,
     directionalHint: DirectionalHint.bottomLeftEdge,
     className: classNames.menu,
@@ -69,7 +68,7 @@ export const ContextualMenuExample: React.FunctionComponent = () => {
         },
       },
     ],
-  }));
+  };
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //@ts-ignore
   return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;

--- a/apps/react-18-tests-v8/src/components/ContextualMenu/ContextualMenuExample.tsx
+++ b/apps/react-18-tests-v8/src/components/ContextualMenu/ContextualMenuExample.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import {
   ContextualMenuItemType,
-  css,
-  DefaultButton,
   DirectionalHint,
-  FocusZoneDirection,
-  IconButton,
+  IContextualMenuProps,
   IContextualMenuItem,
-  mergeStyleSets,
-} from '@fluentui/react';
+} from '@fluentui/react/lib/ContextualMenu';
+import { DefaultButton, IconButton } from '@fluentui/react/lib/Button';
+import { FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
+import { mergeStyleSets } from '@fluentui/react/lib/Styling';
+import { css } from '@fluentui/react/lib/Utilities';
+import { useConst } from '@fluentui/react-hooks';
 
 export const ContextualMenuExample: React.FunctionComponent = () => {
-  const menuProps = {
+  const menuProps = useConst<IContextualMenuProps>(() => ({
     shouldFocusOnMount: true,
     directionalHint: DirectionalHint.bottomLeftEdge,
     className: classNames.menu,
@@ -68,7 +69,7 @@ export const ContextualMenuExample: React.FunctionComponent = () => {
         },
       },
     ],
-  };
+  }));
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //@ts-ignore
   return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;


### PR DESCRIPTION
## Changes
- Removes `type-check` command which is causing a race condition issue in the CI pipeline causing it to fail. `type-check` command for the react-18-tests-v8 app is being ran _BEFORE_ `@fluentui/react` finishes building which causes the intermittent error below.

**Error:**
```
ERR! [@fluentui/react-18-tests-v8 type-check] ERROR DETECTED
ERR! started
ERR! hash: bfb8f2139aa5cf3cc93acad19377a674d8c10378, cache hit? false
ERR! Running /opt/hostedtoolcache/node/14.18.1/x64/bin/npm run type-check
ERR! npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1662060828967-0.16018444283984823/node but npm is using /opt/hostedtoolcache/node/14.18.1/x64/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
ERR! 
ERR! > @fluentui/react-18-tests-v8@1.0.0 type-check /mnt/vss/_work/1/s/apps/react-18-tests-v8
ERR! > tsc -b
ERR! 
ERR! src/components/ContextualMenu/ContextualMenuExample.tsx(7,8): error TS2307: Cannot find module '@fluentui/react/lib/ContextualMenu' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenuExample.tsx(8,43): error TS2307: Cannot find module '@fluentui/react/lib/Button' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenuExample.tsx(9,36): error TS2307: Cannot find module '@fluentui/react/lib/FocusZone' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenuExample.tsx(10,32): error TS2307: Cannot find module '@fluentui/react/lib/Styling' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenuExample.tsx(11,21): error TS2307: Cannot find module '@fluentui/react/lib/Utilities' or its corresponding type declarations.
ERR! src/App.tsx(2,70): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenu.e2e.tsx(3,72): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenu.test.tsx(4,72): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
ERR! src/components/ContextualMenu/ContextualMenu.e2e.tsx(3,72): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
ERR! npm ERR! code ELIFECYCLE
ERR! npm ERR! errno 1
ERR! npm ERR! @fluentui/react-18-tests-v8@1.0.0 type-check: `tsc -b`
ERR! npm ERR! Exit status 1
ERR! npm ERR! 
ERR! npm ERR! Failed at the @fluentui/react-18-tests-v8@1.0.0 type-check script.
ERR! npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

Example Error: https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=265008&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=8250ef03-1890-59ab-a6a8-5d0b4c2baa1b