### PR TITLE
fix: Toolbar context usage

### DIFF
--- a/change/@fluentui-react-toolbar-8d721bbd-1df9-4f48-a11d-397f5e5f1f7c.json
+++ b/change/@fluentui-react-toolbar-8d721bbd-1df9-4f48-a11d-397f5e5f1f7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Toolbar selection should work",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/etc/react-toolbar.api.md
@@ -53,7 +53,7 @@ export type ToolbarButtonState = ComponentState<Partial<ButtonSlots>> & ButtonSt
 export const toolbarClassNames: SlotClassNames<ToolbarSlots>;
 
 // @public (undocumented)
-export type ToolbarContextValue = Pick<ToolbarState, 'size' | 'vertical'> & {
+export type ToolbarContextValue = Pick<ToolbarState, 'size' | 'vertical' | 'checkedValues'> & {
     handleToggleButton?: ToggableHandler;
 };
 
@@ -120,13 +120,12 @@ export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps>;
 // @public
 export type ToolbarToggleButtonProps = ComponentProps<ButtonSlots> & Partial<Pick<ToggleButtonProps, 'disabled' | 'disabledFocusable' | 'size'>> & {
     appearance?: 'primary' | 'subtle';
+    name: string;
+    value: string;
 };
 
 // @public
-export type ToolbarToggleButtonState = ComponentState<Partial<ButtonSlots>> & ToggleButtonState & Required<Pick<ToggleButtonProps, 'checked'>> & {
-    name?: string;
-    value?: string;
-};
+export type ToolbarToggleButtonState = ComponentState<Partial<ButtonSlots>> & ToggleButtonState & Required<Pick<ToggleButtonProps, 'checked'>> & Pick<ToolbarToggleButtonProps, 'name' | 'value'>;
 
 // @public
 export const useToolbar_unstable: (props: ToolbarProps, ref: React_2.Ref<HTMLElement>) => ToolbarState;

--- a/packages/react-components/react-toolbar/src/components/Toolbar/Toolbar.types.ts
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/Toolbar.types.ts
@@ -62,7 +62,7 @@ export type ToolbarState = ComponentState<ToolbarSlots> &
     handleToggleButton: ToggableHandler;
   };
 
