### PR TITLE
Website: fix focus border on UHF footer links

### DIFF
--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -38,7 +38,7 @@
   // Remove dotted outline added by MWF's main.css
   body [contentEditable=true]:focus,
   body [tabindex]:focus,
-  a[href]:not(.c-uhff-link):focus, // Don't remove the uhf link focus
+  a[href]:not(.c-uhff-link):focus, // Remove link focus outline from all links but the UHF ones
   body area[href]:focus,
   body button:focus,
   body iframe:focus,

--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -38,7 +38,7 @@
   // Remove dotted outline added by MWF's main.css
   body [contentEditable=true]:focus,
   body [tabindex]:focus,
-  body a[href]:focus,
+  a[href]:not(.c-uhff-link):focus, // Don't remove the uhf link focus
   body area[href]:focus,
   body button:focus,
   body iframe:focus,


### PR DESCRIPTION
body a[href]:focus was removing the focus outlines of the footer links. This PR uses a not(footer link class) to both omit those links from the selector, and serve as the selector to increase the link specificity for the rest of our docs. 