### PR TITLE
Sync icons and font-icon-mdl2 versions

### DIFF
--- a/change/@uifabric-icons-021a86fa-b129-4dff-b88b-0c41d587f9d5.json
+++ b/change/@uifabric-icons-021a86fa-b129-4dff-b88b-0c41d587f9d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Force syncing icon versions",
+  "packageName": "@uifabric/icons",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/icons",
-  "version": "7.8.4",
+  "version": "7.8.5",
   "description": "Fluent UI React icon set.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/scripts/beachball/index.ts
+++ b/scripts/beachball/index.ts
@@ -21,7 +21,7 @@ export const config: BeachballConfig = {
     },
     {
       name: 'Icons',
-      include: ['packages/icons'],
+      include: ['packages/icons', 'stub-packages/font-icons-mdl2'],
       disallowedChangeTypes: ['major'],
     },
     {


### PR DESCRIPTION
## Changes
Bumped the version in package.json to have font-icons-mdl2 and icons match.  
Restored the version grouping config.


## Issues
Update #24393