### PR TITLE
change homepage title to h1 instead of h2

### DIFF
--- a/apps/public-docsite/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/public-docsite/src/pages/HomePage/HomePage.base.tsx
@@ -125,7 +125,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
       <section className={this._classNames.heroSection}>
         <div className={this._classNames.sectionContent}>
           <div className={this._classNames.oneHalf}>
-            <h2 className={this._classNames.heroTitle}>
+            <h1 className={this._classNames.heroTitle}>
               Fluent{' '}
               <svg width="128" height="92" viewBox="0 0 128 92" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <text x="0" y="90" fill="url(#paint0_linear)">
@@ -145,7 +145,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
                   </linearGradient>
                 </defs>
               </svg>
-            </h2>
+            </h1>
           </div>
           <div className={this._classNames.oneFourth} style={{ flexBasis: '31%' }}>
             <p>


### PR DESCRIPTION
Addresses internal bug 14973

Actual Result:
Heading structure is defined incorrectly in the page, `<h2>` heading is defined for the main page heading.
As of now, "Fluent UI" is defined  H2 heading ,No H1 heading is defined on this page.

Expected Result:
Heading structure should define correctly in the page, `<h1>` heading is defined for the main page heading.
So "fluent UI" should be define in H1 as the main heading of the page.