### PR TITLE
fix(react-utilities): add microdata properties like itemType to allowed html properties

### DIFF
--- a/change/@fluentui-react-utilities-76935223-2ad2-4d45-bb36-7bf9c363389d.json
+++ b/change/@fluentui-react-utilities-76935223-2ad2-4d45-bb36-7bf9c363389d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add microdata properties to allowed html properties",
+  "packageName": "@fluentui/react-utilities",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -127,11 +127,24 @@ export const baseElementProperties = toObjectMap([
 ]);
 
 /**
+ * An array of microdata attributes that are allowed on every html element type.
+ *
+ * @public
+ */
+export const microdataProperties = toObjectMap([
+  'itemID', // global
+  'itemProp', // global
+  'itemRef', // global
+  'itemScope', // global
+  'itemType', // global
+]);
+
+/**
  * An array of HTML element properties and events.
  *
  * @public
  */
-export const htmlElementProperties = toObjectMap(baseElementProperties, baseElementEvents);
+export const htmlElementProperties = toObjectMap(baseElementProperties, baseElementEvents, microdataProperties);
 
 /**
  * An array of LABEL tag properties and events.


### PR DESCRIPTION
Add the below properties to allowed properties for every html element:
[itemid](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemid)
[itemprop](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemprop)
[itemref](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemref)
[itemscope](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemscope)
[itemtype](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemtype)