### PR TITLE
Fix chart title overflow

### DIFF
--- a/change/@fluentui-react-charting-beea75ce-fc3b-4589-8902-28d31ef030fa.json
+++ b/change/@fluentui-react-charting-beea75ce-fc3b-4589-8902-28d31ef030fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix text overflow in horizontal bar chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-beea75ce-fc3b-4589-8902-28d31ef030fa.json
+++ b/change/@fluentui-react-charting-beea75ce-fc3b-4589-8902-28d31ef030fa.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix text overflow in horizontal bar chart",
+  "comment": "Fix chart title overflow",
   "packageName": "@fluentui/react-charting",
   "email": "kumarkshitij@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -89,7 +89,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                   <div className={this._classNames.chartTitle}>
                     {points!.chartTitle && (
                       <div
-                        className={this._classNames.chartDataTextLeft}
+                        className={this._classNames.chartTitleLeft}
                         title={points!.chartTitle}
                         {...getAccessibleDataObject(points!.chartTitleAccessibilityData)}
                       >
@@ -229,21 +229,21 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     switch (chartDataMode) {
       case 'default':
         return (
-          <div className={this._classNames.chartDataTextRight} {...accessibilityData}>
+          <div className={this._classNames.chartTitleRight} {...accessibilityData}>
             {convertToLocaleString(x, culture)}
           </div>
         );
       case 'fraction':
         return (
           <div {...accessibilityData}>
-            <span className={this._classNames.chartDataTextRight}>{convertToLocaleString(x, culture)}</span>
+            <span className={this._classNames.chartTitleRight}>{convertToLocaleString(x, culture)}</span>
             <span className={this._classNames.chartDataTextDenominator}>{'/' + convertToLocaleString(y, culture)}</span>
           </div>
         );
       case 'percentage':
         const dataRatioPercentage = `${convertToLocaleString(Math.round((x / y) * 100), culture)}%`;
         return (
-          <div className={this._classNames.chartDataTextRight} {...accessibilityData}>
+          <div className={this._classNames.chartTitleRight} {...accessibilityData}>
             {dataRatioPercentage}
           </div>
         );

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -89,7 +89,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                   <div className={this._classNames.chartTitle}>
                     {points!.chartTitle && (
                       <div
-                        className={this._classNames.chartDataText}
+                        className={this._classNames.chartDataTextLeft}
+                        title={points!.chartTitle}
                         {...getAccessibleDataObject(points!.chartTitleAccessibilityData)}
                       >
                         {points!.chartTitle}
@@ -228,21 +229,21 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     switch (chartDataMode) {
       case 'default':
         return (
-          <div className={this._classNames.chartDataText} {...accessibilityData}>
+          <div className={this._classNames.chartDataTextRight} {...accessibilityData}>
             {convertToLocaleString(x, culture)}
           </div>
         );
       case 'fraction':
         return (
           <div {...accessibilityData}>
-            <span className={this._classNames.chartDataText}>{convertToLocaleString(x, culture)}</span>
+            <span className={this._classNames.chartDataTextRight}>{convertToLocaleString(x, culture)}</span>
             <span className={this._classNames.chartDataTextDenominator}>{'/' + convertToLocaleString(y, culture)}</span>
           </div>
         );
       case 'percentage':
         const dataRatioPercentage = `${convertToLocaleString(Math.round((x / y) * 100), culture)}%`;
         return (
-          <div className={this._classNames.chartDataText} {...accessibilityData}>
+          <div className={this._classNames.chartDataTextRight} {...accessibilityData}>
             {dataRatioPercentage}
           </div>
         );

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -13,6 +13,7 @@ import {
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { ChartHoverCard, convertToLocaleString, getAccessibleDataObject } from '../../utilities/index';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
+import { TooltipHost, TooltipOverflowMode } from '@fluentui/react';
 
 const getClassNames = classNamesFunction<IHorizontalBarChartStyleProps, IHorizontalBarChartStyles>();
 
@@ -88,13 +89,15 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                 <FocusZone direction={FocusZoneDirection.horizontal}>
                   <div className={this._classNames.chartTitle}>
                     {points!.chartTitle && (
-                      <div
-                        className={this._classNames.chartTitleLeft}
-                        title={points!.chartTitle}
-                        {...getAccessibleDataObject(points!.chartTitleAccessibilityData)}
+                      <TooltipHost
+                        overflowMode={TooltipOverflowMode.Self}
+                        hostClassName={this._classNames.chartTitleLeft}
+                        content={points!.chartTitle}
                       >
-                        {points!.chartTitle}
-                      </div>
+                        <span {...getAccessibleDataObject(points!.chartTitleAccessibilityData)}>
+                          {points!.chartTitle}
+                        </span>
+                      </TooltipHost>
                     )}
                     {chartDataText}
                   </div>

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.styles.ts
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.styles.ts
@@ -34,7 +34,13 @@ export const getHorizontalBarChartStyles = (props: IHorizontalBarChartStyleProps
       justifyContent: 'space-between',
       marginBottom: '3px',
     },
-    chartDataText: {
+    chartDataTextLeft: {
+      fontWeight: FontWeights.bold,
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+    },
+    chartDataTextRight: {
       fontWeight: FontWeights.bold,
     },
     chartDataTextDenominator: {

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.styles.ts
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.styles.ts
@@ -39,6 +39,7 @@ export const getHorizontalBarChartStyles = (props: IHorizontalBarChartStyleProps
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
+      display: 'block',
     },
     chartTitleRight: {
       fontWeight: FontWeights.bold,

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.styles.ts
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.styles.ts
@@ -34,13 +34,13 @@ export const getHorizontalBarChartStyles = (props: IHorizontalBarChartStyleProps
       justifyContent: 'space-between',
       marginBottom: '3px',
     },
-    chartDataTextLeft: {
+    chartTitleLeft: {
       fontWeight: FontWeights.bold,
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
     },
-    chartDataTextRight: {
+    chartTitleRight: {
       fontWeight: FontWeights.bold,
     },
     chartDataTextDenominator: {

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -132,9 +132,14 @@ export interface IHorizontalBarChartStyles {
   barWrapper: IStyle;
 
   /**
-   * Style for the chart data text.
+   * Style for the chart data left text.
    */
-  chartDataText: IStyle;
+  chartDataTextLeft: IStyle;
+
+  /**
+   * Style for the chart data right text.
+   */
+  chartDataTextRight: IStyle;
 
   /**
    * Style for the chart data text denominator.

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -132,14 +132,14 @@ export interface IHorizontalBarChartStyles {
   barWrapper: IStyle;
 
   /**
-   * Style for the chart data left text.
+   * Style for left side text of the chart title
    */
-  chartDataTextLeft: IStyle;
+  chartTitleLeft: IStyle;
 
   /**
-   * Style for the chart data right text.
+   * Style for right side text of the chart title
    */
-  chartDataTextRight: IStyle;
+  chartTitleRight: IStyle;
 
   /**
    * Style for the chart data text denominator.

--- a/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -60,9 +60,13 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
 
                 {
                   font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
                 }
             data-is-focusable={true}
             role="text"
+            title="one"
           >
             one
           </div>
@@ -195,9 +199,13 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
 
                 {
                   font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
                 }
             data-is-focusable={true}
             role="text"
+            title="two"
           >
             two
           </div>
@@ -506,9 +514,13 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
 
                 {
                   font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
                 }
             data-is-focusable={true}
             role="text"
+            title="one"
           >
             one
           </div>
@@ -641,9 +653,13 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
 
                 {
                   font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
                 }
             data-is-focusable={true}
             role="text"
+            title="two"
           >
             two
           </div>

--- a/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -57,18 +57,45 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="one"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            one
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              one
+            </span>
+            <div
+              hidden={true}
+              id="tooltip2"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              one
+            </div>
           </div>
           <div
             className=
@@ -89,7 +116,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone3"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -175,7 +202,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone3"
+        data-focuszone-id="FocusZone4"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -196,18 +223,45 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="two"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            two
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              two
+            </span>
+            <div
+              hidden={true}
+              id="tooltip5"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              two
+            </div>
           </div>
           <div
             className=
@@ -228,7 +282,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone6"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -511,18 +565,45 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="one"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            one
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              one
+            </span>
+            <div
+              hidden={true}
+              id="tooltip2"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              one
+            </div>
           </div>
           <div
             className=
@@ -543,7 +624,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone3"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -629,7 +710,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone3"
+        data-focuszone-id="FocusZone4"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -650,18 +731,45 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="two"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            two
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              two
+            </span>
+            <div
+              hidden={true}
+              id="tooltip5"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              two
+            </div>
           </div>
           <div
             className=
@@ -682,7 +790,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone6"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -237,8 +237,12 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div className={this._classNames.chartTitle}>
             {data!.chartTitle && (
-              <div {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}>
-                <strong>{data!.chartTitle}</strong>
+              <div
+                className={this._classNames.chartTitleLeft}
+                title={data!.chartTitle}
+                {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}
+              >
+                {data!.chartTitle}
               </div>
             )}
             {showRatio && (

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -13,6 +13,7 @@ import {
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 import { ChartHoverCard, convertToLocaleString, getAccessibleDataObject } from '../../utilities/index';
+import { TooltipHost, TooltipOverflowMode } from '@fluentui/react';
 
 const getClassNames = classNamesFunction<IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>();
 
@@ -237,13 +238,13 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div className={this._classNames.chartTitle}>
             {data!.chartTitle && (
-              <div
-                className={this._classNames.chartTitleLeft}
-                title={data!.chartTitle}
-                {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}
+              <TooltipHost
+                overflowMode={TooltipOverflowMode.Self}
+                hostClassName={this._classNames.chartTitleLeft}
+                content={data!.chartTitle}
               >
-                {data!.chartTitle}
-              </div>
+                <span {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}>{data!.chartTitle}</span>
+              </TooltipHost>
             )}
             {showRatio && (
               <div {...getAccessibleDataObject(data!.chartDataAccessibilityData)}>

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -1,4 +1,5 @@
 import { IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles } from './MultiStackedBarChart.types';
+import { FontWeights } from '@fluentui/react/lib/Styling';
 
 export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleProps): IMultiStackedBarChartStyles => {
   const { className, width, barHeight, shouldHighlight, theme, href } = props;
@@ -25,6 +26,12 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       display: 'flex',
       justifyContent: 'space-between',
       marginBottom: '3px',
+    },
+    chartTitleLeft: {
+      fontWeight: FontWeights.bold,
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
     },
     singleChartRoot: {
       width: width ? width : '100%',

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -32,6 +32,7 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
+      display: 'block',
     },
     singleChartRoot: {
       width: width ? width : '100%',

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -169,6 +169,11 @@ export interface IMultiStackedBarChartStyles {
   chartTitle: IStyle;
 
   /**
+   * Style for left side text of the chart title
+   */
+  chartTitleLeft: IStyle;
+
+  /**
    * Style to change the opacity of bars in dataviz when we hover on a single bar or legends
    */
   opacityChangeOnHover: IStyle;

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -105,8 +105,12 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div className={this._classNames.chartTitle}>
             {data!.chartTitle && (
-              <div {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}>
-                <strong>{data!.chartTitle}</strong>
+              <div
+                className={this._classNames.chartTitleLeft}
+                title={data!.chartTitle}
+                {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}
+              >
+                {data!.chartTitle}
               </div>
             )}
             {showRatio && (

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -7,6 +7,7 @@ import { IRefArrayData, IStackedBarChartProps, IStackedBarChartStyleProps, IStac
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 import { ChartHoverCard, convertToLocaleString, getAccessibleDataObject } from '../../utilities/index';
+import { TooltipHost, TooltipOverflowMode } from '@fluentui/react';
 
 const getClassNames = classNamesFunction<IStackedBarChartStyleProps, IStackedBarChartStyles>();
 export interface IStackedBarChartState {
@@ -105,13 +106,13 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <div className={this._classNames.chartTitle}>
             {data!.chartTitle && (
-              <div
-                className={this._classNames.chartTitleLeft}
-                title={data!.chartTitle}
-                {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}
+              <TooltipHost
+                overflowMode={TooltipOverflowMode.Self}
+                hostClassName={this._classNames.chartTitleLeft}
+                content={data!.chartTitle}
               >
-                {data!.chartTitle}
-              </div>
+                <span {...getAccessibleDataObject(data!.chartTitleAccessibilityData)}>{data!.chartTitle}</span>
+              </TooltipHost>
             )}
             {showRatio && (
               <div {...getAccessibleDataObject(data!.chartDataAccessibilityData)}>

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -41,6 +41,7 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
+      display: 'block',
     },
     legendContainer: {
       margin: '4px 0px 0px 4px',

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -36,6 +36,12 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       justifyContent: 'space-between',
       marginBottom: '3px',
     },
+    chartTitleLeft: {
+      fontWeight: FontWeights.bold,
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+    },
     legendContainer: {
       margin: '4px 0px 0px 4px',
     },

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.types.ts
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.types.ts
@@ -211,6 +211,11 @@ export interface IStackedBarChartStyles {
   chartTitle: IStyle;
 
   /**
+   * Style for left side text of the chart title
+   */
+  chartTitleLeft: IStyle;
+
+  /**
    * Style for the legend container div
    */
   legendContainer: IStyle;

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -55,12 +55,19 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
           <div
             data-is-focusable={true}
@@ -207,12 +214,19 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}
@@ -610,12 +624,19 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
           <div
             data-is-focusable={true}
@@ -762,12 +783,19 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}
@@ -1082,12 +1110,19 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
           <div
             data-is-focusable={true}
@@ -1228,12 +1263,19 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}
@@ -1466,12 +1508,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
           <div
             data-is-focusable={true}
@@ -1608,12 +1657,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}
@@ -1842,12 +1898,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
           <div
             data-is-focusable={true}
@@ -1988,12 +2051,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}
@@ -2156,12 +2226,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
         </div>
       </div>
@@ -2290,12 +2367,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}
@@ -2709,12 +2793,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Monitored"
           >
-            <strong>
-              Monitored
-            </strong>
+            Monitored
           </div>
           <div
             data-is-focusable={true}
@@ -2855,12 +2946,19 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               }
         >
           <div
+            className=
+
+                {
+                  font-weight: 700;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
             data-is-focusable={true}
             role="text"
+            title="Unmonitored"
           >
-            <strong>
-              Unmonitored
-            </strong>
+            Unmonitored
           </div>
           <div
             data-is-focusable={true}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -56,18 +56,45 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip2"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -89,7 +116,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone3"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -194,7 +221,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone3"
+        data-focuszone-id="FocusZone4"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -215,18 +242,45 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip5"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -248,7 +302,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone6"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -381,7 +435,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone5"
+              data-focuszone-id="FocusZone7"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -625,18 +679,45 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip2"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -658,7 +739,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone3"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -763,7 +844,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone3"
+        data-focuszone-id="FocusZone4"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -784,18 +865,45 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip5"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -817,7 +925,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone6"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -950,7 +1058,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone5"
+              data-focuszone-id="FocusZone7"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -1111,18 +1219,45 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip2"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -1144,7 +1279,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone3"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1243,7 +1378,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone3"
+        data-focuszone-id="FocusZone4"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1264,18 +1399,45 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip5"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -1297,7 +1459,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone6"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1426,7 +1588,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone5"
+              data-focuszone-id="FocusZone7"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -1488,7 +1650,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone24"
+        data-focuszone-id="FocusZone32"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1509,18 +1671,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip33"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -1538,7 +1727,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone25"
+        data-focuszone-id="FocusZone34"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1555,7 +1744,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-labelledby="callout31"
               className=
 
                   {
@@ -1586,7 +1775,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-labelledby="callout31"
               className=
 
                   {
@@ -1637,7 +1826,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone26"
+        data-focuszone-id="FocusZone35"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1658,18 +1847,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip36"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -1687,7 +1903,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone27"
+        data-focuszone-id="FocusZone37"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1704,7 +1920,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-labelledby="callout31"
               className=
 
                   {
@@ -1735,7 +1951,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-labelledby="callout31"
               className=
 
                   {
@@ -1816,7 +2032,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone28"
+              data-focuszone-id="FocusZone38"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -1878,7 +2094,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone7"
+        data-focuszone-id="FocusZone9"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1899,18 +2115,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip10"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -1932,7 +2175,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone8"
+        data-focuszone-id="FocusZone11"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -1949,7 +2192,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout6"
+              aria-labelledby="callout8"
               className=
 
                   {
@@ -1980,7 +2223,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout6"
+              aria-labelledby="callout8"
               className=
 
                   {
@@ -2031,7 +2274,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone9"
+        data-focuszone-id="FocusZone12"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2052,18 +2295,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip13"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -2085,7 +2355,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone10"
+        data-focuszone-id="FocusZone14"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2102,7 +2372,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout6"
+              aria-labelledby="callout8"
               className=
 
                   {
@@ -2133,7 +2403,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout6"
+              aria-labelledby="callout8"
               className=
 
                   {
@@ -2206,7 +2476,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone18"
+        data-focuszone-id="FocusZone24"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2227,18 +2497,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip25"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
         </div>
       </div>
@@ -2248,7 +2545,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone19"
+        data-focuszone-id="FocusZone26"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2265,7 +2562,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout17"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -2296,7 +2593,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout17"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -2347,7 +2644,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone20"
+        data-focuszone-id="FocusZone27"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2368,18 +2665,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip28"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -2401,7 +2725,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone21"
+        data-focuszone-id="FocusZone29"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2418,7 +2742,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout17"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -2449,7 +2773,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout17"
+              aria-labelledby="callout23"
               className=
 
                   {
@@ -2530,7 +2854,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone22"
+              data-focuszone-id="FocusZone30"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
@@ -2773,7 +3097,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone12"
+        data-focuszone-id="FocusZone16"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2794,18 +3118,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Monitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Monitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Monitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip17"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Monitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -2827,7 +3178,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone13"
+        data-focuszone-id="FocusZone18"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2844,7 +3195,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -2875,7 +3226,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -2926,7 +3277,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone14"
+        data-focuszone-id="FocusZone19"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2947,18 +3298,45 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
         >
           <div
             className=
-
+                ms-TooltipHost
                 {
+                  display: block;
                   font-weight: 700;
                   overflow: hidden;
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
-            data-is-focusable={true}
-            role="text"
-            title="Unmonitored"
+            onBlurCapture={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            role="none"
           >
-            Unmonitored
+            <span
+              data-is-focusable={true}
+              role="text"
+            >
+              Unmonitored
+            </span>
+            <div
+              hidden={true}
+              id="tooltip20"
+              style={
+                Object {
+                  "border": 0,
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": 1,
+                }
+              }
+            >
+              Unmonitored
+            </div>
           </div>
           <div
             data-is-focusable={true}
@@ -2980,7 +3358,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone15"
+        data-focuszone-id="FocusZone21"
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
@@ -2997,7 +3375,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
           >
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -3028,7 +3406,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
             </g>
             <g
               aria-label="Multi stacked bar chart"
-              aria-labelledby="callout11"
+              aria-labelledby="callout15"
               className=
 
                   {
@@ -3109,7 +3487,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone16"
+              data-focuszone-id="FocusZone22"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -43,18 +43,45 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip2"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -94,7 +121,7 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone2"
+    data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -391,18 +418,45 @@ exports[`StackedBarChart - mouse events Should render customized callout on mous
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip2"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -442,7 +496,7 @@ exports[`StackedBarChart - mouse events Should render customized callout on mous
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone2"
+    data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -656,18 +710,45 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip2"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -707,7 +788,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone2"
+    data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -820,7 +901,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone20"
+    data-focuszone-id="FocusZone26"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -841,18 +922,45 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip27"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -892,7 +1000,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone21"
+    data-focuszone-id="FocusZone28"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -911,7 +1019,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout19"
+            aria-labelledby="callout25"
             className=
 
                 {
@@ -943,7 +1051,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout19"
+            aria-labelledby="callout25"
             className=
 
                 {
@@ -1005,7 +1113,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone13"
+    data-focuszone-id="FocusZone17"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1026,18 +1134,45 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip18"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -1063,7 +1198,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone14"
+    data-focuszone-id="FocusZone19"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1082,7 +1217,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout12"
+            aria-labelledby="callout16"
             className=
 
                 {
@@ -1114,7 +1249,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout12"
+            aria-labelledby="callout16"
             className=
 
                 {
@@ -1176,7 +1311,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone4"
+    data-focuszone-id="FocusZone5"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1197,18 +1332,45 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip6"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -1248,7 +1410,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone7"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1267,7 +1429,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout3"
+            aria-labelledby="callout4"
             className=
 
                 {
@@ -1299,7 +1461,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout3"
+            aria-labelledby="callout4"
             className=
 
                 {
@@ -1361,7 +1523,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone10"
+    data-focuszone-id="FocusZone13"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1382,18 +1544,45 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip14"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
     </div>
   </div>
@@ -1403,7 +1592,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone11"
+    data-focuszone-id="FocusZone15"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1422,7 +1611,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout9"
+            aria-labelledby="callout12"
             className=
 
                 {
@@ -1454,7 +1643,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout9"
+            aria-labelledby="callout12"
             className=
 
                 {
@@ -1516,7 +1705,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone7"
+    data-focuszone-id="FocusZone9"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1537,18 +1726,45 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip10"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
       <div
         data-is-focusable={true}
@@ -1588,7 +1804,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone8"
+    data-focuszone-id="FocusZone11"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1607,7 +1823,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout6"
+            aria-labelledby="callout8"
             className=
 
                 {
@@ -1639,7 +1855,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout6"
+            aria-labelledby="callout8"
             className=
 
                 {
@@ -1701,7 +1917,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone16"
+    data-focuszone-id="FocusZone21"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1722,18 +1938,45 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
     >
       <div
         className=
-
+            ms-TooltipHost
             {
+              display: block;
               font-weight: 700;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        data-is-focusable={true}
-        role="text"
-        title="Stacked bar chart 2nd example"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onKeyDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        role="none"
       >
-        Stacked bar chart 2nd example
+        <span
+          data-is-focusable={true}
+          role="text"
+        >
+          Stacked bar chart 2nd example
+        </span>
+        <div
+          hidden={true}
+          id="tooltip22"
+          style={
+            Object {
+              "border": 0,
+              "height": 1,
+              "margin": -1,
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": 1,
+            }
+          }
+        >
+          Stacked bar chart 2nd example
+        </div>
       </div>
     </div>
   </div>
@@ -1743,7 +1986,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
         &:focus {
           outline: none;
         }
-    data-focuszone-id="FocusZone17"
+    data-focuszone-id="FocusZone23"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
@@ -1762,7 +2005,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
         <g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout15"
+            aria-labelledby="callout20"
             className=
 
                 {
@@ -1794,7 +2037,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
           </g>
           <g
             aria-label="Stacked bar chart"
-            aria-labelledby="callout15"
+            aria-labelledby="callout20"
             className=
 
                 {
@@ -1878,7 +2121,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone18"
+              data-focuszone-id="FocusZone24"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -42,12 +42,19 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -383,12 +390,19 @@ exports[`StackedBarChart - mouse events Should render customized callout on mous
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -641,12 +655,19 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -819,12 +840,19 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -997,12 +1025,19 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -1161,12 +1196,19 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -1339,12 +1381,19 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
     </div>
   </div>
@@ -1487,12 +1536,19 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
       <div
         data-is-focusable={true}
@@ -1665,12 +1721,19 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
           }
     >
       <div
+        className=
+
+            {
+              font-weight: 700;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
         data-is-focusable={true}
         role="text"
+        title="Stacked bar chart 2nd example"
       >
-        <strong>
-          Stacked bar chart 2nd example
-        </strong>
+        Stacked bar chart 2nd example
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Current Behavior

Chart title overflows when it is lengthy or zoomed

![Before](https://user-images.githubusercontent.com/110246001/193799558-fd41808b-573e-4901-a509-107b247388d6.png)

## New Behavior

Chart title gets truncated with ellipsis if there is not enough space for it to be completely displayed

![After](https://user-images.githubusercontent.com/110246001/193799597-6ed51998-2156-4c81-8948-2797a64ce97f.png)