### PR TITLE
Fix null ref in use slider

### DIFF
--- a/change/@fluentui-react-a2077894-5d42-47ef-9b1a-5c88edd0eccd.json
+++ b/change/@fluentui-react-a2077894-5d42-47ef-9b1a-5c88edd0eccd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix null-ref in useSlider() when <Slider/> unmounts before mouseUp fires",
+  "packageName": "@fluentui/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -334,10 +334,12 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
     internalState.isAdjustingLowerValue = event.target === lowerValueThumbRef.current;
   };
 
-  const disposeListeners = (): void => {
+  const disposeListeners = React.useCallback((): void => {
     disposables.current.forEach(dispose => dispose());
     disposables.current = [];
-  };
+  }, []);
+
+  React.useEffect(() => disposeListeners, [disposeListeners]);
 
   const lowerValueThumbRef = React.useRef<HTMLElement>(null);
   const thumbRef = React.useRef<HTMLElement>(null);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When you click on a <Slider />, and the component unmounts while the mouse button is down, and you then move the mosue while the mouse button is still down, there is a null-ref in useSlider()

## New Behavior

There is no null-ref errror, as the window `mouseMove` events are cleaned up on unmount

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24727
