### PR TITLE
Fix greyed out legend key contrast ratio

### DIFF
--- a/change/@fluentui-react-charting-d686895a-39e2-4755-a198-862dec13351f.json
+++ b/change/@fluentui-react-charting-d686895a-39e2-4755-a198-862dec13351f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix greyed out legend key contrast ratio",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/Legends.styles.ts
+++ b/packages/react-charting/src/components/Legends/Legends.styles.ts
@@ -81,7 +81,7 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       ...fonts.small,
       lineHeight: '16px',
       color: theme?.semanticColors.bodyText,
-      opacity: props.colorOnSelectedState === palette.white ? '0.6' : '',
+      opacity: props.colorOnSelectedState === palette.white ? '0.67' : '',
     },
     hoverChange: {
       width: '12px',

--- a/packages/react-charting/src/components/Legends/__snapshots__/Legends.test.tsx.snap
+++ b/packages/react-charting/src/components/Legends/__snapshots__/Legends.test.tsx.snap
@@ -1578,7 +1578,7 @@ exports[`Legends snapShot testing renders Legends correctly 1`] = `
                         font-size: 12px;
                         font-weight: 400;
                         line-height: 16px;
-                        opacity: 0.6;
+                        opacity: 0.67;
                       }
                 >
                   Legend 17
@@ -3171,7 +3171,7 @@ exports[`Legends snapShot testing renders allowFocusOnLegends correctly 1`] = `
                         font-size: 12px;
                         font-weight: 400;
                         line-height: 16px;
-                        opacity: 0.6;
+                        opacity: 0.67;
                       }
                 >
                   Legend 17
@@ -4764,7 +4764,7 @@ exports[`Legends snapShot testing renders canSelectMultipleLegends correctly 1`]
                         font-size: 12px;
                         font-weight: 400;
                         line-height: 16px;
-                        opacity: 0.6;
+                        opacity: 0.67;
                       }
                 >
                   Legend 17
@@ -6357,7 +6357,7 @@ exports[`Legends snapShot testing renders styles correctly 1`] = `
                         font-size: 12px;
                         font-weight: 400;
                         line-height: 16px;
-                        opacity: 0.6;
+                        opacity: 0.67;
                       }
                 >
                   Legend 17


### PR DESCRIPTION
## Current Behavior

Greyed out legend keys text don't match expected contrast ratio of 4.5

![Before](https://user-images.githubusercontent.com/110246001/189102962-b39edcc8-15d0-43c5-a3be-8107c827c74d.png)

## New Behavior

Greyed out legend keys text now have a contrast ratio of 4.6

![After](https://user-images.githubusercontent.com/110246001/189103004-3c97c2f1-5afa-4304-9967-5802c447b51b.png)
