### PR TITLE
spinbutton: update internal padding for small size

### DIFF
--- a/change/@fluentui-react-spinbutton-76d708a4-ab34-43c6-a831-8aca052df11b.json
+++ b/change/@fluentui-react-spinbutton-76d708a4-ab34-43c6-a831-8aca052df11b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: updates internal SpinButton padding",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -260,7 +260,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         ref,
         autoComplete: 'off',
         role: 'spinbutton',
-        appearance: appearance,
+        appearance,
         type: 'text',
         ...nativeProps.primary,
       },

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -64,7 +64,7 @@ const useRootStyles = makeStyles({
     paddingLeft: tokens.spacingHorizontalS,
   },
 
-  // intentially empty
+  // intentionally empty
   medium: {},
 
   outline: {

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -208,7 +208,7 @@ const useButtonStyles = makeStyles({
   // Padding values numbers don't align with design specs
   // but visually the padding aligns.
   // The icons are set in a 16x16px square but the artwork is inset from that
-  // so I've had to compute the numbers by handle.
+  // so these padding values are computed by hand.
   // Additionally the design uses fractional values so these are
   // rounded to the nearest integer.
   incrementButtonSmall: {

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -170,6 +170,18 @@ const useInputStyles = makeStyles({
     outlineStyle: 'none',
     ...shorthands.padding(0),
   },
+
+  small: {
+    // Originally the small padding was 6px but the design was
+    // updated to 8px to align with other small inputs.
+    // This negative margin is applied so the external size
+    // of the small SpinButton is not changed (i.e., this change
+    // won't affect anyone's page layout).
+    marginRight: '-2px',
+  },
+
+  // intentionally empty
+  medium: {},
 });
 
 const useButtonStyles = makeStyles({
@@ -477,7 +489,12 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     state.decrementButton.className,
   );
 
-  state.input.className = mergeClasses(spinButtonClassNames.input, state.input.className, inputStyles.base);
+  state.input.className = mergeClasses(
+    spinButtonClassNames.input,
+    state.input.className,
+    inputStyles.base,
+    inputStyles[size],
+  );
 
   return state;
 };

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -170,18 +170,6 @@ const useInputStyles = makeStyles({
     outlineStyle: 'none',
     ...shorthands.padding(0),
   },
-
-  small: {
-    // Originally the small padding was 6px but the design was
-    // updated to 8px to align with other small inputs.
-    // This negative margin is applied so the external size
-    // of the small SpinButton is not changed (i.e., this change
-    // won't affect anyone's page layout).
-    marginRight: '-2px',
-  },
-
-  // intentionally empty
-  medium: {},
 });
 
 const useButtonStyles = makeStyles({
@@ -489,12 +477,7 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     state.decrementButton.className,
   );
 
-  state.input.className = mergeClasses(
-    spinButtonClassNames.input,
-    state.input.className,
-    inputStyles.base,
-    inputStyles[size],
-  );
+  state.input.className = mergeClasses(spinButtonClassNames.input, state.input.className, inputStyles.base);
 
   return state;
 };

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButtonStyles.ts
@@ -60,6 +60,13 @@ const useRootStyles = makeStyles({
     },
   },
 
+  small: {
+    paddingLeft: tokens.spacingHorizontalS,
+  },
+
+  // intentially empty
+  medium: {},
+
   outline: {
     '::before': {
       ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
@@ -198,15 +205,14 @@ const useButtonStyles = makeStyles({
     ...shorthands.borderRadius(0, tokens.borderRadiusMedium, 0, 0),
   },
 
-  // TODO: revisit these padding numbers for aligning the icon.
-  // Padding values aren't perfect.
-  // The icon doesn't align perfectly with the Figma designs.
-  // It's set in a 16x16px square but the artwork is inset from that
+  // Padding values numbers don't align with design specs
+  // but visually the padding aligns.
+  // The icons are set in a 16x16px square but the artwork is inset from that
   // so I've had to compute the numbers by handle.
   // Additionally the design uses fractional values so these are
   // rounded to the nearest integer.
   incrementButtonSmall: {
-    ...shorthands.padding('3px', '5px', '0px', '5px'),
+    ...shorthands.padding('3px', '6px', '0px', '4px'),
   },
 
   incrementButtonMedium: {
@@ -222,7 +228,7 @@ const useButtonStyles = makeStyles({
   },
 
   decrementButtonSmall: {
-    ...shorthands.padding('0px', '5px', '3px', '5px'),
+    ...shorthands.padding('0px', '6px', '3px', '4px'),
   },
 
   decrementButtonMedium: {
@@ -433,6 +439,7 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     state.root.className, // Get the classes from useInputStyles_unstable
     spinButtonClassNames.root,
     rootStyles.base,
+    rootStyles[size],
     appearance === 'outline' && rootStyles.outline,
     appearance === 'underline' && rootStyles.underline,
     filled && rootStyles.filled,


### PR DESCRIPTION
## Current Behavior

Internal SpinButton padding at "small" size does not align with other small input controls.

## New Behavior

Internal SpinButton padding at "small" size aligns with other small input controls.

## Related Issue(s)

Fixes #24516
