### PR TITLE
fix: Remove provider classname from focus styles

### DIFF
--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -22,16 +22,11 @@ export const createCustomFocusIndicatorStyle = (
   ':focus-visible': {
     outlineStyle: 'none',
   },
-  // Remove the `.fui-FluentProvider` global selector once Griffel supports chained global styles
-  // https://github.com/microsoft/griffel/issues/178
+
   ...(selector === 'focus' && {
-    [`:global(.fui-FluentProvider)`]: {
-      [`& .${FOCUS_VISIBLE_CLASS}`]: style,
-    },
+    [`&.${FOCUS_VISIBLE_CLASS}`]: style,
   }),
   ...(selector === 'focus-within' && {
-    [`:global(.fui-FluentProvider)`]: {
-      [`& .${FOCUS_WITHIN_CLASS}:${selector}`]: style,
-    },
+    [`&.${FOCUS_WITHIN_CLASS}:${selector}`]: style,
   }),
 });


### PR DESCRIPTION
Removes the redundant provider class selector from focus outline. It doesn't really improve performance but means we can remove the hard coded class selector

| time elapsed | fast reject count | match attempts |match count |
| - | - | - | - |
| 377 | 0 | 1484 | 364 |
