### PR TITLE
fix(react-shared-contexts): exposes internal leaks used in the API surface

### DIFF
--- a/change/@fluentui-react-shared-contexts-625a6ac7-63ff-4172-a2fd-a4f60b9eff2e.json
+++ b/change/@fluentui-react-shared-contexts-625a6ac7-63ff-4172-a2fd-a4f60b9eff2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "exposes internal methods and types that are used in the API surface",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-shared-contexts/etc/react-shared-contexts.api.md
+++ b/packages/react-components/react-shared-contexts/etc/react-shared-contexts.api.md
@@ -25,13 +25,13 @@ export const ThemeClassNameProvider_unstable: React_2.Provider<string>;
 // @internal (undocumented)
 export const ThemeContext_unstable: React_2.Context<ThemeContextValue_unstable>;
 
-// @internal (undocumented)
+// @public (undocumented)
 export type ThemeContextValue_unstable = Theme | Partial<Theme> | undefined;
 
 // @internal (undocumented)
 export const ThemeProvider_unstable: React_2.Provider<ThemeContextValue_unstable>;
 
-// @internal
+// @public
 export type TooltipVisibilityContextValue_unstable = {
     visibleTooltip?: {
         hide: () => void;
@@ -44,10 +44,10 @@ export const TooltipVisibilityProvider_unstable: React_2.Provider<TooltipVisibil
 // @public (undocumented)
 export function useFluent_unstable(): ProviderContextValue_unstable;
 
-// @internal (undocumented)
+// @public (undocumented)
 export function useThemeClassName_unstable(): ThemeClassNameContextValue_unstable;
 
-// @internal (undocumented)
+// @public (undocumented)
 export function useTooltipVisibility_unstable(): TooltipVisibilityContextValue_unstable;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-components/react-shared-contexts/src/ThemeClassNameContext/ThemeClassNameContext.ts
+++ b/packages/react-components/react-shared-contexts/src/ThemeClassNameContext/ThemeClassNameContext.ts
@@ -17,7 +17,6 @@ const themeClassNameContextDefaultVaue = '';
 export const ThemeClassNameProvider = ThemeClassNameContext.Provider;
 
 /**
- * @internal
  * @returns CSS class that applies css variables
  */
 export function useThemeClassName(): ThemeClassNameContextValue {

--- a/packages/react-components/react-shared-contexts/src/ThemeContext/ThemeContext.ts
+++ b/packages/react-components/react-shared-contexts/src/ThemeContext/ThemeContext.ts
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import type { Theme } from '@fluentui/react-theme';
 
-/**
- * @internal
- */
 export type ThemeContextValue = Theme | Partial<Theme> | undefined;
 
 /**

--- a/packages/react-components/react-shared-contexts/src/TooltipVisibilityContext/TooltipContext.ts
+++ b/packages/react-components/react-shared-contexts/src/TooltipVisibilityContext/TooltipContext.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 /**
- * @internal
  * The context provided by TooltipProvider
  */
 export type TooltipVisibilityContextValue = {
@@ -29,9 +28,6 @@ const tooltipVisibilityContextDefaultValue: TooltipVisibilityContextValue = {};
  */
 export const TooltipVisibilityProvider = TooltipVisibilityContext.Provider;
 
-/**
- * @internal
- */
 export function useTooltipVisibility(): TooltipVisibilityContextValue {
   return React.useContext(TooltipVisibilityContext) ?? tooltipVisibilityContextDefaultValue;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-shared-contexts` by making their leaking internal typings and methods that are leaking to the API surface external.

- `useThemeClassName_unstable` (✅ Make it external, it's exported at react-components)
- `useTooltipVisibility_unstable` (✅ Make it external, it's exported at react-components)
- `TooltipVisibilityContextValue_unstable` (✅ Make it external)
- `ThemeContextValue_unstable` (✅ Make it external, it's part of react-provider surface API)
