### PR TITLE
fix(react-dialog): removes exposing of internal type FluentTriggerComponent

### DIFF
--- a/change/@fluentui-react-dialog-a27523cc-5d13-4fd5-ac46-23fc9218bc73.json
+++ b/change/@fluentui-react-dialog-a27523cc-5d13-4fd5-ac46-23fc9218bc73.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "removes exposing of internal type FluentTriggerComponent",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -10,7 +10,6 @@ import { ARIAButtonResultProps } from '@fluentui/react-aria';
 import { ARIAButtonType } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import type { FluentTriggerComponent } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElementConstructor } from 'react';
 import * as React_2 from 'react';
@@ -163,7 +162,7 @@ export type DialogTitleSlots = {
 export type DialogTitleState = ComponentState<DialogTitleSlots>;
 
 // @public
-export const DialogTrigger: React_2.FC<DialogTriggerProps> & FluentTriggerComponent;
+export const DialogTrigger: React_2.FC<DialogTriggerProps>;
 
 // @public (undocumented)
 export type DialogTriggerAction = 'open' | 'close';

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.tsx
@@ -14,11 +14,12 @@ import type { FluentTriggerComponent } from '@fluentui/react-utilities';
  * to it's wrapped child, but it won't be able to alter the dialog `open` state anymore,
  * in that case the user must provide a `controlled state`
  */
-export const DialogTrigger: React.FC<DialogTriggerProps> & FluentTriggerComponent = props => {
+export const DialogTrigger: React.FC<DialogTriggerProps> = props => {
   const state = useDialogTrigger_unstable(props);
 
   return renderDialogTrigger_unstable(state);
 };
 
 DialogTrigger.displayName = 'DialogTrigger';
-DialogTrigger.isFluentTriggerComponent = true;
+// type casting here is required to ensure internal type FluentTriggerComponent is not leaked
+(DialogTrigger as FluentTriggerComponent).isFluentTriggerComponent = true;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-dialog` by inline casting `FluentTriggerComponent` usage to avoid leaking internal type.

- `FluentTriggerComponent` (❓ shouldn't be external,  inline cast to avoid leaking types)