### PR TITLE
chore(react-aria): improve internal typings

### DIFF
--- a/change/@fluentui-react-aria-5aba4f44-2e23-4c1d-810b-dcc2426ae694.json
+++ b/change/@fluentui-react-aria-5aba4f44-2e23-4c1d-810b-dcc2426ae694.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(react-aria): improve internal typings",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonProps.ts
+++ b/packages/react-components/react-aria/src/hooks/useARIAButton/useARIAButtonProps.ts
@@ -1,6 +1,7 @@
 import { Enter, Space } from '@fluentui/keyboard-keys';
 import { useEventCallback } from '@fluentui/react-utilities';
-import type { ARIAButtonProps, ARIAButtonResultProps, ARIAButtonType } from './types';
+import * as React from 'react';
+import type { ARIAButtonElementIntersection, ARIAButtonProps, ARIAButtonResultProps, ARIAButtonType } from './types';
 
 /**
  * @internal
@@ -48,7 +49,7 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
 
   const isDisabled = disabled || disabledFocusable || normalizedARIADisabled;
 
-  const handleClick: Props['onClick'] = useEventCallback(ev => {
+  const handleClick = useEventCallback((ev: React.MouseEvent<ARIAButtonElementIntersection>) => {
     if (isDisabled) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -57,7 +58,7 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
     }
   });
 
-  const handleKeyDown: Props['onKeyDown'] = useEventCallback(ev => {
+  const handleKeyDown = useEventCallback((ev: React.KeyboardEvent<ARIAButtonElementIntersection>) => {
     onKeyDown?.(ev);
 
     if (ev.isDefaultPrevented()) {
@@ -84,7 +85,7 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
     }
   });
 
-  const handleKeyUp: Props['onKeyUp'] = useEventCallback(ev => {
+  const handleKeyUp = useEventCallback((ev: React.KeyboardEvent<ARIAButtonElementIntersection>) => {
     onKeyUp?.(ev);
 
     if (ev.isDefaultPrevented()) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently `useARIAButtonProps` infers event typings throughout props.

## New Behavior

Instead of inferring throughout props narrowing it down by using `ARIAButtonElementIntersection` would be more appropriate.

## Related Issue(s)

Without narrowing down the type inference are [causing conflicts](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=266109&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=8250ef03-1890-59ab-a6a8-5d0b4c2baa1b&l=5005)