### PR TITLE
chore: add a bundle size fixture (Button, Provider & theme)

### DIFF
--- a/change/@fluentui-react-components-63d50c18-ab92-4fa3-ad8d-694cbf0ad99f.json
+++ b/change/@fluentui-react-components-63d50c18-ab92-4fa3-ad8d-694cbf0ad99f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add a bundle size fixture (Button, Provider & theme)",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/bundle-size/ButtonProviderAndTheme.fixture.js
+++ b/packages/react-components/react-components/bundle-size/ButtonProviderAndTheme.fixture.js
@@ -1,0 +1,7 @@
+import { Button, FluentProvider, webLightTheme } from '@fluentui/react-components';
+
+console.log(Button, FluentProvider, webLightTheme);
+
+export default {
+  name: 'react-components: Button, FluentProvider & webLightTheme',
+};


### PR DESCRIPTION
## New Behavior

We use `Button`, `FluentProvider` & `webLightTheme` is a minimal set to show bundle size improvements. I had this fixture locally, but time to time there are requests for these numbers, so it's better to have it in `master`.
