### PR TITLE
bugfix: adds cursor pointer style to dialog close button

### DIFF
--- a/change/@fluentui-react-dialog-e8675348-6694-4ef1-a767-6c6298ea4515.json
+++ b/change/@fluentui-react-dialog-e8675348-6694-4ef1-a767-6c6298ea4515.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: adds cursor pointer style to dialog close button",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitleStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitleStyles.ts
@@ -38,6 +38,7 @@ export const useDialogTitleInternalStyles = makeStyles({
     color: 'inherit',
     fontFamily: 'inherit',
     fontSize: 'inherit',
+    cursor: 'pointer',
     lineHeight: 0,
     ...shorthands.overflow('visible'),
     ...shorthands.padding(0),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

When hovering over close button in "Non Modal" example, the mouse cursor doesn't change to the typical 'pointer' cursor

## New Behavior

When hovering over the close button, the mouse cursor is a 'pointer' 
![image](https://user-images.githubusercontent.com/1434956/194579192-94868c20-bfd8-4cb5-aec7-3e55f65adcc5.png)

## Related Issue(s)

Fixes #25131
