### PR TITLE
chore(react-dialog): removes `react-button` `max-width` override

### DIFF
--- a/change/@fluentui-react-dialog-5331261d-eb3b-4126-a04e-fbf6d05840ce.json
+++ b/change/@fluentui-react-dialog-5331261d-eb3b-4126-a04e-fbf6d05840ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore(react-dialog): removes react-button max-width overrides",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts
@@ -19,9 +19,6 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
     display: 'flex',
     ...shorthands.gap(DIALOG_GAP),
-    '> .fui-Button': {
-      maxWidth: '100%',
-    },
     [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
       flexDirection: 'column',
       justifySelf: 'stretch',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

# Current behaviour

`DialogActions` component provides an override using `.fui-Button` static class to ensure `max-width` of `Button` is not set.

https://github.com/microsoft/fluentui/blob/330aa6b960d371456667aae70cccbf116ed58cef/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts#L22-L24

## New Behavior

Removes override `max-width` following up on https://github.com/microsoft/fluentui/pull/24647

## Related Issue(s)


Fixes #24650
