### PR TITLE
fix: add Detailslist footer to rowcount, fix example

### DIFF
--- a/change/@fluentui-react-a2709ae0-6ff2-40b5-9f8c-31f7e6ac37a3.json
+++ b/change/@fluentui-react-a2709ae0-6ff2-40b5-9f8c-31f7e6ac37a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DetailsList adds DetailsFooter to rowcount if provided",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomFooter.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomFooter.Example.tsx
@@ -61,7 +61,7 @@ export class DetailsListCustomFooterExample extends React.Component<{}, {}> {
         {...detailsFooterProps}
         columns={detailsFooterProps.columns}
         item={{}}
-        itemIndex={-1}
+        itemIndex={5}
         groupNestingDepth={detailsFooterProps.groupNestingDepth}
         selectionMode={SelectionMode.single}
         selection={detailsFooterProps.selection}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -319,7 +319,11 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     }
   }, [columnReorderOptions, onColumnDragEnd]);
 
-  const rowCount = (isHeaderVisible ? 1 : 0) + GetGroupCount(groups) + (items ? items.length : 0);
+  const rowCount =
+    (isHeaderVisible ? 1 : 0) +
+    (props.onRenderDetailsFooter ? 1 : 0) +
+    GetGroupCount(groups) +
+    (items ? items.length : 0);
   const colCount =
     (selectAllVisibility !== SelectAllVisibility.none ? 1 : 0) +
     (adjustedColumns ? adjustedColumns.length : 0) +

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -727,6 +727,22 @@ describe('DetailsList', () => {
     );
   });
 
+  it('calculates DetailsHeader and DetailsFooter in rowcount', () => {
+    const onRenderDetailsHeaderMock = jest.fn();
+    const onRenderDetailsFooterMock = jest.fn();
+
+    const component = renderer.create(
+      <DetailsList
+        items={mockData(5)}
+        onRenderDetailsHeader={onRenderDetailsHeaderMock}
+        onRenderDetailsFooter={onRenderDetailsFooterMock}
+      />,
+    );
+
+    const grid = component.root.findByProps({ role: 'grid' });
+    expect(grid.props[`aria-rowcount`]).toEqual(7);
+  });
+
   it('invokes onRenderColumnHeaderTooltip to customize DetailsColumn tooltip rendering when provided', () => {
     const NUM_COLUMNS = 2;
     const onRenderColumnHeaderTooltipMock = jest.fn();


### PR DESCRIPTION
Fixes [15452](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15452)

We previously didn't add the footer to the rowcount calculation, which causes JAWS to not expose it with table navigation. This PR updates our `rowCount` calc to use the footer if provided, and fixes the custom footer example.