### PR TITLE
Experiment: measure React context performance

### DIFF
--- a/apps/stress-test/scripts/commands/buildTestConfig.ts
+++ b/apps/stress-test/scripts/commands/buildTestConfig.ts
@@ -85,7 +85,7 @@ const makeConfigJson: MakeConfigJson = (_scenario, browser, testCase, sampleSize
 
           return {
             name: `${target} - ${testCase} - ${size}`,
-            url: `${baseUrl}/${targetWithoutParams}/?${params}`,
+            url: `${baseUrl}/${targetWithoutParams}/${_scenario}/?${params}`,
           };
         }),
       },

--- a/apps/stress-test/src/components/context-perf/StressApp.tsx
+++ b/apps/stress-test/src/components/context-perf/StressApp.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { getTestParams } from '../../shared/testParams';
+import { performanceMeasure } from '../../shared/performanceMeasure';
+import { StressContainer } from './StressContainer';
+
+export const StressApp = () => {
+  const [numChildren, setNumChildren] = React.useState(getTestParams().numStartNodes);
+
+  React.useEffect(() => {
+    const { test, numStartNodes, numAddNodes, numRemoveNodes } = getTestParams();
+    if (test === 'add-node') {
+      performanceMeasure('stress', 'start');
+      setNumChildren(numStartNodes + numAddNodes);
+    } else if (test === 'removeNode') {
+      performanceMeasure('stress', 'start');
+      setNumChildren(numStartNodes - numRemoveNodes);
+    }
+  }, []);
+
+  return <StressContainer numChildren={numChildren} />;
+};
+
+export default StressApp;

--- a/apps/stress-test/src/components/context-perf/StressComponent.tsx
+++ b/apps/stress-test/src/components/context-perf/StressComponent.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { contexts } from './contexts';
+
+export type StressComponentProps = {
+  id?: string;
+  count: number;
+  checked: boolean;
+};
+
+export const StressComponent: React.FC<StressComponentProps> = ({ count, checked }) => {
+  const { value } = React.useContext(contexts[count]);
+  return (
+    <div>
+      Context: {value} {checked}
+    </div>
+  );
+};

