### PR TITLE
chore: Remove max-width style from Button components

### DIFF
--- a/change/@fluentui-react-button-2869c3ac-e452-48e2-9a3c-7712ebbb999e.json
+++ b/change/@fluentui-react-button-2869c3ac-e452-48e2-9a3c-7712ebbb999e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Remove max-width style from Button components.",
+  "packageName": "@fluentui/react-button",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -22,8 +22,6 @@ const useRootStyles = makeStyles({
 
     ...shorthands.margin(0),
 
-    maxWidth: '280px',
-
     ...shorthands.overflow('hidden'),
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',

--- a/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -15,7 +15,6 @@ const useRootStyles = makeStyles({
   // Base styles
   base: {
     height: 'auto',
-    maxWidth: 'unset',
 
     [`& .${compoundButtonClassNames.secondaryContent}`]: {
       color: tokens.colorNeutralForeground2,

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonIcon.stories.tsx
@@ -6,29 +6,12 @@ import {
   FilterFilled,
   FilterRegular,
 } from '@fluentui/react-icons';
-import {
-  makeStyles,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  MenuPopover,
-  MenuTrigger,
-  Tooltip,
-} from '@fluentui/react-components';
-
-const useStyles = makeStyles({
-  longText: {
-    maxWidth: '380px',
-  },
-});
+import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger, Tooltip } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 const Filter = bundleIcon(FilterFilled, FilterRegular);
 
 export const Icon = () => {
-  const styles = useStyles();
-
   return (
     <>
       <Menu>
@@ -45,7 +28,7 @@ export const Icon = () => {
 
       <Menu>
         <MenuTrigger>
-          <MenuButton icon={<CalendarMonth />} menuIcon={<Filter />} className={styles.longText}>
+          <MenuButton icon={<CalendarMonth />} menuIcon={<Filter />}>
             With calendar icon and custom filter menu icon
           </MenuButton>
         </MenuTrigger>

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonIcon.stories.tsx
@@ -6,23 +6,8 @@ import {
   FilterFilled,
   FilterRegular,
 } from '@fluentui/react-icons';
-import {
-  makeStyles,
-  Menu,
-  MenuItem,
-  MenuList,
-  MenuPopover,
-  MenuTrigger,
-  SplitButton,
-  Tooltip,
-} from '@fluentui/react-components';
+import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton, Tooltip } from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
-
-const useStyles = makeStyles({
-  longText: {
-    maxWidth: '350px',
-  },
-});
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 const Filter = bundleIcon(FilterFilled, FilterRegular);
@@ -31,8 +16,6 @@ export const Icon = () => {
   const [primaryActionButtonRef, setPrimaryActionButtonRef] = React.useState<
     HTMLButtonElement | HTMLAnchorElement | null
   >(null);
-
-  const styles = useStyles();
 
   return (
     <>
@@ -71,14 +54,7 @@ export const Icon = () => {
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton
-              menuButton={triggerProps}
-              primaryActionButton={{
-                className: styles.longText,
-              }}
-              icon={<CalendarMonth />}
-              menuIcon={<Filter />}
-            >
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />} menuIcon={<Filter />}>
               With calendar icon and custom filter menu icon
             </SplitButton>
           )}


### PR DESCRIPTION
## Current Behavior

`Button` components have a `maxWidth` defined, which is a constraint that constantly needs to be overridden by developers.

## New Behavior

`Button` components don't have a `maxWidth` defined anymore.