### PR TITLE
fix: Only generate northstar screener states if the artifact is present

### DIFF
--- a/scripts/gulp/tasks/vr-test.ts
+++ b/scripts/gulp/tasks/vr-test.ts
@@ -40,8 +40,10 @@ task('screener:runner', cb => {
     deployUrl: process.env.DEPLOYURL,
   });
 
-  const screenerStates = require(paths.docsDist('screenerStates.json'));
-  screenerConfig.states = screenerStates;
+  if (process.env.IS_ARTIFACT_PRESENT) {
+    const screenerStates = require(paths.docsDist('screenerStates.json'));
+    screenerConfig.states = screenerStates;
+  }
 
   handlePromiseExit(screenerRunner(screenerConfig));
 });


### PR DESCRIPTION
Fixes a bug from #24865 where screener states are generated even if the artifact does not exist