### PR TITLE
ChatItem: share unstable_layout with children via context

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Popup` trigger attribute being override @chpalac ([#24794](https://github.com/microsoft/fluentui/pull/24794))
 - Fix styling mutation when merging themes in `Dropdown` @petrjaros ([#24787](https://github.com/microsoft/fluentui/pull/24787))
 - Fix `Toolbar` submenu closing when another submenu is opened @miroslavstastny ([#24836](https://github.com/microsoft/fluentui/pull/24836))
+- `Chat.Message` now inherits `unstable_layout` from `Chat.Item`. @davezuko ([#25056](https://github.com/microsoft/fluentui/pull/25056))
 
 ### Performance
 - Avoid memory trashing in `felaExpandCssShorthandsPlugin` @layershifter ([#24663](https://github.com/microsoft/fluentui/pull/24663))

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyRefresh.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleComfyRefresh.tsx
@@ -13,7 +13,7 @@ const items: ShorthandCollection<ChatItemProps> = [
         status={{ color: 'green', icon: <AcceptIcon /> }}
       />
     ),
-    message: <Chat.Message unstable_layout="refresh" content="Hello" author="Robin Counts" timestamp="10:15 PM" />,
+    message: <Chat.Message content="Hello" author="Robin Counts" timestamp="10:15 PM" />,
   },
   {
     key: 'message-id-2',
@@ -22,7 +22,6 @@ const items: ShorthandCollection<ChatItemProps> = [
     contentPosition: 'end',
     message: (
       <Chat.Message
-        unstable_layout="refresh"
         content="Hi! How are you doing?"
         author="Tim Deboer"
         timestamp="10:15 PM"

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshSimple.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshSimple.tsx
@@ -14,7 +14,6 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
     message: (
       <Chat.Message
-        unstable_layout="refresh"
         content="Hello"
         author="Robin Counts"
         timestamp="10:15 PM"
@@ -32,7 +31,6 @@ const items: ShorthandCollection<ChatItemProps> = [
     contentPosition: 'end',
     message: (
       <Chat.Message
-        unstable_layout="refresh"
         mine
         content="Hi"
         author="Tim Deboer"

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshStressTest.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshStressTest.tsx
@@ -14,7 +14,6 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
     message: (
       <Chat.Message
-        unstable_layout="refresh"
         content={`This is a really long message. It has a lot of content so that we can see how a chat message looks when it has a lot of content. You get the point? Lots of content to test lots of content. Here's even more content on top of the already long amount of content that we already had. This is a really long message. It has a lot of content so that we can see how a chat message looks when it has a lot of content. You get the point? Lots of content to test lots of content. Here's even more content on top of the already long amount of content that we already had. This is a really long message. It has a lot of content so that we can see how a chat message looks when it has a lot of content. You get the point? Lots of content to test lots of content. Here's even more content on top of the already long amount of content that we already had.`}
         author="Tim Deboer"
         timestamp="10:15 PM"
