### PR TITLE
fix: Fix Button example styles by improving their layout

### DIFF
--- a/packages/react-components/react-button/src/stories/Button/ButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonAppearance.stories.tsx
@@ -1,15 +1,27 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-components';
+import { makeStyles, Button } from '@fluentui/react-components';
 
-export const Appearance = () => (
-  <>
-    <Button>Default</Button>
-    <Button appearance="primary">Primary</Button>
-    <Button appearance="outline">Outline</Button>
-    <Button appearance="subtle">Subtle</Button>
-    <Button appearance="transparent">Transparent</Button>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Appearance = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <Button>Default</Button>
+      <Button appearance="primary">Primary</Button>
+      <Button appearance="outline">Outline</Button>
+      <Button appearance="subtle">Subtle</Button>
+      <Button appearance="transparent">Transparent</Button>
+    </div>
+  );
+};
+
 Appearance.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/Button/ButtonDefault.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonDefault.stories.tsx
@@ -2,6 +2,4 @@ import * as React from 'react';
 import { Button } from '@fluentui/react-components';
 import type { ButtonProps } from '@fluentui/react-components';
 
-export const Default = (props: ButtonProps) => {
-  return <Button {...props}>Example</Button>;
-};
+export const Default = (props: ButtonProps) => <Button {...props}>Example</Button>;

--- a/packages/react-components/react-button/src/stories/Button/ButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonDisabled.stories.tsx
@@ -1,17 +1,29 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-components';
+import { makeStyles, Button } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  innerWrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+  outerWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '15px',
+  },
+});
 
 export const Disabled = () => {
-  const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };
+  const styles = useStyles();
 
   return (
-    <>
-      <div style={groupStyles}>
+    <div className={styles.outerWrapper}>
+      <div className={styles.innerWrapper}>
         <Button>Enabled state</Button>
         <Button disabled>Disabled state</Button>
         <Button disabledFocusable>Disabled focusable state</Button>
       </div>
-      <div style={groupStyles}>
+      <div className={styles.innerWrapper}>
         <Button appearance="primary">Enabled state</Button>
         <Button appearance="primary" disabled>
           Disabled state
@@ -20,7 +32,7 @@ export const Disabled = () => {
           Disabled focusable state
         </Button>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/Button/ButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonIcon.stories.tsx
@@ -1,20 +1,32 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Button, Tooltip } from '@fluentui/react-components';
+import { makeStyles, Button, Tooltip } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
-export const Icon = () => (
-  <>
-    <Button icon={<CalendarMonth />}>With calendar icon before contents</Button>
-    <Button icon={<CalendarMonth />} iconPosition="after">
-      With calendar icon after contents
-    </Button>
-    <Tooltip content="With calendar icon only" relationship="label">
-      <Button icon={<CalendarMonth />} />
-    </Tooltip>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Icon = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <Button icon={<CalendarMonth />}>With calendar icon before contents</Button>
+      <Button icon={<CalendarMonth />} iconPosition="after">
+        With calendar icon after contents
+      </Button>
+      <Tooltip content="With calendar icon only" relationship="label">
+        <Button icon={<CalendarMonth />} />
+      </Tooltip>
+    </div>
+  );
+};
+
 Icon.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/Button/ButtonShape.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonShape.stories.tsx
@@ -1,13 +1,23 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-components';
+import { makeStyles, Button } from '@fluentui/react-components';
 