--- a/apps/stress-test/src/components/context-perf/StressContainer.tsx
+++ b/apps/stress-test/src/components/context-perf/StressContainer.tsx
@@ -1,0 +1,50 @@
+import { makeStyles, shorthands } from '@fluentui/react-components';
+import * as React from 'react';
+import { getTestParams } from '../../shared/testParams';
+import { performanceMeasure } from '../../shared/performanceMeasure';
+import { StressComponent } from './StressComponent';
+import { contexts } from './contexts';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    ...shorthands.gap('10px'),
+  },
+});
+
+export type StressContainerProps = {
+  numChildren?: number;
+};
+
+export const StressContainer: React.FC<StressContainerProps> = ({ numChildren = 10 }) => {
+  const [checked, setChecked] = React.useState(false);
+
+  React.useEffect(() => {
+    const { test } = getTestParams();
+    if (test === 'mount') {
+      performanceMeasure('stress', 'start');
+    } else if (test === 'prop-update') {
+      setTimeout(() => {
+        performanceMeasure('stress', 'start');
+        setChecked(true);
+      }, 2000);
+    }
+  }, []);
+
+  const styles = useStyles();
+
+  const kids = new Array(numChildren).fill('1');
+  return (
+    <div className={styles.container}>
+      {kids.map((_, index) => {
+        const { Provider } = contexts[index];
+        return (
+          <Provider key={index} value={{ value: index }}>
+            <StressComponent count={index} checked={checked} />
+          </Provider>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/stress-test/src/components/context-perf/contexts.ts
+++ b/apps/stress-test/src/components/context-perf/contexts.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { getTestParams } from '../../shared/testParams';
+
+interface ContextValue {
+  value: number;
+}
+
+export const contexts = new Array(getTestParams().numStartNodes)
+  .fill(0)
+  .map(() => React.createContext<ContextValue>({ value: -1 }));

--- a/apps/stress-test/src/components/no-context-perf/StressApp.tsx
+++ b/apps/stress-test/src/components/no-context-perf/StressApp.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { getTestParams } from '../../shared/testParams';
+import { performanceMeasure } from '../../shared/performanceMeasure';
+import { StressContainer } from './StressContainer';
+
+export const StressApp = () => {
+  const [numChildren, setNumChildren] = React.useState(getTestParams().numStartNodes);
+
+  React.useEffect(() => {
+    const { test, numStartNodes, numAddNodes, numRemoveNodes } = getTestParams();
+    if (test === 'add-node') {
+      performanceMeasure('stress', 'start');
+      setNumChildren(numStartNodes + numAddNodes);
+    } else if (test === 'removeNode') {
+      performanceMeasure('stress', 'start');
+      setNumChildren(numStartNodes - numRemoveNodes);
+    }
+  }, []);
+
+  return <StressContainer numChildren={numChildren} />;
+};
+
+export default StressApp;

--- a/apps/stress-test/src/components/no-context-perf/StressComponent.tsx
+++ b/apps/stress-test/src/components/no-context-perf/StressComponent.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export type StressComponentProps = {
+  id?: string;
+  count: number;
+  checked: boolean;
+};
+
+export const StressComponent: React.FC<StressComponentProps> = ({ count, checked }) => {
+  return (
+    <div>
+      Context: {count} {checked}
+    </div>
+  );
+};

--- a/apps/stress-test/src/components/no-context-perf/StressContainer.tsx
+++ b/apps/stress-test/src/components/no-context-perf/StressContainer.tsx
@@ -1,0 +1,44 @@
+import { makeStyles, shorthands } from '@fluentui/react-components';
+import * as React from 'react';
+import { getTestParams } from '../../shared/testParams';
+import { performanceMeasure } from '../../shared/performanceMeasure';
+import { StressComponent } from './StressComponent';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    ...shorthands.gap('10px'),
+  },
+});
+
+export type StressContainerProps = {
+  numChildren?: number;
+};
+
+export const StressContainer: React.FC<StressContainerProps> = ({ numChildren = 10 }) => {
+  const [checked, setChecked] = React.useState(false);
+
+  React.useEffect(() => {
+    const { test } = getTestParams();
+    if (test === 'mount') {
+      performanceMeasure('stress', 'start');
+    } else if (test === 'prop-update') {
+      setTimeout(() => {
+        performanceMeasure('stress', 'start');
+        setChecked(true);
+      }, 2000);
+    }
+  }, []);
+
+  const styles = useStyles();
+
+  const kids = new Array(numChildren).fill('1');
+  return (
+    <div className={styles.container}>
+      {kids.map((_, index) => {
+        return <StressComponent key={index} count={index} checked={checked} />;
+      })}
+    </div>
+  );
+};

--- a/apps/stress-test/src/pages/v9/context-perf/index.html
+++ b/apps/stress-test/src/pages/v9/context-perf/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>v9: Simple Stress</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/apps/stress-test/src/pages/v9/context-perf/index.tsx
+++ b/apps/stress-test/src/pages/v9/context-perf/index.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { StressApp } from '../../../components/context-perf/StressApp';
+
+ReactDOM.render(<StressApp />, document.getElementById('root'));

--- a/apps/stress-test/src/pages/v9/no-context-perf/index.html
+++ b/apps/stress-test/src/pages/v9/no-context-perf/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>v9: Simple Stress</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/apps/stress-test/src/pages/v9/no-context-perf/index.tsx
+++ b/apps/stress-test/src/pages/v9/no-context-perf/index.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { StressApp } from '../../../components/no-context-perf/StressApp';
+
+ReactDOM.render(<StressApp />, document.getElementById('root'));


### PR DESCRIPTION
Used the stress test app to measure 2 scenarios:
* elements consuming context
* elements not consuming context

The results are run for small, medium and large scenarios of 250, 500 and 750 elements rendered respectively.

### no-context

![image](https://user-images.githubusercontent.com/20744592/192788654-200b07db-db47-47c0-9365-5dc051ed91d2.png)
![image](https://user-images.githubusercontent.com/20744592/192788696-849ebc9c-1f4d-4885-9cc2-adffef69f8be.png)
![image](https://user-images.githubusercontent.com/20744592/192788722-2cfff0e2-2112-4622-aa90-338d732a5779.png)


### context

![image](https://user-images.githubusercontent.com/20744592/192788498-530a6be6-6381-4407-895f-7bca2808d013.png)
![image](https://user-images.githubusercontent.com/20744592/192788536-a38b3267-64e8-4d21-becc-fa191cf9cbe0.png)
![image](https://user-images.githubusercontent.com/20744592/192788562-2c68a97d-f9e1-4876-a0cd-d887267f1dbd.png)

