### PR TITLE
Fix ContextualMenu item text overflow ellipsis style

### DIFF
--- a/change/@fluentui-react-1b46290f-859c-474d-8b5f-e63a451287dd.json
+++ b/change/@fluentui-react-1b46290f-859c-474d-8b5f-e63a451287dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes ContextualMenu item text overflow ellipsis style.",
+  "packageName": "@fluentui/react",
+  "email": "ndresx@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -139,6 +139,7 @@ export const getMenuItemStyles = memoizeFunction(
         verticalAlign: 'middle',
         display: 'inline-block',
         flexGrow: '1',
+        overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
       },

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -427,6 +427,7 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                                   margin-left: 4px;
                                   margin-right: 4px;
                                   margin-top: 0;
+                                  overflow: hidden;
                                   text-overflow: ellipsis;
                                   vertical-align: middle;
                                   white-space: nowrap;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

No text ellipsis:
![image](https://user-images.githubusercontent.com/27507295/194703987-71dbe647-e66a-4666-b24c-73db9c4f73a6.png)

## New Behavior

Text ellipsis with `overflow: hidden;` with the following `styles` prop (as from the example in the related issue #23580):

```
styles: {
  subComponentStyles: {
    callout: {
      root: { width: "150px" }
    }
  }
}
```

![image](https://user-images.githubusercontent.com/27507295/194704054-021ff4a6-f960-465b-a33c-e13b3f642b7f.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23580
