### PR TITLE
Export responsive mode

### DIFF
--- a/packages/office-ui-fabric-react/src/ResponsiveMode.ts
+++ b/packages/office-ui-fabric-react/src/ResponsiveMode.ts
@@ -1,0 +1,2 @@
+export * from './utilities/hooks/useResponsiveMode';
+export * from './utilities/decorators/withResponsiveMode';

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -63,6 +63,7 @@ export * from './PositioningContainer';
 export * from './ProgressIndicator';
 export * from './Rating';
 export * from './ResizeGroup';
+export * from './ResponsiveMode';
 export * from './ScrollablePane';
 export * from './SearchBox';
 export * from './SelectableOption';

--- a/packages/react/src/ResponsiveMode.ts
+++ b/packages/react/src/ResponsiveMode.ts
@@ -1,0 +1,1 @@
+export * from 'office-ui-fabric-react/lib/ResponsiveMode';


### PR DESCRIPTION
useResponsiveMode was added in #14229 but it was never exported. This PR gets the exports of 7.0 on par with the exports of 8.0 as to ease the transition from one package to another. 