### PR TITLE
fix(useTable): sort should adapt to enhanced row types

### DIFF
--- a/change/@fluentui-react-table-c3838956-bc8b-4f1d-bcc9-3e89d914bb6f.json
+++ b/change/@fluentui-react-table-c3838956-bc8b-4f1d-bcc9-3e89d914bb6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(useTable): sort should adapt to enhanced row types",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -427,7 +427,7 @@ export type TableSlots = {
 export interface TableSortState<TItem> {
     getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
     setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
-    sort: (rows: RowState<TItem>[]) => RowState<TItem>[];
+    sort: <TRowState extends RowState<TItem>>(rows: TRowState[]) => TRowState[];
     sortColumn: ColumnId | undefined;
     sortDirection: SortDirection;
     toggleColumnSort: (columnId: ColumnId) => void;

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -44,7 +44,7 @@ export interface TableSortState<TItem> {
   /**
    * Sorts rows and returns a **shallow** copy of original items
    */
-  sort: (rows: RowState<TItem>[]) => RowState<TItem>[];
+  sort: <TRowState extends RowState<TItem>>(rows: TRowState[]) => TRowState[];
 }
 
 export interface TableSelectionState {

--- a/packages/react-components/react-table/src/hooks/useSort.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.ts
@@ -6,7 +6,7 @@ const noop = () => undefined;
 export const defaultTableSortState: TableSortState<unknown> = {
   getSortDirection: () => 'ascending',
   setColumnSort: noop,
-  sort: (rows: RowState<unknown>[]) => [...rows],
+  sort: <TRowState extends RowState<unknown>>(rows: TRowState[]) => [...rows],
   sortColumn: undefined,
   sortDirection: 'ascending',
   toggleColumnSort: noop,
@@ -53,7 +53,7 @@ export function useSortState<TItem>(tableState: TableState<TItem>, options: UseS
     setSorted(newState);
   };
 
-  const sort = (rows: RowState<TItem>[]) => {
+  const sort = <TRowState extends RowState<TItem>>(rows: TRowState[]) => {
     return rows.slice().sort((a, b) => {
       const sortColumnDef = columns.find(column => column.columnId === sortColumn);
       if (!sortColumnDef?.compare) {


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

```ts
const rows = sort(getRows(row) => ({...row, foo: 'foo'}))

// Error - `foo` does not exist on row
console.log(rows[0].foo)
```

## New Behavior

```ts
const rows = sort(getRows(row) => ({...row, foo: 'foo'}))

// Supports TS intellisense
console.log(rows[0].foo)
```

