### PR TITLE
fix(create-component): Replace build:local with new generate-api script

### DIFF
--- a/scripts/create-component/create-component.ts
+++ b/scripts/create-component/create-component.ts
@@ -103,7 +103,7 @@ module.exports = (plop: NodePlopAPI) => {
             stdio: 'inherit',
           });
 
-          execSync(`yarn workspace ${data.packageNpmName} build:local`, {
+          execSync(`yarn workspace ${data.packageNpmName} generate-api`, {
             cwd: root,
             stdio: 'inherit',
           });


### PR DESCRIPTION
### Issue:
- When creating a new component via the `create-component` script, an error will be thrown since it tries to run `build:local` which has been replaced by the `generate-api` script in #23369
![image](https://user-images.githubusercontent.com/8649804/192835258-6356cc83-2107-45ea-848e-41ab077f12a1.png)

### Changes:
- This PR fixes this issue by replacing `build:local` with `generate-api` when creating a new component with `create-component`.