### PR TITLE
Pass onRenderItem to onRenderContainer in the Dropdown component

### DIFF
--- a/change/@fluentui-react-18b72fa6-4c4e-4585-b65c-925cc6f1639f.json
+++ b/change/@fluentui-react-18b72fa6-4c4e-4585-b65c-925cc6f1639f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass onRenderItem to Dropdown's onRenderContainer to allow use of onRenderList with default or custom onRenderItem",
+  "packageName": "@fluentui/react",
+  "email": "aepshtein@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -316,6 +316,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       onRenderContainer = this._onRenderContainer,
       onRenderCaretDown = this._onRenderCaretDown,
       onRenderLabel = this._onRenderLabel,
+      onRenderItem = this._onRenderItem,
       hoisted: { selectedIndices },
     } = props;
     const { isOpen, calloutRenderEdge, hasFocus } = this.state;
@@ -397,7 +398,15 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
           </span>
           <span className={this._classNames.caretDownWrapper}>{onRenderCaretDown(props, this._onRenderCaretDown)}</span>
         </div>
-        {isOpen && onRenderContainer({ ...props, onDismiss: this._onDismiss }, this._onRenderContainer)}
+        {isOpen &&
+          onRenderContainer(
+            {
+              ...props,
+              onDismiss: this._onDismiss,
+              onRenderItem,
+            },
+            this._onRenderContainer,
+          )}
         {hasErrorMessage && (
           <div role="alert" id={errorMessageId} className={this._classNames.errorMessage}>
             {errorMessage}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ x ] Code is up-to-date with the `master` branch
* [ x ] Your changes are covered by tests (if possible)
* [ x ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When attempting to use onRenderList with Dropdown, it is impossible to invoke onRenderItem from the props as it's not set. This was handled in ComboBox in a similar fashion but hasn't happened in Dropdown yet.

## New Behavior

onRenderItem (default or custom, if set) is passed onRenderContainer, so now it is possible to invoke it through props for both onRenderList and onRenderContainer, similar to what is done in ComboBox.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12919, #3050
