### PR TITLE
fix(react): No pointer events on focus ring

### DIFF
--- a/change/@fluentui-react-f1a80b64-01ed-4cb6-83c3-9495c9a74e31.json
+++ b/change/@fluentui-react-f1a80b64-01ed-4cb6-83c3-9495c9a74e31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(SplitButton): No pointer events on focus ring",
+  "packageName": "@fluentui/react",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-style-utilities-ac20774e-9182-46f1-ac57-70faa326aa8d.json
+++ b/change/@fluentui-style-utilities-ac20774e-9182-46f1-ac57-70faa326aa8d.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "fix: No pointer events on focus ring",
+  "type": "minor",
+  "comment": "feat(getFocusStyle): Optionally tweak pointer-events on the focus ring",
   "packageName": "@fluentui/style-utilities",
   "email": "miroslav.stastny@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-style-utilities-e38fbe70-986a-42a7-b9d2-396683f75220.json
+++ b/change/@fluentui-style-utilities-e38fbe70-986a-42a7-b9d2-396683f75220.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: No pointer events on focus ring",
+  "packageName": "@fluentui/style-utilities",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -25,7 +25,7 @@ export const getStyles = memoizeFunction(
 
     const splitButtonStyles: IButtonStyles = {
       splitButtonContainer: [
-        getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
+        getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2, pointerEvents: 'none' }),
         {
           display: 'inline-flex',
           selectors: {

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -180,6 +180,7 @@ export interface IGetFocusStylesOptions {
     inset?: number;
     isFocusedOnly?: boolean;
     outlineColor?: string;
+    pointerEvents?: IRawStyle['pointerEvents'];
     position?: 'relative' | 'absolute';
     width?: number;
 }

--- a/packages/style-utilities/src/interfaces/IGetFocusStyles.ts
+++ b/packages/style-utilities/src/interfaces/IGetFocusStyles.ts
@@ -47,4 +47,10 @@ export interface IGetFocusStylesOptions {
    * If the style should include a rounded border.
    */
   borderRadius?: string | number | undefined;
+
+  /**
+   * If default pointer events should be overriden.
+   * @defaultvalue undefined
+   */
+  pointerEvents?: IRawStyle['pointerEvents'];
 }

--- a/packages/style-utilities/src/interfaces/IGetFocusStyles.ts
+++ b/packages/style-utilities/src/interfaces/IGetFocusStyles.ts
@@ -49,7 +49,7 @@ export interface IGetFocusStylesOptions {
   borderRadius?: string | number | undefined;
 
   /**
-   * If default pointer events should be overriden.
+   * If default pointer events should be overridden.
    * @defaultvalue undefined
    */
   pointerEvents?: IRawStyle['pointerEvents'];

--- a/packages/style-utilities/src/styles/getFocusStyle.ts
+++ b/packages/style-utilities/src/styles/getFocusStyle.ts
@@ -72,6 +72,7 @@ function _getFocusStyleInternal(theme: ITheme, options: IGetFocusStylesOptions =
     borderColor = theme.palette.white,
     outlineColor = theme.palette.neutralSecondary,
     isFocusedOnly = true,
+    pointerEvents,
   } = options;
 
   return {
@@ -92,7 +93,7 @@ function _getFocusStyleInternal(theme: ITheme, options: IGetFocusStylesOptions =
       [`.${IsFocusVisibleClassName} &${isFocusedOnly ? ':focus' : ''}:after`]: {
         content: '""',
         position: 'absolute',
-        pointerEvents: 'none',
+        pointerEvents,
         left: inset + 1,
         top: inset + 1,
         bottom: inset + 1,

--- a/packages/style-utilities/src/styles/getFocusStyle.ts
+++ b/packages/style-utilities/src/styles/getFocusStyle.ts
@@ -92,6 +92,7 @@ function _getFocusStyleInternal(theme: ITheme, options: IGetFocusStylesOptions =
       [`.${IsFocusVisibleClassName} &${isFocusedOnly ? ':focus' : ''}:after`]: {
         content: '""',
         position: 'absolute',
+        pointerEvents: 'none',
         left: inset + 1,
         top: inset + 1,
         bottom: inset + 1,


### PR DESCRIPTION
## Current Behavior

`SplitButton` renders two `button` elements inside a `div`:
```html
div
  button
  button
```

When the `SplitButton` is focused, `:after` pseudoelement is added to the wrapping `div` to display a focus ring around both buttons - this now captures all the events:
- when hovered, arrow mouse cursor is used instead of the pointer
- it is not possible to click the secondary button

## New Behavior

I've added `pointer-events: none` to the focus styles so that it passes through all the mouse events.

For `SplitButton`, that means that when it is focused:
- the focus ring is displayed as before
- user can press Enter or Space to press the primary button (as before)
- user can press Alt/Option + Down Arrow to open the Menu (as before)
- user can click primary button (as before)
- user can click the secondary button (fix)
- correct pointer cursor is used when hovering on either primary or secondary button (fix)

## Related Issue(s)

Fixes #20608
