### PR TITLE
feat: Initialize DataGrid components

### DIFF
--- a/change/@fluentui-react-table-ac2472bc-2d1f-4c4d-8800-0224ac8968ca.json
+++ b/change/@fluentui-react-table-ac2472bc-2d1f-4c4d-8800-0224ac8968ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Initialize DataGrid components",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -29,6 +29,114 @@ export interface ColumnDefinition<TItem> {
 // @public (undocumented)
 export type ColumnId = string | number;
 
+// @public
+export const DataGrid: ForwardRefComponent<DataGridProps>;
+
+// @public
+export const DataGridBody: ForwardRefComponent<DataGridBodyProps>;
+
+// @public (undocumented)
+export const dataGridBodyClassNames: SlotClassNames<DataGridBodySlots>;
+
+// @public
+export type DataGridBodyProps = TableBodyProps;
+
+// @public (undocumented)
+export type DataGridBodySlots = TableBodySlots;
+
+// @public
+export type DataGridBodyState = TableBodyState;
+
+// @public
+export const DataGridCell: ForwardRefComponent<DataGridCellProps>;
+
+// @public (undocumented)
+export const dataGridCellClassNames: SlotClassNames<DataGridCellSlots>;
+
+// @public
+export type DataGridCellProps = TableCellProps;
+
+// @public (undocumented)
+export type DataGridCellSlots = TableCellSlots;
+
+// @public
+export type DataGridCellState = TableCellState;
+
+// @public (undocumented)
+export const dataGridClassNames: SlotClassNames<DataGridSlots>;
+
+// @public (undocumented)
+export type DataGridContextValues = TableContextValues;
+
+// @public
+export const DataGridHeader: ForwardRefComponent<DataGridHeaderProps>;
+
+// @public
+export const DataGridHeaderCell: ForwardRefComponent<DataGridHeaderCellProps>;
+
+// @public (undocumented)
+export const dataGridHeaderCellClassNames: SlotClassNames<DataGridHeaderCellSlots>;
+
+// @public
+export type DataGridHeaderCellProps = TableHeaderCellProps;
+
+// @public (undocumented)
+export type DataGridHeaderCellSlots = TableHeaderCellSlots;
+
+// @public
+export type DataGridHeaderCellState = TableHeaderCellState;
+
+// @public (undocumented)
+export const dataGridHeaderClassNames: SlotClassNames<DataGridHeaderSlots>;
+
+// @public
+export type DataGridHeaderProps = TableHeaderProps;
+
+// @public (undocumented)
+export type DataGridHeaderSlots = TableHeaderSlots;
+
+// @public
+export type DataGridHeaderState = TableHeaderState;
+
+// @public
+export type DataGridProps = TableProps;
+
+// @public
+export const DataGridRow: ForwardRefComponent<DataGridRowProps>;
+
+// @public (undocumented)
+export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots>;
+
+// @public
+export type DataGridRowProps = TableRowProps;
+
+// @public (undocumented)
+export type DataGridRowSlots = TableRowSlots;
+
+// @public
+export type DataGridRowState = TableRowState;
+
+// @public
+export const DataGridSelectionCell: ForwardRefComponent<DataGridSelectionCellProps>;
+
+// @public (undocumented)
+export const dataGridSelectionCellClassNames: SlotClassNames<DataGridSelectionCellSlots>;
+
+// @public
+export type DataGridSelectionCellProps = TableSelectionCellProps;
+
+// @public (undocumented)
+export type DataGridSelectionCellSlots = TableSelectionCellSlots;
+
+// @public
+export type DataGridSelectionCellState = TableSelectionCellState;
+
+// @public (undocumented)
+export type DataGridSlots = TableSlots;
+
+// @public
+export type DataGridState = TableState;
+
 // @public (undocumented)
 export interface HeadlessTableState<TItem> extends Pick<UseTableOptions<TItem>, 'items' | 'getRowId'> {
     columns: ColumnDefinition<TItem>[];
@@ -36,6 +144,27 @@ export interface HeadlessTableState<TItem> extends Pick<UseTableOptions<TItem>, 
     selection: TableSelectionState;
     sort: TableSortState<TItem>;
 }
+
+// @public
+export const renderDataGrid_unstable: (state: DataGridState, contextValues: DataGridContextValues) => JSX.Element;
+
+// @public
+export const renderDataGridBody_unstable: (state: DataGridBodyState) => JSX.Element;
+
+// @public
+export const renderDataGridCell_unstable: (state: DataGridCellState) => JSX.Element;
+
+// @public
+export const renderDataGridHeader_unstable: (state: DataGridHeaderState) => JSX.Element;
+
+// @public
+export const renderDataGridHeaderCell_unstable: (state: DataGridHeaderCellState) => JSX.Element;
+
+// @public
+export const renderDataGridRow_unstable: (state: DataGridRowState) => JSX.Element;
+
+// @public
+export const renderDataGridSelectionCell_unstable: (state: DataGridSelectionCellState) => JSX.Element;
 
 // @public
 export const renderTable_unstable: (state: TableState, contextValues: TableContextValues) => JSX.Element;
@@ -309,6 +438,48 @@ export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>,
 
 // @public (undocumented)
 export type TableStatePlugin = <TItem>(tableState: HeadlessTableState<TItem>) => HeadlessTableState<TItem>;
