### PR TITLE
feat: adds disableButtonEnhancement property on triggers

### DIFF
--- a/change/@fluentui-react-dialog-492b7510-f518-4c17-a929-c500874ec6fc.json
+++ b/change/@fluentui-react-dialog-492b7510-f518-4c17-a929-c500874ec6fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: adds disableButtonEnhancement property on DialogTrigger",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-2a082257-9573-43fe-99e1-a4ce48003c46.json
+++ b/change/@fluentui-react-menu-2a082257-9573-43fe-99e1-a4ce48003c46.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds disableButtonEnhancement property on MenuTrigger",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-2a257879-7e46-4b0d-82f2-9dd83e7fcd36.json
+++ b/change/@fluentui-react-popover-2a257879-7e46-4b0d-82f2-9dd83e7fcd36.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds disableButtonEnhancement property on PopoverTrigger",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -176,6 +176,7 @@ export type DialogTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType
 // @public (undocumented)
 export type DialogTriggerProps = TriggerProps<DialogTriggerChildProps> & {
     action?: DialogTriggerAction;
+    disableButtonEnhancement?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -35,7 +35,7 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
       required: modalType === 'non-modal',
       defaultProps: {
         children: (
-          <DialogTrigger action="close">
+          <DialogTrigger disableButtonEnhancement action="close">
             <button
               className={internalStyles.button}
               // TODO: find a better way to add internal labels

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.test.tsx
@@ -34,7 +34,7 @@ describe('DialogTrigger', () => {
    */
   it('renders a default state', () => {
     const component = renderer.create(
-      <DialogTrigger>
+      <DialogTrigger disableButtonEnhancement>
         <button>Dialog trigger</button>
       </DialogTrigger>,
     );
@@ -46,7 +46,7 @@ describe('DialogTrigger', () => {
     // Arrange
     const ref = jest.fn();
     render(
-      <DialogTrigger>
+      <DialogTrigger disableButtonEnhancement>
         <button ref={ref}>Trigger</button>
       </DialogTrigger>,
     );
@@ -58,7 +58,6 @@ describe('DialogTrigger', () => {
         <button
           aria-haspopup="dialog"
           data-tabster="{\\"deloser\\":{}}"
-          type="button"
         >
           Trigger
         </button>,
@@ -75,7 +74,7 @@ describe('DialogTrigger', () => {
         cb(ref.current);
       }, []);
       return (
-        <DialogTrigger>
+        <DialogTrigger disableButtonEnhancement>
           <button ref={ref}>Trigger</button>
         </DialogTrigger>
       );
@@ -89,7 +88,6 @@ describe('DialogTrigger', () => {
         <button
           aria-haspopup="dialog"
           data-tabster="{\\"deloser\\":{}}"
-          type="button"
         >
           Trigger
         </button>,
@@ -116,7 +114,7 @@ describe('DialogTrigger', () => {
     mockUseDialogContext({ requestOpenChange });
 
     const { getByRole } = render(
-      <DialogTrigger action="open">
+      <DialogTrigger disableButtonEnhancement action="open">
         <button aria-disabled={false}>trigger</button>
       </DialogTrigger>,
     );
@@ -131,7 +129,7 @@ describe('DialogTrigger', () => {
     mockUseDialogContext({ requestOpenChange });
 
     const { getByRole } = render(
-      <DialogTrigger>
+      <DialogTrigger disableButtonEnhancement>
         <button disabled>trigger</button>
       </DialogTrigger>,
     );
@@ -143,7 +141,7 @@ describe('DialogTrigger', () => {
   it('should not keyboard click when event is default prevented', () => {
     const onClick = jest.fn();
     const { getByRole } = render(
-      <DialogTrigger>
+      <DialogTrigger disableButtonEnhancement>
         <div role="button" onClick={onClick}>
           trigger
         </div>

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.types.ts
@@ -14,6 +14,11 @@ export type DialogTriggerProps = TriggerProps<DialogTriggerChildProps> & {
    * If `DialogTrigger` is inside `DialogSurface` then it'll be `close` by default
    */
   action?: DialogTriggerAction;
+  /**
+   * Disables internal trigger mechanism that ensures a child provided will be a compliant ARIA button.
+   * @default false
+   */
+  disableButtonEnhancement?: boolean;
 };
 
 /**

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/__snapshots__/DialogTrigger.test.tsx.snap
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/__snapshots__/DialogTrigger.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`DialogTrigger renders a default state 1`] = `
   aria-haspopup="dialog"
   data-tabster="{\\"deloser\\":{}}"
   onClick={[Function]}
-  type="button"
 >
   Dialog trigger
 </button>

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
@@ -14,7 +14,7 @@ import { useARIAButtonProps } from '@fluentui/react-aria';
 export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTriggerState => {
   const isInsideSurfaceDialog = useDialogSurfaceContext_unstable();
 
-  const { children, action = isInsideSurfaceDialog ? 'close' : 'open' } = props;
+  const { children, disableButtonEnhancement = false, action = isInsideSurfaceDialog ? 'close' : 'open' } = props;
 
   const child = getTriggerChild(children);
 
@@ -35,17 +35,26 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
     },
   );
 
+  const triggerChildProps = {
+    ...child?.props,
+    'aria-haspopup': action === 'close' ? undefined : 'dialog',
+    ref: child?.ref,
+    onClick: handleClick,
+    ...triggerAttributes,
+  } as const;
+
+  const ariaButtonTriggerChildProps = useARIAButtonProps(
+    child?.type === 'button' || child?.type === 'a' ? child.type : 'div',
+    {
+      ...triggerChildProps,
+      type: 'button',
+    },
+  );
+
   return {
     children: applyTriggerPropsToChildren(
       children,
-      useARIAButtonProps(child?.type === 'button' || child?.type === 'a' ? child.type : 'div', {
-        type: 'button',
-        ...child?.props,
-        'aria-haspopup': action === 'close' ? undefined : 'dialog',
-        ref: child?.ref,
-        onClick: handleClick,
-        ...triggerAttributes,
-      }),
+      disableButtonEnhancement ? triggerChildProps : ariaButtonTriggerChildProps,
     ),
   };
 };

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -314,7 +314,9 @@ export type MenuTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType, 
 export const MenuTriggerContextProvider: React_2.Provider<boolean>;
 
 // @public (undocumented)
-export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps>;
+export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps> & {
+    disableButtonEnhancement?: boolean;
+};
 
 // @public (undocumented)
 export type MenuTriggerState = {

--- a/packages/react-components/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.test.tsx
@@ -25,7 +25,7 @@ describe('Menu', () => {
     displayName: 'Menu',
     requiredProps: {
       children: [
-        <MenuTrigger key="trigger">
+        <MenuTrigger disableButtonEnhancement key="trigger">
           <button>MenuTrigger</button>
         </MenuTrigger>,
         <MenuPopover key="popover">
@@ -47,7 +47,7 @@ describe('Menu', () => {
   it('renders a default state', () => {
     const { container } = render(
       <Menu>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -66,7 +66,7 @@ describe('Menu', () => {
     const onOpenChange = jest.fn();
     const { getByRole } = render(
       <Menu open={open} onOpenChange={onOpenChange}>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -90,7 +90,7 @@ describe('Menu', () => {
     const onOpenChange = jest.fn();
     const { getByRole } = render(
       <Menu onOpenChange={onOpenChange}>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -119,7 +119,7 @@ describe('Menu', () => {
     // Arrange
     const { getByRole } = render(
       <Menu>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -150,7 +150,7 @@ describe('Menu', () => {
     // Arrange
     const { getByRole } = render(
       <Menu open>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -178,7 +178,7 @@ describe('Menu', () => {
     // Arrange
     const { getByRole } = render(
       <Menu>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -203,7 +203,7 @@ describe('Menu', () => {
     // Arrange
     const { getByRole } = render(
       <Menu>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -230,7 +230,7 @@ describe('Menu', () => {
     // Arrange
     const { container } = render(
       <Menu open>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>
@@ -250,7 +250,7 @@ describe('Menu', () => {
     // Arrange
     const { container } = render(
       <Menu open inline>
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button>Menu trigger</button>
         </MenuTrigger>
         <MenuPopover>

--- a/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -34,7 +34,7 @@ describe('MenuTrigger', () => {
    */
   it('renders a default state', () => {
     const component = renderer.create(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button>Menu trigger</button>
       </MenuTrigger>,
     );
@@ -46,7 +46,7 @@ describe('MenuTrigger', () => {
     // Arrange
     const ref = jest.fn();
     render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button ref={ref}>Trigger</button>
       </MenuTrigger>,
     );
@@ -74,7 +74,7 @@ describe('MenuTrigger', () => {
         cb(ref.current);
       }, []);
       return (
-        <MenuTrigger>
+        <MenuTrigger disableButtonEnhancement>
           <button ref={ref}>Trigger</button>
         </MenuTrigger>
       );
@@ -100,7 +100,7 @@ describe('MenuTrigger', () => {
     mockUseMenuContext({ setOpen });
 
     const { getByRole } = render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button aria-disabled>trigger</button>
       </MenuTrigger>,
     );
@@ -114,7 +114,7 @@ describe('MenuTrigger', () => {
     mockUseMenuContext({ setOpen });
 
     const { getByRole } = render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button aria-disabled={false}>trigger</button>
       </MenuTrigger>,
     );
@@ -129,7 +129,7 @@ describe('MenuTrigger', () => {
     mockUseMenuContext({ setOpen });
 
     const { getByRole } = render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button disabled>trigger</button>
       </MenuTrigger>,
     );
@@ -148,7 +148,7 @@ describe('MenuTrigger', () => {
     };
 
     render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button>
           <TestComponent />
         </button>
@@ -168,7 +168,7 @@ describe('MenuTrigger', () => {
     };
 
     render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <button>
           <TestComponent />
         </button>
@@ -181,7 +181,7 @@ describe('MenuTrigger', () => {
   it('should not keyboard click when event is default prevented', () => {
     const onClick = jest.fn();
     const { getByRole } = render(
-      <MenuTrigger>
+      <MenuTrigger disableButtonEnhancement>
         <div role="button" onClick={onClick}>
           trigger
         </div>

--- a/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -2,7 +2,13 @@ import { ARIAButtonResultProps, ARIAButtonType } from '@fluentui/react-aria';
 import type { TriggerProps } from '@fluentui/react-utilities';
 import * as React from 'react';
 
-export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps>;
+export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps> & {
+  /**
+   * Disables internal trigger mechanism that ensures a child provided will be a compliant ARIA button.
+   * @default false
+   */
+  disableButtonEnhancement?: boolean;
+};
 
 /**
  * Props that are passed to the child of the MenuTrigger when cloned to ensure correct behaviour for the Menu

--- a/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -21,7 +21,7 @@ import { useARIAButtonProps } from '@fluentui/react-aria';
  * @param props - props from this instance of MenuTrigger
  */
 export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerState => {
-  const { children } = props;
+  const { children, disableButtonEnhancement = false } = props;
 
   const triggerRef = useMenuContext_unstable(context => context.triggerRef);
   const menuPopoverRef = useMenuContext_unstable(context => context.menuPopoverRef);
@@ -121,7 +121,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     }
   };
 
-  const triggerProps = {
+  const contextMenuProps = {
     'aria-haspopup': 'menu',
     'aria-expanded': !open && !isSubmenu ? undefined : open,
     id: triggerId,
@@ -133,18 +133,23 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     onMouseMove: useEventCallback(mergeCallbacks(child?.props.onMouseMove, onMouseMove)),
   } as const;
 
-  const ariaButtonTriggerProps = useARIAButtonProps(
+  const triggerChildProps = {
+    ...contextMenuProps,
+    onClick: useEventCallback(mergeCallbacks(child?.props.onClick, onClick)),
+    onKeyDown: useEventCallback(mergeCallbacks(child?.props.onKeyDown, onKeyDown)),
+  };
+
+  const ariaButtonTriggerChildProps = useARIAButtonProps(
     child?.type === 'button' || child?.type === 'a' ? child.type : 'div',
-    {
-      ...triggerProps,
-      onClick: useEventCallback(mergeCallbacks(child?.props.onClick, onClick)),
-      onKeyDown: useEventCallback(mergeCallbacks(child?.props.onKeyDown, onKeyDown)),
-    },
+    triggerChildProps,
   );
 
   return {
     isSubmenu,
-    children: applyTriggerPropsToChildren(children, openOnContext ? triggerProps : ariaButtonTriggerProps),
+    children: applyTriggerPropsToChildren(
+      children,
+      openOnContext ? contextMenuProps : disableButtonEnhancement ? triggerChildProps : ariaButtonTriggerChildProps,
+    ),
   };
 };
 

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -114,7 +114,9 @@ export type PopoverTriggerChildProps<Type extends ARIAButtonType = ARIAButtonTyp
 }>;
 
 // @public
-export type PopoverTriggerProps = TriggerProps<PopoverTriggerChildProps>;
+export type PopoverTriggerProps = TriggerProps<PopoverTriggerChildProps> & {
+    disableButtonEnhancement?: boolean;
+};
 
 // @public
 export type PopoverTriggerState = {

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.test.tsx
@@ -32,7 +32,7 @@ describe('PopoverTrigger', () => {
    */
   it('renders a default state', () => {
     const component = renderer.create(
-      <PopoverTrigger>
+      <PopoverTrigger disableButtonEnhancement>
         <button>Popover trigger</button>
       </PopoverTrigger>,
     );
@@ -50,7 +50,7 @@ describe('PopoverTrigger', () => {
     // Arrange
     const spy = jest.fn();
     const { getByRole } = render(
-      <PopoverTrigger>
+      <PopoverTrigger disableButtonEnhancement>
         <button {...{ [handler]: spy }}>Trigger</button>
       </PopoverTrigger>,
     );
@@ -65,7 +65,7 @@ describe('PopoverTrigger', () => {
   it('should set aria-expanded on trigger element', () => {
     // Arrange
     const { getByRole } = render(
-      <PopoverTrigger>
+      <PopoverTrigger disableButtonEnhancement>
         <button>Trigger</button>
       </PopoverTrigger>,
     );
@@ -79,7 +79,7 @@ describe('PopoverTrigger', () => {
 
     // Arrange
     const { getByRole } = render(
-      <PopoverTrigger>
+      <PopoverTrigger disableButtonEnhancement>
         <button>Trigger</button>
       </PopoverTrigger>,
     );
@@ -91,7 +91,7 @@ describe('PopoverTrigger', () => {
   it('should allow user to override aria-expanded on trigger element', () => {
     // Arrange
     const { getByRole } = render(
-      <PopoverTrigger>
+      <PopoverTrigger disableButtonEnhancement>
         <button aria-expanded={undefined}>Trigger</button>
       </PopoverTrigger>,
     );
@@ -104,7 +104,7 @@ describe('PopoverTrigger', () => {
     // Arrange
     const ref = jest.fn();
     render(
-      <PopoverTrigger>
+      <PopoverTrigger disableButtonEnhancement>
         <button ref={ref}>Trigger</button>
       </PopoverTrigger>,
     );
@@ -132,7 +132,7 @@ describe('PopoverTrigger', () => {
         cb(ref.current);
       }, []);
       return (
-        <PopoverTrigger>
+        <PopoverTrigger disableButtonEnhancement>
           <button ref={ref}>Trigger</button>
         </PopoverTrigger>
       );

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.types.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.types.ts
@@ -5,7 +5,13 @@ import * as React from 'react';
 /**
  * PopoverTrigger Props
  */
-export type PopoverTriggerProps = TriggerProps<PopoverTriggerChildProps>;
+export type PopoverTriggerProps = TriggerProps<PopoverTriggerChildProps> & {
+  /**
+   * Disables internal trigger mechanism that ensures a child provided will be a compliant ARIA button.
+   * @default false
+   */
+  disableButtonEnhancement?: boolean;
+};
 
 /**
  * PopoverTrigger State

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -21,7 +21,7 @@ import { Escape } from '@fluentui/keyboard-keys';
  * @param props - props from this instance of PopoverTrigger
  */
 export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverTriggerState => {
-  const { children } = props;
+  const { children, disableButtonEnhancement = false } = props;
   const child = getTriggerChild(children);
 
   const open = usePopoverContext_unstable(context => context.open);
@@ -66,7 +66,7 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
     }
   };
 
-  const triggerProps = {
+  const contextMenuProps = {
     ...triggerAttributes,
     'aria-expanded': `${open}`,
     ...child?.props,
@@ -76,13 +76,15 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
     ref: useMergedRefs(triggerRef, child?.ref),
   } as const;
 
-  const ariaButtonTriggerProps = useARIAButtonProps(
+  const triggerChildProps = {
+    ...contextMenuProps,
+    onClick: useEventCallback(mergeCallbacks(child?.props.onClick, onClick)),
+    onKeyDown: useEventCallback(mergeCallbacks(child?.props.onKeyDown, onKeyDown)),
+  };
+
+  const ariaButtonTriggerChildProps = useARIAButtonProps(
     child?.type === 'button' || child?.type === 'a' ? child.type : 'div',
-    {
-      ...triggerProps,
-      onClick: useEventCallback(mergeCallbacks(child?.props.onClick, onClick)),
-      onKeyDown: useEventCallback(mergeCallbacks(child?.props.onKeyDown, onKeyDown)),
-    },
+    triggerChildProps,
   );
 
   return {
@@ -90,7 +92,7 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
       props.children,
       useARIAButtonProps(
         child?.type === 'button' || child?.type === 'a' ? child.type : 'div',
-        openOnContext ? triggerProps : ariaButtonTriggerProps,
+        openOnContext ? contextMenuProps : disableButtonEnhancement ? triggerChildProps : ariaButtonTriggerChildProps,
       ),
     ),
   };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Follow up on https://github.com/microsoft/fluentui/pull/24960

Implementing the `disableButtonEnhancement` property that will ensure triggers can opt out of the current behavior where child is enhanced with button-like handlers and properties
