### PR TITLE
feat: Add support for a control's `invalid` prop on Field, as a synonym for `validationState="error"`

### DIFF
--- a/change/@fluentui-react-field-1ccdefdc-d98c-4ce4-a54f-fdcb866fb477.json
+++ b/change/@fluentui-react-field-1ccdefdc-d98c-4ce4-a54f-fdcb866fb477.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Add support for a control's `invalid` prop on Field, as a synonym for validationState=\"error\"",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/src/components/Field/Field.test.tsx
+++ b/packages/react-components/react-field/src/components/Field/Field.test.tsx
@@ -4,7 +4,10 @@ import { render } from '@testing-library/react';
 import type { FieldProps } from './index';
 import { getFieldClassNames, renderField_unstable, useFieldStyles_unstable, useField_unstable } from './index';
 
-const MockComponent: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = props => <input {...props} />;
+const MockComponent: React.FC<React.InputHTMLAttributes<HTMLInputElement> & { invalid?: boolean }> = props => {
+  const { invalid, ...intrinsicProps } = props;
+  return <input {...intrinsicProps} data-mock-invalid={invalid} />;
+};
 
 type MockFieldProps = FieldProps<typeof MockComponent>;
 const mockFieldClassNames = getFieldClassNames('MockField');
@@ -96,11 +99,30 @@ describe('Field', () => {
     expect(input.getAttribute('aria-errormessage')).toBe(validationMessage.id);
   });
 
-  it('sets aria-invalid if an error', () => {
+  it('sets invalid and aria-invalid if an error', () => {
     const result = render(<MockField validationState="error" />);
     const input = result.getByRole('textbox');
 
+    expect(input.getAttribute('data-mock-invalid')).toBeTruthy();
     expect(input.getAttribute('aria-invalid')).toBeTruthy();
+  });
+
+  it('does not set invalid or aria-invalid if not an error', () => {
+    const result = render(<MockField validationState="warning" />);
+    const input = result.getByRole('textbox');
+
+    expect(input.getAttribute('data-mock-invalid')).toBeNull();
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('defaults validationState to "error" if the invalid prop is set', () => {
+    const result = render(<MockField invalid validationMessage="Test validation message" />);
+    const input = result.getByRole('textbox');
+    const validationMessage = result.getByText('Test validation message');
+
+    expect(input.getAttribute('aria-invalid')).toBeTruthy();
+    expect(input.getAttribute('data-mock-invalid')).toBeTruthy();
+    expect(input.getAttribute('aria-errormessage')).toBe(validationMessage.id);
   });
 
   it('does not override user aria props', () => {

--- a/packages/react-components/react-field/src/components/Field/Field.types.ts
+++ b/packages/react-components/react-field/src/components/Field/Field.types.ts
@@ -91,6 +91,11 @@ export type FieldPropsWithOptionalComponentProps<T extends FieldComponent> = Fie
    * Number sizes will be ignored, but are allowed because the HTML `<input>` element has a prop `size?: number`.
    */
   size?: 'small' | 'medium' | 'large' | number;
+
+  /**
+   * If the control has an `invalid` prop, it will be used to set the default value of `validationState="error"`.
+   */
+  invalid?: boolean;
 };
 
 /**

--- a/packages/react-components/react-field/src/components/Field/useField.tsx
+++ b/packages/react-components/react-field/src/components/Field/useField.tsx
@@ -66,7 +66,7 @@ export const useField_unstable = <T extends FieldComponent>(
   params: FieldConfig<T>,
 ): FieldState<T> => {
   const [fieldProps, controlProps] = getPartitionedFieldProps(props);
-  const { orientation = 'vertical', validationState } = fieldProps;
+  const { orientation = 'vertical', validationState = props.invalid ? 'error' : undefined } = fieldProps;
   const { labelConnection = 'htmlFor' } = params;
 
   const baseId = useId('field-');
@@ -81,6 +81,7 @@ export const useField_unstable = <T extends FieldComponent>(
     defaultProps: {
       ref,
       id: baseId + '__control',
+      invalid: validationState === 'error' ? true : undefined,
       ...controlProps,
     },
   });


### PR DESCRIPTION
## Current Behavior

Field has no way of telling the underlying control that it is invalid and should render a red border.

## New Behavior

* Have Field set `invalid` on the control when `validationState="error"`
* Have Field default `validationState="error"` if `invalid` is set on the control.

## Related Issue(s)

* Part of #25023
