### PR TITLE
fix: Adding 'aria-expanded=false' to collapsed MenuButtons

### DIFF
--- a/change/@fluentui-react-button-05205cf2-d4cc-414b-b0e7-dfa4d0da785a.json
+++ b/change/@fluentui-react-button-05205cf2-d4cc-414b-b0e7-dfa4d0da785a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Adding 'aria-expanded=false' to collapsed MenuButtons.",
+  "packageName": "@fluentui/react-button",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-components/react-button/src/components/MenuButton/useMenuButton.tsx
@@ -12,6 +12,7 @@ export const useMenuButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): MenuButtonState => {
   const buttonState = useButton_unstable(props, ref);
+  buttonState.root['aria-expanded'] = props['aria-expanded'] ?? false;
 
   return {
     // Button state
@@ -27,10 +28,6 @@ export const useMenuButton_unstable = (
       menuIcon: 'span',
     },
 
-    root: {
-      ...buttonState.root,
-      'aria-expanded': props['aria-expanded'] ?? false,
-    },
     menuIcon: resolveShorthand(menuIcon, {
       defaultProps: {
         children: <ChevronDownRegular />,

--- a/packages/react-components/react-button/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-components/react-button/src/components/MenuButton/useMenuButton.tsx
@@ -12,6 +12,7 @@ export const useMenuButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): MenuButtonState => {
   const buttonState = useButton_unstable(props, ref);
+
   return {
     // Button state
     ...buttonState,
@@ -26,6 +27,10 @@ export const useMenuButton_unstable = (
       menuIcon: 'span',
     },
 
+    root: {
+      ...buttonState.root,
+      'aria-expanded': props['aria-expanded'] ?? false,
+    },
     menuIcon: resolveShorthand(menuIcon, {
       defaultProps: {
         children: <ChevronDownRegular />,


### PR DESCRIPTION
## Current Behavior

While open `MenuButtons` have `aria-expanded` set to `true`, collapsed `MenuButtons` do not have `aria-expanded` set to `false`, and instead have it `undefined`. This can create some problems regarding screen reader access where users of screen readers do not realize `MenuButtons` have collapsed menus.

## New Behavior

Collapsed `MenuButtons` now have `aria-expanded` set to `false`, correctly indicating this information for all screen readers.

## Related Issue(s)

Fixes #21409
