### PR TITLE
Update changefile for Dialog now that it is released

### DIFF
--- a/change/@fluentui-react-dialog-973c2806-aef3-42cf-9149-111dc824187c.json
+++ b/change/@fluentui-react-dialog-973c2806-aef3-42cf-9149-111dc824187c.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "chore: Bump peer deps to support React 18",
   "packageName": "@fluentui/react-dialog",
   "email": "mgodbolt@microsoft.com",


### PR DESCRIPTION
Seems #24972 snuck a bad change file into master. Dialog went from prerelease to release but did not trigger a build which would see that the type value is invalid. Now other PRs are failing. 