### PR TITLE
V9 Slider is missing cursor pointer

### DIFF
--- a/change/@fluentui-react-slider-6edcf23c-8a46-4642-b3e7-af380c6c87f0.json
+++ b/change/@fluentui-react-slider-6edcf23c-8a46-4642-b3e7-af380c6c87f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding cursor pointer to the Slider component",
+  "packageName": "@fluentui/react-slider",
+  "email": "petrduda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSliderStyles.ts
@@ -221,6 +221,7 @@ const useThumbStyles = makeStyles({
  */
 const useInputStyles = makeStyles({
   input: {
+    cursor: 'pointer',
     opacity: 0,
     gridRowStart: 'slider',
     gridRowEnd: 'slider',
@@ -228,6 +229,9 @@ const useInputStyles = makeStyles({
     gridColumnEnd: 'slider',
     ...shorthands.padding(0),
     ...shorthands.margin(0),
+  },
+  disabled: {
+    cursor: 'default',
   },
   horizontal: {
     height: `var(${thumbSizeVar})`,
@@ -279,6 +283,7 @@ export const useSliderStyles_unstable = (state: SliderState): SliderState => {
     sliderClassNames.input,
     inputStyles.input,
     isVertical ? inputStyles.vertical : inputStyles.horizontal,
+    state.disabled && inputStyles.disabled,
     state.input.className,
   );
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Slider V9 is missing cursor pointer when hovering or interacting with it.

![Screenshot 2022-10-12 at 2 18 18 PM](https://user-images.githubusercontent.com/13124780/195340906-3e344e4b-c32c-42d3-9a57-0eba3bacc60e.png)

## New Behavior

This PR adds `cursor: pointer` to the slider input and also `cursor: default` for input disabled state.

![Screenshot 2022-10-12 at 2 16 53 PM](https://user-images.githubusercontent.com/13124780/195341044-597dfe5d-7800-4eec-83a6-e91c02656215.png)

![Screenshot 2022-10-12 at 2 17 45 PM](https://user-images.githubusercontent.com/13124780/195341045-e6e5e0fa-5e5b-4315-8644-bb8400ffecf1.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
