### PR TITLE
fix: The Tooltip should not hide if it gets keyboard focus

### DIFF
--- a/change/@fluentui-react-tooltip-1a523606-fad3-4e83-bd04-c3e3645d474a.json
+++ b/change/@fluentui-react-tooltip-1a523606-fad3-4e83-bd04-c3e3645d474a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: The Tooltip should not hide if it gets keyboard focus",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -195,8 +195,8 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     [setDelayTimeout, setVisible, state.hideDelay, targetDocument],
   );
 
-  // Cancel the hide timer when the pointer enters the tooltip, and restart it when the mouse leaves.
-  // This keeps the tooltip visible when the pointer is moved over it.
+  // Cancel the hide timer when the mouse or focus enters the tooltip, and restart it when the mouse or focus leaves.
+  // This keeps the tooltip visible when the mouse is moved over it, or it has focus within.
   state.content.onPointerEnter = mergeCallbacks(state.content.onPointerEnter, clearDelayTimeout);
   state.content.onPointerLeave = mergeCallbacks(state.content.onPointerLeave, onLeaveTrigger);
   state.content.onFocus = mergeCallbacks(state.content.onFocus, clearDelayTimeout);

--- a/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -199,6 +199,8 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   // This keeps the tooltip visible when the pointer is moved over it.
   state.content.onPointerEnter = mergeCallbacks(state.content.onPointerEnter, clearDelayTimeout);
   state.content.onPointerLeave = mergeCallbacks(state.content.onPointerLeave, onLeaveTrigger);
+  state.content.onFocus = mergeCallbacks(state.content.onFocus, clearDelayTimeout);
+  state.content.onBlur = mergeCallbacks(state.content.onBlur, onLeaveTrigger);
 
   const child = getTriggerChild(children);
 


### PR DESCRIPTION
## Current Behavior

If a tooltip contains a focusable item, it will hide when the user tries to interact with the focusable item (including clicking or tabbing to it).

## New Behavior

Have the tooltip track if focus is inside, and don't hide if so.

## Related Issue(s)

* Fixes #24054
