### PR TITLE
chore: add toolbar radio controlled and uncontrolled stories

### DIFF
--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadio.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadio.stories.tsx
@@ -1,0 +1,8 @@
+import { ToolbarRadio } from '../../ToolbarRadio';
+
+export { Radio } from './ToolbarRadioDefault.stories';
+
+export default {
+  title: 'Components/ToolbarRadio',
+  component: ToolbarRadio,
+};

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadio.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadio.stories.tsx
@@ -1,8 +1,0 @@
-import { ToolbarRadio } from '../../ToolbarRadio';
-
-export { Radio } from './ToolbarRadioDefault.stories';
-
-export default {
-  title: 'Components/ToolbarRadio',
-  component: ToolbarRadio,
-};

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadioControlled.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadioControlled.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { ToolbarRadio } from '../../ToolbarRadio';
+import { ToolbarRadioGroup, ToolbarRadioGroupProps } from '../../ToolbarRadioGroup';
+
+export const ControlledRadio = (props: Partial<ToolbarRadioGroupProps>) => {
+  const [value, setValue] = React.useState('banana');
+
+  return (
+    <ToolbarRadioGroup value={value} onChange={(_, data) => setValue(data.value)} {...props}>
+      <ToolbarRadio value="apple" label="Apple" />
+      <ToolbarRadio value="pear" label="Pear" />
+      <ToolbarRadio value="banana" label="Banana" />
+      <ToolbarRadio value="orange" label="Orange" />
+    </ToolbarRadioGroup>
+  );
+};

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadioDefault.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarRadioDefault.stories.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { ToolbarRadio } from '../../ToolbarRadio';
+import { ToolbarRadioGroup, ToolbarRadioGroupProps } from '../../ToolbarRadioGroup';
+
+export const Radio = (props: Partial<ToolbarRadioGroupProps>) => (
+  <ToolbarRadioGroup {...props}>
+    <ToolbarRadio value="apple" label="Apple" />
+    <ToolbarRadio value="pear" label="Pear" />
+    <ToolbarRadio value="banana" label="Banana" />
+    <ToolbarRadio value="orange" label="Orange" />
+  </ToolbarRadioGroup>
+);

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/index.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/index.stories.tsx
@@ -10,6 +10,8 @@ export { WithTooltip } from './ToolbarWithTooltip.stories';
 export { WithPopover } from './ToolbarWithPopover.stories';
 export { Subtle } from './ToolbarSubtle.stories';
 export { ControlledToggleButton } from './ToolbarControlledToggleButton.stories';
+export { Radio } from './ToolbarRadioDefault.stories';
+export { ControlledRadio } from './ToolbarRadioControlled.stories';
 
 export default {
   title: 'Preview Components/Toolbar',


### PR DESCRIPTION
# Overview

Adding controlled and uncontrolled Toolbar Radio examples that complains with the `Radio` component usage. 