### PR TITLE
7.0 - Add Signal.scss to react-experiments pre-copy

### DIFF
--- a/change/@fluentui-react-experiments-ddb5ba78-3b3b-4ba6-b97a-30dd9413b998.json
+++ b/change/@fluentui-react-experiments-ddb5ba78-3b3b-4ba6-b97a-30dd9413b998.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add signal styles to pre-copy.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/stub-packages/react-experiments/config/pre-copy.json
+++ b/stub-packages/react-experiments/config/pre-copy.json
@@ -1,5 +1,9 @@
 {
   "copyTo": {
+    "lib/components/signals/a": [
+      "@uifabric/experiments/lib/components/signals/Signal.scss.*",
+      "@uifabric/experiments/lib/components/signals/Signals.scss.*"
+    ],
     "dist": [
       "@uifabric/example-app-base/index.html",
       "react/umd/react.development.js",

--- a/stub-packages/react-experiments/config/pre-copy.json
+++ b/stub-packages/react-experiments/config/pre-copy.json
@@ -1,8 +1,8 @@
 {
   "copyTo": {
-    "lib/components/signals/a": [
-      "@uifabric/experiments/lib/components/signals/Signal.scss.*",
-      "@uifabric/experiments/lib/components/signals/Signals.scss.*"
+    "lib/components/signals": [
+      "@uifabric/experiments/lib/components/signals/**/Signal.scss.*",
+      "@uifabric/experiments/lib/components/signals/**/Signals.scss.*"
     ],
     "dist": [
       "@uifabric/example-app-base/index.html",


### PR DESCRIPTION
The experiments stub package was not aliasing the Signals styles that are expose in 8.0 exports. Since the stub package only has JS exports, the compiled SCSS files needed to be copied over to access them properly. 

