### PR TITLE
fix(codemods): Do not fail on empty configMod config

### DIFF
--- a/change/@fluentui-codemods-c926b650-7f6d-4fbe-b266-eb574a08c173.json
+++ b/change/@fluentui-codemods-c926b650-7f6d-4fbe-b266-eb574a08c173.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Do not fail on empty configMod config",
+  "packageName": "@fluentui/codemods",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.mod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.mod.ts
@@ -131,9 +131,9 @@ const configMod: CodeMod = {
   run: (file: SourceFile) => {
     if (!__configs) {
       __configs = getCodeModsFromJson();
-      if (__configs === undefined || __configs.length === 0) {
+      if (__configs === undefined) {
         return Err<ModResult, ModError>({
-          error: 'failed to get any mods from json. Perhaps the file is missing or malformed?',
+          error: 'Failed to get any mods from json. Perhaps the file is missing or malformed?',
         });
       }
     }
@@ -144,7 +144,7 @@ const configMod: CodeMod = {
       results.push(mod.run(file));
     }
     if (results.length === 0) {
-      return Err<ModResult, NoOp>({ logs: ['No runabble mods were found in the config'] });
+      return Ok({ logs: ['No runnable mods were found in the config'] });
     }
 
     return results.reduce(combineResults);


### PR DESCRIPTION
## Current Behavior

When `@fluentui/codemods` is run, `configMod` fails because of its config is empty. **Changes from other executed codemods are not saved.**

```
npx @fluentui/codemods
...
File index.ts has had the following mods error:
name:  configMod errorData:  {
  modName: 'configMod',
  error: 'failed to get any mods from json. Perhaps the file is missing or malformed?'
}
```

## New Behavior

Empty `configMod` config is considered valid, the mod is skipped.

```
npx @fluentui/codemods
...
File index.ts has had the following mods run: 
name:  configMod logdata:  [ 'No runnable mods were found in the config' ]
...
```

## Related Issue(s)

Fixes #19847
