### PR TITLE
fix(scripts): v9 release should not include v8 docsite in scope

### DIFF
--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -23,6 +23,8 @@ const websitePackages = [
   '@fluentui/api-docs',
 ];
 
+const releaseScope = process.env.RELEASE_VNEXT ? 'v9' : 'v8';
+
 // Only include the packages that are published daily by beachball, and some website/doc packages
 // (which must be built and uploaded with each release). This is similar to "--scope \"!packages/fluentui/*\""
 // in the root package.json's publishing-related scripts and will need to be updated if --scope changes.
@@ -30,16 +32,17 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => {
     const isNorthstar = /[\\/]fluentui[\\/]/.test(packagePath);
 
+    // Northstar has separate release tooling, always ignore northstar
     if (isNorthstar) {
       return false;
     }
 
     const isConverged = isConvergedPackage({ packagePathOrJson: packageJson });
-    if (process.env.RELEASE_VNEXT && isConverged) {
+    if (releaseScope === 'v9') {
       return packageJson.private !== true;
     }
 
-    if (!isConverged) {
+    if (!isConverged && releaseScope === 'v8') {
       // v8 scope
       return websitePackages.includes(packageJson.name) || packageJson.private !== true;
     }

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -38,7 +38,7 @@ const beachballPackageScopes = Object.entries(getAllPackageInfo())
     }
 
     const isConverged = isConvergedPackage({ packagePathOrJson: packageJson });
-    if (releaseScope === 'v9') {
+    if (releaseScope === 'v9' && isConverged) {
       return packageJson.private !== true;
     }
 


### PR DESCRIPTION
The current scoping means that v8 docsites will always be in scope for v9 release
