### PR TITLE
chore(react-dialog): updates disallowed change types

### DIFF
--- a/change/@fluentui-react-dialog-7ebb283d-0dc2-4be2-8c48-931991ff1c06.json
+++ b/change/@fluentui-react-dialog-7ebb283d-0dc2-4be2-8c48-931991ff1c06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: updates disallowed change types",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/package.json
+++ b/packages/react-components/react-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-dialog",
-  "version": "9.0.1-0",
+  "version": "9.0.1",
   "description": "Dialog component for Fluent UI React",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
@@ -53,7 +53,8 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "prerelease"
     ]
   },
   "exports": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

1. add `prerelease` as disallowed change type for `react-dialog` as it was released.
2. fix `react-dialog` version
