### PR TITLE
Removed the initializeThemeInCustomizations side effect from index

### DIFF
--- a/change/@uifabric-styling-452e2438-8a31-4477-8900-e6fb2841f798.json
+++ b/change/@uifabric-styling-452e2438-8a31-4477-8900-e6fb2841f798.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed the initializeThemeInCustomizations side effect from index",
+  "packageName": "@uifabric/styling",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -219,6 +219,9 @@ export interface IIconSubsetRecord extends IIconSubset {
     isRegistered?: boolean;
 }
 
+// @public (undocumented)
+export function initializeThemeInCustomizations(): void;
+
 export { InjectionMode }
 
 export { IPalette }

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -11,7 +11,7 @@
   "module": "lib/index.js",
   "sideEffects": [
     "lib/version.js",
-    "lib/index.js"
+    "lib/styles/theme.js"
   ],
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/packages/styling/src/index.ts
+++ b/packages/styling/src/index.ts
@@ -5,7 +5,3 @@ export * from './interfaces/index';
 export * from './MergeStyles';
 
 import './version';
-
-// Ensure theme is initialized when this package is referenced.
-import { initializeThemeInCustomizations } from './styles/theme';
-initializeThemeInCustomizations();

--- a/packages/styling/src/styles/index.ts
+++ b/packages/styling/src/styles/index.ts
@@ -13,6 +13,7 @@ export {
   getTheme,
   loadTheme,
   createTheme,
+  initializeThemeInCustomizations,
   registerOnThemeChangeCallback,
   removeOnThemeChangeCallback,
 } from './theme';

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -28,6 +28,7 @@ export function initializeThemeInCustomizations(): void {
   }
 }
 
+// Ensure theme is initialized when this package is referenced.
 initializeThemeInCustomizations();
 
 /**


### PR DESCRIPTION
## Issue
The initializeThemeInCustomizations is called from styling/index.ts which causes the index to be marked as a sideEffect in package.json and prevents tree shaking.  As well the styles/theme.ts already calls this method when that module is referenced.

Updates #24393

## Changes
- Removed function call from index.ts
- Exported function from styles/index.ts
- Moved comment for function call to to styles/theme.ts
- Marked lib/styles/theme.js as the side effect in package.json

## Screenshots
Before the method is called twice, after only once.

<img width="251" alt="image" src="https://user-images.githubusercontent.com/28762486/192860860-d593df3f-1b63-436b-914e-11efa99c210f.png">
