### PR TITLE
refactor: Stop using context selector for Table primitives

### DIFF
--- a/change/@fluentui-react-table-c1964582-3ba3-4333-a5b2-7ff17480683a.json
+++ b/change/@fluentui-react-table-c1964582-3ba3-4333-a5b2-7ff17480683a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: Stop using context selector for Table primitives",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -11,11 +11,7 @@ import type { Checkbox } from '@fluentui/react-checkbox';
 import type { CheckboxProps } from '@fluentui/react-checkbox';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import { ContextSelector } from '@fluentui/react-context-selector';
-import { FC } from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { Provider } from 'react';
-import { ProviderProps } from 'react';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -160,7 +156,7 @@ export const tableClassName = "fui-Table";
 export const tableClassNames: SlotClassNames<TableSlots>;
 
 // @public (undocumented)
-export const TableContextProvider: Provider<TableContextValue | undefined> & FC<ProviderProps<TableContextValue | undefined>>;
+export const TableContextProvider: React_2.Provider<TableContextValue | undefined>;
 
 // @public (undocumented)
 export type TableContextValue = {
@@ -327,7 +323,7 @@ export const useTableCellLayoutStyles_unstable: (state: TableCellLayoutState) =>
 export const useTableCellStyles_unstable: (state: TableCellState) => TableCellState;
 
 // @public (undocumented)
-export const useTableContext: <T>(selector: ContextSelector<TableContextValue, T>) => T;
+export const useTableContext: () => TableContextValue;
 
 // @public
 export const useTableHeader_unstable: (props: TableHeaderProps, ref: React_2.Ref<HTMLElement>) => TableHeaderState;

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.1.0",
     "@fluentui/react-checkbox": "^9.0.4",
-    "@fluentui/react-context-selector": "^9.0.2",
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-tabster": "^9.1.0",
     "@fluentui/react-theme": "^9.0.0",

--- a/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableContextValues.ts
@@ -1,13 +1,19 @@
+import * as React from 'react';
 import { TableContextValues, TableState } from './Table.types';
 
 export function useTableContextValues_unstable(state: TableState): TableContextValues {
   const { size, noNativeElements, sortable } = state;
 
-  return {
-    table: {
+  const tableContext = React.useMemo(
+    () => ({
       noNativeElements,
       size,
       sortable,
-    },
+    }),
+    [noNativeElements, size, sortable],
+  );
+
+  return {
+    table: tableContext,
   };
 }

--- a/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
+++ b/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
@@ -13,7 +13,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableBody
  */
 export const useTableBody_unstable = (props: TableBodyProps, ref: React.Ref<HTMLElement>): TableBodyState => {
-  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
+  const { noNativeElements } = useTableContext();
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'tbody';
 
   return {

--- a/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
@@ -13,7 +13,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableCell
  */
 export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTMLElement>): TableCellState => {
-  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
+  const { noNativeElements } = useTableContext();
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'td';
 

--- a/packages/react-components/react-table/src/components/TableHeader/useTableHeader.ts
+++ b/packages/react-components/react-table/src/components/TableHeader/useTableHeader.ts
@@ -14,8 +14,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableHeader
  */
 export const useTableHeader_unstable = (props: TableHeaderProps, ref: React.Ref<HTMLElement>): TableHeaderState => {
-  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
-  const sortable = useTableContext(ctx => ctx.sortable);
+  const { noNativeElements, sortable } = useTableContext();
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'horizontal', circular: true });
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'thead';

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
@@ -23,8 +23,7 @@ export const useTableHeaderCell_unstable = (
   props: TableHeaderCellProps,
   ref: React.Ref<HTMLElement>,
 ): TableHeaderCellState => {
-  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
-  const sortable = useTableContext(ctx => ctx.sortable);
+  const { noNativeElements, sortable } = useTableContext();
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'th';
   return {

--- a/packages/react-components/react-table/src/components/TableRow/useTableRow.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRow.ts
@@ -13,8 +13,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableRow
  */
 export const useTableRow_unstable = (props: TableRowProps, ref: React.Ref<HTMLElement>): TableRowState => {
-  const noNativeElements = useTableContext(ctx => ctx.noNativeElements);
-  const size = useTableContext(ctx => ctx.size);
+  const { noNativeElements, size } = useTableContext();
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'tr';
 
   return {

--- a/packages/react-components/react-table/src/contexts/tableContext.ts
+++ b/packages/react-components/react-table/src/contexts/tableContext.ts
@@ -1,7 +1,7 @@
-import { createContext, useContextSelector, ContextSelector } from '@fluentui/react-context-selector';
+import * as React from 'react';
 import { TableContextValue } from '../components/Table/Table.types';
 
-const tableContext = createContext<TableContextValue | undefined>(undefined);
+const tableContext = React.createContext<TableContextValue | undefined>(undefined);
 
 export const tableContextDefaultValue: TableContextValue = {
   size: 'medium',
@@ -10,5 +10,4 @@ export const tableContextDefaultValue: TableContextValue = {
 };
 
 export const TableContextProvider = tableContext.Provider;
-export const useTableContext = <T>(selector: ContextSelector<TableContextValue, T>) =>
-  useContextSelector(tableContext, (ctx = tableContextDefaultValue) => selector(ctx));
+export const useTableContext = () => React.useContext(tableContext) ?? tableContextDefaultValue;


### PR DESCRIPTION
The current usage of context selector doesn't bring any value. Revert to native react context instead


Fixes #
