### PR TITLE
Bump utilities to republish latest

### DIFF
--- a/change/@fluentui-utilities-ab5f4edb-39a8-4e95-b5f9-eca94cb92af1.json
+++ b/change/@fluentui-utilities-ab5f4edb-39a8-4e95-b5f9-eca94cb92af1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump utilities to republish latest",
+  "packageName": "@fluentui/utilities",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
7.x of utilities got accidentally published as latest
This bumps 8.x utilities to force a republish of latest.