### PR TITLE
chore(react-persona, react-components, vr-tests-v9): Reverting react-persona's version to beta  

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -32,7 +32,7 @@
     "@fluentui/react-label": "^9.0.8",
     "@fluentui/react-link": "^9.0.9",
     "@fluentui/react-menu": "^9.3.1",
-    "@fluentui/react-persona": "^9.0.3",
+    "@fluentui/react-persona": "^9.1.0-beta.0",
     "@fluentui/react-popover": "^9.2.1",
     "@fluentui/react-positioning": "^9.2.2",
     "@fluentui/react-progress": "9.0.0-alpha.2",

--- a/change/@fluentui-react-components-e65f456e-3889-46a3-b460-22b8ca64c163.json
+++ b/change/@fluentui-react-components-e65f456e-3889-46a3-b460-22b8ca64c163.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Updating react-persona's version.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-136c281a-d718-41d2-bf77-89ae7c9570b5.json
+++ b/change/@fluentui-react-persona-136c281a-d718-41d2-bf77-89ae7c9570b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Change version back to beta.",
+  "packageName": "@fluentui/react-persona",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -49,7 +49,7 @@
     "@fluentui/react-link": "^9.0.9",
     "@fluentui/react-menu": "^9.3.1",
     "@fluentui/react-overflow": "9.0.0-beta.12",
-    "@fluentui/react-persona": "^9.0.3",
+    "@fluentui/react-persona": "^9.1.0-beta.0",
     "@fluentui/react-portal": "^9.0.8",
     "@fluentui/react-popover": "^9.2.1",
     "@fluentui/react-positioning": "^9.2.2",

--- a/packages/react-components/react-persona/package.json
+++ b/packages/react-components/react-persona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-persona",
-  "version": "9.0.3",
+  "version": "9.1.0-beta.0",
   "description": "React components for building web experiences",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
This PR reverts Persona's release to stable and moves it back to beta. There's no need to move the exports to unstable since they are already exported in unstable.

Note: the version is `9.1.0-beta.0` since the first stable version of Persona will start in `9.1.0`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related #25325
