### PR TITLE
react-18-tests-v8: Add type-checking again

### DIFF
--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -12,7 +12,8 @@
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",
-    "start": "webpack-dev-server --mode=development --config=webpack.config.js"
+    "start": "webpack-dev-server --mode=development --config=webpack.config.js",
+    "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/lage.config.js
+++ b/lage.config.js
@@ -11,6 +11,7 @@ module.exports = {
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
+    '@fluentui/react-18-tests-v8#type-check': ['@fluentui/react#build'],
   },
 
   // Adds some ADO-specific logging commands for reporting failures


### PR DESCRIPTION
## Changes:
- Was running into the error below on CI when `@fluentui/react-18-tests-v8` package was running its `type-check` script because this package depends on v8 and the `type-check` script was running before v8 had successfully been built. This change in the `lage.config.js` file ensures that v8 completes its `build` step before running the test apps `type-check`.
```
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenuExample.tsx(7,8): error TS2307: Cannot find module '@fluentui/react/lib/ContextualMenu' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenuExample.tsx(8,43): error TS2307: Cannot find module '@fluentui/react/lib/Button' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenuExample.tsx(9,36): error TS2307: Cannot find module '@fluentui/react/lib/FocusZone' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenuExample.tsx(10,32): error TS2307: Cannot find module '@fluentui/react/lib/Styling' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenuExample.tsx(11,21): error TS2307: Cannot find module '@fluentui/react/lib/Utilities' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenuExample.tsx(12,26): error TS2307: Cannot find module '@fluentui/react-hooks' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/App.tsx(2,70): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/App.tsx(3,28): error TS2307: Cannot find module '@fluentui/react-hooks' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenu.e2e.tsx(3,72): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
verb @fluentui/merge-styles build |  Analysis will use the bundled TypeScript version 4.3.5
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenu.test.tsx(4,72): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
verb @fluentui/react-window-provider build |  [5:20:07 PM] ■ Extracting Public API surface from '/mnt/vss/_work/1/s/packages/react-window-provider/lib/index.d.ts'
verb @fluentui/react-18-tests-v8 type-check |  src/components/ContextualMenu/ContextualMenu.e2e.tsx(3,72): error TS2307: Cannot find module '@fluentui/react' or its corresponding type declarations.
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! code ELIFECYCLE
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! errno 1
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! @fluentui/react-18-tests-v8@1.0.0 type-check: `tsc -b tsconfig.json`
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! Exit status 1
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! 
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! Failed at the @fluentui/react-18-tests-v8@1.0.0 type-check script.
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
verb @fluentui/react-18-tests-v8 type-check |  
verb @fluentui/react-18-tests-v8 type-check |  npm ERR! A complete log of this run can be found in:
verb @fluentui/react-18-tests-v8 type-check |  npm ERR!     /home/cloudtest/.npm/_logs/2022-09-19T17_20_07_364Z-debug.log
info @fluentui/react-18-tests-v8 type-check ❌ fail 


```

Follow-up to #24637