### PR TITLE
fix: Combobox text attribute ignored when empty string is passed

### DIFF
--- a/change/@fluentui-react-90cdf79a-346a-4c6d-b507-ff62f6188fb5.json
+++ b/change/@fluentui-react-90cdf79a-346a-4c6d-b507-ff62f6188fb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow empty string as valid value for text property of ComboBox",
+  "packageName": "@fluentui/react",
+  "email": "sebastian.vanik@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -694,7 +694,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     // unless we are open and have a valid current pending index
     if (
       !(isOpen && currentPendingIndexValid) &&
-      text &&
+      (text || text == '') &&
       (currentPendingValue === null || currentPendingValue === undefined)
     ) {
       return text;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
ComboBox Component:
When using text property empty string is ignored, meaning you can't clear the ComboBox freeform value

## New Behavior

Empty string is not ignored and you are able to use text property to clear ComboBox freeform value
