### PR TITLE
fix(tools): conditionally add testing subfolder to tsconfig include glob in migrate-converged-pkg 

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -332,8 +332,6 @@ describe('migrate-converged-pkg generator', () => {
         '**/*.test.js',
         '**/*.test.jsx',
         '**/*.d.ts',
-        './src/testing/**/*.js',
-        './src/testing/**/*.jsx',
       ]);
     });
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -265,12 +265,12 @@ const templates = {
           include: ['**/*.spec.ts', '**/*.spec.tsx', '**/*.test.ts', '**/*.test.tsx', '**/*.d.ts'],
         };
 
-        if (options.js) {
-          tsConfig.include = globsToJs(tsConfig.include);
-        }
-
         if (options.hasConformance) {
           tsConfig.include.push('./src/testing/**/*.ts', './src/testing/**/*.tsx');
+        }
+
+        if (options.js) {
+          tsConfig.include = globsToJs(tsConfig.include);
         }
 
         return tsConfig;

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -262,19 +262,15 @@ const templates = {
             outDir: 'dist',
             types: ['jest', 'node'],
           } as TsConfig['compilerOptions'],
-          include: [
-            '**/*.spec.ts',
-            '**/*.spec.tsx',
-            '**/*.test.ts',
-            '**/*.test.tsx',
-            '**/*.d.ts',
-            './src/testing/**/*.ts',
-            './src/testing/**/*.tsx',
-          ],
+          include: ['**/*.spec.ts', '**/*.spec.tsx', '**/*.test.ts', '**/*.test.tsx', '**/*.d.ts'],
         };
 
         if (options.js) {
           tsConfig.include = globsToJs(tsConfig.include);
+        }
+
+        if (options.hasConformance) {
+          tsConfig.include.push('./src/testing/**/*.ts', './src/testing/**/*.tsx');
         }
 
         return tsConfig;


### PR DESCRIPTION
### Changes:
- Conditionally adds `src/testing/` subfolder to `tsconfig.spec.json` of `migrate-converged-pkg`