### PR TITLE
improve windows support in execSync and exec scripts

### DIFF
--- a/scripts/exec-sync.js
+++ b/scripts/exec-sync.js
@@ -4,8 +4,6 @@ const child_process = require('child_process');
 const chalk = require('chalk');
 const { logStatus } = require('./logging');
 
-const SEPARATOR = process.platform === 'win32' ? ';' : ':';
-
 /**
  * @deprecated Use `child_process.execSync` directly.
  * Execute a command synchronously.
@@ -19,11 +17,6 @@ function execSync(cmd, displayName, cwd = process.cwd()) {
 
   child_process.execSync(cmd, {
     cwd,
-    env: {
-      ...process.env,
-      // Make sure we read "path" case-insensitively (i.e., for Windows Powershell)
-      PATH: path.resolve('./node_modules/.bin') + SEPARATOR + process.env.PATH,
-    },
     stdio: 'inherit',
   });
 }

--- a/scripts/exec-sync.js
+++ b/scripts/exec-sync.js
@@ -7,6 +7,7 @@ const { logStatus } = require('./logging');
 const SEPARATOR = process.platform === 'win32' ? ';' : ':';
 
 /**
+ * @deprecated Use `child_process.execSync` directly.
  * Execute a command synchronously.
  *
  * @param {string} cmd  Command to execute
@@ -14,18 +15,15 @@ const SEPARATOR = process.platform === 'win32' ? ';' : ':';
  * @param {string} [cwd] Working directory in which to run the command
  */
 function execSync(cmd, displayName, cwd = process.cwd()) {
-  // Make sure we read "path" case-insensitively (i.e., for Windows Powershell)
-  const { PATH } = process.env;
-
-  // delay copying the env so that mods to the process.env are captured
-  const env = Object.assign({}, process.env, { PATH });
-  env.PATH = path.resolve('./node_modules/.bin') + SEPARATOR + env.PATH;
-
   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
 
   child_process.execSync(cmd, {
     cwd,
-    env,
+    env: {
+      ...process.env,
+      // Make sure we read "path" case-insensitively (i.e., for Windows Powershell)
+      PATH: path.resolve('./node_modules/.bin') + SEPARATOR + process.env.PATH,
+    },
     stdio: 'inherit',
   });
 }

--- a/scripts/exec-sync.js
+++ b/scripts/exec-sync.js
@@ -14,8 +14,11 @@ const SEPARATOR = process.platform === 'win32' ? ';' : ':';
  * @param {string} [cwd] Working directory in which to run the command
  */
 function execSync(cmd, displayName, cwd = process.cwd()) {
+  // Make sure we read "path" case-insensitively (i.e., for Windows Powershell)
+  const { PATH } = process.env;
+
   // delay copying the env so that mods to the process.env are captured
-  const env = Object.assign({}, process.env);
+  const env = Object.assign({}, process.env, { PATH });
   env.PATH = path.resolve('./node_modules/.bin') + SEPARATOR + env.PATH;
 
   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -4,8 +4,10 @@ const child_process = require('child_process');
 const chalk = require('chalk');
 const { logStatus } = require('./logging');
 
-const SEPARATOR = process.platform === 'win32' ? ';' : ':',
-  env = Object.assign({}, process.env);
+const SEPARATOR = process.platform === 'win32' ? ';' : ':';
+// Make sure we read "path" case-insensitively
+const { PATH } = process.env;
+const env = Object.assign({}, process.env, { PATH });
 
 env.PATH = path.resolve('./node_modules/.bin') + SEPARATOR + env.PATH;
 

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -5,13 +5,9 @@ const chalk = require('chalk');
 const { logStatus } = require('./logging');
 
 const SEPARATOR = process.platform === 'win32' ? ';' : ':';
-// Make sure we read "path" case-insensitively
-const { PATH } = process.env;
-const env = Object.assign({}, process.env, { PATH });
-
-env.PATH = path.resolve('./node_modules/.bin') + SEPARATOR + env.PATH;
 
 /**
+ * @deprecated Use `child_process.exec` directly.
  * Execute a command.
  *
  * @typedef {{
@@ -31,7 +27,11 @@ function exec(cmd, displayName, cwd = process.cwd(), opts = {}) {
 
   const execOptions = {
     cwd,
-    env: env,
+    env: {
+      ...process.env,
+      // Make sure we read "path" case-insensitively (i.e., for Windows Powershell)
+      PATH: path.resolve('./node_modules/.bin') + SEPARATOR + process.env.PATH,
+    },
     encoding: 'utf8',
   };
 

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -4,8 +4,6 @@ const child_process = require('child_process');
 const chalk = require('chalk');
 const { logStatus } = require('./logging');
 
-const SEPARATOR = process.platform === 'win32' ? ';' : ':';
-
 /**
  * @deprecated Use `child_process.exec` directly.
  * Execute a command.
@@ -27,11 +25,6 @@ function exec(cmd, displayName, cwd = process.cwd(), opts = {}) {
 
   const execOptions = {
     cwd,
-    env: {
-      ...process.env,
-      // Make sure we read "path" case-insensitively (i.e., for Windows Powershell)
-      PATH: path.resolve('./node_modules/.bin') + SEPARATOR + process.env.PATH,
-    },
     encoding: 'utf8',
   };
 


### PR DESCRIPTION
## Current Behavior

When using Windows Powershell to run a script that depends on `execSync()` or `exec()` the script may fail because the `PATH` environment variable is not set. This is a case-sensitivity issue as the default name for the "path" variable is `Path` in Powershell (This can be verified by running `dir env:` in Powershell to see the list of all env vars on your system.)

[Powershell itself is generally case-insensitive](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_case-sensitivity?view=powershell-7.2) and this behavior can be observed on the PS command line:

![Powershell Output](https://user-images.githubusercontent.com/93940821/195206977-6f84e05b-8ad2-47e0-9e47-76a9f407713c.png)

Node also accesses env vars case-insensitively, _when you access the env vars from `process.env`_. However, Node is case-sensitive when access env vars that have been spread into an object:

![node output](https://user-images.githubusercontent.com/93940821/195208193-4f30d66f-e493-4d25-9857-8f25218bb5c6.png)

[Currently we access env vars from an object](https://github.com/microsoft/fluentui/blob/616b4b7c381c757871e8a590564d8eff7337834c/scripts/exec-sync.js#L18-L19), making them case-sensitive. Since the default Powershell "path" variable is called "Path" our scripts don't find it when they look for "PATH". 

## New Behavior

`exec.ts` and `exec-sync.ts` access potentially case-sensitive environment variables from `process.env`.