### PR TITLE
fix(react-alert): fix incorrect relative path import and use absolute import for story

### DIFF
--- a/packages/react-components/react-alert/stories/Alert/AlertAvatar.stories.tsx
+++ b/packages/react-components/react-alert/stories/Alert/AlertAvatar.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DismissCircleRegular } from '@fluentui/react-icons';
 
-import { Alert } from '../../index';
+import { Alert } from '@fluentui/react-alert';
 
 export const Avatar = () => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>


### PR DESCRIPTION
## Issue:
- CI pipeline throws an error because of incorrect relative path import of a story after package move. Not caught in PR check because `type-check` on the package is not executed in that pipeline.

Error: https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=270486&view=logs&jobId=258ec178-2d8b-5611-7b9b-60c5c95dae55&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=8250ef03-1890-59ab-a6a8-5d0b4c2baa1b

## Fix:

- Use absolute path import