### PR TITLE
groupedlistv2: update getderivedstatefromprops

### DIFF
--- a/change/@fluentui-react-b5a6d88f-3dd6-4c28-8db1-77f85d5870f5.json
+++ b/change/@fluentui-react-b5a6d88f-3dd6-4c28-8db1-77f85d5870f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: GroupedListV2 state/prop updates trigger re-renders the same as GroupedList",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
@@ -533,10 +533,7 @@ export class GroupedListV2Wrapper
       selectionMode !== previousState.selectionMode ||
       compact !== previousState.compact
     ) {
-      nextState = {
-        ...nextState,
-        version: {},
-      };
+      nextState.version = {};
     }
 
     return nextState;

--- a/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
@@ -276,6 +276,7 @@ export const GroupedListV2FC: React.FC<IGroupedListV2Props> = props => {
     viewport,
     listRef,
     groupExpandedVersion,
+    version: versionFromProps,
   } = props;
 
   const {
@@ -330,7 +331,7 @@ export const GroupedListV2FC: React.FC<IGroupedListV2Props> = props => {
 
   React.useEffect(() => {
     setVersion({});
-  }, [compact]);
+  }, [versionFromProps]);
 
   React.useEffect(() => {
     const newIsSomeGroupExpanded = computeIsSomeGroupExpanded(groups);
@@ -501,7 +502,7 @@ const GroupItem = <T,>({
   const isSelected = useIsGroupSelected(group.startIndex, group.count, selection, eventGroup);
   const mergedProps = {
     ...props,
-    isSelected: isSelected,
+    isSelected,
     selected: isSelected,
   };
   return render(mergedProps, defaultRender);
@@ -517,16 +518,28 @@ export class GroupedListV2Wrapper
     nextProps: IGroupedListProps,
     previousState: IGroupedListV2State,
   ): IGroupedListV2State {
-    const { groups } = nextProps;
+    const { groups, selectionMode, compact, items, listProps } = nextProps;
+    const nextListVersion = listProps && listProps.version;
 
-    if (groups !== previousState.groups) {
-      return {
-        ...previousState,
-        groups,
+    let nextState = {
+      ...previousState,
+      groups,
+    };
+
+    if (
+      nextListVersion !== previousState.version ||
+      items !== previousState.items ||
+      groups !== previousState.groups ||
+      selectionMode !== previousState.selectionMode ||
+      compact !== previousState.compact
+    ) {
+      nextState = {
+        ...nextState,
+        version: {},
       };
     }
 
-    return previousState;
+    return nextState;
   }
 
   constructor(props: IGroupedListProps) {

--- a/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
@@ -521,7 +521,7 @@ export class GroupedListV2Wrapper
     const { groups, selectionMode, compact, items, listProps } = nextProps;
     const nextListVersion = listProps && listProps.version;
 
-    let nextState = {
+    const nextState = {
       ...previousState,
       groups,
     };


### PR DESCRIPTION
## Current Behavior

`GroupedListV2` does not re-render when props/state that should trigger a re-render are changed (i.e., V2's behavior does not match `GroupedList`).

## New Behavior

`GroupedListV2` re-renders as expected.

## Related Issue(s)

Fixes #24992
