### PR TITLE
ci(.github): add reusable build action

### DIFF
--- a/.github/actions/build-to/action.yml
+++ b/.github/actions/build-to/action.yml
@@ -1,0 +1,35 @@
+name: 'Build workspaces'
+description: 'Runs the build command for specific workspaces.'
+inputs:
+  # Because Github Actions doesn't support arrays as inputs we need to pass the workspaces as a string and split them
+  # by spaces https://github.com/community/community/discussions/11692
+  workspaces:
+    required: true
+    description: 'The workspaces you want to build. This parameter accepts multiple workspaces separated by a space.'
+  # This is based on the backfill cache provider options: https://github.com/microsoft/backfill#set-up-remote-cache
+  backfill-cache-provider:
+    required: false
+    description: 'The backfill cache provider'
+    default: 'azure-blob'
+  # Depending on the chosen cache provider there are multiple types of available options. In our case we use Azure Blob
+  # Storage. https://github.com/microsoft/backfill#microsoft-azure-blob-storage
+  backfill-cache-provider-options:
+    required: false
+    description: 'The backfill cache provider options'
+  # Flag to toggle backfill remote caching on / off
+  lage-write-remote-cache:
+    required: true
+    description: 'Whether to write to the remote cache'
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: build package dependency tree (scripts:build)
+      working-directory: .
+      shell: bash
+      run: yarn build --to ${{ inputs.workspaces }}
+      env:
+        BACKFILL_CACHE_PROVIDER: ${{ inputs.backfill-cache-provider }}
+        BACKFILL_CACHE_PROVIDER_OPTIONS: ${{ inputs.backfill-cache-provider-options }}
+        LAGE_WRITE_REMOTE_CACHE: ${{ inputs.lage-write-remote-cache }}

--- a/.github/workflows/docsite-publish-chromatic.yml
+++ b/.github/workflows/docsite-publish-chromatic.yml
@@ -44,7 +44,10 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build dependencies
-        run: yarn build --to @fluentui/public-docsite-v9
+        uses: ./.github/actions/build-to
+        with:
+          workspaces: '@fluentui/public-docsite-v9'
+          backfill-cache-provider-options: ${{ secrets.BACKFILL_CACHE_PROVIDER_OPTIONS }}
 
       - name: Publish to Chromatic
         run: yarn workspace @fluentui/public-docsite-v9 chromatic

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -44,7 +44,10 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build dependencies
-        run: yarn build --to @fluentui/public-docsite-v9
+        uses: ./.github/actions/build-to
+        with:
+          workspaces: '@fluentui/public-docsite-v9'
+          backfill-cache-provider-options: ${{ secrets.BACKFILL_CACHE_PROVIDER_OPTIONS }}
 
       - name: Build storybook
         run: yarn workspace @fluentui/public-docsite-v9 build-storybook


### PR DESCRIPTION
## Current Behavior

1. We don't have a reusable build action, thus having to manually write the build commands (and specific parameters) each time. 
2. `yarn build --to <workspace>` command doesn't cache the content while being ran in the pipeline, thus causing full builds on each run.

## New Behavior

This PR adds a custom build action that can be reused everywhere else and more important, it enables [Backfill remote caching](https://github.com/microsoft/backfill#set-up-remote-cache) so that each run will only build what is invalidated (ie new). This solution makes build times for cached resources almost 50 times faster.

The long term goal is to replace this solution with something that offers better DX and scalability, such as NX.
