### PR TITLE
chore: Reducing bundle size of Stack by moving selector used in multiple places to local const

### DIFF
--- a/change/@fluentui-react-6980f88b-f6c6-426f-a469-d4db3bffadf9.json
+++ b/change/@fluentui-react-6980f88b-f6c6-426f-a469-d4db3bffadf9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Reducing bundle size of Stack by moving selector used in multiple places to local const.",
+  "packageName": "@fluentui/react",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Stack/Stack.styles.ts
+++ b/packages/react/src/components/Stack/Stack.styles.ts
@@ -47,9 +47,11 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
     textOverflow: 'ellipsis',
   };
 
+  const childSelector = enableScopedSelectors ? '.' + GlobalClassNames.child : '*';
+
   const disableShrinkStyles = {
     // flexShrink styles are applied by the StackItem
-    [`> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}:not(.${StackItemGlobalClassNames.root})`]: {
+    [`> ${childSelector}:not(.${StackItemGlobalClassNames.root})`]: {
       flexShrink: 0,
     },
   };
@@ -99,7 +101,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           width: columnGap.value === 0 ? '100%' : `calc(100% + ${columnGap.value}${columnGap.unit})`,
           maxWidth: '100vw',
 
-          [`> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}`]: {
+          [`> ${childSelector}`]: {
             margin: `${0.5 * rowGap.value}${rowGap.unit} ${0.5 * columnGap.value}${columnGap.unit}`,
 
             ...childStyles,
@@ -118,7 +120,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           // avoid unnecessary calc() calls if vertical gap is 0
           height: rowGap.value === 0 ? '100%' : `calc(100% + ${rowGap.value}${rowGap.unit})`,
 
-          [`> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}`]: {
+          [`> ${childSelector}`]: {
             maxWidth: columnGap.value === 0 ? '100%' : `calc(100% - ${columnGap.value}${columnGap.unit})`,
           },
         },
@@ -126,7 +128,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           flexDirection: reversed ? 'column-reverse' : 'column',
           height: `calc(100% + ${rowGap.value}${rowGap.unit})`,
 
-          [`> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}`]: {
+          [`> ${childSelector}`]: {
             maxHeight: rowGap.value === 0 ? '100%' : `calc(100% - ${rowGap.value}${rowGap.unit})`,
           },
         },
@@ -148,7 +150,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         padding: parsePadding(padding, theme),
         boxSizing: 'border-box',
 
-        [`> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}`]: childStyles,
+        [`> ${childSelector}`]: childStyles,
       },
       disableShrink && disableShrinkStyles,
       grow && {
@@ -165,9 +167,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         columnGap.value > 0 && {
           // apply gap margin to every direct child except the first direct child if the direction is not reversed,
           // and the last direct one if it is
-          [reversed
-            ? `> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}:not(:last-child)`
-            : `> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}:not(:first-child)`]: {
+          [reversed ? `> ${childSelector}:not(:last-child)` : `> ${childSelector}:not(:first-child)`]: {
             marginLeft: `${columnGap.value}${columnGap.unit}`,
           },
         },
@@ -175,9 +175,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         rowGap.value > 0 && {
           // apply gap margin to every direct child except the first direct child if the direction is not reversed,
           // and the last direct one if it is
-          [reversed
-            ? `> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}:not(:last-child)`
-            : `> ${enableScopedSelectors ? '.' + GlobalClassNames.child : '*'}:not(:first-child)`]: {
+          [reversed ? `> ${childSelector}:not(:last-child)` : `> ${childSelector}:not(:first-child)`]: {
             marginTop: `${rowGap.value}${rowGap.unit}`,
           },
         },

--- a/packages/react/src/components/Stack/Stack.styles.ts
+++ b/packages/react/src/components/Stack/Stack.styles.ts
@@ -47,11 +47,11 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
     textOverflow: 'ellipsis',
   };
 
-  const childSelector = enableScopedSelectors ? '.' + GlobalClassNames.child : '*';
+  const childSelector = '> ' + (enableScopedSelectors ? '.' + GlobalClassNames.child : '*');
 
   const disableShrinkStyles = {
     // flexShrink styles are applied by the StackItem
-    [`> ${childSelector}:not(.${StackItemGlobalClassNames.root})`]: {
+    [`${childSelector}:not(.${StackItemGlobalClassNames.root})`]: {
       flexShrink: 0,
     },
   };
@@ -101,7 +101,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           width: columnGap.value === 0 ? '100%' : `calc(100% + ${columnGap.value}${columnGap.unit})`,
           maxWidth: '100vw',
 
-          [`> ${childSelector}`]: {
+          [childSelector]: {
             margin: `${0.5 * rowGap.value}${rowGap.unit} ${0.5 * columnGap.value}${columnGap.unit}`,
 
             ...childStyles,
@@ -120,7 +120,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           // avoid unnecessary calc() calls if vertical gap is 0
           height: rowGap.value === 0 ? '100%' : `calc(100% + ${rowGap.value}${rowGap.unit})`,
 
-          [`> ${childSelector}`]: {
+          [childSelector]: {
             maxWidth: columnGap.value === 0 ? '100%' : `calc(100% - ${columnGap.value}${columnGap.unit})`,
           },
         },
@@ -128,7 +128,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
           flexDirection: reversed ? 'column-reverse' : 'column',
           height: `calc(100% + ${rowGap.value}${rowGap.unit})`,
 
-          [`> ${childSelector}`]: {
+          [childSelector]: {
             maxHeight: rowGap.value === 0 ? '100%' : `calc(100% - ${rowGap.value}${rowGap.unit})`,
           },
         },
@@ -150,7 +150,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         padding: parsePadding(padding, theme),
         boxSizing: 'border-box',
 
-        [`> ${childSelector}`]: childStyles,
+        [childSelector]: childStyles,
       },
       disableShrink && disableShrinkStyles,
       grow && {
@@ -167,7 +167,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         columnGap.value > 0 && {
           // apply gap margin to every direct child except the first direct child if the direction is not reversed,
           // and the last direct one if it is
-          [reversed ? `> ${childSelector}:not(:last-child)` : `> ${childSelector}:not(:first-child)`]: {
+          [reversed ? `${childSelector}:not(:last-child)` : `${childSelector}:not(:first-child)`]: {
             marginLeft: `${columnGap.value}${columnGap.unit}`,
           },
         },
@@ -175,7 +175,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         rowGap.value > 0 && {
           // apply gap margin to every direct child except the first direct child if the direction is not reversed,
           // and the last direct one if it is
-          [reversed ? `> ${childSelector}:not(:last-child)` : `> ${childSelector}:not(:first-child)`]: {
+          [reversed ? `${childSelector}:not(:last-child)` : `${childSelector}:not(:first-child)`]: {
             marginTop: `${rowGap.value}${rowGap.unit}`,
           },
         },

--- a/packages/react/src/components/Stack/Stack.types.ts
+++ b/packages/react/src/components/Stack/Stack.types.ts
@@ -152,7 +152,7 @@ export interface IStackProps
 
   /**
    * Defines if scoped style selectors are enabled for the Stack component, which greatly helps in style recalculation
-   * performance but requires children of the Stack to be able to accept a className prop (excluding Fragments).
+   * performance, but requires children of the Stack to be able to accept a className prop (excluding Fragments).
    * @defaultvalue false
    */
   enableScopedSelectors?: boolean;


### PR DESCRIPTION
## PR Description

This PR moves the children selector logic in `Stack`'s styles to a local const that is referenced to avoid duplication and help reduce bundle size of the component.

## Related Issue(s)

Applies suggestions from [this comment](https://github.com/microsoft/fluentui/pull/25397#discussion_r1007459264) in #25397