### PR TITLE
ci: make create-milestone work by adding missing permissions

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions:
+  issues: write
+
 jobs:
   create-milestone:
     name: Create this month's milestone


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

create-milestone GHA is failing

<img width="978" alt="image" src="https://user-images.githubusercontent.com/1223799/191023729-9be674ce-7200-48e7-b917-925643a07d2f.png">


## New Behavior

it works again

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
