### PR TITLE
feat: update v0 input with label inside

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputLabelStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputLabelStyles.ts
@@ -10,7 +10,7 @@ export const inputLabelStyles: ComponentSlotStylesPrepared<InputLabelStylesProps
     marginBottom: v.marginBottom,
 
     ...(p.labelPosition === 'inside' && {
-      bottom: v.insideLabelBottom,
+      bottom: 0,
       top: 0,
       left: 0,
       margin: 0,
@@ -18,10 +18,12 @@ export const inputLabelStyles: ComponentSlotStylesPrepared<InputLabelStylesProps
       display: 'flex',
       alignItems: 'center',
       zIndex: 100,
+      color: v.inputLabelColor,
       paddingLeft: v.insideLabelPaddingLeft,
       ...(p.hasValue && {
         transform: 'translateY(-16px)',
         fontSize: v.insideLabelActiveFontSize,
+        paddingTop: v.insideLabelActivePaddingTop,
       }),
     }),
     ...(p.labelPosition === 'inline' && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputLabelVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputLabelVariables.ts
@@ -4,16 +4,20 @@ export interface InputLabelVariables {
   insideLabelBottom: string;
   insideLabelPaddingLeft: string;
   insideLabelActiveFontSize: string;
+  insideLabelActivePaddingTop: string;
   inlineLabelPaddingRight: string;
   lineHeight: string;
   marginBottom: string;
+  inputLabelColor: string;
 }
 
 export const inputLabelVariables = (siteVars): InputLabelVariables => ({
   insideLabelBottom: pxToRem(-8),
   insideLabelPaddingLeft: pxToRem(12),
-  insideLabelActiveFontSize: pxToRem(12),
+  insideLabelActiveFontSize: siteVars.fontSizes.smaller,
+  insideLabelActivePaddingTop: pxToRem(6),
   inlineLabelPaddingRight: pxToRem(10),
   lineHeight: pxToRem(16),
   marginBottom: pxToRem(4),
+  inputLabelColor: siteVars.colorScheme.default.foreground2,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
@@ -69,7 +69,11 @@ export const inputStyles: ComponentSlotStylesPrepared<InputStylesProps, InputVar
       padding: p.iconPosition === 'start' ? v.inputPaddingWithIconAtStart : v.inputPaddingWithIconAtEnd,
     }),
     ...(p.labelPosition === 'inside' && {
-      paddingTop: v.inputInsideLabelPaddingTop,
+      padding: v.inputInsideLabelPadding,
+      height: v.inputInsideLabelHeight,
+      ...(p.hasValue && {
+        padding: v.inputInsideLabelActivePadding,
+      }),
     }),
     ...(p.error && { border: `${pxToRem(1)} solid ${v.borderColorError}` }),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputVariables.ts
@@ -18,7 +18,9 @@ export interface InputVariables {
   inputPadding: string;
   inputFocusBorderColor: string;
   inputFocusBorderRadius: string;
-  inputInsideLabelPaddingTop: string;
+  inputInsideLabelPadding: string;
+  inputInsideLabelActivePadding: string;
+  inputInsideLabelHeight: string;
   placeholderColor: string;
   successfulColor: string;
   borderColorError: string;
@@ -36,8 +38,9 @@ export const inputVariables = (siteVars): InputVariables => ({
   inputPaddingWithIconAtStart: `${pxToRem(5)} ${pxToRem(12)} ${pxToRem(5)} ${pxToRem(34)}`,
   inputPaddingWithIconAtEnd: `${pxToRem(5)} ${pxToRem(35)} ${pxToRem(5)} ${pxToRem(12)}`,
   inputPadding: `${pxToRem(5)} ${pxToRem(12)}`,
-  inputInsideLabelPaddingTop: pxToRem(14),
-
+  inputInsideLabelPadding: `${pxToRem(11)} ${pxToRem(12)}`,
+  inputInsideLabelActivePadding: `${pxToRem(20)} ${pxToRem(12)} ${pxToRem(4)}`,
+  inputInsideLabelHeight: pxToRem(44),
   borderColor: 'transparent',
   borderRadius: siteVars.borderRadiusMedium,
   borderWidth: `0 0 ${pxToRem(2)} 0`,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
This Pull Request updates the v0 Input component with label inside.

We added 11px of padding top and bottom to the Input component and set a fixed height of 44px.
We have also changed the label inside, setting its color to **Default Foreground 2** and changing its fontsize to 10px when active.
## Current Behavior
<img width="266" alt="Screenshot 2022-10-27 at 18 33 15" src="https://user-images.githubusercontent.com/71330266/198347728-17e4b72a-4467-406d-8ef1-c71873a1747d.png"><img width="350" alt="Screenshot 2022-10-27 at 18 33 29" src="https://user-images.githubusercontent.com/71330266/198347764-f503ca15-b382-4c9a-974d-14be3e848148.png">

<!-- This is the behavior we have today -->

## New Behavior
<img width="1031" alt="Screenshot 2022-10-27 at 18 34 13" src="https://user-images.githubusercontent.com/71330266/198347950-463a0d44-302e-45bf-a469-ad7cc63cd0c4.png">

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
