### PR TITLE
fix: MessageBar actions contrast in high contrast mode

### DIFF
--- a/change/@fluentui-react-f9f3d9e8-481a-4929-9cd1-0623610e48fd.json
+++ b/change/@fluentui-react-f9f3d9e8-481a-4929-9cd1-0623610e48fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MessageBar actions contrast in high contrast mode",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/react/src/components/MessageBar/MessageBar.styles.ts
@@ -252,6 +252,9 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         flexDirection: 'row-reverse',
         alignItems: 'center',
         margin: '0 12px 0 8px',
+        // reset forced colors to browser control for inner actions
+        forcedColorAdjust: 'auto',
+        MsHighContrastAdjust: 'auto',
         selectors: {
           '& button:nth-child(n+2)': {
             marginLeft: 8,


### PR DESCRIPTION
Fixes[14071](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14071)

MessageBar set `forced-color-adjust: none` on its root, which then removed native HCM styling for child buttons. This PR sets `forced-color-adjust: auto` on the inner buttons to restore HCM contrast & user colors.