### PR TITLE
fix(docsite): codesandbox exports now working properly for newly migrated v9 packages

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -71,7 +71,7 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
          */
         enforce: 'post',
         test: /\.stories\.tsx$/,
-        include: /src/,
+        include: /stories|src/,
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -71,6 +71,7 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
          */
         enforce: 'post',
         test: /\.stories\.tsx$/,
+        //TODO: simplify once all v9 packages have been migrated to new package structure. Tracking work: https://github.com/microsoft/fluentui/issues/24129
         include: /stories|src/,
         exclude: /node_modules/,
         use: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- Codesandbox exports do not work for packages that have been migrated to the new package structure in #24129
## New Behavior
- Codesandbox now account for newly migrated v9 packages and codesandbox exports work again while still maintaining support for unmigrated packages.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #25350
