### PR TITLE
chore(react-persona): Update beachball settings and change file's type

### DIFF
--- a/change/@fluentui-react-persona-136c281a-d718-41d2-bf77-89ae7c9570b5.json
+++ b/change/@fluentui-react-persona-136c281a-d718-41d2-bf77-89ae7c9570b5.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "chore: Change version back to beta.",
   "packageName": "@fluentui/react-persona",
   "email": "esteban.230@hotmail.com",

--- a/change/@fluentui-react-persona-136c281a-d718-41d2-bf77-89ae7c9570b5.json
+++ b/change/@fluentui-react-persona-136c281a-d718-41d2-bf77-89ae7c9570b5.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "none",
   "comment": "chore: Change version back to beta.",
   "packageName": "@fluentui/react-persona",
   "email": "esteban.230@hotmail.com",

--- a/change/@fluentui-react-persona-a6c9df1e-3923-4018-b1f8-b8a05f609aad.json
+++ b/change/@fluentui-react-persona-a6c9df1e-3923-4018-b1f8-b8a05f609aad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Update beachball settings.",
+  "packageName": "@fluentui/react-persona",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-persona/package.json
+++ b/packages/react-components/react-persona/package.json
@@ -46,9 +46,11 @@
     "react-dom": ">=16.8.0 <19.0.0"
   },
   "beachball": {
+    "tag": "beta",
     "disallowedChangeTypes": [
       "major",
-      "prerelease"
+      "minor",
+      "patch"
     ]
   }
 }


### PR DESCRIPTION
This PR changes the type of a change file from #25357 to type `none` and updates beachball's configuration in Persona. This change will fix the bug introduced by #24763.