### PR TITLE
fix(react-component): Remove unstable notice from stable components' readmes

### DIFF
--- a/change/@fluentui-babel-preset-global-context-fbab8221-a681-47c4-9b28-96c103f54d5e.json
+++ b/change/@fluentui-babel-preset-global-context-fbab8221-a681-47c4-9b28-96c103f54d5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-global-context-7e868f0c-2416-41a8-acaa-32453ec66400.json
+++ b/change/@fluentui-global-context-7e868f0c-2416-41a8-acaa-32453ec66400.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/global-context",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-priority-overflow-9319a22e-b037-48fe-87c2-5f62be07e729.json
+++ b/change/@fluentui-priority-overflow-9319a22e-b037-48fe-87c2-5f62be07e729.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-19c88c1c-75f8-4759-aa9d-9737b6fe6ced.json
+++ b/change/@fluentui-react-accordion-19c88c1c-75f8-4759-aa9d-9737b6fe6ced.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-accordion",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-alert-ed4573ed-b859-403a-b38c-aa179b4aabea.json
+++ b/change/@fluentui-react-alert-ed4573ed-b859-403a-b38c-aa179b4aabea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-alert",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-139db5a0-3e75-48b3-bc6c-9a9304a17289.json
+++ b/change/@fluentui-react-aria-139db5a0-3e75-48b3-bc6c-9a9304a17289.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-aria",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-combobox-e6b9af6b-d33e-4429-8fb3-c90859af85d5.json
+++ b/change/@fluentui-react-combobox-e6b9af6b-d33e-4429-8fb3-c90859af85d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-combobox",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-6d20d889-3f19-44aa-9169-1fa074e0a949.json
+++ b/change/@fluentui-react-components-6d20d889-3f19-44aa-9169-1fa074e0a949.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-components",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-dialog-5db6f0b6-455a-4ddd-973b-25ae3293eb9b.json
+++ b/change/@fluentui-react-dialog-5db6f0b6-455a-4ddd-973b-25ae3293eb9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-dialog",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-b7e6466b-dcde-4fbf-ba29-19b18ebf9421.json
+++ b/change/@fluentui-react-input-b7e6466b-dcde-4fbf-ba29-19b18ebf9421.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-input",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-f0e700bb-39e2-4ac9-a36e-37e194af4b68.json
+++ b/change/@fluentui-react-menu-f0e700bb-39e2-4ac9-a36e-37e194af4b68.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-menu",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-7ad02b9c-1a39-40ca-9084-4e0a37c2f6b2.json
+++ b/change/@fluentui-react-overflow-7ad02b9c-1a39-40ca-9084-4e0a37c2f6b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-overflow",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-persona-eb8a4fb5-88d1-4f42-8910-f11327e2ef88.json
+++ b/change/@fluentui-react-persona-eb8a4fb5-88d1-4f42-8910-f11327e2ef88.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update package readme",
-  "packageName": "@fluentui/react-persona",
-  "email": "miroslav.stastny@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-react-persona-eb8a4fb5-88d1-4f42-8910-f11327e2ef88.json
+++ b/change/@fluentui-react-persona-eb8a4fb5-88d1-4f42-8910-f11327e2ef88.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-persona",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-1c9aee6e-392e-4f2b-b550-431b23b76377.json
+++ b/change/@fluentui-react-popover-1c9aee6e-392e-4f2b-b550-431b23b76377.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-popover",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-e76727a1-3f22-43ae-a068-3b8c078ff947.json
+++ b/change/@fluentui-react-portal-e76727a1-3f22-43ae-a068-3b8c078ff947.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-portal",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-8f5c6ed7-b4e0-4aad-b90e-6ca5a9c5d36f.json
+++ b/change/@fluentui-react-positioning-8f5c6ed7-b4e0-4aad-b90e-6ca5a9c5d36f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-positioning",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-491a386e-0048-4762-9fc2-e95408eb8221.json
+++ b/change/@fluentui-react-provider-491a386e-0048-4762-9fc2-e95408eb8221.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-provider",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-1ce77ecb-75fd-4ca2-bde4-b3a8a4d5a39a.json
+++ b/change/@fluentui-react-radio-1ce77ecb-75fd-4ca2-bde4-b3a8a4d5a39a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-radio",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-select-635c6d9a-fa57-4b78-b588-20b2c3eb06c7.json
+++ b/change/@fluentui-react-select-635c6d9a-fa57-4b78-b588-20b2c3eb06c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-select",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-a6e870c9-6d36-40ef-9195-ff8fa276e64d.json
+++ b/change/@fluentui-react-shared-contexts-a6e870c9-6d36-40ef-9195-ff8fa276e64d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-20180fd4-f47f-4e55-94e1-beb455941d0e.json
+++ b/change/@fluentui-react-tabster-20180fd4-f47f-4e55-94e1-beb455941d0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-tabster",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-8bd65278-b603-42de-9eaf-38286e42f84a.json
+++ b/change/@fluentui-react-text-8bd65278-b603-42de-9eaf-38286e42f84a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-text",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-textarea-0a5c99e7-b892-46e5-aa67-692c9efba4a6.json
+++ b/change/@fluentui-react-textarea-0a5c99e7-b892-46e5-aa67-692c9efba4a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-textarea",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-78fbbf88-f8ec-4093-a72b-5d6157fbedde.json
+++ b/change/@fluentui-react-theme-78fbbf88-f8ec-4093-a72b-5d6157fbedde.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-sass-af70cf04-7529-45eb-a9c5-a785e3577cdf.json
+++ b/change/@fluentui-react-theme-sass-af70cf04-7529-45eb-a9c5-a785e3577cdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toolbar-49a06b90-69ca-4005-a9e5-9d5af0192bf6.json
+++ b/change/@fluentui-react-toolbar-49a06b90-69ca-4005-a9e5-9d5af0192bf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-3f7815a9-1c42-4076-bda0-ad0b3f3831bb.json
+++ b/change/@fluentui-react-tooltip-3f7815a9-1c42-4076-bda0-ad0b3f3831bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-96703384-9e65-4825-80f0-f97e7fdbe3ae.json
+++ b/change/@fluentui-react-utilities-96703384-9e65-4825-80f0-f97e7fdbe3ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update package readme",
+  "packageName": "@fluentui/react-utilities",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/babel-preset-global-context/README.md
+++ b/packages/react-components/babel-preset-global-context/README.md
@@ -1,6 +1,6 @@
 # @fluentui/babel-preset-global-context
 
