### PR TITLE
Textarea/hc bug

### DIFF
--- a/change/@fluentui-react-textarea-a60f7be9-9011-4b41-81f6-b700be755b8e.json
+++ b/change/@fluentui-react-textarea-a60f7be9-9011-4b41-81f6-b700be755b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Change filled appearances' normal state's token.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -102,14 +102,17 @@ const useRootStyles = makeStyles({
     },
   },
 
+  filled: {
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+    ':hover,:focus-within': {
+      ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
+    },
+  },
   'filled-darker': {
     backgroundColor: tokens.colorNeutralBackground3,
-    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStrokeInteractive),
   },
-
   'filled-lighter': {
     backgroundColor: tokens.colorNeutralBackground1,
-    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStrokeInteractive),
   },
 
   outline: {
@@ -217,14 +220,16 @@ const useTextareaResizeStyles = makeStyles({
  * Apply styling to the Textarea slots based on the state
  */
 export const useTextareaStyles_unstable = (state: TextareaState): TextareaState => {
-  const disabled = state.textarea.disabled;
   const { size, appearance, resize } = state;
+  const disabled = state.textarea.disabled;
+  const filled = appearance.startsWith('filled');
 
   const rootStyles = useRootStyles();
   state.root.className = mergeClasses(
     textareaClassNames.root,
     rootStyles.base,
     rootStyles[appearance],
+    filled && rootStyles.filled,
     disabled && rootStyles.disabled,
     !disabled && rootStyles.interactive,
     !disabled && appearance === 'outline' && rootStyles.outlineInteractive,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

![image](https://user-images.githubusercontent.com/5953191/189005322-72c667fc-ef39-4c5e-9a45-ce414a631693.png)

## New Behavior

![image](https://user-images.githubusercontent.com/5953191/189005262-c8cf588d-8a42-4d04-b1f6-f7f8c5337337.png)

Note: when hovering and focused the border color is still blue, it's only when there's no state that it has that color.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24621
