### PR TITLE
fix: Dropdown icon layout with no placeholder/value

### DIFF
--- a/change/@fluentui-react-combobox-d1ed182f-ed98-446f-8cb6-4c9de248b0ff.json
+++ b/change/@fluentui-react-combobox-d1ed182f-ed98-446f-8cb6-4c9de248b0ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Dropdown arrow icon layout when no placeholder or value is present",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
@@ -85,7 +85,7 @@ const useStyles = makeStyles({
     cursor: 'pointer',
     display: 'grid',
     fontFamily: tokens.fontFamilyBase,
-    gridTemplateColumns: '1fr auto',
+    gridTemplateColumns: '[content] 1fr [icon] auto [end]',
     justifyContent: 'space-between',
     textAlign: 'left',
     width: '100%',
@@ -167,6 +167,8 @@ const useIconStyles = makeStyles({
     color: tokens.colorNeutralStrokeAccessible,
     display: 'block',
     fontSize: tokens.fontSizeBase500,
+    gridColumnStart: 'icon',
+    gridColumnEnd: 'end',
 
     // the SVG must have display: block for accurate positioning
     // otherwise an extra inline space is inserted after the svg element


### PR DESCRIPTION
Fixes the Dropdown layout when no placeholder was provided from this:

![screenshot of an empty dropdown with the arrow icon on the left side](https://user-images.githubusercontent.com/3819570/193643094-3776d9c0-1843-40cb-a9be-26d4b394e5b5.png)

to this:

![screenshot of an empty dropdown with the arrow icon on the right side](https://user-images.githubusercontent.com/3819570/193643214-55744c59-bc43-4200-a72c-bf6f3d9b221f.png)
