### PR TITLE
docs(react-card): remove ASSET_URL export to fix codesandbox examples

### DIFF
--- a/packages/react-components/react-card/src/stories/Card/CardDefault.stories.tsx
+++ b/packages/react-components/react-card/src/stories/Card/CardDefault.stories.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { Body1, Caption1, Button } from '@fluentui/react-components';
 import { ArrowReplyRegular, ShareRegular } from '@fluentui/react-icons';
 import { Card, CardFooter, CardHeader, CardPreview } from '@fluentui/react-card';
-import { ASSET_URL } from './SampleCard.stories';
 
+const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 const avatarElviaURL = ASSET_URL + '/assets/avatar_elvia.svg';
 const wordLogoURL = ASSET_URL + '/assets/word_logo.svg';
 const docTemplateURL = ASSET_URL + '/assets/doc_template.png';

--- a/packages/react-components/react-card/src/stories/Card/CardOrientation.stories.tsx
+++ b/packages/react-components/react-card/src/stories/Card/CardOrientation.stories.tsx
@@ -5,9 +5,7 @@ import { Card, CardHeader, CardPreview } from '@fluentui/react-card';
 import { SampleCard, Title } from './SampleCard.stories';
 import Logo from '../../../assets/logo.svg';
 
-export const ASSET_URL =
-  'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
-
+const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 const avatarElviaURL = ASSET_URL + '/assets/avatar_elvia.svg';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-card/src/stories/Card/CardTemplates.stories.tsx
+++ b/packages/react-components/react-card/src/stories/Card/CardTemplates.stories.tsx
@@ -33,9 +33,7 @@ import office1 from '../../../assets/office1.png';
 import office2 from '../../../assets/office2.png';
 import avatarColin from '../../../assets/avatar_colin.svg';
 
-export const ASSET_URL =
-  'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
-
+const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-card/src/stories/Card/SampleCard.stories.tsx
+++ b/packages/react-components/react-card/src/stories/Card/SampleCard.stories.tsx
@@ -4,9 +4,7 @@ import { MoreHorizontal20Filled, Open16Regular, Share16Regular } from '@fluentui
 import { Card, CardHeader, CardFooter, CardPreview } from '@fluentui/react-card';
 import type { CardProps } from '@fluentui/react-card';
 
-export const ASSET_URL =
-  'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
-
+const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
 const salesPresentationTemplateURL = ASSET_URL + '/assets/sales_template.png';
 


### PR DESCRIPTION
## Current Behavior

By exporting a ASSET_URL, the codesandbox examples were not loading.

## New Behavior

Remove export and use a static variable

## Related Issue(s)

Fixes #24793
