### PR TITLE
Fix: Panel does not aria-hide siblings when only hidden

### DIFF
--- a/change/@fluentui-react-3c5ba995-43db-46ee-80af-32fb80ce4e13.json
+++ b/change/@fluentui-react-3c5ba995-43db-46ee-80af-32fb80ce4e13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Panel should only aria hide siblings when isOpen is true",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -227,7 +227,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
           ariaLabelledBy={this._headerTextId ? this._headerTextId : undefined}
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}
-          enableAriaHiddenSiblings={isOpen ? true : undefined}
+          enableAriaHiddenSiblings={isOpen ? true : false}
           {...popupProps}
         >
           <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={this._panel} className={_classNames.root}>


### PR DESCRIPTION
fixes #25218

enableAriaHiddenSiblings defaults to true, so `enableAriaHiddenSiblings={isOpen ? true : undefined}` was not turning the setting off when isOpen was false. 