### PR TITLE
fix: Menu trigger should be focused when menu is closed with keyboard

### DIFF
--- a/change/@fluentui-react-menu-5b06dfa2-a4e0-4c1c-8a7b-0784fe888b03.json
+++ b/change/@fluentui-react-menu-5b06dfa2-a4e0-4c1c-8a7b-0784fe888b03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Menu trigger should be focused when menu is closed with keyboard",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/e2e/Menu.e2e.tsx
+++ b/packages/react-components/react-menu/e2e/Menu.e2e.tsx
@@ -403,7 +403,14 @@ describe('Menu', () => {
         </MenuPopover>
       </Menu>,
     );
-    cy.get(menuTriggerSelector).click().focused().type('{esc}').get(menuSelector).should('not.exist');
+    cy.get(menuTriggerSelector)
+      .click()
+      .focused()
+      .type('{esc}')
+      .get(menuSelector)
+      .should('not.exist')
+      .get(menuTriggerSelector)
+      .should('be.focused');
   });
 
   it('should be dismissed on outside click', () => {

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -185,10 +185,12 @@ const useMenuOpenState = (
       state.setContextTarget(undefined);
     }
 
-    if (e.type === 'keydown' && (e as React.KeyboardEvent<HTMLElement>).key === Tab) {
+    if (e.type === 'keydown') {
       shouldHandleKeyboardRef.current = true;
-      shouldHandleTabRef.current = true;
-      pressedShiftRef.current = (e as React.KeyboardEvent<HTMLElement>).shiftKey;
+      if ((e as React.KeyboardEvent<HTMLElement>).key === Tab) {
+        shouldHandleTabRef.current = true;
+        pressedShiftRef.current = (e as React.KeyboardEvent<HTMLElement>).shiftKey;
+      }
     }
 
     if (data.bubble) {


### PR DESCRIPTION
#25016 missed out on a crucial condition.

keyboard handling flag was only set when the key was `Tab` this is incorrect and the keyboard handling flag should be set every time the event is a keyboard event

