### PR TITLE
fix: Nightly releases should use `rm -f`

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -44,7 +44,7 @@ jobs:
 
         # Deletes all existing changefiles so that only bump that happens is for nightly
       - script: |
-          rm change/*
+          rm -f change/*
         displayName: 'Delete existing changefiles'
 
         # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files


### PR DESCRIPTION
If there are no changefiles nightly release fails because there is no folder `change/` use `rm -f` to force delete the directory so it doesn't fail if the folder doesn't exist (which can happen after official release)