### PR TITLE
feat: Avatar's aria label includes 'active' or 'inactive' when using the active prop

### DIFF
--- a/change/@fluentui-react-avatar-e4aa8633-f04d-4761-9b6f-d7d78497c1c6.json
+++ b/change/@fluentui-react-avatar-e4aa8633-f04d-4761-9b6f-d7d78497c1c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Avatar's aria label includes 'active' or 'inactive' when using the active prop",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -119,7 +119,6 @@ export type AvatarNamedColor = 'dark-red' | 'cranberry' | 'red' | 'pumpkin' | 'p
 export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
     active?: 'active' | 'inactive' | 'unset';
     activeAppearance?: 'ring' | 'shadow' | 'ring-shadow';
-    activeAriaLabel?: string;
     color?: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
     idForColor?: string | undefined;
     name?: string;
@@ -137,12 +136,12 @@ export type AvatarSlots = {
     initials?: Slot<'span'>;
     icon?: Slot<'span'>;
     badge?: Slot<typeof PresenceBadge>;
-    activeAriaLabel?: Slot<'span'>;
 };
 
 // @public
 export type AvatarState = ComponentState<AvatarSlots> & Required<Pick<AvatarProps, 'active' | 'activeAppearance' | 'shape' | 'size'>> & {
     color: NonNullable<Exclude<AvatarProps['color'], 'colorful'>>;
+    activeAriaLabelElement?: JSX.Element;
 };
 
 // @internal

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -119,6 +119,7 @@ export type AvatarNamedColor = 'dark-red' | 'cranberry' | 'red' | 'pumpkin' | 'p
 export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
     active?: 'active' | 'inactive' | 'unset';
     activeAppearance?: 'ring' | 'shadow' | 'ring-shadow';
+    activeAriaLabel?: string;
     color?: 'neutral' | 'brand' | 'colorful' | AvatarNamedColor;
     idForColor?: string | undefined;
     name?: string;
@@ -136,6 +137,7 @@ export type AvatarSlots = {
     initials?: Slot<'span'>;
     icon?: Slot<'span'>;
     badge?: Slot<typeof PresenceBadge>;
+    activeAriaLabel?: Slot<'span'>;
 };
 
 // @public

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -190,67 +190,67 @@ describe('Avatar', () => {
     expect(screen.getByRole('img').getAttribute('aria-labelledby')).toBe(intialsId);
   });
 
