### PR TITLE
fix: Update package template beachball config to allow only 'prerelease' changes by default

### DIFF
--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -40,5 +40,12 @@
     "@types/react-dom": "",
     "react": "",
     "react-dom": ""
+  },
+  "beachball": {
+    "disallowedChangeTypes": [
+      "major",
+      "minor",
+      "patch"
+    ]
   }
 }

--- a/scripts/create-package/plopfile.ts
+++ b/scripts/create-package/plopfile.ts
@@ -236,10 +236,6 @@ function replaceVersionsFromReference(
     if (packageJsons[0].version?.[0] !== '9') {
       throw new Error(`Converged reference package ${packageJsons[0].name} does not appear to have version 9.x`);
     }
-    // Update beachball config in package.json to match the current v9
-    if (packageJsons[0].beachball) {
-      newPackageJson.beachball = packageJsons[0].beachball;
-    }
   }
 }
 


### PR DESCRIPTION
## Current Behavior

Newly created packages are version `9.0.0-alpha.0` by default, but disallow `prerelease` change types. This makes it so the initial release will likely be `patch` or `minor` by default, which will end up publishing a non-alpha/beta release.

## New Behavior

Update package template beachball config to allow only `prerelease` changes by default

## Related Issue(s)

This came up when publishing the react-field package: https://github.com/microsoft/fluentui/pull/24235#discussion_r966517189
