### PR TITLE
chore: exports DialogContent as unstable

### DIFF
--- a/change/@fluentui-react-components-102726a3-c1d7-4c19-9454-412a1a1d8b7e.json
+++ b/change/@fluentui-react-components-102726a3-c1d7-4c19-9454-412a1a1d8b7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: exports DialogContent as unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -76,6 +76,11 @@ import { dialogBodyClassNames } from '@fluentui/react-dialog';
 import { DialogBodyProps } from '@fluentui/react-dialog';
 import { DialogBodySlots } from '@fluentui/react-dialog';
 import { DialogBodyState } from '@fluentui/react-dialog';
+import { DialogContent } from '@fluentui/react-dialog';
+import { dialogContentClassNames } from '@fluentui/react-dialog';
+import { DialogContentProps } from '@fluentui/react-dialog';
+import { DialogContentSlots } from '@fluentui/react-dialog';
+import { DialogContentState } from '@fluentui/react-dialog';
 import { DialogOpenChangeData } from '@fluentui/react-dialog';
 import { DialogOpenChangeEvent } from '@fluentui/react-dialog';
 import { DialogProps } from '@fluentui/react-dialog';
@@ -147,6 +152,7 @@ import { renderCombobox_unstable } from '@fluentui/react-combobox';
 import { renderDialog_unstable } from '@fluentui/react-dialog';
 import { renderDialogActions_unstable } from '@fluentui/react-dialog';
 import { renderDialogBody_unstable } from '@fluentui/react-dialog';
+import { renderDialogContent_unstable } from '@fluentui/react-dialog';
 import { renderDialogSurface_unstable } from '@fluentui/react-dialog';
 import { renderDialogTitle_unstable } from '@fluentui/react-dialog';
 import { renderDialogTrigger_unstable } from '@fluentui/react-dialog';
@@ -278,6 +284,8 @@ import { useDialogActions_unstable } from '@fluentui/react-dialog';
 import { useDialogActionsStyles_unstable } from '@fluentui/react-dialog';
 import { useDialogBody_unstable } from '@fluentui/react-dialog';
 import { useDialogBodyStyles_unstable } from '@fluentui/react-dialog';
+import { useDialogContent_unstable } from '@fluentui/react-dialog';
+import { useDialogContentStyles_unstable } from '@fluentui/react-dialog';
 import { useDialogSurface_unstable } from '@fluentui/react-dialog';
 import { useDialogSurfaceStyles_unstable } from '@fluentui/react-dialog';
 import { useDialogTitle_unstable } from '@fluentui/react-dialog';
@@ -465,6 +473,16 @@ export { DialogBodySlots }
 
 export { DialogBodyState }
 
+export { DialogContent }
+
+export { dialogContentClassNames }
+
+export { DialogContentProps }
+
+export { DialogContentSlots }
+
+export { DialogContentState }
+
 export { DialogOpenChangeData }
 
 export { DialogOpenChangeEvent }
@@ -606,6 +624,8 @@ export { renderDialog_unstable }
 export { renderDialogActions_unstable }
 
 export { renderDialogBody_unstable }
+
+export { renderDialogContent_unstable }
 
 export { renderDialogSurface_unstable }
 
@@ -868,6 +888,10 @@ export { useDialogActionsStyles_unstable }
 export { useDialogBody_unstable }
 
 export { useDialogBodyStyles_unstable }
+
+export { useDialogContent_unstable }
+
+export { useDialogContentStyles_unstable }
 
 export { useDialogSurface_unstable }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -202,6 +202,11 @@ export {
   useDialogSurface_unstable,
   useDialogSurfaceStyles_unstable,
   renderDialogSurface_unstable,
+  DialogContent,
+  dialogContentClassNames,
+  useDialogContentStyles_unstable,
+  useDialogContent_unstable,
+  renderDialogContent_unstable,
 } from '@fluentui/react-dialog';
 
 export type {
@@ -227,6 +232,9 @@ export type {
   DialogSurfaceProps,
   DialogSurfaceSlots,
   DialogSurfaceState,
+  DialogContentProps,
+  DialogContentSlots,
+  DialogContentState,
 } from '@fluentui/react-dialog';
 
 export {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Exports new compound component for `Dialog`: `DialogContent`