### PR TITLE
add preventDismissOnEvent prop to ContextualMenu

### DIFF
--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1256,6 +1256,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
               alignTargetEdge={alignTargetEdge}
               hidden={props.hidden || menuContext.hidden}
               ref={forwardedRef}
+              preventDismissOnEvent={props.preventDismissOnEvent}
             >
               <div
                 style={contextMenuStyle}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -294,6 +294,12 @@ export interface IContextualMenuProps
    * focus will not be restored automatically, and you'll need to call `params.originalElement.focus()`.
    */
   onRestoreFocus?: (params: IPopupRestoreFocusParams) => void;
+
+  /**
+   * If it returns true, the callout will not dismiss for this event.
+   * If not defined or returns false, the callout can dismiss for this event.
+   */
+  preventDismissOnEvent?: (ev: Event | React.FocusEvent | React.KeyboardEvent | React.MouseEvent) => boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
Currently for [ContextualMenu](https://developer.microsoft.com/en-us/fluentui#/controls/web/contextualmenu) component, there is no preventDismissOnEvent to make the menu not dismiss for events
<!-- This is the behavior we have today -->

## New Behavior
Add preventDismissOnEvent prop to ContextualMenu component to allow the menu could not dismiss for events.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
https://github.com/microsoft/fluentui/issues/25208
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