@@ -27,7 +26,6 @@ const items: ShorthandCollection<ChatItemProps> = [
     contentPosition: 'end',
     message: (
       <Chat.Message
-        unstable_layout="refresh"
         mine
         content={`contentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespacecontentwithnowhitespace`}
         author="Tim Deboer"

--- a/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshTimestampTooltip.tsx
+++ b/packages/fluentui/react-northstar-prototypes/src/prototypes/chatRefresh/ChatRefreshTimestampTooltip.tsx
@@ -14,7 +14,6 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
     message: (
       <Chat.Message
-        unstable_layout="refresh"
         content="Hello"
         author="Robin Counts"
         timestamp={{

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
@@ -24,8 +24,7 @@ import {
 import { Box, BoxProps } from '../Box/Box';
 import { useChatContextSelectors } from './chatContext';
 import { ChatDensity } from './chatDensity';
-import { ChatItemContextProvider } from './chatItemContext';
-import type { ChatMessageLayout } from './ChatMessage';
+import { ChatItemContextProvider, ChatMessageLayout } from './chatItemContext';
 
 export interface ChatItemSlotClassNames {
   message: string;

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
@@ -135,7 +135,7 @@ export const ChatItem = (React.forwardRef<HTMLLIElement, ChatItemProps>((inputPr
     });
 
     return (
-      <ChatItemContextProvider value={{ attached }}>
+      <ChatItemContextProvider value={{ attached, unstable_layout: layout }}>
         {(contentPosition === 'start' || density === 'compact') && gutterElement}
         {messageElement}
         {contentPosition === 'end' && density === 'comfy' && gutterElement}

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -254,7 +254,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
   const { setStart, setEnd } = useTelemetry(ChatMessage.displayName, context.telemetry);
   setStart();
 
-  const parentAttached = useContextSelector(ChatItemContext, v => v.attached);
+  const chatItemProps = useContextSelector(ChatItemContext, v => v);
   const chatProps = useChatContextSelectors({
     density: v => v.density,
     accessibility: v => v.behaviors.message,
@@ -262,6 +262,8 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
 
   const props = {
     ...inputProps,
+    unstable_layout:
+      inputProps.unstable_layout === undefined ? chatItemProps.unstable_layout : inputProps.unstable_layout,
     density: inputProps.density === undefined ? chatProps.density : inputProps.density,
     accessibility:
       inputProps.accessibility === undefined
@@ -270,7 +272,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
   };
   const {
     accessibility,
-    attached = parentAttached,
+    attached = chatItemProps.attached,
     author,
     badge,
     badgePosition,

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -64,7 +64,7 @@ import { ReactionGroupProps } from '../Reaction/ReactionGroup';
 import { Text, TextProps } from '../Text/Text';
 import { useChatContextSelectors } from './chatContext';
 import { ChatDensity } from './chatDensity';
-import { ChatItemContext } from './chatItemContext';
+import { ChatItemContext, ChatMessageLayout } from './chatItemContext';
 import { ChatMessageDetails, ChatMessageDetailsProps } from './ChatMessageDetails';
 import { ChatMessageHeader, ChatMessageHeaderProps } from './ChatMessageHeader';
 import { ChatMessageReadStatus, ChatMessageReadStatusProps } from './ChatMessageReadStatus';
@@ -82,8 +82,6 @@ export interface ChatMessageSlotClassNames {
   reactionGroup: string;
   timestamp: string;
 }
-
-export type ChatMessageLayout = 'default' | 'refresh';
 
 export interface ChatMessageProps
   extends UIComponentProps,

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessageContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessageContent.tsx
@@ -4,7 +4,8 @@ import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
 import { Box, BoxProps, BoxStylesProps } from '../Box/Box';
 import { ChatDensity } from './chatDensity';
-import { ChatMessageLayout, ChatMessageProps } from './ChatMessage';
+import type { ChatMessageLayout } from './chatItemContext';
+import { ChatMessageProps } from './ChatMessage';
 
 export interface ChatMessageContentOwnProps
   extends Pick<ChatMessageProps, 'badgePosition' | 'density' | 'failed' | 'mine' | 'unstable_layout'> {

--- a/packages/fluentui/react-northstar/src/components/Chat/chatItemContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Chat/chatItemContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from '@fluentui/react-bindings';
-import type { ChatMessageLayout } from './ChatMessage';
+
+export type ChatMessageLayout = 'default' | 'refresh';
 
 export type ChatItemContextValue = {
   attached: boolean | 'top' | 'bottom';

--- a/packages/fluentui/react-northstar/src/components/Chat/chatItemContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Chat/chatItemContext.ts
@@ -1,9 +1,11 @@
 import { createContext } from '@fluentui/react-bindings';
+import type { ChatMessageLayout } from './ChatMessage';
 
 export type ChatItemContextValue = {
   attached: boolean | 'top' | 'bottom';
+  unstable_layout: ChatMessageLayout;
 };
 
-export const ChatItemContext = createContext<ChatItemContextValue>({ attached: false });
+export const ChatItemContext = createContext<ChatItemContextValue>({ attached: false, unstable_layout: 'default' });
 
 export const ChatItemContextProvider = ChatItemContext.Provider;


### PR DESCRIPTION
Updates `unstable_layout` behave more like `attached` and `density`. These are properties that should always be the same on `Chat.Item` and its inner `Chat.Message`, so it's more reliable to set it at the uppermost level and then consume it via context.