-export const Shape = () => (
-  <>
-    <Button>Rounded</Button>
-    <Button shape="circular">Circular</Button>
-    <Button shape="square">Square</Button>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Shape = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.wrapper}>
+      <Button>Rounded</Button>
+      <Button shape="circular">Circular</Button>
+      <Button shape="square">Square</Button>
+    </div>
+  );
+};
 
 Shape.parameters = {
   docs: {

--- a/packages/react-components/react-button/src/stories/Button/ButtonSize.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonSize.stories.tsx
@@ -1,17 +1,27 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Button, Tooltip } from '@fluentui/react-components';
+import { makeStyles, Button, Tooltip } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  innerWrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+  outerWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '15px',
+  },
+});
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 export const Size = () => {
-  const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };
-  const headerStyles: React.CSSProperties = { width: '100%', margin: 0 };
+  const styles = useStyles();
 
   return (
-    <>
-      <div style={groupStyles}>
-        <h4 style={headerStyles}>small</h4>
+    <div className={styles.outerWrapper}>
+      <div className={styles.innerWrapper}>
         <Button size="small">Small</Button>
         <Button size="small" icon={<CalendarMonth />}>
           Small with calendar icon
@@ -20,16 +30,14 @@ export const Size = () => {
           <Button size="small" icon={<CalendarMonth />} />
         </Tooltip>
       </div>
-      <div style={groupStyles}>
-        <h4 style={headerStyles}>medium</h4>
+      <div className={styles.innerWrapper}>
         <Button>Medium</Button>
         <Button icon={<CalendarMonth />}>Medium with calendar icon</Button>
         <Tooltip content="Medium with calendar icon only" relationship="label">
           <Button icon={<CalendarMonth />} />
         </Tooltip>
       </div>
-      <div style={groupStyles}>
-        <h4 style={headerStyles}>large</h4>
+      <div className={styles.innerWrapper}>
         <Button size="large">Large</Button>
         <Button size="large" icon={<CalendarMonth />}>
           Large with calendar icon
@@ -38,7 +46,7 @@ export const Size = () => {
           <Button size="large" icon={<CalendarMonth />} />
         </Tooltip>
       </div>
-    </>
+    </div>
   );
 };
 Size.parameters = {

--- a/packages/react-components/react-button/src/stories/Button/ButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/ButtonWithLongText.stories.tsx
@@ -5,16 +5,21 @@ const useStyles = makeStyles({
   longText: {
     width: '280px',
   },
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
 });
 
 export const WithLongText = () => {
   const styles = useStyles();
 
   return (
-    <>
+    <div className={styles.wrapper}>
       <Button>Short text</Button>
       <Button className={styles.longText}>Long text wraps after it hits the max width of the component</Button>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/Button/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { Button } from '@fluentui/react-components';
 import descriptionMd from './ButtonDescription.md';

--- a/packages/react-components/react-button/src/stories/Button/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/Button/index.stories.tsx
@@ -22,11 +22,4 @@ export default {
       },
     },
   },
-  decorators: [
-    Story => (
-      <div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
-        <Story />
-      </div>
-    ),
-  ],
 } as Meta;

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
@@ -1,23 +1,35 @@
 import * as React from 'react';
-import { CompoundButton } from '@fluentui/react-components';
+import { makeStyles, CompoundButton } from '@fluentui/react-components';
 
-export const Appearance = () => (
-  <>
-    <CompoundButton secondaryContent="Secondary content">Default</CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" appearance="primary">
-      Primary
-    </CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" appearance="outline">
-      Outline
-    </CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" appearance="subtle">
-      Subtle
-    </CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" appearance="transparent">
-      Transparent
-    </CompoundButton>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Appearance = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <CompoundButton secondaryContent="Secondary content">Default</CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" appearance="primary">
+        Primary
+      </CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" appearance="outline">
+        Outline
+      </CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" appearance="subtle">
+        Subtle
+      </CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" appearance="transparent">
+        Transparent
+      </CompoundButton>
+    </div>
+  );
+};
+
 Appearance.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonDefault.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonDefault.stories.tsx
