### PR TITLE
chore: fix dependencies in @fluentui/react-toolbar

### DIFF
--- a/change/@fluentui-react-toolbar-c7f69f04-c3be-4906-ad8a-199030c47ebb.json
+++ b/change/@fluentui-react-toolbar-c7f69f04-c3be-4906-ad8a-199030c47ebb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: remove dependencies on Fluent UI v8",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/package.json
+++ b/packages/react-components/react-toolbar/package.json
@@ -38,7 +38,6 @@
     "@fluentui/react-theme": "^9.1.1",
     "@fluentui/react-utilities": "^9.1.2",
     "@fluentui/react-context-selector": "^9.0.5",
-    "@fluentui/react-hooks": "^8.6.12",
     "@fluentui/react-radio": "^9.0.9",
     "@fluentui/react-tabster": "^9.2.0",
     "@griffel/react": "^1.4.1",

--- a/packages/react-components/react-toolbar/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEventCallback } from '@fluentui/react-hooks';
+import { useEventCallback } from '@fluentui/react-utilities';
 import { useToggleButton_unstable } from '@fluentui/react-button';
 import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 import { ToolbarRadioButtonProps, ToolbarRadioButtonState } from './ToolbarRadioButton.types';


### PR DESCRIPTION
## Current Behavior

`@fluentui/react-toolbar` has a dependency on `@fluentui/react-hooks`.

## New Behavior

`@fluentui/react-toolbar` does not have a dependency on `@fluentui/react-hooks`.
