### PR TITLE
chore: Northstar screener should read from screenerStates.json

### DIFF
--- a/apps/vr-tests-react-components/screener.config.js
+++ b/apps/vr-tests-react-components/screener.config.js
@@ -24,7 +24,7 @@ function getCurrentHash() {
  * @param {string} options.sourceBranchName
  * @param {string} options.deployUrl
  * @param {string} options.targetBranch
- * @returns
+ * @returns {import('@fluentui/scripts/screener/screener.types').ScreenerRunnerConfig}
  */
 function getConfig({ screenerApiKey, sourceBranchName, deployUrl, targetBranch }) {
   const baseBranch = targetBranch ? targetBranch.replace(/^refs\/heads\//, '') : 'master';
@@ -38,6 +38,7 @@ function getConfig({ screenerApiKey, sourceBranchName, deployUrl, targetBranch }
     baseBranch,
     failureExitCode: 0,
     alwaysAcceptBaseBranch: true,
+    states: [],
     ...(sourceBranchName !== 'master' ? { commit: getCurrentHash() } : null),
     baseUrl: `${deployUrl}/react-components-screener/iframe.html`,
   };

--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -27,7 +27,7 @@ function getCurrentHash() {
  * @param {string} options.sourceBranchName
  * @param {string} options.deployUrl
  * @param {string} options.targetBranch
- * @returns
+ * @returns {import('@fluentui/scripts/screener/screener.types').ScreenerRunnerConfig}
  */
 function getConfig({ screenerApiKey, sourceBranchName, deployUrl, targetBranch }) {
   const baseBranch = targetBranch ? targetBranch.replace(/^refs\/heads\//, '') : 'master';
@@ -44,6 +44,7 @@ function getConfig({ screenerApiKey, sourceBranchName, deployUrl, targetBranch }
     alwaysAcceptBaseBranch: true,
     ...(sourceBranchName !== 'master' ? { commit: getCurrentHash() } : null),
     baseUrl: `${deployUrl}/react-screener/iframe.html`,
+    states: [],
   };
   console.log('Screener config: ' + JSON.stringify({ ...config, apiKey: '...' }, null, 2));
   return config;

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -22,7 +22,8 @@ tsPaths.register({
 require('./scripts/gulp/tasks/bundle');
 require('./scripts/gulp/tasks/component-info');
 require('./scripts/gulp/tasks/docs');
-require('./scripts/gulp/tasks/screener');
+require('./scripts/gulp/tasks/vr-build');
+require('./scripts/gulp/tasks/vr-test');
 require('./scripts/gulp/tasks/stats');
 require('./scripts/gulp/tasks/test-unit');
 require('./scripts/gulp/tasks/perf');

--- a/scripts/gulp/tasks/screener.ts
+++ b/scripts/gulp/tasks/screener.ts
@@ -5,7 +5,6 @@ import fs from 'fs';
 import config from '../../config';
 import { getAllPackageInfo } from '../../monorepo';
 import { screenerRunner } from '../../screener/screener.runner';
-import states from '../../screener/screener.states';
 import getConfig from '../../screener/screener.config';
 
 const { paths } = config;
@@ -53,6 +52,8 @@ task('screener:runner', cb => {
 // ----------------------------------------
 
 task('screener:states', cb => {
+  const screenerStatesPath = paths.base('scripts/screener/screener.states.ts');
+  const states = require(screenerStatesPath);
   const statesJson = JSON.stringify(states, null, 2);
   fs.writeFile(paths.docsDist('screenerStates.json'), statesJson, { encoding: 'utf8' }, err => {
     if (err) {

--- a/scripts/gulp/tasks/vr-build.ts
+++ b/scripts/gulp/tasks/vr-build.ts
@@ -1,0 +1,21 @@
+import { task, series } from 'gulp';
+import fs from 'fs';
+
+import config from '../../config';
+import getScreenerStates from '../../screener/screener.states';
+
+const { paths } = config;
+
+task('screener:states', cb => {
+  const states = getScreenerStates();
+  const statesJson = JSON.stringify(states, null, 2);
+  fs.writeFile(paths.docsDist('screenerStates.json'), statesJson, { encoding: 'utf8' }, err => {
+    if (err) {
+      cb(err);
+    }
+
+    cb();
+  });
+});
+
+task('screener:build', series('screener:states'));

--- a/scripts/gulp/tasks/vr-build.ts
+++ b/scripts/gulp/tasks/vr-build.ts
@@ -18,4 +18,4 @@ task('screener:states', cb => {
   });
 });
 
-task('screener:build', series('screener:states'));
+task('screener:build', series('docs:build', 'screener:states'));

--- a/scripts/gulp/tasks/vr-build.ts
+++ b/scripts/gulp/tasks/vr-build.ts
@@ -18,4 +18,4 @@ task('screener:states', cb => {
   });
 });
 
-task('screener:build', series('docs:build', 'screener:states'));
+task('screener:build', series('build:docs', 'screener:states'));

--- a/scripts/gulp/tasks/vr-test.ts
+++ b/scripts/gulp/tasks/vr-test.ts
@@ -1,6 +1,5 @@
-import { task, series } from 'gulp';
+import { task } from 'gulp';
 import { argv } from 'yargs';
-import fs from 'fs';
 
 import config from '../../config';
 import { getAllPackageInfo } from '../../monorepo';
@@ -46,22 +45,3 @@ task('screener:runner', cb => {
 
   handlePromiseExit(screenerRunner(screenerConfig));
 });
-
-// ----------------------------------------
-// Default
-// ----------------------------------------
-
-task('screener:states', cb => {
-  const screenerStatesPath = paths.base('scripts/screener/screener.states.ts');
-  const states = require(screenerStatesPath);
-  const statesJson = JSON.stringify(states, null, 2);
-  fs.writeFile(paths.docsDist('screenerStates.json'), statesJson, { encoding: 'utf8' }, err => {
-    if (err) {
-      cb(err);
-    }
-
-    cb();
-  });
-});
-
-task('screener:build', series('build:docs', 'screener:states'));

--- a/scripts/screener/screener.config.js
+++ b/scripts/screener/screener.config.js
@@ -36,11 +36,13 @@ const baseBranch = 'master';
  * @param {Object} options
  * @param {string} options.screenerApiKey
  * @param {string} options.sourceBranchName
- * @returns
+ * @param {string} options.deployUrl
+ * @returns {import('./screener.types').ScreenerRunnerConfig}
  */
-function getConfig({ screenerApiKey, sourceBranchName }) {
+function getConfig({ screenerApiKey, sourceBranchName, deployUrl }) {
   // https://github.com/screener-io/screener-runner
   return {
+    baseUrl: `${deployUrl}/react-northstar-screener`,
     apiKey: screenerApiKey,
     projectRepo: 'microsoft/fluentui/fluentui',
 
@@ -54,9 +56,7 @@ function getConfig({ screenerApiKey, sourceBranchName }) {
       minShiftGraphic: 1, // Optional threshold for pixel shifts in graphics.
       compareSVGDOM: false, // Pass if SVG DOM is the same. Defaults to false.
     },
-
-    // screenshot every example in maximized mode
-    states: require('./screener.states').default,
+    states: [],
 
     alwaysAcceptBaseBranch: true,
     baseBranch,

--- a/scripts/screener/screener.states.ts
+++ b/scripts/screener/screener.states.ts
@@ -7,42 +7,44 @@ import path from 'path';
 import getScreenerSteps from './screener.steps';
 import { ScreenerState } from './screener.types';
 
-const baseUrl = `${process.env.DEPLOYURL}/react-northstar-screener`;
-const examplePaths = glob.sync('packages/fluentui/docs/src/examples/**/*.tsx', {
-  ignore: ['**/index.tsx', '**/*.knobs.tsx', '**/BestPractices/*.tsx', '**/Playground.tsx'],
-});
+export default function getScreenerStates() {
+  const baseUrl = `${process.env.DEPLOYURL}/react-northstar-screener`;
+  const examplePaths = glob.sync('packages/fluentui/docs/src/examples/**/*.tsx', {
+    ignore: ['**/index.tsx', '**/*.knobs.tsx', '**/BestPractices/*.tsx', '**/Playground.tsx'],
+  });
 
-const pathFilter = process.env.SCREENER_FILTER;
-const filteredPaths: string[] = minimatch.match(examplePaths, pathFilter || '*', {
-  matchBase: true,
-});
+  const pathFilter = process.env.SCREENER_FILTER;
+  const filteredPaths: string[] = minimatch.match(examplePaths, pathFilter || '*', {
+    matchBase: true,
+  });
 
-if (pathFilter) {
-  console.log(chalk.bgGreen.black(' --filter '), pathFilter);
-  filteredPaths.forEach(filteredPath => console.log(`${_.repeat(' ', 10)} ${filteredPath}`));
-}
+  if (pathFilter) {
+    console.log(chalk.bgGreen.black(' --filter '), pathFilter);
+    filteredPaths.forEach(filteredPath => console.log(`${_.repeat(' ', 10)} ${filteredPath}`));
+  }
 
-const getStateForPath = (examplePath: string): ScreenerState => {
-  const { name: exampleNameWithoutExtension, base: exampleNameWithExtension, dir: exampleDir } = path.parse(
-    examplePath,
-  );
+  const getStateForPath = (examplePath: string): ScreenerState => {
+    const { name: exampleNameWithoutExtension, base: exampleNameWithExtension, dir: exampleDir } = path.parse(
+      examplePath,
+    );
 
-  const rtl = exampleNameWithExtension.endsWith('.rtl.tsx');
-  const exampleUrl = _.kebabCase(exampleNameWithoutExtension);
-  const pageUrl = `${baseUrl}/maximize/${exampleUrl}/${rtl}`;
+    const rtl = exampleNameWithExtension.endsWith('.rtl.tsx');
+    const exampleUrl = _.kebabCase(exampleNameWithoutExtension);
+    const pageUrl = `${baseUrl}/maximize/${exampleUrl}/${rtl}`;
 
-  return {
-    url: pageUrl,
-    name: exampleNameWithExtension,
+    return {
+      url: pageUrl,
+      name: exampleNameWithExtension,
 
-    // https://www.npmjs.com/package/screener-runner#testing-interactions
-    steps: getScreenerSteps(pageUrl, `${exampleDir}/${exampleNameWithoutExtension}.steps`),
+      // https://www.npmjs.com/package/screener-runner#testing-interactions
+      steps: getScreenerSteps(pageUrl, `${exampleDir}/${exampleNameWithoutExtension}.steps`),
+    };
   };
-};
 
-const screenerStates = filteredPaths.reduce((states, examplePath) => {
-  states.push(getStateForPath(examplePath));
-  return states;
-}, [] as ReturnType<typeof getStateForPath>[]);
+  const screenerStates = filteredPaths.reduce((states, examplePath) => {
+    states.push(getStateForPath(examplePath));
+    return states;
+  }, [] as ReturnType<typeof getStateForPath>[]);
 
-export default screenerStates;
+  return screenerStates;
+}

--- a/scripts/screener/screener.types.ts
+++ b/scripts/screener/screener.types.ts
@@ -2,7 +2,7 @@ export type ScreenerRunnerConfig = {
   apiKey: string;
   projectRepo: string;
 
-  diffOptions: {
+  diffOptions?: {
     structure: boolean;
     layout: boolean;
     style: boolean;
@@ -10,14 +10,14 @@ export type ScreenerRunnerConfig = {
     minLayoutPosition: number; // Optional threshold for Layout changes. Defaults to 4 pixels.
     minLayoutDimension: number; // Optional threshold for Layout changes. Defaults to 10 pixels.
     minShiftGraphic: number; // Optional threshold for pixel shifts in graphics.
-    compareSVGDOM: number; // Pass if SVG DOM is the same. Defaults to false.
+    compareSVGDOM: boolean; // Pass if SVG DOM is the same. Defaults to false.
   };
 
   states: ScreenerState[];
 
   alwaysAcceptBaseBranch: boolean;
   baseBranch: string;
-  commit: string;
+  commit?: string;
   failureExitCode: number;
 
   /** Base url of deployed storybook screener should test */


### PR DESCRIPTION
Screener is now separated into two workflows for secrets encapsulation, the code to trigger the screener run is actually run on the master branch.

## Current Behavior

The current northstar screener states are generated directly before running, this means that any changes to N* screener tests in a PR will never result in updated screenshots

## New Behavior

Update the `screener:build` gulp command to write all states to a json file and updeates the `screener:runner` gulp tasks to read states from the json file as a result of the build.

Since the entire `docs/dist` artifact is uploaded, there should be no changes needed for the pipeline


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24842
