### PR TITLE
fix(CI): include type-check in lage config to have all packages type checked again

### DIFF
--- a/apps/stress-test/src/shared/react/TestMount.tsx
+++ b/apps/stress-test/src/shared/react/TestMount.tsx
@@ -18,7 +18,7 @@ const debouncedOnRender: DebouncedOnRender = () => {
       clearTimeout(timeoutId);
     }
 
-    timeoutId = setTimeout(() => {
+    timeoutId = (setTimeout(() => {
       requestAnimationFrame(() => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -27,7 +27,7 @@ const debouncedOnRender: DebouncedOnRender = () => {
           end: performance.now(),
         });
       });
-    }, 250);
+    }, 250) as unknown) as number;
   };
 };
 

--- a/apps/stress-test/src/shared/react/TestMount.tsx
+++ b/apps/stress-test/src/shared/react/TestMount.tsx
@@ -18,7 +18,7 @@ const debouncedOnRender: DebouncedOnRender = () => {
       clearTimeout(timeoutId);
     }
 
-    timeoutId = (setTimeout(() => {
+    timeoutId = window.setTimeout(() => {
       requestAnimationFrame(() => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -27,7 +27,7 @@ const debouncedOnRender: DebouncedOnRender = () => {
           end: performance.now(),
         });
       });
-    }, 250) as unknown) as number;
+    }, 250);
   };
 };
 

