### PR TITLE
allow details element to be toggled inside selection and focus zones

### DIFF
--- a/change/@fluentui-react-7161ec44-2213-4a2c-8b26-aacc793b05d0.json
+++ b/change/@fluentui-react-7161ec44-2213-4a2c-8b26-aacc793b05d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add support for HTML defails element",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-e075be55-1aa4-43b0-aeb5-ffdb377f6070.json
+++ b/change/@fluentui-react-focus-e075be55-1aa4-43b0-aeb5-ffdb377f6070.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add support for HTML details element",
+  "packageName": "@fluentui/react-focus",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -849,7 +849,8 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         target.tagName === 'BUTTON' ||
         target.tagName === 'A' ||
         target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA'
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'DETAILS'
       ) {
         return false;
       }

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -850,7 +850,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         target.tagName === 'A' ||
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||
-        target.tagName === 'DETAILS'
+        target.tagName === 'SUMMARY'
       ) {
         return false;
       }

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -575,7 +575,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
         } else if (
           // eslint-disable-next-line deprecation/deprecation
           (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) &&
-          (target.tagName === 'BUTTON' || target.tagName === 'A' || target.tagName === 'INPUT')
+          (target.tagName === 'BUTTON' ||
+            target.tagName === 'A' ||
+            target.tagName === 'INPUT' ||
+            target.tagName === 'DETAILS')
         ) {
           return false;
         } else if (target === itemRoot) {

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -578,7 +578,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
           (target.tagName === 'BUTTON' ||
             target.tagName === 'A' ||
             target.tagName === 'INPUT' ||
-            target.tagName === 'DETAILS')
+            target.tagName === 'SUMMARY')
         ) {
           return false;
         } else if (target === itemRoot) {


### PR DESCRIPTION
## Current Behavior

[HTML `<details>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) would not toggle when inside a `DetailsList`.

## New Behavior

`<details>` element now toggles with both the enter and space keys.

## Related Issue(s)

Fixes #22135
