### PR TITLE
Rounded FocusBorder for ToolbarItem

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Popup` trigger attribute being override @chpalac ([#24794](https://github.com/microsoft/fluentui/pull/24794))
 - Fix styling mutation when merging themes in `Dropdown` @petrjaros ([#24787](https://github.com/microsoft/fluentui/pull/24787))
 - Fix `Toolbar` submenu closing when another submenu is opened @miroslavstastny ([#24836](https://github.com/microsoft/fluentui/pull/24836))
+- Rounded focus border for `ToolbarItem` @Hirse ([#25084](https://github.com/microsoft/fluentui/pull/25084))
 
 ### Performance
 - Avoid memory trashing in `felaExpandCssShorthandsPlugin` @layershifter ([#24663](https://github.com/microsoft/fluentui/pull/24663))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarCustomItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarCustomItemStyles.ts
@@ -9,6 +9,7 @@ export const toolbarCustomItemStyles: ComponentSlotStylesPrepared<ToolbarCustomI
     const colors = getColorScheme(v.colorScheme);
     const { borderWidth } = siteVariables;
     const borderFocusStyles = getBorderFocusStyles({
+      borderRadius: v.borderRadius,
       variables: siteVariables,
     });
 
@@ -18,6 +19,7 @@ export const toolbarCustomItemStyles: ComponentSlotStylesPrepared<ToolbarCustomI
       borderColor: 'transparent',
       borderWidth,
       borderStyle: 'solid',
+      borderRadius: v.borderRadius,
       height: v.itemHeight,
       color: v.foreground || colors.foreground1,
       display: 'flex',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarItemStyles.ts
@@ -10,6 +10,7 @@ export const toolbarItemStyles: ComponentSlotStylesPrepared<ToolbarItemStylesPro
     const colors = getColorScheme(v.colorScheme);
     const { borderWidth } = siteVariables;
     const borderFocusStyles = getBorderFocusStyles({
+      borderRadius: v.borderRadius,
       variables: siteVariables,
     });
 


### PR DESCRIPTION
Add border radius to the ToolbarItem focus border to align with other button styles.

*Before*
![image](https://user-images.githubusercontent.com/2564094/135002886-c47ea900-3cab-415e-80ce-28807f819029.png)

*After*
![image](https://user-images.githubusercontent.com/2564094/135002866-8cf83be0-8141-4188-a07f-cc7a687acd61.png)

Adding this change for a single component because the previous work cleaning up all the focus borders (#20230) got reverted.