### PR TITLE
Added PivotLinkFormatType and PivotLinkSizeType

### DIFF
--- a/change/office-ui-fabric-react-d4d38137-bba4-4a45-a5f9-d94fb3ed6ea4.json
+++ b/change/office-ui-fabric-react-d4d38137-bba4-4a45-a5f9-d94fb3ed6ea4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added PivotLinkFormatType and PivotLinkSizeType",
+  "packageName": "office-ui-fabric-react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -9430,11 +9430,17 @@ export enum PivotLinkFormat {
     tabs = 1
 }
 
+// @public
+export type PivotLinkFormatType = 'links' | 'tabs';
+
 // @public (undocumented)
 export enum PivotLinkSize {
     large = 1,
     normal = 0
 }
+
+// @public
+export type PivotLinkSizeType = 'normal' | 'large';
 
 // @public (undocumented)
 export const PlainCard: React.FunctionComponent<IPlainCardProps>;

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -151,6 +151,18 @@ export interface IPivotStyles {
 
 /**
  * {@docCategory Pivot}
+ * Display mode for the pivot links/tabs
+ */
+export type PivotLinkFormatType = 'links' | 'tabs';
+
+/**
+ * {@docCategory Pivot}
+ * Size of the pivot links/tabs
+ */
+export type PivotLinkSizeType = 'normal' | 'large';
+
+/**
+ * {@docCategory Pivot}
  */
 export enum PivotLinkFormat {
   /**


### PR DESCRIPTION
## Issue
ODSP needs to depend on the type unions rather than the enums as in v8 there are const enums.

## Changes
- Added PivotLinkFormatType
- Added PivotLinkSizeType

## Issues
Updates #24393