### PR TITLE
bugfix(react-tooltip): stops propagation on Escape keydown

### DIFF
--- a/change/@fluentui-react-dialog-4c5ea8d4-22d0-4d9e-a2b6-c4730f2760c7.json
+++ b/change/@fluentui-react-dialog-4c5ea8d4-22d0-4d9e-a2b6-c4730f2760c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Includes Tooltip Escape scenarios on e2e tests",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-cd8ed1f4-6139-4f4e-b524-3d882bce4cac.json
+++ b/change/@fluentui-react-tooltip-cd8ed1f4-6139-4f4e-b524-3d882bce4cac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: stops propagation on Escape key",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/e2e/Dialog.e2e.tsx
+++ b/packages/react-components/react-dialog/e2e/Dialog.e2e.tsx
@@ -15,6 +15,7 @@ import {
   Popover,
   PopoverSurface,
   PopoverTrigger,
+  Tooltip,
 } from '@fluentui/react-components';
 import {
   dialogSurfaceSelector,
@@ -215,22 +216,30 @@ describe('Dialog', () => {
           </DialogBody>
           <DialogActions>
             <DialogTrigger>
-              <Button id={dialogTriggerCloseId} appearance="secondary">
-                Close
-              </Button>
+              <Tooltip hideDelay={0} showDelay={0} content="Test tooltip" relationship="label">
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
+              </Tooltip>
             </DialogTrigger>
             <Button appearance="primary">Do Something</Button>
           </DialogActions>
         </DialogSurface>
       </Dialog>,
     );
+    // Open Menu and then close it with Escape
     cy.get(dialogTriggerOpenSelector).realClick();
     cy.get('#open-menu-btn').realClick();
     cy.focused().realType('{esc}');
     cy.get(dialogSurfaceSelector).should('exist');
 
+    // Open Popover and then close it with Escape
     cy.get('#open-popover-btn').realClick();
     cy.focused().realType('{esc}');
+    cy.get(dialogSurfaceSelector).should('exist');
+
+    // Open Tooltip, wait for the tooltip to appear and then close it with Escape
+    cy.get(dialogTriggerCloseSelector).focus().wait(0).realType('{esc}');
     cy.get(dialogSurfaceSelector).should('exist');
   });
   describe('modalType = modal', () => {

--- a/packages/react-components/react-tooltip/package.json
+++ b/packages/react-components/react-tooltip/package.json
@@ -32,6 +32,7 @@
     "@fluentui/scripts": "^1.0.0"
   },
   "dependencies": {
+    "@fluentui/keyboard-keys": "^9.0.0",
     "@fluentui/react-portal": "^9.0.5",
     "@fluentui/react-positioning": "^9.2.0",
     "@fluentui/react-shared-contexts": "^9.0.1",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently  pressing `Escape` key to dismiss a `Tooltip`, will propagate a `Escape` keydown event that might trigger dismiss in more than just the `Tooltip` itself. see https://github.com/microsoft/fluentui/pull/24750

## New Behavior

1. Stops propagating `Escape` keydown to ensure only `Tooltip` is dismissed.
2. Captures keydown event on target document, to ensure `Tooltip` escape behaviour is the first thing to be executed.
3. Adds Dialog e2e test scenario to ensure this behaviour

