### PR TITLE
fix: Replacing bottom border styles with text decoration underline in Link

### DIFF
--- a/change/@fluentui-react-link-ace1a119-44f0-4cac-96a5-b757d4abee30.json
+++ b/change/@fluentui-react-link-ace1a119-44f0-4cac-96a5-b757d4abee30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Replacing bottom border styles with text decoration underline.",
+  "packageName": "@fluentui/react-link",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
@@ -17,7 +17,6 @@ const useStyles = makeStyles({
   // Common styles.
   root: {
     backgroundColor: 'transparent',
-    ...shorthands.borderStyle('none'),
     boxSizing: 'border-box',
     color: tokens.colorBrandForegroundLink,
     cursor: 'pointer',
@@ -69,7 +68,7 @@ const useStyles = makeStyles({
   },
   // Overrides when the Link is rendered inline within text and appears subtle.
   inlineSubtle: {
-    borderBottomColor: tokens.colorNeutralForeground2,
+    textDecorationColor: tokens.colorNeutralForeground2,
   },
   // Overrides when the Link is disabled.
   disabled: {

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
@@ -28,21 +28,24 @@ const useStyles = makeStyles({
     ...shorthands.padding(0),
     ...shorthands.overflow('inherit'),
     textAlign: 'left',
-    textDecorationColor: 'transparent',
-    textDecorationLine: 'underline',
+    textDecorationLine: 'none',
     textDecorationThickness: tokens.strokeWidthThin,
     textOverflow: 'inherit',
     userSelect: 'text',
 
     ':hover': {
-      textDecorationColor: tokens.colorBrandForegroundLinkHover,
+      textDecorationLine: 'underline',
       color: tokens.colorBrandForegroundLinkHover,
     },
 
     ':active': {
-      textDecorationColor: tokens.colorBrandForegroundLinkPressed,
+      textDecorationLine: 'underline',
       color: tokens.colorBrandForegroundLinkPressed,
     },
+  },
+  // Overrides when the Link renders as a button.
+  button: {
+    ...shorthands.borderStyle('none'),
   },
   // Overrides when an href is present so the Link renders as an anchor.
   href: {
@@ -53,36 +56,32 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
 
     ':hover': {
-      textDecorationColor: tokens.colorNeutralForeground2Hover,
+      textDecorationLine: 'underline',
       color: tokens.colorNeutralForeground2Hover,
     },
 
     ':active': {
-      textDecorationColor: tokens.colorNeutralForeground2Pressed,
+      textDecorationLine: 'underline',
       color: tokens.colorNeutralForeground2Pressed,
     },
   },
   // Overrides when the Link is rendered inline within text.
   inline: {
-    textDecorationColor: tokens.colorBrandForegroundLink,
-  },
-  // Overrides when the Link is rendered inline within text and appears subtle.
-  inlineSubtle: {
-    textDecorationColor: tokens.colorNeutralForeground2,
+    textDecorationLine: 'underline',
   },
   // Overrides when the Link is disabled.
   disabled: {
-    textDecorationColor: 'transparent',
+    textDecorationLine: 'none',
     color: tokens.colorNeutralForegroundDisabled,
     cursor: 'not-allowed',
 
     ':hover': {
-      textDecorationColor: 'transparent',
+      textDecorationLine: 'none',
       color: tokens.colorNeutralForegroundDisabled,
     },
 
     ':active': {
-      textDecorationColor: 'transparent',
+      textDecorationLine: 'none',
       color: tokens.colorNeutralForegroundDisabled,
     },
   },
@@ -97,9 +96,9 @@ export const useLinkStyles_unstable = (state: LinkState): LinkState => {
     styles.root,
     styles.focusIndicator,
     root.as === 'a' && root.href && styles.href,
+    root.as === 'button' && styles.button,
     appearance === 'subtle' && styles.subtle,
     inline && styles.inline,
-    appearance === 'subtle' && inline && styles.inlineSubtle,
     disabled && styles.disabled,
     state.root.className,
   );

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.ts
@@ -10,7 +10,6 @@ export const linkClassNames: SlotClassNames<LinkSlots> = {
 
 const useStyles = makeStyles({
   focusIndicator: createCustomFocusIndicatorStyle({
-    borderBottomColor: 'transparent',
     textDecorationColor: tokens.colorStrokeFocus2,
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
@@ -18,12 +17,7 @@ const useStyles = makeStyles({
   // Common styles.
   root: {
     backgroundColor: 'transparent',
-    borderTopStyle: 'none',
-    borderLeftStyle: 'none',
-    borderRightStyle: 'none',
-    borderBottomColor: 'transparent',
-    borderBottomStyle: 'solid',
-    borderBottomWidth: tokens.strokeWidthThin,
+    ...shorthands.borderStyle('none'),
     boxSizing: 'border-box',
     color: tokens.colorBrandForegroundLink,
     cursor: 'pointer',
@@ -35,17 +29,19 @@ const useStyles = makeStyles({
     ...shorthands.padding(0),
     ...shorthands.overflow('inherit'),
     textAlign: 'left',
-    textDecorationLine: 'none',
+    textDecorationColor: 'transparent',
+    textDecorationLine: 'underline',
+    textDecorationThickness: tokens.strokeWidthThin,
     textOverflow: 'inherit',
     userSelect: 'text',
 
     ':hover': {
-      borderBottomColor: tokens.colorBrandForegroundLinkHover,
+      textDecorationColor: tokens.colorBrandForegroundLinkHover,
       color: tokens.colorBrandForegroundLinkHover,
     },
 
     ':active': {
-      borderBottomColor: tokens.colorBrandForegroundLinkPressed,
+      textDecorationColor: tokens.colorBrandForegroundLinkPressed,
       color: tokens.colorBrandForegroundLinkPressed,
     },
   },
@@ -58,18 +54,18 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
 
     ':hover': {
-      borderBottomColor: tokens.colorNeutralForeground2Hover,
+      textDecorationColor: tokens.colorNeutralForeground2Hover,
       color: tokens.colorNeutralForeground2Hover,
     },
 
     ':active': {
-      borderBottomColor: tokens.colorNeutralForeground2Pressed,
+      textDecorationColor: tokens.colorNeutralForeground2Pressed,
       color: tokens.colorNeutralForeground2Pressed,
     },
   },
   // Overrides when the Link is rendered inline within text.
   inline: {
-    borderBottomColor: tokens.colorBrandForegroundLink,
+    textDecorationColor: tokens.colorBrandForegroundLink,
   },
   // Overrides when the Link is rendered inline within text and appears subtle.
   inlineSubtle: {
@@ -77,17 +73,17 @@ const useStyles = makeStyles({
   },
   // Overrides when the Link is disabled.
   disabled: {
-    borderBottomColor: 'transparent',
+    textDecorationColor: 'transparent',
     color: tokens.colorNeutralForegroundDisabled,
     cursor: 'not-allowed',
 
     ':hover': {
-      borderBottomColor: 'transparent',
+      textDecorationColor: 'transparent',
       color: tokens.colorNeutralForegroundDisabled,
     },
 
     ':active': {
-      borderBottomColor: 'transparent',
+      textDecorationColor: 'transparent',
       color: tokens.colorNeutralForegroundDisabled,
     },
   },


### PR DESCRIPTION
## Current Behavior

`Link` uses `border-bottom` styles for its underline.

## New Behavior

`Link` uses `text-decoration: underline` styles for its underline, which is more inline with most implementations out there.

## Related Issue(s)

Fixes #24729
