### PR TITLE
fix: update non-focus-trap Popover role to be group

### DIFF
--- a/change/@fluentui-react-popover-66a51d32-93ef-481a-bef9-5595c8ef528a.json
+++ b/change/@fluentui-react-popover-66a51d32-93ef-481a-bef9-5595c8ef528a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update popover role to be note when it does not trap focus",
+  "packageName": "@fluentui/react-popover",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/Spec.md
+++ b/packages/react-components/react-popover/Spec.md
@@ -348,7 +348,7 @@ Default popover
 </div>
 
 // on document.body
-<div role="complementary">
+<div role="note">
   {/** content */}
 </div>
 ```
@@ -499,7 +499,7 @@ Accessible markup is divided into two scenarios:
 ```tsx
 // Popover that does not trap focus
 <button aria-expanded="false">Trigger</button>
-<div role="complementary">
+<div role="note">
   No focus trap
 </div>
 

--- a/packages/react-components/react-popover/Spec.md
+++ b/packages/react-components/react-popover/Spec.md
@@ -348,7 +348,7 @@ Default popover
 </div>
 
 // on document.body
-<div role="note">
+<div role="group">
   {/** content */}
 </div>
 ```
@@ -499,7 +499,7 @@ Accessible markup is divided into two scenarios:
 ```tsx
 // Popover that does not trap focus
 <button aria-expanded="false">Trigger</button>
-<div role="note">
+<div role="group">
   No focus trap
 </div>
 

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -11,7 +11,7 @@ const mount = (element: JSX.Element) => {
 };
 
 const popoverTriggerSelector = '[aria-expanded]';
-const popoverContentSelector = '[role="note"]';
+const popoverContentSelector = '[role="group"]';
 const popoverInteractiveContentSelector = '[role="dialog"]';
 
 describe('Popover', () => {

--- a/packages/react-components/react-popover/e2e/Popover.e2e.tsx
+++ b/packages/react-components/react-popover/e2e/Popover.e2e.tsx
@@ -11,7 +11,7 @@ const mount = (element: JSX.Element) => {
 };
 
 const popoverTriggerSelector = '[aria-expanded]';
-const popoverContentSelector = '[role="complementary"]';
+const popoverContentSelector = '[role="note"]';
 const popoverInteractiveContentSelector = '[role="dialog"]';
 
 describe('Popover', () => {

--- a/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.test.tsx
@@ -72,7 +72,7 @@ describe('PopoverSurface', () => {
     expect(queryByRole('dialog')).not.toBeNull();
   });
 
-  it('should set role note if focus trap is not active', () => {
+  it('should set role group if focus trap is not active', () => {
     // Arrange
     mockPopoverContext({ trapFocus: false });
     const { getByTestId } = render(<PopoverSurface {...props}>Content</PopoverSurface>);

--- a/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/PopoverSurface.test.tsx
@@ -72,7 +72,7 @@ describe('PopoverSurface', () => {
     expect(queryByRole('dialog')).not.toBeNull();
   });
 
-  it('should set role complementary if focus trap is not active', () => {
+  it('should set role note if focus trap is not active', () => {
     // Arrange
     mockPopoverContext({ trapFocus: false });
     const { getByTestId } = render(<PopoverSurface {...props}>Content</PopoverSurface>);

--- a/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PopoverSurface renders a default state 1`] = `
   class="fui-PopoverSurface"
   data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true}}"
   data-testid="component"
-  role="note"
+  role="group"
 >
   Default PopoverSurface
 </div>

--- a/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PopoverSurface renders a default state 1`] = `
   class="fui-PopoverSurface"
   data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true}}"
   data-testid="component"
-  role="complementary"
+  role="note"
 >
   Default PopoverSurface
 </div>

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -42,7 +42,7 @@ export const usePopoverSurface_unstable = (
     },
     root: getNativeElementProps('div', {
       ref: useMergedRefs(ref, contentRef),
-      role: trapFocus ? 'dialog' : 'complementary',
+      role: trapFocus ? 'dialog' : 'note',
       'aria-modal': trapFocus ? true : undefined,
       ...modalAttributes,
       ...props,

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -42,7 +42,7 @@ export const usePopoverSurface_unstable = (
     },
     root: getNativeElementProps('div', {
       ref: useMergedRefs(ref, contentRef),
-      role: trapFocus ? 'dialog' : 'note',
+      role: trapFocus ? 'dialog' : 'group',
       'aria-modal': trapFocus ? true : undefined,
       ...modalAttributes,
       ...props,


### PR DESCRIPTION
Related to #21416

We do want to use a non-dialog role for the non-focus-trapping variant, but `complementary` isn't the best fit -- it refers specifically to content that is complementary to the main region, and on the same level as the main region in content hierarchy. That doesn't really apply to most popovers, so this PR updates it to the `group` role for the following reasons:
- Popovers may be nested, and `group` in particular enables that
- It's the lowest common accessible base role in that it is flexible in its use cases, and allows naming & exposes its bounds
- It is extremely flexible in allowed content (both in a strict spec sense, and in a general user expectation sense)

Other roles that were considered:
- `note`: it generally seems fine, but it would be weird to have nested notes, and it has a narrow range of expected use cases
- `region`: this would add popovers to the landmark list. It seems too heavy for something that is probably going to be a small, transient addition to the page, but we could reconsider it based on user feedback. The benefit would be that it would be easier to find with a screen reader's virtual cursor.