### PR TITLE
feat: autocontrolled `useTable` hook

### DIFF
--- a/change/@fluentui-react-table-f0050981-47d5-4725-9d63-99142fda10f9.json
+++ b/change/@fluentui-react-table-f0050981-47d5-4725-9d63-99142fda10f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: autocontrolled `useTable` hook",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -240,13 +240,7 @@ export type TablePrimaryCellSlots = {
 export type TablePrimaryCellState = ComponentState<TablePrimaryCellSlots>;
 
 // @public
-export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue> & {
-    onSortColumnChange?: (e: React_2.MouseEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement>, data: {
-        sortState: SortState_2;
-    }) => void;
-    sortState?: SortState_2;
-    defaultSortState?: SortState_2;
-};
+export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue>;
 
 // @public
 export const TableRow: ForwardRefComponent<TableRowProps>;
@@ -342,14 +336,26 @@ export const useTableHeaderStyles_unstable: (state: TableHeaderState) => TableHe
 export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowState<TItem>> {
     // (undocumented)
     columns: ColumnDefinition<TItem>[];
+    defaultSelectedRows?: Set<RowId>;
+    defaultSortState?: {
+        sortColumn: ColumnId | undefined;
+        sortDirection: SortDirection;
+    };
     // (undocumented)
     getRowId?: (item: TItem) => RowId;
     // (undocumented)
     items: TItem[];
+    onSelectionChange?: OnSelectionChangeCallback;
+    onSortChange?: OnSortChangeCallback;
     // (undocumented)
     rowEnhancer?: RowEnhancer<TItem, TRowState>;
+    selectedRows?: Set<RowId>;
     // (undocumented)
     selectionMode?: SelectionMode_2;
+    sortState?: {
+        sortColumn: ColumnId | undefined;
+        sortDirection: SortDirection;
+    };
 }
 
 // @public

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -218,7 +218,7 @@ export type TablePrimaryCellSlots = {
 export type TablePrimaryCellState = ComponentState<TablePrimaryCellSlots>;
 
 // @public
-export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue>;
+export type TableProps = ComponentProps<TableSlots> & Partial<TableContextValue>;
 
 // @public
 export const TableRow: ForwardRefComponent<TableRowProps>;

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -337,10 +337,7 @@ export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowS
     // (undocumented)
     columns: ColumnDefinition<TItem>[];
     defaultSelectedRows?: Set<RowId>;
-    defaultSortState?: {
-        sortColumn: ColumnId | undefined;
-        sortDirection: SortDirection;
-    };
+    defaultSortState?: SortState;
     // (undocumented)
     getRowId?: (item: TItem) => RowId;
     // (undocumented)
@@ -352,10 +349,7 @@ export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowS
     selectedRows?: Set<RowId>;
     // (undocumented)
     selectionMode?: SelectionMode_2;
-    sortState?: {
-        sortColumn: ColumnId | undefined;
-        sortDirection: SortDirection;
-    };
+    sortState?: SortState;
 }
 
 // @public

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -68,29 +68,7 @@ export interface RowState<TItem> {
 }
 
 // @public (undocumented)
-export interface SelectionState {
-    allRowsSelected: boolean;
-    clearRows: () => void;
-    deselectRow: (rowId: RowId) => void;
-    isRowSelected: (rowId: RowId) => boolean;
-    selectedRows: RowId[];
-    selectRow: (rowId: RowId) => void;
-    someRowsSelected: boolean;
-    toggleAllRows: () => void;
-    toggleRow: (rowId: RowId) => void;
-}
-
-// @public (undocumented)
 export type SortDirection = 'ascending' | 'descending';
-
-// @public (undocumented)
-export interface SortState {
-    getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
-    setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
-    sortColumn: ColumnId | undefined;
-    sortDirection: SortDirection;
-    toggleColumnSort: (columnId: ColumnId) => void;
-}
 
 // @public
 export const Table: ForwardRefComponent<TableProps>;
