### PR TITLE
Clarify the documentation of RadioGroup's `required` prop

### DIFF
--- a/change/@fluentui-react-radio-05cc89eb-04f6-4d83-ad59-96c8633a7954.json
+++ b/change/@fluentui-react-radio-05cc89eb-04f6-4d83-ad59-96c8633a7954.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Clarify the documentation of RadioGroup's required prop",
+  "packageName": "@fluentui/react-radio",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-05cc89eb-04f6-4d83-ad59-96c8633a7954.json
+++ b/change/@fluentui-react-radio-05cc89eb-04f6-4d83-ad59-96c8633a7954.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Clarify the documentation of RadioGroup's required prop",
+  "comment": "docs: Clarify the documentation of RadioGroup's required prop",
   "packageName": "@fluentui/react-radio",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "none"

--- a/packages/react-components/react-radio/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/react-components/react-radio/src/components/RadioGroup/RadioGroup.types.ts
@@ -48,7 +48,7 @@ export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'on
   disabled?: boolean;
 
   /**
-   * Require all Radio items in this group.
+   * Require a selection in this group. Adds the `required` prop to all child Radio items.
    */
   required?: boolean;
 };

--- a/packages/react-components/react-radio/src/stories/Radio/RadioGroupRequired.stories.tsx
+++ b/packages/react-components/react-radio/src/stories/Radio/RadioGroupRequired.stories.tsx
@@ -20,7 +20,7 @@ export const Required = () => {
 Required.parameters = {
   docs: {
     description: {
-      story: 'Use the `required` prop on `RadioGroup` to indicate that a selection must be made.',
+      story: 'Use the `required` prop on `RadioGroup` to indicate that one of the radio items must be selected.',
     },
   },
 };

--- a/packages/react-components/react-radio/src/stories/Radio/RadioGroupRequired.stories.tsx
+++ b/packages/react-components/react-radio/src/stories/Radio/RadioGroupRequired.stories.tsx
@@ -20,7 +20,7 @@ export const Required = () => {
 Required.parameters = {
   docs: {
     description: {
-      story: 'Use the `required` prop on `RadioGroup` to make all child `Radio`s required.',
+      story: 'Use the `required` prop on `RadioGroup` to indicate that a selection must be made.',
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The documentation of RadioGroup's `required` prop is potentially confusing. It doesn't require you to select all radios--that's impossible; instead it requires that there is a selection in the group.

## New Behavior

Clarify the documentation of RadioGroup's `required` prop.