### PR TITLE
chore(react-dialog): scaffold DialogContent component

### DIFF
--- a/change/@fluentui-react-dialog-d69ce942-a1c5-4bc6-83b5-c91a69d5c2b5.json
+++ b/change/@fluentui-react-dialog-d69ce942-a1c5-4bc6-83b5-c91a69d5c2b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: scaffold DialogContent component",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-dialog/config/api-extractor.json
+++ b/packages/react-components/react-dialog/config/api-extractor.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "",
+    "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts"
+  }
 }

--- a/packages/react-components/react-dialog/config/api-extractor.local.json
+++ b/packages/react-components/react-dialog/config/api-extractor.local.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "./api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/packages/react-components/<unscopedPackageName>/src/index.d.ts"
-}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -62,6 +62,23 @@ export type DialogBodySlots = {
 // @public
 export type DialogBodyState = ComponentState<DialogBodySlots>;
 
+// @public
+export const DialogContent: ForwardRefComponent<DialogContentProps>;
+
+// @public (undocumented)
+export const dialogContentClassNames: SlotClassNames<DialogContentSlots>;
+
+// @public
+export type DialogContentProps = ComponentProps<DialogContentSlots> & {};
+
+// @public (undocumented)
+export type DialogContentSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type DialogContentState = ComponentState<DialogContentSlots>;
+
 // @public (undocumented)
 export type DialogOpenChangeData = {
     type: 'dialogCancel';
@@ -174,6 +191,9 @@ export const renderDialogActions_unstable: (state: DialogActionsState) => JSX.El
 export const renderDialogBody_unstable: (state: DialogBodyState) => JSX.Element;
 
 // @public
+export const renderDialogContent_unstable: (state: DialogContentState) => JSX.Element;
+
+// @public
 export const renderDialogSurface_unstable: (state: DialogSurfaceState, contextValues: DialogSurfaceContextValues) => JSX.Element;
 
 // @public
@@ -196,6 +216,12 @@ export const useDialogBody_unstable: (props: DialogBodyProps, ref: React_2.Ref<H
 
 // @public
 export const useDialogBodyStyles_unstable: (state: DialogBodyState) => DialogBodyState;
+
+// @public
+export const useDialogContent_unstable: (props: DialogContentProps, ref: React_2.Ref<HTMLElement>) => DialogContentState;
+
+// @public
+export const useDialogContentStyles_unstable: (state: DialogContentState) => DialogContentState;
 
 // @public
 export const useDialogSurface_unstable: (props: DialogSurfaceProps, ref: React_2.Ref<DialogSurfaceElement>) => DialogSurfaceState;

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -129,6 +129,9 @@ export const DialogSurface: ForwardRefComponent<DialogSurfaceProps>;
 export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots>;
 
 // @public
+export type DialogSurfaceElement = HTMLDialogElement | HTMLDivElement;
+
+// @public
 export type DialogSurfaceProps = Omit<ComponentProps<DialogSurfaceSlots>, 'open' | 'onCancel' | 'onClose'>;
 
 // @public (undocumented)

--- a/packages/react-components/react-dialog/package.json
+++ b/packages/react-components/react-dialog/package.json
@@ -22,10 +22,9 @@
     "test": "jest --passWithNoTests",
     "e2e": "cypress run --component",
     "e2e:local": "cypress open --component",
-    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
-    "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-dialog/src && yarn docs",
     "storybook": "start-storybook",
-    "type-check": "tsc -b tsconfig.json"
+    "type-check": "tsc -b tsconfig.json",
+    "generate-api": "tsc -p ./tsconfig.lib.json --emitDeclarationOnly && just-scripts api-extractor"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/react-components/react-dialog/src/DialogContent.ts
+++ b/packages/react-components/react-dialog/src/DialogContent.ts
@@ -1,0 +1,1 @@
+export * from './components/DialogContent/index';

--- a/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DialogContent } from './DialogContent';
+import { isConformant } from '../../common/isConformant';
+
+describe('DialogContent', () => {
+  isConformant({
+    Component: DialogContent,
+    displayName: 'DialogContent',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DialogContent>Default DialogContent</DialogContent>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDialogContent_unstable } from './useDialogContent';
+import { renderDialogContent_unstable } from './renderDialogContent';
+import { useDialogContentStyles_unstable } from './useDialogContentStyles';
+import type { DialogContentProps } from './DialogContent.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DialogContent component - TODO: add more docs
+ */
+export const DialogContent: ForwardRefComponent<DialogContentProps> = React.forwardRef((props, ref) => {
+  const state = useDialogContent_unstable(props, ref);
+
+  useDialogContentStyles_unstable(state);
+  return renderDialogContent_unstable(state);
+});
+
+DialogContent.displayName = 'DialogContent';

--- a/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.types.ts
@@ -13,5 +13,3 @@ export type DialogContentProps = ComponentProps<DialogContentSlots> & {};
  * State used in rendering DialogContent
  */
 export type DialogContentState = ComponentState<DialogContentSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from DialogContentProps.
-// & Required<Pick<DialogContentProps, 'propName'>>

--- a/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type DialogContentSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * DialogContent Props
+ */
+export type DialogContentProps = ComponentProps<DialogContentSlots> & {};
+
+/**
+ * State used in rendering DialogContent
+ */
+export type DialogContentState = ComponentState<DialogContentSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from DialogContentProps.
+// & Required<Pick<DialogContentProps, 'propName'>>

--- a/packages/react-components/react-dialog/src/components/DialogContent/__snapshots__/DialogContent.test.tsx.snap
+++ b/packages/react-components/react-dialog/src/components/DialogContent/__snapshots__/DialogContent.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DialogContent renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DialogContent"
+  >
+    Default DialogContent
+  </div>
+</div>
+`;

--- a/packages/react-components/react-dialog/src/components/DialogContent/index.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/index.ts
@@ -1,0 +1,5 @@
+export * from './DialogContent';
+export * from './DialogContent.types';
+export * from './renderDialogContent';
+export * from './useDialogContent';
+export * from './useDialogContentStyles';

--- a/packages/react-components/react-dialog/src/components/DialogContent/renderDialogContent.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogContent/renderDialogContent.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { DialogContentState, DialogContentSlots } from './DialogContent.types';
+
+/**
+ * Render the final JSX of DialogContent
+ */
+export const renderDialogContent_unstable = (state: DialogContentState) => {
+  const { slots, slotProps } = getSlots<DialogContentSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContent.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContent.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { DialogContentProps, DialogContentState } from './DialogContent.types';
+
+/**
+ * Create the state required to render DialogContent.
+ *
+ * The returned state can be modified with hooks such as useDialogContentStyles_unstable,
+ * before being passed to renderDialogContent_unstable.
+ *
+ * @param props - props from this instance of DialogContent
+ * @param ref - reference to root HTMLElement of DialogContent
+ */
+export const useDialogContent_unstable = (
+  props: DialogContentProps,
+  ref: React.Ref<HTMLElement>,
+): DialogContentState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { DialogContentSlots, DialogContentState } from './DialogContent.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const dialogContentClassNames: SlotClassNames<DialogContentSlots> = {
+  root: 'fui-DialogContent',
+  // TODO: add class names for all slots on DialogContentSlots.
+  // Should be of the form `<slotName>: 'fui-DialogContent__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the DialogContent slots based on the state
+ */
+export const useDialogContentStyles_unstable = (state: DialogContentState): DialogContentState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(dialogContentClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
@@ -15,7 +15,9 @@ export type DialogSurfaceSlots = {
   root: NonNullable<Slot<'dialog', 'div'>>;
 };
 
-/** @internal */
+/**
+ * Union between all possible semantic element that represent a DialogSurface
+ */
 export type DialogSurfaceElement = HTMLDialogElement | HTMLDivElement;
 
 /** @internal */

--- a/packages/react-components/react-dialog/src/index.ts
+++ b/packages/react-components/react-dialog/src/index.ts
@@ -56,3 +56,12 @@ export {
   renderDialogSurface_unstable,
 } from './DialogSurface';
 export type { DialogSurfaceProps, DialogSurfaceSlots, DialogSurfaceState } from './DialogSurface';
+
+export {
+  DialogContent,
+  dialogContentClassNames,
+  useDialogContent_unstable,
+  useDialogContentStyles_unstable,
+  renderDialogContent_unstable,
+} from './DialogContent';
+export type { DialogContentProps, DialogContentSlots, DialogContentState } from './DialogContent';

--- a/packages/react-components/react-dialog/src/index.ts
+++ b/packages/react-components/react-dialog/src/index.ts
@@ -55,7 +55,7 @@ export {
   useDialogSurfaceStyles_unstable,
   renderDialogSurface_unstable,
 } from './DialogSurface';
-export type { DialogSurfaceProps, DialogSurfaceSlots, DialogSurfaceState } from './DialogSurface';
+export type { DialogSurfaceProps, DialogSurfaceSlots, DialogSurfaceState, DialogSurfaceElement } from './DialogSurface';
 
 export {
   DialogContent,

--- a/packages/react-components/react-dialog/tsconfig.lib.json
+++ b/packages/react-components/react-dialog/tsconfig.lib.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "lib": ["ES2019", "dom"],
-    "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "../../../dist/out-tsc/types",
+    "outDir": "../../../dist/out-tsc",
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

1. Scaffolds `DialogContent` component with `yarn create-component`
2. bugfix: exports `DialogSurfaceElement` to ensure new API extractor validation.
