### PR TITLE
chore(react-persona): Add bundle-size command for bundle-size fixtures

### DIFF
--- a/change/@fluentui-react-persona-ddb5ba78-3b3b-4ba6-b97a-30dd9413b998.json
+++ b/change/@fluentui-react-persona-ddb5ba78-3b3b-4ba6-b97a-30dd9413b998.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Adding bundle-size command for bundle-size fixtures.",
+  "packageName": "@fluentui/react-persona",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-persona/package.json
+++ b/packages/react-components/react-persona/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
This PR adds the missing `bundle-size` command to run the bundle-size fixtures.
