### PR TITLE
feat: add helper types to assist DOM element handling

### DIFF
--- a/change/@fluentui-react-aria-4fd3fe1f-3f59-48b1-acab-2e459a62c03d.json
+++ b/change/@fluentui-react-aria-4fd3fe1f-3f59-48b1-acab-2e459a62c03d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add helper types to assist DOM element handling",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -9,6 +9,12 @@ import * as React_2 from 'react';
 import type { ResolveShorthandFunction } from '@fluentui/react-utilities';
 import type { Slot } from '@fluentui/react-utilities';
 
+// @internal (undocumented)
+export type ARIAButtonElement<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = HTMLButtonElement | (AlternateAs extends 'a' ? HTMLAnchorElement : never) | (AlternateAs extends 'div' ? HTMLDivElement : never);
+
+// @internal (undocumented)
+export type ARIAButtonElementIntersection<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = UnionToIntersection<ARIAButtonElement<AlternateAs>>;
+
 // @public
 export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = React_2.PropsWithRef<JSX.IntrinsicElements[Type]> & {
     disabled?: boolean;

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/types.ts
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/types.ts
@@ -1,7 +1,24 @@
 import type { ExtractSlotProps, Slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
+
 export type ARIAButtonType = 'button' | 'a' | 'div';
+
+/**
+ * @internal
+ */
+export type ARIAButtonElement<AlternateAs extends 'a' | 'div' = 'a' | 'div'> =
+  | HTMLButtonElement
+  | (AlternateAs extends 'a' ? HTMLAnchorElement : never)
+  | (AlternateAs extends 'div' ? HTMLDivElement : never);
+
+/**
+ * @internal
+ */
+export type ARIAButtonElementIntersection<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = UnionToIntersection<
+  ARIAButtonElement<AlternateAs>
+>;
 
 /**
  * Props expected by `useARIAButtonProps` hooks
@@ -47,8 +64,6 @@ export type ARIAButtonAlteredProps<Type extends ARIAButtonType> =
   | (Type extends 'div'
       ? Pick<JSX.IntrinsicElements['div'], 'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role'>
       : never);
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
 
 /**
  * Merge of props provided by the user and props provided internally.

--- a/packages/react-components/react-aria/src/index.ts
+++ b/packages/react-components/react-aria/src/index.ts
@@ -4,4 +4,6 @@ export type {
   ARIAButtonProps,
   ARIAButtonResultProps,
   ARIAButtonType,
+  ARIAButtonElement,
+  ARIAButtonElementIntersection,
 } from './hooks/useARIAButton/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Adds 2 helper types to assist DOM element handling on scenarios that is required to know the element type. `ARIAButtonElement` and `ARIAButtonElementIntersection`. 

### ARIAButtonElement

should be used on references definition for example.It's almost equivalent to: `HTMLButtonElement | HTMLAnchorElement | HTMLDivElement`

```ts
function useComponent(props, ref: React.Ref<ARIAButtonElement>) {}
```

### ARIAButtonElementIntersection

should be used on cases that narrowing down the type is required, for example, an even handler declaration. It's almost equivalent to: `HTMLButtonElement & HTMLAnchorElement & HTMLDivElement`

```ts
const handleClick = (event: React.MouseEvent<ARIAButtonElementIntersection>) => {
    event.currentTarget // HTMLButtonElement & HTMLAnchorElement & HTMLDivElement
}
```