@@ -5,10 +5,8 @@ import type { CompoundButtonProps } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
-export const Default = (props: CompoundButtonProps) => {
-  return (
-    <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" {...props}>
-      Example
-    </CompoundButton>
-  );
-};
+export const Default = (props: CompoundButtonProps) => (
+  <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" {...props}>
+    Example
+  </CompoundButton>
+);

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonDisabled.stories.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
-import { CompoundButton } from '@fluentui/react-components';
+import { makeStyles, CompoundButton } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  innerWrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+  outerWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '15px',
+  },
+});
 
 export const Disabled = () => {
-  const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };
+  const styles = useStyles();
 
   return (
-    <>
-      <div style={groupStyles}>
+    <div className={styles.outerWrapper}>
+      <div className={styles.innerWrapper}>
         <CompoundButton secondaryContent="Secondary content">Enabled state</CompoundButton>
         <CompoundButton disabled secondaryContent="Secondary content">
           Disabled state
@@ -15,7 +27,7 @@ export const Disabled = () => {
           Disabled focusable state
         </CompoundButton>
       </div>
-      <div style={groupStyles}>
+      <div className={styles.innerWrapper}>
         <CompoundButton appearance="primary" secondaryContent="Secondary content">
           Enabled state
         </CompoundButton>
@@ -26,7 +38,7 @@ export const Disabled = () => {
           Disabled focusable state
         </CompoundButton>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonIcon.stories.tsx
@@ -1,22 +1,35 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { CompoundButton, Tooltip } from '@fluentui/react-components';
+import { makeStyles, CompoundButton, Tooltip } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
-export const Icon = () => (
-  <>
-    <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonth />}>
-      With calendar icon before contents
-    </CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonth />} iconPosition="after">
-      With calendar icon after contents
-    </CompoundButton>
-    <Tooltip content="With calendar icon only" relationship="label">
-      <CompoundButton icon={<CalendarMonth />} />
-    </Tooltip>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Icon = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonth />}>
+        With calendar icon before contents
+      </CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonth />} iconPosition="after">
+        With calendar icon after contents
+      </CompoundButton>
+      <Tooltip content="With calendar icon only" relationship="label">
+        <CompoundButton icon={<CalendarMonth />} />
+      </Tooltip>
+    </div>
+  );
+};
+
 Icon.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonShape.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonShape.stories.tsx
@@ -1,17 +1,28 @@
 import * as React from 'react';
-import { CompoundButton } from '@fluentui/react-components';
+import { makeStyles, CompoundButton } from '@fluentui/react-components';
 
