### PR TITLE
fix(react-context-selector): exposes internal type ContextSelector

### DIFF
--- a/change/@fluentui-react-context-selector-23a9c999-a4fe-4e81-849b-27a96d250a13.json
+++ b/change/@fluentui-react-context-selector-23a9c999-a4fe-4e81-849b-27a96d250a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "exposes internal type: ContextSelector",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-context-selector/etc/react-context-selector.api.md
+++ b/packages/react-components/react-context-selector/etc/react-context-selector.api.md
@@ -12,7 +12,7 @@ export type Context<Value> = React_2.Context<Value> & {
     Consumer: never;
 };
 
-// @internal (undocumented)
+// @public (undocumented)
 export type ContextSelector<Value, SelectedValue> = (value: Value) => SelectedValue;
 
 // @internal (undocumented)

--- a/packages/react-components/react-context-selector/src/types.ts
+++ b/packages/react-components/react-context-selector/src/types.ts
@@ -8,9 +8,6 @@ export type Context<Value> = React.Context<Value> & {
   Consumer: never;
 };
 
-/**
- * @internal
- */
 export type ContextSelector<Value, SelectedValue> = (value: Value) => SelectedValue;
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-context-selector` by making their leaking internal typings external.

- `ContextSelector` (✅ Make it external)