### PR TITLE
chore: Expand scope of dependency mismatch generator

### DIFF
--- a/tools/generators/dependency-mismatch/index.spec.ts
+++ b/tools/generators/dependency-mismatch/index.spec.ts
@@ -195,7 +195,7 @@ describe('dependency-mismatch generator', () => {
         devDependencies: {},
         peerDependencies: {},
       },
-      ['northstar'],
+      ['react-northstar'],
     );
 
     setupDummyPackage(appTree, {

--- a/tools/generators/dependency-mismatch/index.spec.ts
+++ b/tools/generators/dependency-mismatch/index.spec.ts
@@ -18,7 +18,7 @@ describe('dependency-mismatch generator', () => {
       name: 'public-docsite-v9',
       version: '9.0.0',
       dependencies: {
-        [`${workspaceNpmScope}/react-theme`]: '^9.0.0',
+        [`@${workspaceNpmScope}/react-theme`]: '^9.0.0',
       },
       devDependencies: {},
       peerDependencies: {},
@@ -36,7 +36,7 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/react-theme": "^9.0.1",
+        "@proj/react-theme": "^9.0.1",
       }
     `);
   });
@@ -46,7 +46,7 @@ describe('dependency-mismatch generator', () => {
       name: 'public-docsite-v9',
       version: '9.0.0',
       devDependencies: {
-        [`${workspaceNpmScope}/react-theme`]: '^9.0.0',
+        [`@${workspaceNpmScope}/react-theme`]: '^9.0.0',
       },
       dependencies: {},
       peerDependencies: {},
@@ -64,7 +64,7 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.devDependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/react-theme": "^9.0.1",
+        "@proj/react-theme": "^9.0.1",
       }
     `);
   });
@@ -74,7 +74,7 @@ describe('dependency-mismatch generator', () => {
       name: 'public-docsite-v9',
       version: '9.0.0',
       peerDependencies: {
-        [`${workspaceNpmScope}/react-theme`]: '^9.0.0',
+        [`@${workspaceNpmScope}/react-theme`]: '^9.0.0',
       },
       dependencies: {},
       devDependencies: {},
@@ -92,7 +92,7 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.peerDependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/react-theme": "^9.0.1",
+        "@proj/react-theme": "^9.0.1",
       }
     `);
   });
@@ -102,8 +102,8 @@ describe('dependency-mismatch generator', () => {
       name: 'public-docsite-v9',
       version: '9.0.0',
       dependencies: {
-        [`${workspaceNpmScope}/react-select`]: '^9.0.0-beta.1',
-        [`${workspaceNpmScope}/react-spinbutton`]: '9.0.0-beta.1',
+        [`@${workspaceNpmScope}/react-select`]: '^9.0.0-beta.1',
+        [`@${workspaceNpmScope}/react-spinbutton`]: '9.0.0-beta.1',
       },
       devDependencies: {},
       peerDependencies: {},
@@ -128,8 +128,8 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/react-select": "^9.0.0-beta.2",
-        "proj/react-spinbutton": "9.0.0-beta.2",
+        "@proj/react-select": "^9.0.0-beta.2",
+        "@proj/react-spinbutton": "9.0.0-beta.2",
       }
     `);
   });
@@ -139,7 +139,7 @@ describe('dependency-mismatch generator', () => {
       name: 'react',
       version: '8.0.0',
       dependencies: {
-        [`${workspaceNpmScope}/react-portal-compat-context`]: '^9.0.0',
+        [`@${workspaceNpmScope}/react-portal-compat-context`]: '^9.0.0',
       },
       devDependencies: {},
       peerDependencies: {},
@@ -157,7 +157,7 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/react-portal-compat-context": "^9.0.1",
+        "@proj/react-portal-compat-context": "^9.0.1",
       }
     `);
   });
@@ -167,7 +167,7 @@ describe('dependency-mismatch generator', () => {
       name: 'react',
       version: '8.0.0',
       dependencies: {
-        [`${workspaceNpmScope}/tslib`]: '^2.1.1',
+        [`@${workspaceNpmScope}/tslib`]: '^2.1.1',
       },
       devDependencies: {},
       peerDependencies: {},
@@ -178,19 +178,19 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/tslib": "^2.1.1",
+        "@proj/tslib": "^2.1.1",
       }
     `);
   });
 
