### PR TITLE
fix(react-card): fix import path of asset file

### DIFF
--- a/packages/react-components/react-card/stories/Card/CardOrientation.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardOrientation.stories.tsx
@@ -3,7 +3,7 @@ import { makeStyles, shorthands, Avatar, Body1, Button, Caption1 } from '@fluent
 import { MoreHorizontal24Regular } from '@fluentui/react-icons';
 import { Card, CardHeader, CardPreview } from '@fluentui/react-card';
 import { SampleCard, Title } from './SampleCard.stories';
-import Logo from '../../../assets/logo.svg';
+import Logo from '../assets/logo.svg';
 
 const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
 const avatarElviaURL = ASSET_URL + '/stories/assets/avatar_elvia.svg';

--- a/packages/react-components/react-card/stories/Card/CardTemplates.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardTemplates.stories.tsx
@@ -34,7 +34,7 @@ import office2 from '../assets/office2.png';
 import avatarColin from '../assets/avatar_colin.svg';
 
 const ASSET_URL = 'https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card';
-const powerpointLogoURL = ASSET_URL + '/assets/powerpoint_logo.svg';
+const powerpointLogoURL = ASSET_URL + '/stories/assets/powerpoint_logo.svg';
 
 const useStyles = makeStyles({
   mainContainer: {


### PR DESCRIPTION
Follow up to #25229

Fixes issue introduced by latest commit to master: https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=270905&view=logs&jobId=be0e6c0b-16d6-5408-4b39-461952619dc9&j=be0e6c0b-16d6-5408-4b39-461952619dc9&t=91e838fc-b8f7-564c-c417-9130335111f3