### PR TITLE
fix(react-utilities): exposes internal methods used in API surface

### DIFF
--- a/change/@fluentui-react-utilities-4b8968e2-4358-44f1-9085-11dc0120eb70.json
+++ b/change/@fluentui-react-utilities-4b8968e2-4358-44f1-9085-11dc0120eb70.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "exposes internal methods that are used in the API surface",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-4b8968e2-4358-44f1-9085-11dc0120eb70.json
+++ b/change/@fluentui-react-utilities-4b8968e2-4358-44f1-9085-11dc0120eb70.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "exposes internal methods that are used in the API surface",
+  "comment": "feat: exposes internal methods that are used in the API surface",
   "packageName": "@fluentui/react-utilities",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -78,7 +78,7 @@ export function isResolvedShorthand<Shorthand extends Slot<UnknownSlotProps>>(sh
 // @internal
 export function mergeCallbacks<Args extends unknown[]>(callback1: ((...args: Args) => void) | undefined, callback2: ((...args: Args) => void) | undefined): (...args: Args) => void;
 
-// @internal
+// @public
 export type RefObjectFunction<T> = React_2.RefObject<T> & ((value: T) => void);
 
 // @public
@@ -133,7 +133,7 @@ export type SlotShorthandValue = React_2.ReactChild | React_2.ReactNode[] | Reac
 // @public
 export const SSRProvider: React_2.FC;
 
-// @internal
+// @public
 export type TriggerProps<TriggerChildProps = unknown> = {
     children?: React_2.ReactElement | ((props: TriggerChildProps) => React_2.ReactElement | null) | null;
 };
@@ -160,13 +160,13 @@ export function useForceUpdate(): DispatchWithoutAction;
 // @public
 export function useId(prefix?: string, providedId?: string): string;
 
-// @internal
+// @public
 export const useIsomorphicLayoutEffect: typeof React_2.useEffect;
 
 // @public
 export function useIsSSR(): boolean;
 
-// @internal
+// @public
 export function useMergedRefs<T>(...refs: (React_2.Ref<T> | undefined)[]): RefObjectFunction<T>;
 
 // @internal (undocumented)

--- a/packages/react-components/react-utilities/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react-components/react-utilities/src/hooks/useIsomorphicLayoutEffect.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { canUseDOM } from '../ssr/index';
 
 /**
- * @internal
  * React currently throws a warning when using useLayoutEffect on the server. To get around it, we can conditionally
  * useEffect on the server (no-op) and useLayoutEffect in the browser. We occasionally need useLayoutEffect to
  * ensure we don't get a render flash for certain operations, but we may also need affected components to render on

--- a/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
@@ -1,14 +1,12 @@
 import * as React from 'react';
 
 /**
- * @internal
  * A Ref function which can be treated like a ref object in that it has an attached
  * current property, which will be updated as the ref is evaluated.
  */
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 
 /**
- * @internal
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs - Refs to collectively update with one ref value.

--- a/packages/react-components/react-utilities/src/trigger/types.ts
+++ b/packages/react-components/react-utilities/src/trigger/types.ts
@@ -19,7 +19,6 @@ export type FluentTriggerComponent = {
 };
 
 /**
- * @internal
  * A trigger may have a children that could be either:
  * 1. A single element
  * 2. A render function that will receive properties and must return a valid element or null


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-utilities` by making their internal typings and methods external.

- `useIsomorphicLayoutEffect` (✅ Make it external, it's exported at react-components)
- `useMergedRefs` (✅ Make it external, it's exported at react-components)
- `FluentTriggerComponent` (❓ shouldn't be external,  inline cast to avoid leaking types)
- `TriggerProps` (✅ Make it external)