### PR TITLE
chore: enable object-shorthand in ESLint

### DIFF
--- a/change/@fluentui-eslint-plugin-ec734cab-e66a-4e3e-8678-7123ea508e1e.json
+++ b/change/@fluentui-eslint-plugin-ec734cab-e66a-4e3e-8678-7123ea508e1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: enable object-shorthand in ESLint",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/core.js
+++ b/packages/eslint-plugin/src/configs/core.js
@@ -124,7 +124,7 @@ const config = {
     'no-useless-escape': 'off',
     'no-useless-rename': 'off',
     'no-useless-return': 'off',
-    'object-shorthand': 'off',
+    'object-shorthand': 'warn',
     'operator-assignment': 'off',
     'prefer-destructuring': 'off',
     'prefer-template': 'off',


### PR DESCRIPTION
## Related Issue(s)

Fixes #25030.

## New Behavior

This PR enables [object-shorthand](https://eslint.org/docs/latest/rules/object-shorthand) rule in our ESLint config for v9 which is currently disabled:

https://github.com/microsoft/fluentui/blob/8d6c673ca9d07fd329c26f16b4c69ea32d284dd4/packages/eslint-plugin/src/configs/core.js#L127

### What it does?

Rule enforces shorthands (that is ES6 feature) to be consistent across codebase:

```js
const foo = {
    x: x,
    y: y,
    z: z,
};
// ⬇️⬇️⬇️
const foo = {x, y, z};
```

### Why `warn`?

This rule does handle a real code issue, it's features more a formatting. However, as the rule has autofix - issues will be automatically fixed by precommit hooks 💪 

