### PR TITLE
feat(react-avatar): Add `addOverflowIndicatorSpace` to `partitionAvatarGroupItems`

### DIFF
--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.test.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.test.ts
@@ -64,4 +64,20 @@ describe('partitionAvatarGroupItems', () => {
     expect(inlineItems).toEqual([3, 4, 5, 6, 7, 8, 9]);
     expect(overflowItems).toEqual([0, 1, 2]);
   });
+
+  it('makes space for AvatarGroupPopover when addOverflowIndicatorSpace is true', () => {
+    const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items });
+
+    expect(inlineItems).toEqual([6, 7, 8, 9]);
+    expect(overflowItems).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it('makes space for AvatarGroupPopover when addOverflowIndicatorSpace is true', () => {
+    const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items, addOverflowIndicatorSpace: false });
+
+    expect(inlineItems).toEqual([5, 6, 7, 8, 9]);
+    expect(overflowItems).toEqual([0, 1, 2, 3, 4]);
+  });
 });

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
@@ -35,7 +35,7 @@ export type PartitionAvatarGroupItems<T> = {
  *
  * @param options - Configure the partition options
  *
- * @returns Two arrays partitioned into inline items and overflow items based on maxInlineItems.
+ * @returns Two arrays, one containing the inline items and another the overflow items.
  */
 export const partitionAvatarGroupItems = <T>(
   options: PartitionAvatarGroupItemsOptions<T>,

--- a/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
+++ b/packages/react-components/react-avatar/src/utils/partitionAvatarGroupItems.ts
@@ -1,7 +1,28 @@
 export type PartitionAvatarGroupItemsOptions<T> = {
+  /**
+   * Items to partition for the AvatarGroup.
+   */
   items: readonly T[];
+
+  /**
+   * Layout to base the partitioning on.
+   *
+   * @default 'spread'
+   */
   layout?: 'spread' | 'stack' | 'pie';
+
+  /**
+   * Maximum number of inline items to show.
+   */
   maxInlineItems?: number;
+
+  /**
+   * When the layout is `spread` or `stack`, partitionAvatarGroupItems makes space for AvatarGroupPopover in the
+   * inlineItems.
+   *
+   * @default 'true'
+   */
+  addOverflowIndicatorSpace?: boolean;
 };
 
 export type PartitionAvatarGroupItems<T> = {
@@ -14,12 +35,12 @@ export type PartitionAvatarGroupItems<T> = {
  *
  * @param options - Configure the partition options
  *
- * @returns Two arrays split into inline items and overflow items based on maxInlineItems.
+ * @returns Two arrays partitioned into inline items and overflow items based on maxInlineItems.
  */
 export const partitionAvatarGroupItems = <T>(
   options: PartitionAvatarGroupItemsOptions<T>,
 ): PartitionAvatarGroupItems<T> => {
-  const { items } = options;
+  const { items, addOverflowIndicatorSpace = true } = options;
   const isPie = options.layout === 'pie';
 
   if (isPie) {
@@ -30,7 +51,7 @@ export const partitionAvatarGroupItems = <T>(
   }
 
   const maxInlineItems = options.maxInlineItems ?? 5;
-  const inlineCount = -(maxInlineItems - (items.length > maxInlineItems ? 1 : 0));
+  const inlineCount = -(maxInlineItems - (addOverflowIndicatorSpace && items.length > maxInlineItems ? 1 : 0));
   const overflowItems = items.slice(0, inlineCount);
 
   return {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently `partitionAvatarGroupItems` adds a space for the overflow indicator and there's no way to turn it ignore this behavior.

## New Behavior

This PR adds the `addOverflowIndicatorSpace` to `partitionAvatarGroupItems` to allow the user to remove this behavior. Note that by default it still adds the space for the overflow indicator.

