### PR TITLE
fix(scripts): don't run publish if web-components are affected

### DIFF
--- a/scripts/monorepo/getAllPackageInfo.js
+++ b/scripts/monorepo/getAllPackageInfo.js
@@ -3,7 +3,7 @@ const path = require('path');
 const lernaAlias = require('lerna-alias');
 const findGitRoot = require('./findGitRoot');
 
-/** @type {import('./index').AllPackageInfo} */
+/** @type {import('./').AllPackageInfo} */
 let packageInfo;
 /**
  * @type {string}
@@ -11,7 +11,7 @@ let packageInfo;
 let cwdForPackageInfo;
 
 /**
- * @returns {import('./index').AllPackageInfo}
+ * @returns {typeof packageInfo}
  */
 function getAllPackageInfo() {
   if (packageInfo && cwdForPackageInfo === process.cwd()) {

--- a/scripts/monorepo/getAllPackageInfo.spec.ts
+++ b/scripts/monorepo/getAllPackageInfo.spec.ts
@@ -1,0 +1,21 @@
+import * as path from 'path';
+import getAllPackageInfo from './getAllPackageInfo';
+
+describe(`#getAllPackageinfo`, () => {
+  it(`should return workspace packages record with metadata as values`, () => {
+    const allPackages = getAllPackageInfo();
+    const entries = Object.entries(allPackages);
+    const [packageName, packageMetadata] = entries[0];
+
+    expect(allPackages['@fluentui/noop']).toBe(undefined);
+    expect(packageName).toEqual(expect.stringMatching(/^@fluentui\/[a-z-]+/));
+    expect(packageMetadata).toEqual({
+      packagePath: expect.any(String),
+      packageJson: expect.objectContaining({
+        name: expect.any(String),
+        version: expect.any(String),
+      }),
+    });
+    expect(path.isAbsolute(packageMetadata.packagePath)).toBe(false);
+  });
+});

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -3,64 +3,105 @@ const getAllPackageInfo = require('./getAllPackageInfo');
 const isConvergedPackage = require('./isConvergedPackage');
 const lageBin = require.resolve('lage/bin/lage.js');
 
-const argv = process.argv.slice(2);
+/**
+ * @typedef {{argv:string[]; workspacePackagesMetadata:ReturnType<typeof getAllPackageInfo>}} Options
+ */
 
-if (argv.length < 1) {
-  console.log(`Usage:
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  main({ argv, workspacePackagesMetadata: getAllPackageInfo() });
+}
+
+module.exports = main;
+
+/**
+ *
+ * @param {Options} options
+ */
+function main(options) {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('This is not supposed to be used as API only via direct node execution');
+  }
+
+  const lageArgs = getLageArgs(options);
+
+  const result = spawnSync(process.execPath, [lageBin, ...lageArgs], {
+    stdio: 'inherit',
+    maxBuffer: 500 * 1024 * 1024,
+  });
+
+  process.exit(result.status ?? undefined);
+}
+
+/**
+ *
+ * @param {string[]} args
+ */
+function assertArgs(args) {
+  if (args.length < 1) {
+    console.log(`Usage:
 
   yarn run:published <script> [<args>]
 
 This command runs <script> for all beachball-published packages, as well as packages for the version 8 website.
 `);
 
-  process.exit(0);
+    process.exit(0);
+  }
 }
 
-const websitePackages = [
-  '@fluentui/public-docsite',
-  '@fluentui/public-docsite-resources',
-  '@fluentui/react-examples',
-  '@fluentui/api-docs',
-];
+/**
+ *
+ * @param {Options} options
+ * @returns
+ */
+function getLageArgs(options) {
+  const { argv, workspacePackagesMetadata } = options;
+  assertArgs(argv);
 
-// Only include the packages that are published daily by beachball, and some website/doc packages
-// (which must be built and uploaded with each release). This is similar to "--scope \"!packages/fluentui/*\""
-// in the root package.json's publishing-related scripts and will need to be updated if --scope changes.
-const beachballPackageScopes = Object.entries(getAllPackageInfo())
-  .filter(([, { packageJson, packagePath }]) => {
-    const isNorthstar = /[\\/]fluentui[\\/]/.test(packagePath);
+  const releaseScope = process.env.RELEASE_VNEXT ? 'v9' : 'v8';
+  const websitePackages = [
+    '@fluentui/public-docsite',
+    '@fluentui/public-docsite-resources',
+    '@fluentui/react-examples',
+    '@fluentui/api-docs',
+  ];
 
-    if (isNorthstar) {
+  // Only include the packages that are published daily by beachball, and some website/doc packages
+  // (which must be built and uploaded with each release). This is similar to "--scope \"!packages/fluentui/*\""
+  // in the root package.json's publishing-related scripts and will need to be updated if --scope changes.
+  const beachballPackageScopes = Object.values(workspacePackagesMetadata)
+    .filter(({ packageJson, packagePath }) => {
+      const isNorthstar = /[\\/]fluentui[\\/]/.test(packagePath);
+      const isWebComponents = packageJson.name === '@fluentui/web-components';
+
+      if (isNorthstar || isWebComponents) {
+        return false;
+      }
+
+      const isConverged = isConvergedPackage({ packagePathOrJson: packageJson });
+      if (releaseScope === 'v9' && isConverged) {
+        return packageJson.private !== true;
+      }
+
+      if (releaseScope === 'v8' && !isConverged) {
+        // v8 scope
+        return websitePackages.includes(packageJson.name) || packageJson.private !== true;
+      }
+
+      // Ignore v9/converged packages when releasing v8
       return false;
-    }
+    })
+    .map(({ packageJson }) => `--to=${packageJson.name}`);
 
-    const isConverged = isConvergedPackage({ packagePathOrJson: packageJson });
-    if (process.env.RELEASE_VNEXT && isConverged) {
-      return packageJson.private !== true;
-    }
+  const lageArgs = [
+    'run',
+    ...argv,
+    // default to verbose mode unless already/otherwise specified
+    ...(argv.some(arg => /^--(no-)?verbose/.test(arg)) ? [] : ['--verbose']),
+    ...beachballPackageScopes,
+  ];
+  console.log(`lage ${lageArgs.join(' ')}`); // for debugging
 
-    if (!isConverged) {
-      // v8 scope
-      return websitePackages.includes(packageJson.name) || packageJson.private !== true;
-    }
-
-    // Ignore v9/converged packages when releasing v8
-    return false;
-  })
-  .map(([packageName]) => `--to=${packageName}`);
-
-const lageArgs = [
-  'run',
-  ...argv,
-  // default to verbose mode unless already/otherwise specified
-  ...(argv.some(arg => /^--(no-)?verbose/.test(arg)) ? [] : ['--verbose']),
-  ...beachballPackageScopes,
-];
-console.log(`lage ${lageArgs.join(' ')}`); // for debugging
-
-const result = spawnSync(process.execPath, [lageBin, ...lageArgs], {
-  stdio: 'inherit',
-  maxBuffer: 500 * 1024 * 1024,
-});
-
-process.exit(result.status ?? undefined);
+  return lageArgs;
+}

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -22,6 +22,9 @@ function main(options) {
   if (process.env.NODE_ENV !== 'test') {
     throw new Error('This is not supposed to be used as API only via direct node execution');
   }
+  if (!assertArgs(options.argv)) {
+    return;
+  }
 
   const lageArgs = getLageArgs(options);
 
@@ -46,8 +49,10 @@ function assertArgs(args) {
 This command runs <script> for all beachball-published packages, as well as packages for the version 8 website.
 `);
 
-    process.exit(0);
+    return false;
   }
+
+  return true;
 }
 
 /**
@@ -57,7 +62,6 @@ This command runs <script> for all beachball-published packages, as well as pack
  */
 function getLageArgs(options) {
   const { argv, workspacePackagesMetadata } = options;
-  assertArgs(argv);
 
   const releaseScope = process.env.RELEASE_VNEXT ? 'v9' : 'v8';
   const websitePackages = [

--- a/scripts/monorepo/runPublished.spec.ts
+++ b/scripts/monorepo/runPublished.spec.ts
@@ -1,0 +1,124 @@
+import childProcess from 'child_process';
+
+import main from './runPublished';
+
+// ☝️ NOTE - don't comment or remove this mock while running tests - you will need to manually kill lot of node processes :P
+jest.mock('child_process');
+
+describe(`#runPublished`, () => {
+  const originalConsoleLog = console.log;
+  beforeEach(() => {
+    console.log = () => {};
+  });
+  afterAll(() => {
+    console.log = originalConsoleLog;
+  });
+
+  function setup() {
+    const workspacePackagesMetadata = {
+      '@fluentui/web-components': {
+        packagePath: 'packages/web-components',
+        packageJson: { name: '@fluentui/web-components', version: '1.0.0', main: 'lib/index.js', private: false },
+      },
+      '@fluentui/react': {
+        packagePath: 'packages/react',
+        packageJson: { name: '@fluentui/react', version: '8.0.0', main: 'lib/index.js', private: false },
+      },
+      '@fluentui/react-northstar': {
+        packagePath: 'packages/fluentui/react-northstar',
+        packageJson: { name: '@fluentui/react-northstar', version: '0.1.0', main: 'lib/index.js', private: false },
+      },
+      '@fluentui/react-components': {
+        packagePath: 'packages/react-components/react-components',
+        packageJson: { name: '@fluentui/react-components', version: '9.0.0', main: 'lib/index.js', private: false },
+      },
+    };
+
+    const spawnSyncMock = jest.spyOn(childProcess, 'spawnSync').mockImplementation((() => {
+      return { status: 0 };
+    }) as any);
+
+    jest.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+    function getSpawnCallArguments() {
+      const [, spawnSyncArgs, spawnSyncOptions] = spawnSyncMock.mock.calls[0];
+      const [lagePath, ...restArgs] = spawnSyncArgs as string[];
+
+      return { spawnSyncArgs, spawnSyncOptions, lagePath, restArgs };
+    }
+
+    return { workspacePackagesMetadata, spawnSyncMock, getSpawnCallArguments };
+  }
+
+  it(`should not do invoke lage with '--to' if all packages are private`, () => {
+    const { workspacePackagesMetadata, getSpawnCallArguments } = setup();
+    const metadataCopy = { ...workspacePackagesMetadata };
+    metadataCopy['@fluentui/react'].packageJson.private = true;
+    metadataCopy['@fluentui/react-components'].packageJson.private = true;
+
+    main({
+      argv: ['build'],
+      workspacePackagesMetadata: metadataCopy,
+    });
+
+    const { restArgs } = getSpawnCallArguments();
+
+    expect(restArgs).toMatchInlineSnapshot(`
+      Array [
+        "run",
+        "build",
+        "--verbose",
+      ]
+    `);
+  });
+
+  it(`should never invoke built --to for northstar and web-components`, () => {
+    const { spawnSyncMock, workspacePackagesMetadata, getSpawnCallArguments } = setup();
+
+    main({
+      argv: ['build'],
+      workspacePackagesMetadata,
+    });
+
+    const { lagePath, restArgs, spawnSyncOptions } = getSpawnCallArguments();
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(lagePath.endsWith('node_modules/lage/bin/lage.js')).toBe(true);
+    expect(restArgs).toMatchInlineSnapshot(`
+      Array [
+        "run",
+        "build",
+        "--verbose",
+        "--to=@fluentui/react",
+      ]
+    `);
+    expect(spawnSyncOptions).toEqual({ stdio: 'inherit', maxBuffer: 524288000 });
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it(`should invoke built --to for v9`, () => {
+    const { workspacePackagesMetadata, getSpawnCallArguments } = setup();
+
+    process.env.RELEASE_VNEXT = 'true';
+
+    main({
+      argv: ['build'],
+      workspacePackagesMetadata,
+    });
+
+    const { restArgs } = getSpawnCallArguments();
+
+    expect(restArgs).toMatchInlineSnapshot(`
+      Array [
+        "run",
+        "build",
+        "--verbose",
+        "--to=@fluentui/react-components",
+      ]
+    `);
+
+    expect(process.exit).toHaveBeenCalledWith(0);
+
+    delete process.env['RELEASE_VNEXT'];
+  });
+});

--- a/scripts/monorepo/runPublished.spec.ts
+++ b/scripts/monorepo/runPublished.spec.ts
@@ -50,7 +50,27 @@ describe(`#runPublished`, () => {
     return { workspacePackagesMetadata, spawnSyncMock, getSpawnCallArguments };
   }
 
-  it(`should not do invoke lage with '--to' if all packages are private`, () => {
+  it(`should exit and provide help info if there are not arguments provided`, () => {
+    const { workspacePackagesMetadata, spawnSyncMock } = setup();
+    const logSpy = jest.spyOn(console, 'log');
+
+    main({
+      argv: [],
+      workspacePackagesMetadata,
+    });
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls[0][0]).toMatchInlineSnapshot(`
+      "Usage:
+
+        yarn run:published <script> [<args>]
+
+      This command runs <script> for all beachball-published packages, as well as packages for the version 8 website.
+      "
+    `);
+  });
+
+  it(`should do not invoke lage with '--to' if all packages are private`, () => {
     const { workspacePackagesMetadata, getSpawnCallArguments } = setup();
     const metadataCopy = { ...workspacePackagesMetadata };
     metadataCopy['@fluentui/react'].packageJson.private = true;

--- a/scripts/monorepo/tsconfig.json
+++ b/scripts/monorepo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.scripts.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "include": ["*"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

web-components build pipeline is executed for v9 and nightly release and v8, if affected

## New Behavior

- web-components build pipeline is not executed for v9 and nightly releases and v8
- refactored runPublished + test coverage

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Super-seeds https://github.com/microsoft/fluentui/pull/24809

