### PR TITLE
fix: Fixing the styles of Buttons rendered as anchor tags

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Button.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button.stories.tsx
@@ -30,6 +30,11 @@ storiesOf('Button Converged', module)
     includeHighContrast: true,
     includeDarkMode: true,
   })
+  .addStory('As an anchor', () => (
+    <Button id={buttonId} as="a" href="#">
+      Hello, world
+    </Button>
+  ))
   .addStory('Circular', () => (
     <Button id={buttonId} shape="circular">
       Hello, world

--- a/change/@fluentui-react-button-9d40ec0c-0f48-4396-ae0c-330db4a060b9.json
+++ b/change/@fluentui-react-button-9d40ec0c-0f48-4396-ae0c-330db4a060b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing the styles of Buttons rendered as anchor tags.",
+  "packageName": "@fluentui/react-button",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -19,8 +19,10 @@ const useRootStyles = makeStyles({
   // Base styles
   base: {
     alignItems: 'center',
+    boxSizing: 'border-box',
     display: 'inline-flex',
     justifyContent: 'center',
+    textDecorationLine: 'none',
     verticalAlign: 'middle',
 
     ...shorthands.margin(0),


### PR DESCRIPTION
## Previous Behavior

`Buttons` had some different styles when rendered as `anchor` tags than when rendered as `button` tags:

![image](https://user-images.githubusercontent.com/7798177/195951602-e0c24e22-0b53-4056-9ce6-5805faed4d1f.png)

## New Behavior

`Buttons` now have the same styles whether they're rendered as `anchor` tags or `button` tags:

![image](https://user-images.githubusercontent.com/7798177/195951694-cf82d61d-7dc9-4cb9-ba02-f450b4fc6140.png)

This PR also adds a vr test to catch this kind of inconsistencies in the future.

## Related Issue(s)

Fixes #23849
