### PR TITLE
chore(keyboard-keys, priority-overflow, react-context-selector, react-conformance-griffel): migrate to new package structure

### DIFF
--- a/change/@fluentui-keyboard-keys-17568f3b-0c78-4d62-9a8e-3bcbfc909077.json
+++ b/change/@fluentui-keyboard-keys-17568f3b-0c78-4d62-9a8e-3bcbfc909077.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-priority-overflow-dbd9bb57-0b7c-4fd7-a98c-e010ee4fa3ed.json
+++ b/change/@fluentui-priority-overflow-dbd9bb57-0b7c-4fd7-a98c-e010ee4fa3ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-griffel-8a8f2459-c754-4132-bc30-e2c4ae5e619d.json
+++ b/change/@fluentui-react-conformance-griffel-8a8f2459-c754-4132-bc30-e2c4ae5e619d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-93df1771-1d6a-42b0-9ae9-81c69d985405.json
+++ b/change/@fluentui-react-context-selector-93df1771-1d6a-42b0-9ae9-81c69d985405.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/keyboard-keys/.npmignore
+++ b/packages/react-components/keyboard-keys/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/keyboard-keys/tsconfig.spec.json
+++ b/packages/react-components/keyboard-keys/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }

--- a/packages/react-components/priority-overflow/.npmignore
+++ b/packages/react-components/priority-overflow/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/priority-overflow/tsconfig.spec.json
+++ b/packages/react-components/priority-overflow/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }

--- a/packages/react-components/react-conformance-griffel/.npmignore
+++ b/packages/react-components/react-conformance-griffel/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/react-conformance-griffel/tsconfig.spec.json
+++ b/packages/react-components/react-conformance-griffel/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }

--- a/packages/react-components/react-context-selector/.npmignore
+++ b/packages/react-components/react-context-selector/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/react-context-selector/tsconfig.spec.json
+++ b/packages/react-components/react-context-selector/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }


### PR DESCRIPTION
## Changes:
- Runs `migrate-converged-pkg` on `@fluentui/keyboard-keys`, `@fluentui/priority-overflow`, `@fluentui/react-context-selector` and `@fluentui/react-conformance-griffel` which reflects updates made in #24458.
	- Ony minor changes to `.npmignore` and `tsconfig.spec.json` were applied to these packages.