### PR TITLE
fix(screener-build workflow): scope package to build for v9 VR tests to speed up perf

### DIFF
--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -272,8 +272,8 @@ jobs:
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: build vr-tests-react-components storybook
-        run: yarn lage build --to @fluentui/vr-tests-react-components
+      - name: build @fluentui/react-storybook-addon
+        run: yarn build --to @fluentui/react-storybook-addon
         if: ${{env.SKIP_SCREENER_BUILD == 'false'}}
 
       - name: build vr-tests-react-components storybook

--- a/.github/workflows/screener-build.yml
+++ b/.github/workflows/screener-build.yml
@@ -272,7 +272,7 @@ jobs:
           printenv | sort ;\
           echo "SHELLOPTS $SHELLOPTS" ;\
 
-      - name: build @fluentui/react-storybook-addon
+      - name: build  @fluentui/react-storybook-addon
         run: yarn build --to @fluentui/react-storybook-addon
         if: ${{env.SKIP_SCREENER_BUILD == 'false'}}
 


### PR DESCRIPTION
### Issue:
- Current workflow setup introduced in #25108 tries to build `@fluentui/vr-tests-react-components` and all of its dependencies which slows down workflow considerably.
![image](https://user-images.githubusercontent.com/8649804/199572573-e56fe5ed-6222-4e02-837d-e2d851b613ff.png)



### Changes:
- only build what's needed (`@fluentui/react-storybook-addon`) to speed up workflow completion.
![image](https://user-images.githubusercontent.com/8649804/199574208-0371fce9-515d-4306-b441-a5b53b84af77.png)

