### PR TITLE
chore: export useViewport via lib/Viewport

### DIFF
--- a/change/@fluentui-react-aa1768fc-3f4c-43dc-898f-1f1de8576f77.json
+++ b/change/@fluentui-react-aa1768fc-3f4c-43dc-898f-1f1de8576f77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: export useViewport via lib/Viewport",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9611,6 +9611,12 @@ export interface IWithViewportProps {
 }
 
 // @public (undocumented)
+export interface IWithViewportState {
+    // (undocumented)
+    viewport?: IViewport;
+}
+
+// @public (undocumented)
 export enum KeyboardSpinDirection {
     // (undocumented)
     down = -1,
@@ -11368,6 +11374,11 @@ export { WindowProviderProps }
 // @public @deprecated (undocumented)
 export function withResponsiveMode<TProps extends {
     responsiveMode?: ResponsiveMode;
+}, TState>(ComposedComponent: new (props: TProps, ...args: any[]) => React_2.Component<TProps, TState>): any;
+
+// @public
+export function withViewport<TProps extends {
+    viewport?: IViewport;
 }, TState>(ComposedComponent: new (props: TProps, ...args: any[]) => React_2.Component<TProps, TState>): any;
 
 export { ZIndexes }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1027,6 +1027,11 @@
       "import": "./lib/Utilities.js",
       "require": "./lib-commonjs/Utilities.js"
     },
+    "./lib/Viewport": {
+      "types": "./lib/Viewport.d.ts",
+      "import": "./lib/Viewport.js",
+      "require": "./lib-commonjs/Viewport.js"
+    },
     "./lib/version": {
       "types": "./lib/version.d.ts",
       "import": "./lib/version.js",

--- a/packages/react/src/Viewport.ts
+++ b/packages/react/src/Viewport.ts
@@ -1,0 +1,1 @@
+export * from './utilities/decorators/withViewport';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -86,6 +86,7 @@ export * from './TimePicker';
 export * from './Toggle';
 export * from './Tooltip';
 export * from './Utilities';
+export * from './Viewport';
 export * from './WeeklyDayPicker';
 export * from './WindowProvider';
 /**

--- a/packages/react/src/utilities/decorators/withViewport.tsx
+++ b/packages/react/src/utilities/decorators/withViewport.tsx
@@ -71,7 +71,7 @@ const MAX_RESIZE_ATTEMPTS = 3;
 /**
  * A decorator to update decorated component on viewport or window resize events.
  *
- * @param ComposedComponent decorated React component reference.
+ * @param ComposedComponent - decorated React component reference.
  */
 export function withViewport<TProps extends { viewport?: IViewport }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>,


### PR DESCRIPTION
We removed decorators in v8 and are exporting those decorators in dedicated paths (like useResponsiveMode is now lib/ResponsiveMode). This change exposes useViewport using the same approach

Afterwards, this will be cherrypicked back to v7 to give users an upgrade path away from the old lib/Decorators

