### PR TITLE
fix: Detailslist hides columns even with horizontal scroll, CustomColumns example does not hide all columns at small screens

### DIFF
--- a/change/@fluentui-react-c1711406-0feb-4e85-8e43-a143f1bcb3ec.json
+++ b/change/@fluentui-react-c1711406-0feb-4e85-8e43-a143f1bcb3ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: DetailsList should collapse columns even with horizontal scroll, and the CustomColumns example should not hide all columns",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -78,10 +78,12 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
     thumbnailColumn.ariaLabel = 'Thumbnail';
     thumbnailColumn.onColumnClick = undefined;
 
-    //indicate that all columns except thumbnail column can be sorted
+    // Indicate that all columns except thumbnail column can be sorted,
+    // and only the description colum should disappear at small screen sizes
     columns.forEach((column: IColumn) => {
       if (column.name) {
         column.showSortIconWhenUnsorted = true;
+        column.isCollapsible = column.name === 'description';
       }
     });
 

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -1304,7 +1304,6 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden ? CHECKBOX_WIDTH : 0;
     const groupExpandWidth = this._getGroupNestingDepth() * GROUP_EXPAND_WIDTH;
     let totalWidth = 0; // offset because we have one less inner padding.
-    let minimumWidth = 0;
     const availableWidth = viewportWidth - (rowCheckWidth + groupExpandWidth);
     const adjustedColumns: IColumn[] = newColumns.map((column, i) => {
       const baseColumn = {
@@ -1317,17 +1316,12 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
         ...this._columnOverrides[column.key],
       };
 
-      // eslint-disable-next-line deprecation/deprecation
-      if (!(baseColumn.isCollapsible || baseColumn.isCollapsable)) {
-        minimumWidth += getPaddedWidth(baseColumn, props);
-      }
-
       totalWidth += getPaddedWidth(newColumn, props);
 
       return newColumn;
     });
 
-    if (minimumWidth > availableWidth) {
+    if (availableWidth >= totalWidth) {
       return adjustedColumns;
     }
 
@@ -1508,7 +1502,6 @@ export function buildColumns(
           fieldName: propName,
           minWidth: MIN_COLUMN_WIDTH,
           maxWidth: 300,
-          isCollapsable: !!columns.length,
           isCollapsible: !!columns.length,
           isMultiline: isMultiline === undefined ? false : isMultiline,
           isSorted: sortedColumnKey === propName,


### PR DESCRIPTION
Fixes the bug on the CustomColumns example, which set all columns' `isCollapsible` to `true`, which hid all columns but thumbnail at high zoom.

While fixing that, I noticed that DetailsList does not collapse columns if the "minimum width" won't fit on screen -- i.e. if there is any horizontal scroll at all, DetailsList will go back to rendering all columns, regardless of `isCollapsible`. Because of this, when I updated the example to collapse only the `description` column, the `description` column would remain collapsed only between screen widths 1160px-1040px -- above 1160 or below 1040, it would appear again.

This change ensures that columns remain collapsed when below the width they would fit, regardless of whether the permanently visible columns fit on screen.
