### PR TITLE
fix: Set github user in nightly release pipeline

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -49,7 +49,7 @@ jobs:
 
         # Deletes all existing changefiles so that only bump that happens is for nightly
       - script: |
-          rm change/*
+          rm -f change/*
         displayName: 'Delete existing changefiles'
 
         # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -37,6 +37,11 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
+      - script: |
+          git config user.name "Fluent UI Build"
+          git config user.email "fluentui-internal@service.microsoft.com"
+        displayName: Configure git user (used by beachball)
+
       - task: Bash@3
         inputs:
           filePath: yarn-ci.sh


### PR DESCRIPTION
It seems that some kind of change happened with our user agents and github user is no longer set by default. So we have to do this manually

## Current Behavior

Nightly release pipeline does not set github user

## New Behavior

Nightly release pipeline sets github user

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
