### PR TITLE
remove unnecessary nohoist for react 18 tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,11 +291,7 @@
       "@fluentui/web-components/@storybook/html",
       "@fluentui/web-components/ts-loader",
       "@fluentui/web-components/ts-loader/**",
-      "@fluentui/web-components/webpack",
-      "@fluentui/react-18-tests-v8/react",
-      "@fluentui/react-18-tests-v8/react-dom",
-      "@fluentui/react-18-tests-v9/react",
-      "@fluentui/react-18-tests-v9/react-dom"
+      "@fluentui/web-components/webpack"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
after trying to recreate the original hoisting problem, I was unable to repro nohoist making any difference. I am confident that the webpack alias is necessary though, so those can stay in, as well as the syncpack updates.