### PR TITLE
fix(react-persona): Changing persona's versions to pinned versions

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -32,7 +32,7 @@
     "@fluentui/react-label": "^9.0.8",
     "@fluentui/react-link": "^9.0.9",
     "@fluentui/react-menu": "^9.3.1",
-    "@fluentui/react-persona": "^9.1.0-beta.1",
+    "@fluentui/react-persona": "9.1.0-beta.1",
     "@fluentui/react-popover": "^9.2.1",
     "@fluentui/react-positioning": "^9.2.2",
     "@fluentui/react-progress": "9.0.0-alpha.3",

--- a/change/@fluentui-react-components-24a1fd19-7047-45d2-91ae-c60cd3c5d84e.json
+++ b/change/@fluentui-react-components-24a1fd19-7047-45d2-91ae-c60cd3c5d84e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Change react-persona to pinned version.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -49,7 +49,7 @@
     "@fluentui/react-link": "^9.0.9",
     "@fluentui/react-menu": "^9.3.1",
     "@fluentui/react-overflow": "9.0.0-beta.12",
-    "@fluentui/react-persona": "^9.1.0-beta.1",
+    "@fluentui/react-persona": "9.1.0-beta.1",
     "@fluentui/react-portal": "^9.0.8",
     "@fluentui/react-popover": "^9.2.1",
     "@fluentui/react-positioning": "^9.2.2",


### PR DESCRIPTION
This PR fixes an issue with `@fluentui/react-persona` having a caret instead of being a pinned version. This is due to beta/alpha packages needing to be pinned versions.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes [#25357#discussion_r1004118197](https://github.com/microsoft/fluentui/pull/25357#discussion_r1004118197)