--- a/lage.config.js
+++ b/lage.config.js
@@ -12,6 +12,8 @@ module.exports = {
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
+    '@fluentui/react-button#type-check': ['@fluentui/a11y-testing#build'],
+    '@fluentui/react-link#type-check': ['@fluentui/a11y-testing#build'],
     '@fluentui/react-18-tests-v8#type-check': ['@fluentui/react#build'],
     '@fluentui/react-migration-v8-v9#type-check': ['@fluentui/react#build'],
     '@fluentui/stress-test#type-check': ['@fluentui/react#build', '@fluentui/web-components#build'],

--- a/lage.config.js
+++ b/lage.config.js
@@ -8,15 +8,10 @@ module.exports = {
     lint: ['build'],
     clean: [],
     test: ['build'],
-    'type-check': [],
+    'type-check': ['build'],
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
-    '@fluentui/react-button#type-check': ['@fluentui/a11y-testing#build'],
-    '@fluentui/react-link#type-check': ['@fluentui/a11y-testing#build'],
-    '@fluentui/react-18-tests-v8#type-check': ['@fluentui/react#build'],
-    '@fluentui/react-migration-v8-v9#type-check': ['@fluentui/react#build'],
-    '@fluentui/stress-test#type-check': ['@fluentui/react#build', '@fluentui/web-components#build'],
   },
 
   // Adds some ADO-specific logging commands for reporting failures

--- a/lage.config.js
+++ b/lage.config.js
@@ -8,6 +8,7 @@ module.exports = {
     lint: ['build'],
     clean: [],
     test: ['build'],
+    'type-check': [],
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],

--- a/lage.config.js
+++ b/lage.config.js
@@ -13,6 +13,7 @@ module.exports = {
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
     '@fluentui/react-18-tests-v8#type-check': ['@fluentui/react#build'],
+    '@fluentui/react-migration-v8-v9#type-check': ['@fluentui/react#build'],
     '@fluentui/stress-test#type-check': ['@fluentui/react#build', '@fluentui/web-components#build'],
   },
 

--- a/lage.config.js
+++ b/lage.config.js
@@ -13,6 +13,7 @@ module.exports = {
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
     '@fluentui/react-18-tests-v8#type-check': ['@fluentui/react#build'],
+    '@fluentui/stress-test#type-check': ['@fluentui/react#build', '@fluentui/web-components#build'],
   },
 
   // Adds some ADO-specific logging commands for reporting failures

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@types/lerna__project": "5.1.0",
     "@types/loader-utils": "2.0.3",
     "@types/markdown-table": "2.0.0",
+    "@types/micromatch": "4.0.2",
     "@types/node": "10.17.55",
     "@types/node-fetch": "2.5.7",
     "@types/prettier": "2.2.3",

--- a/packages/react-components/react-overflow/src/useOverflowContainer.test.ts
+++ b/packages/react-components/react-overflow/src/useOverflowContainer.test.ts
@@ -8,10 +8,12 @@ jest.mock('@fluentui/priority-overflow');
 const mockOverflowManager = (options: Partial<OverflowManager> = {}) => {
   const defaultMock: OverflowManager = {
     addItem: jest.fn(),
+    addOverflowMenu: jest.fn(),
     disconnect: jest.fn(),
     forceUpdate: jest.fn(),
     observe: jest.fn(),
     removeItem: jest.fn(),
+    removeOverflowMenu: jest.fn(),
     update: jest.fn(),
   };
   (createOverflowManager as jest.Mock).mockReturnValue({

--- a/packages/react-migration-v8-v9/src/stories/Stack/index.stories.tsx
+++ b/packages/react-migration-v8-v9/src/stories/Stack/index.stories.tsx
@@ -71,7 +71,7 @@ export const Playground = () => {
   const [paddingToken, setPaddingToken] = React.useState<number | string>('10px');
 
   const onCheckboxChange = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
-    const { name } = ev.target;
+    const { name } = ev?.target as HTMLInputElement;
 
     setState({ ...state, [name]: checked });
   };

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/createBrandVariants/index.stories.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/createBrandVariants/index.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import { createTheme, DefaultPalette } from '@fluentui/react';
+import { DefaultPalette } from '@fluentui/react';
 import { Button, makeStyles, Textarea, TextareaProps, shorthands, RadioGroup, Radio } from '@fluentui/react-components';
-import { createBrandVariants, createV9Theme } from '../../../components/Theme/index';
+import { createBrandVariants } from '../../../components/Theme/index';
 
 import descriptionMd from './Description.md';
 import { Meta } from '@storybook/react';

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/createBrandVariants/index.stories.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/createBrandVariants/index.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { DefaultPalette } from '@fluentui/react';
 import { Button, makeStyles, Textarea, TextareaProps, shorthands, RadioGroup, Radio } from '@fluentui/react-components';
-import { createBrandVariants } from '../../../components/Theme/index';
+import { createBrandVariants } from '../../../components/Theme';
 
 import descriptionMd from './Description.md';
 import { Meta } from '@storybook/react';

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/createBrandVariants/index.stories.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/createBrandVariants/index.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { DefaultPalette } from '@fluentui/react';
 import { Button, makeStyles, Textarea, TextareaProps, shorthands, RadioGroup, Radio } from '@fluentui/react-components';
-import { createBrandVariants } from '../../../components/Theme';
+import { createBrandVariants } from '../../../components/Theme/index';
 
 import descriptionMd from './Description.md';
 import { Meta } from '@storybook/react';

--- a/scripts/exec-sync.js
+++ b/scripts/exec-sync.js
@@ -1,5 +1,4 @@
 // @ts-check
-const path = require('path');
 const child_process = require('child_process');
 const chalk = require('chalk');
 const { logStatus } = require('./logging');

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -1,5 +1,4 @@
 // @ts-check
-const path = require('path');
 const child_process = require('child_process');
 const chalk = require('chalk');
 const { logStatus } = require('./logging');

--- a/scripts/lint-staged/tsconfig.json
+++ b/scripts/lint-staged/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.scripts.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/scripts/tasks/storybook.ts
+++ b/scripts/tasks/storybook.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { findGitRoot } from '../monorepo';
 
 // TODO: this should be replaced with `'@storybook/core-server';` API
-// @ts-expect-error - standalone.js is basically private API/thus doesn't ship types. NOTE: Storybook can be run standalone from Node, although it should be noted this isn't officially supported any more. - https://github.com/storybookjs/storybook/blob/master/lib/core/docs/standalone.md#standalone-mode
+// @ts-ignore- standalone.js is basically private API/thus doesn't ship types. NOTE: Storybook can be run standalone from Node, although it should be noted this isn't officially supported any more. - https://github.com/storybookjs/storybook/blob/master/lib/core/docs/standalone.md#standalone-mode
 import _storybook from '@storybook/react/standalone';
 const storybook: StorybookStandaloneBuildFn = _storybook;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5332,6 +5332,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/braces@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.1.tgz#5a284d193cfc61abb2e5a50d36ebbc50d942a32b"
+  integrity sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -5965,6 +5970,13 @@
   integrity sha512-YwR7OK8aPmaBvMMUi+pZXBNoW2unbVbfok4YRqGMJBe1dpDlzpRkJrYEYmvjxgs5JhuQmKfDexrN98u941Zasg==
   dependencies:
     "@types/unist" "*"
+
+"@types/micromatch@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.2.tgz#ce29c8b166a73bf980a5727b1e4a4d099965151d"
+  integrity sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==
+  dependencies:
+    "@types/braces" "*"
 
 "@types/mime@*":
   version "2.0.1"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Right now, whenever `lage type-check` is ran, only the `react-18-tests-v8` package's `type-check` executes so other packages are not getting proper type checking in local builds or CI. It seems we need to explicitly declare a `type-check` for all packages in the `lage.config` before having one scoped to just a single package to ensure proper type-checking for all packages.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Re-enables type-check of packages in the repo
- Fixes type-check errors that were introduced to master

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #25245
