### PR TITLE
fix: Add explicit children prop to TeachingBubble to support React 18

### DIFF
--- a/change/@fluentui-react-ea32524a-6ed8-4a2c-bbda-87c6389f2dd1.json
+++ b/change/@fluentui-react-ea32524a-6ed8-4a2c-bbda-87c6389f2dd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Add explicit children prop to TeachingBubble to support React 18",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9105,6 +9105,8 @@ export interface ITeachingBubbleProps extends React_2.RefAttributes<HTMLDivEleme
     ariaDescribedBy?: string;
     ariaLabelledBy?: string;
     calloutProps?: ICalloutProps;
+    // (undocumented)
+    children?: React_2.ReactNode;
     componentRef?: IRefObject<ITeachingBubble>;
     focusTrapZoneProps?: IFocusTrapZoneProps;
     footerContent?: string | JSX.Element;

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -21,6 +21,8 @@ export interface ITeachingBubble {
  * {@docCategory TeachingBubble}
  */
 export interface ITeachingBubbleProps extends React.RefAttributes<HTMLDivElement>, IAccessiblePopupProps {
+  children?: React.ReactNode;
+
   /**
    * Optional callback to access the ITeachingBubble interface. Use this instead of ref for accessing
    * the public methods and properties of the component.


### PR DESCRIPTION
In React 18 we need to explicitly define if a component accepts children. 

#22592