### PR TITLE
chore(react-aria): user defined tabIndex should prevail

### DIFF
--- a/change/@fluentui-react-aria-601b8c0d-d97a-4365-9dc5-41df68787f92.json
+++ b/change/@fluentui-react-aria-601b8c0d-d97a-4365-9dc5-41df68787f92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: user defined tabIndex should prevail aria-button defined",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/src/button/useARIAButtonProps.test.tsx
+++ b/packages/react-components/react-aria/src/button/useARIAButtonProps.test.tsx
@@ -106,7 +106,7 @@ describe('useARIAButton', () => {
     it('should be aria-disabled when disabled', () => {
       const {
         result: { current },
-      } = renderHook(() => useARIAButtonProps('a', { disabled: true }));
+      } = renderHook(() => useARIAButtonProps('div', { disabled: true }));
       expect(current).not.toHaveProperty('as');
       expect(current).not.toHaveProperty('disabledFocusable');
       expect(current).toEqual(
@@ -123,7 +123,7 @@ describe('useARIAButton', () => {
     it('should be aria-disabled when disabledFocusable but still focusabled', () => {
       const {
         result: { current },
-      } = renderHook(() => useARIAButtonProps('a', { disabledFocusable: true }));
+      } = renderHook(() => useARIAButtonProps('div', { disabledFocusable: true }));
       expect(current).not.toHaveProperty('as');
       expect(current).not.toHaveProperty('disabledFocusable');
       expect(current).toEqual(
@@ -133,7 +133,18 @@ describe('useARIAButton', () => {
         }),
       );
     });
+    it('should keep user defined tabIndex', () => {
+      const {
+        result: { current },
+      } = renderHook(() => useARIAButtonProps('div', { tabIndex: undefined }));
+      expect(current).toEqual(
+        expect.objectContaining<ARIAButtonProps>({
+          tabIndex: undefined,
+        }),
+      );
+    });
   });
+
   describe('<a>', () => {
     it('should omit href if disabled', () => {
       const href = '/';
@@ -153,6 +164,7 @@ describe('useARIAButton', () => {
       );
     });
   });
+
   it.each(['button', 'div', 'a'] as const)('should not be possible to click %p when aria-disabled is true', type => {
     const handleClick = jest.fn();
     const { getByRole } = render(<TestButton as={type} onClick={handleClick} aria-disabled />);

--- a/packages/react-components/react-aria/src/button/useARIAButtonProps.ts
+++ b/packages/react-components/react-aria/src/button/useARIAButtonProps.ts
@@ -34,16 +34,8 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
   type?: Type,
   props?: Props,
 ): ARIAButtonResultProps<Type, Props> {
-  const {
-    disabled,
-    tabIndex,
-    disabledFocusable = false,
-    onClick,
-    onKeyDown,
-    onKeyUp,
-    ['aria-disabled']: ariaDisabled,
-    ...rest
-  } = props ?? {};
+  const { disabled, disabledFocusable = false, ['aria-disabled']: ariaDisabled, onClick, onKeyDown, onKeyUp, ...rest } =
+    props ?? {};
 
   const normalizedARIADisabled = typeof ariaDisabled === 'string' ? ariaDisabled === 'true' : ariaDisabled;
 
@@ -110,7 +102,6 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
   if (type === 'button' || type === undefined) {
     return {
       ...rest,
-      tabIndex,
       disabled: disabled && !disabledFocusable,
       'aria-disabled': disabledFocusable ? true : normalizedARIADisabled,
       // onclick should still use internal handler to ensure prevention if disabled
@@ -126,6 +117,7 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
   else {
     const resultProps = {
       role: 'button',
+      tabIndex: disabled && !disabledFocusable ? undefined : 0,
       ...rest,
       // If it's not a <button> than listeners are required even with disabledFocusable
       // Since you cannot assure the default behavior of the element
@@ -134,7 +126,6 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
       onKeyUp: handleKeyUp,
       onKeyDown: handleKeyDown,
       'aria-disabled': disabled || disabledFocusable || normalizedARIADisabled,
-      tabIndex: disabled && !disabledFocusable ? undefined : tabIndex ?? 0,
     } as ARIAButtonResultProps<Type, Props>;
 
     if (type === 'a' && isDisabled) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

```html

<Trigger>
  <!-- tabIndex here is ignored as it's undefined and 0 is provided as default value -->
  <div tabIndex={undefined}>Custom trigger</div>
</Trigger>

```

## New Behavior

```html

<Trigger>
  <!-- tabIndex should be undefined -->
  <div tabIndex={undefined}>Custom trigger</div>
</Trigger>

```

