### PR TITLE
Calendar: support ID prop

### DIFF
--- a/change/@fluentui-react-170d6594-4aee-4504-8885-b70ae2901269.json
+++ b/change/@fluentui-react-170d6594-4aee-4504-8885-b70ae2901269.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "chore: support ID prop ",
+  "comment": "chore: support ID prop in Calendar",
   "packageName": "@fluentui/react",
   "email": "mgodbolt@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-170d6594-4aee-4504-8885-b70ae2901269.json
+++ b/change/@fluentui-react-170d6594-4aee-4504-8885-b70ae2901269.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: support ID prop ",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3007,6 +3007,7 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React_2.RefAttrib
     firstWeekOfYear?: FirstWeekOfYear;
     highlightCurrentMonth?: boolean;
     highlightSelectedMonth?: boolean;
+    id?: string;
     isDayPickerVisible?: boolean;
     isMonthPickerVisible?: boolean;
     maxDate?: Date;

--- a/packages/react/src/components/Calendar/Calendar.base.tsx
+++ b/packages/react/src/components/Calendar/Calendar.base.tsx
@@ -281,6 +281,7 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
       minDate,
       maxDate,
       restrictedDates,
+      id,
       className,
       showCloseButton,
       allFocusable,
@@ -326,6 +327,7 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
 
     return (
       <div
+        id={id}
         ref={forwardedRef}
         role="group"
         aria-label={selectionAndTodayString}

--- a/packages/react/src/components/Calendar/Calendar.types.ts
+++ b/packages/react/src/components/Calendar/Calendar.types.ts
@@ -63,6 +63,11 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.RefAttribut
   onDismiss?: () => void;
 
   /**
+   * ID for the calendar
+   */
+  id?: string;
+
+  /**
    * Default value of the Calendar, if any
    */
   value?: Date;


### PR DESCRIPTION
v8 calendar does not support ID prop (and v7 does). This fix helps with migration as well as consistency between components. 