-export type ToolbarContextValue = Pick<ToolbarState, 'size' | 'vertical'> & {
+export type ToolbarContextValue = Pick<ToolbarState, 'size' | 'vertical' | 'checkedValues'> & {
   handleToggleButton?: ToggableHandler;
 };
 

--- a/packages/react-components/react-toolbar/src/components/Toolbar/ToolbarContext.ts
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/ToolbarContext.ts
@@ -1,17 +1,15 @@
-import * as React from 'react';
 import { ContextSelector, createContext, useContextSelector } from '@fluentui/react-context-selector';
 import type { Context } from '@fluentui/react-context-selector';
 import type { ToolbarContextValue } from './Toolbar.types';
 
 export const ToolbarContext = createContext<ToolbarContextValue | undefined>(undefined) as Context<ToolbarContextValue>;
 
-const toolbarContextDefaultValue = {
+const toolbarContextDefaultValue: ToolbarContextValue = {
   size: 'medium' as 'medium',
   handleToggleButton: () => null,
   vertical: false,
+  checkedValues: {},
 };
-
-export const useToolbarContext = () => React.useContext(ToolbarContext) ?? toolbarContextDefaultValue;
 
 export const useToolbarContext_unstable = <T>(selector: ContextSelector<ToolbarContextValue, T>): T =>
   useContextSelector(ToolbarContext, (ctx = toolbarContextDefaultValue) => selector(ctx));

--- a/packages/react-components/react-toolbar/src/components/Toolbar/useToolbarContextValues.tsx
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/useToolbarContextValues.tsx
@@ -1,12 +1,13 @@
 import type { ToolbarContextValue, ToolbarContextValues, ToolbarState } from './Toolbar.types';
 
 export function useToolbarContextValues_unstable(state: ToolbarState): ToolbarContextValues {
-  const { size, handleToggleButton, vertical } = state;
+  const { size, handleToggleButton, vertical, checkedValues } = state;
   // This context is created with "@fluentui/react-context-selector", these is no sense to memoize it
   const toolbar: ToolbarContextValue = {
     size,
     vertical,
     handleToggleButton,
+    checkedValues,
   };
 
   return { toolbar };

--- a/packages/react-components/react-toolbar/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/react-components/react-toolbar/src/components/ToolbarButton/ToolbarButton.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import type { ToolbarButtonProps } from './ToolbarButton.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { renderButton_unstable, useButtonStyles_unstable, useButton_unstable } from '@fluentui/react-button';
-import { useToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 
 /**
  * ToolbarButton component is a Button to be used inside Toolbar
  * which will respect toolbar props such as `size`
  */
 export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps> = React.forwardRef((props, ref) => {
-  const { size } = useToolbarContext();
+  const size = useToolbarContext_unstable(ctx => ctx.size);
   const state = useButton_unstable({ size, appearance: 'transparent', ...props }, ref);
   useButtonStyles_unstable(state);
   return renderButton_unstable(state);

--- a/packages/react-components/react-toolbar/src/components/ToolbarDivider/useToolbarDivider.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarDivider/useToolbarDivider.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider.types';
 import { useDivider_unstable } from '@fluentui/react-divider';
-import { useToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 
 /**
  * Create the state required to render ToolbarDivider.
@@ -16,6 +16,6 @@ export const useToolbarDivider_unstable = (
   props: ToolbarDividerProps,
   ref: React.Ref<HTMLElement>,
 ): ToolbarDividerState => {
-  const { vertical } = useToolbarContext();
+  const vertical = useToolbarContext_unstable(ctx => ctx.vertical);
   return useDivider_unstable({ vertical: !vertical, ...props }, ref);
 };

--- a/packages/react-components/react-toolbar/src/components/ToolbarRadio/ToolbarRadio.tsx
+++ b/packages/react-components/react-toolbar/src/components/ToolbarRadio/ToolbarRadio.tsx
@@ -3,13 +3,13 @@ import type { ToolbarRadioProps } from './ToolbarRadio.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useRadio_unstable, renderRadio_unstable } from '@fluentui/react-radio';
 import { useToolbarRadioStyles_unstable } from './useToolbarRadioStyles';
-import { useToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 
 /**
  * ToolbarRadio component is a Radio to be used inside Toolbar
  */
 export const ToolbarRadio: ForwardRefComponent<ToolbarRadioProps> = React.forwardRef((props, ref) => {
-  const { size } = useToolbarContext();
+  const size = useToolbarContext_unstable(ctx => ctx.size);
   const state = useRadio_unstable(props, ref);
   useToolbarRadioStyles_unstable({ size, ...state });
   return renderRadio_unstable(state);

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/ToolbarToggleButton.test.tsx
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/ToolbarToggleButton.test.tsx
@@ -14,7 +14,11 @@ describe('ToolbarToggleButton', () => {
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests
 
   it('renders a default state', () => {
-    const result = render(<ToolbarToggleButton>Default ToolbarToggleButton</ToolbarToggleButton>);
+    const result = render(
+      <ToolbarToggleButton name="name" value="value">
+        Default ToolbarToggleButton
+      </ToolbarToggleButton>,
+    );
     expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/ToolbarToggleButton.types.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/ToolbarToggleButton.types.ts
@@ -7,6 +7,8 @@ import { ToggleButtonProps, ButtonSlots, ToggleButtonState } from '@fluentui/rea
 export type ToolbarToggleButtonProps = ComponentProps<ButtonSlots> &
   Partial<Pick<ToggleButtonProps, 'disabled' | 'disabledFocusable' | 'size'>> & {
     appearance?: 'primary' | 'subtle';
+    name: string;
+    value: string;
   };
 
 /**
@@ -14,7 +16,5 @@ export type ToolbarToggleButtonProps = ComponentProps<ButtonSlots> &
  */
 export type ToolbarToggleButtonState = ComponentState<Partial<ButtonSlots>> &
   ToggleButtonState &
-  Required<Pick<ToggleButtonProps, 'checked'>> & {
-    name?: string;
-    value?: string;
-  };
+  Required<Pick<ToggleButtonProps, 'checked'>> &
+  Pick<ToolbarToggleButtonProps, 'name' | 'value'>;

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/__snapshots__/ToolbarToggleButton.test.tsx.snap
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/__snapshots__/ToolbarToggleButton.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`ToolbarToggleButton renders a default state 1`] = `
   <button
     aria-pressed="false"
     class="fui-Button fui-ToggleButton"
+    name="name"
     type="button"
+    value="value"
   >
     Default ToolbarToggleButton
   </button>

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/useToolbarToggleButton.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/useToolbarToggleButton.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useToggleButton_unstable } from '@fluentui/react-button';
-import { useToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 import { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton.types';
 
 /**
@@ -13,9 +13,17 @@ export const useToolbarToggleButton_unstable = (
   props: ToolbarToggleButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarToggleButtonState => {
-  const { handleToggleButton, size } = useToolbarContext();
+  const handleToggleButton = useToolbarContext_unstable(ctx => ctx.handleToggleButton);
+  const checked = useToolbarContext_unstable(ctx => !!ctx.checkedValues[props.name]?.includes(props.value));
+  const size = useToolbarContext_unstable(ctx => ctx.size);
+
   const { onClick: onClickOriginal } = props;
-  const state = useToggleButton_unstable({ size, ...props }, ref) as ToolbarToggleButtonState;
+  const toggleButtonState = useToggleButton_unstable({ size, checked, ...props }, ref);
+  const state: ToolbarToggleButtonState = {
+    ...toggleButtonState,
+    name: props.name,
+    value: props.value,
+  };
 
   const handleOnClick = (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent> & React.MouseEvent<HTMLAnchorElement, MouseEvent>,

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarControlledToggleButton.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarControlledToggleButton.stories.tsx
@@ -11,8 +11,12 @@ export const ControlledToggleButton = () => {
 
   return (
     <Toolbar checkedValues={checkedValues} onCheckedValueChange={onChange}>
-      <ToolbarToggleButton name="group">Enable Group</ToolbarToggleButton>
-      <ToolbarToggleButton name="group">Enable Group</ToolbarToggleButton>
+      <ToolbarToggleButton name="edit" value="cut">
+        Enable Group
+      </ToolbarToggleButton>
+      <ToolbarToggleButton name="edit" value="paste">
+        Enable Group
+      </ToolbarToggleButton>
     </Toolbar>
   );
 };

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarDefault.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarDefault.stories.tsx
@@ -8,7 +8,9 @@ export const Default = (props: Partial<ToolbarProps>) => (
     <ToolbarButton>Click me</ToolbarButton>
     <ToolbarDivider />
     <ToolbarButton>Click me</ToolbarButton>
-    <ToolbarToggleButton>Click me to Toggle</ToolbarToggleButton>
+    <ToolbarToggleButton name="toggle" value="toggle">
+      Click me to Toggle
+    </ToolbarToggleButton>
     <ToolbarDivider />
   </Toolbar>
 );

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarSmall.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarSmall.stories.tsx
@@ -8,7 +8,9 @@ export const Small = (props: Partial<ToolbarProps>) => (
     <ToolbarButton>Click me</ToolbarButton>
     <ToolbarDivider />
     <ToolbarButton>Click me</ToolbarButton>
-    <ToolbarToggleButton>Click me to Toggle</ToolbarToggleButton>
+    <ToolbarToggleButton name="toggle" value="toggle">
+      Click me to Toggle
+    </ToolbarToggleButton>
     <ToolbarDivider />
   </Toolbar>
 );

--- a/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarSubtle.stories.tsx
+++ b/packages/react-components/react-toolbar/src/stories/Toolbar/ToolbarSubtle.stories.tsx
@@ -8,6 +8,8 @@ export const Subtle = (props: Partial<ToolbarProps>) => (
     <ToolbarButton appearance="subtle">Click me</ToolbarButton>
     <ToolbarButton appearance="subtle">Click me</ToolbarButton>
     <ToolbarDivider />
-    <ToolbarToggleButton appearance="subtle">Click me to Toggle</ToolbarToggleButton>
+    <ToolbarToggleButton name="toggle" value="toggle" appearance="subtle">
+      Click me to Toggle
+    </ToolbarToggleButton>
   </Toolbar>
 );


### PR DESCRIPTION
There are currently two different toolbar context hooks:

- `useToolbarContext` - cruft hook that still exists and is being used
- `useToolbarContext_unstable` - This is the correct hook to use

This caused the toolbar selection scenarios to break because the wrong context hook was always being used.

This PR fixes the usage of context hooks and assorted typings for `ToolbarToggleButton` which were also incorrect

