### PR TITLE
fix(react-aria): exposes internal leaking typings

### DIFF
--- a/change/@fluentui-react-aria-5228383f-9887-4ca8-9cc2-53527f839cbf.json
+++ b/change/@fluentui-react-aria-5228383f-9887-4ca8-9cc2-53527f839cbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "exposes internal typings: ARIAButtonAlteredProps and ARIAButtonElement",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -9,7 +9,10 @@ import * as React_2 from 'react';
 import type { ResolveShorthandFunction } from '@fluentui/react-utilities';
 import type { Slot } from '@fluentui/react-utilities';
 
-// @internal (undocumented)
+// @public
+export type ARIAButtonAlteredProps<Type extends ARIAButtonType> = (Type extends 'button' ? Pick<JSX.IntrinsicElements['button'], 'onClick' | 'onKeyDown' | 'onKeyUp' | 'disabled' | 'aria-disabled' | 'tabIndex'> : never) | (Type extends 'a' ? Pick<JSX.IntrinsicElements['a'], 'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role' | 'href'> : never) | (Type extends 'div' ? Pick<JSX.IntrinsicElements['div'], 'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-disabled' | 'tabIndex' | 'role'> : never);
+
+// @public (undocumented)
 export type ARIAButtonElement<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = HTMLButtonElement | (AlternateAs extends 'a' ? HTMLAnchorElement : never) | (AlternateAs extends 'div' ? HTMLDivElement : never);
 
 // @internal (undocumented)

--- a/packages/react-components/react-aria/src/button/types.ts
+++ b/packages/react-components/react-aria/src/button/types.ts
@@ -5,9 +5,6 @@ type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends 
 
 export type ARIAButtonType = 'button' | 'a' | 'div';
 
-/**
- * @internal
- */
 export type ARIAButtonElement<AlternateAs extends 'a' | 'div' = 'a' | 'div'> =
   | HTMLButtonElement
   | (AlternateAs extends 'a' ? HTMLAnchorElement : never)
@@ -44,7 +41,6 @@ export type ARIAButtonSlotProps<AlternateAs extends 'a' | 'div' = 'a' | 'div'> =
   Pick<ARIAButtonProps<ARIAButtonType>, 'disabled' | 'disabledFocusable'>;
 
 /**
- * @internal
  * Props that will be modified internally by `useARIAButtonProps` by each case.
  * This typing is to ensure a well specified return value for `useARIAbButtonProps`
  */

--- a/packages/react-components/react-aria/src/index.ts
+++ b/packages/react-components/react-aria/src/index.ts
@@ -6,4 +6,5 @@ export type {
   ARIAButtonType,
   ARIAButtonElement,
   ARIAButtonElementIntersection,
+  ARIAButtonAlteredProps,
 } from './button/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-aria` by making their internal typings external.

 - `ARIAButtonAlteredProps` (✅ Make it external)
 - `ARIAButtonElement` (✅ Make it external)