### PR TITLE
fix: Improve Stack's style recalculation performance by selectively applying children selectors

### DIFF
--- a/change/@fluentui-react-ecb76517-ad98-4a5e-b9ca-e853cae9a44d.json
+++ b/change/@fluentui-react-ecb76517-ad98-4a5e-b9ca-e853cae9a44d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Improve Stack's style recalculation performance by selectively applying children selectors.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
@@ -28,9 +28,6 @@ exports[`Card Item renders correctly 1`] = `
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -94,9 +91,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       }
       & > *:not(:first-child) {
         margin-left: 12px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
@@ -188,9 +182,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -280,9 +271,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       }
       & > *:not(:first-child) {
         margin-left: 12px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
@@ -374,9 +362,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -466,9 +451,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       }
       & > *:not(:first-child) {
         margin-left: 12px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
@@ -586,9 +568,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -705,9 +684,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(:first-child) {
         margin-left: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -772,9 +748,6 @@ exports[`Card Item renders correctly when filling up the margins while being the
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -838,9 +811,6 @@ exports[`Card Item renders correctly when having tokens passed to it 1`] = `
       }
       & > *:not(:first-child) {
         margin-top: 12px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;

--- a/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
@@ -28,9 +28,6 @@ exports[`Card Section renders correctly 1`] = `
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -68,9 +65,6 @@ exports[`Card Section renders correctly 1`] = `
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -106,9 +100,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-left: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -147,9 +138,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -183,9 +171,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -221,9 +206,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -262,9 +244,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -298,9 +277,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -336,9 +312,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-left: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -377,9 +350,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -413,9 +383,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -451,9 +418,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -492,9 +456,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -528,9 +489,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -566,9 +524,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-left: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -607,9 +562,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -644,9 +596,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -680,9 +629,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -718,9 +664,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -759,9 +702,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -795,9 +735,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -833,9 +770,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -869,9 +803,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       }
       & > *:not(:first-child) {
         margin-left: 12px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
@@ -910,9 +841,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />
@@ -948,9 +876,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
       & > *:not(:first-child) {
         margin-top: 12px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
       }
@@ -989,9 +914,6 @@ exports[`Card Section renders correctly when filling up the margins while being 
         & > *:not(:first-child) {
           margin-top: 12px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div />
   </div>
@@ -1025,9 +947,6 @@ exports[`Card Section renders correctly when having tokens passed to it 1`] = `
       }
       & > *:not(:first-child) {
         margin-top: 12px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
       @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
         box-shadow: 0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight;
@@ -1066,9 +985,6 @@ exports[`Card Section renders correctly when having tokens passed to it 1`] = `
         }
         & > *:not(:first-child) {
           margin-top: 12px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div />

--- a/packages/react-cards/src/components/Card/__snapshots__/Card.view.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/__snapshots__/Card.view.test.tsx.snap
@@ -17,12 +17,6 @@ exports[`CardView renders a Horizontal Card with an onClick function specified c
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"
@@ -69,12 +63,6 @@ exports[`CardView renders a Horizontal Card with contents correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
   onKeyDown={[Function]}
   role="presentation"
@@ -166,12 +154,6 @@ exports[`CardView renders a Horizontal Card without contents correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
   onKeyDown={[Function]}
   role="presentation"
   tabIndex={-1}
@@ -194,12 +176,6 @@ exports[`CardView renders a Vertical Card with an onClick function specified cor
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -247,12 +223,6 @@ exports[`CardView renders a Vertical Card with contents correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
   onKeyDown={[Function]}
   role="presentation"
@@ -343,12 +313,6 @@ exports[`CardView renders a Vertical Card without contents correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
   onKeyDown={[Function]}
   role="presentation"

--- a/packages/react-experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
+++ b/packages/react-experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
@@ -19,12 +19,6 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -40,12 +34,6 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
         }
         & > * {
           text-overflow: ellipsis;
-        }
-        & > *:not(:first-child) {
-          margin-left: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div>
@@ -335,12 +323,6 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -356,12 +338,6 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
         }
         & > * {
           text-overflow: ellipsis;
-        }
-        & > *:not(:first-child) {
-          margin-left: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div>

--- a/packages/react/src/components/Stack/Stack.styles.ts
+++ b/packages/react/src/components/Stack/Stack.styles.ts
@@ -45,10 +45,10 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
   };
 
   // selectors to be applied regardless of wrap or direction
-  const commonSelectors = {
+  const disableShrinkStyles = {
     // flexShrink styles are applied by the StackItem
     '> *:not(.ms-StackItem)': {
-      flexShrink: disableShrink ? 0 : 1,
+      flexShrink: 0,
     },
   };
 
@@ -97,15 +97,13 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           width: columnGap.value === 0 ? '100%' : `calc(100% + ${columnGap.value}${columnGap.unit})`,
           maxWidth: '100vw',
 
-          selectors: {
-            '> *': {
-              margin: `${0.5 * rowGap.value}${rowGap.unit} ${0.5 * columnGap.value}${columnGap.unit}`,
+          '> *': {
+            margin: `${0.5 * rowGap.value}${rowGap.unit} ${0.5 * columnGap.value}${columnGap.unit}`,
 
-              ...childStyles,
-            },
-            ...commonSelectors,
+            ...childStyles,
           },
         },
+        disableShrink && disableShrinkStyles,
         horizontalAlign && {
           [horizontal ? 'justifyContent' : 'alignItems']: nameMap[horizontalAlign] || horizontalAlign,
         },
@@ -118,20 +116,16 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           // avoid unnecessary calc() calls if vertical gap is 0
           height: rowGap.value === 0 ? '100%' : `calc(100% + ${rowGap.value}${rowGap.unit})`,
 
-          selectors: {
-            '> *': {
-              maxWidth: columnGap.value === 0 ? '100%' : `calc(100% - ${columnGap.value}${columnGap.unit})`,
-            },
+          '> *': {
+            maxWidth: columnGap.value === 0 ? '100%' : `calc(100% - ${columnGap.value}${columnGap.unit})`,
           },
         },
         !horizontal && {
           flexDirection: reversed ? 'column-reverse' : 'column',
           height: `calc(100% + ${rowGap.value}${rowGap.unit})`,
 
-          selectors: {
-            '> *': {
-              maxHeight: rowGap.value === 0 ? '100%' : `calc(100% - ${rowGap.value}${rowGap.unit})`,
-            },
+          '> *': {
+            maxHeight: rowGap.value === 0 ? '100%' : `calc(100% - ${rowGap.value}${rowGap.unit})`,
           },
         },
       ],
@@ -152,26 +146,28 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         padding: parsePadding(padding, theme),
         boxSizing: 'border-box',
 
-        selectors: {
-          '> *': childStyles,
-
-          // apply gap margin to every direct child except the first direct child if the direction is not reversed,
-          // and the last direct one if it is
-          [reversed ? '> *:not(:last-child)' : '> *:not(:first-child)']: [
-            horizontal && {
-              marginLeft: `${columnGap.value}${columnGap.unit}`,
-            },
-            !horizontal && {
-              marginTop: `${rowGap.value}${rowGap.unit}`,
-            },
-          ],
-
-          ...commonSelectors,
-        },
+        '> *': childStyles,
       },
+      disableShrink && disableShrinkStyles,
       grow && {
         flexGrow: grow === true ? 1 : grow,
       },
+      horizontal &&
+        columnGap.value > 0 && {
+          // apply gap margin to every direct child except the first direct child if the direction is not reversed,
+          // and the last direct one if it is
+          [reversed ? '> *:not(:last-child)' : '> *:not(:first-child)']: {
+            marginLeft: `${columnGap.value}${columnGap.unit}`,
+          },
+        },
+      !horizontal &&
+        rowGap.value > 0 && {
+          // apply gap margin to every direct child except the first direct child if the direction is not reversed,
+          // and the last direct one if it is
+          [reversed ? '> *:not(:last-child)' : '> *:not(:first-child)']: {
+            marginTop: `${rowGap.value}${rowGap.unit}`,
+          },
+        },
       horizontalAlign && {
         [horizontal ? 'justifyContent' : 'alignItems']: nameMap[horizontalAlign] || horizontalAlign,
       },

--- a/packages/react/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/react/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -15,12 +15,6 @@ exports[`Stack accepts custom className on child items 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -67,12 +61,6 @@ exports[`Stack renders default horizontal Stack correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div>
     Item 1
@@ -98,12 +86,6 @@ exports[`Stack renders default vertical Stack correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div>
     Item 1
@@ -128,12 +110,6 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -262,12 +238,6 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -320,12 +290,6 @@ exports[`Stack renders horizontal Stack with StackItems inside a React.Fragment 
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -382,9 +346,6 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
       }
       & > *:not(:first-child) {
         margin-left: 10px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -464,9 +425,6 @@ exports[`Stack renders horizontal Stack with a gap in rtl context correctly 1`] 
         & > *:not(:first-child) {
           margin-right: 10px;
         }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     <div
       className=
@@ -521,12 +479,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -542,12 +494,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
         }
         & > * {
           text-overflow: ellipsis;
-        }
-        & > *:not(:first-child) {
-          margin-left: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     Item 1
@@ -567,12 +513,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
         & > * {
           text-overflow: ellipsis;
         }
-        & > *:not(:first-child) {
-          margin-left: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     Item 2
   </div>
@@ -590,12 +530,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
         }
         & > * {
           text-overflow: ellipsis;
-        }
-        & > *:not(:first-child) {
-          margin-left: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     Item 3
@@ -617,12 +551,6 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 1`] 
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -676,12 +604,6 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 2`] 
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -738,12 +660,6 @@ exports[`Stack renders horizontal Stack with vertical and horizontal alignment c
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div>
     Item 1
@@ -768,12 +684,6 @@ exports[`Stack renders horizontal Stack with vertical fill correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div>
@@ -800,12 +710,6 @@ exports[`Stack renders reversed horizontal Stack correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:last-child) {
-        margin-left: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div>
     Item 1
@@ -831,12 +735,6 @@ exports[`Stack renders reversed vertical Stack correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:last-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div>
     Item 1
@@ -861,12 +759,6 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -920,12 +812,6 @@ exports[`Stack renders vertical Stack with StackItems inside a React.Fragment co
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -983,9 +869,6 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
       & > *:not(:first-child) {
         margin-top: 10px;
       }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -1039,12 +922,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -1060,12 +937,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
         }
         & > * {
           text-overflow: ellipsis;
-        }
-        & > *:not(:first-child) {
-          margin-top: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     Item 1
@@ -1085,12 +956,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
         & > * {
           text-overflow: ellipsis;
         }
-        & > *:not(:first-child) {
-          margin-top: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
-        }
   >
     Item 2
   </div>
@@ -1108,12 +973,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
         }
         & > * {
           text-overflow: ellipsis;
-        }
-        & > *:not(:first-child) {
-          margin-top: 0px;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     Item 3
@@ -1135,12 +994,6 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -1269,12 +1122,6 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 1`] = 
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div
     className=
@@ -1327,12 +1174,6 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 2`] = 
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div
@@ -1389,12 +1230,6 @@ exports[`Stack renders vertical Stack with vertical and horizontal alignment cor
       & > * {
         text-overflow: ellipsis;
       }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
-      }
 >
   <div>
     Item 1
@@ -1419,12 +1254,6 @@ exports[`Stack renders vertical Stack with vertical fill correctly 1`] = `
       }
       & > * {
         text-overflow: ellipsis;
-      }
-      & > *:not(:first-child) {
-        margin-top: 0px;
-      }
-      & > *:not(.ms-StackItem) {
-        flex-shrink: 1;
       }
 >
   <div>
@@ -1472,9 +1301,6 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           margin-top: 0px;
           max-width: 100%;
           text-overflow: ellipsis;
-        }
-        & > *:not(.ms-StackItem) {
-          flex-shrink: 1;
         }
   >
     <div

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -121,12 +121,6 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
             & > * {
               text-overflow: ellipsis;
             }
-            & > *:not(:first-child) {
-              margin-left: 0px;
-            }
-            & > *:not(.ms-StackItem) {
-              flex-shrink: 1;
-            }
             & .ms-Button:not(:first-child) {
               margin-left: 10px;
             }

--- a/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -403,12 +403,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
             & > * {
               text-overflow: ellipsis;
             }
-            & > *:not(:first-child) {
-              margin-left: 0px;
-            }
-            & > *:not(.ms-StackItem) {
-              flex-shrink: 1;
-            }
             & .ms-Button:not(:first-child) {
               margin-left: 10px;
             }
@@ -1196,12 +1190,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
             }
             & > * {
               text-overflow: ellipsis;
-            }
-            & > *:not(:first-child) {
-              margin-left: 0px;
-            }
-            & > *:not(.ms-StackItem) {
-              flex-shrink: 1;
             }
             & .ms-Button:not(:first-child) {
               margin-left: 10px;


### PR DESCRIPTION
## Previous Behavior

The `Stack` component applied children selectors independently of if they really needed to be applied or not. These selectors are expensive for style recalculation and are major contributors for slowdown in that step.

Here are the results of a trace running on our v8 docsite's `Stack` page, where most of the most expensive selectors are `Stack`-related:
- rulesFastRejected: 77823
- rulesRejected: 6660
- elapsed time: 7329 microseconds

## New Behavior

The `Stack` component now applies most children selectors only when the props indicate they are needed to be applied, which should create better style recalculation performance depending on the props passed in.

Here are the results of a trace running on our v8 docsite's `Stack` page after the change:
- rulesFastRejected: 46619
- rulesRejected: 5935
- elapsed time: 5199 microseconds

This PR also removes the usage of the `selectors` keyword in `Stack.styles.ts` since that is not needed anymore and removing them should help with bundle size.

## Related Issue(s)

Fixes part of #24259
