### PR TITLE
fix: Portal compat should apply `focus-visible` ponyfill

### DIFF
--- a/change/@fluentui-react-portal-compat-41d872da-79ea-43a1-b05e-1b14ac071531.json
+++ b/change/@fluentui-react-portal-compat-41d872da-79ea-43a1-b05e-1b14ac071531.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Portal compat should apply `focus-visible` ponyfill",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-9c99ffaf-f241-4958-8747-b139e37e838e.json
+++ b/change/@fluentui-react-tabster-9c99ffaf-f241-4958-8747-b139e37e838e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Exports `applyFocusVisible` as internal",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal-compat/bundle-size/PortalCompat.fixture.js
+++ b/packages/react-components/react-portal-compat/bundle-size/PortalCompat.fixture.js
@@ -1,0 +1,7 @@
+import { PortalCompatProvider } from '@fluentui/react-portal-compat';
+
+console.log(PortalCompatProvider);
+
+export default {
+  name: 'PortalCompatProvider',
+};

--- a/packages/react-components/react-portal-compat/cypress.config.ts
+++ b/packages/react-components/react-portal-compat/cypress.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '@fluentui/scripts/cypress/cypress.config';
+
+export default baseConfig;

--- a/packages/react-components/react-portal-compat/e2e/PortalCompat.e2e.tsx
+++ b/packages/react-components/react-portal-compat/e2e/PortalCompat.e2e.tsx
@@ -13,7 +13,7 @@ const mount = (element: JSX.Element) => {
   );
 };
 
