### PR TITLE
feat: Add `invalid` prop to Input, which causes the border to be red

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Input.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Input.stories.tsx
@@ -30,6 +30,15 @@ storiesOf('Input Converged', module)
       <Input appearance="filled-lighter" placeholder="Placeholder" />
     </div>
   ))
+  .addStory('Invalid: outline', () => <Input invalid placeholder="Placeholder" />)
+  .addStory('Invalid: underline', () => <Input invalid appearance="underline" placeholder="Placeholder" />)
+  .addStory('Invalid: filled-darker', () => <Input invalid appearance="filled-darker" placeholder="Placeholder" />)
+  .addStory('Invalid: filled-lighter', () => (
+    // filledLighter requires a background to show up (this is colorNeutralBackground3 in web light theme)
+    <div style={{ background: '#f5f5f5', padding: '10px' }}>
+      <Input invalid appearance="filled-lighter" placeholder="Placeholder" />
+    </div>
+  ))
   .addStory('Disabled', () => <Input disabled />)
   .addStory('With value', () => <Input defaultValue="Value!" />);
 

--- a/change/@fluentui-react-input-105813c0-5c64-4920-aeb3-38de5cb902be.json
+++ b/change/@fluentui-react-input-105813c0-5c64-4920-aeb3-38de5cb902be.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add `invalid` prop to Input, which causes the border to be red",
+  "packageName": "@fluentui/react-input",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/etc/react-input.api.md
+++ b/packages/react-components/react-input/etc/react-input.api.md
@@ -27,6 +27,7 @@ export type InputProps = Omit<ComponentProps<Partial<InputSlots>, 'input'>, 'chi
     children?: never;
     size?: 'small' | 'medium' | 'large';
     appearance?: 'outline' | 'underline' | 'filled-darker' | 'filled-lighter' | 'filled-darker-shadow' | 'filled-lighter-shadow';
+    invalid?: boolean;
     defaultValue?: string;
     value?: string;
     onChange?: (ev: React_2.ChangeEvent<HTMLInputElement>, data: InputOnChangeData) => void;
@@ -42,7 +43,7 @@ export type InputSlots = {
 };
 
 // @public
-export type InputState = Required<Pick<InputProps, 'appearance' | 'size'>> & ComponentState<InputSlots>;
+export type InputState = Required<Pick<InputProps, 'appearance' | 'size' | 'invalid'>> & ComponentState<InputSlots>;
 
 // @public
 export const renderInput_unstable: (state: InputState) => JSX.Element;

--- a/packages/react-components/react-input/src/components/Input/Input.test.tsx
+++ b/packages/react-components/react-input/src/components/Input/Input.test.tsx
@@ -95,4 +95,9 @@ describe('Input', () => {
     renderedComponent.rerender(<Input value="world" onChange={onChange} />);
     expect(onChange).toHaveBeenCalledTimes(0);
   });
+
+  it('sets aria-invalid when invalid is true', () => {
+    renderedComponent = render(<Input invalid />);
+    expect(getInput().getAttribute('aria-invalid')).toEqual('true');
+  });
 });

--- a/packages/react-components/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-components/react-input/src/components/Input/Input.types.ts
@@ -59,13 +59,6 @@ export type InputProps = Omit<
     | 'filled-lighter-shadow';
 
   /**
-   * Causes the border to be red, indicating that the value entered by the user has failed validation.
-   *
-   * It is recommended to set `aria-invalid` and `aria-errormessage` as well.
-   */
-  invalid?: boolean;
-
-  /**
    * Default value of the input. Provide this if the input should be an uncontrolled component
    * which tracks its current state internally; otherwise, use `value`.
    *
@@ -85,6 +78,14 @@ export type InputProps = Omit<
    * Called when the user changes the input's value.
    */
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>, data: InputOnChangeData) => void;
+
+  /**
+   * Causes the border to be red and marks the input as `aria-invalid`, indicating that the value entered by the user
+   * has failed validation.
+   *
+   * It is recommended to include an error message linked by `aria-errormessage`, or use `InputField` to handle it.
+   */
+  invalid?: boolean;
 
   /**
    * An input can have different text-based [types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#input_types)

--- a/packages/react-components/react-input/src/components/Input/Input.types.ts
+++ b/packages/react-components/react-input/src/components/Input/Input.types.ts
@@ -59,6 +59,13 @@ export type InputProps = Omit<
     | 'filled-lighter-shadow';
 
   /**
+   * Causes the border to be red, indicating that the value entered by the user has failed validation.
+   *
+   * It is recommended to set `aria-invalid` and `aria-errormessage` as well.
+   */
+  invalid?: boolean;
+
+  /**
    * Default value of the input. Provide this if the input should be an uncontrolled component
    * which tracks its current state internally; otherwise, use `value`.
    *
@@ -108,7 +115,7 @@ export type InputProps = Omit<
 /**
  * State used in rendering Input.
  */
-export type InputState = Required<Pick<InputProps, 'appearance' | 'size'>> & ComponentState<InputSlots>;
+export type InputState = Required<Pick<InputProps, 'appearance' | 'size' | 'invalid'>> & ComponentState<InputSlots>;
 
 /**
  * Data passed to the `onChange` callback when a user changes the input's value.

--- a/packages/react-components/react-input/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/src/components/Input/useInput.ts
@@ -17,7 +17,7 @@ import type { InputProps, InputState } from './Input.types';
  * @param ref - reference to `<input>` element of Input
  */
 export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
