### PR TITLE
chore: Migrate react-table to use new build

### DIFF
--- a/change/@fluentui-react-table-7bc36841-f472-43be-97c0-3885e7f42c1e.json
+++ b/change/@fluentui-react-table-7bc36841-f472-43be-97c0-3885e7f42c1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate react-table to use new build",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-table/config/api-extractor.json
+++ b/packages/react-components/react-table/config/api-extractor.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts"
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "",
+    "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts"
+  }
 }

--- a/packages/react-components/react-table/config/api-extractor.local.json
+++ b/packages/react-components/react-table/config/api-extractor.local.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "./api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/types/packages/react-components/<unscopedPackageName>/src/index.d.ts"
-}

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -18,11 +18,10 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "test": "jest --passWithNoTests",
-    "docs": "api-extractor run --config=config/api-extractor.local.json --local",
-    "build:local": "tsc -p ./tsconfig.lib.json --module esnext --emitDeclarationOnly && node ../../../scripts/typescript/normalize-import --output ./dist/types/packages/react-components/react-table/src && yarn docs",
     "type-check": "tsc -b tsconfig.json",
     "storybook": "start-storybook",
-    "start": "yarn storybook"
+    "start": "yarn storybook",
+    "generate-api": "tsc -p ./tsconfig.lib.json --emitDeclarationOnly && just-scripts api-extractor"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/react-components/react-table/tsconfig.lib.json
+++ b/packages/react-components/react-table/tsconfig.lib.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "lib": ["ES2019", "dom"],
-    "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "../../../dist/out-tsc/types",
+    "outDir": "../../../dist/out-tsc",
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },


### PR DESCRIPTION
Migrates the react-table package to use the new build experience introduced in #23369
