### PR TITLE
chore: Migrate react-avatar to use new build

### DIFF
--- a/change/@fluentui-react-avatar-ad6cefba-a092-49d7-8cf6-bac42f97eb2b.json
+++ b/change/@fluentui-react-avatar-ad6cefba-a092-49d7-8cf6-bac42f97eb2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate react-avatar to use new build",
+  "packageName": "@fluentui/react-avatar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/config/api-extractor.json
+++ b/packages/react-components/react-avatar/config/api-extractor.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "",
+    "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts"
+  }
 }

--- a/packages/react-components/react-avatar/config/api-extractor.local.json
+++ b/packages/react-components/react-avatar/config/api-extractor.local.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "./api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/packages/react-components/<unscopedPackageName>/src/index.d.ts"
-}

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -19,13 +19,12 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook",
-    "e2e": "yarn cypress run --component",
-    "e2e:local": "yarn cypress open --component",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component",
     "test": "jest --passWithNoTests",
-    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
-    "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-avatar/src && yarn docs",
     "storybook": "start-storybook",
-    "type-check": "tsc -b tsconfig.json"
+    "type-check": "tsc -b tsconfig.json",
+    "generate-api": "tsc -p ./tsconfig.lib.json --emitDeclarationOnly && just-scripts api-extractor"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/react-components/react-avatar/tsconfig.json
+++ b/packages/react-components/react-avatar/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "./.storybook/tsconfig.json"
+    },
+    {
+      "path": "./e2e/tsconfig.json"
     }
   ]
 }

--- a/packages/react-components/react-avatar/tsconfig.lib.json
+++ b/packages/react-components/react-avatar/tsconfig.lib.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "lib": ["ES2019", "dom"],
-    "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "../../../dist/out-tsc/types",
+    "outDir": "../../../dist/out-tsc",
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },


### PR DESCRIPTION
Migrates the react-avatar package to use the new build experience introduced in #23369