-describe('Keyborg', () => {
+describe('PortalCompat', () => {
   const Example = () => {
     const registerPortal = usePortalCompat();
     const ref = React.useRef<HTMLDivElement>(null);

--- a/packages/react-components/react-portal-compat/e2e/PortalCompat.e2e.tsx
+++ b/packages/react-components/react-portal-compat/e2e/PortalCompat.e2e.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { mount as mountBase } from '@cypress/react';
+import { FluentProvider } from '@fluentui/react-provider';
+import { teamsLightTheme } from '@fluentui/react-theme';
+import { PortalCompatProvider } from '../src';
+import { usePortalCompat } from '@fluentui/react-portal-compat-context';
+
+const mount = (element: JSX.Element) => {
+  mountBase(
+    <FluentProvider theme={teamsLightTheme}>
+      <PortalCompatProvider>{element}</PortalCompatProvider>
+    </FluentProvider>,
+  );
+};
+
+describe('Keyborg', () => {
+  const Example = () => {
+    const registerPortal = usePortalCompat();
+    const ref = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+      if (ref.current) {
+        return registerPortal(ref.current);
+      }
+    }, []);
+
+    return (
+      <div ref={ref}>
+        <button>First</button>
+        <button>Second</button>
+      </div>
+    );
+  };
+
+  it('should apply focus visible ponyfill', () => {
+    mount(<Example />);
+    cy.contains('First').focus().realPress('Tab');
+    cy.contains('Second').should('have.class', 'fui-focus-visible');
+  });
+});

--- a/packages/react-components/react-portal-compat/e2e/tsconfig.json
+++ b/packages/react-components/react-portal-compat/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
+    "lib": ["ES2019", "dom"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -28,11 +28,11 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-components": "^9.2.0",
     "@fluentui/react-shared-contexts": "^9.0.0",
-    "@fluentui/react-tabster": "^9.1.0",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
     "@fluentui/react-portal-compat-context": "^9.0.1",
+    "@fluentui/react-tabster": "^9.1.0",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build --module esm,cjs,amd",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "e2e": "cypress run --component",

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -15,6 +15,8 @@
     "build": "just-scripts build --module esm,cjs,amd",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component",
     "just": "just-scripts",
     "lint": "just-scripts lint && just-scripts lint-imports",
     "test": "jest --passWithNoTests",
@@ -26,6 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-components": "^9.2.0",
     "@fluentui/react-shared-contexts": "^9.0.0",
+    "@fluentui/react-tabster": "^9.1.0",
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
@@ -64,24 +64,6 @@ describe('PortalCompatProvider', () => {
     expect(element.classList.length).toBe(0);
   });
 
-  it.only('adds focus-visible ponyfill to registered element', () => {
-    const element = document.createElement('div');
-    const button = document.createElement('button');
-    element.appendChild(button);
-
-    const { result } = renderHook(() => usePortalCompat(), {
-      wrapper: props => (
-        <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
-          <PortalCompatProvider>{props.children}</PortalCompatProvider>
-        </FluentProvider>
-      ),
-    });
-    result.current(element);
-
-    button.focus();
-    expect(button.classList).toMatchInlineSnapshot(`DOMTokenList {}`);
-  });
-
   it('during register adds only proper className', () => {
     const element = document.createElement('div');
     const { result } = renderHook(() => usePortalCompat(), {

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
@@ -64,6 +64,24 @@ describe('PortalCompatProvider', () => {
     expect(element.classList.length).toBe(0);
   });
 
+  it.only('adds focus-visible ponyfill to registered element', () => {
+    const element = document.createElement('div');
+    const button = document.createElement('button');
+    element.appendChild(button);
+
+    const { result } = renderHook(() => usePortalCompat(), {
+      wrapper: props => (
+        <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
+          <PortalCompatProvider>{props.children}</PortalCompatProvider>
+        </FluentProvider>
+      ),
+    });
+    result.current(element);
+
+    button.focus();
+    expect(button.classList).toMatchInlineSnapshot(`DOMTokenList {}`);
+  });
+
   it('during register adds only proper className', () => {
     const element = document.createElement('div');
     const { result } = renderHook(() => usePortalCompat(), {

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { fluentProviderClassNames, useThemeClassName } from '@fluentui/react-components';
 import { PortalCompatContextProvider } from '@fluentui/react-portal-compat-context';
+import { applyFocusVisiblePolyfill } from '@fluentui/react-tabster';
 
 import type { RegisterPortalFn } from '@fluentui/react-portal-compat-context';
 
@@ -19,14 +20,19 @@ export const PortalCompatProvider: React.FC = props => {
 
   const registerPortalEl = React.useCallback<RegisterPortalFn>(
     element => {
+      let disposeFocusVisiblePolyfill: () => void = () => undefined;
       if (cssVariablesClassName) {
         element.classList.add(cssVariablesClassName);
+        if (element.ownerDocument.defaultView) {
+          disposeFocusVisiblePolyfill = applyFocusVisiblePolyfill(element, element.ownerDocument.defaultView);
+        }
       }
 
       return () => {
         if (cssVariablesClassName) {
           element.classList.remove(cssVariablesClassName);
         }
+        disposeFocusVisiblePolyfill();
       };
     },
     [cssVariablesClassName],

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -9,6 +9,9 @@ import * as React_2 from 'react';
 import type { RefObject } from 'react';
 import { Types } from 'tabster';
 
+// @internal (undocumented)
+export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () => void;
+
 // @public
 export const createCustomFocusIndicatorStyle: (style: GriffelStyle, { selector }?: CreateCustomFocusIndicatorStyleOptions) => GriffelStyle;
 

--- a/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
@@ -19,6 +19,11 @@ type HTMLElementWithFocusVisibleScope = {
   focusVisible: boolean | undefined;
 } & HTMLElement;
 
+/**
+ * @internal
+ * @param scope - Applies the ponyfill to all DOM children
+ * @param win - window
+ */
 export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () => void {
   if (alreadyInScope(scope)) {
     // Focus visible polyfill already applied at this scope

--- a/packages/react-components/react-tabster/src/focus/index.ts
+++ b/packages/react-components/react-tabster/src/focus/index.ts
@@ -1,2 +1,4 @@
 export * from './createCustomFocusIndicatorStyle';
 export * from './createFocusOutlineStyle';
+export * from './focusVisiblePolyfill';
+export * from './focusWithinPolyfill';

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -22,3 +22,5 @@ export type {
   FocusOutlineOffset,
   FocusOutlineStyleOptions,
 } from './focus/index';
+
+export { applyFocusVisiblePolyfill } from './focus/index';


### PR DESCRIPTION
`@fluentui/react-portal-compat` now takes a dependency on `@fluentui/react-tabster` to apply the `focus-vislble` ponyfill. Also setup e2e tests for the portal compat package to test that the ponyfill is correctly applied.

## Current Behavior

Portal compat will not apply v9 focus outline styles

## New Behavior

Portal compat will apply v9 focus outline styles

## Related Issue(s)

Fixes #24411
