### PR TITLE
Pass variables to Carousel components

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Popup` trigger attribute being override @chpalac ([#24794](https://github.com/microsoft/fluentui/pull/24794))
 - Fix styling mutation when merging themes in `Dropdown` @petrjaros ([#24787](https://github.com/microsoft/fluentui/pull/24787))
 - Fix `Toolbar` submenu closing when another submenu is opened @miroslavstastny ([#24836](https://github.com/microsoft/fluentui/pull/24836))
+- Fix `Carousel` `variable` prop inheritence to `CarouselPaddlesContainer` and `CarouselItem` @Hirse ([#25347](https://github.com/microsoft/fluentui/pull/25347))
 
 ### Performance
 - Avoid memory trashing in `felaExpandCssShorthandsPlugin` @layershifter ([#24663](https://github.com/microsoft/fluentui/pull/24663))

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -34,7 +34,7 @@ import {
   ForwardRefWithAs,
 } from '@fluentui/react-bindings';
 import { createCarouselManager, CarouselState, CarouselActions } from '@fluentui/state';
-import { CarouselPaddlesContainer } from './CarouselPaddlesContainer';
+import { CarouselPaddlesContainer, CarouselPaddlesContainerProps } from './CarouselPaddlesContainer';
 import { getAnimationName } from './utils';
 
 export interface CarouselSlotClassNames {
@@ -82,6 +82,7 @@ export interface CarouselProps extends UIComponentProps, ChildrenComponentProps 
   /** Shorthand array of props for CarouselItem. */
   items?: ShorthandCollection<CarouselItemProps>;
 
+  /** A navigation may have thumbnails. */
   thumbnails?: boolean;
 
   /** Shorthand array of props for the buttons of the CarouselNavigation. */
@@ -314,7 +315,7 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
     }
   };
 
-  const overrideItemProps = predefinedProps => ({
+  const overrideItemProps = (predefinedProps: CarouselItemProps) => ({
     onFocus: (e, itemProps) => {
       actions.setShouldFocusContainer(e.currentTarget === e.target);
       actions.setIsFromKeyboard(isEventFromKeyboard());
@@ -325,6 +326,7 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
       actions.setIsFromKeyboard(false);
       _.invoke(predefinedProps, 'onBlur', e, itemProps);
     },
+    variables: mergeVariablesOverrides(variables, predefinedProps.variables),
   });
 
   const renderContent = () => {
@@ -454,8 +456,9 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
       CarouselPaddlesContainer,
       {},
       {
-        overrideProps: () => ({
+        overrideProps: (predefinedProps: CarouselPaddlesContainerProps) => ({
           children: paddles,
+          variables: mergeVariablesOverrides(variables, predefinedProps.variables),
         }),
       },
     );

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
@@ -66,6 +66,7 @@ export interface CarouselNavigationItemProps extends UIComponentProps, ChildrenC
   /** A vertical carousel navigation displays elements vertically. */
   vertical?: boolean;
 
+  /** A navigation may have thumbnails. */
   thumbnails?: boolean;
 
   /** A navigation may be clickable */


### PR DESCRIPTION
Fixes #24120

Pass variables set on Carousel to child components.
Also adds missing `thumbnails` prop documentation.