### PR TITLE
Trigger VR tests using comments

### DIFF
--- a/.github/workflows/create-label.yml
+++ b/.github/workflows/create-label.yml
@@ -1,0 +1,39 @@
+name: Create label
+
+on:
+  workflow_run:
+    workflows:
+      - Trigger comment
+    types:
+      - completed
+
+jobs:
+  Action:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download environment variables artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: trigger-comment.yml
+          run_id: ${{github.event.workflow_run.id}}
+          name: pr_number
+
+      - name: Define env variable
+        run: |
+          var=$(head -1 number)
+          echo "$var" >> $GITHUB_ENV
+
+      - run: |
+          printenv | sort
+
+      - name: script_label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{env.PR_NUMBER}},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Ready for VR']
+            })

--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -1,11 +1,11 @@
 name: Screener build
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Create label
+    types:
+      - completed
 
 env:
   DEPLOYHOST: 'fluentuipr.z22.web.core.windows.net'

--- a/.github/workflows/screener-run.yml
+++ b/.github/workflows/screener-run.yml
@@ -10,6 +10,7 @@ env:
   AZURE_STORAGE_CONNECTION_STRING: ${{secrets.AZURE_STORAGE_CONNECTION_STRING}}
 jobs:
   screener-react-northstar:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: 'ubuntu-latest'
     name: Screener @fluentui/react-northstar
     steps:
@@ -87,6 +88,7 @@ jobs:
           SCREENER_API_KEY: ${{secrets.SCREENER_API_KEY}}
 
   screener-react:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: 'ubuntu-latest'
     name: Screener @fluentui/react
     steps:
@@ -161,6 +163,7 @@ jobs:
           SCREENER_API_KEY: ${{secrets.SCREENER_API_KEY}}
 
   screener-react-components:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: 'ubuntu-latest'
     name: Screener @fluentui/react-components
     steps:

--- a/.github/workflows/trigger-comment.yml
+++ b/.github/workflows/trigger-comment.yml
@@ -1,0 +1,16 @@
+name: Trigger comment
+on:
+  issue_comment:
+    types: [created, edited]
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    if: github.event.comment.body == 'Run VR tests' && github.event.issue.pull_request
+    steps:
+      - run: |
+          echo "PR_NUMBER=${{github.event.issue.number}}" > number
+      - name: Upload the PR number
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr_number
+          path: number


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

The GitHub Actions workflows that are starting the visual regression tests are triggered by the specific activities of the `pull_request` event - each time a new PR is created, the workflows run, and the screener checks are performed if it is the case.

## New Behavior

The screener checks only run if a PR has the `Ready for VR` label assigned to it, which happens automatically when a contributor comments 'Run VR tests' on their PR.

The GitHub Actions workflows are triggered by the 'Run VR tests' comment, which creates the 'Ready for VR' label for that PR and then starts the usual screener workflows.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Addresses #23903 
