### PR TITLE
test(react-charting): update obsolete snapshots

### DIFF
--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"
@@ -157,7 +157,7 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
                 fill: #ffffff;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
-                font-weight: 400;
+                font-weight: 600;
                 pointer-events: none;
               }
           dominantBaseline="middle"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

react-charting `test` is broken and blocks release of v9

<img width="515" alt="image" src="https://user-images.githubusercontent.com/1223799/190357247-4938d50c-c94d-497a-b373-ccc71814a74f.png">


## New Behavior

- updated snapshots so master can be used to release v9
- Im not sure what's going on, this was introduced in following PR where pipelines passed https://github.com/microsoft/fluentui/pull/24390

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


