### PR TITLE
fix: Calendar should not append day letter to weekday headers

### DIFF
--- a/change/@fluentui-react-4ed89861-a35a-49cc-b44b-db273d7451a4.json
+++ b/change/@fluentui-react-4ed89861-a35a-49cc-b44b-db273d7451a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not append first of month day letter after day name",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
@@ -25,7 +25,7 @@ export const CalendarMonthHeaderRow: React.FunctionComponent<ICalendarDayMonthHe
       {showWeekNumbers && <th className={classNames.dayCell} />}
       {dayLabels.map((val: string, index: number) => {
         const i = (index + firstDayOfWeek) % DAYS_IN_WEEK;
-        const label = index === firstOfMonthIndex ? strings.days[i] + ' ' + dayLabels[i] : strings.days[i];
+        const label = strings.days[i];
         return (
           <th
             className={css(classNames.dayCell, classNames.weekDayLabelCell)}

--- a/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/react/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -454,7 +454,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             M
           </th>
           <th
-            aria-label="Tuesday Jan"
+            aria-label="Tuesday"
             className=
 
                 {
@@ -525,7 +525,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
                   animation-timing-function: cubic-bezier(.1,.25,.75,.9);
                 }
             scope="col"
-            title="Tuesday Jan"
+            title="Tuesday"
           >
             Jan
           </th>
@@ -3679,7 +3679,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             M
           </th>
           <th
-            aria-label="Tuesday Jan"
+            aria-label="Tuesday"
             className=
 
                 {
@@ -3750,7 +3750,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
                   animation-timing-function: cubic-bezier(.1,.25,.75,.9);
                 }
             scope="col"
-            title="Tuesday Jan"
+            title="Tuesday"
           >
             Jan
           </th>


### PR DESCRIPTION
Currently the Calendar appends a letter to a single day header in the week (so "Thursday T" instead of "Thursday"). This is only done for the day of the week that the first day of the month falls on. This seems pretty clearly undesirable, and is fixed in this PR.