### PR TITLE
fix: Progress should set aria-valuemin and aria-valuemax when the value is 0

### DIFF
--- a/change/@fluentui-react-progress-d07f157a-df1e-4b91-a34d-484fc1e640ad.json
+++ b/change/@fluentui-react-progress-d07f157a-df1e-4b91-a34d-484fc1e640ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Progress should set aria-valuemin and aria-valuemax when the value is 0",
+  "packageName": "@fluentui/react-progress",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-progress/src/components/Progress/Progress.test.tsx
+++ b/packages/react-components/react-progress/src/components/Progress/Progress.test.tsx
@@ -41,4 +41,10 @@ describe('Progress', () => {
     expect(result.getByRole('progressbar').getAttribute('aria-valuemin')).toEqual('0');
     expect(result.getByRole('progressbar').getAttribute('aria-valuemax')).toEqual('42');
   });
+  it('sets valuemin and valuemax when value is 0', () => {
+    const result = render(<Progress value={0} />);
+    expect(result.getByRole('progressbar').getAttribute('aria-valuenow')).toEqual('0');
+    expect(result.getByRole('progressbar').getAttribute('aria-valuemin')).toEqual('0');
+    expect(result.getByRole('progressbar').getAttribute('aria-valuemax')).toEqual('1');
+  });
 });

--- a/packages/react-components/react-progress/src/components/Progress/useProgress.tsx
+++ b/packages/react-components/react-progress/src/components/Progress/useProgress.tsx
@@ -18,8 +18,8 @@ export const useProgress_unstable = (props: ProgressProps, ref: React.Ref<HTMLEl
   const root = getNativeElementProps('div', {
     ref,
     role: 'progressbar',
-    'aria-valuemin': value ? 0 : undefined,
-    'aria-valuemax': value ? max : undefined,
+    'aria-valuemin': value !== undefined ? 0 : undefined,
+    'aria-valuemax': value !== undefined ? max : undefined,
     'aria-valuenow': value,
     ...props,
   });


### PR DESCRIPTION
## Current Behavior

Progress uses a falsy test to see if it should add aria-valuemin and aria-valuemax. That results in those props not being set when the value is 0.

## New Behavior

Change the falsy test to an `!== undefined` test.
