### PR TITLE
Bump icons version without bumping font-icons-mdl2

### DIFF
--- a/change/@uifabric-icons-40124900-4bd1-48bb-8969-116bb72632e4.json
+++ b/change/@uifabric-icons-40124900-4bd1-48bb-8969-116bb72632e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump icons version without bumping font-icons-mdl2",
+  "packageName": "@uifabric/icons",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/scripts/beachball/index.ts
+++ b/scripts/beachball/index.ts
@@ -21,7 +21,7 @@ export const config: BeachballConfig = {
     },
     {
       name: 'Icons',
-      include: ['packages/icons', 'stub-packages/font-icons-mdl2'],
+      include: ['packages/icons'],
       disallowedChangeTypes: ['major'],
     },
     {


### PR DESCRIPTION
@uifabric/icons needs a patch bump to match up with @fluentui/font-icons/mdl2
This needs to be done without the grouping on.
Grouping will be restored after a published build of 7.