### PR TITLE
Fix legend overflow-indication-text role

### DIFF
--- a/change/@fluentui-react-charting-fe6d38c5-47ee-48e4-8bef-d3df5d7f44be.json
+++ b/change/@fluentui-react-charting-fe6d38c5-47ee-48e4-8bef-d3df5d7f44be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix legend overflow-indication-text role",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -306,7 +306,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
           className={classNames.overflowIndicationTextStyle}
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
           {...(allowFocusOnLegends && {
-            role: 'link',
+            role: 'button',
             'aria-expanded': this.state.isHoverCardVisible,
             'aria-label': `${items.length} ${overflowString}`,
           })}


### PR DESCRIPTION
## Current Behavior

Legend overflow indication text has 'link' role which is an accessibility issue because it doesn't redirect to another page

## New Behavior

Legend overflow indication text has 'button' role 

Fixes #24692 
