### PR TITLE
ci(.github): add issues write permisions to triage-bot worflow

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   triage-issue:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/github-script@v6


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Triage bot throws 403 when running github-scripts

https://github.com/microsoft/fluentui/actions/runs/3134318373/jobs/5088716330#step:3:81
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/1223799/192509509-6fb54fef-bd09-4a0c-8d2d-60d2f1cc9131.png">


## New Behavior

adding explicit permision for issues write

## Related Issue(s)

follows https://github.com/microsoft/fluentui/pull/24911