-  it('should ignore northstar packages', async () => {
+  it('generator should not run on northstar packages', async () => {
     const { readPackageJson: readTargetPackageJson } = setupDummyPackage(
       appTree,
       {
         name: 'react-northstar',
         version: '0.66.0',
         dependencies: {
-          [`${workspaceNpmScope}/dom-utilities`]: '^1.1.1',
+          [`@${workspaceNpmScope}/dom-utilities`]: '^1.1.1',
         },
         devDependencies: {},
         peerDependencies: {},
@@ -211,7 +211,7 @@ describe('dependency-mismatch generator', () => {
     const packageJson: PackageJson = await readTargetPackageJson();
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
       Object {
-        "proj/dom-utilities": "^1.1.1",
+        "@proj/dom-utilities": "^1.1.1",
       }
     `);
   });
@@ -230,7 +230,7 @@ function setupDummyPackage(
 ) {
   const workspaceConfig = readWorkspaceConfiguration(tree);
 
-  const normalizedPkgName = `${workspaceConfig.npmScope}/${packageJson.name}`;
+  const normalizedPkgName = `@${workspaceConfig.npmScope}/${packageJson.name}`;
   const paths = {
     root: `packages/${packageJson.name}`,
   };

--- a/tools/generators/dependency-mismatch/index.ts
+++ b/tools/generators/dependency-mismatch/index.ts
@@ -1,7 +1,7 @@
 import * as semver from 'semver';
 import { Tree, formatFiles, updateJson, readJson, readProjectConfiguration } from '@nrwl/devkit';
 
-import { getProjectConfig, getProjects, isPackageVersionConverged, isPackageVersionPrerelease } from '../../utils';
+import { getProjectConfig, getProjects, isPackageVersionPrerelease } from '../../utils';
 import { PackageJson } from '../../types';
 
 export default async function (tree: Tree) {
@@ -10,6 +10,12 @@ export default async function (tree: Tree) {
   projects.forEach((_project, projectName) => {
     const config = getProjectConfig(tree, { packageName: projectName });
 
+    const { tags = [] } = readProjectConfiguration(tree, projectName);
+    // Ignore northstar packages
+    if (tags.includes('northstar')) {
+      return;
+    }
+
     updateJson(tree, config.paths.packageJson, (packageJson: PackageJson) => {
       if (packageJson.dependencies) {
         packageJson.dependencies = getUpdatedDependencies(tree, packageJson.dependencies);
@@ -17,6 +23,10 @@ export default async function (tree: Tree) {
 
       if (packageJson.devDependencies) {
         packageJson.devDependencies = getUpdatedDependencies(tree, packageJson.devDependencies);
+      }
+
+      if (packageJson.peerDependencies) {
+        packageJson.peerDependencies = getUpdatedDependencies(tree, packageJson.peerDependencies);
       }
 
       return packageJson;
@@ -38,6 +48,10 @@ function isProjectInWorkspace(tree: Tree, projectName: string) {
 
 function getUpdatedDependencies(tree: Tree, dependencies: Record<string, string>) {
   return Object.entries(dependencies).reduce((acc, [dependencyName, versionRange]) => {
+    if (versionRange === '*') {
+      return acc;
+    }
+
     if (!isProjectInWorkspace(tree, dependencyName)) {
       return acc;
     }
@@ -45,10 +59,6 @@ function getUpdatedDependencies(tree: Tree, dependencies: Record<string, string>
     const minVersion = semver.minVersion(versionRange);
 
     if (!minVersion) {
-      return acc;
-    }
-
-    if (!isPackageVersionConverged(minVersion.raw)) {
       return acc;
     }
 

--- a/tools/generators/dependency-mismatch/index.ts
+++ b/tools/generators/dependency-mismatch/index.ts
@@ -12,7 +12,7 @@ export default async function (tree: Tree) {
 
     const { tags = [] } = readProjectConfiguration(tree, projectName);
     // Ignore northstar packages
-    if (tags.includes('northstar')) {
+    if (tags.includes('react-northstar')) {
       return;
     }
 

--- a/workspace.json
+++ b/workspace.json
@@ -11,13 +11,13 @@
       "root": "packages/fluentui/ability-attributes",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/accessibility": {
       "root": "packages/fluentui/accessibility",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/api-docs": {
       "root": "packages/api-docs",
@@ -48,13 +48,13 @@
       "root": "packages/fluentui/circulars-test",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/code-sandbox": {
       "root": "packages/fluentui/code-sandbox",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/codemods": {
       "root": "packages/codemods",
@@ -81,19 +81,19 @@
       "root": "packages/fluentui/digest",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/docs": {
       "root": "packages/fluentui/docs",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/docs-components": {
       "root": "packages/fluentui/docs-components",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/dom-utilities": {
       "root": "packages/dom-utilities",
@@ -104,7 +104,7 @@
       "root": "packages/fluentui/e2e",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/eslint-plugin": {
       "root": "packages/eslint-plugin",
@@ -155,7 +155,7 @@
       "root": "packages/fluentui/local-sandbox",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/merge-styles": {
       "root": "packages/merge-styles",
@@ -206,7 +206,7 @@
       "root": "packages/fluentui/perf",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/perf-test": {
       "root": "apps/perf-test",
@@ -217,7 +217,7 @@
       "root": "packages/fluentui/perf-test-northstar",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/perf-test-react-components": {
       "root": "apps/perf-test-react-components",
@@ -240,7 +240,7 @@
       "root": "packages/fluentui/projects-test",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/public-docsite": {
       "root": "apps/public-docsite",
@@ -316,13 +316,13 @@
       "root": "packages/fluentui/react-bindings",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-builder": {
       "root": "packages/fluentui/react-builder",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-button": {
       "root": "packages/react-components/react-button",
@@ -373,19 +373,19 @@
       "root": "packages/fluentui/react-component-event-listener",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-component-nesting-registry": {
       "root": "packages/fluentui/react-component-nesting-registry",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-component-ref": {
       "root": "packages/fluentui/react-component-ref",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-components": {
       "root": "packages/react-components/react-components",
@@ -489,7 +489,7 @@
       "root": "packages/fluentui/react-icons-northstar",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-image": {
       "root": "packages/react-components/react-image",
@@ -542,31 +542,31 @@
       "root": "packages/fluentui/react-northstar",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-northstar-emotion-renderer": {
       "root": "packages/fluentui/react-northstar-emotion-renderer",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-northstar-fela-renderer": {
       "root": "packages/fluentui/react-northstar-fela-renderer",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-northstar-prototypes": {
       "root": "packages/fluentui/react-northstar-prototypes",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-northstar-styles-renderer": {
       "root": "packages/fluentui/react-northstar-styles-renderer",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-overflow": {
       "root": "packages/react-components/react-overflow",
@@ -628,7 +628,7 @@
       "root": "packages/fluentui/react-proptypes",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-provider": {
       "root": "packages/react-components/react-provider",
@@ -732,7 +732,7 @@
       "root": "packages/fluentui/react-telemetry",
       "projectType": "library",
       "implicitDependencies": [],
-      "tags": ["northstar"]
+      "tags": ["react-northstar"]
     },
     "@fluentui/react-text": {
       "root": "packages/react-components/react-text",

--- a/workspace.json
+++ b/workspace.json
@@ -10,12 +10,14 @@
     "@fluentui/ability-attributes": {
       "root": "packages/fluentui/ability-attributes",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/accessibility": {
       "root": "packages/fluentui/accessibility",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/api-docs": {
       "root": "packages/api-docs",
@@ -45,12 +47,14 @@
     "@fluentui/circulars-test": {
       "root": "packages/fluentui/circulars-test",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/code-sandbox": {
       "root": "packages/fluentui/code-sandbox",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/codemods": {
       "root": "packages/codemods",
@@ -76,17 +80,20 @@
     "@fluentui/digest": {
       "root": "packages/fluentui/digest",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/docs": {
       "root": "packages/fluentui/docs",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/docs-components": {
       "root": "packages/fluentui/docs-components",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/dom-utilities": {
       "root": "packages/dom-utilities",
@@ -96,7 +103,8 @@
     "@fluentui/e2e": {
       "root": "packages/fluentui/e2e",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/eslint-plugin": {
       "root": "packages/eslint-plugin",
@@ -146,7 +154,8 @@
     "@fluentui/local-sandbox": {
       "root": "packages/fluentui/local-sandbox",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/merge-styles": {
       "root": "packages/merge-styles",
@@ -196,7 +205,8 @@
     "@fluentui/perf": {
       "root": "packages/fluentui/perf",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/perf-test": {
       "root": "apps/perf-test",
@@ -206,7 +216,8 @@
     "@fluentui/perf-test-northstar": {
       "root": "packages/fluentui/perf-test-northstar",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/perf-test-react-components": {
       "root": "apps/perf-test-react-components",
@@ -228,7 +239,8 @@
     "@fluentui/projects-test": {
       "root": "packages/fluentui/projects-test",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/public-docsite": {
       "root": "apps/public-docsite",
@@ -303,12 +315,14 @@
     "@fluentui/react-bindings": {
       "root": "packages/fluentui/react-bindings",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-builder": {
       "root": "packages/fluentui/react-builder",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-button": {
       "root": "packages/react-components/react-button",
@@ -358,17 +372,20 @@
     "@fluentui/react-component-event-listener": {
       "root": "packages/fluentui/react-component-event-listener",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-component-nesting-registry": {
       "root": "packages/fluentui/react-component-nesting-registry",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-component-ref": {
       "root": "packages/fluentui/react-component-ref",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-components": {
       "root": "packages/react-components/react-components",
@@ -471,7 +488,8 @@
     "@fluentui/react-icons-northstar": {
       "root": "packages/fluentui/react-icons-northstar",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-image": {
       "root": "packages/react-components/react-image",
@@ -523,27 +541,32 @@
     "@fluentui/react-northstar": {
       "root": "packages/fluentui/react-northstar",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-northstar-emotion-renderer": {
       "root": "packages/fluentui/react-northstar-emotion-renderer",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-northstar-fela-renderer": {
       "root": "packages/fluentui/react-northstar-fela-renderer",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-northstar-prototypes": {
       "root": "packages/fluentui/react-northstar-prototypes",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-northstar-styles-renderer": {
       "root": "packages/fluentui/react-northstar-styles-renderer",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-overflow": {
       "root": "packages/react-components/react-overflow",
@@ -604,7 +627,8 @@
     "@fluentui/react-proptypes": {
       "root": "packages/fluentui/react-proptypes",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-provider": {
       "root": "packages/react-components/react-provider",
@@ -707,7 +731,8 @@
     "@fluentui/react-telemetry": {
       "root": "packages/fluentui/react-telemetry",
       "projectType": "library",
-      "implicitDependencies": []
+      "implicitDependencies": [],
+      "tags": ["northstar"]
     },
     "@fluentui/react-text": {
       "root": "packages/react-components/react-text",


### PR DESCRIPTION
Expands the scope of the dependency mismatch generator to align dependencies in the repo even if they are not v9.

The exception here is northstar/v0, since it has a dependency on a former major of a v8 dependency

Partially addresses: #23147