### PR TITLE
stress-test: update webpack config

### DIFF
--- a/apps/stress-test/webpack/webpack.config.ts
+++ b/apps/stress-test/webpack/webpack.config.ts
@@ -53,9 +53,6 @@ const createConfig: WebpackConfigurationCreator = (_env, argv) => {
             loader: 'swc-loader',
             options: {
               jsc: {
-                minify: {
-                  compress: true,
-                },
                 target: 'es2019',
                 parser: {
                   syntax: 'typescript',
@@ -79,7 +76,7 @@ const createConfig: WebpackConfigurationCreator = (_env, argv) => {
     plugins: [new CleanWebpackPlugin()],
 
     optimization: {
-      minimize: false,
+      minimize: isProd,
       splitChunks: {
         chunks: 'all',
       },


### PR DESCRIPTION
## Current Behavior

SWC compression breaks a React 18 feature detection.

## New Behavior

Disable SWC compression in Webpack config in favor of Terser.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #25283
