### PR TITLE
fix(react-menu): removes exposing of internal type FluentTriggerComponent

### DIFF
--- a/change/@fluentui-react-menu-b1450657-0808-4269-92c5-c0c54be96f02.json
+++ b/change/@fluentui-react-menu-b1450657-0808-4269-92c5-c0c54be96f02.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "removes exposing of internal type FluentTriggerComponent",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -13,14 +13,14 @@ import { ARIAButtonType } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';
-import type { FluentTriggerComponent } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
+import { PositioningVirtualElement } from '@fluentui/react-positioning';
 import * as React_2 from 'react';
+import { SetVirtualMouseTarget } from '@fluentui/react-positioning';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
-import { usePositioningMouseTarget } from '@fluentui/react-positioning';
 
 // @public
 export const Menu: React_2.FC<MenuProps>;
@@ -284,19 +284,19 @@ export type MenuSplitGroupState = ComponentState<MenuSplitGroupSlots>;
 
 // @public (undocumented)
 export type MenuState = ComponentState<MenuSlots> & Pick<MenuProps, 'onOpenChange' | 'defaultCheckedValues'> & Required<Pick<MenuProps, 'hasCheckmarks' | 'hasIcons' | 'inline' | 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover' | 'closeOnScroll' | 'hoverDelay' | 'openOnContext' | 'persistOnItemClick'>> & {
-    contextTarget: ReturnType<typeof usePositioningMouseTarget>[0];
+    contextTarget?: PositioningVirtualElement;
     isSubmenu: boolean;
     menuPopover: React_2.ReactNode;
     menuPopoverRef: React_2.MutableRefObject<HTMLElement>;
     menuTrigger: React_2.ReactNode;
-    setContextTarget: ReturnType<typeof usePositioningMouseTarget>[1];
+    setContextTarget: SetVirtualMouseTarget;
     setOpen: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
     triggerId: string;
     triggerRef: React_2.MutableRefObject<HTMLElement>;
 };
 
 // @public
-export const MenuTrigger: React_2.FC<MenuTriggerProps> & FluentTriggerComponent;
+export const MenuTrigger: React_2.FC<MenuTriggerProps>;
 
 // @public
 export type MenuTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType, Props = {}> = ARIAButtonResultProps<Type, Props & {

--- a/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { usePositioningMouseTarget } from '@fluentui/react-positioning';
+import { PositioningVirtualElement, SetVirtualMouseTarget } from '@fluentui/react-positioning';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import type { MenuContextValue } from '../../contexts/menuContext';
@@ -109,7 +109,7 @@ export type MenuState = ComponentState<MenuSlots> &
     /**
      * Anchors the popper to the mouse click for context events
      */
-    contextTarget: ReturnType<typeof usePositioningMouseTarget>[0];
+    contextTarget?: PositioningVirtualElement;
 
     /**
      * Whether this menu is a submenu
@@ -134,7 +134,7 @@ export type MenuState = ComponentState<MenuSlots> &
     /**
      * A callback to set the target of the popper to the mouse click for context events
      */
-    setContextTarget: ReturnType<typeof usePositioningMouseTarget>[1];
+    setContextTarget: SetVirtualMouseTarget;
 
     /**
      * Callback to open/close the popup

--- a/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.tsx
@@ -8,11 +8,12 @@ import type { FluentTriggerComponent } from '@fluentui/react-utilities';
  * Wraps a trigger element as an only child
  * and adds the necessary event handling to open a popup menu
  */
-export const MenuTrigger: React.FC<MenuTriggerProps> & FluentTriggerComponent = props => {
+export const MenuTrigger: React.FC<MenuTriggerProps> = props => {
   const state = useMenuTrigger_unstable(props);
 
   return renderMenuTrigger_unstable(state);
 };
 
 MenuTrigger.displayName = 'MenuTrigger';
-MenuTrigger.isFluentTriggerComponent = true;
+// type casting here is required to ensure internal type FluentTriggerComponent is not leaked
+(MenuTrigger as FluentTriggerComponent).isFluentTriggerComponent = true;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-menu` by inline casting `FluentTriggerComponent` usage to avoid leaking internal type, and adopting new `SetVirtualMouseTarget` type to avoid leaking `usePositioningMouseTarget`

- `FluentTriggerComponent` (❓ shouldn't be external,  inline cast to avoid leaking types)
- `usePositioningMouseTarget` (❓ use `SetVirtualMouseTarget`)