+
+// @public
+export const useDataGrid_unstable: (props: DataGridProps, ref: React_2.Ref<HTMLElement>) => DataGridState;
+
+// @public
+export const useDataGridBody_unstable: (props: DataGridBodyProps, ref: React_2.Ref<HTMLElement>) => DataGridBodyState;
+
+// @public
+export const useDataGridBodyStyles_unstable: (state: DataGridBodyState) => DataGridBodyState;
+
+// @public
+export const useDataGridCell_unstable: (props: DataGridCellProps, ref: React_2.Ref<HTMLElement>) => DataGridCellState;
+
+// @public
+export const useDataGridCellStyles_unstable: (state: DataGridCellState) => DataGridCellState;
+
+// @public
+export const useDataGridHeader_unstable: (props: DataGridHeaderProps, ref: React_2.Ref<HTMLElement>) => DataGridHeaderState;
+
+// @public
+export const useDataGridHeaderCell_unstable: (props: DataGridHeaderCellProps, ref: React_2.Ref<HTMLElement>) => DataGridHeaderCellState;
+
+// @public
+export const useDataGridHeaderCellStyles_unstable: (state: DataGridHeaderCellState) => DataGridHeaderCellState;
+
+// @public
+export const useDataGridHeaderStyles_unstable: (state: DataGridHeaderState) => DataGridHeaderState;
+
+// @public
+export const useDataGridRow_unstable: (props: DataGridRowProps, ref: React_2.Ref<HTMLElement>) => DataGridRowState;
+
+// @public
+export const useDataGridRowStyles_unstable: (state: DataGridRowState) => DataGridRowState;
+
+// @public
+export const useDataGridSelectionCell_unstable: (props: DataGridSelectionCellProps, ref: React_2.Ref<HTMLElement>) => DataGridSelectionCellState;
+
+// @public
+export const useDataGridSelectionCellStyles_unstable: (state: DataGridSelectionCellState) => DataGridSelectionCellState;
+
+// @public
+export const useDataGridStyles_unstable: (state: DataGridState) => DataGridState;
 
 // @public (undocumented)
 export function useSelection<TItem>(options: UseSelectionOptions): (tableState: HeadlessTableState<TItem>) => HeadlessTableState<TItem>;

--- a/packages/react-components/react-table/src/DataGrid.ts
+++ b/packages/react-components/react-table/src/DataGrid.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGrid/index';

--- a/packages/react-components/react-table/src/DataGridBody.ts
+++ b/packages/react-components/react-table/src/DataGridBody.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGridBody/index';

--- a/packages/react-components/react-table/src/DataGridCell.ts
+++ b/packages/react-components/react-table/src/DataGridCell.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGridCell/index';

--- a/packages/react-components/react-table/src/DataGridHeader.ts
+++ b/packages/react-components/react-table/src/DataGridHeader.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGridHeader/index';

--- a/packages/react-components/react-table/src/DataGridHeaderCell.ts
+++ b/packages/react-components/react-table/src/DataGridHeaderCell.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGridHeaderCell/index';

--- a/packages/react-components/react-table/src/DataGridRow.ts
+++ b/packages/react-components/react-table/src/DataGridRow.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGridRow/index';

