### PR TITLE
fix: Remove SwitchField's labelPosition prop, as it has no effect

### DIFF
--- a/change/@fluentui-react-field-3a6a0878-e060-4cc5-aa5c-9b68eed1f5f3.json
+++ b/change/@fluentui-react-field-3a6a0878-e060-4cc5-aa5c-9b68eed1f5f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Remove SwitchField's labelPosition prop, as it has no effect",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/Spec.md
+++ b/packages/react-components/react-field/Spec.md
@@ -231,8 +231,8 @@ The Checkbox and Switch components already have a `label` prop, which conflicts 
 
 #### `SwitchField`
 
-- New `valueLabel` prop for the label of the Switch
 - The `label` prop will go to the Field and NOT the Switch
+- The Switch's `labelPosition` prop is therefore not supported, and is omitted from SwitchField.
 
 ## Structure
 

--- a/packages/react-components/react-field/etc/react-field.api.md
+++ b/packages/react-components/react-field/etc/react-field.api.md
@@ -133,7 +133,7 @@ export const SwitchField: ForwardRefComponent<SwitchFieldProps>;
 export const switchFieldClassNames: SlotClassNames<FieldSlots<FieldComponent>>;
 
 // @public (undocumented)
-export type SwitchFieldProps = FieldProps<typeof Switch>;
+export type SwitchFieldProps = Omit<FieldProps<typeof Switch>, 'labelPosition'>;
 
 // @public (undocumented)
 export const TextareaField: ForwardRefComponent<TextareaFieldProps>;

--- a/packages/react-components/react-field/src/components/SwitchField/SwitchField.tsx
+++ b/packages/react-components/react-field/src/components/SwitchField/SwitchField.tsx
@@ -4,7 +4,9 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { FieldProps } from '../../Field';
 import { getFieldClassNames, renderField_unstable, useFieldStyles_unstable, useField_unstable } from '../../Field';
 
-export type SwitchFieldProps = FieldProps<typeof Switch>;
+// The Field's `label` prop overrides the Switch's built-in `label`.
+// Therefore, the Switch's `labelPosition` has no effect and is omitted to avoid confusion.
+export type SwitchFieldProps = Omit<FieldProps<typeof Switch>, 'labelPosition'>;
 
 export const switchFieldClassNames = getFieldClassNames('SwitchField');
 


### PR DESCRIPTION
## Current Behavior

The SwitchField control inherits the `labelPosition` prop from Switch. However, the `label` prop goes to the field and not the Switch, and so the Switch's `labelPosition` prop has no effect.

## New Behavior

Omit the `labelPosition` prop from SwitchField to avoid confusion.

## Related Issue(s)

* Fixes #24685
