### PR TITLE
feat(react-components): Adding missing AvatarGroup exports

### DIFF
--- a/change/@fluentui-react-components-27ab0583-ddc1-41ff-abe2-0ab8fe34d69b.json
+++ b/change/@fluentui-react-components-27ab0583-ddc1-41ff-abe2-0ab8fe34d69b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Adding missing AvatarGroup exports.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-27ab0583-ddc1-41ff-abe2-0ab8fe34d69b.json
+++ b/change/@fluentui-react-components-27ab0583-ddc1-41ff-abe2-0ab8fe34d69b.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "feat: Adding missing AvatarGroup exports.",
   "packageName": "@fluentui/react-components",
   "email": "esteban.230@hotmail.com",

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -16,7 +16,13 @@ import { avatarGroupItemClassNames } from '@fluentui/react-avatar';
 import { AvatarGroupItemProps } from '@fluentui/react-avatar';
 import { AvatarGroupItemSlots } from '@fluentui/react-avatar';
 import { AvatarGroupItemState } from '@fluentui/react-avatar';
+import { AvatarGroupPopover } from '@fluentui/react-avatar';
+import { avatarGroupPopoverClassNames } from '@fluentui/react-avatar';
+import { AvatarGroupPopoverProps } from '@fluentui/react-avatar';
+import { AvatarGroupPopoverSlots } from '@fluentui/react-avatar';
+import { AvatarGroupPopoverState } from '@fluentui/react-avatar';
 import { AvatarGroupProps } from '@fluentui/react-avatar';
+import { AvatarGroupProvider } from '@fluentui/react-avatar';
 import { AvatarGroupSlots } from '@fluentui/react-avatar';
 import { AvatarGroupState } from '@fluentui/react-avatar';
 import { Card } from '@fluentui/react-card';
@@ -132,6 +138,7 @@ import { RadioGroupFieldProps } from '@fluentui/react-field';
 import { renderAlert_unstable } from '@fluentui/react-alert';
 import { renderAvatarGroup_unstable } from '@fluentui/react-avatar';
 import { renderAvatarGroupItem_unstable } from '@fluentui/react-avatar';
+import { renderAvatarGroupPopover_unstable } from '@fluentui/react-avatar';
 import { renderCard_unstable } from '@fluentui/react-card';
 import { renderCardFooter_unstable } from '@fluentui/react-card';
 import { renderCardHeader_unstable } from '@fluentui/react-card';
@@ -251,8 +258,11 @@ import { ToolbarToggleButtonState } from '@fluentui/react-toolbar';
 import { useAlert_unstable } from '@fluentui/react-alert';
 import { useAlertStyles_unstable } from '@fluentui/react-alert';
 import { useAvatarGroup_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupContext_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupItem_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupItemStyles_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupPopover_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupPopoverStyles_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupStyles_unstable } from '@fluentui/react-avatar';
 import { useCard_unstable } from '@fluentui/react-card';
 import { useCardFooter_unstable } from '@fluentui/react-card';
@@ -336,7 +346,19 @@ export { AvatarGroupItemSlots }
 
 export { AvatarGroupItemState }
 
+export { AvatarGroupPopover }
+
+export { avatarGroupPopoverClassNames }
+
+export { AvatarGroupPopoverProps }
+
+export { AvatarGroupPopoverSlots }
+
+export { AvatarGroupPopoverState }
+
 export { AvatarGroupProps }
+
+export { AvatarGroupProvider }
 
 export { AvatarGroupSlots }
 
@@ -567,6 +589,8 @@ export { renderAlert_unstable }
 export { renderAvatarGroup_unstable }
 
 export { renderAvatarGroupItem_unstable }
+
+export { renderAvatarGroupPopover_unstable }
 
 export { renderCard_unstable }
 
@@ -806,9 +830,15 @@ export { useAlertStyles_unstable }
 
 export { useAvatarGroup_unstable }
 
+export { useAvatarGroupContext_unstable }
+
 export { useAvatarGroupItem_unstable }
 
 export { useAvatarGroupItemStyles_unstable }
+
+export { useAvatarGroupPopover_unstable }
+
+export { useAvatarGroupPopoverStyles_unstable }
 
 export { useAvatarGroupStyles_unstable }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -11,14 +11,21 @@ export type { AlertProps, AlertSlots, AlertState } from '@fluentui/react-alert';
 export {
   AvatarGroup,
   AvatarGroupItem,
+  AvatarGroupPopover,
+  AvatarGroupProvider,
   avatarGroupClassNames,
   avatarGroupItemClassNames,
+  avatarGroupPopoverClassNames,
   renderAvatarGroup_unstable,
   renderAvatarGroupItem_unstable,
+  renderAvatarGroupPopover_unstable,
   useAvatarGroup_unstable,
   useAvatarGroupItem_unstable,
+  useAvatarGroupPopover_unstable,
   useAvatarGroupStyles_unstable,
   useAvatarGroupItemStyles_unstable,
+  useAvatarGroupPopoverStyles_unstable,
+  useAvatarGroupContext_unstable,
 } from '@fluentui/react-avatar';
 export type {
   AvatarGroupProps,
@@ -27,6 +34,9 @@ export type {
   AvatarGroupItemProps,
   AvatarGroupItemSlots,
   AvatarGroupItemState,
+  AvatarGroupPopoverProps,
+  AvatarGroupPopoverSlots,
+  AvatarGroupPopoverState,
 } from '@fluentui/react-avatar';
 export {
   Card,


### PR DESCRIPTION
This PR adds missing exports from AvatarGroup to `@fluentui/react-components/unstable`.

Fixes #24767
