### PR TITLE
fix(react-popover): removes exposing of internal type FluentTriggerComponent

### DIFF
--- a/change/@fluentui-react-popover-4a2a3285-fde0-4d76-ae6d-aaac8c82c420.json
+++ b/change/@fluentui-react-popover-4a2a3285-fde0-4d76-ae6d-aaac8c82c420.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "removes exposing of internal type FluentTriggerComponent",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -10,7 +10,6 @@ import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';
 import { FC } from 'react';
-import type { FluentTriggerComponent } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElementConstructor } from 'react';
 import type { PortalProps } from '@fluentui/react-portal';
@@ -20,11 +19,11 @@ import { Provider } from 'react';
 import { ProviderProps } from 'react';
 import * as React_2 from 'react';
 import { ReactElement } from 'react';
+import type { SetVirtualMouseTarget } from '@fluentui/react-positioning';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
 import type { UseModalAttributesOptions } from '@fluentui/react-tabster';
-import type { usePositioningMouseTarget } from '@fluentui/react-positioning';
 
 // @public (undocumented)
 export const arrowHeights: Record<PopoverSize, number>;
@@ -75,7 +74,7 @@ export type PopoverState = Pick<PopoverProps, 'appearance' | 'mountNode' | 'onOp
     contextTarget: PositioningVirtualElement | undefined;
     popoverSurface: React_2.ReactElement | undefined;
     popoverTrigger: React_2.ReactElement | undefined;
-    setContextTarget: ReturnType<typeof usePositioningMouseTarget>[1];
+    setContextTarget: SetVirtualMouseTarget;
     setOpen: (e: OpenPopoverEvents, open: boolean) => void;
     size: NonNullable<PopoverProps['size']>;
     toggleOpen: (e: OpenPopoverEvents) => void;
@@ -102,7 +101,7 @@ export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> & Pick<Pop
 };
 
 // @public
-export const PopoverTrigger: React_2.FC<PopoverTriggerProps> & FluentTriggerComponent;
+export const PopoverTrigger: React_2.FC<PopoverTriggerProps>;
 
 // @public
 export type PopoverTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType, Props = {}> = ARIAButtonResultProps<Type, Props & {

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type {
   PositioningVirtualElement,
   PositioningShorthand,
-  usePositioningMouseTarget,
+  SetVirtualMouseTarget,
 } from '@fluentui/react-positioning';
 import type { PortalProps } from '@fluentui/react-portal';
 import type { UseModalAttributesOptions } from '@fluentui/react-tabster';
@@ -157,7 +157,7 @@ export type PopoverState = Pick<
     /**
      * A callback to set the target of the popper to the mouse click for context events
      */
-    setContextTarget: ReturnType<typeof usePositioningMouseTarget>[1];
+    setContextTarget: SetVirtualMouseTarget;
 
     /**
      * Callback to open/close the Popover

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/PopoverTrigger.tsx
@@ -7,11 +7,12 @@ import type { PopoverTriggerProps } from './PopoverTrigger.types';
 /**
  * Wraps a trigger element as an only child and adds the necessary event handling to open a popover.
  */
-export const PopoverTrigger: React.FC<PopoverTriggerProps> & FluentTriggerComponent = props => {
+export const PopoverTrigger: React.FC<PopoverTriggerProps> = props => {
   const state = usePopoverTrigger_unstable(props);
 
   return renderPopoverTrigger_unstable(state);
 };
 
 PopoverTrigger.displayName = 'PopoverTrigger';
-PopoverTrigger.isFluentTriggerComponent = true;
+// type casting here is required to ensure internal type FluentTriggerComponent is not leaked
+(PopoverTrigger as FluentTriggerComponent).isFluentTriggerComponent = true;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

As described in https://github.com/microsoft/fluentui/pull/25319

We have some internal leaks due to wrongly usage of `@internal` annotation, the newest API extraction tool will break on those scenarios

## New Behavior

This PR solves internal leakages from `@fluentui/react-popover` by inline casting `FluentTriggerComponent` usage to avoid leaking internal type, and adopting new `SetVirtualMouseTarget` type to avoid leaking `usePositioningMouseTarget`

- `FluentTriggerComponent` (❓ shouldn't be external,  inline cast to avoid leaking types)
- `usePositioningMouseTarget` (❓ use `SetVirtualMouseTarget`)