### PR TITLE
fix(cicd): rename docsite deployment github actions to have unique names

### DIFF
--- a/.github/workflows/docsite-publish-chromatic.yml
+++ b/.github/workflows/docsite-publish-chromatic.yml
@@ -1,5 +1,5 @@
 # Workflow name
-name: 'Docsite publish'
+name: 'Docsite publish to Chromatic'
 
 on:
   push:

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -1,5 +1,5 @@
 # Workflow name
-name: 'Docsite publish'
+name: 'Docsite publish to Github Pages'
 
 on:
   push:


### PR DESCRIPTION
## Current Behavior

Docsite publish workflows have the same name and it creates confusion.

## New Behavior

Different names for each docsite publish workflow.
