### PR TITLE
Patch bump @uifabric/icons and @uifabric/file-type-icons

### DIFF
--- a/change/@uifabric-file-type-icons-473eed16-0e70-4d5f-8d42-1dbda5cae347.json
+++ b/change/@uifabric-file-type-icons-473eed16-0e70-4d5f-8d42-1dbda5cae347.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Patch bump file-type-icons",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-icons-5a7a49fa-11d9-477c-b670-c9ed25de91ca.json
+++ b/change/@uifabric-icons-5a7a49fa-11d9-477c-b670-c9ed25de91ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Patch bumping to match font-icons-mdl2",
+  "packageName": "@uifabric/icons",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Changes
- bumped patch version of icons to match font-icons-mdl2 in v7
- bumped patch version of file-type-icons to match react-file-type-icons in v7

## Issues
Updates #24648