### PR TITLE
feat: v0 Tooltip migration from v9

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 
 - Add a new comfy layout variation for `ChatMessage` @davezuko ([#23974](https://github.com/microsoft/fluentui/pull/23974))
+- Add new style to v0 Tooltip to match v9 Tooltip @GianoglioEnrico ([#24908](https://github.com/microsoft/fluentui/pull/24908))
 
 ### Fixes
 - Allow React 17 in `peerDependencies` of all packages and bump react-is to 17 @TristanWatanabe ([#24356](https://github.com/microsoft/fluentui/pull/24356))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
@@ -51,7 +51,7 @@ export const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentSty
     fontSize: pxToRem(12),
     padding: v.padding,
     textAlign: 'left',
-
+    lineHeight: pxToRem(16),
     color: v.color,
     background: v.backgroundColor,
     borderRadius: v.borderRadius,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
@@ -32,7 +32,7 @@ export const tooltipContentVariables = (siteVars: any): TooltipContentVariables 
 
   borderRadius: siteVars.borderRadiusMedium,
   borderColor: 'transparent',
-  borderSize: '1px',
+  borderSize: '0px',
   borderStyle: 'none',
   padding: `${pxToRem(5)} ${pxToRem(12)} ${pxToRem(7)} ${pxToRem(12)}`,
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
@@ -36,7 +36,7 @@ export const tooltipContentVariables = (siteVars: any): TooltipContentVariables 
   borderStyle: 'none',
   padding: `${pxToRem(5)} ${pxToRem(12)} ${pxToRem(7)} ${pxToRem(12)}`,
 
-  maxWidth: pxToRem(246),
+  maxWidth: pxToRem(240),
 
   svgPointer: true,
   pointerMargin: pxToRem(6),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
This PR modifies v0 Tooltip to match the one from v9.

To do this we've added a line-height property of 16px and we removed 1px borders around the Tooltip's content to make it height 28px on single line.
We have also changed the max-width from 246px to 240px to match the v9's Tooltip max width.
<!-- This is the behavior we have today -->
<img width="197" alt="Schermata 2022-09-22 alle 15 26 09" src="https://user-images.githubusercontent.com/71330266/191759408-1846cd6e-c100-4b9b-86f4-6486d6c4b88a.png"><img width="276" alt="Schermata 2022-09-22 alle 15 27 23" src="https://user-images.githubusercontent.com/71330266/191759674-c43cc91e-052c-4a75-b369-9c6172df78b7.png">

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
<img width="205" alt="Schermata 2022-09-22 alle 15 25 18" src="https://user-images.githubusercontent.com/71330266/191759230-6fa876b2-bfc7-4742-b8db-2dfbf7880d55.png"><img width="275" alt="Schermata 2022-09-22 alle 15 27 03" src="https://user-images.githubusercontent.com/71330266/191759608-3e422880-6a89-4df8-a78e-4217a7bf05d6.png">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