-export const Shape = () => (
-  <>
-    <CompoundButton secondaryContent="Secondary content">Rounded</CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" shape="circular">
-      Circular
-    </CompoundButton>
-    <CompoundButton secondaryContent="Secondary content" shape="square">
-      Square
-    </CompoundButton>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Shape = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <CompoundButton secondaryContent="Secondary content">Rounded</CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" shape="circular">
+        Circular
+      </CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" shape="square">
+        Square
+      </CompoundButton>
+    </div>
+  );
+};
 
 Shape.parameters = {
   docs: {

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonSize.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonSize.stories.tsx
@@ -1,12 +1,22 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { CompoundButton } from '@fluentui/react-components';
+import { makeStyles, CompoundButton } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
+const useStyles = makeStyles({
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const Size = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" size="small">
         Size: small
       </CompoundButton>
@@ -16,7 +26,7 @@ export const Size = () => {
       <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" size="large">
         Size: large
       </CompoundButton>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/CompoundButtonWithLongText.stories.tsx
@@ -2,8 +2,13 @@ import * as React from 'react';
 import { makeStyles, CompoundButton } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
-  maxWidth: {
-    maxWidth: '280px',
+  longText: {
+    width: '280px',
+  },
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
   },
 });
 
@@ -11,16 +16,15 @@ export const WithLongText = () => {
   const styles = useStyles();
 
   return (
-    <>
-      <CompoundButton className={styles.maxWidth} secondaryContent="Secondary content">
-        Short text
-      </CompoundButton>
-      <CompoundButton className={styles.maxWidth} secondaryContent="Secondary content">
+    <div className={styles.wrapper}>
+      <CompoundButton secondaryContent="Secondary content">Short text</CompoundButton>
+      <CompoundButton className={styles.longText} secondaryContent="Secondary content">
         Long text wraps after it hits the max width of the component
       </CompoundButton>
-    </>
+    </div>
   );
 };
+
 WithLongText.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/CompoundButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { CompoundButton } from '@fluentui/react-components';
 import descriptionMd from './CompoundButtonDescription.md';

--- a/packages/react-components/react-button/src/stories/CompoundButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/CompoundButton/index.stories.tsx
@@ -22,11 +22,4 @@ export default {
       },
     },
   },
-  decorators: [
-    Story => (
-      <div style={{ display: 'flex', gap: '1em', flexFlow: 'wrap', justifyContent: 'space-evenly' }}>
-        <Story />
-      </div>
-    ),
-  ],
 } as Meta;

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonAppearance.stories.tsx
@@ -1,74 +1,86 @@
 import * as React from 'react';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+import { makeStyles, Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
 
-export const Appearance = () => (
-  <>
-    <Menu>
-      <MenuTrigger>
-        <MenuButton>Default</MenuButton>
-      </MenuTrigger>
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+export const Appearance = () => {
+  const styles = useStyles();
 
-    <Menu>
-      <MenuTrigger>
-        <MenuButton appearance="primary">Primary</MenuButton>
-      </MenuTrigger>
+  return (
+    <div className={styles.wrapper}>
+      <Menu>
+        <MenuTrigger>
+          <MenuButton>Default</MenuButton>
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu>
-      <MenuTrigger>
-        <MenuButton appearance="outline">Outline</MenuButton>
-      </MenuTrigger>
+      <Menu>
+        <MenuTrigger>
+          <MenuButton appearance="primary">Primary</MenuButton>
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu>
-      <MenuTrigger>
-        <MenuButton appearance="subtle">Subtle</MenuButton>
-      </MenuTrigger>
+      <Menu>
+        <MenuTrigger>
+          <MenuButton appearance="outline">Outline</MenuButton>
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu>
-      <MenuTrigger>
-        <MenuButton appearance="transparent">Transparent</MenuButton>
-      </MenuTrigger>
+      <Menu>
+        <MenuTrigger>
+          <MenuButton appearance="subtle">Subtle</MenuButton>
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  </>
-);
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+
+      <Menu>
+        <MenuTrigger>
+          <MenuButton appearance="transparent">Transparent</MenuButton>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </div>
+  );
+};
+
 Appearance.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonDefault.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonDefault.stories.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
 import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
 
-export const Default = () => {
-  return (
-    <Menu>
-      <MenuTrigger>
-        <MenuButton>Example</MenuButton>
-      </MenuTrigger>
+export const Default = () => (
+  <Menu>
+    <MenuTrigger>
+      <MenuButton>Example</MenuButton>
+    </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  );
-};
+    <MenuPopover>
+      <MenuList>
+        <MenuItem>Item a</MenuItem>
+        <MenuItem>Item b</MenuItem>
+      </MenuList>
+    </MenuPopover>
+  </Menu>
+);

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonDisabled.stories.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+import { makeStyles, Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const Disabled = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton>Enabled state</MenuButton>
@@ -40,7 +49,7 @@ export const Disabled = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonIcon.stories.tsx
@@ -6,14 +6,32 @@ import {
   FilterFilled,
   FilterRegular,
 } from '@fluentui/react-icons';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Tooltip,
+} from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 const Filter = bundleIcon(FilterFilled, FilterRegular);
 
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const Icon = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton icon={<CalendarMonth />}>With calendar icon</MenuButton>
@@ -53,9 +71,10 @@ export const Icon = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
+
 Icon.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonShape.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonShape.stories.tsx
@@ -1,48 +1,59 @@
 import * as React from 'react';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+import { makeStyles, Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
 
-export const Shape = () => (
-  <>
-    <Menu>
-      <MenuTrigger>
-        <MenuButton>Rounded</MenuButton>
-      </MenuTrigger>
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+export const Shape = () => {
+  const styles = useStyles();
 
-    <Menu>
-      <MenuTrigger>
-        <MenuButton shape="circular">Circular</MenuButton>
-      </MenuTrigger>
+  return (
+    <div className={styles.wrapper}>
+      <Menu>
+        <MenuTrigger>
+          <MenuButton>Rounded</MenuButton>
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu>
-      <MenuTrigger>
-        <MenuButton shape="square">Square</MenuButton>
-      </MenuTrigger>
+      <Menu>
+        <MenuTrigger>
+          <MenuButton shape="circular">Circular</MenuButton>
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  </>
-);
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+
+      <Menu>
+        <MenuTrigger>
+          <MenuButton shape="square">Square</MenuButton>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </div>
+  );
+};
 
 Shape.parameters = {
   docs: {

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSize.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSize.stories.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+import { makeStyles, Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const Size = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton size="small">Size: small</MenuButton>
@@ -42,7 +52,7 @@ export const Size = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSizeLarge.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSizeLarge.stories.tsx
@@ -1,12 +1,30 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Tooltip,
+} from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const SizeLarge = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton size="large">Large</MenuButton>
@@ -49,7 +67,7 @@ export const SizeLarge = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSizeMedium.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSizeMedium.stories.tsx
@@ -1,12 +1,30 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Tooltip,
+} from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const SizeMedium = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton size="medium">Medium</MenuButton>
@@ -49,7 +67,7 @@ export const SizeMedium = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonSizeSmall.stories.tsx
@@ -1,12 +1,30 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Menu, MenuButton, MenuItem, MenuList, MenuPopover, MenuTrigger, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Tooltip,
+} from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const SizeSmall = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton size="small">Small</MenuButton>
@@ -49,7 +67,7 @@ export const SizeSmall = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/MenuButton/MenuButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/MenuButtonWithLongText.stories.tsx
@@ -5,13 +5,18 @@ const useStyles = makeStyles({
   longText: {
     width: '280px',
   },
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
 });
 
 export const WithLongText = () => {
   const styles = useStyles();
 
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger>
           <MenuButton>Short text</MenuButton>
@@ -39,7 +44,7 @@ export const WithLongText = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/MenuButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/index.stories.tsx
@@ -25,11 +25,4 @@ export default {
       },
     },
   },
-  decorators: [
-    Story => (
-      <div style={{ display: 'flex', gap: '1em', flexFlow: 'wrap', justifyContent: 'space-evenly' }}>
-        <Story />
-      </div>
-    ),
-  ],
 } as Meta;

