### PR TITLE
ci(github): add GH Action to add issue labels based on new GH issue template

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,21 @@
+name: Triage Bot
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  triage-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Naturalclar/issue-action@v2.0.2
+        with:
+          title-or-body: 'body'
+          parameters: >
+            '[
+              {"keywords": ["@fluentui/react-northstar"], "labels": ["Fluent UI react-northstar (v0)"]},
+              {"keywords": ["@fluentui/react"], "labels": ["Fluent UI react (v8)"]},
+              {"keywords": ["@fluentui/react-components"], "labels": ["Fluent UI react-components (v9)"]},
+              {"keywords": ["@fluentui/web-components"],"labels": ["web-components"],"assignees": ["@chrisdholt"]}
+            ]'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- issue is created for particular project but manual work needs to be done to properly assign project label

## New Behavior

- based on picked project, we will automatically add proper label. 

<img width="362" alt="image" src="https://user-images.githubusercontent.com/1223799/190106265-80c3aac8-0f6e-4a83-a7a0-94f6c44d2d0b.png">
↓↓↓
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/1223799/190106473-fd007d87-f09a-4493-aafd-781a8404ae45.png">


> **Note:** Adding to unified board will be done in separate PR after internal team discussion

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows https://github.com/microsoft/fluentui/pull/22337
