### PR TITLE
docs: Make Callout title in basic example be a proper heading.

### DIFF
--- a/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Callout/Callout.Basic.Example.tsx
@@ -28,7 +28,7 @@ export const CalloutBasicExample: React.FunctionComponent = () => {
           onDismiss={toggleIsCalloutVisible}
           setInitialFocus
         >
-          <Text block variant="xLarge" className={styles.title} id={labelId}>
+          <Text as="h1" block variant="xLarge" className={styles.title} id={labelId}>
             Callout title here
           </Text>
           <Text block variant="small" id={descriptionId}>


### PR DESCRIPTION
## Previous Behavior

The `Callout title` in `Callout.Basic.Example.tsx` is styled as a heading but does not behave like one.

## New Behavior

The `Callout title` in `Callout.Basic.Example.tsx` is now a proper heading.

## Related Issue(s)

Fixes [15473](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15473)
