### PR TITLE
chore(global-context): migrate to new package structure

### DIFF
--- a/change/@fluentui-global-context-3a76592d-05b4-4b6e-a538-86abd33e1d4c.json
+++ b/change/@fluentui-global-context-3a76592d-05b4-4b6e-a538-86abd33e1d4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/global-context",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/global-context/.npmignore
+++ b/packages/react-components/global-context/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/global-context/src/global-context.cy.tsx
+++ b/packages/react-components/global-context/src/global-context.cy.tsx
@@ -1,6 +1,6 @@
 import { createContext, createContextSelector } from '@fluentui/global-context';
-import { SYMBOL_NAMESPACE } from '../src/global-context';
-import { SYMBOL_NAMESPACE as CONTEXT_SELECTOR_SYMBOL_NAMESPACE } from '../src/global-context-selector';
+import { SYMBOL_NAMESPACE } from './global-context';
+import { SYMBOL_NAMESPACE as CONTEXT_SELECTOR_SYMBOL_NAMESPACE } from './global-context-selector';
 
 function cleanWindowSymbols(namespace: string) {
   getGlobalContextSymbols(namespace).forEach(sym => {

--- a/packages/react-components/global-context/src/global-context.cy.tsx
+++ b/packages/react-components/global-context/src/global-context.cy.tsx
@@ -28,13 +28,13 @@ describe('createContext', () => {
   beforeEach(() => cleanWindowSymbols(SYMBOL_NAMESPACE));
 
   it('should create context on window', () => {
-    const MyContext = createContext({}, 'MyContext', 'package', '9.0.0');
+    const MyContext = createContext(undefined, 'MyContext', 'package', '9.0.0');
     expect(getWindowProperty(getGlobalContextSymbols(SYMBOL_NAMESPACE)[0])).equals(MyContext);
   });
 
   it('should create single context', () => {
-    const MyContext = createContext({}, 'MyContext', 'package', '9.0.0');
-    const MyContext2 = createContext({}, 'MyContext', 'package', '9.0.0');
+    const MyContext = createContext(undefined, 'MyContext', 'package', '9.0.0');
+    const MyContext2 = createContext(undefined, 'MyContext', 'package', '9.0.0');
 
     expect(getGlobalContextSymbols(SYMBOL_NAMESPACE).length).equals(1);
     expect(getWindowProperty(getGlobalContextSymbols(SYMBOL_NAMESPACE)[0])).equals(MyContext);

--- a/packages/react-components/global-context/tsconfig.cy.json
+++ b/packages/react-components/global-context/tsconfig.cy.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "isolatedModules": false,
     "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
     "lib": ["ES2019", "dom"]
   },
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.cy.ts", "**/*.cy.tsx"]
 }

--- a/packages/react-components/global-context/tsconfig.json
+++ b/packages/react-components/global-context/tsconfig.json
@@ -19,7 +19,7 @@
       "path": "./tsconfig.spec.json"
     },
     {
-      "path": "./e2e/tsconfig.json"
+      "path": "./tsconfig.cy.json"
     }
   ]
 }

--- a/packages/react-components/global-context/tsconfig.lib.json
+++ b/packages/react-components/global-context/tsconfig.lib.json
@@ -9,6 +9,6 @@
     "inlineSources": true,
     "types": ["static-assets", "environment", "node"]
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.cy.ts", "**/*.cy.tsx"],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/global-context/tsconfig.spec.json
+++ b/packages/react-components/global-context/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }


### PR DESCRIPTION
## Changes:
- Runs `migrate-converged-pkg` which reflects updates made in #24458.
	- Moves stories to `stories/` folder in the root of the package.
	- Collocates any e2e tests with the component implementation and jest tests.
	- removes `common/` folder and moves contents to new `testing/` folder 
	- adds `docs/` folder to package root.
- Fixes linting errors

## Issue:
- Part of #24129