### PR TITLE
fix: focus outline selectors are data attributes

### DIFF
--- a/packages/react-components/react-tabster/src/focus/constants.ts
+++ b/packages/react-components/react-tabster/src/focus/constants.ts
@@ -1,7 +1,21 @@
 export const KEYBOARD_NAV_ATTRIBUTE = 'data-keyboard-nav' as const;
 export const KEYBOARD_NAV_SELECTOR = `:global([${KEYBOARD_NAV_ATTRIBUTE}])` as const;
+/**
+ * @internal
+ */
 export const FOCUS_VISIBLE_CLASS = 'fui-focus-visible';
+/**
+ * @internal
+ */
+export const FOCUS_VISIBLE_ATTR = 'data-fui-focus-visible';
+/**
+ * @internal
+ */
 export const FOCUS_WITHIN_CLASS = 'fui-focus-within';
+/**
+ * @internal
+ */
+export const FOCUS_WITHIN_ATTR = 'data-fui-focus-visible';
 export const defaultOptions = {
   style: {},
   selector: 'focus',

--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -1,4 +1,10 @@
-import { FOCUS_VISIBLE_CLASS, defaultOptions, FOCUS_WITHIN_CLASS } from './constants';
+import {
+  FOCUS_VISIBLE_CLASS,
+  defaultOptions,
+  FOCUS_WITHIN_CLASS,
+  FOCUS_VISIBLE_ATTR,
+  FOCUS_WITHIN_ATTR,
+} from './constants';
 import type { GriffelStyle } from '@griffel/react';
 
 export interface CreateCustomFocusIndicatorStyleOptions {
@@ -24,9 +30,11 @@ export const createCustomFocusIndicatorStyle = (
   },
 
   ...(selector === 'focus' && {
-    [`&.${FOCUS_VISIBLE_CLASS}`]: style,
+    // [`&.${FOCUS_VISIBLE_CLASS}`]: style,
+    [`&[${FOCUS_VISIBLE_ATTR}]`]: style,
   }),
   ...(selector === 'focus-within' && {
-    [`&.${FOCUS_WITHIN_CLASS}:${selector}`]: style,
+    // [`&.${FOCUS_WITHIN_CLASS}:${selector}`]: style,
+    [`&[${FOCUS_WITHIN_ATTR}]:${selector}`]: style,
   }),
 });

--- a/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
@@ -1,5 +1,5 @@
 import { KEYBORG_FOCUSIN, KeyborgFocusInEvent, createKeyborg, disposeKeyborg } from 'keyborg';
-import { FOCUS_VISIBLE_CLASS } from './constants';
+import { FOCUS_VISIBLE_ATTR } from './constants';
 
 /**
  * Because `addEventListener` type override falls back to 2nd definition (evt name is unknown string literal)
@@ -83,11 +83,11 @@ export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () =
 }
 
 function applyFocusVisibleClass(el: HTMLElement) {
-  el.classList.add(FOCUS_VISIBLE_CLASS);
+  el.setAttribute(FOCUS_VISIBLE_ATTR, '');
 }
 
 function removeFocusVisibleClass(el: HTMLElement) {
-  el.classList.remove(FOCUS_VISIBLE_CLASS);
+  el.removeAttribute(FOCUS_VISIBLE_ATTR);
 }
 
 function isHTMLElement(target: EventTarget | null): target is HTMLElement {

--- a/packages/react-components/react-tabster/src/focus/focusWithinPolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusWithinPolyfill.ts
@@ -1,5 +1,5 @@
 import { KEYBORG_FOCUSIN, KeyborgFocusInEvent, createKeyborg, disposeKeyborg } from 'keyborg';
-import { FOCUS_WITHIN_CLASS } from './constants';
+import { FOCUS_WITHIN_ATTR } from './constants';
 
 /**
  * Because `addEventListener` type override falls back to 2nd definition (evt name is unknown string literal)
@@ -51,11 +51,11 @@ export function applyFocusWithinPolyfill(element: HTMLElement, win: Window): () 
 }
 
 function applyFocusWithinClass(el: HTMLElement) {
-  el.classList.add(FOCUS_WITHIN_CLASS);
+  el.setAttribute(FOCUS_WITHIN_ATTR, '');
 }
 
 function removeFocusWithinClass(el: HTMLElement) {
-  el.classList.remove(FOCUS_WITHIN_CLASS);
+  el.removeAttribute(FOCUS_WITHIN_ATTR);
 }
 
 function isHTMLElement(target: EventTarget | null): target is HTMLElement {


### PR DESCRIPTION
## Current Behavior

The focus outline selectors are classnames which are overriden when react re-renders a component

## New Behavior

The focus outline selectors are data-attributes which decreases the likelihood there will be conflicts with attributes set in react

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #24875