@@ -286,9 +264,31 @@ export type TableSelectionCellSlots = {
 export type TableSelectionCellState = ComponentState<TableSelectionCellSlots> & Pick<TableCellState, 'media'> & Pick<Required<TableSelectionCellProps>, 'type' | 'checked'>;
 
 // @public (undocumented)
+export interface TableSelectionState {
+    allRowsSelected: boolean;
+    clearRows: () => void;
+    deselectRow: (rowId: RowId) => void;
+    isRowSelected: (rowId: RowId) => boolean;
+    selectedRows: RowId[];
+    selectRow: (rowId: RowId) => void;
+    someRowsSelected: boolean;
+    toggleAllRows: () => void;
+    toggleRow: (rowId: RowId) => void;
+}
+
+// @public (undocumented)
 export type TableSlots = {
     root: Slot<'table', 'div'>;
 };
+
+// @public (undocumented)
+export interface TableSortState {
+    getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
+    setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
+    sortColumn: ColumnId | undefined;
+    sortDirection: SortDirection;
+    toggleColumnSort: (columnId: ColumnId) => void;
+}
 
 // @public
 export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'> & TableContextValue;

--- a/packages/react-components/react-table/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/src/components/Table/Table.types.ts
@@ -1,5 +1,4 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import * as React from 'react';
 
 export type TableSlots = {
   root: Slot<'table', 'div'>;
@@ -14,10 +13,6 @@ export type TableContextValue = {
 };
 
 export type SortDirection = 'ascending' | 'descending';
-export type SortState = {
-  sortColumn: string | undefined;
-  sortDirection: 'ascending' | 'descending';
-};
 
 export type TableContextValues = {
   table: TableContextValue;
@@ -26,19 +21,7 @@ export type TableContextValues = {
 /**
  * Table Props
  */
-export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue> & {
-    /**
-     * Called when the sorted column changes
-     */
-    onSortColumnChange?: (
-      e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-      data: { sortState: SortState },
-    ) => void;
-
-    sortState?: SortState;
-
-    defaultSortState?: SortState;
-  };
+export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue>;
 
 /**
  * State used in rendering Table

--- a/packages/react-components/react-table/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/src/components/Table/Table.types.ts
@@ -21,7 +21,7 @@ export type TableContextValues = {
 /**
  * Table Props
  */
-export type TableProps = ComponentProps<TableSlots> & {} & Partial<TableContextValue>;
+export type TableProps = ComponentProps<TableSlots> & Partial<TableContextValue>;
 
 /**
  * State used in rendering Table

--- a/packages/react-components/react-table/src/hooks/selectionManager.ts
+++ b/packages/react-components/react-table/src/hooks/selectionManager.ts
@@ -3,12 +3,12 @@ import { SelectionMode } from './types';
 type OnSelectionChangeCallback = (selectedItems: Set<SelectionItemId>) => void;
 
 export interface SelectionManager {
-  toggleItem(id: SelectionItemId): void;
-  selectItem(id: SelectionItemId): void;
-  deselectItem(id: SelectionItemId): void;
+  toggleItem(id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  selectItem(id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  deselectItem(id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
   clearItems(): void;
-  isSelected(id: SelectionItemId): boolean;
-  toggleAllItems(itemIds: SelectionItemId[]): void;
+  isSelected(id: SelectionItemId, selectedItems: Set<SelectionItemId>): boolean;
+  toggleAllItems(itemIds: SelectionItemId[], selectedItems: Set<SelectionItemId>): void;
 }
 
 export type SelectionItemId = string | number;
@@ -23,8 +23,7 @@ export function createSelectionManager(
 }
 
 function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCallback): SelectionManager {
-  const selectedItems = new Set<SelectionItemId>();
-  const toggleAllItems = (itemIds: SelectionItemId[]) => {
+  const toggleAllItems = (itemIds: SelectionItemId[], selectedItems: Set<SelectionItemId>) => {
     const allItemsSelected = itemIds.every(itemId => selectedItems.has(itemId));
 
     if (allItemsSelected) {
@@ -36,7 +35,7 @@ function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCall
     onSelectionChange(new Set(selectedItems));
   };
 
-  const toggleItem = (itemId: SelectionItemId) => {
+  const toggleItem = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
     if (selectedItems.has(itemId)) {
       selectedItems.delete(itemId);
     } else {
@@ -46,22 +45,21 @@ function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCall
     onSelectionChange(new Set(selectedItems));
   };
 
-  const selectItem = (itemId: SelectionItemId) => {
+  const selectItem = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
     selectedItems.add(itemId);
     onSelectionChange(new Set(selectedItems));
   };
 
-  const deselectItem = (itemId: SelectionItemId) => {
+  const deselectItem = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
     selectedItems.delete(itemId);
     onSelectionChange(new Set(selectedItems));
   };
 
   const clearItems = () => {
-    selectedItems.clear();
-    onSelectionChange(new Set(selectedItems));
+    onSelectionChange(new Set());
   };
 
-  const isSelected = (itemId: SelectionItemId) => {
+  const isSelected = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
     return selectedItems.has(itemId);
   };
 
@@ -76,24 +74,20 @@ function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCall
 }
 
 function createSingleSelectionManager(onSelectionChange: OnSelectionChangeCallback): SelectionManager {
-  let selectedItem: SelectionItemId | undefined = undefined;
   const toggleItem = (itemId: SelectionItemId) => {
-    selectedItem = itemId;
-    onSelectionChange(new Set([selectedItem]));
+    onSelectionChange(new Set([itemId]));
   };
 
   const clearItems = () => {
-    selectedItem = undefined;
     onSelectionChange(new Set<SelectionItemId>());
   };
 
-  const isSelected = (itemId: SelectionItemId) => {
-    return selectedItem === itemId;
+  const isSelected = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
+    return selectedItems.has(itemId);
   };
 
   const selectItem = (itemId: SelectionItemId) => {
-    selectedItem = itemId;
-    onSelectionChange(new Set([selectedItem]));
+    onSelectionChange(new Set([itemId]));
   };
 
   return {

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -4,6 +4,8 @@ export type RowId = string | number;
 export type ColumnId = string | number;
 export type GetRowIdInternal<TItem> = (rowId: TItem, index: number) => RowId;
 export type SelectionMode = 'single' | 'multiselect';
+export type OnSelectionChangeCallback = (selectedItems: Set<RowId>) => void;
+export type OnSortChangeCallback = (state: { sortColumn: ColumnId | undefined; sortDirection: SortDirection }) => void;
 
 export interface ColumnDefinition<TItem> {
   columnId: ColumnId;
@@ -31,6 +33,36 @@ export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowS
   columns: ColumnDefinition<TItem>[];
   items: TItem[];
   selectionMode?: SelectionMode;
+  /**
+   * Used in uncontrolled mode to set initial selected rows on mount
+   */
+  defaultSelectedRows?: Set<RowId>;
+  /**
+   * Used to control row selection
+   */
+  selectedRows?: Set<RowId>;
+  /**
+   * Called when selection changes
+   */
+  onSelectionChange?: OnSelectionChangeCallback;
+  /**
+   * Used to control sorting
+   */
+  sortState?: {
+    sortColumn: ColumnId | undefined;
+    sortDirection: SortDirection;
+  };
+  /**
+   * Used in uncontrolled mode to set initial sort column and direction on mount
+   */
+  defaultSortState?: {
+    sortColumn: ColumnId | undefined;
+    sortDirection: SortDirection;
+  };
+  /**
+   * Called when sort changes
+   */
+  onSortChange?: OnSortChangeCallback;
   getRowId?: (item: TItem) => RowId;
   rowEnhancer?: RowEnhancer<TItem, TRowState>;
 }

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -14,10 +14,10 @@ export interface ColumnDefinition<TItem> {
 
 export type RowEnhancer<TItem, TRowState extends RowState<TItem> = RowState<TItem>> = (
   row: RowState<TItem>,
-  state: { selection: SelectionState; sort: SortState },
+  state: { selection: TableSelectionState; sort: TableSortState },
 ) => TRowState;
 
-export interface SortStateInternal<TItem> {
+export interface TableSortStateInternal<TItem> {
   sortDirection: SortDirection;
   sortColumn: ColumnId | undefined;
   setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
@@ -67,7 +67,7 @@ export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowS
   rowEnhancer?: RowEnhancer<TItem, TRowState>;
 }
 
-export interface SelectionStateInternal {
+export interface TableSelectionStateInternal {
   clearRows: () => void;
   deselectRow: (rowId: RowId) => void;
   selectRow: (rowId: RowId) => void;
@@ -79,7 +79,7 @@ export interface SelectionStateInternal {
   someRowsSelected: boolean;
 }
 
-export interface SortState {
+export interface TableSortState {
   /**
    * Current sort direction
    */
@@ -103,7 +103,7 @@ export interface SortState {
   getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
 }
 
-export interface SelectionState {
+export interface TableSelectionState {
   /**
    * Clears all selected rows
    */
@@ -162,9 +162,9 @@ export interface TableState<TItem, TRowState extends RowState<TItem> = RowState<
   /**
    * State and actions to manage row selection
    */
-  selection: SelectionState;
+  selection: TableSelectionState;
   /**
    * State and actions to manage row sorting
    */
-  sort: SortState;
+  sort: TableSortState;
 }

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -7,6 +7,11 @@ export type SelectionMode = 'single' | 'multiselect';
 export type OnSelectionChangeCallback = (selectedItems: Set<RowId>) => void;
 export type OnSortChangeCallback = (state: { sortColumn: ColumnId | undefined; sortDirection: SortDirection }) => void;
 
+export interface SortState {
+  sortColumn: ColumnId | undefined;
+  sortDirection: SortDirection;
+}
+
 export interface ColumnDefinition<TItem> {
   columnId: ColumnId;
   compare?: (a: TItem, b: TItem) => number;
@@ -48,17 +53,11 @@ export interface UseTableOptions<TItem, TRowState extends RowState<TItem> = RowS
   /**
    * Used to control sorting
    */
-  sortState?: {
-    sortColumn: ColumnId | undefined;
-    sortDirection: SortDirection;
-  };
+  sortState?: SortState;
   /**
    * Used in uncontrolled mode to set initial sort column and direction on mount
    */
-  defaultSortState?: {
-    sortColumn: ColumnId | undefined;
-    sortDirection: SortDirection;
-  };
+  defaultSortState?: SortState;
   /**
    * Called when sort changes
    */

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -8,7 +8,13 @@ describe('useSelection', () => {
 
   describe('multiselect', () => {
     it('should use custom row id', () => {
-      const { result } = renderHook(() => useSelection('multiselect', items, (item: { value: string }) => item.value));
+      const { result } = renderHook(() =>
+        useSelection({
+          selectionMode: 'multiselect',
+          items,
+          getRowId: (item: { value: string }) => item.value,
+        }),
+      );
       act(() => {
         result.current.toggleAllRows();
       });
@@ -18,7 +24,7 @@ describe('useSelection', () => {
 
     describe('toggleAllRows', () => {
       it('should select all rows', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -28,7 +34,7 @@ describe('useSelection', () => {
       });
 
       it('should deselect all rows', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -43,7 +49,7 @@ describe('useSelection', () => {
     });
     describe('clearRows', () => {
       it('should clear selection', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -58,7 +64,7 @@ describe('useSelection', () => {
 
     describe('selectRow', () => {
       it('should select row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -68,7 +74,7 @@ describe('useSelection', () => {
       });
 
       it('should select multiple rows', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -86,7 +92,7 @@ describe('useSelection', () => {
 
     describe('deselectRow', () => {
       it('should make row unselected', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -102,7 +108,7 @@ describe('useSelection', () => {
 
     describe('toggleRow', () => {
       it('should select unselected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -113,7 +119,7 @@ describe('useSelection', () => {
       });
 
       it('should deselect selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -128,7 +134,7 @@ describe('useSelection', () => {
       });
 
       it('should select another unselected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -146,7 +152,7 @@ describe('useSelection', () => {
 
     describe('allRowsSelected', () => {
       it('should return true if all rows are selected', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -156,14 +162,14 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.allRowsSelected).toBe(false);
       });
 
       it('should return false if not all rows are selected', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.toggleAllRows();
@@ -180,7 +186,7 @@ describe('useSelection', () => {
 
     describe('someRowsSelected', () => {
       it('should return true if there is a selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -191,7 +197,7 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('multiselect', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.someRowsSelected).toBe(false);
@@ -202,7 +208,7 @@ describe('useSelection', () => {
   describe('single select', () => {
     describe('toggleAllRows', () => {
       it('should throw when not in production', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         expect(result.current.toggleAllRows).toThrowErrorMatchingInlineSnapshot(
           `"[react-table]: \`toggleAllItems\` should not be used in single selection mode"`,
@@ -211,7 +217,7 @@ describe('useSelection', () => {
 
       it('should be a noop in production', () => {
         const nodeEnv = (process.env.NODE_ENV = 'production');
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         result.current.toggleAllRows;
         expect(result.current.selectedRows.size).toBe(0);
@@ -221,7 +227,7 @@ describe('useSelection', () => {
     });
     describe('clearRows', () => {
       it('should clear selection', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -236,7 +242,7 @@ describe('useSelection', () => {
 
     describe('selectRow', () => {
       it('should select row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -246,7 +252,7 @@ describe('useSelection', () => {
       });
 
       it('should select another row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -263,7 +269,7 @@ describe('useSelection', () => {
 
     describe('deselectRow', () => {
       it('should make row unselected', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -279,7 +285,7 @@ describe('useSelection', () => {
 
     describe('toggleRow', () => {
       it('should select unselected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -290,7 +296,7 @@ describe('useSelection', () => {
       });
 
       it('should deselect selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -305,7 +311,7 @@ describe('useSelection', () => {
       });
 
       it('should select another unselected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.toggleRow(1);
@@ -323,7 +329,7 @@ describe('useSelection', () => {
 
     describe('allRowsSelected', () => {
       it('should return true if there is a selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -334,7 +340,7 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.allRowsSelected).toBe(false);
@@ -343,7 +349,7 @@ describe('useSelection', () => {
 
     describe('someRowsSelected', () => {
       it('should return true if there is a selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         act(() => {
           result.current.selectRow(1);
@@ -354,7 +360,7 @@ describe('useSelection', () => {
       });
 
       it('should return false if there is no selected row', () => {
-        const { result } = renderHook(() => useSelection('single', items, getRowId));
+        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.someRowsSelected).toBe(false);

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -6,6 +6,22 @@ describe('useSelection', () => {
 
   const getRowId = (item: {}, index: number) => index;
 
+  it('should use default selected state', () => {
+    const { result } = renderHook(() =>
+      useSelection({ selectionMode: 'multiselect', items, getRowId, defaultSelectedItems: new Set([1]) }),
+    );
+
+    expect(Array.from(result.current.selectedRows)).toEqual([1]);
+  });
+
+  it('should use user selected state', () => {
+    const { result } = renderHook(() =>
+      useSelection({ selectionMode: 'multiselect', items, getRowId, selectedItems: new Set([1]) }),
+    );
+
+    expect(Array.from(result.current.selectedRows)).toEqual([1]);
+  });
+
   describe('multiselect', () => {
     it('should use custom row id', () => {
       const { result } = renderHook(() =>
@@ -24,17 +40,25 @@ describe('useSelection', () => {
 
     describe('toggleAllRows', () => {
       it('should select all rows', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleAllRows();
         });
         expect(result.current.selectedRows.size).toBe(items.length);
         expect(Array.from(result.current.selectedRows)).toEqual(items.map((_, i) => i));
+        expect(onSelectionChange).toHaveBeenCalledTimes(1);
+        expect(onSelectionChange).toHaveBeenCalledWith(new Set([0, 1, 2, 3]));
       });
 
       it('should deselect all rows', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleAllRows();
@@ -45,11 +69,16 @@ describe('useSelection', () => {
         });
 
         expect(result.current.selectedRows.size).toBe(0);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
       });
     });
     describe('clearRows', () => {
       it('should clear selection', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleAllRows();
@@ -59,22 +88,32 @@ describe('useSelection', () => {
         });
 
         expect(result.current.selectedRows.size).toBe(0);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
       });
     });
 
     describe('selectRow', () => {
       it('should select row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
         });
 
         expect(result.current.selectedRows.has(1)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(1);
+        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
       });
 
       it('should select multiple rows', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
@@ -87,12 +126,17 @@ describe('useSelection', () => {
         expect(result.current.selectedRows.size).toBe(2);
         expect(result.current.selectedRows.has(1)).toBe(true);
         expect(result.current.selectedRows.has(2)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([1, 2]));
       });
     });
 
     describe('deselectRow', () => {
       it('should make row unselected', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
@@ -103,12 +147,17 @@ describe('useSelection', () => {
         });
 
         expect(result.current.selectedRows.size).toBe(0);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
       });
     });
 
     describe('toggleRow', () => {
       it('should select unselected row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleRow(1);
@@ -116,10 +165,15 @@ describe('useSelection', () => {
 
         expect(result.current.selectedRows.size).toBe(1);
         expect(result.current.selectedRows.has(1)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(1);
+        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
       });
 
       it('should deselect selected row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleRow(1);
@@ -131,10 +185,15 @@ describe('useSelection', () => {
 
         expect(result.current.selectedRows.size).toBe(0);
         expect(result.current.selectedRows.has(1)).toBe(false);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
       });
 
       it('should select another unselected row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'multiselect', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'multiselect', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleRow(1);
@@ -147,6 +206,8 @@ describe('useSelection', () => {
         expect(result.current.selectedRows.size).toBe(2);
         expect(result.current.selectedRows.has(1)).toBe(true);
         expect(result.current.selectedRows.has(2)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([1, 2]));
       });
     });
 
@@ -208,26 +269,37 @@ describe('useSelection', () => {
   describe('single select', () => {
     describe('toggleAllRows', () => {
       it('should throw when not in production', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         expect(result.current.toggleAllRows).toThrowErrorMatchingInlineSnapshot(
           `"[react-table]: \`toggleAllItems\` should not be used in single selection mode"`,
         );
+        expect(onSelectionChange).toHaveBeenCalledTimes(0);
       });
 
       it('should be a noop in production', () => {
         const nodeEnv = (process.env.NODE_ENV = 'production');
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         result.current.toggleAllRows;
         expect(result.current.selectedRows.size).toBe(0);
+        expect(onSelectionChange).toHaveBeenCalledTimes(0);
 
         process.env.NODE_ENV = nodeEnv;
       });
     });
     describe('clearRows', () => {
       it('should clear selection', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
@@ -237,22 +309,32 @@ describe('useSelection', () => {
         });
 
         expect(result.current.selectedRows.size).toBe(0);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
       });
     });
 
     describe('selectRow', () => {
       it('should select row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
         });
 
         expect(result.current.selectedRows.has(1)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(1);
+        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
       });
 
       it('should select another row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
@@ -264,12 +346,17 @@ describe('useSelection', () => {
 
         expect(result.current.selectedRows.size).toBe(1);
         expect(result.current.selectedRows.has(2)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([2]));
       });
     });
 
     describe('deselectRow', () => {
       it('should make row unselected', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.selectRow(1);
@@ -280,12 +367,17 @@ describe('useSelection', () => {
         });
 
         expect(result.current.selectedRows.size).toBe(0);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
       });
     });
 
     describe('toggleRow', () => {
       it('should select unselected row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleRow(1);
@@ -293,10 +385,15 @@ describe('useSelection', () => {
 
         expect(result.current.selectedRows.size).toBe(1);
         expect(result.current.selectedRows.has(1)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(1);
+        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
       });
 
       it('should deselect selected row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleRow(1);
@@ -308,10 +405,15 @@ describe('useSelection', () => {
 
         expect(result.current.selectedRows.size).toBe(1);
         expect(result.current.selectedRows.has(1)).toBe(false);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([2]));
       });
 
       it('should select another unselected row', () => {
-        const { result } = renderHook(() => useSelection({ selectionMode: 'single', items, getRowId }));
+        const onSelectionChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSelection({ selectionMode: 'single', items, getRowId, onSelectionChange }),
+        );
 
         act(() => {
           result.current.toggleRow(1);
@@ -324,6 +426,8 @@ describe('useSelection', () => {
         expect(result.current.selectedRows.size).toBe(1);
         expect(result.current.selectedRows.has(1)).toBe(false);
         expect(result.current.selectedRows.has(2)).toBe(true);
+        expect(onSelectionChange).toHaveBeenCalledTimes(2);
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([2]));
       });
     });
 

--- a/packages/react-components/react-table/src/hooks/useSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.ts
@@ -1,38 +1,73 @@
 import * as React from 'react';
-import { useEventCallback, usePrevious } from '@fluentui/react-utilities';
+import { useControllableState, useEventCallback } from '@fluentui/react-utilities';
 import { createSelectionManager } from './selectionManager';
-import { GetRowIdInternal, RowId, SelectionMode, SelectionStateInternal } from './types';
+import type {
+  GetRowIdInternal,
+  OnSelectionChangeCallback,
+  RowId,
+  SelectionMode,
+  SelectionStateInternal,
+} from './types';
 
-export function useSelection<TItem>(
-  selectionMode: SelectionMode,
-  items: TItem[],
-  getRowId: GetRowIdInternal<TItem>,
-): SelectionStateInternal {
-  const prevSelectionMode = usePrevious(selectionMode);
-  const [selected, setSelected] = React.useState(() => new Set<RowId>());
-  const [selectionManager, setSelectionManager] = React.useState(() =>
-    createSelectionManager(selectionMode, setSelected),
-  );
+interface UseSelectionOptions<TItem> {
+  selectionMode: SelectionMode;
+  items: TItem[];
+  getRowId: GetRowIdInternal<TItem>;
+  defaultSelectedItems?: Set<RowId>;
+  selectedItems?: Set<RowId>;
+  onSelectionChange?: OnSelectionChangeCallback;
+}
 
-  React.useEffect(() => {
-    if (prevSelectionMode !== selectionMode) {
-      setSelectionManager(createSelectionManager(selectionMode, setSelected));
-    }
-  }, [selectionMode, prevSelectionMode]);
+export function useSelection<TItem>(options: UseSelectionOptions<TItem>): SelectionStateInternal {
+  const { selectionMode, items, getRowId, defaultSelectedItems, selectedItems, onSelectionChange } = options;
+
+  const [selected, setSelected] = useControllableState({
+    initialState: new Set<RowId>(),
+    defaultState: defaultSelectedItems,
+    state: selectedItems,
+  });
+
+  const selectionManager = React.useMemo(() => {
+    return createSelectionManager(selectionMode, newSelectedItems => {
+      setSelected(() => {
+        onSelectionChange?.(newSelectedItems);
+        return newSelectedItems;
+      });
+    });
+  }, [onSelectionChange, selectionMode, setSelected]);
 
   const toggleAllRows: SelectionStateInternal['toggleAllRows'] = useEventCallback(() => {
-    selectionManager.toggleAllItems(items.map((item, i) => getRowId(item, i)));
+    selectionManager.toggleAllItems(
+      items.map((item, i) => getRowId(item, i)),
+      selected,
+    );
   });
+
+  const toggleRow: SelectionStateInternal['toggleRow'] = useEventCallback((rowId: RowId) =>
+    selectionManager.toggleItem(rowId, selected),
+  );
+
+  const deselectRow: SelectionStateInternal['deselectRow'] = useEventCallback((rowId: RowId) =>
+    selectionManager.deselectItem(rowId, selected),
+  );
+
+  const selectRow: SelectionStateInternal['selectRow'] = useEventCallback((rowId: RowId) =>
+    selectionManager.selectItem(rowId, selected),
+  );
+
+  const isRowSelected: SelectionStateInternal['isRowSelected'] = useEventCallback((rowId: RowId) =>
+    selectionManager.isSelected(rowId, selected),
+  );
 
   return {
     someRowsSelected: selected.size > 0,
     allRowsSelected: selectionMode === 'single' ? selected.size > 0 : selected.size === items.length,
     selectedRows: selected,
-    toggleRow: selectionManager.toggleItem,
+    toggleRow,
     toggleAllRows,
     clearRows: selectionManager.clearItems,
-    deselectRow: selectionManager.deselectItem,
-    selectRow: selectionManager.selectItem,
-    isRowSelected: selectionManager.isSelected,
+    deselectRow,
+    selectRow,
+    isRowSelected,
   };
 }

--- a/packages/react-components/react-table/src/hooks/useSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.ts
@@ -6,7 +6,7 @@ import type {
   OnSelectionChangeCallback,
   RowId,
   SelectionMode,
-  SelectionStateInternal,
+  TableSelectionStateInternal,
 } from './types';
 
 interface UseSelectionOptions<TItem> {
@@ -18,7 +18,7 @@ interface UseSelectionOptions<TItem> {
   onSelectionChange?: OnSelectionChangeCallback;
 }
 
-export function useSelection<TItem>(options: UseSelectionOptions<TItem>): SelectionStateInternal {
+export function useSelection<TItem>(options: UseSelectionOptions<TItem>): TableSelectionStateInternal {
   const { selectionMode, items, getRowId, defaultSelectedItems, selectedItems, onSelectionChange } = options;
 
   const [selected, setSelected] = useControllableState({
@@ -36,28 +36,27 @@ export function useSelection<TItem>(options: UseSelectionOptions<TItem>): Select
     });
   }, [onSelectionChange, selectionMode, setSelected]);
 
-  const toggleAllRows: SelectionStateInternal['toggleAllRows'] = useEventCallback(() => {
+  const toggleAllRows: TableSelectionStateInternal['toggleAllRows'] = useEventCallback(() => {
     selectionManager.toggleAllItems(
       items.map((item, i) => getRowId(item, i)),
       selected,
     );
   });
 
-  const toggleRow: SelectionStateInternal['toggleRow'] = useEventCallback((rowId: RowId) =>
+  const toggleRow: TableSelectionStateInternal['toggleRow'] = useEventCallback((rowId: RowId) =>
     selectionManager.toggleItem(rowId, selected),
   );
 
-  const deselectRow: SelectionStateInternal['deselectRow'] = useEventCallback((rowId: RowId) =>
+  const deselectRow: TableSelectionStateInternal['deselectRow'] = useEventCallback((rowId: RowId) =>
     selectionManager.deselectItem(rowId, selected),
   );
 
-  const selectRow: SelectionStateInternal['selectRow'] = useEventCallback((rowId: RowId) =>
+  const selectRow: TableSelectionStateInternal['selectRow'] = useEventCallback((rowId: RowId) =>
     selectionManager.selectItem(rowId, selected),
   );
 
-  const isRowSelected: SelectionStateInternal['isRowSelected'] = useEventCallback((rowId: RowId) =>
-    selectionManager.isSelected(rowId, selected),
-  );
+  const isRowSelected: TableSelectionStateInternal['isRowSelected'] = (rowId: RowId) =>
+    selectionManager.isSelected(rowId, selected);
 
   return {
     someRowsSelected: selected.size > 0,

--- a/packages/react-components/react-table/src/hooks/useSort.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.test.ts
@@ -6,7 +6,7 @@ describe('useSort', () => {
   describe('toggleColumnSort', () => {
     it('should sort a new column in ascending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.toggleColumnSort(1);
       });
@@ -17,7 +17,7 @@ describe('useSort', () => {
 
     it('should toggle sort direction on a column', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.toggleColumnSort(1);
       });
@@ -34,7 +34,7 @@ describe('useSort', () => {
   describe('setColumnSort', () => {
     it('should sort a column in ascending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.setColumnSort(1, 'ascending');
       });
@@ -45,7 +45,7 @@ describe('useSort', () => {
 
     it('should sort a column in descending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.setColumnSort(1, 'descending');
       });
@@ -65,7 +65,7 @@ describe('useSort', () => {
         { columnId: 3, compare: createMockCompare() },
       ];
 
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.toggleColumnSort(2);
       });
@@ -79,7 +79,7 @@ describe('useSort', () => {
         { columnId: 1, compare: (a, b) => a.value - b.value },
       ];
 
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.toggleColumnSort(1);
       });
@@ -93,7 +93,7 @@ describe('useSort', () => {
         { columnId: 1, compare: (a, b) => a.value - b.value },
       ];
 
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.toggleColumnSort(1);
       });
@@ -110,7 +110,7 @@ describe('useSort', () => {
     it('should return sort direction for the sorted column', () => {
       const columnDefinition: ColumnDefinition<{ value: number }>[] = [{ columnId: 1 }];
 
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.setColumnSort(1, 'descending');
       });
@@ -121,7 +121,7 @@ describe('useSort', () => {
     it('should return undefined for unsorted column', () => {
       const columnDefinition: ColumnDefinition<{ value: number }>[] = [{ columnId: 1 }, { columnId: 2 }];
 
-      const { result } = renderHook(() => useSort(columnDefinition));
+      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
       act(() => {
         result.current.setColumnSort(1, 'descending');
       });

--- a/packages/react-components/react-table/src/hooks/useSort.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.test.ts
@@ -3,21 +3,45 @@ import { ColumnDefinition } from './types';
 import { useSort } from './useSort';
 
 describe('useSort', () => {
+  it('should use default sort state', () => {
+    const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+    const { result } = renderHook(() =>
+      useSort({ columns: columnDefinition, defaultSortState: { sortColumn: 2, sortDirection: 'descending' } }),
+    );
+
+    expect(result.current.getSortDirection(2)).toBe('descending');
+    expect(result.current.sortColumn).toBe(2);
+  });
+
+  it('should use user sort state', () => {
+    const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+    const { result } = renderHook(() =>
+      useSort({ columns: columnDefinition, sortState: { sortColumn: 2, sortDirection: 'descending' } }),
+    );
+
+    expect(result.current.getSortDirection(2)).toBe('descending');
+    expect(result.current.sortColumn).toBe(2);
+  });
+
   describe('toggleColumnSort', () => {
     it('should sort a new column in ascending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
+      const onSortChange = jest.fn();
+      const { result } = renderHook(() => useSort({ columns: columnDefinition, onSortChange }));
       act(() => {
         result.current.toggleColumnSort(1);
       });
 
       expect(result.current.sortColumn).toBe(1);
       expect(result.current.sortDirection).toBe('ascending');
+      expect(onSortChange).toHaveBeenCalledTimes(1);
+      expect(onSortChange).toHaveBeenCalledWith({ sortColumn: 1, sortDirection: 'ascending' });
     });
 
     it('should toggle sort direction on a column', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
+      const onSortChange = jest.fn();
+      const { result } = renderHook(() => useSort({ columns: columnDefinition, onSortChange }));
       act(() => {
         result.current.toggleColumnSort(1);
       });
@@ -28,30 +52,38 @@ describe('useSort', () => {
 
       expect(result.current.sortColumn).toBe(1);
       expect(result.current.sortDirection).toBe('descending');
+      expect(onSortChange).toHaveBeenCalledTimes(2);
+      expect(onSortChange).toHaveBeenNthCalledWith(2, { sortColumn: 1, sortDirection: 'descending' });
     });
   });
 
   describe('setColumnSort', () => {
     it('should sort a column in ascending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
+      const onSortChange = jest.fn();
+      const { result } = renderHook(() => useSort({ columns: columnDefinition, onSortChange }));
       act(() => {
         result.current.setColumnSort(1, 'ascending');
       });
 
       expect(result.current.sortColumn).toBe(1);
       expect(result.current.sortDirection).toBe('ascending');
+      expect(onSortChange).toHaveBeenCalledTimes(1);
+      expect(onSortChange).toHaveBeenCalledWith({ sortColumn: 1, sortDirection: 'ascending' });
     });
 
     it('should sort a column in descending order', () => {
       const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
-      const { result } = renderHook(() => useSort({ columns: columnDefinition }));
+      const onSortChange = jest.fn();
+      const { result } = renderHook(() => useSort({ columns: columnDefinition, onSortChange }));
       act(() => {
         result.current.setColumnSort(1, 'descending');
       });
 
       expect(result.current.sortColumn).toBe(1);
       expect(result.current.sortDirection).toBe('descending');
+      expect(onSortChange).toHaveBeenCalledTimes(1);
+      expect(onSortChange).toHaveBeenCalledWith({ sortColumn: 1, sortDirection: 'descending' });
     });
   });
 

--- a/packages/react-components/react-table/src/hooks/useSort.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.ts
@@ -1,20 +1,20 @@
 import { SortDirection } from '../components/Table/Table.types';
 import { useControllableState } from '@fluentui/react-utilities';
-import type { ColumnDefinition, ColumnId, OnSortChangeCallback, SortStateInternal } from './types';
+import type { ColumnDefinition, ColumnId, OnSortChangeCallback, TableSortStateInternal } from './types';
 
-interface SortState {
+interface TableSortState {
   sortDirection: SortDirection;
   sortColumn: ColumnId | undefined;
 }
 
 interface UseSortOptions<TItem> {
   columns: ColumnDefinition<TItem>[];
-  sortState?: SortState;
-  defaultSortState?: SortState;
+  sortState?: TableSortState;
+  defaultSortState?: TableSortState;
   onSortChange?: OnSortChangeCallback;
 }
 
-export function useSort<TItem>(options: UseSortOptions<TItem>): SortStateInternal<TItem> {
+export function useSort<TItem>(options: UseSortOptions<TItem>): TableSortStateInternal<TItem> {
   const { columns, sortState, defaultSortState, onSortChange } = options;
 
   const [sorted, setSorted] = useControllableState({
@@ -42,7 +42,7 @@ export function useSort<TItem>(options: UseSortOptions<TItem>): SortStateInterna
     });
   };
 
-  const setColumnSort: SortStateInternal<TItem>['setColumnSort'] = (nextSortColumn, nextSortDirection) => {
+  const setColumnSort: TableSortStateInternal<TItem>['setColumnSort'] = (nextSortColumn, nextSortDirection) => {
     const newState = { sortColumn: nextSortColumn, sortDirection: nextSortDirection };
     onSortChange?.(newState);
     setSorted(newState);
@@ -59,7 +59,7 @@ export function useSort<TItem>(options: UseSortOptions<TItem>): SortStateInterna
       return sortColumnDef.compare(a, b) * mod;
     });
 
-  const getSortDirection: SortStateInternal<TItem>['getSortDirection'] = (columnId: ColumnId) => {
+  const getSortDirection: TableSortStateInternal<TItem>['getSortDirection'] = (columnId: ColumnId) => {
     return sortColumn === columnId ? sortDirection : undefined;
   };
 

--- a/packages/react-components/react-table/src/hooks/useSort.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.ts
@@ -1,26 +1,20 @@
-import { SortDirection } from '../components/Table/Table.types';
 import { useControllableState } from '@fluentui/react-utilities';
-import type { ColumnDefinition, ColumnId, OnSortChangeCallback, TableSortStateInternal } from './types';
-
-interface TableSortState {
-  sortDirection: SortDirection;
-  sortColumn: ColumnId | undefined;
-}
+import type { ColumnDefinition, ColumnId, OnSortChangeCallback, SortState, TableSortStateInternal } from './types';
 
 interface UseSortOptions<TItem> {
   columns: ColumnDefinition<TItem>[];
-  sortState?: TableSortState;
-  defaultSortState?: TableSortState;
+  sortState?: SortState;
+  defaultSortState?: SortState;
   onSortChange?: OnSortChangeCallback;
 }
 
 export function useSort<TItem>(options: UseSortOptions<TItem>): TableSortStateInternal<TItem> {
   const { columns, sortState, defaultSortState, onSortChange } = options;
 
-  const [sorted, setSorted] = useControllableState({
+  const [sorted, setSorted] = useControllableState<SortState>({
     initialState: {
-      sortDirection: 'ascending' as SortDirection,
-      sortColumn: undefined as ColumnId | undefined,
+      sortDirection: 'ascending' as const,
+      sortColumn: undefined,
     },
     defaultState: defaultSortState,
     state: sortState,

--- a/packages/react-components/react-table/src/hooks/useTable.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { UseTableOptions, TableState, RowState, SelectionState, SortState } from './types';
+import type { UseTableOptions, TableState, RowState, SelectionState, SortState, GetRowIdInternal } from './types';
 import { useSelection } from './useSelection';
 import { useSort } from './useSort';
 
@@ -12,10 +12,24 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
     getRowId: getUserRowId = () => undefined,
     selectionMode = 'multiselect',
     rowEnhancer = (row: RowState<TItem>) => row as TRowState,
+    defaultSelectedRows,
+    selectedRows: userSelectedRows,
+    onSelectionChange,
+    sortState: userSortState,
+    defaultSortState,
+    onSortChange,
   } = options;
 
-  const getRowId = React.useCallback((item: TItem, index: number) => getUserRowId(item) ?? index, [getUserRowId]);
-  const { sortColumn, sortDirection, toggleColumnSort, setColumnSort, getSortDirection, sort } = useSort(columns);
+  const getRowId: GetRowIdInternal<TItem> = React.useCallback(
+    (item: TItem, index: number) => getUserRowId(item) ?? index,
+    [getUserRowId],
+  );
+  const { sortColumn, sortDirection, toggleColumnSort, setColumnSort, getSortDirection, sort } = useSort({
+    columns,
+    sortState: userSortState,
+    defaultSortState,
+    onSortChange,
+  });
   const sortState: SortState = React.useMemo(
     () => ({
       sortColumn,
@@ -37,7 +51,14 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
     someRowsSelected,
     selectRow,
     deselectRow,
-  } = useSelection(selectionMode, baseItems, getRowId);
+  } = useSelection({
+    selectionMode,
+    items: baseItems,
+    getRowId,
+    defaultSelectedItems: defaultSelectedRows,
+    selectedItems: userSelectedRows,
+    onSelectionChange,
+  });
 
   const selectionState: SelectionState = React.useMemo(
     () => ({

--- a/packages/react-components/react-table/src/hooks/useTable.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import type { UseTableOptions, TableState, RowState, SelectionState, SortState, GetRowIdInternal } from './types';
+import type {
+  UseTableOptions,
+  TableState,
+  RowState,
+  TableSelectionState,
+  TableSortState,
+  GetRowIdInternal,
+} from './types';
 import { useSelection } from './useSelection';
 import { useSort } from './useSort';
 
@@ -30,7 +37,7 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
     defaultSortState,
     onSortChange,
   });
-  const sortState: SortState = React.useMemo(
+  const sortState: TableSortState = React.useMemo(
     () => ({
       sortColumn,
       sortDirection,
@@ -60,7 +67,7 @@ export function useTable<TItem, TRowState extends RowState<TItem> = RowState<TIt
     onSelectionChange,
   });
 
-  const selectionState: SelectionState = React.useMemo(
+  const selectionState: TableSelectionState = React.useMemo(
     () => ({
       isRowSelected,
       clearRows,

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -1,5 +1,13 @@
 export { useTable } from './hooks';
-export type { UseTableOptions, SelectionState, SortState, ColumnDefinition, RowState, RowId, ColumnId } from './hooks';
+export type {
+  UseTableOptions,
+  TableSelectionState,
+  TableSortState,
+  ColumnDefinition,
+  RowState,
+  RowId,
+  ColumnId,
+} from './hooks';
 
 export {
   TableCell,

--- a/packages/react-components/react-table/src/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/MultipleSelect.stories.tsx
@@ -101,6 +101,7 @@ export const MultipleSelect = () => {
   } = useTable({
     columns,
     items,
+    defaultSelectedRows: new Set([0, 1]),
     rowEnhancer: (row, { selection }) => ({
       ...row,
       onClick: () => selection.toggleRow(row.rowId),

--- a/packages/react-components/react-table/src/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SingleSelect.stories.tsx
@@ -99,6 +99,7 @@ export const SingleSelect = () => {
     columns,
     items,
     selectionMode: 'single',
+    defaultSelectedRows: new Set([1]),
     rowEnhancer: (row, { selection }) => ({
       ...row,
       selected: selection.isRowSelected(row.rowId),

--- a/packages/react-components/react-table/src/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SingleSelectControlled.stories.tsx
@@ -9,8 +9,9 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell } from '../..';
-import { useTable, ColumnDefinition, ColumnId } from '../../hooks';
+import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell, TableSelectionCell } from '../..';
+import { useTable, ColumnDefinition, RowId } from '../../hooks';
+import { useNavigationMode } from '../../navigationModes/useNavigationMode';
 
 type FileCell = {
   label: string;
@@ -81,56 +82,55 @@ const items: Item[] = [
 const columns: ColumnDefinition<Item>[] = [
   {
     columnId: 'file',
-    compare: (a, b) => {
-      return a.file.label.localeCompare(b.file.label);
-    },
   },
   {
     columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
   },
   {
     columnId: 'lastUpdated',
-    compare: (a, b) => {
-      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
-    },
   },
   {
     columnId: 'lastUpdate',
-    compare: (a, b) => {
-      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
-    },
   },
 ];
 
-export const Sort = () => {
-  const {
-    rows,
-    sort: { getSortDirection, toggleColumnSort },
-  } = useTable({ columns, items, defaultSortState: { sortColumn: 'file', sortDirection: 'ascending' } });
-
-  const headerSortProps = (columnId: ColumnId) => ({
-    onClick: () => {
-      toggleColumnSort(columnId);
-    },
-    sortDirection: getSortDirection(columnId),
+export const SingleSelectControlled = () => {
+  const [selectedRows, setSelectedRows] = React.useState(new Set<RowId>());
+  const { rows } = useTable({
+    columns,
+    items,
+    selectionMode: 'single',
+    selectedRows,
+    onSelectionChange: setSelectedRows,
+    rowEnhancer: (row, { selection }) => ({
+      ...row,
+      selected: selection.isRowSelected(row.rowId),
+      onClick: () => selection.toggleRow(row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          selection.toggleRow(row.rowId);
+        }
+      },
+    }),
   });
+  // eslint-disable-next-line deprecation/deprecation
+  const ref = useNavigationMode<HTMLDivElement>('row');
 
   return (
-    <Table sortable>
+    <Table ref={ref}>
       <TableHeader>
         <TableRow>
-          <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>
-          <TableHeaderCell {...headerSortProps('author')}>Author</TableHeaderCell>
-          <TableHeaderCell {...headerSortProps('lastUpdated')}>Last updated</TableHeaderCell>
-          <TableHeaderCell {...headerSortProps('lastUpdate')}>Last update</TableHeaderCell>
+          <TableSelectionCell type="radio" />
+          <TableHeaderCell>File</TableHeaderCell>
+          <TableHeaderCell>Author</TableHeaderCell>
+          <TableHeaderCell>Last updated</TableHeaderCell>
+          <TableHeaderCell>Last update</TableHeaderCell>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {rows.map(({ item }) => (
-          <TableRow key={item.file.label}>
+        {rows.map(({ item, selected, onClick, onKeyDown }) => (
+          <TableRow tabIndex={0} key={item.file.label} onClick={onClick} onKeyDown={onKeyDown} aria-selected={selected}>
+            <TableSelectionCell type="radio" checked={selected} />
             <TableCell media={item.file.icon}>{item.file.label}</TableCell>
             <TableCell media={<Avatar badge={{ status: item.author.status }} />}>{item.author.label}</TableCell>
             <TableCell>{item.lastUpdated.label}</TableCell>

--- a/packages/react-components/react-table/src/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SortControlled.stories.tsx
@@ -10,8 +10,7 @@ import {
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell } from '../..';
-import { useTable, ColumnDefinition, ColumnId } from '../../hooks';
-import { SortDirection } from '../../components/Table/Table.types';
+import { useTable, ColumnDefinition, ColumnId, SortState } from '../../hooks';
 
 type FileCell = {
   label: string;
@@ -107,9 +106,9 @@ const columns: ColumnDefinition<Item>[] = [
 ];
 
 export const SortControlled = () => {
-  const [sortState, setSortState] = React.useState({
-    sortDirection: 'ascending' as SortDirection,
-    sortColumn: 'file' as ColumnId | undefined,
+  const [sortState, setSortState] = React.useState<SortState>({
+    sortDirection: 'ascending' as const,
+    sortColumn: 'file',
   });
 
   const {

--- a/packages/react-components/react-table/src/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/SortControlled.stories.tsx
@@ -11,6 +11,7 @@ import {
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import { TableBody, TableCell, TableRow, Table, TableHeader, TableHeaderCell } from '../..';
 import { useTable, ColumnDefinition, ColumnId } from '../../hooks';
+import { SortDirection } from '../../components/Table/Table.types';
 
 type FileCell = {
   label: string;
@@ -105,16 +106,19 @@ const columns: ColumnDefinition<Item>[] = [
   },
 ];
 
-export const Sort = () => {
+export const SortControlled = () => {
+  const [sortState, setSortState] = React.useState({
+    sortDirection: 'ascending' as SortDirection,
+    sortColumn: 'file' as ColumnId | undefined,
+  });
+
   const {
     rows,
     sort: { getSortDirection, toggleColumnSort },
-  } = useTable({ columns, items, defaultSortState: { sortColumn: 'file', sortDirection: 'ascending' } });
+  } = useTable({ columns, items, sortState, onSortChange: setSortState });
 
   const headerSortProps = (columnId: ColumnId) => ({
-    onClick: () => {
-      toggleColumnSort(columnId);
-    },
+    onClick: () => toggleColumnSort(columnId),
     sortDirection: getSortDirection(columnId),
   });
 

--- a/packages/react-components/react-table/src/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/src/stories/Table/index.stories.tsx
@@ -2,6 +2,7 @@ import { Table } from '../..';
 
 export { Default } from './Default.stories';
 export { Sort } from './Sort.stories';
+export { SortControlled } from './SortControlled.stories';
 export { CellActions } from './CellActions.stories';
 export { PrimaryCell } from './PrimaryCell.stories';
 export { SizeSmall } from './SizeSmall.stories';
@@ -9,6 +10,8 @@ export { SizeSmaller } from './SizeSmaller.stories';
 export { NonNativeElements } from './NonNativeElements.stories';
 export { MultipleSelect } from './MultipleSelect.stories';
 export { SingleSelect } from './SingleSelect.stories';
+export { MultipleSelectControlled } from './MultipleSelectControlled.stories';
+export { SingleSelectControlled } from './SingleSelectControlled.stories';
 export { CellNavigationMode } from './CellNavigationMode.stories';
 export { RowNavigationMode } from './RowNavigationMode.stories';
 export { CompositeNavigationMode } from './CompositeNavigationMode.stories';


### PR DESCRIPTION
`useTable` hook now supports autoncontrolling sort and selection states

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

`useTable` is completely uncontrolled

## New Behavior

`useTable` can be controlled and uncontrolled, added extra stories to that effect

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Addresses #24226
