### PR TITLE
fix: Making the hidden input on Radio only cover the indicator and not also the label

### DIFF
--- a/change/@fluentui-react-radio-8d11e9d2-7b87-4a02-bbc2-7b443528252a.json
+++ b/change/@fluentui-react-radio-8d11e9d2-7b87-4a02-bbc2-7b443528252a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Making the hidden input only cover the indicator and not also the label.",
+  "packageName": "@fluentui/react-radio",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -44,6 +44,9 @@ const useInputStyles = makeStyles({
 
     ':enabled': {
       cursor: 'pointer',
+      [`& ~ .${radioClassNames.label}`]: {
+        cursor: 'pointer',
+      },
     },
 
     // When unchecked, hide the circle icon (child of the indicator)
@@ -108,6 +111,7 @@ const useInputStyles = makeStyles({
     ':disabled': {
       [`& ~ .${radioClassNames.label}`]: {
         color: tokens.colorNeutralForegroundDisabled,
+        cursor: 'default',
       },
       [`& ~ .${radioClassNames.indicator}`]: {
         ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -117,12 +117,10 @@ const useInputStyles = makeStyles({
   },
 
   after: {
-    height: '100%',
     width: `calc(${indicatorSize} + 2 * ${tokens.spacingHorizontalS})`,
   },
   below: {
-    height: `calc(${indicatorSize} + ${tokens.spacingVerticalS})`,
-    width: '100%',
+    height: `calc(${indicatorSize} + 2 * ${tokens.spacingVerticalS})`,
   },
 });
 
@@ -173,7 +171,7 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Radio slots based on the state
  */
 export const useRadioStyles_unstable = (state: RadioState) => {
-  const { label, labelPosition } = state;
+  const { labelPosition } = state;
 
   const rootStyles = useRootStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -21,7 +21,6 @@ const useRootStyles = makeStyles({
   base: {
     display: 'inline-flex',
     position: 'relative',
-    ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalS),
   },
 
   vertical: {
@@ -116,6 +115,22 @@ const useInputStyles = makeStyles({
       },
     },
   },
+
+  after: {
+    height: '100%',
+    width: `calc(${indicatorSize} + 2 * ${tokens.spacingHorizontalS})`,
+  },
+  below: {
+    height: `calc(${indicatorSize} + 2 * ${tokens.spacingVerticalS})`,
+    width: '100%',
+  },
+
+  labelAfter: {
+    width: `calc(${indicatorSize} + ${tokens.spacingHorizontalS})`,
+  },
+  labelBelow: {
+    height: `calc(${indicatorSize} + ${tokens.spacingVerticalS})`,
+  },
 });
 
 const useIndicatorStyles = makeStyles({
@@ -133,18 +148,28 @@ const useIndicatorStyles = makeStyles({
 
     ...shorthands.border(tokens.strokeWidthThin, 'solid'),
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    ...shorthands.margin(tokens.spacingVerticalS, tokens.spacingHorizontalS),
     fill: 'currentColor',
     pointerEvents: 'none',
+  },
+
+  labelAfter: {
+    marginRight: 0,
+  },
+  labelBelow: {
+    marginBottom: 0,
   },
 });
 
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
+
+    ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalS),
   },
 
   after: {
-    marginLeft: tokens.spacingHorizontalM,
+    paddingLeft: tokens.spacingHorizontalM,
 
     // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
     // This prevents the label from expanding the height of the Radio, but preserves line height if the label wraps.
@@ -153,7 +178,7 @@ const useLabelStyles = makeStyles({
   },
 
   below: {
-    marginTop: tokens.spacingVerticalM,
+    paddingTop: tokens.spacingVerticalM,
     textAlign: 'center',
   },
 });
@@ -162,27 +187,42 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Radio slots based on the state
  */
 export const useRadioStyles_unstable = (state: RadioState) => {
+  const { label, labelPosition } = state;
+
   const rootStyles = useRootStyles();
   state.root.className = mergeClasses(
     radioClassNames.root,
     rootStyles.base,
     rootStyles.focusIndicator,
-    state.labelPosition === 'below' && rootStyles.vertical,
+    labelPosition === 'below' && rootStyles.vertical,
     state.root.className,
   );
 
   const inputStyles = useInputStyles();
-  state.input.className = mergeClasses(radioClassNames.input, inputStyles.base, state.input.className);
+  state.input.className = mergeClasses(
+    radioClassNames.input,
+    inputStyles.base,
+    inputStyles[labelPosition],
+    label && labelPosition === 'after' && inputStyles.labelAfter,
+    label && labelPosition === 'below' && inputStyles.labelBelow,
+    state.input.className,
+  );
 
   const indicatorStyles = useIndicatorStyles();
-  state.indicator.className = mergeClasses(radioClassNames.indicator, indicatorStyles.base, state.indicator.className);
+  state.indicator.className = mergeClasses(
+    radioClassNames.indicator,
+    indicatorStyles.base,
+    label && labelPosition === 'after' && indicatorStyles.labelAfter,
+    label && labelPosition === 'below' && indicatorStyles.labelBelow,
+    state.indicator.className,
+  );
 
   const labelStyles = useLabelStyles();
   if (state.label) {
     state.label.className = mergeClasses(
       radioClassNames.label,
       labelStyles.base,
-      labelStyles[state.labelPosition],
+      labelStyles[labelPosition],
       state.label.className,
     );
   }

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -121,15 +121,8 @@ const useInputStyles = makeStyles({
     width: `calc(${indicatorSize} + 2 * ${tokens.spacingHorizontalS})`,
   },
   below: {
-    height: `calc(${indicatorSize} + 2 * ${tokens.spacingVerticalS})`,
-    width: '100%',
-  },
-
-  labelAfter: {
-    width: `calc(${indicatorSize} + ${tokens.spacingHorizontalS})`,
-  },
-  labelBelow: {
     height: `calc(${indicatorSize} + ${tokens.spacingVerticalS})`,
+    width: '100%',
   },
 });
 
@@ -152,13 +145,6 @@ const useIndicatorStyles = makeStyles({
     fill: 'currentColor',
     pointerEvents: 'none',
   },
-
-  labelAfter: {
-    marginRight: 0,
-  },
-  labelBelow: {
-    marginBottom: 0,
-  },
 });
 
 const useLabelStyles = makeStyles({
@@ -169,7 +155,7 @@ const useLabelStyles = makeStyles({
   },
 
   after: {
-    paddingLeft: tokens.spacingHorizontalM,
+    paddingLeft: tokens.spacingHorizontalXS,
 
     // Use a (negative) margin to account for the difference between the indicator's height and the label's line height.
     // This prevents the label from expanding the height of the Radio, but preserves line height if the label wraps.
@@ -178,7 +164,7 @@ const useLabelStyles = makeStyles({
   },
 
   below: {
-    paddingTop: tokens.spacingVerticalM,
+    paddingTop: tokens.spacingVerticalXS,
     textAlign: 'center',
   },
 });
@@ -203,19 +189,11 @@ export const useRadioStyles_unstable = (state: RadioState) => {
     radioClassNames.input,
     inputStyles.base,
     inputStyles[labelPosition],
-    label && labelPosition === 'after' && inputStyles.labelAfter,
-    label && labelPosition === 'below' && inputStyles.labelBelow,
     state.input.className,
   );
 
   const indicatorStyles = useIndicatorStyles();
-  state.indicator.className = mergeClasses(
-    radioClassNames.indicator,
-    indicatorStyles.base,
-    label && labelPosition === 'after' && indicatorStyles.labelAfter,
-    label && labelPosition === 'below' && indicatorStyles.labelBelow,
-    state.indicator.className,
-  );
+  state.indicator.className = mergeClasses(radioClassNames.indicator, indicatorStyles.base, state.indicator.className);
 
   const labelStyles = useLabelStyles();
   if (state.label) {

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -113,6 +113,7 @@ const useInputStyles = makeStyles({
 
       [`& ~ .${switchClassNames.label}`]: {
         color: tokens.colorNeutralForegroundDisabled,
+        cursor: 'default',
       },
     },
 

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -113,7 +113,6 @@ const useInputStyles = makeStyles({
 
       [`& ~ .${switchClassNames.label}`]: {
         color: tokens.colorNeutralForegroundDisabled,
-        cursor: 'default',
       },
     },
 


### PR DESCRIPTION
## Current Behavior

The hidden input in the `Radio` component covers both the indicator and the label, making any interactive elements within the label, like links, impossible to be clicked.

We also noticed that when hovering over the label of disabled `Switches`, it still showed `cursor: pointer` styles.

### Input

<img alt="image" src="https://user-images.githubusercontent.com/7798177/193154055-ee7d091f-edd8-47d2-81db-e3cb0df52a36.png">

### Label

<img alt="image" src="https://user-images.githubusercontent.com/7798177/193154115-e1e530d5-b276-4540-ae9c-889a5901da91.png">

## New Behavior

The hidden input in the `Radio` component now covers only the indicator and its surrounding space, not the label. This makes any interactive elements within the label, like links, possible to be clicked. We verified that clicking on the label still toggles the state of the component. We also expanded the size of the label so it covers the empty space around it that was previously being covered by the hidden input.

Hovering over the label of disabled `Switches` now shows `cursor: default` instead of `cursor: pointer`.

### Input

<img alt="image" src="https://user-images.githubusercontent.com/7798177/193159336-aa9afd6a-ba76-4885-acf0-74ba16812734.png">

### Label

<img alt="image" src="https://user-images.githubusercontent.com/7798177/193159374-e46c7236-f7da-46b6-9f49-7cacaf366f0b.png">

## Related Issue(s)

Fixes #25021
