### PR TITLE
chore(react-popover): update package scaffold

### DIFF
--- a/change/@fluentui-react-popover-37cc067c-8474-4cca-b718-d6b06ea02f96.json
+++ b/change/@fluentui-react-popover-37cc067c-8474-4cca-b718-d6b06ea02f96.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update package scaffold",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-popover/config/api-extractor.json
+++ b/packages/react-components/react-popover/config/api-extractor.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "",
+    "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts"
+  }
 }

--- a/packages/react-components/react-popover/config/api-extractor.local.json
+++ b/packages/react-components/react-popover/config/api-extractor.local.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "./api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/packages/react-components/<unscopedPackageName>/src/index.d.ts"
-}

--- a/packages/react-components/react-popover/package.json
+++ b/packages/react-components/react-popover/package.json
@@ -23,9 +23,8 @@
     "e2e:local": "cypress open --component",
     "storybook": "start-storybook",
     "test": "jest --passWithNoTests",
-    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
-    "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-popover/src && yarn docs",
-    "type-check": "tsc -b tsconfig.json"
+    "type-check": "tsc -b tsconfig.json",
+    "generate-api": "tsc -p ./tsconfig.lib.json --emitDeclarationOnly && just-scripts api-extractor"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/react-components/react-popover/tsconfig.lib.json
+++ b/packages/react-components/react-popover/tsconfig.lib.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "lib": ["ES2019", "dom"],
-    "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "../../../dist/out-tsc/types",
+    "outDir": "../../../dist/out-tsc",
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Migrates `react-popover` converged package to new DX by using the migration command:

```bash
yarn nx workspace-generator migrate-converged-pkg --name='@fluentui/react-popover'
```