### PR TITLE
fix: CheckboxField to set a generated ID on the input, to match the label's htmlFor

### DIFF
--- a/change/@fluentui-react-field-16bb1d7a-fa7b-41d6-92ec-5e18e0669150.json
+++ b/change/@fluentui-react-field-16bb1d7a-fa7b-41d6-92ec-5e18e0669150.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: CheckboxField to set a generated ID on the input, to match the label's htmlFor",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/src/components/CheckboxField/CheckboxField.test.tsx
+++ b/packages/react-components/react-field/src/components/CheckboxField/CheckboxField.test.tsx
@@ -24,7 +24,18 @@ describe('CheckboxField', () => {
 
   // Most functionality is tested by Field.test.tsx, and Checkbox's tests
 
-  it('sets htmlFor of both label and fieldLabel', () => {
+  it('sets htmlFor on label', () => {
+    const result = render(<CheckboxField label="checkbox label" />);
+
+    const checkbox = result.getByRole('checkbox');
+    const checkboxLabel = result.getByText('checkbox label') as HTMLLabelElement;
+
+    expect(checkbox.id).toBeTruthy();
+    expect(checkboxLabel.htmlFor).toBe(checkbox.id);
+    expect(checkbox.getAttribute('aria-labelledby')).toBeFalsy();
+  });
+
+  it('sets htmlFor on both label and fieldLabel', () => {
     const result = render(<CheckboxField label="checkbox label" fieldLabel="field label" />);
 
     const checkbox = result.getByRole('checkbox');

--- a/packages/react-components/react-field/src/components/Field/Field.test.tsx
+++ b/packages/react-components/react-field/src/components/Field/Field.test.tsx
@@ -102,4 +102,26 @@ describe('Field', () => {
 
     expect(input.getAttribute('aria-invalid')).toBeTruthy();
   });
+
+  it('does not override user aria props', () => {
+    const result = render(
+      <MockField
+        label="test label"
+        validationState="error"
+        validationMessage="test description"
+        hint="test hint"
+        aria-labelledby="test-labelledby"
+        aria-describedby="test-describedby"
+        aria-errormessage="test-errormessage"
+        aria-invalid={false}
+      />,
+    );
+
+    const input = result.getByRole('textbox');
+
+    expect(input.getAttribute('aria-labelledby')).toBe('test-labelledby');
+    expect(input.getAttribute('aria-describedby')).toBe('test-describedby');
+    expect(input.getAttribute('aria-errormessage')).toBe('test-errormessage');
+    expect(input.getAttribute('aria-invalid')).toBe('false');
+  });
 });

--- a/packages/react-components/react-field/src/components/Field/useField.tsx
+++ b/packages/react-components/react-field/src/components/Field/useField.tsx
@@ -17,12 +17,6 @@ const validationMessageIcons = {
 } as const;
 
 /**
- * Merge two possibly-undefined IDs for aria-describedby. If both IDs are defined, combines
- * them into a string separated by a space. Otherwise, returns just the defined ID (if any).
- */
-const mergeAriaDescribedBy = (a?: string, b?: string) => (a && b ? `${a} ${b}` : a || b);
-
-/**
  * Partition the props used by the Field itself, from the props that are passed to the underlying field component.
  */
 export const getPartitionedFieldProps = <Props extends FieldProps<FieldComponent>>(props: Props) => {
@@ -120,15 +114,24 @@ export const useField_unstable = <T extends FieldComponent>(
   });
 
   // Hook up aria props on the control
-  if (labelConnection === 'aria-labelledby') {
-    control['aria-labelledby'] ??= label?.id;
+  if (label && labelConnection === 'aria-labelledby') {
+    control['aria-labelledby'] ??= label.id;
   }
+
   if (validationState === 'error') {
     control['aria-invalid'] ??= true;
-    control['aria-errormessage'] ??= validationMessage?.id;
-    control['aria-describedby'] ??= hint?.id;
+    if (validationMessage) {
+      control['aria-errormessage'] ??= validationMessage.id;
+    }
+    if (hint) {
+      control['aria-describedby'] ??= hint.id;
+    }
   } else {
-    control['aria-describedby'] ??= mergeAriaDescribedBy(validationMessage?.id, hint?.id);
+    // If the state is not an error, then the control is described by the validation message, or hint, or both
+    const describedby = validationMessage || hint;
+    if (describedby) {
+      control['aria-describedby'] ??= validationMessage && hint ? `${validationMessage.id} ${hint.id}` : describedby.id;
+    }
   }
 
   const state: FieldState<FieldComponent> = {


### PR DESCRIPTION
## Current Behavior

Field sets the input's `id` to `undefined` if there is no field label. CheckboxField is unique in that it doesn't use the field label, but rather an internal label built into Checkbox. The Field's `id={undefined}` gets passed to the Checkbox component, which prevents it from setting a generated ID on the input element.

## New Behavior

* Have field _always_ set a generated ID on the input component, even if there is no field label.
* Refactor useField to not set input props to `undefined` if they aren't relevant (instead they will be unset in that case)
* Add tests for these changes.

## Related Issue(s)

* Fixes #25072
