### PR TITLE
fix: Make Menu openOnHover prop work again

### DIFF
--- a/change/@fluentui-react-menu-5eeb5c9b-a02e-4d75-aeee-9e9fd45a5aac.json
+++ b/change/@fluentui-react-menu-5eeb5c9b-a02e-4d75-aeee-9e9fd45a5aac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make Menu openOnHover prop work again",
+  "packageName": "@fluentui/react-menu",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/e2e/Menu.e2e.tsx
+++ b/packages/react-components/react-menu/e2e/Menu.e2e.tsx
@@ -51,6 +51,28 @@ describe('MenuTrigger', () => {
       .should('be.focused');
   });
 
+  it('should open menu on hover if openOnHover is set', () => {
+    mount(
+      <Menu openOnHover hoverDelay={1}>
+        <MenuTrigger>
+          <button>Menu</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+    cy.get(menuTriggerSelector)
+      .realHover()
+      .wait(1)
+      .get(menuSelector)
+      .should('be.visible')
+      .get(menuItemSelector)
+      .should('be.focused');
+  });
+
   it('should close menu on escape when focus is on the trigger', () => {
     mount(
       <Menu>

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -25,6 +25,7 @@ import { Tab } from '@fluentui/keyboard-keys';
  * @param props - props from this instance of Menu
  */
 export const useMenu_unstable = (props: MenuProps): MenuState => {
+  const isSubmenu = useIsSubmenu();
   const {
     hoverDelay = 500,
     inline = false,
@@ -33,10 +34,10 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     closeOnScroll = false,
     openOnContext = false,
     persistOnItemClick = false,
+    openOnHover = isSubmenu,
     defaultCheckedValues,
   } = props;
   const triggerId = useId('menu');
-  const isSubmenu = useIsSubmenu();
   const [contextTarget, setContextTarget] = usePositioningMouseTarget();
 
   const positioningState = {
@@ -96,7 +97,7 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     hoverDelay,
     triggerId,
     isSubmenu,
-    openOnHover: isSubmenu,
+    openOnHover,
     contextTarget,
     setContextTarget,
     hasCheckmarks,


### PR DESCRIPTION
## Current Behavior

Regression from the refactoring in PR https://github.com/microsoft/fluentui/pull/24562, Menu no longer respects the `openOnHover` prop.

## New Behavior

Use the `openOnHover` prop in Menu again. It defaults to `isSubmenu` but can be overridden.

## Related Issue(s)

* Fixes #24841
