### PR TITLE
fix: list even/odd off-by-one issue

### DIFF
--- a/packages/react-examples/src/react/List/List.Scrolling.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Scrolling.Example.tsx
@@ -8,8 +8,8 @@ import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { mergeStyleSets, getTheme, normalize } from '@fluentui/react/lib/Styling';
 import { useConst } from '@fluentui/react-hooks';
 
-const evenItemHeight = 25;
-const oddItemHeight = 50;
+const evenItemHeight = 50;
+const oddItemHeight = 25;
 const numberOfItemsOnPage = 10;
 const theme = getTheme();
 const dropdownOptions = [
@@ -26,14 +26,14 @@ const styles = mergeStyleSets({
     border: '1px solid #CCC',
     marginTop: 20,
     selectors: {
-      '.ms-List-cell:nth-child(odd)': {
-        height: 50,
-        lineHeight: 50,
-        background: theme.palette.neutralLighter,
+      '.ms-List-cell .odd': {
+        height: oddItemHeight,
+        lineHeight: oddItemHeight,
       },
-      '.ms-List-cell:nth-child(even)': {
-        height: 25,
-        lineHeight: 25,
+      '.ms-List-cell .even': {
+        height: evenItemHeight,
+        lineHeight: evenItemHeight,
+        background: theme.palette.neutralLighter,
       },
     },
   },
@@ -52,7 +52,7 @@ const styles = mergeStyleSets({
 
 const onRenderCell = (item: IExampleItem, index: number): JSX.Element => {
   return (
-    <div data-is-focusable>
+    <div data-is-focusable className={index % 2 === 0 ? 'even' : 'odd'}>
       <div className={styles.itemContent}>
         {index} &nbsp; {item.name}
       </div>


### PR DESCRIPTION
## Current Behavior

`List`'s scrolling example computes even/odd in two different ways which results in even/odd height calculations being mismatched.

The first method of computing even/odd is via [`nth-child(odd)`](https://github.com/microsoft/fluentui/blob/master/packages/react-examples/src/react/List/List.Scrolling.Example.tsx#L29) and [`nth-child(even)`](https://github.com/microsoft/fluentui/blob/master/packages/react-examples/src/react/List/List.Scrolling.Example.tsx#L34) in CSS which is a [1-based syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#syntax).

The second method of even/odd computation in in Javascript via the [tried-and-true `i % 2 === 0`](https://github.com/microsoft/fluentui/blob/master/packages/react-examples/src/react/List/List.Scrolling.Example.tsx#L84) which is a 0-based syntax.

This mismatch means that JS thinks the first element in the list is even while CSS thinks it is odd. Because the even rows in the example have different heights than the odd ones this means the computations for scrolling items into view are "off-by-one".

## New Behavior

Removes the `nth-child` selectors for even and odd, replacing them with classes `.even` and `.odd`. These class are computed in Javascript when rendering the list cell, ensuring we use the same number base for all even/odd computations in the example.

Swaps the values of `evenItemHeight` and `oddItemHeight` to maintain the visual appearance of the example.

## Related Issue(s)

Fixes #23765
