### PR TITLE
feat: Adding subtle transition between states on Button components

### DIFF
--- a/change/@fluentui-react-button-eeea86af-7338-4688-ace7-75aa8d2fb347.json
+++ b/change/@fluentui-react-button-eeea86af-7338-4688-ace7-75aa8d2fb347.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: Adding subtle transition between states on Button components.",
+  "packageName": "@fluentui/react-button",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -66,6 +66,17 @@ const useRootStyles = makeStyles({
     },
   },
 
+  // Transition styles
+  transition: {
+    transitionDuration: '100ms',
+    transitionProperty: 'background, border, color',
+    transitionTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
+
+    '@media screen and (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01ms',
+    },
+  },
+
   // High contrast styles
   highContrast: {
     '@media (forced-colors: active)': {
@@ -450,6 +461,7 @@ export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
 
     // Root styles
     rootStyles.base,
+    rootStyles.transition,
     rootStyles.highContrast,
     appearance && rootStyles[appearance],
     rootStyles[size],


### PR DESCRIPTION
## Previous Behavior

Style changes between states in `Button` components had no transition between them.

## New Behavior

Style changes between states in `Button` components have a subtle transition between them according to the design spec: `all 100ms easyEase`. We are also making sure that we support the reduced motion settings by turning down the transition duration.

_Note:_ We are not really using `all` as the `transitionProperty` as that would be really expensive and are instead opting for defining only the properties that change between states, which are `background`, `border` and `color`. If more properties change between states in the future, they'll need to be added as well.

## Related Issue(s)

Fixes #22552
