### PR TITLE
fix(react-avatar): AvatarGroupPopover is still rendered when there's no items overflowing

### DIFF
--- a/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
@@ -48,7 +48,10 @@ const sizes = [16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 120, 128];
 const AvatarGroupList: React.FC<
   AvatarGroupProps & { overflowIndicator?: AvatarGroupPopoverProps['indicator'] }
 > = props => {
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, layout: props.layout });
+  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({
+    items: names,
+    layout: props.layout,
+  });
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap', gap: '10px', padding: '10px' }}>
@@ -57,11 +60,13 @@ const AvatarGroupList: React.FC<
           {inlineItems.map(name => (
             <AvatarGroupItem key={name} name={name} />
           ))}
-          <AvatarGroupPopover indicator={props.overflowIndicator}>
-            {overflowItems.map(name => (
-              <AvatarGroupItem key={name} name={name} />
-            ))}
-          </AvatarGroupPopover>
+          {renderOverflowButton && (
+            <AvatarGroupPopover indicator={props.overflowIndicator}>
+              {overflowItems.map(name => (
+                <AvatarGroupItem key={name} name={name} />
+              ))}
+            </AvatarGroupPopover>
+          )}
         </AvatarGroup>
       ))}
     </div>
@@ -138,18 +143,20 @@ storiesOf('AvatarGroup Converged', module)
   .addStory(
     'overflowContent',
     () => {
-      const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
+      const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
       return (
         <div style={{ padding: '10px' }}>
           <AvatarGroup>
             {inlineItems.map(name => (
               <AvatarGroupItem key={name} name={name} />
             ))}
-            <AvatarGroupPopover triggerButton={{ id: 'show-overflow' }}>
-              {overflowItems.map(name => (
-                <AvatarGroupItem key={name} name={name} />
-              ))}
-            </AvatarGroupPopover>
+            {renderOverflowButton && (
+              <AvatarGroupPopover triggerButton={{ id: 'show-overflow' }}>
+                {overflowItems.map(name => (
+                  <AvatarGroupItem key={name} name={name} />
+                ))}
+              </AvatarGroupPopover>
+            )}
           </AvatarGroup>
         </div>
       );

--- a/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
@@ -48,7 +48,7 @@ const sizes = [16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 120, 128];
 const AvatarGroupList: React.FC<
   AvatarGroupProps & { overflowIndicator?: AvatarGroupPopoverProps['indicator'] }
 > = props => {
-  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({
     items: names,
     layout: props.layout,
   });
@@ -60,7 +60,7 @@ const AvatarGroupList: React.FC<
           {inlineItems.map(name => (
             <AvatarGroupItem key={name} name={name} />
           ))}
-          {renderOverflowButton && (
+          {overflowItems && (
             <AvatarGroupPopover indicator={props.overflowIndicator}>
               {overflowItems.map(name => (
                 <AvatarGroupItem key={name} name={name} />
@@ -143,14 +143,14 @@ storiesOf('AvatarGroup Converged', module)
   .addStory(
     'overflowContent',
     () => {
-      const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
+      const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
       return (
         <div style={{ padding: '10px' }}>
           <AvatarGroup>
             {inlineItems.map(name => (
               <AvatarGroupItem key={name} name={name} />
             ))}
-            {renderOverflowButton && (
+            {overflowItems && (
               <AvatarGroupPopover triggerButton={{ id: 'show-overflow' }}>
                 {overflowItems.map(name => (
                   <AvatarGroupItem key={name} name={name} />

--- a/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/AvatarGroup.stories.tsx
@@ -48,10 +48,7 @@ const sizes = [16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 120, 128];
 const AvatarGroupList: React.FC<
   AvatarGroupProps & { overflowIndicator?: AvatarGroupPopoverProps['indicator'] }
 > = props => {
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({
-    items: names,
-    layout: props.layout,
-  });
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, layout: props.layout });
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap', gap: '10px', padding: '10px' }}>

--- a/change/@fluentui-react-avatar-45cbd570-4f1a-45a8-991c-081cd8781bdf.json
+++ b/change/@fluentui-react-avatar-45cbd570-4f1a-45a8-991c-081cd8781bdf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: AvatarGroupPopover does not render when children is an empty array, undefined, or null.",
+  "comment": "fix: Add renderOverflowButton variable to partitionAvatarGroupItems.",
   "packageName": "@fluentui/react-avatar",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-avatar-45cbd570-4f1a-45a8-991c-081cd8781bdf.json
+++ b/change/@fluentui-react-avatar-45cbd570-4f1a-45a8-991c-081cd8781bdf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Add renderOverflowButton variable to partitionAvatarGroupItems.",
+  "comment": "fix: Add undefined option to overflowItems in partitionAvatarGroupItems.",
   "packageName": "@fluentui/react-avatar",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-avatar-45cbd570-4f1a-45a8-991c-081cd8781bdf.json
+++ b/change/@fluentui-react-avatar-45cbd570-4f1a-45a8-991c-081cd8781bdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: AvatarGroupPopover does not render when children is an empty array, undefined, or null.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-94d4c956-05ab-4a3e-9df4-edcfa91f7a21.json
+++ b/change/@fluentui-react-components-94d4c956-05ab-4a3e-9df4-edcfa91f7a21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Export missing partitionAvatarGroupItems in unstable.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -98,7 +98,7 @@ export type AvatarGroupPopoverSlots = {
 };
 
 // @public
-export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> & Required<Pick<AvatarGroupPopoverProps, 'indicator' | 'count'>> & {
+export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> & Required<Pick<AvatarGroupPopoverProps, 'count' | 'indicator'>> & {
     popoverOpen: boolean;
     layout: AvatarGroupProps['layout'];
     size: AvatarSizes;

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -98,7 +98,7 @@ export type AvatarGroupPopoverSlots = {
 };
 
 // @public
-export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> & Required<Pick<AvatarGroupPopoverProps, 'indicator'>> & {
+export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> & Required<Pick<AvatarGroupPopoverProps, 'indicator' | 'count'>> & {
     popoverOpen: boolean;
     layout: AvatarGroupProps['layout'];
     size: AvatarSizes;
@@ -159,11 +159,15 @@ export function getInitials(displayName: string | undefined | null, isRtl: boole
     firstInitialOnly?: boolean;
 }): string;
 
-// @public
-export const partitionAvatarGroupItems: <T>(options: PartitionAvatarGroupItemsOptions<T>) => {
-    inlineItems: T[];
+// @public (undocumented)
+export type PartitionAvatarGroupItems<T> = {
+    inlineItems: readonly T[];
     overflowItems: readonly T[];
+    renderOverflowButton: boolean;
 };
+
+// @public
+export const partitionAvatarGroupItems: <T>(options: PartitionAvatarGroupItemsOptions<T>) => PartitionAvatarGroupItems<T>;
 
 // @public (undocumented)
 export type PartitionAvatarGroupItemsOptions<T> = {

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -162,8 +162,7 @@ export function getInitials(displayName: string | undefined | null, isRtl: boole
 // @public (undocumented)
 export type PartitionAvatarGroupItems<T> = {
     inlineItems: readonly T[];
-    overflowItems: readonly T[];
-    renderOverflowButton: boolean;
+    overflowItems?: readonly T[];
 };
 
 // @public

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
@@ -59,4 +59,9 @@ export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> &
     popoverOpen: boolean;
     layout: AvatarGroupProps['layout'];
     size: AvatarSizes;
+
+    /**
+     * When the AvatarGroupPopover recieves an empty array of children, null, or undefined, it should not render.
+     */
+    shouldRender: boolean;
   };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
@@ -61,7 +61,7 @@ export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> &
     size: AvatarSizes;
 
     /**
-     * When the AvatarGroupPopover recieves an empty array of children, null, or undefined, it should not render.
+     * Whether the component should render or not.
      */
     shouldRender: boolean;
   };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
@@ -55,13 +55,8 @@ export type AvatarGroupPopoverProps = Omit<ComponentProps<Partial<AvatarGroupPop
  * State used in rendering AvatarGroupPopover
  */
 export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> &
-  Required<Pick<AvatarGroupPopoverProps, 'indicator'>> & {
+  Required<Pick<AvatarGroupPopoverProps, 'indicator' | 'count'>> & {
     popoverOpen: boolean;
     layout: AvatarGroupProps['layout'];
     size: AvatarSizes;
-
-    /**
-     * Whether the component should render or not.
-     */
-    shouldRender: boolean;
   };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.types.ts
@@ -55,7 +55,7 @@ export type AvatarGroupPopoverProps = Omit<ComponentProps<Partial<AvatarGroupPop
  * State used in rendering AvatarGroupPopover
  */
 export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> &
-  Required<Pick<AvatarGroupPopoverProps, 'indicator' | 'count'>> & {
+  Required<Pick<AvatarGroupPopoverProps, 'count' | 'indicator'>> & {
     popoverOpen: boolean;
     layout: AvatarGroupProps['layout'];
     size: AvatarSizes;

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
@@ -14,19 +14,22 @@ export const renderAvatarGroupPopover_unstable = (
   contextValues: AvatarGroupContextValues,
 ) => {
   const { slots, slotProps } = getSlots<AvatarGroupPopoverSlots>(state);
+  const { shouldRender } = state;
 
   return (
-    <slots.root {...(slotProps.root as PopoverProps)}>
-      <PopoverTrigger>
-        <slots.tooltip {...(slotProps.tooltip as TooltipProps)}>
-          <slots.triggerButton {...slotProps.triggerButton} />
-        </slots.tooltip>
-      </PopoverTrigger>
-      <slots.popoverSurface {...slotProps.popoverSurface}>
-        <AvatarGroupProvider value={contextValues.avatarGroup}>
-          <slots.content {...slotProps.content} />
-        </AvatarGroupProvider>
-      </slots.popoverSurface>
-    </slots.root>
+    shouldRender && (
+      <slots.root {...(slotProps.root as PopoverProps)}>
+        <PopoverTrigger>
+          <slots.tooltip {...(slotProps.tooltip as TooltipProps)}>
+            <slots.triggerButton {...slotProps.triggerButton} />
+          </slots.tooltip>
+        </PopoverTrigger>
+        <slots.popoverSurface {...slotProps.popoverSurface}>
+          <AvatarGroupProvider value={contextValues.avatarGroup}>
+            <slots.content {...slotProps.content} />
+          </AvatarGroupProvider>
+        </slots.popoverSurface>
+      </slots.root>
+    )
   );
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
@@ -14,22 +14,19 @@ export const renderAvatarGroupPopover_unstable = (
   contextValues: AvatarGroupContextValues,
 ) => {
   const { slots, slotProps } = getSlots<AvatarGroupPopoverSlots>(state);
-  const { shouldRender } = state;
 
   return (
-    shouldRender && (
-      <slots.root {...(slotProps.root as PopoverProps)}>
-        <PopoverTrigger>
-          <slots.tooltip {...(slotProps.tooltip as TooltipProps)}>
-            <slots.triggerButton {...slotProps.triggerButton} />
-          </slots.tooltip>
-        </PopoverTrigger>
-        <slots.popoverSurface {...slotProps.popoverSurface}>
-          <AvatarGroupProvider value={contextValues.avatarGroup}>
-            <slots.content {...slotProps.content} />
-          </AvatarGroupProvider>
-        </slots.popoverSurface>
-      </slots.root>
-    )
+    <slots.root {...(slotProps.root as PopoverProps)}>
+      <PopoverTrigger>
+        <slots.tooltip {...(slotProps.tooltip as TooltipProps)}>
+          <slots.triggerButton {...slotProps.triggerButton} />
+        </slots.tooltip>
+      </PopoverTrigger>
+      <slots.popoverSurface {...slotProps.popoverSurface}>
+        <AvatarGroupProvider value={contextValues.avatarGroup}>
+          <slots.content {...slotProps.content} />
+        </AvatarGroupProvider>
+      </slots.popoverSurface>
+    </slots.root>
   );
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -45,13 +45,11 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
     triggerButtonChildren = count > 99 ? '99+' : `+${count}`;
   }
 
-  const shouldRender = React.Children.count(children) > 0;
-
   return {
-    popoverOpen,
-    layout,
+    count,
     indicator,
-    shouldRender,
+    layout,
+    popoverOpen,
     size,
 
     components: {

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -51,8 +51,8 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
     popoverOpen,
     layout,
     indicator,
-    size,
     shouldRender,
+    size,
 
     components: {
       root: Popover,

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -45,11 +45,14 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
     triggerButtonChildren = count > 99 ? '99+' : `+${count}`;
   }
 
+  const shouldRender = React.Children.count(children) > 0;
+
   return {
     popoverOpen,
     layout,
     indicator,
     size,
+    shouldRender,
 
     components: {
       root: Popover,
@@ -77,7 +80,7 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
     content: resolveShorthand(props.content, {
       required: true,
       defaultProps: {
-        children: children,
+        children,
         role: 'list',
       },
     }),

--- a/packages/react-components/react-avatar/src/index.ts
+++ b/packages/react-components/react-avatar/src/index.ts
@@ -7,7 +7,7 @@ export {
 } from './Avatar';
 export type { AvatarNamedColor, AvatarProps, AvatarSlots, AvatarState, AvatarSizes } from './Avatar';
 export { getInitials, partitionAvatarGroupItems } from './utils/index';
-export type { PartitionAvatarGroupItemsOptions } from './utils/index';
+export type { PartitionAvatarGroupItems, PartitionAvatarGroupItemsOptions } from './utils/index';
 export {
   AvatarGroup,
   avatarGroupClassNames,

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -17,14 +17,14 @@ const names = [
 ];
 
 export const Default = (props: Partial<AvatarGroupProps>) => {
-  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
 
   return (
     <AvatarGroup {...props}>
       {inlineItems.map(name => (
         <AvatarGroupItem name={name} key={name} />
       ))}
-      {renderOverflowButton && (
+      {overflowItems && (
         <AvatarGroupPopover>
           {overflowItems.map(name => (
             <AvatarGroupItem name={name} key={name} />

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -17,7 +17,9 @@ const names = [
 ];
 
 export const Default = (props: Partial<AvatarGroupProps>) => {
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, maxInlineItems: 4 });
+
+  console.log({ inlineItems, overflowItems });
 
   return (
     <AvatarGroup {...props}>

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -17,9 +17,7 @@ const names = [
 ];
 
 export const Default = (props: Partial<AvatarGroupProps>) => {
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, maxInlineItems: 4 });
-
-  console.log({ inlineItems, overflowItems });
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
 
   return (
     <AvatarGroup {...props}>

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -17,18 +17,20 @@ const names = [
 ];
 
 export const Default = (props: Partial<AvatarGroupProps>) => {
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
+  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
 
   return (
     <AvatarGroup {...props}>
       {inlineItems.map(name => (
         <AvatarGroupItem name={name} key={name} />
       ))}
-      <AvatarGroupPopover>
-        {overflowItems.map(name => (
-          <AvatarGroupItem name={name} key={name} />
-        ))}
-      </AvatarGroupPopover>
+      {renderOverflowButton && (
+        <AvatarGroupPopover>
+          {overflowItems.map(name => (
+            <AvatarGroupItem name={name} key={name} />
+          ))}
+        </AvatarGroupPopover>
+      )}
     </AvatarGroup>
   );
 };

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
@@ -26,7 +26,7 @@ const names = [
 
 export const Indicator = () => {
   const styles = useStyles();
-  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
 
   return (
     <div className={styles.root}>
@@ -34,7 +34,7 @@ export const Indicator = () => {
         {inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        {renderOverflowButton && (
+        {overflowItems && (
           <AvatarGroupPopover indicator="count">
             {overflowItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
@@ -46,7 +46,7 @@ export const Indicator = () => {
         {inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        {renderOverflowButton && (
+        {overflowItems && (
           <AvatarGroupPopover indicator="icon">
             {overflowItems.map(name => (
               <AvatarGroupItem name={name} key={name} />

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupIndicator.stories.tsx
@@ -26,7 +26,7 @@ const names = [
 
 export const Indicator = () => {
   const styles = useStyles();
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
+  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
 
   return (
     <div className={styles.root}>
@@ -34,21 +34,25 @@ export const Indicator = () => {
         {inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        <AvatarGroupPopover indicator="count">
-          {overflowItems.map(name => (
-            <AvatarGroupItem name={name} key={name} />
-          ))}
-        </AvatarGroupPopover>
+        {renderOverflowButton && (
+          <AvatarGroupPopover indicator="count">
+            {overflowItems.map(name => (
+              <AvatarGroupItem name={name} key={name} />
+            ))}
+          </AvatarGroupPopover>
+        )}
       </AvatarGroup>
       <AvatarGroup>
         {inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        <AvatarGroupPopover indicator="icon">
-          {overflowItems.map(name => (
-            <AvatarGroupItem name={name} key={name} />
-          ))}
-        </AvatarGroupPopover>
+        {renderOverflowButton && (
+          <AvatarGroupPopover indicator="icon">
+            {overflowItems.map(name => (
+              <AvatarGroupItem name={name} key={name} />
+            ))}
+          </AvatarGroupPopover>
+        )}
       </AvatarGroup>
     </div>
   );

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
@@ -35,7 +35,7 @@ export const Layout = () => {
         {partitionedItems.inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        {partitionedItems.renderOverflowButton && (
+        {partitionedItems.overflowItems && (
           <AvatarGroupPopover>
             {partitionedItems.overflowItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
@@ -47,7 +47,7 @@ export const Layout = () => {
         {partitionedItems.inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        {partitionedItems.renderOverflowButton && (
+        {partitionedItems.overflowItems && (
           <AvatarGroupPopover>
             {partitionedItems.overflowItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
@@ -59,7 +59,7 @@ export const Layout = () => {
         {piePartitionedItems.inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        {piePartitionedItems.renderOverflowButton && (
+        {piePartitionedItems.overflowItems && (
           <AvatarGroupPopover>
             {piePartitionedItems.overflowItems.map(name => (
               <AvatarGroupItem name={name} key={name} />

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupLayout.stories.tsx
@@ -35,31 +35,37 @@ export const Layout = () => {
         {partitionedItems.inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        <AvatarGroupPopover>
-          {partitionedItems.overflowItems.map(name => (
-            <AvatarGroupItem name={name} key={name} />
-          ))}
-        </AvatarGroupPopover>
+        {partitionedItems.renderOverflowButton && (
+          <AvatarGroupPopover>
+            {partitionedItems.overflowItems.map(name => (
+              <AvatarGroupItem name={name} key={name} />
+            ))}
+          </AvatarGroupPopover>
+        )}
       </AvatarGroup>
       <AvatarGroup layout="stack">
         {partitionedItems.inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        <AvatarGroupPopover>
-          {partitionedItems.overflowItems.map(name => (
-            <AvatarGroupItem name={name} key={name} />
-          ))}
-        </AvatarGroupPopover>
+        {partitionedItems.renderOverflowButton && (
+          <AvatarGroupPopover>
+            {partitionedItems.overflowItems.map(name => (
+              <AvatarGroupItem name={name} key={name} />
+            ))}
+          </AvatarGroupPopover>
+        )}
       </AvatarGroup>
       <AvatarGroup layout="pie">
         {piePartitionedItems.inlineItems.map(name => (
           <AvatarGroupItem name={name} key={name} />
         ))}
-        <AvatarGroupPopover>
-          {piePartitionedItems.overflowItems.map(name => (
-            <AvatarGroupItem name={name} key={name} />
-          ))}
-        </AvatarGroupPopover>
+        {piePartitionedItems.renderOverflowButton && (
+          <AvatarGroupPopover>
+            {piePartitionedItems.overflowItems.map(name => (
+              <AvatarGroupItem name={name} key={name} />
+            ))}
+          </AvatarGroupPopover>
+        )}
       </AvatarGroup>
     </div>
   );

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
@@ -29,7 +29,7 @@ const sizes: AvatarSizes[] = [16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 12
 
 export const SizePie = () => {
   const styles = useStyles();
-  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({
     items: names,
     layout: 'pie',
   });
@@ -42,7 +42,7 @@ export const SizePie = () => {
             {inlineItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
             ))}
-            {renderOverflowButton && (
+            {overflowItems && (
               <AvatarGroupPopover>
                 {overflowItems.map(name => (
                   <AvatarGroupItem name={name} key={name} />

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
@@ -29,10 +29,7 @@ const sizes: AvatarSizes[] = [16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 12
 
 export const SizePie = () => {
   const styles = useStyles();
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({
-    items: names,
-    layout: 'pie',
-  });
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, layout: 'pie' });
 
   return (
     <div className={styles.root}>

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizePie.stories.tsx
@@ -29,7 +29,10 @@ const sizes: AvatarSizes[] = [16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 12
 
 export const SizePie = () => {
   const styles = useStyles();
-  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, layout: 'pie' });
+  const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({
+    items: names,
+    layout: 'pie',
+  });
 
   return (
     <div className={styles.root}>
@@ -39,11 +42,13 @@ export const SizePie = () => {
             {inlineItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
             ))}
-            <AvatarGroupPopover>
-              {overflowItems.map(name => (
-                <AvatarGroupItem name={name} key={name} />
-              ))}
-            </AvatarGroupPopover>
+            {renderOverflowButton && (
+              <AvatarGroupPopover>
+                {overflowItems.map(name => (
+                  <AvatarGroupItem name={name} key={name} />
+                ))}
+              </AvatarGroupPopover>
+            )}
           </AvatarGroup>
         );
       })}

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
@@ -33,14 +33,14 @@ export const SizeSpread = () => {
   return (
     <div className={styles.root}>
       {sizes.map(size => {
-        const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
+        const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
 
         return (
           <AvatarGroup layout="spread" size={size} key={size}>
             {inlineItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
             ))}
-            {renderOverflowButton && (
+            {overflowItems && (
               <AvatarGroupPopover>
                 {overflowItems.map(name => (
                   <AvatarGroupItem name={name} key={name} />

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeSpread.stories.tsx
@@ -33,18 +33,20 @@ export const SizeSpread = () => {
   return (
     <div className={styles.root}>
       {sizes.map(size => {
-        const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
+        const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({ items: names });
 
         return (
           <AvatarGroup layout="spread" size={size} key={size}>
             {inlineItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
             ))}
-            <AvatarGroupPopover>
-              {overflowItems.map(name => (
-                <AvatarGroupItem name={name} key={name} />
-              ))}
-            </AvatarGroupPopover>
+            {renderOverflowButton && (
+              <AvatarGroupPopover>
+                {overflowItems.map(name => (
+                  <AvatarGroupItem name={name} key={name} />
+                ))}
+              </AvatarGroupPopover>
+            )}
           </AvatarGroup>
         );
       })}

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
@@ -33,18 +33,23 @@ export const SizeStack = () => {
   return (
     <div className={styles.root}>
       {sizes.map(size => {
-        const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, layout: 'stack' });
+        const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({
+          items: names,
+          layout: 'stack',
+        });
 
         return (
           <AvatarGroup layout="stack" size={size} key={size}>
             {inlineItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
             ))}
-            <AvatarGroupPopover>
-              {overflowItems.map(name => (
-                <AvatarGroupItem name={name} key={name} />
-              ))}
-            </AvatarGroupPopover>
+            {renderOverflowButton && (
+              <AvatarGroupPopover>
+                {overflowItems.map(name => (
+                  <AvatarGroupItem name={name} key={name} />
+                ))}
+              </AvatarGroupPopover>
+            )}
           </AvatarGroup>
         );
       })}

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
@@ -33,10 +33,7 @@ export const SizeStack = () => {
   return (
     <div className={styles.root}>
       {sizes.map(size => {
-        const { inlineItems, overflowItems } = partitionAvatarGroupItems({
-          items: names,
-          layout: 'stack',
-        });
+        const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names, layout: 'stack' });
 
         return (
           <AvatarGroup layout="stack" size={size} key={size}>

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/AvatarGroupSizeStack.stories.tsx
@@ -33,7 +33,7 @@ export const SizeStack = () => {
   return (
     <div className={styles.root}>
       {sizes.map(size => {
-        const { inlineItems, overflowItems, renderOverflowButton } = partitionAvatarGroupItems({
+        const { inlineItems, overflowItems } = partitionAvatarGroupItems({
           items: names,
           layout: 'stack',
         });
@@ -43,7 +43,7 @@ export const SizeStack = () => {
             {inlineItems.map(name => (
               <AvatarGroupItem name={name} key={name} />
             ))}
-            {renderOverflowButton && (
+            {overflowItems && (
               <AvatarGroupPopover>
                 {overflowItems.map(name => (
                   <AvatarGroupItem name={name} key={name} />

--- a/packages/react-components/react-avatar/src/stories/AvatarGroup/index.stories.tsx
+++ b/packages/react-components/react-avatar/src/stories/AvatarGroup/index.stories.tsx
@@ -5,10 +5,10 @@ import descriptionMd from './AvatarGroupDescription.md';
 
 export { Default } from './AvatarGroupDefault.stories';
 export { Layout } from './AvatarGroupLayout.stories';
+export { Indicator } from './AvatarGroupIndicator.stories';
 export { SizeSpread } from './AvatarGroupSizeSpread.stories';
 export { SizeStack } from './AvatarGroupSizeStack.stories';
 export { SizePie } from './AvatarGroupSizePie.stories';
-export { Indicator } from './AvatarGroupIndicator.stories';
 
 export default {
   title: 'Preview Components/AvatarGroup',

--- a/packages/react-components/react-avatar/src/utils/index.ts
+++ b/packages/react-components/react-avatar/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { getInitials } from './getInitials';
 export { partitionAvatarGroupItems } from './partitionAvatarGroupItems';
-export type { PartitionAvatarGroupItemsOptions } from './partitionAvatarGroupItems';
+export type { PartitionAvatarGroupItems, PartitionAvatarGroupItemsOptions } from './partitionAvatarGroupItems';

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.test.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.test.ts
@@ -64,4 +64,12 @@ describe('partitionAvatarGroupItems', () => {
     expect(inlineItems).toEqual([3, 4, 5, 6, 7, 8, 9]);
     expect(overflowItems).toEqual([0, 1, 2]);
   });
+
+  it('returns undefined when there are no overflowing items', () => {
+    const items = [0, 1, 2, 3, 4, 5];
+    const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items });
+
+    expect(inlineItems).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(overflowItems).toEqual(undefined);
+  });
 });

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.test.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.test.ts
@@ -38,7 +38,7 @@ describe('partitionAvatarGroupItems', () => {
     const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items });
 
     expect(inlineItems).toEqual([0, 1, 2]);
-    expect(overflowItems).toEqual([]);
+    expect(overflowItems).toBeUndefined();
   });
 
   it('partitions the items correctly when there is no overflow when using the pie layout', () => {
@@ -63,13 +63,5 @@ describe('partitionAvatarGroupItems', () => {
 
     expect(inlineItems).toEqual([3, 4, 5, 6, 7, 8, 9]);
     expect(overflowItems).toEqual([0, 1, 2]);
-  });
-
-  it('returns undefined when there are no overflowing items', () => {
-    const items = [0, 1, 2, 3, 4, 5];
-    const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items });
-
-    expect(inlineItems).toEqual([0, 1, 2, 3, 4, 5]);
-    expect(overflowItems).toEqual(undefined);
   });
 });

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
@@ -25,7 +25,7 @@ export const partitionAvatarGroupItems = <T>(
   if (isPie) {
     return {
       inlineItems: items.slice(0, 3),
-      overflowItems: items.length > 3 ? items : undefined,
+      overflowItems: items.length > 0 ? items : undefined,
     };
   }
 

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
@@ -25,7 +25,7 @@ export const partitionAvatarGroupItems = <T>(
   if (isPie) {
     return {
       inlineItems: items.slice(0, 3),
-      overflowItems: items.length > 0 ? items : undefined,
+      overflowItems: items.length > 3 ? items : undefined,
     };
   }
 

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
@@ -6,8 +6,7 @@ export type PartitionAvatarGroupItemsOptions<T> = {
 
 export type PartitionAvatarGroupItems<T> = {
   inlineItems: readonly T[];
-  overflowItems: readonly T[];
-  renderOverflowButton: boolean;
+  overflowItems?: readonly T[];
 };
 
 /**
@@ -26,17 +25,16 @@ export const partitionAvatarGroupItems = <T>(
   if (isPie) {
     return {
       inlineItems: items.slice(0, 3),
-      overflowItems: items,
-      renderOverflowButton: items.length > 3,
+      overflowItems: items.length > 0 ? items : undefined,
     };
   }
 
   const maxInlineItems = options.maxInlineItems ?? 5;
   const inlineCount = -(maxInlineItems - (items.length > maxInlineItems ? 1 : 0));
+  const overflowItems = items.slice(0, inlineCount);
 
   return {
     inlineItems: items.slice(inlineCount),
-    overflowItems: items.slice(0, inlineCount),
-    renderOverflowButton: items.length > maxInlineItems,
+    overflowItems: overflowItems.length > 0 ? overflowItems : undefined,
   };
 };

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
@@ -4,6 +4,12 @@ export type PartitionAvatarGroupItemsOptions<T> = {
   maxInlineItems?: number;
 };
 
+export type PartitionAvatarGroupItems<T> = {
+  inlineItems: readonly T[];
+  overflowItems: readonly T[];
+  renderOverflowButton: boolean;
+};
+
 /**
  * Get the inline items and overflowing items based on the array of AvatarGroupItems needed for AvatarGroup.
  *
@@ -11,7 +17,9 @@ export type PartitionAvatarGroupItemsOptions<T> = {
  *
  * @returns Two arrays split into inline items and overflow items based on maxInlineItems.
  */
-export const partitionAvatarGroupItems = <T>(options: PartitionAvatarGroupItemsOptions<T>) => {
+export const partitionAvatarGroupItems = <T>(
+  options: PartitionAvatarGroupItemsOptions<T>,
+): PartitionAvatarGroupItems<T> => {
   const { items } = options;
   const isPie = options.layout === 'pie';
 
@@ -19,6 +27,7 @@ export const partitionAvatarGroupItems = <T>(options: PartitionAvatarGroupItemsO
     return {
       inlineItems: items.slice(0, 3),
       overflowItems: items,
+      renderOverflowButton: items.length > 3,
     };
   }
 
@@ -28,5 +37,6 @@ export const partitionAvatarGroupItems = <T>(options: PartitionAvatarGroupItemsO
   return {
     inlineItems: items.slice(inlineCount),
     overflowItems: items.slice(0, inlineCount),
+    renderOverflowButton: items.length > maxInlineItems,
   };
 };

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -100,6 +100,9 @@ import { Overflow } from '@fluentui/react-overflow';
 import { OverflowItem } from '@fluentui/react-overflow';
 import { OverflowItemProps } from '@fluentui/react-overflow';
 import { OverflowProps } from '@fluentui/react-overflow';
+import { PartitionAvatarGroupItems } from '@fluentui/react-avatar';
+import { partitionAvatarGroupItems } from '@fluentui/react-avatar';
+import { PartitionAvatarGroupItemsOptions } from '@fluentui/react-avatar';
 import { Persona } from '@fluentui/react-persona';
 import { personaClassNames } from '@fluentui/react-persona';
 import { PersonaProps } from '@fluentui/react-persona';
@@ -472,6 +475,12 @@ export { OverflowItem }
 export { OverflowItemProps }
 
 export { OverflowProps }
+
+export { PartitionAvatarGroupItems }
+
+export { partitionAvatarGroupItems }
+
+export { PartitionAvatarGroupItemsOptions }
 
 export { Persona }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -16,6 +16,7 @@ export {
   avatarGroupClassNames,
   avatarGroupItemClassNames,
   avatarGroupPopoverClassNames,
+  partitionAvatarGroupItems,
   renderAvatarGroup_unstable,
   renderAvatarGroupItem_unstable,
   renderAvatarGroupPopover_unstable,
@@ -37,6 +38,7 @@ export type {
   AvatarGroupPopoverProps,
   AvatarGroupPopoverSlots,
   AvatarGroupPopoverState,
+  PartitionAvatarGroupItemsOptions,
 } from '@fluentui/react-avatar';
 export {
   Card,

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -38,6 +38,7 @@ export type {
   AvatarGroupPopoverProps,
   AvatarGroupPopoverSlots,
   AvatarGroupPopoverState,
+  PartitionAvatarGroupItems,
   PartitionAvatarGroupItemsOptions,
 } from '@fluentui/react-avatar';
 export {


### PR DESCRIPTION
## Current Behavior

When there are no overflow items, partitionAvatarGroupItems returns an empty array which causes the button to still show up.

`partitionAvatarGroupItems` is not exported in `react-components/unstable`.

## New Behavior

`partitionAvatarGroupItems` now returns undefined in `overflowItems` when there are no items overflow. This will be used to check if the AvatarGroupPopover should be rendered or not.

`partitionAvatarGroupItems` is now exported in `react-components/unstable`.