--- a/packages/react-components/react-table/src/DataGridSelectionCell.ts
+++ b/packages/react-components/react-table/src/DataGridSelectionCell.ts
@@ -1,0 +1,1 @@
+export * from './components/DataGridSelectionCell/index';

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGrid } from './DataGrid';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridProps } from './DataGrid.types';
+
+describe('DataGrid', () => {
+  isConformant<DataGridProps>({
+    Component: DataGrid,
+    displayName: 'DataGrid',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGrid>Default DataGrid</DataGrid>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { useDataGrid_unstable } from './useDataGrid';
+import { renderDataGrid_unstable } from './renderDataGrid';
+import { useDataGridStyles_unstable } from './useDataGridStyles';
+import type { DataGridProps } from './DataGrid.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useDataGridContextValues_unstable } from './useDataGridContextValues';
+
+/**
+ * DataGrid component - TODO: add more docs
+ */
+export const DataGrid: ForwardRefComponent<DataGridProps> = React.forwardRef((props, ref) => {
+  const state = useDataGrid_unstable(props, ref);
+
+  useDataGridStyles_unstable(state);
+  return renderDataGrid_unstable(state, useDataGridContextValues_unstable(state));
+});
+
+DataGrid.displayName = 'DataGrid';

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
@@ -1,0 +1,15 @@
+import { TableContextValues, TableProps, TableSlots, TableState } from '../Table/Table.types';
+
+export type DataGridSlots = TableSlots;
+
+export type DataGridContextValues = TableContextValues;
+
+/**
+ * DataGrid Props
+ */
+export type DataGridProps = TableProps;
+
+/**
+ * State used in rendering DataGrid
+ */
+export type DataGridState = TableState;

--- a/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGrid renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGrid fui-Table"
+    role="table"
+  >
+    Default DataGrid
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGrid/index.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGrid';
+export * from './DataGrid.types';
+export * from './renderDataGrid';
+export * from './useDataGrid';
+export * from './useDataGridStyles';

--- a/packages/react-components/react-table/src/components/DataGrid/renderDataGrid.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/renderDataGrid.tsx
@@ -1,0 +1,9 @@
+import type { DataGridContextValues, DataGridState } from './DataGrid.types';
+import { renderTable_unstable } from '../Table/renderTable';
+
+/**
+ * Render the final JSX of DataGrid
+ */
+export const renderDataGrid_unstable = (state: DataGridState, contextValues: DataGridContextValues) => {
+  return renderTable_unstable(state, contextValues);
+};

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import type { DataGridProps, DataGridState } from './DataGrid.types';
+import { useTable_unstable } from '../Table/useTable';
+
+/**
+ * Create the state required to render DataGrid.
+ *
+ * The returned state can be modified with hooks such as useDataGridStyles_unstable,
+ * before being passed to renderDataGrid_unstable.
+ *
+ * @param props - props from this instance of DataGrid
+ * @param ref - reference to root HTMLElement of DataGrid
+ */
+export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLElement>): DataGridState => {
+  return useTable_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGridContextValues.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGridContextValues.ts
@@ -1,0 +1,6 @@
+import { useTableContextValues_unstable } from '../Table/useTableContextValues';
+import { DataGridState } from './DataGrid.types';
+
+export function useDataGridContextValues_unstable(state: DataGridState) {
+  return useTableContextValues_unstable(state);
+}

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGridStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGridStyles.ts
@@ -1,0 +1,18 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridSlots, DataGridState } from './DataGrid.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableStyles_unstable } from '../Table/useTableStyles';
+
+export const dataGridClassNames: SlotClassNames<DataGridSlots> = {
+  root: 'fui-DataGrid',
+};
+
+/**
+ * Apply styling to the DataGrid slots based on the state
+ */
+export const useDataGridStyles_unstable = (state: DataGridState): DataGridState => {
+  useTableStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridClassNames.root, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGridBody } from './DataGridBody';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridBodyProps } from './DataGridBody.types';
+
+describe('DataGridBody', () => {
+  isConformant<DataGridBodyProps>({
+    Component: DataGridBody,
+    displayName: 'DataGridBody',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGridBody>Default DataGridBody</DataGridBody>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDataGridBody_unstable } from './useDataGridBody';
+import { renderDataGridBody_unstable } from './renderDataGridBody';
+import { useDataGridBodyStyles_unstable } from './useDataGridBodyStyles';
+import type { DataGridBodyProps } from './DataGridBody.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DataGridBody component - TODO: add more docs
+ */
+export const DataGridBody: ForwardRefComponent<DataGridBodyProps> = React.forwardRef((props, ref) => {
+  const state = useDataGridBody_unstable(props, ref);
+
+  useDataGridBodyStyles_unstable(state);
+  return renderDataGridBody_unstable(state);
+});
+
+DataGridBody.displayName = 'DataGridBody';

--- a/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.types.ts
@@ -1,0 +1,13 @@
+import { TableBodySlots, TableBodyProps, TableBodyState } from '../TableBody/TableBody.types';
+
+export type DataGridBodySlots = TableBodySlots;
+
+/**
+ * DataGridBody Props
+ */
+export type DataGridBodyProps = TableBodyProps;
+
+/**
+ * State used in rendering DataGridBody
+ */
+export type DataGridBodyState = TableBodyState;

--- a/packages/react-components/react-table/src/components/DataGridBody/__snapshots__/DataGridBody.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridBody/__snapshots__/DataGridBody.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGridBody renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGridBody fui-TableBody"
+    role="rowgroup"
+  >
+    Default DataGridBody
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGridBody/index.ts
+++ b/packages/react-components/react-table/src/components/DataGridBody/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGridBody';
+export * from './DataGridBody.types';
+export * from './renderDataGridBody';
+export * from './useDataGridBody';
+export * from './useDataGridBodyStyles';

--- a/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
@@ -1,0 +1,9 @@
+import type { DataGridBodyState } from './DataGridBody.types';
+import { renderTableBody_unstable } from '../TableBody/renderTableBody';
+
+/**
+ * Render the final JSX of DataGridBody
+ */
+export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
+  return renderTableBody_unstable(state);
+};

--- a/packages/react-components/react-table/src/components/DataGridBody/useDataGridBody.ts
+++ b/packages/react-components/react-table/src/components/DataGridBody/useDataGridBody.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import type { DataGridBodyProps, DataGridBodyState } from './DataGridBody.types';
+import { useTableBody_unstable } from '../TableBody/useTableBody';
+
+/**
+ * Create the state required to render DataGridBody.
+ *
+ * The returned state can be modified with hooks such as useDataGridBodyStyles_unstable,
+ * before being passed to renderDataGridBody_unstable.
+ *
+ * @param props - props from this instance of DataGridBody
+ * @param ref - reference to root HTMLElement of DataGridBody
+ */
+export const useDataGridBody_unstable = (props: DataGridBodyProps, ref: React.Ref<HTMLElement>): DataGridBodyState => {
+  return useTableBody_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGridBody/useDataGridBodyStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGridBody/useDataGridBodyStyles.ts
@@ -1,0 +1,18 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridBodySlots, DataGridBodyState } from './DataGridBody.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableBodyStyles_unstable } from '../TableBody/useTableBodyStyles';
+
+export const dataGridBodyClassNames: SlotClassNames<DataGridBodySlots> = {
+  root: 'fui-DataGridBody',
+};
+
+/**
+ * Apply styling to the DataGridBody slots based on the state
+ */
+export const useDataGridBodyStyles_unstable = (state: DataGridBodyState): DataGridBodyState => {
+  useTableBodyStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridBodyClassNames.root, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGridCell } from './DataGridCell';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridCellProps } from './DataGridCell.types';
+
+describe('DataGridCell', () => {
+  isConformant<DataGridCellProps>({
+    Component: DataGridCell,
+    displayName: 'DataGridCell',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGridCell>Default DataGridCell</DataGridCell>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.tsx
+++ b/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDataGridCell_unstable } from './useDataGridCell';
+import { renderDataGridCell_unstable } from './renderDataGridCell';
+import { useDataGridCellStyles_unstable } from './useDataGridCellStyles';
+import type { DataGridCellProps } from './DataGridCell.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DataGridCell component - TODO: add more docs
+ */
+export const DataGridCell: ForwardRefComponent<DataGridCellProps> = React.forwardRef((props, ref) => {
+  const state = useDataGridCell_unstable(props, ref);
+
+  useDataGridCellStyles_unstable(state);
+  return renderDataGridCell_unstable(state);
+});
+
+DataGridCell.displayName = 'DataGridCell';

--- a/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.types.ts
@@ -1,0 +1,13 @@
+import { TableCellProps, TableCellSlots, TableCellState } from '../TableCell/TableCell.types';
+
+export type DataGridCellSlots = TableCellSlots;
+
+/**
+ * DataGridCell Props
+ */
+export type DataGridCellProps = TableCellProps;
+
+/**
+ * State used in rendering DataGridCell
+ */
+export type DataGridCellState = TableCellState;

--- a/packages/react-components/react-table/src/components/DataGridCell/__snapshots__/DataGridCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridCell/__snapshots__/DataGridCell.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGridCell renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGridCell fui-TableCell"
+    role="cell"
+  >
+    Default DataGridCell
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGridCell/index.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGridCell';
+export * from './DataGridCell.types';
+export * from './renderDataGridCell';
+export * from './useDataGridCell';
+export * from './useDataGridCellStyles';

--- a/packages/react-components/react-table/src/components/DataGridCell/renderDataGridCell.tsx
+++ b/packages/react-components/react-table/src/components/DataGridCell/renderDataGridCell.tsx
@@ -1,0 +1,9 @@
+import type { DataGridCellState } from './DataGridCell.types';
+import { renderTableCell_unstable } from '../TableCell/renderTableCell';
+
+/**
+ * Render the final JSX of DataGridCell
+ */
+export const renderDataGridCell_unstable = (state: DataGridCellState) => {
+  return renderTableCell_unstable(state);
+};

--- a/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import type { DataGridCellProps, DataGridCellState } from './DataGridCell.types';
+import { useTableCell_unstable } from '../TableCell/useTableCell';
+
+/**
+ * Create the state required to render DataGridCell.
+ *
+ * The returned state can be modified with hooks such as useDataGridCellStyles_unstable,
+ * before being passed to renderDataGridCell_unstable.
+ *
+ * @param props - props from this instance of DataGridCell
+ * @param ref - reference to root HTMLElement of DataGridCell
+ */
+export const useDataGridCell_unstable = (props: DataGridCellProps, ref: React.Ref<HTMLElement>): DataGridCellState => {
+  return useTableCell_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGridCell/useDataGridCellStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/useDataGridCellStyles.ts
@@ -1,0 +1,18 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridCellSlots, DataGridCellState } from './DataGridCell.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableCellStyles_unstable } from '../TableCell/useTableCellStyles';
+
+export const dataGridCellClassNames: SlotClassNames<DataGridCellSlots> = {
+  root: 'fui-DataGridCell',
+};
+
+/**
+ * Apply styling to the DataGridCell slots based on the state
+ */
+export const useDataGridCellStyles_unstable = (state: DataGridCellState): DataGridCellState => {
+  useTableCellStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridCellClassNames.root, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/DataGridHeader/DataGridHeader.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridHeader/DataGridHeader.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGridHeader } from './DataGridHeader';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridHeaderProps } from './DataGridHeader.types';
+
+describe('DataGridHeader', () => {
+  isConformant<DataGridHeaderProps>({
+    Component: DataGridHeader,
+    displayName: 'DataGridHeader',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGridHeader>Default DataGridHeader</DataGridHeader>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGridHeader/DataGridHeader.tsx
+++ b/packages/react-components/react-table/src/components/DataGridHeader/DataGridHeader.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDataGridHeader_unstable } from './useDataGridHeader';
+import { renderDataGridHeader_unstable } from './renderDataGridHeader';
+import { useDataGridHeaderStyles_unstable } from './useDataGridHeaderStyles';
+import type { DataGridHeaderProps } from './DataGridHeader.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DataGridHeader component - TODO: add more docs
+ */
+export const DataGridHeader: ForwardRefComponent<DataGridHeaderProps> = React.forwardRef((props, ref) => {
+  const state = useDataGridHeader_unstable(props, ref);
+
+  useDataGridHeaderStyles_unstable(state);
+  return renderDataGridHeader_unstable(state);
+});
+
+DataGridHeader.displayName = 'DataGridHeader';

--- a/packages/react-components/react-table/src/components/DataGridHeader/DataGridHeader.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeader/DataGridHeader.types.ts
@@ -1,0 +1,13 @@
+import { TableHeaderProps, TableHeaderSlots, TableHeaderState } from '../TableHeader/TableHeader.types';
+
+export type DataGridHeaderSlots = TableHeaderSlots;
+
+/**
+ * DataGridHeader Props
+ */
+export type DataGridHeaderProps = TableHeaderProps;
+
+/**
+ * State used in rendering DataGridHeader
+ */
+export type DataGridHeaderState = TableHeaderState;

--- a/packages/react-components/react-table/src/components/DataGridHeader/__snapshots__/DataGridHeader.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridHeader/__snapshots__/DataGridHeader.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGridHeader renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGridHeader fui-TableHeader"
+    role="rowgroup"
+  >
+    Default DataGridHeader
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGridHeader/index.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeader/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGridHeader';
+export * from './DataGridHeader.types';
+export * from './renderDataGridHeader';
+export * from './useDataGridHeader';
+export * from './useDataGridHeaderStyles';

--- a/packages/react-components/react-table/src/components/DataGridHeader/renderDataGridHeader.tsx
+++ b/packages/react-components/react-table/src/components/DataGridHeader/renderDataGridHeader.tsx
@@ -1,0 +1,9 @@
+import { renderTableHeader_unstable } from '../TableHeader/renderTableHeader';
+import type { DataGridHeaderState } from './DataGridHeader.types';
+
+/**
+ * Render the final JSX of DataGridHeader
+ */
+export const renderDataGridHeader_unstable = (state: DataGridHeaderState) => {
+  return renderTableHeader_unstable(state);
+};

--- a/packages/react-components/react-table/src/components/DataGridHeader/useDataGridHeader.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeader/useDataGridHeader.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import type { DataGridHeaderProps, DataGridHeaderState } from './DataGridHeader.types';
+import { useTableHeader_unstable } from '../TableHeader/useTableHeader';
+
+/**
+ * Create the state required to render DataGridHeader.
+ *
+ * The returned state can be modified with hooks such as useDataGridHeaderStyles_unstable,
+ * before being passed to renderDataGridHeader_unstable.
+ *
+ * @param props - props from this instance of DataGridHeader
+ * @param ref - reference to root HTMLElement of DataGridHeader
+ */
+export const useDataGridHeader_unstable = (
+  props: DataGridHeaderProps,
+  ref: React.Ref<HTMLElement>,
+): DataGridHeaderState => {
+  return useTableHeader_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGridHeader/useDataGridHeaderStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeader/useDataGridHeaderStyles.ts
@@ -1,0 +1,18 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridHeaderSlots, DataGridHeaderState } from './DataGridHeader.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableHeaderStyles_unstable } from '../TableHeader/useTableHeaderStyles';
+
+export const dataGridHeaderClassNames: SlotClassNames<DataGridHeaderSlots> = {
+  root: 'fui-DataGridHeader',
+};
+
+/**
+ * Apply styling to the DataGridHeader slots based on the state
+ */
+export const useDataGridHeaderStyles_unstable = (state: DataGridHeaderState): DataGridHeaderState => {
+  useTableHeaderStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridHeaderClassNames.root, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGridHeaderCell } from './DataGridHeaderCell';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridHeaderCellProps } from './DataGridHeaderCell.types';
+
+describe('DataGridHeaderCell', () => {
+  isConformant<DataGridHeaderCellProps>({
+    Component: DataGridHeaderCell,
+    displayName: 'DataGridHeaderCell',
+    testOptions: {
+      'has-static-classnames': [
+        {
+          props: {
+            sortIcon: 'Test Icon',
+          },
+        },
+      ],
+    },
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGridHeaderCell>Default DataGridHeaderCell</DataGridHeaderCell>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDataGridHeaderCell_unstable } from './useDataGridHeaderCell';
+import { renderDataGridHeaderCell_unstable } from './renderDataGridHeaderCell';
+import { useDataGridHeaderCellStyles_unstable } from './useDataGridHeaderCellStyles';
+import type { DataGridHeaderCellProps } from './DataGridHeaderCell.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DataGridHeaderCell component - TODO: add more docs
+ */
+export const DataGridHeaderCell: ForwardRefComponent<DataGridHeaderCellProps> = React.forwardRef((props, ref) => {
+  const state = useDataGridHeaderCell_unstable(props, ref);
+
+  useDataGridHeaderCellStyles_unstable(state);
+  return renderDataGridHeaderCell_unstable(state);
+});
+
+DataGridHeaderCell.displayName = 'DataGridHeaderCell';

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.types.ts
@@ -1,0 +1,17 @@
+import {
+  TableHeaderCellProps,
+  TableHeaderCellSlots,
+  TableHeaderCellState,
+} from '../TableHeaderCell/TableHeaderCell.types';
+
+export type DataGridHeaderCellSlots = TableHeaderCellSlots;
+
+/**
+ * DataGridHeaderCell Props
+ */
+export type DataGridHeaderCellProps = TableHeaderCellProps;
+
+/**
+ * State used in rendering DataGridHeaderCell
+ */
+export type DataGridHeaderCellState = TableHeaderCellState;

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/__snapshots__/DataGridHeaderCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/__snapshots__/DataGridHeaderCell.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGridHeaderCell renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGridHeaderCell fui-TableHeaderCell"
+    role="columnheader"
+  >
+    <button
+      class="fui-DataGridHeaderCell__button fui-TableHeaderCell__button"
+      role="presentation"
+      tabindex="-1"
+      type="button"
+    >
+      Default DataGridHeaderCell
+    </button>
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/index.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGridHeaderCell';
+export * from './DataGridHeaderCell.types';
+export * from './renderDataGridHeaderCell';
+export * from './useDataGridHeaderCell';
+export * from './useDataGridHeaderCellStyles';

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/renderDataGridHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/renderDataGridHeaderCell.tsx
@@ -1,0 +1,9 @@
+import type { DataGridHeaderCellState } from './DataGridHeaderCell.types';
+import { renderTableHeaderCell_unstable } from '../TableHeaderCell/renderTableHeaderCell';
+
+/**
+ * Render the final JSX of DataGridHeaderCell
+ */
+export const renderDataGridHeaderCell_unstable = (state: DataGridHeaderCellState) => {
+  return renderTableHeaderCell_unstable(state);
+};

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import type { DataGridHeaderCellProps, DataGridHeaderCellState } from './DataGridHeaderCell.types';
+import { useTableHeaderCell_unstable } from '../TableHeaderCell/useTableHeaderCell';
+
+/**
+ * Create the state required to render DataGridHeaderCell.
+ *
+ * The returned state can be modified with hooks such as useDataGridHeaderCellStyles_unstable,
+ * before being passed to renderDataGridHeaderCell_unstable.
+ *
+ * @param props - props from this instance of DataGridHeaderCell
+ * @param ref - reference to root HTMLElement of DataGridHeaderCell
+ */
+export const useDataGridHeaderCell_unstable = (
+  props: DataGridHeaderCellProps,
+  ref: React.Ref<HTMLElement>,
+): DataGridHeaderCellState => {
+  return useTableHeaderCell_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/useDataGridHeaderCellStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/useDataGridHeaderCellStyles.ts
@@ -1,0 +1,28 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridHeaderCellSlots, DataGridHeaderCellState } from './DataGridHeaderCell.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableHeaderCellStyles_unstable } from '../TableHeaderCell/useTableHeaderCellStyles';
+
+export const dataGridHeaderCellClassNames: SlotClassNames<DataGridHeaderCellSlots> = {
+  root: 'fui-DataGridHeaderCell',
+  button: 'fui-DataGridHeaderCell__button',
+  sortIcon: 'fui-DataGridHeaderCell__sortIcon',
+};
+
+/**
+ * Apply styling to the DataGridHeaderCell slots based on the state
+ */
+export const useDataGridHeaderCellStyles_unstable = (state: DataGridHeaderCellState): DataGridHeaderCellState => {
+  useTableHeaderCellStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridHeaderCellClassNames.root, state.root.className);
+
+  if (state.button) {
+    state.button.className = mergeClasses(dataGridHeaderCellClassNames.button, state.button.className);
+  }
+
+  if (state.sortIcon) {
+    state.sortIcon.className = mergeClasses(dataGridHeaderCellClassNames.sortIcon, state.sortIcon.className);
+  }
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGridRow } from './DataGridRow';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridRowProps } from './DataGridRow.types';
+
+describe('DataGridRow', () => {
+  isConformant<DataGridRowProps>({
+    Component: DataGridRow,
+    displayName: 'DataGridRow',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGridRow>Default DataGridRow</DataGridRow>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDataGridRow_unstable } from './useDataGridRow';
+import { renderDataGridRow_unstable } from './renderDataGridRow';
+import { useDataGridRowStyles_unstable } from './useDataGridRowStyles';
+import type { DataGridRowProps } from './DataGridRow.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DataGridRow component - TODO: add more docs
+ */
+export const DataGridRow: ForwardRefComponent<DataGridRowProps> = React.forwardRef((props, ref) => {
+  const state = useDataGridRow_unstable(props, ref);
+
+  useDataGridRowStyles_unstable(state);
+  return renderDataGridRow_unstable(state);
+});
+
+DataGridRow.displayName = 'DataGridRow';

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
@@ -1,0 +1,13 @@
+import { TableRowProps, TableRowSlots, TableRowState } from '../TableRow/TableRow.types';
+
+export type DataGridRowSlots = TableRowSlots;
+
+/**
+ * DataGridRow Props
+ */
+export type DataGridRowProps = TableRowProps;
+
+/**
+ * State used in rendering DataGridRow
+ */
+export type DataGridRowState = TableRowState;

--- a/packages/react-components/react-table/src/components/DataGridRow/__snapshots__/DataGridRow.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridRow/__snapshots__/DataGridRow.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGridRow renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGridRow fui-TableRow"
+    role="row"
+  >
+    Default DataGridRow
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGridRow/index.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGridRow';
+export * from './DataGridRow.types';
+export * from './renderDataGridRow';
+export * from './useDataGridRow';
+export * from './useDataGridRowStyles';

--- a/packages/react-components/react-table/src/components/DataGridRow/renderDataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/renderDataGridRow.tsx
@@ -1,0 +1,9 @@
+import type { DataGridRowState } from './DataGridRow.types';
+import { renderTableRow_unstable } from '../TableRow/renderTableRow';
+
+/**
+ * Render the final JSX of DataGridRow
+ */
+export const renderDataGridRow_unstable = (state: DataGridRowState) => {
+  return renderTableRow_unstable(state);
+};

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import type { DataGridRowProps, DataGridRowState } from './DataGridRow.types';
+import { useTableRow_unstable } from '../TableRow/useTableRow';
+
+/**
+ * Create the state required to render DataGridRow.
+ *
+ * The returned state can be modified with hooks such as useDataGridRowStyles_unstable,
+ * before being passed to renderDataGridRow_unstable.
+ *
+ * @param props - props from this instance of DataGridRow
+ * @param ref - reference to root HTMLElement of DataGridRow
+ */
+export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<HTMLElement>): DataGridRowState => {
+  return useTableRow_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRowStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRowStyles.ts
@@ -1,0 +1,18 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridRowSlots, DataGridRowState } from './DataGridRow.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableRowStyles_unstable } from '../TableRow/useTableRowStyles';
+
+export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots> = {
+  root: 'fui-DataGridRow',
+};
+
+/**
+ * Apply styling to the DataGridRow slots based on the state
+ */
+export const useDataGridRowStyles_unstable = (state: DataGridRowState): DataGridRowState => {
+  useTableRowStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridRowClassNames.root, state.root.className);
+
+  return state;
+};

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DataGridSelectionCell } from './DataGridSelectionCell';
+import { isConformant } from '../../testing/isConformant';
+import { DataGridSelectionCellProps } from '../../../dist/index';
+import { dataGridSelectionCellClassNames } from './useDataGridSelectionCellStyles';
+
+describe('DataGridSelectionCell', () => {
+  isConformant<DataGridSelectionCellProps>({
+    Component: DataGridSelectionCell,
+    displayName: 'DataGridSelectionCell',
+    testOptions: {
+      'has-static-classnames': [
+        {
+          props: {
+            type: 'checkbox',
+          },
+          expectedClassNames: {
+            root: dataGridSelectionCellClassNames.root,
+            checkboxIndicator: dataGridSelectionCellClassNames.checkboxIndicator,
+          },
+        },
+        {
+          props: {
+            type: 'radio',
+          },
+          expectedClassNames: {
+            root: dataGridSelectionCellClassNames.root,
+            radioIndicator: dataGridSelectionCellClassNames.radioIndicator,
+          },
+        },
+      ],
+    },
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DataGridSelectionCell>Default DataGridSelectionCell</DataGridSelectionCell>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.tsx
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDataGridSelectionCell_unstable } from './useDataGridSelectionCell';
+import { renderDataGridSelectionCell_unstable } from './renderDataGridSelectionCell';
+import { useDataGridSelectionCellStyles_unstable } from './useDataGridSelectionCellStyles';
+import type { DataGridSelectionCellProps } from './DataGridSelectionCell.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DataGridSelectionCell component - TODO: add more docs
+ */
+export const DataGridSelectionCell: ForwardRefComponent<DataGridSelectionCellProps> = React.forwardRef((props, ref) => {
+  const state = useDataGridSelectionCell_unstable(props, ref);
+
+  useDataGridSelectionCellStyles_unstable(state);
+  return renderDataGridSelectionCell_unstable(state);
+});
+
+DataGridSelectionCell.displayName = 'DataGridSelectionCell';

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.types.ts
@@ -1,0 +1,17 @@
+import {
+  TableSelectionCellProps,
+  TableSelectionCellSlots,
+  TableSelectionCellState,
+} from '../TableSelectionCell/TableSelectionCell.types';
+
+export type DataGridSelectionCellSlots = TableSelectionCellSlots;
+
+/**
+ * DataGridSelectionCell Props
+ */
+export type DataGridSelectionCellProps = TableSelectionCellProps;
+
+/**
+ * State used in rendering DataGridSelectionCell
+ */
+export type DataGridSelectionCellState = TableSelectionCellState;

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/__snapshots__/DataGridSelectionCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/__snapshots__/DataGridSelectionCell.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGridSelectionCell renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DataGridSelectionCell fui-TableSelectionCell"
+    role="cell"
+  >
+    <span
+      class="fui-Checkbox fui-DataGridSelectionCell__checkboxIndicator fui-TableSelectionCell__checkboxIndicator"
+    >
+      <input
+        class="fui-Checkbox__input"
+        id="checkbox-9"
+        type="checkbox"
+      />
+      <div
+        aria-hidden="true"
+        class="fui-Checkbox__indicator"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          fill="currentColor"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+    </span>
+  </div>
+</div>
+`;

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/index.ts
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/index.ts
@@ -1,0 +1,5 @@
+export * from './DataGridSelectionCell';
+export * from './DataGridSelectionCell.types';
+export * from './renderDataGridSelectionCell';
+export * from './useDataGridSelectionCell';
+export * from './useDataGridSelectionCellStyles';

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/renderDataGridSelectionCell.tsx
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/renderDataGridSelectionCell.tsx
@@ -1,0 +1,9 @@
+import type { DataGridSelectionCellState } from './DataGridSelectionCell.types';
+import { renderTableSelectionCell_unstable } from '../TableSelectionCell/renderTableSelectionCell';
+
+/**
+ * Render the final JSX of DataGridSelectionCell
+ */
+export const renderDataGridSelectionCell_unstable = (state: DataGridSelectionCellState) => {
+  return renderTableSelectionCell_unstable(state);
+};

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { useTableSelectionCell_unstable } from '../TableSelectionCell/useTableSelectionCell';
+import type { DataGridSelectionCellProps, DataGridSelectionCellState } from './DataGridSelectionCell.types';
+
+/**
+ * Create the state required to render DataGridSelectionCell.
+ *
+ * The returned state can be modified with hooks such as useDataGridSelectionCellStyles_unstable,
+ * before being passed to renderDataGridSelectionCell_unstable.
+ *
+ * @param props - props from this instance of DataGridSelectionCell
+ * @param ref - reference to root HTMLElement of DataGridSelectionCell
+ */
+export const useDataGridSelectionCell_unstable = (
+  props: DataGridSelectionCellProps,
+  ref: React.Ref<HTMLElement>,
+): DataGridSelectionCellState => {
+  return useTableSelectionCell_unstable({ ...props, as: 'div' }, ref);
+};

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCellStyles.ts
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCellStyles.ts
@@ -1,0 +1,36 @@
+import { mergeClasses } from '@griffel/react';
+import type { DataGridSelectionCellSlots, DataGridSelectionCellState } from './DataGridSelectionCell.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { useTableSelectionCellStyles_unstable } from '../TableSelectionCell/useTableSelectionCellStyles';
+
+export const dataGridSelectionCellClassNames: SlotClassNames<DataGridSelectionCellSlots> = {
+  root: 'fui-DataGridSelectionCell',
+  checkboxIndicator: 'fui-DataGridSelectionCell__checkboxIndicator',
+  radioIndicator: 'fui-DataGridSelectionCell__radioIndicator',
+};
+
+/**
+ * Apply styling to the DataGridSelectionCell slots based on the state
+ */
+export const useDataGridSelectionCellStyles_unstable = (
+  state: DataGridSelectionCellState,
+): DataGridSelectionCellState => {
+  useTableSelectionCellStyles_unstable(state);
+  state.root.className = mergeClasses(dataGridSelectionCellClassNames.root, state.root.className);
+
+  if (state.checkboxIndicator) {
+    state.checkboxIndicator.className = mergeClasses(
+      dataGridSelectionCellClassNames.checkboxIndicator,
+      state.checkboxIndicator.className,
+    );
+  }
+
+  if (state.radioIndicator) {
+    state.radioIndicator.className = mergeClasses(
+      dataGridSelectionCellClassNames.radioIndicator,
+      state.radioIndicator.className,
+    );
+  }
+
+  return state;
+};

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -98,3 +98,71 @@ export {
   renderTableCellLayout_unstable,
 } from './TableCellLayout';
 export type { TableCellLayoutProps, TableCellLayoutSlots, TableCellLayoutState } from './TableCellLayout';
+
+export {
+  DataGridCell,
+  dataGridCellClassNames,
+  useDataGridCellStyles_unstable,
+  useDataGridCell_unstable,
+  renderDataGridCell_unstable,
+} from './DataGridCell';
+export type { DataGridCellProps, DataGridCellState, DataGridCellSlots } from './DataGridCell';
+
+export {
+  DataGridRow,
+  dataGridRowClassNames,
+  useDataGridRowStyles_unstable,
+  useDataGridRow_unstable,
+  renderDataGridRow_unstable,
+} from './DataGridRow';
+export type { DataGridRowProps, DataGridRowState, DataGridRowSlots } from './DataGridRow';
+
+export {
+  DataGridBody,
+  dataGridBodyClassNames,
+  useDataGridBodyStyles_unstable,
+  useDataGridBody_unstable,
+  renderDataGridBody_unstable,
+} from './DataGridBody';
+export type { DataGridBodyProps, DataGridBodyState, DataGridBodySlots } from './DataGridBody';
+
+export {
+  DataGrid,
+  dataGridClassNames,
+  useDataGridStyles_unstable,
+  useDataGrid_unstable,
+  renderDataGrid_unstable,
+} from './DataGrid';
+export type { DataGridProps, DataGridSlots, DataGridState, DataGridContextValues } from './DataGrid';
+
+export {
+  DataGridHeader,
+  dataGridHeaderClassNames,
+  useDataGridHeaderStyles_unstable,
+  useDataGridHeader_unstable,
+  renderDataGridHeader_unstable,
+} from './DataGridHeader';
+export type { DataGridHeaderProps, DataGridHeaderSlots, DataGridHeaderState } from './DataGridHeader';
+
+export {
+  DataGridHeaderCell,
+  dataGridHeaderCellClassNames,
+  useDataGridHeaderCellStyles_unstable,
+  useDataGridHeaderCell_unstable,
+  renderDataGridHeaderCell_unstable,
+} from './DataGridHeaderCell';
+export type { DataGridHeaderCellProps, DataGridHeaderCellSlots, DataGridHeaderCellState } from './DataGridHeaderCell';
+
+export {
+  DataGridSelectionCell,
+  useDataGridSelectionCellStyles_unstable,
+  useDataGridSelectionCell_unstable,
+  renderDataGridSelectionCell_unstable,
+  dataGridSelectionCellClassNames,
+} from './DataGridSelectionCell';
+
+export type {
+  DataGridSelectionCellProps,
+  DataGridSelectionCellState,
+  DataGridSelectionCellSlots,
+} from './DataGridSelectionCell';


### PR DESCRIPTION
Initializes `DataGrid` components as simple recomposition of existing `Table` primitives

Fixes #
