### PR TITLE
fix(react-avatar): Make AvatarGroupPopover's focus indicator the same for all layouts

### DIFF
--- a/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
@@ -132,7 +132,12 @@ storiesOf('AvatarGroup Converged', module)
   .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
     <Screener
-      steps={new Screener.Steps().focus('#show-overflow').click('#show-overflow').snapshot('overflowContentOpen').end()}
+      steps={new Screener.Steps()
+        .focus('#show-overflow')
+        .snapshot('popoverFocusIndicator')
+        .click('#show-overflow')
+        .snapshot('popoverContentOpen')
+        .end()}
     >
       {story()}
     </Screener>

--- a/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
@@ -131,14 +131,7 @@ storiesOf('AvatarGroup Converged', module)
 storiesOf('AvatarGroup Converged', module)
   .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
-    <Screener
-      steps={new Screener.Steps()
-        .focus('#show-overflow')
-        .snapshot('popoverFocusIndicator')
-        .click('#show-overflow')
-        .snapshot('popoverContentOpen')
-        .end()}
-    >
+    <Screener steps={new Screener.Steps().click('#show-overflow').snapshot('popoverContentOpen').end()}>
       {story()}
     </Screener>
   ))

--- a/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
@@ -131,7 +131,9 @@ storiesOf('AvatarGroup Converged', module)
 storiesOf('AvatarGroup Converged', module)
   .addDecorator(TestWrapperDecorator)
   .addDecorator(story => (
-    <Screener steps={new Screener.Steps().click('#show-overflow').snapshot('overflowContentOpen').end()}>
+    <Screener
+      steps={new Screener.Steps().focus('#show-overflow').click('#show-overflow').snapshot('overflowContentOpen').end()}
+    >
       {story()}
     </Screener>
   ))

--- a/change/@fluentui-react-avatar-4fdb06be-0dd3-462e-ade1-b57f8857ff6a.json
+++ b/change/@fluentui-react-avatar-4fdb06be-0dd3-462e-ade1-b57f8857ff6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make AvatarGroupPopover's focus indicator the same for all layouts.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.ts
@@ -67,16 +67,7 @@ const useTriggerButtonStyles = makeStyles({
     color: 'transparent',
   },
 
-  // These styles match the default button styles.
   focusIndicator: createCustomFocusIndicatorStyle({
-    ...shorthands.borderColor('transparent'),
-    outlineColor: tokens.colorStrokeFocus2,
-    outlineWidth: tokens.strokeWidthThick,
-    outlineStyle: 'solid',
-  }),
-
-  // This custom focus indicator is required for the pie layout due to the clip-path applied to the root
-  pieFocusIndicator: createCustomFocusIndicatorStyle({
     ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
   }),
 
@@ -179,8 +170,7 @@ export const useAvatarGroupPopoverStyles_unstable = (state: AvatarGroupPopoverSt
     sizeStyles[size],
     triggerButtonStyles.base,
     layout === 'pie' && triggerButtonStyles.pie,
-    layout === 'pie' && triggerButtonStyles.pieFocusIndicator,
-    layout !== 'pie' && triggerButtonStyles.focusIndicator,
+    triggerButtonStyles.focusIndicator,
     layout !== 'pie' && triggerButtonStyles.states,
     layout !== 'pie' && popoverOpen && triggerButtonStyles.selected,
     ...triggerButtonClasses,


### PR DESCRIPTION
## Previous Behavior

![image](https://user-images.githubusercontent.com/5953191/192964855-9eb328d6-6cac-4979-9920-1c6888431416.png)

## New Behavior

![image](https://user-images.githubusercontent.com/5953191/192964978-93bc4468-093c-490f-9363-075c5814590f.png)