-  const { size = 'medium', appearance = 'outline', onChange } = props;
+  const { size = 'medium', appearance = 'outline', invalid = false, onChange } = props;
 
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -45,6 +45,7 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
   const state: InputState = {
     size,
     appearance,
+    invalid,
     components: {
       root: 'span',
       input: 'input',

--- a/packages/react-components/react-input/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/src/components/Input/useInput.ts
@@ -57,6 +57,7 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
       defaultProps: {
         type: 'text',
         ref,
+        'aria-invalid': invalid || undefined,
         ...nativeProps.primary,
       },
     }),

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -153,6 +153,14 @@ const useRootStyles = makeStyles({
       ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
     },
   },
+  invalid: {
+    ...shorthands.borderColor(tokens.colorPaletteRedBorder2),
+  },
+  invalidInteractive: {
+    ':hover': {
+      ...shorthands.borderColor(tokens.colorPaletteRedBorder2),
+    },
+  },
   'filled-darker': {
     backgroundColor: tokens.colorNeutralBackground3,
   },
@@ -243,7 +251,7 @@ const useContentStyles = makeStyles({
  * Apply styling to the Input slots based on the state
  */
 export const useInputStyles_unstable = (state: InputState): InputState => {
-  const { size, appearance } = state;
+  const { size, appearance, invalid } = state;
   const disabled = state.input.disabled;
   const filled = appearance.startsWith('filled');
 
@@ -256,11 +264,13 @@ export const useInputStyles_unstable = (state: InputState): InputState => {
     rootStyles.base,
     rootStyles[size],
     rootStyles[appearance],
+    filled && rootStyles.filled,
+    invalid && rootStyles.invalid,
     !disabled && rootStyles.interactive,
     !disabled && appearance === 'outline' && rootStyles.outlineInteractive,
     !disabled && appearance === 'underline' && rootStyles.underlineInteractive,
     !disabled && filled && rootStyles.filledInteractive,
-    filled && rootStyles.filled,
+    !disabled && invalid && rootStyles.invalidInteractive,
     disabled && rootStyles.disabled,
     state.root.className,
   );

--- a/packages/react-components/react-input/src/stories/Input/InputInvalid.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputInvalid.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { makeStyles, shorthands, useId, Input, Label } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    // Stack the label above the field
+    display: 'flex',
+    flexDirection: 'column',
+    // Use 2px gap below the label (per the design system)
+    ...shorthands.gap('2px'),
+    // Prevent the example from taking the full width of the page (optional)
+    maxWidth: '400px',
+  },
+});
+
+export const Invalid = () => {
+  const inputId = useId('input');
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <Label htmlFor={inputId}>Input that has failed form validation</Label>
+      <Input id={inputId} defaultValue="invalid value" invalid />
+    </div>
+  );
+};
+
+Invalid.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the `invalid` prop is set, the Input has a red border. It is recommended to also set ' +
+        '`aria-invalid`, and `aria-errormessage` with an element that describes the error.',
+    },
+  },
+};

--- a/packages/react-components/react-input/src/stories/Input/InputInvalid.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/InputInvalid.stories.tsx
@@ -15,12 +15,14 @@ const useStyles = makeStyles({
 
 export const Invalid = () => {
   const inputId = useId('input');
+  const errormessageId = useId('errormessage');
   const styles = useStyles();
 
   return (
     <div className={styles.root}>
       <Label htmlFor={inputId}>Input that has failed form validation</Label>
-      <Input id={inputId} defaultValue="invalid value" invalid />
+      <Input id={inputId} defaultValue="invalid value" invalid aria-errormessage={errormessageId} />
+      <div id={errormessageId}>This is an example error message</div>
     </div>
   );
 };
@@ -29,8 +31,9 @@ Invalid.parameters = {
   docs: {
     description: {
       story:
-        'When the `invalid` prop is set, the Input has a red border. It is recommended to also set ' +
-        '`aria-invalid`, and `aria-errormessage` with an element that describes the error.',
+        'When the `invalid` prop is set, the Input has a red border and is marked as `aria-invalid`. It is ' +
+        'recommended to also set `aria-errormessage` with an element that describes the error. Consider using ' +
+        '`InputField` to handle the layout and styling of the error message.',
     },
   },
 };

--- a/packages/react-components/react-input/src/stories/Input/index.stories.tsx
+++ b/packages/react-components/react-input/src/stories/Input/index.stories.tsx
@@ -8,6 +8,7 @@ export { Default } from './InputDefault.stories';
 export { Appearance } from './InputAppearance.stories';
 export { ContentBeforeAfter } from './InputContentBeforeAfter.stories';
 export { Disabled } from './InputDisabled.stories';
+export { Invalid } from './InputInvalid.stories';
 export { Inline } from './InputInline.stories';
 export { Placeholder } from './InputPlaceholder.stories';
 export { Size } from './InputSize.stories';


### PR DESCRIPTION
## New Behavior

* Add an `invalid` prop to Input
* Add styling to cause the border to become red when `invalid` is set
  * ![image](https://user-images.githubusercontent.com/48106640/195726587-b7061059-9c39-4f87-a960-1fdf1542093b.png)
* Add screener tests for the invalid prop
* Add a story for the invalid prop

## Related Issue(s)

* Part of #25023 