### PR TITLE
Set minimum width of 1% for multi stacked horizontal bar chart

### DIFF
--- a/change/@fluentui-react-charting-3df6df5e-105a-42a8-813e-82c2bb4f5eef.json
+++ b/change/@fluentui-react-charting-3df6df5e-105a-42a8-813e-82c2bb4f5eef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix multi stacked bar chart min width",
+  "packageName": "@fluentui/react-charting",
+  "email": "atishay.jain@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -140,6 +140,22 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       0,
     );
 
+    let sumOfPercent = 0;
+    data.chartData!.map((point: IChartDataPoint, index: number) => {
+      const pointData = point.data ? point.data : 0;
+      value = (pointData / total) * 100 ? (pointData / total) * 100 : 0;
+      if (value < 1 && value !== 0) {
+        value = 1;
+      } else if (value > 99 && value !== 100) {
+        value = 99;
+      }
+      sumOfPercent += value;
+
+      return sumOfPercent;
+    });
+
+    const scalingRatio = sumOfPercent !== 0 ? sumOfPercent / 100 : 1;
+
     let prevPosition = 0;
     let value = 0;
 
@@ -154,6 +170,13 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         prevPosition += value;
       }
       value = (pointData / total) * 100 ? (pointData / total) * 100 : 0;
+      if (value < 1 && value !== 0) {
+        value = 1 / scalingRatio;
+      } else if (value > 99 && value !== 100) {
+        value = 99 / scalingRatio;
+      } else {
+        value = value / scalingRatio;
+      }
 
       startingPoint.push(prevPosition);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

## New Behavior
Set minimum width of 1% for multi stacked horizontal bar chart elements
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