--- a/packages/react-components/react-button/src/stories/MenuButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/MenuButton/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { MenuButton } from '@fluentui/react-components';
 import descriptionMd from './MenuButtonDescription.md';

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonAppearance.stories.tsx
@@ -1,91 +1,111 @@
 import * as React from 'react';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
-export const Appearance = () => (
-  <>
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Default</SplitButton>}
-      </MenuTrigger>
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+export const Appearance = () => {
+  const styles = useStyles();
 
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => (
-          <SplitButton menuButton={triggerProps} appearance="primary">
-            Primary
-          </SplitButton>
-        )}
-      </MenuTrigger>
+  return (
+    <div className={styles.wrapper}>
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Default</SplitButton>}
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => (
-          <SplitButton menuButton={triggerProps} appearance="outline">
-            Outline
-          </SplitButton>
-        )}
-      </MenuTrigger>
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton menuButton={triggerProps} appearance="primary">
+              Primary
+            </SplitButton>
+          )}
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => (
-          <SplitButton menuButton={triggerProps} appearance="subtle">
-            Subtle
-          </SplitButton>
-        )}
-      </MenuTrigger>
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton menuButton={triggerProps} appearance="outline">
+              Outline
+            </SplitButton>
+          )}
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => (
-          <SplitButton menuButton={triggerProps} appearance="transparent">
-            Transparent
-          </SplitButton>
-        )}
-      </MenuTrigger>
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton menuButton={triggerProps} appearance="subtle">
+              Subtle
+            </SplitButton>
+          )}
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  </>
-);
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton menuButton={triggerProps} appearance="transparent">
+              Transparent
+            </SplitButton>
+          )}
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </div>
+  );
+};
+
 Appearance.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonDefault.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonDefault.stories.tsx
@@ -2,19 +2,17 @@ import * as React from 'react';
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton } from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
-export const Default = () => {
-  return (
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Example</SplitButton>}
-      </MenuTrigger>
+export const Default = () => (
+  <Menu positioning="below-end">
+    <MenuTrigger>
+      {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Example</SplitButton>}
+    </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  );
-};
+    <MenuPopover>
+      <MenuList>
+        <MenuItem>Item a</MenuItem>
+        <MenuItem>Item b</MenuItem>
+      </MenuList>
+    </MenuPopover>
+  </Menu>
+);

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonDisabled.stories.tsx
@@ -1,10 +1,27 @@
 import * as React from 'react';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const Disabled = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Enabled state</SplitButton>}
