### PR TITLE
Fix themedesigner slots

### DIFF
--- a/apps/theming-designer/src/components/FabricPalette.tsx
+++ b/apps/theming-designer/src/components/FabricPalette.tsx
@@ -99,13 +99,13 @@ export const FabricPalette: React.FunctionComponent<IFabricPaletteProps> = (prop
             <Text as="td">{themeRules[FabricSlots[FabricSlots.neutralDark]].color.str}</Text>
             <Text as="td">
               <FabricSlotWidget
-                slotRule={themeRules[FabricSlots[FabricSlots.neutralDark]]}
+                slotRule={themeRules[FabricSlots[FabricSlots.neutralQuaternary]]}
                 slot={FabricSlots.neutralQuaternary}
                 onFabricPaletteColorChange={onFabricPaletteColorChange}
                 directionalHint={DirectionalHint.leftCenter}
               />
             </Text>
-            <Text as="td">{themeRules[FabricSlots[FabricSlots.neutralDark]].color.str}</Text>
+            <Text as="td">{themeRules[FabricSlots[FabricSlots.neutralQuaternary]].color.str}</Text>
           </tr>
           <tr>
             <Text as="td">

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -151,14 +151,6 @@ export class ThemingDesigner extends React.Component<{}, IThemingDesignerState> 
     }
     this._fabricPaletteColorChangeTimeout = this._async.setTimeout(() => {
       const { themeRules } = this.state;
-      if (themeRules) {
-        const currentIsDark = isDark(themeRules[FabricSlots[fabricSlot]].color!);
-        ThemeGenerator.setSlot(themeRules[FabricSlots[fabricSlot]], newColor, currentIsDark, true, true);
-        if (currentIsDark !== isDark(themeRules[FabricSlots[fabricSlot]].color!)) {
-          // isInverted got swapped, so need to refresh slots with new shading rules
-          ThemeGenerator.insureSlots(themeRules, currentIsDark);
-        }
-      }
       this.setState({ themeRules: themeRules }, this._makeNewTheme);
     }, 20);
   };

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -118,7 +118,7 @@ function _renderItemColumn(item: IExampleItem, index: number, column: IColumn) {
       );
 
     default:
-      return <span>{fieldContent}</span>;
+      return <span data-is-focusable={true}>Hello</span>; //{fieldContent}
   }
 }
 

--- a/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -44,7 +44,7 @@ export class DetailsHeaderBase
     useFastIcons: true,
   };
 
-  private _classNames: IProcessedStyleSet<IDetailsHeaderStyles>;
+  private _: IProcessedStyleSet<IDetailsHeaderStyles>;
   private _rootElement = React.createRef<HTMLElement>();
   private _events: EventGroup;
   private _rootComponent = React.createRef<IFocusZone>();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Incorrect slot display / behaviour for neutralQuaternary.
Incorrect slot override darkness change cascade behaviour.

## New Behavior

Correct slot display / behaviour for neutralQuaternary.
No slot override darkness change cascade behaviour

## Related Issue(s)

partially addresses https://github.com/microsoft/fluentui/issues/24905

