### PR TITLE
fix(projects-test): explicitly install next version 12 to fix CI

### DIFF
--- a/packages/fluentui/projects-test/src/nextjs.ts
+++ b/packages/fluentui/projects-test/src/nextjs.ts
@@ -19,7 +19,7 @@ export async function nextjs() {
   logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
   logger('STEP 1. Add dependencies to test project');
-  const dependencies = ['next', 'react@17', 'react-dom@17'].join(' ');
+  const dependencies = ['next@12', 'react@17', 'react-dom@17'].join(' ');
   await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
   logger(`✔️ Dependencies were installed`);
 


### PR DESCRIPTION
## Changes:
- `next` major bump to version `13.0.0` was just [released ](https://www.npmjs.com/package/next) which is causing `projects-test` to break since it now requires a peer dependency on React 18. This PR explicitly installs the previous major version of  `next` which is version 12 to fix CI error.

Fixes error below:

```
verb @fluentui/projects-test test |  warning package.json: No license field
verb @fluentui/projects-test test |  $ /tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/.bin/next build
verb @fluentui/projects-test test |  warn  - No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
verb @fluentui/projects-test test |  Attention: Next.js now collects completely anonymous telemetry regarding usage.
verb @fluentui/projects-test test |  This information is used to shape Next.js' roadmap and prioritize features.
verb @fluentui/projects-test test |  You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
verb @fluentui/projects-test test |  https://nextjs.org/telemetry
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  info  - Linting and checking validity of types...
verb @fluentui/projects-test test |  info  - Creating an optimized production build...
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  > Build error occurred
verb @fluentui/projects-test test |  Error: Next.js requires React 18.2.0 to be installed.
verb @fluentui/projects-test test |      at Object.getBaseWebpackConfig [as default] (/tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/next/dist/build/webpack-config.js:59:19)
verb @fluentui/projects-test test |      at async Promise.all (index 0)
verb @fluentui/projects-test test |      at async Span.traceAsyncFn (/tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/next/dist/trace/trace.js:79:20)
verb @fluentui/projects-test test |      at async /tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/next/dist/build/index.js:449:33
verb @fluentui/projects-test test |      at async /tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/next/dist/build/index.js:433:13
verb @fluentui/projects-test test |      at async Span.traceAsyncFn (/tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/next/dist/trace/trace.js:79:20)
verb @fluentui/projects-test test |      at async Object.build [as default] (/tmp/project-nextjs--1760-DcBG6QG62tc5/test-app/node_modules/next/dist/build/index.js:64:29)
verb @fluentui/projects-test test |  error Command failed with exit code 1.
verb @fluentui/projects-test test |  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
verb @fluentui/react-northstar test |  PASS test/specs/components/Carousel/CarouselPaddle-test.tsx (6.109 s)
verb @fluentui/projects-test test |  Error: child process exited with code 1
verb @fluentui/projects-test test |      at ChildProcess.<anonymous> (/mnt/vss/_work/1/s/scripts/gulp/sh.ts:29:14)
verb @fluentui/projects-test test |      at ChildProcess.emit (events.js:400:28)
verb @fluentui/projects-test test |      at maybeClose (internal/child_process.js:1058:16)
verb @fluentui/projects-test test |      at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  
verb @fluentui/projects-test test |  @fluentui/projects-test: The test suite failed, please check FAQ in "packages/fluentui/projects-test/README.md" for more details
verb @fluentui/projects-test test |  