-**Babel Preset Global Context for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Babel Preset Global Context for [Fluent UI React](https://react.fluentui.dev)**
 
 Babel preset that transforms createContext calls to use global context shims
 

--- a/packages/react-components/global-context/README.md
+++ b/packages/react-components/global-context/README.md
@@ -1,6 +1,6 @@
 # @fluentui/global-context
 
-**Global Context for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Global Context for [Fluent UI React](https://react.fluentui.dev)**
 
 This package contains a shim for `React.createContext` API that will register the context object to the global
 scope (`window` for browsers, `global` for nodejs). This means that contexts will be real singletons.

--- a/packages/react-components/priority-overflow/README.md
+++ b/packages/react-components/priority-overflow/README.md
@@ -1,5 +1,5 @@
 # @fluentui/priority-overflow
 
-**Priority Overflow components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Priority Overflow components for [Fluent UI React](https://react.fluentui.dev)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-accordion/README.md
+++ b/packages/react-components/react-accordion/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-accordion
 
 **React Accordion components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-accordion/README.md
+++ b/packages/react-components/react-accordion/README.md
@@ -1,3 +1,3 @@
 # @fluentui/react-accordion
 
-**React Accordion components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Accordion components for [Fluent UI React](https://react.fluentui.dev)**

--- a/packages/react-components/react-alert/README.md
+++ b/packages/react-components/react-alert/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-alert
 
-**React Alert component for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Alert component for [Fluent UI React](https://react.fluentui.dev)**
 
 > WIP 🚧 - These are not production-ready components as we are still in a Beta phase.
 > See the [spec.md](./Spec.md) for usage and component API details

--- a/packages/react-components/react-aria/README.md
+++ b/packages/react-components/react-aria/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-aria
 
 **React Aria components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-aria/README.md
+++ b/packages/react-components/react-aria/README.md
@@ -1,3 +1,3 @@
 # @fluentui/react-aria
 
-**React Aria components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Aria components for [Fluent UI React](https://react.fluentui.dev)**

--- a/packages/react-components/react-combobox/README.md
+++ b/packages/react-components/react-combobox/README.md
@@ -1,5 +1,5 @@
 # @fluentui/react-combobox
 
-**Combobox component for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Combobox component for [Fluent UI React](https://react.fluentui.dev)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-components/README.md
+++ b/packages/react-components/react-components/README.md
@@ -4,8 +4,6 @@
 
 This is a suite package for converged components and related utilities. It is a result of a dedupe effort for `@fluentui/react` and `@fluentui/react-northstar`.
 
-The components are available for limited production use, please contact us if you intend to use them in your product. The APIs might change before final release.
-
 ### Usage
 
 Add @fluentui/react-components to a project:

--- a/packages/react-components/react-dialog/README.md
+++ b/packages/react-components/react-dialog/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-dialog
 
-**React Dialog components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Dialog components for [Fluent UI React](https://react.fluentui.dev)**
 
 To import React Dialog components:
 

--- a/packages/react-components/react-input/README.md
+++ b/packages/react-components/react-input/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-input
 
-**React Input components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Input components for [Fluent UI React](https://react.fluentui.dev)**
 
 Inputs give people a way to enter and edit text.
 

--- a/packages/react-components/react-input/README.md
+++ b/packages/react-components/react-input/README.md
@@ -2,8 +2,6 @@
 
 **React Input components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 Inputs give people a way to enter and edit text.
 
 ### Usage

--- a/packages/react-components/react-menu/README.md
+++ b/packages/react-components/react-menu/README.md
@@ -1,3 +1,3 @@
 # @fluentui/react-menu
 
-**React Menu components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Menu components for [Fluent UI React](https://react.fluentui.dev)**

--- a/packages/react-components/react-menu/README.md
+++ b/packages/react-components/react-menu/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-menu
 
 **React Menu components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-overflow/README.md
+++ b/packages/react-components/react-overflow/README.md
@@ -1,5 +1,5 @@
 # @fluentui/react-overflow
 
-**React Priority Overflow components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Priority Overflow components for [Fluent UI React](https://react.fluentui.dev)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-persona/README.md
+++ b/packages/react-components/react-persona/README.md
@@ -2,6 +2,10 @@
 
 **React Persona components for [Fluent UI React](https://react.fluentui.dev/)**
 
+## STATUS: WIP 🚧
+
+These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+
 ## Usage
 
 To import Persona:

--- a/packages/react-components/react-persona/README.md
+++ b/packages/react-components/react-persona/README.md
@@ -2,10 +2,6 @@
 
 **React Persona components for [Fluent UI React](https://react.fluentui.dev/)**
 
-## STATUS: WIP 🚧
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 ## Usage
 
 To import Persona:

--- a/packages/react-components/react-popover/README.md
+++ b/packages/react-components/react-popover/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-popover
 
-**React Popover components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Popover components for [Fluent UI React](https://react.fluentui.dev)**
 
 To import React Popover components:
 

--- a/packages/react-components/react-popover/README.md
+++ b/packages/react-components/react-popover/README.md
@@ -2,8 +2,6 @@
 
 **React Popover components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 To import React Popover components:
 
 ```js

--- a/packages/react-components/react-portal/README.md
+++ b/packages/react-components/react-portal/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-portal
 
-**React Portal components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Portal components for [Fluent UI React](https://react.fluentui.dev)**
 
 This package contains the `Portal` component, which allow consumers to render [React portals](https://reactjs.org/docs/portals.html) with Fluent styling and RTL awareness.
 

--- a/packages/react-components/react-portal/README.md
+++ b/packages/react-components/react-portal/README.md
@@ -2,8 +2,6 @@
 
 **React Portal components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 This package contains the `Portal` component, which allow consumers to render [React portals](https://reactjs.org/docs/portals.html) with Fluent styling and RTL awareness.
 
 ## Usage

--- a/packages/react-components/react-positioning/README.md
+++ b/packages/react-components/react-positioning/README.md
@@ -2,8 +2,6 @@
 
 A react hook wrapper around [Popper.js](https://popper.js.org/) for Fluent UI.
 
-These are not production-ready utilities and **should never be used in product**. This space is useful for testing new utilities whose APIs might change before final release.
-
 ## Usage
 
 ```tsx

--- a/packages/react-components/react-provider/README.md
+++ b/packages/react-components/react-provider/README.md
@@ -1,3 +1,3 @@
 # @fluentui/react-provider
 
-**React Provider component for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Provider component for [Fluent UI React](https://react.fluentui.dev)**

--- a/packages/react-components/react-provider/README.md
+++ b/packages/react-components/react-provider/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-provider
 
 **React Provider component for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-radio/README.md
+++ b/packages/react-components/react-radio/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-radio
 
-**React Radio components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Radio components for [Fluent UI React](https://react.fluentui.dev)**
 
 A Radio allows a user to select a single value from two or more options. All Radios with the same `name` are considered to be part of the same group. However, a `RadioGroup` is recommended to add a group label, formatting, and other functionality.
 

--- a/packages/react-components/react-radio/README.md
+++ b/packages/react-components/react-radio/README.md
@@ -2,8 +2,6 @@
 
 **React Radio components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 A Radio allows a user to select a single value from two or more options. All Radios with the same `name` are considered to be part of the same group. However, a `RadioGroup` is recommended to add a group label, formatting, and other functionality.
 
 ### Usage

--- a/packages/react-components/react-select/README.md
+++ b/packages/react-components/react-select/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-select
 
-**React Select components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Select components for [Fluent UI React](https://react.fluentui.dev)**
 
 The Select component provides a styled wrapper around the native `<select>` element. It is recommended over Combobox when features like filtering and virtualization are not required. It provides better cross-platform functionality particularly on mobile, and better accessibility.
 

--- a/packages/react-components/react-shared-contexts/README.md
+++ b/packages/react-components/react-shared-contexts/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-shared-contexts
 
-**Shared contexts for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Shared contexts for [Fluent UI React](https://react.fluentui.dev)**
 
 This package includes a number of exported React Contexts that are shared by Fluent UI components.
 

--- a/packages/react-components/react-tabster/README.md
+++ b/packages/react-components/react-tabster/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-tabster
 
-**Tabster components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Tabster components for [Fluent UI React](https://react.fluentui.dev)**
 
 Library for focus management that leverages [tabster](https://github.com/microsoft/tabster).
 

--- a/packages/react-components/react-text/README.md
+++ b/packages/react-components/react-text/README.md
@@ -1,8 +1,6 @@
 # @fluentui/react-text
 
-> WIP 🚧 - These are not production-ready components as we are still in a Beta phase.
-
-<!-- TODO: Add link to the new website -->
+**React Text components for [Fluent UI React](https://react.fluentui.dev/)**
 
 The Text component exists to ensure consistency in your application's content by setting fixed sizes and other styles.
 This package also exports wrappers which ensure your text follows the Fluent design standards of typography.

--- a/packages/react-components/react-textarea/README.md
+++ b/packages/react-components/react-textarea/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-textarea
 
-**React Textarea components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Textarea components for [Fluent UI React](https://react.fluentui.dev)**
 
 The Textarea component is a multiline text input that allows the user to enter
 

--- a/packages/react-components/react-textarea/README.md
+++ b/packages/react-components/react-textarea/README.md
@@ -4,10 +4,6 @@
 
 The Textarea component is a multiline text input that allows the user to enter
 
-## STATUS: WIP 🚧
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 ## Usage
 
 To import Textarea:

--- a/packages/react-components/react-theme-sass/README.md
+++ b/packages/react-components/react-theme-sass/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-theme-sass
 
-**React Theme Sass for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Theme Sass for [Fluent UI React](https://react.fluentui.dev)**
 
 SASS variables referencing react-theme design tokens injected to DOM by react-provider.
 

--- a/packages/react-components/react-theme/README.md
+++ b/packages/react-components/react-theme/README.md
@@ -1,6 +1,6 @@
 # @fluentui/react-theme
 
-**React Theme for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Theme for [Fluent UI React](https://react.fluentui.dev)**
 
 ## Usage
 

--- a/packages/react-components/react-toolbar/README.md
+++ b/packages/react-components/react-toolbar/README.md
@@ -2,6 +2,6 @@
 
 ## WIP
 
-**React Toolbar components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Toolbar components for [Fluent UI React](https://react.fluentui.dev)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-tooltip/README.md
+++ b/packages/react-components/react-tooltip/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-tooltip
 
 **React Tooltip components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/react-tooltip/README.md
+++ b/packages/react-components/react-tooltip/README.md
@@ -1,3 +1,3 @@
 # @fluentui/react-tooltip
 
-**React Tooltip components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**React Tooltip components for [Fluent UI React](https://react.fluentui.dev)**

--- a/packages/react-components/react-utilities/README.md
+++ b/packages/react-components/react-utilities/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-utilities
 
 **React Utilities for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) components**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.

--- a/packages/react-components/theme-designer/README.md
+++ b/packages/react-components/theme-designer/README.md
@@ -1,5 +1,5 @@
 # @fluentui/theme-designer
 
-**Theme Designer components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+**Theme Designer components for [Fluent UI React](https://react.fluentui.dev)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.


### PR DESCRIPTION
## Current Behavior

`react-components` package as well as other stable components contain unstable notice in readme:

```
These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
```

That message is not correct and confuses partners.

## New Behavior

- [x] The message has been removed from `react-components` and all stable packages.
- [x] I've also updated the project URLs in the readmes to match the current template.
- [x] All changes marked as `none` to avoid useless release.