### PR TITLE
fix(react-tabster): make acceptCondition optional as Tabster dont require it

### DIFF
--- a/change/@fluentui-react-tabster-59ed64de-6eec-46c5-b0d6-2cd22cba4d0c.json
+++ b/change/@fluentui-react-tabster-59ed64de-6eec-46c5-b0d6-2cd22cba4d0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make allowCondition a optional parameter for findAllFocusable function",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -64,7 +64,7 @@ export interface UseFocusableGroupOptions {
 
 // @public
 export const useFocusFinders: () => {
-    findAllFocusable: (container: HTMLElement, acceptCondition: (el: HTMLElement) => boolean) => HTMLElement[];
+    findAllFocusable: (container: HTMLElement, acceptCondition?: ((el: HTMLElement) => boolean) | undefined) => HTMLElement[];
     findFirstFocusable: (container: HTMLElement) => HTMLElement | null | undefined;
     findLastFocusable: (container: HTMLElement) => HTMLElement | null | undefined;
     findNextFocusable: (currentElement: HTMLElement, options?: Pick<Types.FindNextProps, 'container'>) => HTMLElement | null | undefined;

--- a/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
@@ -10,7 +10,7 @@ export const useFocusFinders = () => {
 
   // Narrow props for now and let need dictate additional props in the future
   const findAllFocusable = React.useCallback(
-    (container: HTMLElement, acceptCondition: (el: HTMLElement) => boolean) =>
+    (container: HTMLElement, acceptCondition?: (el: HTMLElement) => boolean) =>
       tabster?.focusable.findAll({ container, acceptCondition }) || [],
     [tabster],
   );


### PR DESCRIPTION
## Current Behavior
Tabster don't require an `acceptCondition` function, but the `findAllFocusable` in `react-tabster` has it required.

## New Behavior
Make `acceptCondition` parameter optional.

## Related Issue(s)
This is a quick fix for #25413
