### PR TITLE
fix: Allowing DatePicker to be focusable within FocusZones by default

### DIFF
--- a/change/@fluentui-react-fd0c9c49-c0d9-4b5b-8991-45f1667ef481.json
+++ b/change/@fluentui-react-fd0c9c49-c0d9-4b5b-8991-45f1667ef481.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Allowing DatePicker to be focusable within FocusZones by default.",
+  "packageName": "@fluentui/react",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -454,6 +454,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
     <div {...nativeProps} className={classNames.root} ref={forwardedRef}>
       <div ref={datePickerDiv} aria-owns={isCalendarShown ? calloutId : undefined} className={classNames.wrapper}>
         <TextField
+          data-is-focusable
           role="combobox"
           label={label}
           aria-expanded={isCalendarShown}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -450,11 +450,12 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
     textFieldProps && textFieldProps.id && textFieldProps.id !== id ? textFieldProps.id : id + '-label';
   const readOnly = !allowTextInput && !disabled;
 
+  const dataIsFocusable = (textFieldProps as any)['data-is-focusable'] ?? (props as any)['data-is-focusable'] ?? true;
+
   return (
     <div {...nativeProps} className={classNames.root} ref={forwardedRef}>
       <div ref={datePickerDiv} aria-owns={isCalendarShown ? calloutId : undefined} className={classNames.wrapper}>
         <TextField
-          data-is-focusable
           role="combobox"
           label={label}
           aria-expanded={isCalendarShown}
@@ -472,6 +473,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
           tabIndex={tabIndex}
           readOnly={!allowTextInput}
           {...textFieldProps}
+          data-is-focusable={dataIsFocusable}
           id={textFieldId}
           className={css(classNames.textField, textFieldProps && textFieldProps.className)}
           iconProps={{

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -450,7 +450,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
     textFieldProps && textFieldProps.id && textFieldProps.id !== id ? textFieldProps.id : id + '-label';
   const readOnly = !allowTextInput && !disabled;
 
-  const dataIsFocusable = (textFieldProps as any)['data-is-focusable'] ?? (props as any)['data-is-focusable'] ?? true;
+  const dataIsFocusable = (textFieldProps as any)?.['data-is-focusable'] ?? (props as any)['data-is-focusable'] ?? true;
 
   return (
     <div {...nativeProps} className={classNames.root} ref={forwardedRef}>

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
                 @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&::-ms-input-placeholder {
                   color: GrayText;
                 }
+            data-is-focusable={true}
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}
@@ -390,6 +391,7 @@ exports[`DatePicker renders DatePicker with value correctly 1`] = `
                   overflow: hidden;
                   text-overflow: ellipsis;
                 }
+            data-is-focusable={true}
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}
@@ -622,6 +624,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   overflow: hidden;
                   text-overflow: ellipsis;
                 }
+            data-is-focusable={true}
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}


### PR DESCRIPTION
## Previous Behavior

`DatePickers` were skipped within `FocusZones` because the `data-is-focusable` attribute needed for a component to work within a `FocusZone` was not passed to it.

![Before](https://user-images.githubusercontent.com/7798177/198409575-46be6239-6956-4185-af20-d57826500cbf.gif)

## New Behavior

`DatePickers` are now focusable within `FocusZones` because the `data-is-focusable` attribute is added to them in this PR.

![After](https://user-images.githubusercontent.com/7798177/198409646-a3f3633b-5f40-4710-a8bd-4d7f9f383ccd.gif)

## Related Issue(s)

Fixes [15509](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15509)
