### PR TITLE
feat(tools): add unstable API setup updates

### DIFF
--- a/tools/types.ts
+++ b/tools/types.ts
@@ -25,6 +25,8 @@ export interface PackageJson {
   typings?: string;
   private?: boolean;
   name: string;
+  main: string;
+  module?: string;
   version: string;
   scripts?: Record<string, string>;
   dependencies?: Record<string, string>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- setting export maps for both stable and unstable is mixed within 1 function call which breaks domain boundaries and hard migration by scope
- export maps are not set by source of truth which is presence of `main` and `module` fields

## New Behavior

- new API `setupUnstableApi` that handles package.json and api-extractor updates for unstable API (encapsulates logic so it's easy to turn off for scoped migration runs)
- export maps are created based on `main` and `module` fields

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows https://github.com/microsoft/fluentui/pull/25033
