### PR TITLE
fix: Tooltip should not hide if an element inside it gets focused

### DIFF
--- a/change/@fluentui-react-2752e34e-9f61-47b8-965c-16b9ab348583.json
+++ b/change/@fluentui-react-2752e34e-9f61-47b8-965c-16b9ab348583.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Tooltip should not hide if an element inside it gets focused.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Tooltip/Tooltip.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Tooltip/Tooltip.Basic.Example.tsx
@@ -8,12 +8,6 @@ const calloutProps = { gapSpace: 0 };
 // If that's causing sizing issues or tooltip positioning issues, try overriding to inline-block.
 const hostStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
 
-const info: JSX.Element[] = [
-  <a href={'https://www.microsoft.com'} target={'_blank'}>
-    {'Help Link'}
-  </a>,
-];
-
 export const TooltipBasicExample: React.FunctionComponent = () => {
   // Use useId() to ensure that the ID is unique on the page.
   // (It's also okay to use a plain string and manually ensure uniqueness.)
@@ -22,7 +16,7 @@ export const TooltipBasicExample: React.FunctionComponent = () => {
   return (
     <div>
       <TooltipHost
-        content={info}
+        content="This is the tooltip content"
         // This id is used on the tooltip itself, not the host
         // (so an element with this id only exists when the tooltip is shown)
         id={tooltipId}

--- a/packages/react-examples/src/react/Tooltip/Tooltip.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Tooltip/Tooltip.Basic.Example.tsx
@@ -8,6 +8,12 @@ const calloutProps = { gapSpace: 0 };
 // If that's causing sizing issues or tooltip positioning issues, try overriding to inline-block.
 const hostStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
 
+const info: JSX.Element[] = [
+  <a href={'https://www.microsoft.com'} target={'_blank'}>
+    {'Help Link'}
+  </a>,
+];
+
 export const TooltipBasicExample: React.FunctionComponent = () => {
   // Use useId() to ensure that the ID is unique on the page.
   // (It's also okay to use a plain string and manually ensure uniqueness.)
@@ -16,7 +22,7 @@ export const TooltipBasicExample: React.FunctionComponent = () => {
   return (
     <div>
       <TooltipHost
-        content="This is the tooltip content"
+        content={info}
         // This id is used on the tooltip itself, not the host
         // (so an element with this id only exists when the tooltip is shown)
         id={tooltipId}

--- a/packages/react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.base.tsx
@@ -57,6 +57,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
         <div
           className={this._classNames.content}
           id={id}
+          onFocus={this.props.onFocus}
           onMouseEnter={this.props.onMouseEnter}
           onMouseLeave={this.props.onMouseLeave}
         >

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -192,7 +192,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
 
     this._dismissTimerId = this._async.setTimeout(() => {
       this._hideTooltip();
-    }, 1);
+    }, 0);
   };
 
   // Show Tooltip

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -49,7 +49,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
     initializeComponentRef(this);
 
     this.state = {
-      isAriaPlaceholderRendered: false, // eslint-disable-line react/no-unused-state
+      isAriaPlaceholderRendered: false,
       isTooltipVisible: false,
     };
 
@@ -107,6 +107,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
             directionalHintForRTL={directionalHintForRTL}
             calloutProps={assign({}, calloutProps, {
               onDismiss: this._hideTooltip,
+              onFocus: this._onTooltipContentFocus,
               onMouseEnter: this._onTooltipMouseEnter,
               onMouseLeave: this._onTooltipMouseLeave,
             })}
@@ -170,6 +171,16 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
     this._onTooltipMouseEnter(ev);
   };
 
+  private _onTooltipContentFocus = (ev: React.FocusEvent<HTMLElement>) => {
+    if (TooltipHostBase._currentVisibleTooltip && TooltipHostBase._currentVisibleTooltip !== this) {
+      TooltipHostBase._currentVisibleTooltip.dismiss();
+    }
+    TooltipHostBase._currentVisibleTooltip = this;
+
+    this._clearDismissTimer();
+    this._clearOpenTimer();
+  };
+
   private _onTooltipBlur = (ev: React.FocusEvent<HTMLElement>) => {
     // The focused element gets a blur event when the document loses focus
     // (e.g. switching tabs in the browser), but we don't want to show the
@@ -179,7 +190,9 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
     // See https://github.com/microsoft/fluentui/issues/13541
     this._ignoreNextFocusEvent = document?.activeElement === ev.target;
 
-    this._hideTooltip();
+    this._dismissTimerId = this._async.setTimeout(() => {
+      this._hideTooltip();
+    }, 1);
   };
 
   // Show Tooltip


### PR DESCRIPTION
## Previous Behavior

If a `Tooltip` is triggered by focusing on the element within `TooltipHost`, and the `Tooltip` contains any interactable items, then trying to interact with these items within the `Tooltip` (for example, clicking on a link within it) will cause the `Tooltip` to close. This occurs because the `Tooltip` closes immediately on `blur`, which precedes other interactions like `focus` or `click`.

## New Behavior

A 1ms timeout has been added before the `Tooltip` closes on blur, and a check has been added so that if anything within the `Tooltip` gets focus then the timeout is cleared. Because of the way that events queue on the browser, this ensures that we can always interact with content within the `Tooltip` before it closes on `blur`.

## Related Issue(s)

Fixes #24054
Fixes #25001 

PR #25138 fixes the same issue in v9+
