### PR TITLE
Wrap toggleScrollListener calls in requestAnimationFrame callback to prevent forced style recalculations

### DIFF
--- a/change/@fluentui-react-positioning-49f77ad4-3265-436c-b6b1-51312f5591ae.json
+++ b/change/@fluentui-react-positioning-49f77ad4-3265-436c-b6b1-51312f5591ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Wrap toggleScrollListener calls in requestAnimationFrame callback.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "xinychen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -267,17 +267,21 @@ function useContainerRef(updatePosition: () => void, enabled: boolean) {
       Object.assign(container.style, { position: 'fixed', left: 0, top: 0, margin: 0 });
     }
 
-    toggleScrollListener(container, prevContainer, updatePosition);
-
-    updatePosition();
+    // toggleScrollListener requires computed styles; thus use RAF to prevent forced style reevaluation.
+    window.requestAnimationFrame(() => {
+      toggleScrollListener(container, prevContainer, updatePosition);
+      updatePosition();
+    });
   });
 }
 
 function useTargetRef(updatePosition: () => void) {
   return useCallbackRef<HTMLElement | PositioningVirtualElement | null>(null, (target, prevTarget) => {
-    toggleScrollListener(target, prevTarget, updatePosition);
-
-    updatePosition();
+    // toggleScrollListener requires computed styles; thus use RAF to prevent forced style reevaluation.
+    window.requestAnimationFrame(() => {
+      toggleScrollListener(target, prevTarget, updatePosition);
+      updatePosition();
+    });
   });
 }
 


### PR DESCRIPTION
## Current Behavior
Rendering `<Tooltips>` will force style recalculations during `toggleScrollListener` calls.

## New Behavior
`toggleScrollListener` calls are deferred until the next animation frame, when the browser has already calculated the styles and done page layout.

## Related Issue(s)
Fixes #25326 
