### PR TITLE
Allowing Popup configuration on Modal component

### DIFF
--- a/change/@fluentui-react-b4e5742f-312c-4c83-93ad-7da95b6de7d9.json
+++ b/change/@fluentui-react-b4e5742f-312c-4c83-93ad-7da95b6de7d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "@fluentui/react: allowing Popup configuration on Modal component",
+  "packageName": "@fluentui/react",
+  "email": "gasramirez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6977,6 +6977,7 @@ export interface IModalProps extends React_2.RefAttributes<HTMLDivElement>, IAcc
     // @deprecated
     onLayerDidMount?: () => void;
     overlay?: IOverlayProps;
+    popupProps?: IPopupProps;
     responsiveMode?: ResponsiveMode;
     scrollableContentClassName?: string;
     styles?: IStyleFunctionOrObject<IModalStyleProps, IModalStyles>;

--- a/packages/react/src/components/Modal/Modal.base.tsx
+++ b/packages/react/src/components/Modal/Modal.base.tsx
@@ -128,6 +128,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
       onDismissed,
       // eslint-disable-next-line deprecation/deprecation
       enableAriaHiddenSiblings,
+      popupProps,
     } = props;
 
     const rootRef = React.useRef<HTMLDivElement>(null);
@@ -477,6 +478,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
             // Popup will automatically handle this based on the aria-modal setting.
             enableAriaHiddenSiblings={enableAriaHiddenSiblings}
             aria-modal={!isModeless}
+            {...popupProps}
           >
             <div className={classNames.root} role={!isModeless ? 'document' : undefined}>
               {!isModeless && (

--- a/packages/react/src/components/Modal/Modal.types.ts
+++ b/packages/react/src/components/Modal/Modal.types.ts
@@ -8,6 +8,7 @@ import type { ILayerProps } from '../../Layer';
 import type { IOverlayProps } from '../../Overlay';
 import type { IStyle, ITheme } from '../../Styling';
 import type { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IPopupProps } from '../Popup/Popup.types';
 
 export interface IDragOptions {
   /**
@@ -195,6 +196,11 @@ export interface IModalProps extends React.RefAttributes<HTMLDivElement>, IAcces
    * @default `{}`
    */
   focusTrapZoneProps?: IFocusTrapZoneProps;
+
+  /**
+   * Props to be passed through to Popup
+   */
+  popupProps?: IPopupProps;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
When using the Modal component (or Dialog) the popup component that is being used under the hood cannot be configured. In cases where were need to have a different behavior for the `onRestoreFocus` method, we have no way to configure it while using either the Dialog or Modal components.

## New Behavior
Adding the `IPopupProps` as a property of the Modal component and then passing it to the popup being used under the hood, we provide more flexibility on that popup's configuration.
