### PR TITLE
fix(react-positioning): exposes new typings to avoid exposing internal methods

### DIFF
--- a/change/@fluentui-react-positioning-12f69b12-6e86-4415-8a0d-b34318f3b71e.json
+++ b/change/@fluentui-react-positioning-12f69b12-6e86-4415-8a0d-b34318f3b71e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "exposes new typings to avoid exposing internal methods",
+  "packageName": "@fluentui/react-positioning",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -101,6 +101,9 @@ export type PositioningVirtualElement = {
 // @public (undocumented)
 export function resolvePositioningShorthand(shorthand: PositioningShorthand | undefined | null): Readonly<PositioningProps>;
 
+// @public (undocumented)
+export type SetVirtualMouseTarget = (event: React_2.MouseEvent | MouseEvent | undefined | null) => void;
+
 // @internal (undocumented)
 export function usePositioning(options: UsePositioningOptions): {
     targetRef: React_2.MutableRefObject<any>;
@@ -109,7 +112,7 @@ export function usePositioning(options: UsePositioningOptions): {
 };
 
 // @internal
-export const usePositioningMouseTarget: (initialState?: PositioningVirtualElement | (() => PositioningVirtualElement) | undefined) => readonly [PositioningVirtualElement | undefined, (event: React_2.MouseEvent | MouseEvent | undefined | null) => void];
+export const usePositioningMouseTarget: (initialState?: PositioningVirtualElement | (() => PositioningVirtualElement) | undefined) => readonly [PositioningVirtualElement | undefined, SetVirtualMouseTarget];
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-positioning/src/index.ts
+++ b/packages/react-components/react-positioning/src/index.ts
@@ -19,4 +19,5 @@ export type {
   PositioningShorthand,
   PositioningShorthandValue,
   PositioningVirtualElement,
+  SetVirtualMouseTarget,
 } from './types';

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -57,6 +57,8 @@ export type PositioningVirtualElement = {
   contextElement?: Element;
 };
 
+export type SetVirtualMouseTarget = (event: React.MouseEvent | MouseEvent | undefined | null) => void;
+
 export interface PositioningOptions {
   /** Alignment for the component. Only has an effect if used with the @see position option */
   align?: Alignment;

--- a/packages/react-components/react-positioning/src/usePositioningMouseTarget.ts
+++ b/packages/react-components/react-positioning/src/usePositioningMouseTarget.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createVirtualElementFromClick } from './createVirtualElementFromClick';
-import { PositioningVirtualElement } from './types';
+import { PositioningVirtualElement, SetVirtualMouseTarget } from './types';
 
 /**
  * @internal
@@ -16,7 +16,7 @@ export const usePositioningMouseTarget = (
 ) => {
   const [virtualElement, setVirtualElement] = React.useState<PositioningVirtualElement | undefined>(initialState);
 
-  const setVirtualMouseTarget = (event: React.MouseEvent | MouseEvent | undefined | null) => {
+  const setVirtualMouseTarget: SetVirtualMouseTarget = event => {
     if (event === undefined || event === null) {
       setVirtualElement(undefined);
       return;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-positioning` by creating `SetVirtualMouseTarget` type and exposing it instead of exposing internal method `usePositioningMouseTarget`.

- `usePositioningMouseTarget` (❓ create new type `SetVirtualMouseTarget` and make the type external)