### PR TITLE
bugfix: `Dialog`, `MenuPopover` and `PopoverTrigger` stops propagation on Escape keydown 

### DIFF
--- a/change/@fluentui-react-dialog-7e8df864-5916-4a65-a8e8-10c99bfe06c3.json
+++ b/change/@fluentui-react-dialog-7e8df864-5916-4a65-a8e8-10c99bfe06c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix(react-dialog): prevent default on Escape key",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-7e8df864-5916-4a65-a8e8-10c99bfe06c3.json
+++ b/change/@fluentui-react-dialog-7e8df864-5916-4a65-a8e8-10c99bfe06c3.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "bugfix(react-dialog): prevent default on Escape key",
+  "comment": "bugfix: stops propagation on Escape key",
   "packageName": "@fluentui/react-dialog",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-menu-6654ec9f-d860-48a1-be2c-8e8a6fd74f2d.json
+++ b/change/@fluentui-react-menu-6654ec9f-d860-48a1-be2c-8e8a6fd74f2d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "bugfix: prevent default on Escape keydown",
+  "comment": "bugfix: stops propagation on Escape keydown",
   "packageName": "@fluentui/react-menu",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-menu-6654ec9f-d860-48a1-be2c-8e8a6fd74f2d.json
+++ b/change/@fluentui-react-menu-6654ec9f-d860-48a1-be2c-8e8a6fd74f2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: prevent default on Escape keydown",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-2678e585-4053-46ec-8b8c-5d73a8978dde.json
+++ b/change/@fluentui-react-popover-2678e585-4053-46ec-8b8c-5d73a8978dde.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: prevent default on Escape keydown",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-2678e585-4053-46ec-8b8c-5d73a8978dde.json
+++ b/change/@fluentui-react-popover-2678e585-4053-46ec-8b8c-5d73a8978dde.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "bugfix: prevent default on Escape keydown",
+  "comment": "bugfix: stops propagation on Escape keydown",
   "packageName": "@fluentui/react-popover",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-dialog/e2e/Dialog.e2e.tsx
+++ b/packages/react-components/react-dialog/e2e/Dialog.e2e.tsx
@@ -5,7 +5,17 @@ import { FluentProvider } from '@fluentui/react-provider';
 import { teamsLightTheme } from '@fluentui/react-theme';
 
 import { Dialog, DialogActions, DialogBody, DialogSurface, DialogTitle, DialogTrigger } from '@fluentui/react-dialog';
-import { Button } from '@fluentui/react-components';
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+} from '@fluentui/react-components';
 import {
   dialogSurfaceSelector,
   dialogTriggerCloseId,
@@ -175,6 +185,53 @@ describe('Dialog', () => {
     mount(<CustomFocusedElementOnOpen />);
     cy.get(dialogTriggerOpenSelector).realClick();
     cy.get(dialogTriggerCloseSelector).should('be.focused');
+  });
+  it('should not close with Escape keydown while focusing other elements that control Escape', () => {
+    mount(
+      <Dialog modalType="non-modal">
+        <DialogTrigger>
+          <Button>Open dialog</Button>
+        </DialogTrigger>
+        <DialogSurface>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogBody>
+            <Menu>
+              <MenuTrigger>
+                <Button id="open-menu-btn">Toggle menu</Button>
+              </MenuTrigger>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>Item</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+            <Popover>
+              <PopoverTrigger>
+                <Button id="open-popover-btn">Popover trigger</Button>
+              </PopoverTrigger>
+              <PopoverSurface aria-label="label">Content</PopoverSurface>
+            </Popover>
+          </DialogBody>
+          <DialogActions>
+            <DialogTrigger>
+              <Button id={dialogTriggerCloseId} appearance="secondary">
+                Close
+              </Button>
+            </DialogTrigger>
+            <Button appearance="primary">Do Something</Button>
+          </DialogActions>
+        </DialogSurface>
+      </Dialog>,
+    );
+    cy.get(dialogTriggerOpenSelector).realClick();
+    cy.get('#open-menu-btn').realClick();
+    cy.focused().realType('{esc}');
+    cy.get(dialogSurfaceSelector).should('exist');
+
+    cy.get('#open-popover-btn').realClick();
+    cy.focused().realType('{esc}');
+    cy.get(dialogSurfaceSelector).should('exist');
   });
   describe('modalType = modal', () => {
     it('should close with escape keydown', () => {

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -36,7 +36,6 @@ export const useDialogSurface_unstable = (
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
   const dialogTitleID = useDialogContext_unstable(ctx => ctx.dialogTitleID);
   const dialogBodyID = useDialogContext_unstable(ctx => ctx.dialogBodyID);
-  const isNestedDialog = useDialogContext_unstable(ctx => ctx.isNestedDialog);
 
   const handleNativeClick = useEventCallback((event: React.MouseEvent<DialogSurfaceElementIntersection>) => {
     props.onClick?.(event);
@@ -108,10 +107,9 @@ export const useDialogSurface_unstable = (
         open: false,
         type: 'escapeKeyDown',
       });
-      if (isNestedDialog) {
-        // Escape keydown should be stopped to avoid closing multiple dialogs
-        event.stopPropagation();
-      }
+      // prevent default to avoid conflicting with other elements that listen for `Escape`
+      // e,g: nested Dialog, Popover, Menu and Tooltip
+      event.preventDefault();
     }
   });
 

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -107,9 +107,9 @@ export const useDialogSurface_unstable = (
         open: false,
         type: 'escapeKeyDown',
       });
-      // prevent default to avoid conflicting with other elements that listen for `Escape`
+      // stop propagation to avoid conflicting with other elements that listen for `Escape`
       // e,g: nested Dialog, Popover, Menu and Tooltip
-      event.preventDefault();
+      event.stopPropagation();
     }
   });
 

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -19,6 +19,7 @@ import { useIsSubmenu } from '../../utils/useIsSubmenu';
 export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
   const popoverRef = useMenuContext_unstable(context => context.menuPopoverRef);
   const setOpen = useMenuContext_unstable(context => context.setOpen);
