### PR TITLE
fix: export `tableCellActionsClassNames` from unstable

### DIFF
--- a/change/@fluentui-react-components-7af2adef-a1c8-4aed-b2b3-0cdb7c48f10c.json
+++ b/change/@fluentui-react-components-7af2adef-a1c8-4aed-b2b3-0cdb7c48f10c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export `tableCellActionsClassNames` from unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -193,6 +193,7 @@ import { TableBodySlots } from '@fluentui/react-table';
 import { TableBodyState } from '@fluentui/react-table';
 import { TableCell } from '@fluentui/react-table';
 import { TableCellActions } from '@fluentui/react-table';
+import { tableCellActionsClassNames } from '@fluentui/react-table';
 import { TableCellActionsProps } from '@fluentui/react-table';
 import { TableCellActionsSlots } from '@fluentui/react-table';
 import { TableCellActionsState } from '@fluentui/react-table';
@@ -697,6 +698,8 @@ export { TableBodyState }
 export { TableCell }
 
 export { TableCellActions }
+
+export { tableCellActionsClassNames }
 
 export { TableCellActionsProps }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -277,6 +277,7 @@ export {
   useTableCellActionsStyles_unstable,
   useTableCellActions_unstable,
   renderTableCellActions_unstable,
+  tableCellActionsClassNames,
   TableCellLayout,
   useTableCellLayout_unstable,
   useTableCellLayoutStyles_unstable,


### PR DESCRIPTION
Fixes #