-  it('sets aria-labelledby to the avatar + badge', () => {
+  it('sets aria-labelledby to the name + badge', () => {
     const name = 'First Last';
     render(<Avatar id="root-id" name={name} badge={{ status: 'away', id: 'badge-id' }} />);
 
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-label')).toBe(name);
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe('root-id badge-id');
+    const root = screen.getAllByRole('img')[0];
+    expect(root.getAttribute('aria-label')).toBe(name);
+    expect(root.getAttribute('aria-labelledby')).toBe('root-id badge-id');
   });
 
-  it('sets aria-labelledby to the avatar + activeAriaLabel when active="active"', () => {
-    render(<Avatar id="root-id" name="First Last" active="active" activeAriaLabel={{ id: 'active-id' }} />);
+  it('sets aria-label to the name + activeState when active="active"', () => {
+    const name = 'First Last';
+    render(<Avatar id="root-id" name={name} active="active" />);
 
-    const activeAriaLabel = screen.getByText(DEFAULT_STRINGS.active);
-
-    expect(activeAriaLabel.id).toBe('active-id');
-    expect(activeAriaLabel.hidden).toBeTruthy();
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe('root-id active-id');
+    const root = screen.getAllByRole('img')[0];
+    expect(root.getAttribute('aria-label')).toBe(`${name} ${DEFAULT_STRINGS.active}`);
   });
 
-  it('sets aria-labelledby to the avatar + activeAriaLabel when active="inactive"', () => {
-    render(<Avatar id="root-id" name="First Last" active="inactive" />);
+  it('sets aria-label to the name + activeState when active="inactive"', () => {
+    const name = 'First Last';
+    render(<Avatar id="root-id" name={name} active="inactive" />);
 
-    const activeAriaLabel = screen.getByText(DEFAULT_STRINGS.inactive);
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe(`root-id ${activeAriaLabel.id}`);
+    const root = screen.getAllByRole('img')[0];
+    expect(root.getAttribute('aria-label')).toBe(`${name} ${DEFAULT_STRINGS.inactive}`);
   });
 
-  it('sets aria-labelledby to the avatar + activeAriaLabel, when custom activeAriaLabel is provided', () => {
-    const customActiveAriaLabelText = 'custom active aria label';
-    render(<Avatar id="root-id" name="First Last" active="active" activeAriaLabel={customActiveAriaLabelText} />);
-
-    const activeAriaLabel = screen.getByText('hello world');
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe(`root-id ${activeAriaLabel.id}`);
-  });
-
-  it('sets aria-labelledby to the avatar + badge + activeAriaLabel', () => {
+  it('sets aria-labelledby to the name + badge + activeState when there is a badge and active state', () => {
     render(<Avatar id="root-id" name="First Last" badge={{ status: 'away', id: 'badge-id' }} active="active" />);
 
-    const activeAriaLabel = screen.getByText(DEFAULT_STRINGS.active);
+    const activeAriaLabelElement = screen.getByText(DEFAULT_STRINGS.active);
+    expect(activeAriaLabelElement.id).toBeTruthy();
+    expect(activeAriaLabelElement.hidden).toBeTruthy();
 
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe(
-      `root-id badge-id ${activeAriaLabel.id}`,
-    );
+    const root = screen.getAllByRole('img')[0];
+    expect(root.getAttribute('aria-labelledby')).toBe(`root-id badge-id ${activeAriaLabelElement.id}`);
   });
 
-  it('sets aria-labelledby to the initials + badge + activeAriaLabel, if no name is provided', () => {
+  it('sets aria-labelledby to the initials + badge + activeState, if no name is provided', () => {
     render(
       <Avatar
         initials={{ children: 'FL', id: 'initials-id' }}
         badge={{ status: 'away', id: 'badge-id' }}
-        activeAriaLabel={{ id: 'active-id' }}
         active="inactive"
       />,
     );
 
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBe('initials-id badge-id active-id');
+    const activeAriaLabelElement = screen.getByText(DEFAULT_STRINGS.inactive);
+    expect(activeAriaLabelElement.id).toBeTruthy();
+    expect(activeAriaLabelElement.hidden).toBeTruthy();
+
+    const root = screen.getAllByRole('img')[0];
+    expect(root.getAttribute('aria-labelledby')).toBe(`initials-id badge-id ${activeAriaLabelElement.id}`);
   });
 
-  it('does not render an activeAriaLabel when active state is unset', () => {
-    const nonRenderedActiveAriaLabelText = 'this should not be rendered';
-    render(<Avatar name="First Last" activeAriaLabel={nonRenderedActiveAriaLabelText} />);
+  it('does not render an activeAriaLabelElement when active state is unset', () => {
+    render(<Avatar name="First Last" />);
 
-    expect(screen.queryByText(nonRenderedActiveAriaLabelText)).toBeFalsy();
-    expect(screen.getAllByRole('img')[0].getAttribute('aria-labelledby')).toBeFalsy();
+    expect(screen.queryByText(DEFAULT_STRINGS.active)).toBeNull();
+    expect(screen.queryByText(DEFAULT_STRINGS.inactive)).toBeNull();
+
+    const root = screen.getAllByRole('img')[0];
+    expect(root.getAttribute('aria-label')).toBe('First Last');
+    expect(root.getAttribute('aria-labelledby')).toBeFalsy();
   });
 });

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -32,6 +32,17 @@ export type AvatarSlots = {
    * Badge to show the avatar's presence status.
    */
   badge?: Slot<typeof PresenceBadge>;
+
+  /**
+   * Hidden text that is appended to the generated aria-labelledby to describe the active state.
+   * This will be ignored if a custom `aria-label` or `aria-labelledby` is set on this Avatar.
+   *
+   * The default value depends on the `active` prop:
+   * * unset: `undefined`
+   * * active: `strings.active`
+   * * inactive: `strings.inactive`
+   */
+  activeAriaLabel?: Slot<'span'>;
 };
 
 /**

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -32,17 +32,6 @@ export type AvatarSlots = {
    * Badge to show the avatar's presence status.
    */
   badge?: Slot<typeof PresenceBadge>;
-
-  /**
-   * Hidden text that is appended to the generated aria-labelledby to describe the active state.
-   * This will be ignored if a custom `aria-label` or `aria-labelledby` is set on this Avatar.
-   *
-   * The default value depends on the `active` prop:
-   * * unset: `undefined`
-   * * active: `strings.active`
-   * * inactive: `strings.inactive`
-   */
-  activeAriaLabel?: Slot<'span'>;
 };
 
 /**
@@ -165,4 +154,6 @@ export type AvatarState = ComponentState<AvatarSlots> &
      * The Avatar's color, it matches props.color but with `'colorful'` resolved to a named color
      */
     color: NonNullable<Exclude<AvatarProps['color'], 'colorful'>>;
+
+    activeAriaLabelElement?: JSX.Element;
   };

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -155,5 +155,8 @@ export type AvatarState = ComponentState<AvatarSlots> &
      */
     color: NonNullable<Exclude<AvatarProps['color'], 'colorful'>>;
 
+    /**
+     * Hidden span to render the active state label for the purposes of including in the aria-labelledby, if needed.
+     */
     activeAriaLabelElement?: JSX.Element;
   };

--- a/packages/react-components/react-avatar/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/renderAvatar.tsx
@@ -11,7 +11,7 @@ export const renderAvatar_unstable = (state: AvatarState) => {
       {slots.icon && <slots.icon {...slotProps.icon} />}
       {slots.image && <slots.image {...slotProps.image} />}
       {slots.badge && <slots.badge {...slotProps.badge} />}
-      {slots.activeAriaLabel && <slots.activeAriaLabel {...slotProps.activeAriaLabel} />}
+      {state.activeAriaLabelElement}
     </slots.root>
   );
 };

--- a/packages/react-components/react-avatar/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/renderAvatar.tsx
@@ -11,6 +11,7 @@ export const renderAvatar_unstable = (state: AvatarState) => {
       {slots.icon && <slots.icon {...slotProps.icon} />}
       {slots.image && <slots.image {...slotProps.image} />}
       {slots.badge && <slots.badge {...slotProps.badge} />}
+      {slots.activeAriaLabel && <slots.activeAriaLabel {...slotProps.activeAriaLabel} />}
     </slots.root>
   );
 };

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -6,6 +6,11 @@ import { PersonRegular } from '@fluentui/react-icons';
 import { PresenceBadge } from '@fluentui/react-badge';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
+export const DEFAULT_STRINGS = {
+  active: 'active',
+  inactive: 'inactive',
+};
+
 export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElement>): AvatarState => {
   const { dir } = useFluent();
   const { name, size = 32, shape = 'circular', active = 'unset', activeAppearance = 'ring', idForColor } = props;
@@ -75,18 +80,32 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     },
   });
 
+  // The activeAriaLabel slot is only used if there is an active state and no user-defined aria label
+  let activeAriaLabel;
+
   // Resolve aria-label and/or aria-labelledby if not provided by the user
   if (!root['aria-label'] && !root['aria-labelledby']) {
+    if (active === 'active' || active === 'inactive') {
+      activeAriaLabel = resolveShorthand(props.activeAriaLabel, {
+        required: true,
+        defaultProps: {
+          children: DEFAULT_STRINGS[active],
+          id: baseId + '__activeAriaLabel',
+          hidden: true,
+        },
+      });
+    }
+
     if (name) {
       root['aria-label'] = name;
 
-      // Include the badge in labelledby if it exists
-      if (badge) {
-        root['aria-labelledby'] = root.id + ' ' + badge.id;
+      // Include the badge and/or activeAriaLabel in labelledby if they exist
+      if (badge || activeAriaLabel) {
+        root['aria-labelledby'] = [root.id, badge?.id, activeAriaLabel?.id].filter(id => id).join(' ');
       }
     } else if (initials) {
       // root's aria-label should be the name, but fall back to being labelledby the initials if name is missing
-      root['aria-labelledby'] = initials.id + (badge ? ' ' + badge.id : '');
+      root['aria-labelledby'] = [initials.id, badge?.id, activeAriaLabel?.id].filter(id => id).join(' ');
     }
   }
 
@@ -103,6 +122,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
       icon: 'span',
       image: 'img',
       badge: PresenceBadge,
+      activeAriaLabel: 'span',
     },
 
     root,
@@ -110,6 +130,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     icon,
     image,
     badge,
+    activeAriaLabel,
   };
 };
 

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -80,32 +80,38 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     },
   });
 
