### PR TITLE
Prevent group toggling from selecting the whole group

### DIFF
--- a/change/@fluentui-react-ab3b8086-f406-44cd-bef5-7782fdef2863.json
+++ b/change/@fluentui-react-ab3b8086-f406-44cd-bef5-7782fdef2863.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure toggling group state does not select it",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -7951,6 +7951,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     background-color: #e1dfdd;
                                   }
                               data-is-focusable={false}
+                              data-selection-disabled={true}
                               onClick={[Function]}
                               type="button"
                             >
@@ -8812,6 +8813,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     background-color: #e1dfdd;
                                   }
                               data-is-focusable={false}
+                              data-selection-disabled={true}
                               onClick={[Function]}
                               type="button"
                             >

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -165,6 +165,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
           <div role="gridcell">
             <button
               data-is-focusable={false}
+              data-selection-disabled={true}
               type="button"
               className={this._classNames.expand}
               onClick={this._onToggleClick}


### PR DESCRIPTION
## Current Behavior

Since the most-recent changes to improve group selection have gone in, there is a bug where clicking the button to toggle group state is propagating to select the whole group.

## New Behavior

This PR prevents a click on the toggle button from propagating to select the whole group.
