### PR TITLE
Fix: Contextual menu focus with custom UI

### DIFF
--- a/change/@fluentui-react-ec99cae8-1b1d-491a-967b-e7f051ee1c72.json
+++ b/change/@fluentui-react-ec99cae8-1b1d-491a-967b-e7f051ee1c72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Fix focus returning to correct element on menu close",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -20,7 +20,6 @@ import {
   memoizeFunction,
   getPropsWithDefaults,
   getDocument,
-  FocusRects,
 } from '../../Utilities';
 import { hasSubmenu, getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
 import { Callout } from '../../Callout';
@@ -183,7 +182,6 @@ function useSubMenuState(
       }
 
       target.focus();
-
       setShouldFocusOnContainer(focusContainer);
       setExpandedMenuItemKey(submenuItemKey);
       setSubmenuTarget(target);
@@ -252,8 +250,12 @@ function useShouldUpdateFocusOnMouseMove({ delayUpdateFocusOnHover, hidden }: IC
   return [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] as const;
 }
 
-function usePreviousActiveElement({ hidden, onRestoreFocus }: IContextualMenuProps, targetWindow: Window | undefined) {
-  const previousElementsQueue = React.useRef<HTMLElement[]>([]);
+function usePreviousActiveElement(
+  { hidden, onRestoreFocus }: IContextualMenuProps,
+  targetWindow: Window | undefined,
+  hostElement: any,
+) {
+  const previousActiveElement = React.useRef<undefined | HTMLElement>();
 
   const tryFocusPreviousActiveElement = React.useCallback(
     (options: IPopupRestoreFocusParams) => {
@@ -263,8 +265,7 @@ function usePreviousActiveElement({ hidden, onRestoreFocus }: IContextualMenuPro
         // Make sure that the focus method actually exists
         // In some cases the object might exist but not be a real element.
         // This is primarily for IE 11 and should be removed once IE 11 is no longer in use.
-
-        previousElementsQueue.current[0]?.focus?.();
+        previousActiveElement.current?.focus?.();
       }
     },
     [onRestoreFocus],
@@ -272,24 +273,20 @@ function usePreviousActiveElement({ hidden, onRestoreFocus }: IContextualMenuPro
 
   useIsomorphicLayoutEffect(() => {
     if (!hidden) {
-      const targetElement = targetWindow?.document.activeElement as HTMLElement;
-      const targetPosition = previousElementsQueue.current.indexOf(targetElement);
-
-      if (targetPosition > -1) {
-        previousElementsQueue.current = previousElementsQueue.current.slice(targetPosition + 1);
-      } else {
-        previousElementsQueue.current = [targetElement, ...previousElementsQueue.current];
+      const newElement = targetWindow?.document.activeElement as HTMLElement;
+      if (!hostElement.current?.contains(newElement) && newElement.tagName !== 'BODY') {
+        previousActiveElement.current = newElement;
       }
-    } else if (previousElementsQueue.current.length > 0) {
+    } else if (previousActiveElement.current) {
       tryFocusPreviousActiveElement({
-        originalElement: previousElementsQueue.current[0],
+        originalElement: previousActiveElement.current,
         containsFocus: true,
         documentContainsFocus: getDocument()?.hasFocus() || false,
       });
 
-      previousElementsQueue.current = [];
+      previousActiveElement.current = undefined;
     }
-  }, [hidden, targetWindow?.document.activeElement, tryFocusPreviousActiveElement]);
+  }, [hidden, targetWindow?.document.activeElement, tryFocusPreviousActiveElement, hostElement]);
 
   return [tryFocusPreviousActiveElement] as const;
 }
@@ -724,7 +721,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const dismiss = (ev?: any, dismissAll?: boolean) => props.onDismiss?.(ev, dismissAll);
     const [targetRef, targetWindow] = useTarget(props.target, hostElement);
-    const [tryFocusPreviousActiveElement] = usePreviousActiveElement(props, targetWindow);
+    const [tryFocusPreviousActiveElement] = usePreviousActiveElement(props, targetWindow, hostElement);
     const [expandedMenuItemKey, openSubMenu, getSubmenuProps, onSubMenuDismiss] = useSubMenuState(props, dismiss);
     const [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] = useShouldUpdateFocusOnMouseMove(props);
     const [onScroll, isScrollIdle] = useScrollHandler(asyncTracker);
@@ -1296,7 +1293,6 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
                   : null}
                 {submenuProps && onRenderSubMenu(submenuProps, onDefaultRenderSubMenu)}
               </div>
-              <FocusRects />
             </Callout>
           )}
         </MenuContext.Consumer>

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -20,6 +20,7 @@ import {
   memoizeFunction,
   getPropsWithDefaults,
   getDocument,
+  FocusRects,
 } from '../../Utilities';
 import { hasSubmenu, getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
 import { Callout } from '../../Callout';
@@ -1293,6 +1294,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
                   : null}
                 {submenuProps && onRenderSubMenu(submenuProps, onDefaultRenderSubMenu)}
               </div>
+              <FocusRects />
             </Callout>
           )}
         </MenuContext.Consumer>


### PR DESCRIPTION
Looking deeper into focus functionality in the Contextualmenu, I realized that the original non queued approach was actually correct (each nested menu was its own contextual menu with its own context). The problem ended up being "last focused elements" either being switch to a child element (when focus returns TO a menu), or to the body (when the old menu closes). Filtering out those two cases allows the behavior to work as expected in 3+ menu depths, as well as custom UI like a textfield