### PR TITLE
fix: react-combobox Option focus outline only shows with keyboard nav

### DIFF
--- a/change/@fluentui-react-combobox-4f9e8f26-0811-4f02-b45e-61f97b2dfbbe.json
+++ b/change/@fluentui-react-combobox-4f9e8f26-0811-4f02-b45e-61f97b2dfbbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Combobox and Dropdown only show option focus outline when navigating by keyboard",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -99,6 +99,7 @@ export type ListboxSlots = {
 // @public
 export type ListboxState = ComponentState<ListboxSlots> & OptionCollectionState & SelectionState & {
     activeOption?: OptionValue;
+    focusVisible: boolean;
     selectOption(event: SelectionEvents, option: OptionValue): void;
     setActiveOption(option?: OptionValue): void;
 };
@@ -143,6 +144,7 @@ export type OptionSlots = {
 // @public
 export type OptionState = ComponentState<OptionSlots> & Pick<OptionProps, 'disabled'> & {
     active: boolean;
+    focusVisible: boolean;
     multiselect?: boolean;
     selected: boolean;
 };

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -37,6 +37,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     selectOption,
     selectedOptions,
     setActiveOption,
+    setFocusVisible,
     setOpen,
     setValue,
     value,
@@ -117,6 +118,8 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     // handle updating active option based on input
     const matchingOption = getOptionFromInput(inputValue);
     setActiveOption(matchingOption);
+
+    setFocusVisible(true);
 
     // clear selection for single-select if the input value no longer matches the selection
     if (

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
@@ -132,6 +132,7 @@ const useInputStyles = makeStyles({
   input: {
     backgroundColor: tokens.colorTransparentBackground,
     ...shorthands.border('0'),
+    color: tokens.colorNeutralForeground1,
     fontFamily: tokens.fontFamilyBase,
 
     '&:focus': {

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -21,7 +21,15 @@ import type { DropdownProps, DropdownState } from './Dropdown.types';
  */
 export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLButtonElement>): DropdownState => {
   const baseState = useComboboxBaseState(props);
-  const { activeOption, getIndexOfId, getOptionsMatchingValue, open, setActiveOption, setOpen } = baseState;
+  const {
+    activeOption,
+    getIndexOfId,
+    getOptionsMatchingValue,
+    open,
+    setActiveOption,
+    setFocusVisible,
+    setOpen,
+  } = baseState;
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
@@ -86,6 +94,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
 
       const nextOption = getNextMatchingOption();
       setActiveOption(nextOption);
+      setFocusVisible(true);
     }
   };
 

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
@@ -80,6 +80,7 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorTransparentBackground,
     ...shorthands.border('0'),
     boxSizing: 'border-box',
+    color: tokens.colorNeutralForeground1,
     columnGap: tokens.spacingHorizontalXXS,
     cursor: 'pointer',
     display: 'grid',

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.types.ts
@@ -22,6 +22,9 @@ export type ListboxState = ComponentState<ListboxSlots> &
     /* Option data for the currently highlighted option (not the selected option) */
     activeOption?: OptionValue;
 
+    // Whether the keyboard focus outline style should be visible
+    focusVisible: boolean;
+
     selectOption(event: SelectionEvents, option: OptionValue): void;
 
     setActiveOption(option?: OptionValue): void;

--- a/packages/react-components/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-components/react-combobox/src/components/Option/Option.types.ts
@@ -33,6 +33,9 @@ export type OptionState = ComponentState<OptionSlots> &
     /* If true, this is the currently highlighted option */
     active: boolean;
 
+    // Whether the keyboard focus outline style should be visible
+    focusVisible: boolean;
+
     /* If true, the option is part of a multiselect combobox or listbox */
     multiselect?: boolean;
 

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -46,6 +46,7 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
   ]);
 
   // context values
+  const focusVisible = useContextSelector(ListboxContext, ctx => ctx.focusVisible);
   const multiselect = useContextSelector(ListboxContext, ctx => ctx.multiselect);
   const registerOption = useContextSelector(ListboxContext, ctx => ctx.registerOption);
   const selected = useContextSelector(ListboxContext, ctx => {
@@ -118,6 +119,7 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
     }),
     active,
     disabled,
+    focusVisible,
     multiselect,
     selected,
   };

--- a/packages/react-components/react-combobox/src/components/Option/useOptionStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Option/useOptionStyles.ts
@@ -113,12 +113,12 @@ const useStyles = makeStyles({
  * Apply styling to the Option slots based on the state
  */
 export const useOptionStyles_unstable = (state: OptionState): OptionState => {
-  const { active, disabled, multiselect, selected } = state;
+  const { active, disabled, focusVisible, multiselect, selected } = state;
   const styles = useStyles();
   state.root.className = mergeClasses(
     optionClassNames.root,
     styles.root,
-    active && styles.active,
+    active && focusVisible && styles.active,
     disabled && styles.disabled,
     selected && styles.selected,
     state.root.className,

--- a/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
@@ -8,6 +8,7 @@ export type ComboboxContextValue = Pick<
   ComboboxState,
   | 'activeOption'
   | 'appearance'
+  | 'focusVisible'
   | 'open'
   | 'registerOption'
   | 'selectedOptions'
@@ -21,6 +22,7 @@ export type ComboboxContextValue = Pick<
 export const ComboboxContext = createContext<ComboboxContextValue>({
   activeOption: undefined,
   appearance: 'outline',
+  focusVisible: false,
   open: false,
   registerOption() {
     return () => undefined;

--- a/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
@@ -6,12 +6,19 @@ import { ListboxState } from '../components/Listbox/Listbox.types';
  */
 export type ListboxContextValue = Pick<
   ListboxState,
-  'activeOption' | 'multiselect' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption'
+  | 'activeOption'
+  | 'focusVisible'
+  | 'multiselect'
+  | 'registerOption'
+  | 'selectedOptions'
+  | 'selectOption'
+  | 'setActiveOption'
 >;
 
 // eslint-disable-next-line @fluentui/no-context-default-value
 export const ListboxContext = createContext<ListboxContextValue>({
   activeOption: undefined,
+  focusVisible: false,
   multiselect: false,
   registerOption() {
     return () => undefined;

--- a/packages/react-components/react-combobox/src/contexts/useComboboxContextValues.ts
+++ b/packages/react-components/react-combobox/src/contexts/useComboboxContextValues.ts
@@ -4,6 +4,7 @@ export function useComboboxContextValues(state: ComboboxBaseState): ComboboxBase
   const {
     activeOption,
     appearance,
+    focusVisible,
     open,
     registerOption,
     selectedOptions,
@@ -16,6 +17,7 @@ export function useComboboxContextValues(state: ComboboxBaseState): ComboboxBase
   const combobox = {
     activeOption,
     appearance,
+    focusVisible,
     open,
     registerOption,
     selectedOptions,

--- a/packages/react-components/react-combobox/src/contexts/useListboxContextValues.ts
+++ b/packages/react-components/react-combobox/src/contexts/useListboxContextValues.ts
@@ -4,7 +4,15 @@ import { ComboboxContext } from './ComboboxContext';
 
 export function useListboxContextValues(state: ListboxState): ListboxContextValues {
   const hasComboboxContext = useHasParentContext(ComboboxContext);
-  const { activeOption, multiselect, registerOption, selectedOptions, selectOption, setActiveOption } = state;
+  const {
+    activeOption,
+    focusVisible,
+    multiselect,
+    registerOption,
+    selectedOptions,
+    selectOption,
+    setActiveOption,
+  } = state;
 
   // get register/unregister functions from parent combobox context
   const comboboxRegisterOption = useContextSelector(ComboboxContext, ctx => ctx.registerOption);
@@ -13,6 +21,7 @@ export function useListboxContextValues(state: ListboxState): ListboxContextValu
 
   const listbox = {
     activeOption,
+    focusVisible,
     multiselect,
     registerOption: registerOptionValue,
     selectedOptions,

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -77,6 +77,9 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     /* Option data for the currently highlighted option (not the selected option) */
     activeOption?: OptionValue;
 
+    // Whether the keyboard focus outline style should be visible
+    focusVisible: boolean;
+
     // whether the combobox/dropdown currently has focus
     hasFocus: boolean;
 
@@ -86,6 +89,8 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     selectOption(event: SelectionEvents, option: OptionValue): void;
 
     setActiveOption(option?: OptionValue): void;
+
+    setFocusVisible(focusVisible: boolean): void;
 
     setHasFocus(hasFocus: boolean): void;
 

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -16,6 +16,10 @@ export const useComboboxBaseState = (props: ComboboxBaseProps) => {
 
   const [activeOption, setActiveOption] = React.useState<OptionValue | undefined>();
 
+  // track whether keyboard focus outline should be shown
+  // tabster/keyborg doesn't work here, since the actual keyboard focus target doesn't move
+  const [focusVisible, setFocusVisible] = React.useState(false);
+
   // track focused state to conditionally render collapsed listbox
   const [hasFocus, setHasFocus] = React.useState(false);
 
@@ -88,11 +92,13 @@ export const useComboboxBaseState = (props: ComboboxBaseProps) => {
     ...selectionState,
     activeOption,
     appearance,
+    focusVisible,
     hasFocus,
     ignoreNextBlur,
     inlinePopup,
     open,
     setActiveOption,
+    setFocusVisible,
     setHasFocus,
     setOpen,
     setValue,


### PR DESCRIPTION
Resolves an item on the design review, #23926

Existing focus outline helpers and even `useKeyboardNavAttribute` from tabster don't work in this case, since keyboard focus doesn't move from the trigger, and the style is on the options.

My solution was to set a `focusVisible` state, set to true by keyboard interactions that open the listbox, move the `activeOption`, or type characters; and set to false by `mouseOver` events.
