### PR TITLE
Fixed a prop name in doc

### DIFF
--- a/specs/Checkbox.md
+++ b/specs/Checkbox.md
@@ -166,7 +166,7 @@ Removing the following two props because the ARIA spec dictates role='checkbox' 
 
 Props being removed:
 
-ariaPoisitionInSet and ariaSetSize - when writing parent component, user should set these on the checkbox.
+ariaPositionInSet and ariaSetSize - when writing parent component, user should set these on the checkbox.
 
 ## Slots
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

wrong prop name: ariaPoisitionInSet

## New Behavior

it is `ariaPositionInSet` now

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
