### PR TITLE
feat: add data attr to react-combobox Options

### DIFF
--- a/change/@fluentui-react-combobox-9835f101-f7a3-415d-975f-1caeea8cb899.json
+++ b/change/@fluentui-react-combobox-9835f101-f7a3-415d-975f-1caeea8cb899.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add data prop to Option element to be passed through to callback data\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -131,6 +131,7 @@ export type OptionGroupState = ComponentState<OptionGroupSlots>;
 
 // @public
 export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
+    data?: any;
     disabled?: boolean;
     value?: string;
 };

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -131,7 +131,7 @@ export type OptionGroupState = ComponentState<OptionGroupSlots>;
 
 // @public
 export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
-    data?: any;
+    data?: unknown;
     disabled?: boolean;
     value?: string;
 };

--- a/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
@@ -112,9 +112,10 @@ describe('Option', () => {
 
   it('registers with default values', () => {
     const registerOption = jest.fn();
+    const testData = { key: 'test' };
     const { getByRole } = render(
       <ListboxContext.Provider value={{ ...defaultContextValues, registerOption }}>
-        <Option>Option 1</Option>
+        <Option data={testData}>Option 1</Option>
       </ListboxContext.Provider>,
     );
 
@@ -126,6 +127,7 @@ describe('Option', () => {
     expect(typeof registerProps?.id).toEqual('string');
     expect(registerProps?.disabled).toBeFalsy();
     expect(registerProps?.value).toEqual('Option 1');
+    expect(registerProps?.data).toEqual(testData);
     expect(registerRef).toEqual(getByRole('option'));
   });
 

--- a/packages/react-components/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-components/react-combobox/src/components/Option/Option.types.ts
@@ -15,8 +15,7 @@ export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
   /**
    * Add optional custom data to options, which will be passed through to onOptionSelect
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any;
+  data?: unknown;
 
   /**
    * Sets an option to the `disabled` state.

--- a/packages/react-components/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-components/react-combobox/src/components/Option/Option.types.ts
@@ -13,14 +13,20 @@ export type OptionSlots = {
  */
 export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
   /**
+   * Add optional custom data to options, which will be passed through to onOptionSelect
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any;
+
+  /**
    * Sets an option to the `disabled` state.
    * Disabled options cannot be selected, but are still keyboard navigable
    */
   disabled?: boolean;
 
   /*
-   * Defines a string value for the option, used for the parent Combobox's value.
-   * Use this if the children are not a string, or you wish the value to differ from the displayed text.
+   * Defines a string value for the option, used for the parent Combobox's value and filtering/typing logic.
+   * Use this if the children use JSX instead of a simple string (e.g. options that include an icon or image).
    */
   value?: string;
 };

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -31,7 +31,7 @@ function getValueString(value: string | undefined, children: React.ReactNode) {
  * @param ref - reference to root HTMLElement of Option
  */
 export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElement>): OptionState => {
-  const { disabled, value } = props;
+  const { data, disabled, value } = props;
   const optionRef = React.useRef<HTMLElement>(null);
   const optionValue = getValueString(value, props.children);
 
@@ -39,8 +39,9 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
   const id = useId('fluent-option', props.id);
 
   // data used for context registration & events
-  const optionData = React.useMemo<OptionValue>(() => ({ id, disabled, value: optionValue }), [
+  const optionData = React.useMemo<OptionValue>(() => ({ id, data, disabled, value: optionValue }), [
     id,
+    data,
     disabled,
     optionValue,
   ]);

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxControlled.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxControlled.stories.tsx
@@ -58,7 +58,7 @@ export const Controlled = (props: Partial<ComboboxProps>) => {
 
   const onSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
     setValue(data.optionValue);
-    setSelectedIcon(data.optionData);
+    setSelectedIcon(data.optionData as string | undefined);
   };
 
   return (

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxControlled.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxControlled.stories.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import {
+  AnimalCat20Filled,
+  AnimalDog20Filled,
+  AnimalRabbit20Filled,
+  AnimalTurtle20Filled,
+  FoodFish20Filled,
+} from '@fluentui/react-icons';
+import { Combobox, Option } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
+
+const useStyles = makeStyles({
+  root: {
+    // Stack the label above the field with a gap
+    display: 'grid',
+    gridTemplateRows: 'repeat(1fr)',
+    justifyItems: 'start',
+    ...shorthands.gap('2px'),
+    maxWidth: '400px',
+  },
+  selection: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+const iconMap = (icon?: string): React.FunctionComponent | null => {
+  switch (icon) {
+    case 'Animal Cat':
+      return AnimalCat20Filled;
+    case 'Animal Dog':
+      return AnimalDog20Filled;
+    case 'Animal Rabbit':
+      return AnimalRabbit20Filled;
+    case 'Animal Turtle':
+      return AnimalTurtle20Filled;
+    case 'Food Fish':
+      return FoodFish20Filled;
+    default:
+      return null;
+  }
+};
+
+export const Controlled = (props: Partial<ComboboxProps>) => {
+  const comboId = useId('combo-controlled');
+  const [value, setValue] = React.useState<string | undefined>();
+  const [selectedIcon, setSelectedIcon] = React.useState<string | undefined>();
+  const SelectedIcon = iconMap(selectedIcon);
+  const options = [
+    { name: 'Cat', icon: 'Animal Cat' },
+    { name: 'Dog', icon: 'Animal Dog' },
+    { name: 'Rabbit', icon: 'Animal Rabbit' },
+    { name: 'Fish', icon: 'Food Fish' },
+    { name: 'Turtle', icon: 'Animal Turtle' },
+  ];
+  const styles = useStyles();
+
+  const onSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
+    setValue(data.optionValue);
+    setSelectedIcon(data.optionData);
+  };
+
+  return (
+    <div className={styles.root}>
+      <label id={comboId}>Best pet</label>
+      <Combobox
+        aria-labelledby={comboId}
+        value={value}
+        placeholder="Select an animal"
+        onOptionSelect={onSelect}
+        {...props}
+      >
+        {options.map(option => {
+          const Icon = iconMap(option.icon);
+          return (
+            <Option key={option.name} value={option.name} data={option.icon}>
+              {Icon ? <Icon /> : null} {option.name}
+            </Option>
+          );
+        })}
+      </Combobox>
+      {SelectedIcon ? (
+        <span className={styles.selection}>
+          Selected: <SelectedIcon />
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+Controlled.parameters = {
+  docs: {
+    description: {
+      story: "A Combobox's value can be controlled by updating the `value` prop in response to `onOptionSelect`.",
+    },
+  },
+};

--- a/packages/react-components/react-combobox/src/stories/Combobox/index.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/index.stories.tsx
@@ -11,6 +11,7 @@ export { Multiselect } from './ComboboxMultiselect.stories';
 export { Grouped } from './ComboboxGrouped.stories';
 export { Appearance } from './ComboboxAppearance.stories';
 export { Size } from './ComboboxSize.stories';
+export { Controlled } from './ComboboxControlled.stories';
 
 export default {
   title: 'Preview Components/Combobox',

--- a/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
@@ -1,4 +1,8 @@
 export type OptionValue = {
+  /** Custom author-provided data defined in the Option's `data` attribute */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
+
   /** The disabled state of the option. */
   disabled?: boolean;
 

--- a/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
@@ -1,7 +1,6 @@
 export type OptionValue = {
   /** Custom author-provided data defined in the Option's `data` attribute */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any;
+  data: unknown;
 
   /** The disabled state of the option. */
   disabled?: boolean;

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -35,8 +35,14 @@ export type SelectionValue = {
 /*
  * Data for the onOptionSelect callback.
  * `optionValue` will be undefined if the multiple options are modified at once.
+ * `optionData` passes through any custom value defined in the selected Option's `data` attribute.
  */
-export type OptionOnSelectData = { optionValue: string | undefined; selectedOptions: string[] };
+export type OptionOnSelectData = {
+  optionValue: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  optionData: any;
+  selectedOptions: string[];
+};
 
 /* Possible event types for onOptionSelect */
 export type SelectionEvents =

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -39,8 +39,7 @@ export type SelectionValue = {
  */
 export type OptionOnSelectData = {
   optionValue: string | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  optionData: any;
+  optionData: unknown;
   selectedOptions: string[];
 };
 

--- a/packages/react-components/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-components/react-combobox/src/utils/useSelection.ts
@@ -33,12 +33,12 @@ export const useSelection = (props: SelectionProps): SelectionValue => {
     }
 
     setSelectedOptions(newSelection);
-    onOptionSelect?.(event, { optionValue: option.value, selectedOptions: newSelection });
+    onOptionSelect?.(event, { optionValue: option.value, optionData: option.data, selectedOptions: newSelection });
   };
 
   const clearSelection = (event: SelectionEvents) => {
     setSelectedOptions([]);
-    onOptionSelect?.(event, { optionValue: undefined, selectedOptions: [] });
+    onOptionSelect?.(event, { optionValue: undefined, optionData: undefined, selectedOptions: [] });
   };
 
   return { clearSelection, selectOption, selectedOptions };


### PR DESCRIPTION
This is in response to a product team request to be able to pass through a custom data value that is available in the `onOptionSelect` callback (something that might be equivalent to the HTML `value` attribute, except our `value` attribute is used to define string values used for the input value and type-to-search functionality).

A `data` prop is added to OptionProps, and is included in the `onOptionSelect` data object.