### PR TITLE
feat(react-utilties): add dialog properties to getNativeElementProps

### DIFF
--- a/change/@fluentui-react-utilities-3b90ac0a-38dc-4a1f-876b-613ec6eade09.json
+++ b/change/@fluentui-react-utilities-3b90ac0a-38dc-4a1f-876b-613ec6eade09.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add dialog properties to getNativeElementProps",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-components/react-utilities/src/utils/getNativeElementProps.ts
@@ -24,6 +24,7 @@ import {
   htmlElementProperties,
   getNativeProps,
   timeProperties,
+  dialogProperties,
 } from './properties';
 
 const nativeElementMap: Record<string, Record<string, number>> = {
@@ -49,6 +50,7 @@ const nativeElementMap: Record<string, Record<string, number>> = {
   iframe: iframeProperties,
   img: imgProperties,
   time: timeProperties,
+  dialog: dialogProperties,
 };
 
 /**

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -412,6 +412,13 @@ export const imgProperties = toObjectMap(htmlElementProperties, [
 ]);
 
 /**
+ * An array of DIALOG tag properties and events.
+ *
+ * @public
+ */
+export const dialogProperties = toObjectMap(htmlElementProperties, ['open', 'onCancel', 'onClose']);
+
+/**
  * An array of DIV tag properties and events.
  *
  * @public


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Split PR from https://github.com/microsoft/fluentui/pull/24525

## New Behaviour

Adds `dialog` props to `getNativeElementProps`