### PR TITLE
update browser support in fluent v8 readme

### DIFF
--- a/change/@fluentui-react-0f3db7f0-d444-4e3b-8082-84b9ad15e83d.json
+++ b/change/@fluentui-react-0f3db7f0-d444-4e3b-8082-84b9ad15e83d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: update ie11 support in fluent v8 readme",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,7 +62,9 @@ Fluent UI React adheres to [semantic versioning](http://www.semver.org/). Howeve
 
 ### Browser support
 
-Fluent UI React supports all evergreen browsers, with IE 11 as the min-bar version of Internet Explorer. See the [browser support doc](https://github.com/microsoft/fluentui/wiki/Browser-Support) for more information.
+Fluent UI React supports all evergreen browsers, with IE 11 as the min-bar version of Internet Explorer<sup>\*</sup>. See the [browser support doc](https://github.com/microsoft/fluentui/wiki/Browser-Support) for more information.
+
+<sup>\*</sup>**NOTE**: [Internet Explorer 11 has been sunset](https://github.com/microsoft/fluentui/wiki/Internet-Explorer-11-Sunset). Features and bug fixes after the sunset date may not be compatible with IE11.
 
 ### Right-to-left support
 


### PR DESCRIPTION
## Current Behavior

Fluent v8 README states what we fully support IE11.

## New Behavior

[IE11 has been sunset by Microsoft](https://github.com/microsoft/fluentui/wiki/Internet-Explorer-11-Sunset) and is no longer officially supported in v8 going forward (though we are not going out of our way to remove any existing support for IE).