-  // The activeAriaLabel slot is only used if there is an active state and no user-defined aria label
-  let activeAriaLabel;
+  let activeAriaLabelElement: AvatarState['activeAriaLabelElement'];
 
   // Resolve aria-label and/or aria-labelledby if not provided by the user
   if (!root['aria-label'] && !root['aria-labelledby']) {
-    if (active === 'active' || active === 'inactive') {
-      activeAriaLabel = resolveShorthand(props.activeAriaLabel, {
-        required: true,
-        defaultProps: {
-          children: DEFAULT_STRINGS[active],
-          id: baseId + '__activeAriaLabel',
-          hidden: true,
-        },
-      });
-    }
-
     if (name) {
       root['aria-label'] = name;
 
-      // Include the badge and/or activeAriaLabel in labelledby if they exist
-      if (badge || activeAriaLabel) {
-        root['aria-labelledby'] = [root.id, badge?.id, activeAriaLabel?.id].filter(id => id).join(' ');
+      // Include the badge in labelledby if it exists
+      if (badge) {
+        root['aria-labelledby'] = root.id + ' ' + badge.id;
       }
     } else if (initials) {
       // root's aria-label should be the name, but fall back to being labelledby the initials if name is missing
-      root['aria-labelledby'] = [initials.id, badge?.id, activeAriaLabel?.id].filter(id => id).join(' ');
+      root['aria-labelledby'] = initials.id + (badge ? ' ' + badge.id : '');
+    }
+
+    // Add the active state to the aria label
+    if (active === 'active' || active === 'inactive') {
+      const activeText = DEFAULT_STRINGS[active];
+      if (root['aria-labelledby']) {
+        // If using aria-labelledby, render a hidden span and append it to the labelledby
+        const activeId = baseId + '__active';
+        root['aria-labelledby'] += ' ' + activeId;
+        activeAriaLabelElement = (
+          <span hidden id={activeId}>
+            {activeText}
+          </span>
+        );
+      } else if (root['aria-label']) {
+        // Otherwise, just append it to the aria-label
+        root['aria-label'] += ' ' + activeText;
+      }
     }
   }
 
@@ -114,6 +120,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     shape,
     active,
     activeAppearance,
+    activeAriaLabelElement,
     color,
 
     components: {
@@ -122,7 +129,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
       icon: 'span',
       image: 'img',
       badge: PresenceBadge,
-      activeAriaLabel: 'span',
     },
 
     root,
@@ -130,7 +136,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     icon,
     image,
     badge,
-    activeAriaLabel,
   };
 };
 

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -9,6 +9,7 @@ export const avatarClassNames: SlotClassNames<AvatarSlots> = {
   initials: 'fui-Avatar__initials',
   icon: 'fui-Avatar__icon',
   badge: 'fui-Avatar__badge',
+  activeAriaLabel: 'fui-Avatar__activeAriaLabel',
 };
 
 //