@@ -49,7 +66,7 @@ export const Disabled = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonIcon.stories.tsx
@@ -6,19 +6,37 @@ import {
   FilterFilled,
   FilterRegular,
 } from '@fluentui/react-icons';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+  Tooltip,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 const Filter = bundleIcon(FilterFilled, FilterRegular);
+
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const Icon = () => {
   const [primaryActionButtonRef, setPrimaryActionButtonRef] = React.useState<
     HTMLButtonElement | HTMLAnchorElement | null
   >(null);
 
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
@@ -90,7 +108,7 @@ export const Icon = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonShape.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonShape.stories.tsx
@@ -1,57 +1,76 @@
 import * as React from 'react';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
-export const Shape = () => (
-  <>
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Rounded</SplitButton>}
-      </MenuTrigger>
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+export const Shape = () => {
+  const styles = useStyles();
 
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => (
-          <SplitButton menuButton={triggerProps} shape="circular">
-            Circular
-          </SplitButton>
-        )}
-      </MenuTrigger>
+  return (
+    <div className={styles.wrapper}>
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Rounded</SplitButton>}
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
 
-    <Menu positioning="below-end">
-      <MenuTrigger>
-        {(triggerProps: MenuButtonProps) => (
-          <SplitButton menuButton={triggerProps} shape="square">
-            Square
-          </SplitButton>
-        )}
-      </MenuTrigger>
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton menuButton={triggerProps} shape="circular">
+              Circular
+            </SplitButton>
+          )}
+        </MenuTrigger>
 
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>Item a</MenuItem>
-          <MenuItem>Item b</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  </>
-);
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+
+      <Menu positioning="below-end">
+        <MenuTrigger>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton menuButton={triggerProps} shape="square">
+              Square
+            </SplitButton>
+          )}
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item a</MenuItem>
+            <MenuItem>Item b</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </div>
+  );
+};
 
 Shape.parameters = {
   docs: {

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSize.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSize.stories.tsx
@@ -1,10 +1,28 @@
 import * as React from 'react';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
+const useStyles = makeStyles({
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
 export const Size = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
@@ -55,7 +73,7 @@ export const Size = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSizeLarge.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSizeLarge.stories.tsx
@@ -1,17 +1,35 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+  Tooltip,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const SizeLarge = () => {
   const [primaryActionButtonRef, setPrimaryActionButtonRef] = React.useState<
     HTMLButtonElement | HTMLAnchorElement | null
   >(null);
 
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
@@ -71,7 +89,7 @@ export const SizeLarge = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSizeMedium.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSizeMedium.stories.tsx
@@ -1,17 +1,35 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+  Tooltip,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const SizeMedium = () => {
   const [primaryActionButtonRef, setPrimaryActionButtonRef] = React.useState<
     HTMLButtonElement | HTMLAnchorElement | null
   >(null);
 
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
@@ -71,7 +89,7 @@ export const SizeMedium = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonSizeSmall.stories.tsx
@@ -1,17 +1,35 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, SplitButton, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  SplitButton,
+  Tooltip,
+} from '@fluentui/react-components';
 import type { MenuButtonProps } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const SizeSmall = () => {
   const [primaryActionButtonRef, setPrimaryActionButtonRef] = React.useState<
     HTMLButtonElement | HTMLAnchorElement | null
   >(null);
 
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => (
@@ -71,7 +89,7 @@ export const SizeSmall = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/SplitButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/SplitButtonWithLongText.stories.tsx
@@ -14,13 +14,18 @@ const useStyles = makeStyles({
   longText: {
     width: '280px',
   },
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
 });
 
 export const WithLongText = () => {
   const styles = useStyles();
 
   return (
-    <>
+    <div className={styles.wrapper}>
       <Menu positioning="below-end">
         <MenuTrigger>
           {(triggerProps: MenuButtonProps) => <SplitButton menuButton={triggerProps}>Short text</SplitButton>}
@@ -50,7 +55,7 @@ export const WithLongText = () => {
           </MenuList>
         </MenuPopover>
       </Menu>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/SplitButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { SplitButton } from '@fluentui/react-components';
 import descriptionMd from './SplitButtonDescription.md';

--- a/packages/react-components/react-button/src/stories/SplitButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/SplitButton/index.stories.tsx
@@ -25,11 +25,4 @@ export default {
       },
     },
   },
-  decorators: [
-    Story => (
-      <div style={{ display: 'flex', gap: '1em', flexFlow: 'wrap', justifyContent: 'space-evenly' }}>
-        <Story />
-      </div>
-    ),
-  ],
 } as Meta;

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
@@ -1,15 +1,27 @@
 import * as React from 'react';
-import { ToggleButton } from '@fluentui/react-components';
+import { makeStyles, ToggleButton } from '@fluentui/react-components';
 
-export const Appearance = () => (
-  <>
-    <ToggleButton>Default</ToggleButton>
-    <ToggleButton appearance="primary">Primary</ToggleButton>
-    <ToggleButton appearance="outline">Outline</ToggleButton>
-    <ToggleButton appearance="subtle">Subtle</ToggleButton>
-    <ToggleButton appearance="transparent">Transparent</ToggleButton>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Appearance = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <ToggleButton>Default</ToggleButton>
+      <ToggleButton appearance="primary">Primary</ToggleButton>
+      <ToggleButton appearance="outline">Outline</ToggleButton>
+      <ToggleButton appearance="subtle">Subtle</ToggleButton>
+      <ToggleButton appearance="transparent">Transparent</ToggleButton>
+    </div>
+  );
+};
+
 Appearance.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonChecked.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonChecked.stories.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react';
-import { ToggleButton } from '@fluentui/react-components';
+import { makeStyles, ToggleButton } from '@fluentui/react-components';
 
-export const Checked = () => (
-  <>
-    <ToggleButton checked={true}>Controlled checked state</ToggleButton>
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
-    <ToggleButton checked={false}>Controlled unchecked state</ToggleButton>
-  </>
-);
+export const Checked = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <ToggleButton checked={true}>Controlled checked state</ToggleButton>
+      <ToggleButton checked={false}>Controlled unchecked state</ToggleButton>
+    </div>
+  );
+};
+
 Checked.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonDefault.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonDefault.stories.tsx
@@ -2,6 +2,4 @@ import * as React from 'react';
 import { ToggleButton } from '@fluentui/react-components';
 import type { ToggleButtonProps } from '@fluentui/react-components';
 
-export const Default = (props: ToggleButtonProps) => {
-  return <ToggleButton {...props}>Example</ToggleButton>;
-};
+export const Default = (props: ToggleButtonProps) => <ToggleButton {...props}>Example</ToggleButton>;

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonDisabled.stories.tsx
@@ -1,17 +1,29 @@
 import * as React from 'react';
-import { ToggleButton } from '@fluentui/react-components';
+import { makeStyles, ToggleButton } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  innerWrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+  outerWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '15px',
+  },
+});
 
 export const Disabled = () => {
-  const groupStyles: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: '0.5em' };
+  const styles = useStyles();
 
   return (
-    <>
-      <div style={groupStyles}>
+    <div className={styles.outerWrapper}>
+      <div className={styles.innerWrapper}>
         <ToggleButton>Enabled state</ToggleButton>
         <ToggleButton disabled>Disabled state</ToggleButton>
         <ToggleButton disabledFocusable>Disabled focusable state</ToggleButton>
       </div>
-      <div style={groupStyles}>
+      <div className={styles.innerWrapper}>
         <ToggleButton appearance="primary">Enabled state</ToggleButton>
         <ToggleButton appearance="primary" disabled>
           Disabled state
@@ -20,7 +32,7 @@ export const Disabled = () => {
           Disabled focusable state
         </ToggleButton>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonIcon.stories.tsx
@@ -1,20 +1,32 @@
 import * as React from 'react';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
-import { ToggleButton, Tooltip } from '@fluentui/react-components';
+import { makeStyles, ToggleButton, Tooltip } from '@fluentui/react-components';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
-export const Icon = () => (
-  <>
-    <ToggleButton icon={<CalendarMonth />}>With calendar icon before contents</ToggleButton>
-    <ToggleButton icon={<CalendarMonth />} iconPosition="after">
-      With calendar icon after contents
-    </ToggleButton>
-    <Tooltip content="With calendar icon only" relationship="label">
-      <ToggleButton icon={<CalendarMonth />} aria-label="Icon only" />
-    </Tooltip>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Icon = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <ToggleButton icon={<CalendarMonth />}>With calendar icon before contents</ToggleButton>
+      <ToggleButton icon={<CalendarMonth />} iconPosition="after">
+        With calendar icon after contents
+      </ToggleButton>
+      <Tooltip content="With calendar icon only" relationship="label">
+        <ToggleButton icon={<CalendarMonth />} aria-label="Icon only" />
+      </Tooltip>
+    </div>
+  );
+};
+
 Icon.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonShape.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonShape.stories.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react';
-import { ToggleButton } from '@fluentui/react-components';
+import { makeStyles, ToggleButton } from '@fluentui/react-components';
 
-export const Shape = () => (
-  <>
-    <ToggleButton>Rounded</ToggleButton>
-    <ToggleButton shape="circular">Circular</ToggleButton>
-    <ToggleButton shape="square">Square</ToggleButton>
-  </>
-);
+const useStyles = makeStyles({
+  wrapper: {
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
+
+export const Shape = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.wrapper}>
+      <ToggleButton>Rounded</ToggleButton>
+      <ToggleButton shape="circular">Circular</ToggleButton>
+      <ToggleButton shape="square">Square</ToggleButton>
+    </div>
+  );
+};
 
 Shape.parameters = {
   docs: {

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonSize.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonSize.stories.tsx
@@ -1,13 +1,23 @@
 import * as React from 'react';
-import { ToggleButton } from '@fluentui/react-components';
+import { makeStyles, ToggleButton } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
+});
 
 export const Size = () => {
+  const styles = useStyles();
+
   return (
-    <>
+    <div className={styles.wrapper}>
       <ToggleButton size="small">Size: small</ToggleButton>
       <ToggleButton size="medium">Size: medium</ToggleButton>
       <ToggleButton size="large">Size: large</ToggleButton>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/ToggleButtonWithLongText.stories.tsx
@@ -5,18 +5,23 @@ const useStyles = makeStyles({
   longText: {
     width: '280px',
   },
+  wrapper: {
+    alignItems: 'center',
+    columnGap: '15px',
+    display: 'flex',
+  },
 });
 
 export const WithLongText = () => {
   const styles = useStyles();
 
   return (
-    <>
+    <div className={styles.wrapper}>
       <ToggleButton>Short text</ToggleButton>
       <ToggleButton className={styles.longText}>
         Long text wraps after it hits the max width of the component
       </ToggleButton>
-    </>
+    </div>
   );
 };
 

--- a/packages/react-components/react-button/src/stories/ToggleButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Meta } from '@storybook/react';
 import { ToggleButton } from '@fluentui/react-components';
 import descriptionMd from './ToggleButtonDescription.md';

--- a/packages/react-components/react-button/src/stories/ToggleButton/index.stories.tsx
+++ b/packages/react-components/react-button/src/stories/ToggleButton/index.stories.tsx
@@ -23,11 +23,4 @@ export default {
       },
     },
   },
-  decorators: [
-    Story => (
-      <div style={{ display: 'flex', gap: '1em', flexFlow: 'wrap', justifyContent: 'space-evenly' }}>
-        <Story />
-      </div>
-    ),
-  ],
 } as Meta;


### PR DESCRIPTION
## Previous Behavior

The layout in the `Button.Sizes.stories.tsx` file is creating an issue where the buttons are being vertically stretched to the height of the largest button within the layout instead of showing the actual sizes of all buttons.

![image](https://user-images.githubusercontent.com/7798177/196548516-ddf59c63-2411-4c11-b225-ec3fd3c68ccc.png)

## New Behavior

This PR fixes the issue described above by removing the `flex` wrapper that was used as a default in all stories and applying a specific layout to each story separately.

<img width="324" alt="image" src="https://user-images.githubusercontent.com/7798177/196564392-a1f807f6-0128-4757-878e-2f936ea0ebc6.png">

## Related Issue(s)

Fixes #25285
