### PR TITLE
fix: Fixing color of disabled links in High Contrast mode.

### DIFF
--- a/change/@fluentui-react-a356b1ec-2b79-42ad-b811-964c899f748c.json
+++ b/change/@fluentui-react-a356b1ec-2b79-42ad-b811-964c899f748c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing color of disabled links in High Contrast mode.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Link/Link.styles.ts
+++ b/packages/react/src/components/Link/Link.styles.ts
@@ -89,6 +89,11 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
             '&:link, &:visited': {
               pointerEvents: 'none',
             },
+
+            [HighContrastSelector]: {
+              // We need to specify the color in High Contrast because of the case of Links rendering as buttons.
+              color: 'GrayText',
+            },
           },
         },
       ],

--- a/packages/react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -304,7 +304,7 @@ exports[`Link renders disabled Link correctly 1`] = `
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: auto;
         border-bottom: none;
-        color: CanvasText;
+        color: GrayText;
         forced-color-adjust: auto;
       }
       &:link {
@@ -362,7 +362,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-bottom: none;
-        color: CanvasText;
+        color: GrayText;
         forced-color-adjust: none;
       }
       &:link {

--- a/packages/react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -304,6 +304,7 @@ exports[`Link renders disabled Link correctly 1`] = `
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         -ms-high-contrast-adjust: auto;
         border-bottom: none;
+        color: CanvasText;
         forced-color-adjust: auto;
       }
       &:link {
@@ -361,7 +362,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         border-bottom: none;
-        color: LinkText;
+        color: CanvasText;
         forced-color-adjust: none;
       }
       &:link {


### PR DESCRIPTION
## Previous Behavior

Disabled links that did not have an href defined would show as enabled in High Contrast due to them being rendered as `button` tags. Here is how they looked in every default High Contrast theme in Windows 11:

#### Aquatic

![image](https://user-images.githubusercontent.com/7798177/197291751-59895b65-b2bf-459a-b56c-faf84ae43285.png)

#### Desert

![image](https://user-images.githubusercontent.com/7798177/197291815-473771ad-0c49-44eb-98de-553950556d74.png)

#### Dusk

![image](https://user-images.githubusercontent.com/7798177/197291852-ea28f14f-867f-4818-96fa-4abe0ac9f85f.png)

#### Night sky

![image](https://user-images.githubusercontent.com/7798177/197291892-c9d48ea7-842a-4685-b665-10a53922da5e.png)

## New Behavior

Disabled links that do not have an href defined are now shown as disabled in High Contrast even if they are being rendered as `button` tags. Here is how they look in every default High Contrast theme in Windows 11:

#### Aquatic

![image](https://user-images.githubusercontent.com/7798177/197292121-ee55cf73-d775-492c-8b24-368fd35867a6.png)

#### Desert

![image](https://user-images.githubusercontent.com/7798177/197292083-4446234c-135e-48fb-89a7-0a5ef8c2bf11.png)

#### Dusk

![image](https://user-images.githubusercontent.com/7798177/197292045-daa881a8-1712-46e3-a6d3-4e7b9cbf5647.png)

#### Night sky

![image](https://user-images.githubusercontent.com/7798177/197292004-758b550c-5d90-43ce-9908-505a72b6d4e9.png)

## Related Issue(s)

Fixes [15275](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15275)