### PR TITLE
return skipToMain functionality and hide back to top button

### DIFF
--- a/apps/public-docsite/src/root.tsx
+++ b/apps/public-docsite/src/root.tsx
@@ -36,7 +36,7 @@ registerIcons({
   },
 });
 
-const skipToMain = document.querySelector('[href="#mainContent"]') as HTMLAnchorElement;
+const skipToMain = document.getElementById('uhfSkipToMain') as HTMLAnchorElement;
 if (skipToMain) {
   // This link points to #mainContent by default, which would be interpreted as a route in our app.
   // Handle focusing the main content manually instead.

--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -114,7 +114,7 @@
   // and #flightPicker element which creates accessibility issues.
   // Hide #socialMediaContainer element which holds the footer with social media links
   // and #signInPrompt element which contains the sign in modal
-  a.m-back-to-top,
+  [href="#mainContent"],
   #flightPicker,
   #socialMediaContainer,
   #signInPrompt {

--- a/change/@fluentui-public-docsite-setup-c9310141-1481-42db-9b89-3a3649aca0d9.json
+++ b/change/@fluentui-public-docsite-setup-c9310141-1481-42db-9b89-3a3649aca0d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "return skipToMain functionality and hide back to top button",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/public-docsite-setup/index.html
+++ b/packages/public-docsite-setup/index.html
@@ -66,7 +66,7 @@
 
   <body>
     <!-- Copied from UHF site -->
-    <a class="m-skip-to-main" href="#mainContent" tabindex="0">Skip to main content</a>
+    <a id="uhfSkipToMain" class="m-skip-to-main" href="#mainContent" tabindex="0">Skip to main content</a>
     <div id="main">
       <div class="loading">
         <img


### PR DESCRIPTION
I mistakenly changed the skipToMain functionality to affect the 'back to top button', which broke the former and didn't fix the latter. 

I returned the skipToMain functionality to how it was (it was not broken), and fixed the display: none selection that we were using to hide the 'back to top' button.

Fixes #24610