+  const open = useMenuContext_unstable(context => context.open);
   const openOnHover = useMenuContext_unstable(context => context.openOnHover);
   const isSubmenu = useIsSubmenu();
   const canDispatchCustomEventRef = React.useRef(true);
@@ -74,8 +75,11 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
     const key = e.key;
 
     if (key === Escape || (isSubmenu && key === CloseArrowKey)) {
-      if (popoverRef.current?.contains(e.target as HTMLElement)) {
+      if (open && popoverRef.current?.contains(e.target as HTMLElement)) {
         setOpen(e, { open: false, keyboard: true });
+        // prevent default to avoid conflicting with other elements that listen for `Escape`
+        // e,g: Dialog, Popover and Tooltip
+        e.preventDefault();
       }
     }
 

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -77,9 +77,9 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
     if (key === Escape || (isSubmenu && key === CloseArrowKey)) {
       if (open && popoverRef.current?.contains(e.target as HTMLElement)) {
         setOpen(e, { open: false, keyboard: true });
-        // prevent default to avoid conflicting with other elements that listen for `Escape`
+        // stop propagation to avoid conflicting with other elements that listen for `Escape`
         // e,g: Dialog, Popover and Tooltip
-        e.preventDefault();
+        e.stopPropagation();
       }
     }
 

--- a/packages/react-components/react-popover/package.json
+++ b/packages/react-components/react-popover/package.json
@@ -34,6 +34,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
+    "@fluentui/keyboard-keys": "^9.0.0",
     "@fluentui/react-aria": "^9.1.0",
     "@fluentui/react-context-selector": "^9.0.2",
     "@fluentui/react-portal": "^9.0.4",

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -10,6 +10,7 @@ import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverTriggerChildProps, PopoverTriggerProps, PopoverTriggerState } from './PopoverTrigger.types';
 import { useARIAButtonProps } from '@fluentui/react-aria';
+import { Escape } from '@fluentui/keyboard-keys';
 
 /**
  * Create the state required to render PopoverTrigger.
@@ -47,8 +48,11 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-    if (e.key === 'Escape') {
+    if (e.key === Escape && open) {
       setOpen(e, false);
+      // prevent default to avoid conflicting with other elements that listen for `Escape`
+      // e,g: Dialog, Menu
+      e.preventDefault();
     }
   };
 

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -50,9 +50,9 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
   const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === Escape && open) {
       setOpen(e, false);
-      // prevent default to avoid conflicting with other elements that listen for `Escape`
+      // stop propagation to avoid conflicting with other elements that listen for `Escape`
       // e,g: Dialog, Menu
-      e.preventDefault();
+      e.stopPropagation();
     }
   };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Multiple components might listen to `Escape`.

Those components might have their own `Escape` key dismiss behaviour. At the moment `Escape` key pressing will dismiss `Menu`, `Popover` and `Dialog`.

### Problem

When interacting with multiple layout components that have behaviours associated with `Escape` pressing, conflicts might happen.

E,g: a `Menu` or a `Popover` inside a `Dialog`
```tsx
const MenuInsideDialogExample = () => {
  return (
    <Dialog>
      <DialogTrigger>
        <Button>Open dialog</Button>
      </DialogTrigger>
      <DialogSurface>
        <Menu>
          <MenuTrigger>
            <Button>Toggle menu</Button>
          </MenuTrigger>

          <MenuPopover>
            <MenuList>
              <MenuItem>Item</MenuItem>
            </MenuList>
          </MenuPopover>
        </Menu>
        <DialogActions>
          <DialogTrigger>
            <Button>
              Close
            </Button>
          </DialogTrigger>
        </DialogActions>
      </DialogSurface>
    </Dialog>,
  );
}
```

In this scenario, when `Escape` is pressed inside an open `Menu` it should only dismiss `Menu`, at the moment it's currently dismissing both `Menu` and `Dialog`


## New Behavior

By stopping propagation on `Escape` keydown, this conflict is avoided since no other component will listen to this event
