### PR TITLE
fix: new overflow items should only be enqueued while observing

### DIFF
--- a/change/@fluentui-priority-overflow-faf497c0-15d0-4c21-b8cf-b5d7fdeafd9f.json
+++ b/change/@fluentui-priority-overflow-faf497c0-15d0-4c21-b8cf-b5d7fdeafd9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "new overflow items should only be enqueued while observing",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-e4d1fe92-3bdb-420c-81a0-65c956db0e95.json
+++ b/change/@fluentui-react-overflow-e4d1fe92-3bdb-420c-81a0-65c956db0e95.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add browser e2e tests",
+  "packageName": "@fluentui/react-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -164,7 +164,7 @@ export function createOverflowManager(): OverflowManager {
   const observe: OverflowManager['observe'] = (observedContainer, userOptions) => {
     Object.assign(options, userOptions);
     observing = true;
-    Object.values(overflowItems).forEach(item => addItem(item));
+    Object.values(overflowItems).forEach(item => visibleItemQueue.enqueue(item.id));
 
     container = observedContainer;
     resizeObserver.observe(container);

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -8,6 +8,7 @@ import type { OverflowGroupState, OverflowItemEntry, OverflowManager, ObserveOpt
  */
 export function createOverflowManager(): OverflowManager {
   let container: HTMLElement | undefined;
+  let observing = false;
   const options: Required<ObserveOptions> = {
     padding: 10,
     overflowAxis: 'horizontal',
@@ -162,6 +163,9 @@ export function createOverflowManager(): OverflowManager {
 
   const observe: OverflowManager['observe'] = (observedContainer, userOptions) => {
     Object.assign(options, userOptions);
+    observing = true;
+    Object.values(overflowItems).forEach(item => addItem(item));
+
     container = observedContainer;
     resizeObserver.observe(container);
   };
@@ -172,7 +176,11 @@ export function createOverflowManager(): OverflowManager {
 
   const addItem: OverflowManager['addItem'] = item => {
     overflowItems[item.id] = item;
-    visibleItemQueue.enqueue(item.id);
+
+    // some options can affect priority which are only set on `observe`
+    if (observing) {
+      visibleItemQueue.enqueue(item.id);
+    }
 
     if (item.groupId) {
       if (!overflowGroups[item.groupId]) {

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -171,6 +171,7 @@ export function createOverflowManager(): OverflowManager {
   };
 
   const disconnect: OverflowManager['disconnect'] = () => {
+    observing = false;
     resizeObserver.disconnect();
   };
 

--- a/packages/react-components/react-overflow/cypress.config.ts
+++ b/packages/react-components/react-overflow/cypress.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '@fluentui/scripts/cypress/cypress.config';
+
+export default baseConfig;

--- a/packages/react-components/react-overflow/e2e/Overflow.e2e.tsx
+++ b/packages/react-components/react-overflow/e2e/Overflow.e2e.tsx
@@ -1,0 +1,417 @@
+import * as React from 'react';
+import { mount } from '@cypress/react';
+import {
+  Overflow,
+  OverflowItem,
+  OverflowItemProps,
+  OverflowProps,
+  useIsOverflowGroupVisible,
+  useOverflowMenu,
+} from '@fluentui/react-overflow';
+
+const selectors = {
+  container: 'data-test-container',
+  item: 'data-test-item',
+  divider: 'data-test-divider',
+  menu: 'data-test-menu',
+};
+
+const Container: React.FC<{ children?: React.ReactNode; width?: number } & Omit<OverflowProps, 'children'>> = ({
+  children,
+  width,
+  ...overflowProps
+}) => {
+  const selector = {
+    [selectors.container]: '',
+  };
+
+  return (
+    <Overflow padding={0} {...overflowProps}>
+      <div
+        {...selector}
+        style={{
+          width: width ?? 500,
+          border: '1px dashed red',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          resize: 'horizontal',
+        }}
+      >
+        {children}
+      </div>
+    </Overflow>
+  );
+};
+
+const setContainerSize = (size: number) => {
+  cy.get(`[${selectors.container}]`)
+    .then(container => {
+      container.css('width', `${size}px`);
+    })
+    .log(`Setting container size to ${size}px`);
+};
+
+const Item: React.FC<{ children?: React.ReactNode; width?: number } & Omit<OverflowItemProps, 'children'>> = ({
+  children,
+  width,
+  ...overflowItemProps
+}) => {
+  const selector = {
+    [selectors.item]: overflowItemProps.id,
+  };
+
+  return (
+    <OverflowItem {...overflowItemProps}>
+      <button {...selector} style={{ width: width ?? 50, height: 20 }}>
+        {children}
+      </button>
+    </OverflowItem>
+  );
+};
+
+const Menu: React.FC<{ width?: number }> = ({ width }) => {
+  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+  const selector = {
+    [selectors.menu]: '',
+  };
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  // No need to actually render a menu, we're testing state
+  return (
+    <button {...selector} ref={ref} style={{ width: width ?? 50, height: 20 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+export const Divider: React.FC<{
+  groupId: string;
+  children?: React.ReactNode;
+}> = ({ groupId, children }) => {
+  const isGroupVisible = useIsOverflowGroupVisible(groupId);
+
+  if (isGroupVisible === 'hidden') {
+    return null;
+  }
+
+  const styles = {
+    outer: {
+      display: 'inline-block',
+      paddingBottom: '0px',
+      height: '20px',
+    },
+
+    inner: {
+      width: '2px',
+      backgroundColor: 'green',
+      height: '100%',
+    },
+  };
+
+  const selector = {
+    [selectors.divider]: groupId,
+  };
+
+  return (
+    <div {...selector} style={styles.outer}>
+      <div style={styles.inner} />
+      {children}
+    </div>
+  );
+};
+
+describe('Overflow', () => {
+  before(() => {
+    cy.viewport(700, 700);
+  });
+
+  it('should not overflow when there is enough space', () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(
+      <Container>
+        {mapHelper.map(i => (
+          <Item key={i} id={i.toString()}>
+            {i}
+          </Item>
+        ))}
+        <Menu />
+      </Container>,
+    );
+
+    setContainerSize(500);
+    cy.get(`[${selectors.menu}]`).should('not.exist');
+  });
+
+  it(`should overflow items`, () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(
+      <Container>
+        {mapHelper.map(i => (
+          <Item key={i} id={i.toString()}>
+            {i}
+          </Item>
+        ))}
+        <Menu />
+      </Container>,
+    );
+    const overflowCases = [
+      { containerSize: 450, overflowCount: 2 },
+      { containerSize: 400, overflowCount: 3 },
+      { containerSize: 350, overflowCount: 4 },
+      { containerSize: 300, overflowCount: 5 },
+      { containerSize: 250, overflowCount: 6 },
+      { containerSize: 200, overflowCount: 7 },
+      { containerSize: 150, overflowCount: 8 },
+      { containerSize: 100, overflowCount: 9 },
+      { containerSize: 50, overflowCount: 10 },
+    ];
+
+    overflowCases.forEach(({ overflowCount, containerSize }) => {
+      setContainerSize(containerSize);
+      cy.get(`[${selectors.menu}]`).should('have.text', `+${overflowCount}`);
+    });
+  });
+
+  it(`should overflow items in reverse order`, () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(
+      <Container overflowDirection="start">
+        <Menu />
+        {mapHelper.map(i => (
+          <Item key={i} id={i.toString()}>
+            {i}
+          </Item>
+        ))}
+      </Container>,
+    );
+    const overflowCases = [
+      { containerSize: 450, latestOverflowed: 1 },
+      { containerSize: 400, latestOverflowed: 2 },
+      { containerSize: 350, latestOverflowed: 3 },
+      { containerSize: 300, latestOverflowed: 4 },
+      { containerSize: 250, latestOverflowed: 5 },
+      { containerSize: 200, latestOverflowed: 6 },
+      { containerSize: 150, latestOverflowed: 7 },
+      { containerSize: 100, latestOverflowed: 8 },
+      { containerSize: 50, latestOverflowed: 9 },
+    ];
+
+    overflowCases.forEach(({ containerSize, latestOverflowed }) => {
+      setContainerSize(containerSize);
+      cy.get(`[${selectors.item}=${latestOverflowed}]`).should('not.be.visible');
+    });
+  });
+
+  it('should overflow based on priority', () => {
+    const priorities = [0, 1, 4, 6, 2, 5, 3, 9, 8, 7];
+    mount(
+      <Container>
+        {priorities.map(i => (
+          <Item key={i} id={i.toString()} priority={i}>
+            {i}
+          </Item>
+        ))}
+        <Menu />
+      </Container>,
+    );
+
+    const overflowCases = [
+      { containerSize: 450, latestOverflowed: 1 },
+      { containerSize: 400, latestOverflowed: 2 },
+      { containerSize: 350, latestOverflowed: 3 },
+      { containerSize: 300, latestOverflowed: 4 },
+      { containerSize: 250, latestOverflowed: 5 },
+      { containerSize: 200, latestOverflowed: 6 },
+      { containerSize: 150, latestOverflowed: 7 },
+      { containerSize: 100, latestOverflowed: 8 },
+      { containerSize: 50, latestOverflowed: 9 },
+    ];
+
+    overflowCases.forEach(({ containerSize, latestOverflowed }) => {
+      setContainerSize(containerSize);
+      cy.get(`[${selectors.item}=${latestOverflowed}]`).should('not.be.visible');
+    });
+  });
+
+  it(`should expand items`, () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(
+      <Container>
+        {mapHelper.map(i => (
+          <Item key={i} id={i.toString()}>
+            {i}
+          </Item>
+        ))}
+        <Menu />
+      </Container>,
+    );
+    const overflowCases = [
+      { containerSize: 50, overflowCount: 10 },
+      { containerSize: 100, overflowCount: 9 },
+      { containerSize: 150, overflowCount: 8 },
+      { containerSize: 200, overflowCount: 7 },
+      { containerSize: 250, overflowCount: 6 },
+      { containerSize: 300, overflowCount: 5 },
+      { containerSize: 350, overflowCount: 4 },
+      { containerSize: 400, overflowCount: 3 },
+      { containerSize: 450, overflowCount: 2 },
+    ];
+
+    overflowCases.forEach(({ overflowCount, containerSize }) => {
+      setContainerSize(containerSize);
+      cy.get(`[${selectors.menu}]`).should('have.text', `+${overflowCount}`);
+    });
+  });
+
+  it(`should expand items in reverse order`, () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(
+      <Container overflowDirection="start">
+        <Menu />
+        {mapHelper.map(i => (
+          <Item key={i} id={i.toString()}>
+            {i}
+          </Item>
+        ))}
+      </Container>,
+    );
+    const overflowCases = [
+      { containerSize: 100, latestOverflowed: 9 },
+      { containerSize: 150, latestOverflowed: 8 },
+      { containerSize: 200, latestOverflowed: 7 },
+      { containerSize: 250, latestOverflowed: 6 },
+      { containerSize: 300, latestOverflowed: 5 },
+      { containerSize: 350, latestOverflowed: 4 },
+      { containerSize: 400, latestOverflowed: 3 },
+      { containerSize: 450, latestOverflowed: 2 },
+    ];
+
+    overflowCases.forEach(({ containerSize, latestOverflowed }) => {
+      setContainerSize(containerSize);
+      cy.get(`[${selectors.item}=${latestOverflowed}]`).should('be.visible');
+    });
+  });
+
+  it('should expand items based on priority', () => {
+    const priorities = [0, 1, 4, 6, 2, 5, 3, 9, 8, 7];
+    mount(
+      <Container>
+        {priorities.map(i => (
+          <Item key={i} id={i.toString()} priority={i}>
+            {i}
+          </Item>
+        ))}
+        <Menu />
+      </Container>,
+    );
+
+    const overflowCases = [
+      { containerSize: 100, latestOverflowed: 9 },
+      { containerSize: 150, latestOverflowed: 8 },
+      { containerSize: 200, latestOverflowed: 7 },
+      { containerSize: 250, latestOverflowed: 6 },
+      { containerSize: 300, latestOverflowed: 5 },
+      { containerSize: 350, latestOverflowed: 4 },
+      { containerSize: 400, latestOverflowed: 3 },
+      { containerSize: 450, latestOverflowed: 2 },
+    ];
+
+    overflowCases.forEach(({ containerSize, latestOverflowed }) => {
+      setContainerSize(containerSize);
+      cy.get(`[${selectors.item}=${latestOverflowed}]`).should('be.visible');
+    });
+  });
+
+  it('should react to priority changes within the container', () => {
+    const Example = () => {
+      const [selected, setSelelected] = React.useState(0);
+      return (
+        <>
+          <Container>
+            {mapHelper.map(i => (
+              <Item key={i} id={i.toString()} priority={selected === i ? 1000 : 0}>
+                <span onClick={() => setSelelected(i)} style={{ color: selected === i ? 'red' : 'black' }}>
+                  {i}
+                </span>
+              </Item>
+            ))}
+            <Menu />
+          </Container>
+          <div>
+            <button id="select-9" onClick={() => setSelelected(9)}>
+              Select 9
+            </button>
+          </div>
+        </>
+      );
+    };
+
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(<Example />);
+
+    cy.get(`[${selectors.item}="3"]`).click();
+    setContainerSize(150);
+    cy.get(`[${selectors.item}="3"]`).should('be.visible');
+    cy.get('#select-9').click();
+    cy.get(`[${selectors.item}="9"]`).should('be.visible');
+    cy.get(`[${selectors.item}="2"]`).should('not.be.visible');
+  });
+
+  it('should notify group visibility changes correctly', () => {
+    mount(
+      <Container padding={8}>
+        <Item id={'6'} priority={6} groupId={'1'}>
+          6-1
+        </Item>
+        <Divider groupId={'1'}>
+          <span data-divider="1" />
+        </Divider>
+        <Item id={'7'} priority={7} groupId={'2'}>
+          7-2
+        </Item>
+        <Divider groupId={'2'} data-divider="2">
+          <span data-divider="2" />
+        </Divider>
+        <Item id={'4'} priority={4} groupId={'3'}>
+          4-3
+        </Item>
+        <Item id={'5'} priority={5} groupId={'3'}>
+          5-3
+        </Item>
+        <Divider groupId={'3'} data-divider="3">
+          <span data-divider="3" />
+        </Divider>
+        <Item id={'1'} priority={1} groupId={'4'}>
+          1-4
+        </Item>
+        <Item id={'2'} priority={2} groupId={'4'}>
+          2-4
+        </Item>
+        <Item id={'3'} priority={3} groupId={'4'}>
+          3-4
+        </Item>
+        <Divider groupId={'4'} data-divider="4">
+          <span data-divider="4" />
+        </Divider>
+        <Item id={'8'} priority={8} groupId={'5'}>
+          8-5
+        </Item>
+        <Menu />
+      </Container>,
+    );
+
+    setContainerSize(350);
+    cy.get(`[${selectors.divider}="4"]`);
+    cy.get(`[${selectors.divider}="4"]`).should('not.exist');
+    cy.get(`[${selectors.divider}]`).should('have.length', 3);
+    setContainerSize(250);
+    cy.get(`[${selectors.divider}="3"]`).should('not.exist');
+    cy.get(`[${selectors.divider}]`).should('have.length', 2);
+    setContainerSize(200);
+    cy.get(`[${selectors.divider}="1"]`).should('not.exist');
+    cy.get(`[${selectors.divider}]`).should('have.length', 1);
+  });
+});

--- a/packages/react-components/react-overflow/e2e/tsconfig.json
+++ b/packages/react-components/react-overflow/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
+    "lib": ["ES2019", "dom"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/packages/react-components/react-overflow/package.json
+++ b/packages/react-components/react-overflow/package.json
@@ -16,6 +16,8 @@
     "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "yarn storybook",

--- a/packages/react-components/react-overflow/src/useOverflowContainer.test.ts
+++ b/packages/react-components/react-overflow/src/useOverflowContainer.test.ts
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { createOverflowManager, OverflowManager } from '@fluentui/priority-overflow';
 import { useOverflowContainer } from './useOverflowContainer';
 import { renderHook } from '@testing-library/react-hooks';
-import React = require('react');
 
 jest.mock('@fluentui/priority-overflow');
 

--- a/packages/react-components/react-overflow/src/useOverflowContainer.test.ts
+++ b/packages/react-components/react-overflow/src/useOverflowContainer.test.ts
@@ -1,0 +1,94 @@
+import { createOverflowManager, OverflowManager } from '@fluentui/priority-overflow';
+import { useOverflowContainer } from './useOverflowContainer';
+import { renderHook } from '@testing-library/react-hooks';
+import React = require('react');
+
+jest.mock('@fluentui/priority-overflow');
+
+const mockOverflowManager = (options: Partial<OverflowManager> = {}) => {
+  const defaultMock: OverflowManager = {
+    addItem: jest.fn(),
+    disconnect: jest.fn(),
+    forceUpdate: jest.fn(),
+    observe: jest.fn(),
+    removeItem: jest.fn(),
+    update: jest.fn(),
+  };
+  (createOverflowManager as jest.Mock).mockReturnValue({
+    ...defaultMock,
+    ...options,
+  } as OverflowManager);
+};
+
+describe('useOverflowContainer', () => {
+  it('should create overflow manager', () => {
+    renderHook(() => useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined }));
+
+    expect(createOverflowManager).toHaveBeenCalledTimes(1);
+  });
+
+  it('should add to overflow manager when registering item', () => {
+    const addItemMock = jest.fn();
+    mockOverflowManager({ addItem: addItemMock });
+    const { result } = renderHook(() =>
+      useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined }),
+    );
+
+    const overflowItem = { element: document.createElement('div'), id: 'test', priority: 0, groupId: '0' };
+    result.current.registerItem(overflowItem);
+
+    expect(addItemMock).toHaveBeenCalledTimes(1);
+    expect(addItemMock).toHaveBeenCalledWith(overflowItem);
+  });
+
+  it('should return cleanup when registering item', () => {
+    const removeItemMock = jest.fn();
+    mockOverflowManager({ removeItem: removeItemMock });
+    const { result } = renderHook(() =>
+      useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined }),
+    );
+
+    const overflowItem = { element: document.createElement('div'), id: 'test', priority: 0, groupId: '0' };
+    const deregister = result.current.registerItem(overflowItem);
+
+    deregister();
+    expect(removeItemMock).toHaveBeenCalledTimes(1);
+    expect(removeItemMock).toHaveBeenCalledWith(overflowItem.id);
+  });
+
+  it('should call observe with default options', () => {
+    const observeMock = jest.fn();
+    mockOverflowManager({ observe: observeMock });
+    const { result, rerender } = renderHook(() => {
+      return useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined });
+    });
+    (result.current.containerRef as React.MutableRefObject<HTMLDivElement>).current = document.createElement('div');
+    rerender();
+    expect(observeMock).toHaveBeenCalledTimes(1);
+    expect(observeMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        <div />,
+        Object {
+          "minimumVisible": 0,
+          "onUpdateItemVisibility": [Function],
+          "onUpdateOverflow": [Function],
+          "overflowAxis": "horizontal",
+          "overflowDirection": "end",
+          "padding": 10,
+        },
+      ]
+    `);
+  });
+
+  it('should invoke updateOverflow on overflow manager', () => {
+    const updateMock = jest.fn();
+    mockOverflowManager({ update: updateMock });
+    const { result } = renderHook(() =>
+      useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined }),
+    );
+
+    result.current.updateOverflow();
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/react-overflow/src/useOverflowItem.test.tsx
+++ b/packages/react-components/react-overflow/src/useOverflowItem.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useOverflowItem } from './useOverflowItem';
+import { OverflowContext, OverflowContextValue } from './overflowContext';
+import { renderHook } from '@testing-library/react-hooks';
+
+const mockContextValue = (options: Partial<OverflowContextValue> = {}) =>
+  ({
+    groupVisibility: {},
+    hasOverflow: false,
+    itemVisibility: {},
+    registerItem: jest.fn(),
+    updateOverflow: jest.fn(),
+    ...options,
+  } as OverflowContextValue);
+
+describe('useOverflowItem', () => {
+  it('should register item', () => {
+    const registerItemMock = jest.fn();
+    const value = mockContextValue({ registerItem: registerItemMock });
+    renderHook(
+      () => {
+        const ref = useOverflowItem('test', 0, '0');
+        (ref as React.MutableRefObject<HTMLDivElement>).current = document.createElement('div');
+      },
+      {
+        wrapper: ({ children }) => <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>,
+      },
+    );
+
+    expect(registerItemMock).toHaveBeenCalledTimes(1);
+    expect(registerItemMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "element": <div />,
+          "groupId": "0",
+          "id": "test",
+          "priority": 0,
+        },
+      ]
+    `);
+  });
+
+  it('should cleanup item on unmount', () => {
+    const cleanupMock = jest.fn();
+    const registerItemMock = jest.fn().mockReturnValue(cleanupMock);
+    const value = mockContextValue({ registerItem: registerItemMock });
+    const { unmount } = renderHook(
+      () => {
+        const ref = useOverflowItem('test', 0, '0');
+        (ref as React.MutableRefObject<HTMLDivElement>).current = document.createElement('div');
+      },
+      {
+        wrapper: ({ children }) => <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>,
+      },
+    );
+
+    unmount();
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -16,13 +16,6 @@ export const createCustomFocusIndicatorStyle = (
   style: GriffelStyle,
   { selector = defaultOptions.selector }: CreateCustomFocusIndicatorStyleOptions = defaultOptions,
 ): GriffelStyle => ({
-  ':focus': {
-    outlineStyle: 'none',
-  },
-  ':focus-visible': {
-    outlineStyle: 'none',
-  },
-
   ...(selector === 'focus' && {
     [`&[${FOCUS_VISIBLE_ATTR}]`]: style,
   }),

--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -16,6 +16,13 @@ export const createCustomFocusIndicatorStyle = (
   style: GriffelStyle,
   { selector = defaultOptions.selector }: CreateCustomFocusIndicatorStyleOptions = defaultOptions,
 ): GriffelStyle => ({
+  ':focus': {
+    outlineStyle: 'none',
+  },
+  ':focus-visible': {
+    outlineStyle: 'none',
+  },
+
   ...(selector === 'focus' && {
     [`&[${FOCUS_VISIBLE_ATTR}]`]: style,
   }),


### PR DESCRIPTION
## Current Behavior

Currently overflow items are enqueued immediately when added to the manager. This can create subtle bugs because all options are set during `.observe()`. Some of those options can alter the priority of the items in the queue.

## New Behavior

Adds a new `observing` flag to the overflow manager and enqueues all overflow items during `observe()` any new items added while `observing` is true will be enqueued directly.

Also adds tests

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
