### PR TITLE
fix(react-tooltip): removes exposing of internal type FluentTriggerComponent

### DIFF
--- a/change/@fluentui-react-tooltip-f6b6fe84-a30a-41b8-9e3c-6df347d764bb.json
+++ b/change/@fluentui-react-tooltip-f6b6fe84-a30a-41b8-9e3c-6df347d764bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "removes exposing of internal type FluentTriggerComponent",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/etc/react-tooltip.api.md
+++ b/packages/react-components/react-tooltip/etc/react-tooltip.api.md
@@ -6,7 +6,6 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import type { FluentTriggerComponent } from '@fluentui/react-utilities';
 import type { PortalProps } from '@fluentui/react-portal';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
@@ -23,7 +22,7 @@ export type OnVisibleChangeData = {
 export const renderTooltip_unstable: (state: TooltipState) => JSX.Element;
 
 // @public
-export const Tooltip: React_2.FC<TooltipProps> & FluentTriggerComponent;
+export const Tooltip: React_2.FC<TooltipProps>;
 
 // @public (undocumented)
 export const tooltipClassNames: SlotClassNames<TooltipSlots>;

--- a/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/Tooltip.tsx
@@ -8,7 +8,7 @@ import type { FluentTriggerComponent } from '@fluentui/react-utilities';
 /**
  * A tooltip provides light weight contextual information on top of its target element.
  */
-export const Tooltip: React.FC<TooltipProps> & FluentTriggerComponent = props => {
+export const Tooltip: React.FC<TooltipProps> = props => {
   const state = useTooltip_unstable(props);
 
   useTooltipStyles_unstable(state);
@@ -16,4 +16,5 @@ export const Tooltip: React.FC<TooltipProps> & FluentTriggerComponent = props =>
 };
 
 Tooltip.displayName = 'Tooltip';
-Tooltip.isFluentTriggerComponent = true;
+// type casting here is required to ensure internal type FluentTriggerComponent is not leaked
+(Tooltip as FluentTriggerComponent).isFluentTriggerComponent = true;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-tooltip` by inline casting `FluentTriggerComponent` usage to avoid leaking internal type.

- `FluentTriggerComponent` (❓ shouldn't be external,  inline cast to avoid leaking types)