@@ -490,6 +491,10 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
       iconSizeClass,
       state.icon.className,
     );
+  }
+
+  if (state.activeAriaLabel) {
+    state.activeAriaLabel.className = mergeClasses(avatarClassNames.activeAriaLabel, state.activeAriaLabel.className);
   }
 
   return state;

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatarStyles.ts
@@ -9,7 +9,6 @@ export const avatarClassNames: SlotClassNames<AvatarSlots> = {
   initials: 'fui-Avatar__initials',
   icon: 'fui-Avatar__icon',
   badge: 'fui-Avatar__badge',
-  activeAriaLabel: 'fui-Avatar__activeAriaLabel',
 };
 
 //
@@ -491,10 +490,6 @@ export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
       iconSizeClass,
       state.icon.className,
     );
-  }
-
-  if (state.activeAriaLabel) {
-    state.activeAriaLabel.className = mergeClasses(avatarClassNames.activeAriaLabel, state.activeAriaLabel.className);
   }
 
   return state;

--- a/packages/react-components/react-avatar/src/stories/Avatar/AvatarActive.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/Avatar/AvatarActive.stories.tsx
@@ -3,8 +3,8 @@ import { Avatar } from '@fluentui/react-avatar';
 
 export const Active = () => (
   <div style={{ display: 'flex', gap: '20px' }}>
-    <Avatar active="active" name="Active" />
-    <Avatar active="inactive" name="Inactive" />
+    <Avatar active="active" name="Ashley McCarthy" />
+    <Avatar active="inactive" name="Isaac Fielder" badge={{ status: 'away' }} />
   </div>
 );
 


### PR DESCRIPTION
## Current Behavior

The state of Avatar's `active` prop is conveyed visually via a highlight ring, but not conveyed to accessibility tools.

## New Behavior

Append "active" or "inactive" to the aria label when the `active` prop is set. 
* When the Avatar is using the `aria-label` prop, simply append the string to it.
* If the Avatar needs to use `aria-labelledby`, then render a hidden span with the active label, and append the span's ID to `aria-labelledby`

There is no prop to control the strings yet; they are hardcoded for now. In the future, they will be able to be localized once we implement an i18n solution.

## Related Issue(s)

* Fixes #23128
