### PR TITLE
fix: Showing correct behavior for icons inside of Buttons on hover, pressed and toggle states

### DIFF
--- a/change/@fluentui-react-button-c452c0d5-b913-4697-906a-ab9effbe88b2.json
+++ b/change/@fluentui-react-button-c452c0d5-b913-4697-906a-ab9effbe88b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Showing correct behavior for icons inside of Buttons on hover, pressed and toggle states.",
+  "packageName": "@fluentui/react-button",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -143,12 +143,20 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundHover,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2Hover,
+
+      [`& .${buttonClassNames.icon}`]: {
+        color: tokens.colorNeutralForeground2BrandHover,
+      },
     },
 
     ':hover:active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2Pressed,
+
+      [`& .${buttonClassNames.icon}`]: {
+        color: tokens.colorNeutralForeground2BrandPressed,
+      },
     },
   },
   transparent: {
@@ -429,17 +437,6 @@ const useIconStyles = makeStyles({
     [iconSpacingVar]: tokens.spacingHorizontalSNudge,
   },
 
-  // Appearance variations
-  subtle: {
-    ':hover': {
-      color: tokens.colorNeutralForeground2BrandHover,
-    },
-
-    ':hover:active': {
-      color: tokens.colorNeutralForeground2BrandPressed,
-    },
-  },
-
   // Icon position variations
   before: {
     marginRight: `var(${iconSpacingVar})`,
@@ -492,7 +489,6 @@ export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
       buttonClassNames.icon,
       iconStyles.base,
       state.root.children !== undefined && state.root.children !== null && iconStyles[iconPosition],
-      appearance === 'subtle' && iconStyles.subtle,
       iconStyles[size],
       state.icon.className,
     );

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -212,25 +212,17 @@ const useDisabledStyles = makeStyles({
   },
 });
 
-const useIconStyles = makeStyles({
+const useIconCheckedStyles = makeStyles({
   // Appearance variations
   subtle: {
     color: tokens.colorNeutralForeground2BrandSelected,
-
-    ':hover': {
-      color: tokens.colorNeutralForeground2BrandHover,
-    },
-
-    ':hover:active': {
-      color: tokens.colorNeutralForeground2BrandPressed,
-    },
   },
 });
 
 export const useToggleButtonStyles_unstable = (state: ToggleButtonState): ToggleButtonState => {
   const checkedStyles = useCheckedStyles();
   const disabledStyles = useDisabledStyles();
-  const iconStyles = useIconStyles();
+  const iconStyles = useIconCheckedStyles();
 
   const { appearance, checked, disabled, disabledFocusable } = state;
 
@@ -253,7 +245,7 @@ export const useToggleButtonStyles_unstable = (state: ToggleButtonState): Toggle
   if (state.icon) {
     state.icon.className = mergeClasses(
       toggleButtonClassNames.icon,
-      appearance === 'subtle' && iconStyles.subtle,
+      appearance === 'subtle' && checked && iconStyles.subtle,
       state.icon.className,
     );
   }

--- a/packages/react-components/react-button/stories/Button/ButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonAppearance.stories.tsx
@@ -20,7 +20,7 @@ export const Appearance = () => {
       <Button appearance="primary" icon={<CalendarMonthRegular />}>
         Primary
       </Button>
-      <Button appearance="outline" icon={<CalendarMonthRegular />}>
+      <Button appearance="outline" icon={<CalendarMonth />}>
         Outline
       </Button>
       <Button appearance="subtle" icon={<CalendarMonth />}>

--- a/packages/react-components/react-button/stories/Button/ButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonAppearance.stories.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { makeStyles, Button } from '@fluentui/react-components';
+import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
+
+const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -13,11 +16,19 @@ export const Appearance = () => {
 
   return (
     <div className={styles.wrapper}>
-      <Button>Default</Button>
-      <Button appearance="primary">Primary</Button>
-      <Button appearance="outline">Outline</Button>
-      <Button appearance="subtle">Subtle</Button>
-      <Button appearance="transparent">Transparent</Button>
+      <Button icon={<CalendarMonthRegular />}>Default</Button>
+      <Button appearance="primary" icon={<CalendarMonthRegular />}>
+        Primary
+      </Button>
+      <Button appearance="outline" icon={<CalendarMonthRegular />}>
+        Outline
+      </Button>
+      <Button appearance="subtle" icon={<CalendarMonth />}>
+        Subtle
+      </Button>
+      <Button appearance="transparent" icon={<CalendarMonth />}>
+        Transparent
+      </Button>
     </div>
   );
 };

--- a/packages/react-components/react-button/stories/Button/ButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonIcon.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import { makeStyles, Button, Tooltip } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -16,12 +14,12 @@ export const Icon = () => {
 
   return (
     <div className={styles.wrapper}>
-      <Button icon={<CalendarMonth />}>With calendar icon before contents</Button>
-      <Button icon={<CalendarMonth />} iconPosition="after">
+      <Button icon={<CalendarMonthRegular />}>With calendar icon before contents</Button>
+      <Button icon={<CalendarMonthRegular />} iconPosition="after">
         With calendar icon after contents
       </Button>
       <Tooltip content="With calendar icon only" relationship="label">
-        <Button icon={<CalendarMonth />} />
+        <Button icon={<CalendarMonthRegular />} />
       </Tooltip>
     </div>
   );

--- a/packages/react-components/react-button/stories/Button/ButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonSize.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import { makeStyles, Button, Tooltip } from '@fluentui/react-components';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   innerWrapper: {
@@ -14,8 +14,6 @@ const useStyles = makeStyles({
   },
 });
 
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
-
 export const Size = () => {
   const styles = useStyles();
 
@@ -23,27 +21,27 @@ export const Size = () => {
     <div className={styles.outerWrapper}>
       <div className={styles.innerWrapper}>
         <Button size="small">Small</Button>
-        <Button size="small" icon={<CalendarMonth />}>
+        <Button size="small" icon={<CalendarMonthRegular />}>
           Small with calendar icon
         </Button>
         <Tooltip content="Small with calendar icon only" relationship="label">
-          <Button size="small" icon={<CalendarMonth />} />
+          <Button size="small" icon={<CalendarMonthRegular />} />
         </Tooltip>
       </div>
       <div className={styles.innerWrapper}>
         <Button>Medium</Button>
-        <Button icon={<CalendarMonth />}>Medium with calendar icon</Button>
+        <Button icon={<CalendarMonthRegular />}>Medium with calendar icon</Button>
         <Tooltip content="Medium with calendar icon only" relationship="label">
-          <Button icon={<CalendarMonth />} />
+          <Button icon={<CalendarMonthRegular />} />
         </Tooltip>
       </div>
       <div className={styles.innerWrapper}>
         <Button size="large">Large</Button>
-        <Button size="large" icon={<CalendarMonth />}>
+        <Button size="large" icon={<CalendarMonthRegular />}>
           Large with calendar icon
         </Button>
         <Tooltip content="Large with calendar icon only" relationship="label">
-          <Button size="large" icon={<CalendarMonth />} />
+          <Button size="large" icon={<CalendarMonthRegular />} />
         </Tooltip>
       </div>
     </div>

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { makeStyles, CompoundButton } from '@fluentui/react-components';
+import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
+
+const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -13,17 +16,19 @@ export const Appearance = () => {
 
   return (
     <div className={styles.wrapper}>
-      <CompoundButton secondaryContent="Secondary content">Default</CompoundButton>
-      <CompoundButton secondaryContent="Secondary content" appearance="primary">
+      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonthRegular />}>
+        Default
+      </CompoundButton>
+      <CompoundButton secondaryContent="Secondary content" appearance="primary" icon={<CalendarMonthRegular />}>
         Primary
       </CompoundButton>
-      <CompoundButton secondaryContent="Secondary content" appearance="outline">
+      <CompoundButton secondaryContent="Secondary content" appearance="outline" icon={<CalendarMonthRegular />}>
         Outline
       </CompoundButton>
-      <CompoundButton secondaryContent="Secondary content" appearance="subtle">
+      <CompoundButton secondaryContent="Secondary content" appearance="subtle" icon={<CalendarMonth />}>
         Subtle
       </CompoundButton>
-      <CompoundButton secondaryContent="Secondary content" appearance="transparent">
+      <CompoundButton secondaryContent="Secondary content" appearance="transparent" icon={<CalendarMonth />}>
         Transparent
       </CompoundButton>
     </div>

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
@@ -22,7 +22,7 @@ export const Appearance = () => {
       <CompoundButton secondaryContent="Secondary content" appearance="primary" icon={<CalendarMonthRegular />}>
         Primary
       </CompoundButton>
-      <CompoundButton secondaryContent="Secondary content" appearance="outline" icon={<CalendarMonthRegular />}>
+      <CompoundButton secondaryContent="Secondary content" appearance="outline" icon={<CalendarMonth />}>
         Outline
       </CompoundButton>
       <CompoundButton secondaryContent="Secondary content" appearance="subtle" icon={<CalendarMonth />}>

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonDefault.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonDefault.stories.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import { CompoundButton } from '@fluentui/react-components';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 import type { CompoundButtonProps } from '@fluentui/react-components';
 
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
-
 export const Default = (props: CompoundButtonProps) => (
-  <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" {...props}>
+  <CompoundButton icon={<CalendarMonthRegular />} secondaryContent="Secondary content" {...props}>
     Example
   </CompoundButton>
 );

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonIcon.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import { makeStyles, CompoundButton, Tooltip } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -17,14 +15,14 @@ export const Icon = () => {
 
   return (
     <div className={styles.wrapper}>
-      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonth />}>
+      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonthRegular />}>
         With calendar icon before contents
       </CompoundButton>
-      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonth />} iconPosition="after">
+      <CompoundButton secondaryContent="Secondary content" icon={<CalendarMonthRegular />} iconPosition="after">
         With calendar icon after contents
       </CompoundButton>
       <Tooltip content="With calendar icon only" relationship="label">
-        <CompoundButton icon={<CalendarMonth />} />
+        <CompoundButton icon={<CalendarMonthRegular />} />
       </Tooltip>
     </div>
   );

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonSize.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import { makeStyles, CompoundButton } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -17,13 +15,13 @@ export const Size = () => {
 
   return (
     <div className={styles.wrapper}>
-      <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" size="small">
+      <CompoundButton icon={<CalendarMonthRegular />} secondaryContent="Secondary content" size="small">
         Size: small
       </CompoundButton>
-      <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" size="medium">
+      <CompoundButton icon={<CalendarMonthRegular />} secondaryContent="Secondary content" size="medium">
         Size: medium
       </CompoundButton>
-      <CompoundButton icon={<CalendarMonth />} secondaryContent="Secondary content" size="large">
+      <CompoundButton icon={<CalendarMonthRegular />} secondaryContent="Secondary content" size="large">
         Size: large
       </CompoundButton>
     </div>

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonIcon.stories.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
 import {
-  bundleIcon,
-  CalendarMonthFilled,
-  CalendarMonthRegular,
-  FilterFilled,
-  FilterRegular,
-} from '@fluentui/react-icons';
-import {
   makeStyles,
   Menu,
   MenuButton,
@@ -16,9 +9,7 @@ import {
   MenuTrigger,
   Tooltip,
 } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
-const Filter = bundleIcon(FilterFilled, FilterRegular);
+import { CalendarMonthRegular, FilterRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -34,7 +25,7 @@ export const Icon = () => {
     <div className={styles.wrapper}>
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <MenuButton icon={<CalendarMonth />}>With calendar icon</MenuButton>
+          <MenuButton icon={<CalendarMonthRegular />}>With calendar icon</MenuButton>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -46,7 +37,7 @@ export const Icon = () => {
 
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <MenuButton icon={<CalendarMonth />} menuIcon={<Filter />}>
+          <MenuButton icon={<CalendarMonthRegular />} menuIcon={<FilterRegular />}>
             With calendar icon and custom filter menu icon
           </MenuButton>
         </MenuTrigger>
@@ -61,7 +52,7 @@ export const Icon = () => {
       <Menu>
         <MenuTrigger disableButtonEnhancement>
           <Tooltip content="With calendar icon and no contents" relationship="label">
-            <MenuButton icon={<CalendarMonth />} />
+            <MenuButton icon={<CalendarMonthRegular />} />
           </Tooltip>
         </MenuTrigger>
         <MenuPopover>

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeLarge.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeLarge.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import {
   makeStyles,
   Menu,
@@ -10,8 +9,7 @@ import {
   MenuTrigger,
   Tooltip,
 } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -40,7 +38,7 @@ export const SizeLarge = () => {
 
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <MenuButton icon={<CalendarMonth />} size="large">
+          <MenuButton icon={<CalendarMonthRegular />} size="large">
             Large with calendar icon
           </MenuButton>
         </MenuTrigger>
@@ -56,7 +54,7 @@ export const SizeLarge = () => {
       <Menu>
         <MenuTrigger disableButtonEnhancement>
           <Tooltip content="Large with calendar icon only" relationship="label">
-            <MenuButton icon={<CalendarMonth />} size="large" />
+            <MenuButton icon={<CalendarMonthRegular />} size="large" />
           </Tooltip>
         </MenuTrigger>
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeMedium.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeMedium.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import {
   makeStyles,
   Menu,
@@ -10,8 +9,7 @@ import {
   MenuTrigger,
   Tooltip,
 } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -40,7 +38,7 @@ export const SizeMedium = () => {
 
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <MenuButton icon={<CalendarMonth />} size="medium">
+          <MenuButton icon={<CalendarMonthRegular />} size="medium">
             Medium with calendar icon
           </MenuButton>
         </MenuTrigger>
@@ -56,7 +54,7 @@ export const SizeMedium = () => {
       <Menu>
         <MenuTrigger disableButtonEnhancement>
           <Tooltip content="Medium with calendar icon only" relationship="label">
-            <MenuButton icon={<CalendarMonth />} size="medium" />
+            <MenuButton icon={<CalendarMonthRegular />} size="medium" />
           </Tooltip>
         </MenuTrigger>
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeSmall.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import {
   makeStyles,
   Menu,
@@ -10,8 +9,7 @@ import {
   MenuTrigger,
   Tooltip,
 } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -40,7 +38,7 @@ export const SizeSmall = () => {
 
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <MenuButton icon={<CalendarMonth />} size="small">
+          <MenuButton icon={<CalendarMonthRegular />} size="small">
             Small with calendar icon
           </MenuButton>
         </MenuTrigger>
@@ -56,7 +54,7 @@ export const SizeSmall = () => {
       <Menu>
         <MenuTrigger disableButtonEnhancement>
           <Tooltip content="Small with calendar icon only" relationship="label">
-            <MenuButton icon={<CalendarMonth />} size="small" />
+            <MenuButton icon={<CalendarMonthRegular />} size="small" />
           </Tooltip>
         </MenuTrigger>
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonIcon.stories.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
 import {
-  bundleIcon,
-  CalendarMonthFilled,
-  CalendarMonthRegular,
-  FilterFilled,
-  FilterRegular,
-} from '@fluentui/react-icons';
-import {
   makeStyles,
   Menu,
   MenuItem,
@@ -16,10 +9,8 @@ import {
   SplitButton,
   Tooltip,
 } from '@fluentui/react-components';
+import { CalendarMonthRegular, FilterRegular } from '@fluentui/react-icons';
 import type { MenuButtonProps } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
-const Filter = bundleIcon(FilterFilled, FilterRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -40,7 +31,7 @@ export const Icon = () => {
       <Menu positioning="below-end">
         <MenuTrigger disableButtonEnhancement>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />}>
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonthRegular />}>
               With calendar icon before contents
             </SplitButton>
           )}
@@ -56,7 +47,7 @@ export const Icon = () => {
       <Menu positioning="below-end">
         <MenuTrigger disableButtonEnhancement>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />} iconPosition="after">
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonthRegular />} iconPosition="after">
               With calendar icon after contents
             </SplitButton>
           )}
@@ -72,7 +63,7 @@ export const Icon = () => {
       <Menu positioning="below-end">
         <MenuTrigger disableButtonEnhancement>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />} menuIcon={<Filter />}>
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonthRegular />} menuIcon={<FilterRegular />}>
               With calendar icon and custom filter menu icon
             </SplitButton>
           )}
@@ -96,7 +87,7 @@ export const Icon = () => {
               <SplitButton
                 menuButton={triggerProps}
                 primaryActionButton={{ ref: setPrimaryActionButtonRef }}
-                icon={<CalendarMonth />}
+                icon={<CalendarMonthRegular />}
               />
             </Tooltip>
           )}

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeLarge.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeLarge.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import {
   makeStyles,
   Menu,
@@ -10,9 +9,8 @@ import {
   SplitButton,
   Tooltip,
 } from '@fluentui/react-components';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 import type { MenuButtonProps } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -50,7 +48,7 @@ export const SizeLarge = () => {
       <Menu positioning="below-end">
         <MenuTrigger disableButtonEnhancement>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />} size="large">
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonthRegular />} size="large">
               Large with calendar icon
             </SplitButton>
           )}
@@ -75,7 +73,7 @@ export const SizeLarge = () => {
               <SplitButton
                 menuButton={triggerProps}
                 primaryActionButton={{ ref: setPrimaryActionButtonRef }}
-                icon={<CalendarMonth />}
+                icon={<CalendarMonthRegular />}
                 size="large"
               />
             </Tooltip>

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeMedium.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeMedium.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import {
   makeStyles,
   Menu,
@@ -10,9 +9,8 @@ import {
   SplitButton,
   Tooltip,
 } from '@fluentui/react-components';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 import type { MenuButtonProps } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -50,7 +48,7 @@ export const SizeMedium = () => {
       <Menu positioning="below-end">
         <MenuTrigger disableButtonEnhancement>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />} size="medium">
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonthRegular />} size="medium">
               Medium with calendar icon
             </SplitButton>
           )}
@@ -75,7 +73,7 @@ export const SizeMedium = () => {
               <SplitButton
                 menuButton={triggerProps}
                 primaryActionButton={{ ref: setPrimaryActionButtonRef }}
-                icon={<CalendarMonth />}
+                icon={<CalendarMonthRegular />}
                 size="medium"
               />
             </Tooltip>

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeSmall.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import {
   makeStyles,
   Menu,
@@ -10,9 +9,8 @@ import {
   SplitButton,
   Tooltip,
 } from '@fluentui/react-components';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
 import type { MenuButtonProps } from '@fluentui/react-components';
-
-const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -50,7 +48,7 @@ export const SizeSmall = () => {
       <Menu positioning="below-end">
         <MenuTrigger disableButtonEnhancement>
           {(triggerProps: MenuButtonProps) => (
-            <SplitButton menuButton={triggerProps} icon={<CalendarMonth />} size="small">
+            <SplitButton menuButton={triggerProps} icon={<CalendarMonthRegular />} size="small">
               Small with calendar icon
             </SplitButton>
           )}
@@ -75,7 +73,7 @@ export const SizeSmall = () => {
               <SplitButton
                 menuButton={triggerProps}
                 primaryActionButton={{ ref: setPrimaryActionButtonRef }}
-                icon={<CalendarMonth />}
+                icon={<CalendarMonthRegular />}
                 size="small"
               />
             </Tooltip>

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { makeStyles, ToggleButton } from '@fluentui/react-components';
+import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
+
+const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 const useStyles = makeStyles({
   wrapper: {
@@ -9,15 +12,59 @@ const useStyles = makeStyles({
 });
 
 export const Appearance = () => {
+  const [checked1, setChecked1] = React.useState(false);
+  const [checked2, setChecked2] = React.useState(false);
+  const [checked3, setChecked3] = React.useState(false);
   const styles = useStyles();
+
+  const toggleChecked = React.useCallback(
+    (buttonIndex: number) => {
+      switch (buttonIndex) {
+        case 1:
+          setChecked1(!checked1);
+          break;
+        case 2:
+          setChecked2(!checked2);
+          break;
+        case 3:
+          setChecked3(!checked3);
+          break;
+      }
+    },
+    [checked1, checked2, checked3],
+  );
 
   return (
     <div className={styles.wrapper}>
-      <ToggleButton>Default</ToggleButton>
-      <ToggleButton appearance="primary">Primary</ToggleButton>
-      <ToggleButton appearance="outline">Outline</ToggleButton>
-      <ToggleButton appearance="subtle">Subtle</ToggleButton>
-      <ToggleButton appearance="transparent">Transparent</ToggleButton>
+      <ToggleButton
+        checked={checked1}
+        icon={checked1 ? <CalendarMonth /> : <CalendarMonthRegular />}
+        onClick={() => toggleChecked(1)}
+      >
+        Default
+      </ToggleButton>
+      <ToggleButton
+        appearance="primary"
+        checked={checked2}
+        icon={checked2 ? <CalendarMonth /> : <CalendarMonthRegular />}
+        onClick={() => toggleChecked(2)}
+      >
+        Primary
+      </ToggleButton>
+      <ToggleButton
+        appearance="outline"
+        checked={checked3}
+        icon={checked3 ? <CalendarMonth /> : <CalendarMonthRegular />}
+        onClick={() => toggleChecked(3)}
+      >
+        Outline
+      </ToggleButton>
+      <ToggleButton appearance="subtle" icon={<CalendarMonth />}>
+        Subtle
+      </ToggleButton>
+      <ToggleButton appearance="transparent" icon={<CalendarMonth />}>
+        Transparent
+      </ToggleButton>
     </div>
   );
 };

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
@@ -14,7 +14,6 @@ const useStyles = makeStyles({
 export const Appearance = () => {
   const [checked1, setChecked1] = React.useState(false);
   const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
   const styles = useStyles();
 
   const toggleChecked = React.useCallback(
@@ -26,12 +25,9 @@ export const Appearance = () => {
         case 2:
           setChecked2(!checked2);
           break;
-        case 3:
-          setChecked3(!checked3);
-          break;
       }
     },
-    [checked1, checked2, checked3],
+    [checked1, checked2],
   );
 
   return (
@@ -51,12 +47,7 @@ export const Appearance = () => {
       >
         Primary
       </ToggleButton>
-      <ToggleButton
-        appearance="outline"
-        checked={checked3}
-        icon={checked3 ? <CalendarMonth /> : <CalendarMonthRegular />}
-        onClick={() => toggleChecked(3)}
-      >
+      <ToggleButton appearance="outline" icon={<CalendarMonth />} onClick={() => toggleChecked(3)}>
         Outline
       </ToggleButton>
       <ToggleButton appearance="subtle" icon={<CalendarMonth />}>

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonIcon.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import { makeStyles, ToggleButton, Tooltip } from '@fluentui/react-components';
+import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
@@ -12,16 +12,52 @@ const useStyles = makeStyles({
 });
 
 export const Icon = () => {
+  const [checked1, setChecked1] = React.useState(false);
+  const [checked2, setChecked2] = React.useState(false);
+  const [checked3, setChecked3] = React.useState(false);
   const styles = useStyles();
+
+  const toggleChecked = React.useCallback(
+    (buttonIndex: number) => {
+      switch (buttonIndex) {
+        case 1:
+          setChecked1(!checked1);
+          break;
+        case 2:
+          setChecked2(!checked2);
+          break;
+        case 3:
+          setChecked3(!checked3);
+          break;
+      }
+    },
+    [checked1, checked2, checked3],
+  );
 
   return (
     <div className={styles.wrapper}>
-      <ToggleButton icon={<CalendarMonth />}>With calendar icon before contents</ToggleButton>
-      <ToggleButton icon={<CalendarMonth />} iconPosition="after">
+      <ToggleButton
+        checked={checked1}
+        icon={checked1 ? <CalendarMonth /> : <CalendarMonthRegular />}
+        onClick={() => toggleChecked(1)}
+      >
+        With calendar icon before contents
+      </ToggleButton>
+      <ToggleButton
+        checked={checked2}
+        icon={checked2 ? <CalendarMonth /> : <CalendarMonthRegular />}
+        iconPosition="after"
+        onClick={() => toggleChecked(2)}
+      >
         With calendar icon after contents
       </ToggleButton>
       <Tooltip content="With calendar icon only" relationship="label">
-        <ToggleButton icon={<CalendarMonth />} aria-label="Icon only" />
+        <ToggleButton
+          aria-label="Icon only"
+          checked={checked3}
+          icon={checked3 ? <CalendarMonth /> : <CalendarMonthRegular />}
+          onClick={() => toggleChecked(3)}
+        />
       </Tooltip>
     </div>
   );


### PR DESCRIPTION
## Previous Behavior

The documentation on `Buttons` showed usage of icons that is not according to the design specification regarding when they should be shown as regular vs filled.

## New Behavior

The documentation on `Buttons` now shows the correct usage of icons according to the design specification regarding when they should be shown as regular vs filled. This PR also fixes some issues with the icon color on `subtle` `Buttons` on hovered and pressed states.

## Related Issue(s)

Fixes #23808
