### PR TITLE
feat: export contexts from react-combobox

### DIFF
--- a/change/@fluentui-react-combobox-cb21bbcc-609e-40f4-9a10-0fa16f2ad882.json
+++ b/change/@fluentui-react-combobox-cb21bbcc-609e-40f4-9a10-0fa16f2ad882.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: export contexts from react-combobox",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -8,8 +8,11 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import { FC } from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
+import { Provider } from 'react';
+import { ProviderProps } from 'react';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
@@ -19,6 +22,9 @@ export const Combobox: ForwardRefComponent<ComboboxProps>;
 
 // @public (undocumented)
 export const comboboxClassNames: SlotClassNames<ComboboxSlots>;
+
+// @public
+export type ComboboxContextValue = Pick<ComboboxState, 'activeOption' | 'appearance' | 'focusVisible' | 'open' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption' | 'setOpen' | 'size'>;
 
 // @public (undocumented)
 export type ComboboxContextValues = ComboboxBaseContextValues;
@@ -34,6 +40,9 @@ export type ComboboxProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>
     freeform?: boolean;
     children?: React_2.ReactNode;
 };
+
+// @public (undocumented)
+export const ComboboxProvider: Provider<ComboboxContextValue> & FC<ProviderProps<ComboboxContextValue>>;
 
 // @public (undocumented)
 export type ComboboxSlots = {
@@ -83,6 +92,9 @@ export const Listbox: ForwardRefComponent<ListboxProps>;
 // @public (undocumented)
 export const listboxClassNames: SlotClassNames<ListboxSlots>;
 
+// @public
+export type ListboxContextValue = Pick<ListboxState, 'activeOption' | 'focusVisible' | 'multiselect' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption'>;
+
 // @public (undocumented)
 export type ListboxContextValues = {
     listbox: ListboxContextValue;
@@ -90,6 +102,9 @@ export type ListboxContextValues = {
 
 // @public
 export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps;
+
+// @public (undocumented)
+export const ListboxProvider: Provider<ListboxContextValue> & FC<ProviderProps<ListboxContextValue>>;
 
 // @public (undocumented)
 export type ListboxSlots = {
@@ -167,6 +182,9 @@ export const renderOptionGroup_unstable: (state: OptionGroupState) => JSX.Elemen
 // @public
 export const useCombobox_unstable: (props: ComboboxProps, ref: React_2.Ref<HTMLInputElement>) => ComboboxState;
 
+// @public (undocumented)
+export function useComboboxContextValues(state: ComboboxBaseState): ComboboxBaseContextValues;
+
 // @public
 export const useComboboxStyles_unstable: (state: ComboboxState) => ComboboxState;
 
@@ -178,6 +196,9 @@ export const useDropdownStyles_unstable: (state: DropdownState) => DropdownState
 
 // @public
 export const useListbox_unstable: (props: ListboxProps, ref: React_2.Ref<HTMLElement>) => ListboxState;
+
+// @public (undocumented)
+export function useListboxContextValues(state: ListboxState): ListboxContextValues;
 
 // @public
 export const useListboxStyles_unstable: (state: ListboxState) => ListboxState;

--- a/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
@@ -39,3 +39,5 @@ export const ComboboxContext = createContext<ComboboxContextValue>({
   },
   size: 'medium',
 });
+
+export const ComboboxProvider = ComboboxContext.Provider;

--- a/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
@@ -31,3 +31,5 @@ export const ListboxContext = createContext<ListboxContextValue>({
     // noop
   },
 });
+
+export const ListboxProvider = ListboxContext.Provider;

--- a/packages/react-components/react-combobox/src/index.ts
+++ b/packages/react-components/react-combobox/src/index.ts
@@ -1,3 +1,9 @@
+export { ComboboxProvider } from './contexts/ComboboxContext';
+export type { ComboboxContextValue } from './contexts/ComboboxContext';
+export { ListboxProvider } from './contexts/ListboxContext';
+export type { ListboxContextValue } from './contexts/ListboxContext';
+export { useComboboxContextValues } from './contexts/useComboboxContextValues';
+export { useListboxContextValues } from './contexts/useListboxContextValues';
 export {
   Listbox,
   listboxClassNames,


### PR DESCRIPTION
Exports context types and values from the `react-combobox` package