### PR TITLE
fix: Detailslist is still tabbable when isHeaderVisible=false

### DIFF
--- a/change/@fluentui-react-55edf27b-cadb-4057-98bd-3e097dc780aa.json
+++ b/change/@fluentui-react-55edf27b-cadb-4057-98bd-3e097dc780aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DetailsList is still tabbable when header is not visible",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -486,6 +486,9 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
 
       const rowRole = role === defaultRole ? undefined : 'presentation';
 
+      // add tabindex="0" to first row if no header exists, to ensure the focuszone is in the tab order
+      const rowFocusZoneProps = isHeaderVisible || index > 0 ? {} : { tabIndex: 0 };
+
       const rowProps: IDetailsRowProps = {
         item: item,
         itemIndex: index,
@@ -520,6 +523,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
         useFastIcons,
         role: rowRole,
         isGridRow: true,
+        focusZoneProps: rowFocusZoneProps,
       };
 
       if (!item) {

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -1077,4 +1077,14 @@ describe('DetailsList', () => {
     const groupNameId = checkbox.getAttribute('aria-labelledby')?.split(' ')[1];
     expect(container.querySelector(`#${groupNameId} span`)!.textContent).toEqual('Group 0');
   });
+
+  it('makes the first row tabbable if isHeaderVisible is false', () => {
+    const component = renderer.create(
+      <DetailsList items={mockData(5)} columns={mockData(5, true)} isHeaderVisible={false} />,
+    );
+
+    const firstRow = component.root.findAllByType(DetailsRow)[0];
+
+    expect(firstRow.props.focusZoneProps?.tabIndex).toEqual(0);
+  });
 });


### PR DESCRIPTION
Fixes [15391](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15391)

Adds `tabindex="0"` to the first row if `isHeaderVisible=false` is set on the parent DetailsList. This ensures tab focus will always enter the DetailsList, and go to the correct element if there is no header (normally it lands on the first header cell).

FocusZone takes care of tabindex & arrow key behavior after the first time tab enters the DetailsList.