### PR TITLE
Fix value font-weight inside heatmap chart

### DIFF
--- a/change/@fluentui-react-charting-bb27a991-70f3-49c3-9940-6ff73c090c66.json
+++ b/change/@fluentui-react-charting-bb27a991-70f3-49c3-9940-6ff73c090c66.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix value font-weight inside heatmap chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.styles.ts
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.styles.ts
@@ -1,4 +1,4 @@
-import { FontWeights } from '@fluentui/react';
+import { FontWeights } from '@fluentui/react/lib/Styling';
 import { IHeatMapChartStyleProps, IHeatMapChartStyles } from './HeatMapChart.types';
 
 export const getHeatMapChartStyles = (props: IHeatMapChartStyleProps): IHeatMapChartStyles => {

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.styles.ts
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.styles.ts
@@ -1,3 +1,4 @@
+import { FontWeights } from '@fluentui/react';
 import { IHeatMapChartStyleProps, IHeatMapChartStyles } from './HeatMapChart.types';
 
 export const getHeatMapChartStyles = (props: IHeatMapChartStyleProps): IHeatMapChartStyles => {
@@ -9,6 +10,7 @@ export const getHeatMapChartStyles = (props: IHeatMapChartStyleProps): IHeatMapC
       {
         pointerEvents: 'none',
         fill: theme.palette.white,
+        fontWeight: FontWeights.semibold,
       },
     ],
     subComponentStyles: {

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -153,7 +153,7 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -447,7 +447,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -480,7 +480,7 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -864,7 +864,7 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -897,7 +897,7 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -1032,7 +1032,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -1065,7 +1065,7 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -1359,7 +1359,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -1392,7 +1392,7 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"


### PR DESCRIPTION
## Current Behavior

Heatmap chart data values in less contrasted boxes don't pass accessibility

![Before](https://user-images.githubusercontent.com/110246001/189184693-0e23b083-4b62-43e6-8414-9c28e4712698.png)

## New Behavior

Heatmap chart displays values in semi-bold to help less contrasted boxes

![After](https://user-images.githubusercontent.com/110246001/189184765-38cd9312-25de-42e3-bb94-2fc6e119a6df.png)
