### PR TITLE
Divider - allow default prop override

### DIFF
--- a/change/@fluentui-react-divider-f95da959-6db2-4b33-9ec7-d3a4e44656c0.json
+++ b/change/@fluentui-react-divider-f95da959-6db2-4b33-9ec7-d3a4e44656c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Divider - allow props to override default values",
+  "packageName": "@fluentui/react-divider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-divider/src/components/Divider/useDivider.ts
+++ b/packages/react-components/react-divider/src/components/Divider/useDivider.ts
@@ -25,11 +25,11 @@ export const useDivider_unstable = (props: DividerProps, ref: React.Ref<HTMLElem
     },
 
     root: getNativeElementProps('div', {
-      ...props,
-      ref,
       role: 'separator',
       'aria-orientation': vertical ? 'vertical' : 'horizontal',
       'aria-labelledby': props.children ? dividerId : undefined,
+      ...props,
+      ref,
     }),
     wrapper: resolveShorthand(wrapper, {
       required: true,


### PR DESCRIPTION
Customer wanted to use divider as a visual wrapper around a button. Due to role="separator", the button was marked as role="presentational" so it was ignored by narrator.

Moving props to be able to override the default values will give users escape hatches when they need to customize those values (custom orientation, custom labeledby, custom role)