### PR TITLE
fix: Menu triggers no longer take focus when they are mounted

### DIFF
--- a/change/@fluentui-react-menu-be54a5cf-5794-430d-a10e-a84b223e4eef.json
+++ b/change/@fluentui-react-menu-be54a5cf-5794-430d-a10e-a84b223e4eef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Menu triggers no longer take focus when they are mounted",
+  "packageName": "@fluentui/react-menu",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/e2e/Menu.e2e.tsx
+++ b/packages/react-components/react-menu/e2e/Menu.e2e.tsx
@@ -115,6 +115,22 @@ describe('MenuTrigger', () => {
       cy.get(menuSelector).should('be.visible').get(menuItemSelector).first().should('be.focused');
     });
   });
+
+  it('should not automatically focus itself when mounted', () => {
+    mount(
+      <Menu>
+        <MenuTrigger>
+          <button>Menu</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+    cy.get(menuTriggerSelector).should('not.be.focused');
+  });
 });
 
 describe('Custom Trigger', () => {

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -162,6 +162,7 @@ const useMenuOpenState = (
   const parentSetOpen = useMenuContext_unstable(context => context.setOpen);
   const onOpenChange: MenuState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
 
+  const shouldHandleKeyboardRef = React.useRef(false);
   const shouldHandleTabRef = React.useRef(false);
   const pressedShiftRef = React.useRef(false);
   const setOpenTimeout = React.useRef(0);
@@ -185,6 +186,7 @@ const useMenuOpenState = (
     }
 
     if (e.type === 'keydown' && (e as React.KeyboardEvent<HTMLElement>).key === Tab) {
+      shouldHandleKeyboardRef.current = true;
       shouldHandleTabRef.current = true;
       pressedShiftRef.current = (e as React.KeyboardEvent<HTMLElement>).shiftKey;
     }
@@ -288,7 +290,7 @@ const useMenuOpenState = (
       focusFirst();
     }
 
-    if (!open) {
+    if (shouldHandleKeyboardRef.current && !open) {
       if (shouldHandleTabRef.current && !state.isSubmenu) {
         pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
       } else {
@@ -296,6 +298,7 @@ const useMenuOpenState = (
       }
     }
 
+    shouldHandleKeyboardRef.current = false;
     shouldHandleTabRef.current = false;
     pressedShiftRef.current = false;
   }, [state.triggerRef, state.isSubmenu, open, focusFirst, focusAfterMenuTrigger, focusBeforeMenuTrigger]);


### PR DESCRIPTION
## Current Behavior

Menu triggers take focus when they're first mounted. 

This is likely a regression from #24738. Specifically, the removal of `shouldHandleKeyboardRef` from useMenu.tsx is causing it to always call `state.triggerRef.current?.focus()` when mounted.

```diff
-    if (shouldHandleKeyboardRef.current && !open) {
+    if (!open) {
      if (shouldHandleTabRef.current && !state.isSubmenu) {
        pressedShiftRef.current ? focusBeforeMenuTrigger() : focusAfterMenuTrigger();
      } else {
        state.triggerRef.current?.focus();
      }
    }
```

## New Behavior

Restore the `shouldHandleKeyboardRef` check to `useMenu_unstable`.

@bsunderhus I'm not familiar with the reason that it was removed in the first place. If this is not the correct fix, please assign the issue to yourself so you can make the correct fix. Thanks!

## Related Issue(s)

* Fixes #24981
