### PR TITLE
Undo PR 24998 - Removed the initializeThemeInCustomizations side effect from index 

### DIFF
--- a/change/@uifabric-styling-46803f93-7053-4973-9e30-2d6f0e0fa6c8.json
+++ b/change/@uifabric-styling-46803f93-7053-4973-9e30-2d6f0e0fa6c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "undo removal of initializeThemeInCustomizations sideeffect",
+  "packageName": "@uifabric/styling",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -219,9 +219,6 @@ export interface IIconSubsetRecord extends IIconSubset {
     isRegistered?: boolean;
 }
 
-// @public (undocumented)
-export function initializeThemeInCustomizations(): void;
-
 export { InjectionMode }
 
 export { IPalette }

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -11,7 +11,7 @@
   "module": "lib/index.js",
   "sideEffects": [
     "lib/version.js",
-    "lib/styles/theme.js"
+    "lib/index.js"
   ],
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/packages/styling/src/Icons.ts
+++ b/packages/styling/src/Icons.ts
@@ -1,0 +1,13 @@
+export {
+  IIconRecord,
+  IIconSubset,
+  IIconSubsetRecord,
+  IIconOptions,
+  getIcon,
+  registerIcons,
+  registerIconAlias,
+  unregisterIcons,
+  setIconOptions,
+} from './utilities/icons';
+
+export { getIconClassName } from './utilities/getIconClassName';

--- a/packages/styling/src/index.ts
+++ b/packages/styling/src/index.ts
@@ -5,3 +5,7 @@ export * from './interfaces/index';
 export * from './MergeStyles';
 
 import './version';
+
+// Ensure theme is initialized when this package is referenced.
+import { initializeThemeInCustomizations } from './styles/theme';
+initializeThemeInCustomizations();

--- a/packages/styling/src/styles/index.ts
+++ b/packages/styling/src/styles/index.ts
@@ -13,7 +13,6 @@ export {
   getTheme,
   loadTheme,
   createTheme,
-  initializeThemeInCustomizations,
   registerOnThemeChangeCallback,
   removeOnThemeChangeCallback,
 } from './theme';


### PR DESCRIPTION
## Changes
- Undo of PR #24998 as it causes breaking tree shaking when applied to style-utilities in v8.
- Will do a separate change for handling side-effect in v7 and v8.