### PR TITLE
feat(tools): add exports map support to migrate-converged-pkg generator

### DIFF
--- a/change/@fluentui-react-components-a03fef34-ebd4-4d4f-9203-384df97ccc9d.json
+++ b/change/@fluentui-react-components-a03fef34-ebd4-4d4f-9203-384df97ccc9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: normalize relative import for unstable package.json",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/src/unstable/package.json__tmpl__
+++ b/packages/react-components/react-components/src/unstable/package.json__tmpl__
@@ -2,7 +2,7 @@
   "description": "Separate entrypoint for unstable Fluent UI components",
   "main": "../lib-commonjs/unstable/index.js",
   "module": "../lib/unstable/index.js",
-  "typings": "../dist/unstable.d.ts",
+  "typings": "./../dist/unstable.d.ts",
   "sideEffects": false,
   "license": "MIT",
   "exports": {

--- a/tools/generators/migrate-converged-pkg/schema.json
+++ b/tools/generators/migrate-converged-pkg/schema.json
@@ -27,6 +27,5 @@
       "pattern": "^@[/-\\w]+$"
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/tools/types.ts
+++ b/tools/types.ts
@@ -30,6 +30,7 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  exports?: Record<string, string | Partial<{ types: string; import: string; require: string }>>;
 }
 
 // ===============

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -94,6 +94,10 @@ export function getProjectConfig(tree: Tree, options: { packageName: string }) {
       test: joinPathFragments(projectConfig.root, 'tsconfig.spec.json'),
     },
     sourceRoot: joinPathFragments(projectConfig.root, 'src'),
+    unstable: {
+      sourceRoot: joinPathFragments(projectConfig.root, 'src', 'unstable'),
+      rootPackageJson: joinPathFragments(projectConfig.root, 'src', 'unstable', 'package.json__tmpl__'),
+    },
     conformanceSetup: joinPathFragments(projectConfig.root, 'src', 'common', 'isConformant.ts'),
     babelConfig: joinPathFragments(projectConfig.root, '.babelrc.json'),
     jestConfig: joinPathFragments(projectConfig.root, 'jest.config.js'),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

migration generator doesn't provide setup for exports map

## New Behavior

migration generator setups exports map including unstable API if present

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes partially https://github.com/microsoft/fluentui/issues/25034
