### PR TITLE
Fixes #23633 - Use Object.assign to reduce loop length

### DIFF
--- a/change/@fluentui-react-theme-6b37e9cc-8f6e-4c94-b79d-d42e1bddab74.json
+++ b/change/@fluentui-react-theme-6b37e9cc-8f6e-4c94-b79d-d42e1bddab74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use Object.assign to reduce loop runtime",
+  "packageName": "@fluentui/react-theme",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-6b37e9cc-8f6e-4c94-b79d-d42e1bddab74.json
+++ b/change/@fluentui-react-theme-6b37e9cc-8f6e-4c94-b79d-d42e1bddab74.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Use Object.assign to reduce loop runtime",
+  "comment": "refactor: Use Object.assign to reduce loop runtime",
   "packageName": "@fluentui/react-theme",
   "email": "tigeroakes@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-theme/src/alias/darkColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/darkColorPalette.ts
@@ -16,8 +16,7 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: statusSharedColors[sharedColor].tint20,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as StatusColorPaletteTokens);
 
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
@@ -28,8 +27,7 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: personaSharedColors[sharedColor].tint30,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/darkColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/darkColorPalette.ts
@@ -16,7 +16,8 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: statusSharedColors[sharedColor].tint20,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as StatusColorPaletteTokens);
 
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
@@ -27,7 +28,8 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: personaSharedColors[sharedColor].tint30,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/highContrastColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/highContrastColorPalette.ts
@@ -16,7 +16,8 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: hcCanvasText,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as StatusColorPaletteTokens);
 
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
@@ -27,7 +28,8 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: hcHighlight,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/highContrastColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/highContrastColorPalette.ts
@@ -16,8 +16,7 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: hcCanvasText,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as StatusColorPaletteTokens);
 
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
@@ -28,8 +27,7 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: hcHighlight,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/lightColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/lightColorPalette.ts
@@ -16,7 +16,8 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: statusSharedColors[sharedColor].primary,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as StatusColorPaletteTokens);
 
 // one-off patch for yellow
@@ -30,7 +31,8 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: personaSharedColors[sharedColor].primary,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/lightColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/lightColorPalette.ts
@@ -16,8 +16,7 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: statusSharedColors[sharedColor].primary,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as StatusColorPaletteTokens);
 
 // one-off patch for yellow
@@ -31,8 +30,7 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: personaSharedColors[sharedColor].primary,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/teamsDarkColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/teamsDarkColorPalette.ts
@@ -16,8 +16,7 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: statusSharedColors[sharedColor].tint20,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as StatusColorPaletteTokens);
 
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
@@ -28,8 +27,7 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: personaSharedColors[sharedColor].tint30,
   };
 
-  Object.assign(acc, sharedColorTokens);
-  return acc;
+  return Object.assign(acc, sharedColorTokens);
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };

--- a/packages/react-components/react-theme/src/alias/teamsDarkColorPalette.ts
+++ b/packages/react-components/react-theme/src/alias/teamsDarkColorPalette.ts
@@ -16,7 +16,8 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
     [`colorPalette${color}Border2`]: statusSharedColors[sharedColor].tint20,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as StatusColorPaletteTokens);
 
 const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedColor) => {
@@ -27,7 +28,8 @@ const personaColorPaletteTokens = personaSharedColorNames.reduce((acc, sharedCol
     [`colorPalette${color}BorderActive`]: personaSharedColors[sharedColor].tint30,
   };
 
-  return { ...acc, ...sharedColorTokens };
+  Object.assign(acc, sharedColorTokens);
+  return acc;
 }, {} as PersonaColorPaletteTokens);
 
 export const colorPaletteTokens: ColorPaletteTokens = { ...statusColorPaletteTokens, ...personaColorPaletteTokens };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

A few `.reduce` loops do unnecessary work that increases the runtime when merging objects

## New Behavior

The loops have been updated to mutate `acc` rather than return a new object, which avoids the need to iterate over all existing keys of `acc`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #23633 
