### PR TITLE
fix: color for selected items in toolbar

### DIFF
--- a/change/@fluentui-react-toolbar-646c7c94-50c8-4258-a8a9-351b877b0cd4.json
+++ b/change/@fluentui-react-toolbar-646c7c94-50c8-4258-a8a9-351b877b0cd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: typo",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "chassunc@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/ToolbarToggleButton.tsx
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/ToolbarToggleButton.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import type { ToolbarToggleButtonProps } from './ToolbarToggleButton.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { renderToggleButton_unstable, useToggleButtonStyles_unstable } from '@fluentui/react-button';
+import { renderToggleButton_unstable } from '@fluentui/react-button';
 import { useToolbarToggleButton_unstable } from './useToolbarToggleButton';
+import { useToolbarToggleButtonStyles_unstable } from './useToolbarToggleButtonStyles';
 
 /**
  * ToolbarToggleButton component
@@ -10,7 +11,7 @@ import { useToolbarToggleButton_unstable } from './useToolbarToggleButton';
 export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps> = React.forwardRef((props, ref) => {
   const state = useToolbarToggleButton_unstable(props, ref);
 
-  useToggleButtonStyles_unstable(state);
+  useToolbarToggleButtonStyles_unstable(state);
   return renderToggleButton_unstable(state);
 }) as ForwardRefComponent<ToolbarToggleButtonProps>;
 

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.ts
@@ -1,0 +1,20 @@
+import { tokens } from '@fluentui/react-theme';
+import { makeStyles, mergeClasses } from '@griffel/react';
+import { useToggleButtonStyles_unstable } from '@fluentui/react-button';
+import { ToolbarToggleButtonState } from './ToolbarToggleButton.types';
+
+const useBaseStyles = makeStyles({
+  selected: {
+    color: tokens.colorBrandForeground1,
+  },
+});
+
+/**
+ * Apply styling to the ToolbarRadio slots based on the state
+ */
+export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButtonState) => {
+  useToggleButtonStyles_unstable(state);
+  const toggleButtonStyles = useBaseStyles();
+
+  state.root.className = mergeClasses(state.root.className, state.checked && toggleButtonStyles.selected);
+};

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.ts
@@ -10,7 +10,7 @@ const useBaseStyles = makeStyles({
 });
 
 /**
- * Apply styling to the ToolbarRadio slots based on the state
+ * Apply styling to the ToolbarToggleButton slots based on the state
  */
 export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButtonState) => {
   useToggleButtonStyles_unstable(state);


### PR DESCRIPTION
# Overview

Fix: #25157 

Update color for `ToolbarToggleButton` to match design spec when item is selected.
