### PR TITLE
chore: bump @octokit/rest to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@nrwl/js": "13.10.6",
     "@nrwl/node": "13.10.6",
     "@nrwl/workspace": "13.10.6",
+    "@octokit/rest": "18.12.0",
     "@storybook/addon-a11y": "6.5.5",
     "@storybook/addon-actions": "6.5.5",
     "@storybook/addon-docs": "6.5.5",

--- a/scripts/github/pullRequests.ts
+++ b/scripts/github/pullRequests.ts
@@ -1,5 +1,5 @@
-import type { Octokit } from '@octokit/rest';
-import type { IPullRequest, IRepoDetails } from './types';
+import type { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
+import { IPullRequest, IRepoDetails } from './types';
 
 export interface IGetPullRequestFromCommitParams {
   github: Octokit;
@@ -54,17 +54,18 @@ export async function getPullRequestForCommit(
  */
 export function processPullRequestApiResponse(
   pr:
-    | Octokit.ReposListPullRequestsAssociatedWithCommitResponseItem
-    | Octokit.SearchIssuesAndPullRequestsResponseItemsItem,
+    | RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'][number]
+    | RestEndpointMethodTypes['repos']['listPullRequestsAssociatedWithCommit']['response']['data'][number],
   authorEmail?: string,
 ): IPullRequest {
+  const user = pr.user as NonNullable<typeof pr['user']>;
   return {
     number: pr.number,
     url: pr.html_url,
     author: {
       email: authorEmail,
-      username: pr.user.login,
-      url: pr.user.html_url,
+      username: user.login,
+      url: user.html_url,
     },
   };
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,6 @@
     "@mdx-js/loader": "^1.5.5",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@microsoft/loader-load-themed-styles": "^1.7.205",
-    "@octokit/rest": "^16.28.2",
     "@types/babel__traverse": "^7.0.4",
     "@types/inquirer": "^6.5.0",
     "@types/lerna-alias": "^3.0.0",

--- a/scripts/update-release-notes/index.ts
+++ b/scripts/update-release-notes/index.ts
@@ -4,7 +4,7 @@
  * given tag.
  */
 
-import { Octokit } from '@octokit/rest';
+import type { RestEndpointMethodTypes } from '@octokit/rest';
 import { argv, repoDetails, github } from './init';
 import { getTagToChangelogMap, getTags } from './changelogsAndTags';
 import { getReleases } from './releases';
@@ -49,7 +49,9 @@ async function updateReleaseNotes() {
     console.log(`${hasBeenReleased ? 'Patching' : 'Creating'} release notes for ${entryInfo}...\n`);
     count++;
 
-    const releaseDetails: Partial<Octokit.ReposUpdateReleaseParams> = {
+    const releaseDetails:
+      | RestEndpointMethodTypes['repos']['updateRelease']['parameters']
+      | RestEndpointMethodTypes['repos']['createRelease']['parameters'] = {
       ...repoDetails,
       tag_name: entry.tag,
       name: `${entry.name} v${entry.version}`,
@@ -64,9 +66,13 @@ async function updateReleaseNotes() {
     if (argv.apply) {
       try {
         if (hasBeenReleased) {
-          await github.repos.updateRelease(releaseDetails as Octokit.ReposUpdateReleaseParams);
+          await github.repos.updateRelease(
+            releaseDetails as RestEndpointMethodTypes['repos']['updateRelease']['parameters'],
+          );
         } else {
-          await github.repos.createRelease(releaseDetails as Octokit.ReposCreateReleaseParams);
+          await github.repos.createRelease(
+            releaseDetails as RestEndpointMethodTypes['repos']['createRelease']['parameters'],
+          );
         }
         console.log(`Successfully ${hasBeenReleased ? 'updated' : 'created'} release notes for ${entryInfo}`);
       } catch (err) {

--- a/scripts/update-release-notes/pullRequests.ts
+++ b/scripts/update-release-notes/pullRequests.ts
@@ -1,4 +1,3 @@
-import { Octokit } from '@octokit/rest';
 import { ChangelogEntry } from 'beachball';
 import { IPullRequest, processPullRequestApiResponse, getPullRequestForCommit } from '../github';
 import { repoDetails, github } from './init';
@@ -93,7 +92,7 @@ async function getRecentPrsByAuthor(
       // Get the author's 10 most recently updated merged PRs
       console.log(`Getting ${count} most recent PRs by ${authorUsername}...`);
       // (this is not quite the right type, since merge_commit_sha doesn't exist on the real response)
-      const result: Octokit.SearchIssuesAndPullRequestsResponseItemsItem[] = (
+      const result = (
         await github.search.issuesAndPullRequests({
           q: [
             'type:pr',

--- a/scripts/update-release-notes/releases.ts
+++ b/scripts/update-release-notes/releases.ts
@@ -1,4 +1,3 @@
-import { Octokit } from '@octokit/rest';
 import { repoDetails, github } from './init';
 import { IRelease } from './types';
 
@@ -32,7 +31,7 @@ export async function getReleases(tags?: string[]): Promise<Map<string, IRelease
     // Get all the releases
     console.log('Getting all releases...');
     try {
-      const res: Octokit.ReposListReleasesResponseItem[] = await github.paginate(
+      const res = await github.paginate<{ tag_name: string; id: number }>(
         github.repos.listReleases.endpoint.merge(repoDetails),
       );
 

--- a/scripts/update-release-notes/types.ts
+++ b/scripts/update-release-notes/types.ts
@@ -1,5 +1,5 @@
 import { ChangelogJsonEntry } from 'beachball';
-import { IPullRequest } from '../github/index';
+import { IPullRequest } from '../github';
 
 /** Entry in a CHANGELOG.json's `entries` array, plus the package name */
 export interface IChangelogEntry extends ChangelogJsonEntry {
@@ -15,7 +15,7 @@ export interface ICommit {
   /** Author GitHub username */
   author: string;
   /** Author email */
-  authorEmail: string;
+  authorEmail?: string;
 }
 
 export interface IExtendedPullRequest extends IPullRequest {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,27 +3519,15 @@
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^16.28.2":
-  version "16.43.1"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.43.1.tgz#3b11e7d1b1ac2bbeeb23b08a17df0b20947eda6b"
-  integrity sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==
+"@octokit/rest@18.12.0", "@octokit/rest@^16.43.0 || ^17.11.0 || ^18.12.0", "@octokit/rest@^18.12.0":
+  version "18.12.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
   dependencies:
-    "@octokit/auth-token" "^2.4.0"
-    "@octokit/plugin-paginate-rest" "^1.1.1"
-    "@octokit/plugin-request-log" "^1.0.0"
-    "@octokit/plugin-rest-endpoint-methods" "2.4.0"
-    "@octokit/request" "^5.2.0"
-    "@octokit/request-error" "^1.0.2"
-    atob-lite "^2.0.0"
-    before-after-hook "^2.0.0"
-    btoa-lite "^1.0.0"
-    deprecation "^2.0.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
-    once "^1.4.0"
-    universal-user-agent "^4.0.0"
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
 "@octokit/rest@^16.28.4":
   version "16.43.2"
@@ -3562,16 +3550,6 @@
     octokit-pagination-methods "^1.1.0"
     once "^1.4.0"
     universal-user-agent "^4.0.0"
-
-"@octokit/rest@^16.43.0 || ^17.11.0 || ^18.12.0", "@octokit/rest@^18.12.0":
-  version "18.12.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
-  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
-  dependencies:
-    "@octokit/core" "^3.5.1"
-    "@octokit/plugin-paginate-rest" "^2.16.8"
-    "@octokit/plugin-request-log" "^1.0.4"
-    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
   version "2.1.1"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

we use v 16.  Danger uses v18

## New Behavior

we use v18

**NOTE:**
Lot of things changed since v16 including types... those types moves are not very well documented, so I did the best I could. If we are no 100% confident we can drop this and use v16.

- v17 breaking changes (go to the bottom to see type related notes) https://github.com/octokit/rest.js/releases/tag/v17.0.0



