### PR TITLE
stress-test: add ability to target any url

### DIFF
--- a/apps/stress-test/scripts/commands/buildTestConfig.ts
+++ b/apps/stress-test/scripts/commands/buildTestConfig.ts
@@ -53,8 +53,15 @@ const buildTestConfig: BuildTestConfig = options => {
   return configs;
 };
 
+const getUrl = (target: string, port: number): string => {
+  if (target.startsWith('http')) {
+    return target;
+  }
+
+  return `http://localhost:${port}/${target}`;
+};
+
 const makeConfigJson: MakeConfigJson = (_scenario, browser, testCase, sampleSize, targets, size, testOptions, port) => {
-  const baseUrl = `http://localhost:${port}`;
   const json = {
     $schema: 'https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json',
     sampleSize,
@@ -84,7 +91,7 @@ const makeConfigJson: MakeConfigJson = (_scenario, browser, testCase, sampleSize
 
           return {
             name: `${target} - ${testCase} - ${size}`,
-            url: `${baseUrl}/${targetWithoutParams}/?${params}`,
+            url: `${getUrl(targetWithoutParams, port)}/?${params}`,
           };
         }),
       },


### PR DESCRIPTION
## Current Behavior

Only pages built by the stress test app can be tested.

## New Behavior

Any page can be tested by passing at target that starts with `http`.
