### PR TITLE
fix: version-bump generator removes beachball disallowedChangeType config for nightly releases

### DIFF
--- a/tools/generators/version-bump/index.ts
+++ b/tools/generators/version-bump/index.ts
@@ -33,6 +33,11 @@ function runMigrationOnProject(host: Tree, schema: ValidatedSchema, userLog: Use
 
   updateJson(host, packageJsonPath, (packageJson: PackageJson) => {
     nextVersion = bumpVersion(packageJson, schema.bumpType, schema.prereleaseTag);
+
+    // nightly releases should bypass beachball disallowed changetypes
+    if (schema.bumpType === 'nightly' && packageJson.beachball?.disallowedChangeTypes) {
+      packageJson.beachball.disallowedChangeTypes = undefined;
+    }
     packageJson.version = nextVersion;
 
     return packageJson;

--- a/tools/types.ts
+++ b/tools/types.ts
@@ -31,6 +31,9 @@ export interface PackageJson {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   exports?: Record<string, string | Partial<{ types: string; import: string; require: string }>>;
+  beachball?: {
+    disallowedChangeTypes?: string[];
+  };
 }
 
 // ===============


### PR DESCRIPTION
Fixes #25116

