### PR TITLE
add v9 link to homepage

### DIFF
--- a/packages/fluentui/docs/src/views/Introduction.tsx
+++ b/packages/fluentui/docs/src/views/Introduction.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import { Flex, Header } from '@fluentui/react-northstar';
 
 import pkg from '@fluentui/react-northstar/package.json';
@@ -47,6 +47,11 @@ const Introduction = () => (
     <h3>Start</h3>
     <p>
       If you want to get going right away, see the <NavLink to="quick-start">Quick Start</NavLink> guide.
+    </p>
+
+    <h3>Fluent UI React V9</h3>
+    <p>
+      This is our latest and more performant library, <Link to="https://react.fluentui.dev/">link to docs</Link>.
     </p>
   </div>
 );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Why not adding V9 link on the homepage of V0? 
-- Copy is just a placeholder --

## Current Behavior

![image](https://user-images.githubusercontent.com/22919198/189897655-8306c34e-b967-4dca-bed5-6d6b6ab5f890.png)

## New Behavior

![image](https://user-images.githubusercontent.com/22919198/189897610-88142652-2d9f-482b-a321-6ad70777fb09.png)
