### PR TITLE
feat: Implement render function for DataGridRow

### DIFF
--- a/change/@fluentui-react-components-a065d3d7-c686-4ce0-b520-0b1875853ca0.json
+++ b/change/@fluentui-react-components-a065d3d7-c686-4ce0-b520-0b1875853ca0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: Exports `createColumn` utility from `@fluentui/react-table` as unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-a94f4f80-c021-4eb8-a8e3-789425aee9e2.json
+++ b/change/@fluentui-react-table-a94f4f80-c021-4eb8-a8e3-789425aee9e2.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "feat: Implement render function for DataGridRow",
+  "comment": "BREAKING: ColumnDefinition type is stricter, use createColumn to create column definition. Implments render function for DataGridRow.",
   "packageName": "@fluentui/react-table",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-table-a94f4f80-c021-4eb8-a8e3-789425aee9e2.json
+++ b/change/@fluentui-react-table-a94f4f80-c021-4eb8-a8e3-789425aee9e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Implement render function for DataGridRow",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -63,6 +63,8 @@ import { ComboboxOpenEvents } from '@fluentui/react-combobox';
 import { ComboboxProps } from '@fluentui/react-combobox';
 import { ComboboxSlots } from '@fluentui/react-combobox';
 import { ComboboxState } from '@fluentui/react-combobox';
+import { createColumn } from '@fluentui/react-table';
+import { CreateColumnOptions } from '@fluentui/react-table';
 import { DATA_OVERFLOW_ITEM } from '@fluentui/react-overflow';
 import { DATA_OVERFLOW_MENU } from '@fluentui/react-overflow';
 import { DATA_OVERFLOWING } from '@fluentui/react-overflow';
@@ -420,6 +422,10 @@ export { ComboboxProps }
 export { ComboboxSlots }
 
 export { ComboboxState }
+
+export { createColumn }
+
+export { CreateColumnOptions }
 
 export { DATA_OVERFLOW_ITEM }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -235,6 +235,7 @@ export {
   useTable,
   useSelection,
   useSort,
+  createColumn,
 } from '@fluentui/react-table';
 
 export type {
@@ -274,6 +275,7 @@ export type {
   RowId,
   ColumnDefinition,
   ColumnId,
+  CreateColumnOptions,
 } from '@fluentui/react-table';
 
 export {

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -24,6 +24,10 @@ export interface ColumnDefinition<TItem> {
     columnId: ColumnId;
     // (undocumented)
     compare?: (a: TItem, b: TItem) => number;
+    // (undocumented)
+    renderCell?: (item: TItem) => React_2.ReactNode;
+    // (undocumented)
+    renderHeader?: () => React_2.ReactNode;
 }
 
 // @public (undocumented)
@@ -115,7 +119,9 @@ export const DataGridRow: ForwardRefComponent<DataGridRowProps>;
 export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots>;
 
 // @public
-export type DataGridRowProps = TableRowProps;
+export type DataGridRowProps = Omit<TableRowProps, 'children'> & {
+    children: CellRenderFunction;
+};
 
 // @public (undocumented)
 export type DataGridRowSlots = TableRowSlots;

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -15,23 +15,41 @@ import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { Radio } from '@fluentui/react-radio';
 import * as React_2 from 'react';
+import { ReactNode } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+
+// @public (undocumented)
+export type CellRenderFunction = (column: ColumnDefinition<any>) => React_2.ReactNode;
 
 // @public (undocumented)
 export interface ColumnDefinition<TItem> {
     // (undocumented)
     columnId: ColumnId;
     // (undocumented)
-    compare?: (a: TItem, b: TItem) => number;
+    compare: (a: TItem, b: TItem) => number;
     // (undocumented)
-    renderCell?: (item: TItem) => React_2.ReactNode;
+    renderCell: (item: TItem) => React_2.ReactNode;
     // (undocumented)
-    renderHeader?: () => React_2.ReactNode;
+    renderHeaderCell: () => React_2.ReactNode;
 }
 
 // @public (undocumented)
 export type ColumnId = string | number;
+
+// @public
+export function createColumn<TItem>(options: CreateColumnOptions<TItem>): {
+    columnId: ColumnId;
+    renderCell: (item: TItem) => ReactNode;
+    renderHeaderCell: () => ReactNode;
+    compare: (a: TItem, b: TItem) => number;
+};
+
+// @public (undocumented)
+export interface CreateColumnOptions<TItem> extends Partial<ColumnDefinition<TItem>> {
+    // (undocumented)
+    columnId: ColumnId;
+}
 
 // @public
 export const DataGrid: ForwardRefComponent<DataGridProps>;

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
@@ -7,6 +7,7 @@ import { ColumnDefinition, RowState } from '../../hooks';
 import { DataGridBody } from '../DataGridBody/DataGridBody';
 import { DataGridRow } from '../DataGridRow/DataGridRow';
 import { DataGridCell } from '../DataGridCell/DataGridCell';
+import { DataGridHeader } from '../DataGridHeader/DataGridHeader';
 
 describe('DataGrid', () => {
   isConformant<DataGridProps>({
@@ -20,7 +21,11 @@ describe('DataGrid', () => {
     third: string;
   }
 
-  const testColumns: ColumnDefinition<Item>[] = [{ columnId: 'first' }, { columnId: 'second' }, { columnId: 'third' }];
+  const testColumns: ColumnDefinition<Item>[] = [
+    { columnId: 'first', renderHeader: () => 'first', renderCell: item => item.first },
+    { columnId: 'second', renderHeader: () => 'second', renderCell: item => item.second },
+    { columnId: 'third', renderHeader: () => 'third', renderCell: item => item.third },
+  ];
   const testItems: Item[] = [
     { first: 'first', second: 'second', third: 'third' },
     { first: 'first', second: 'second', third: 'third' },
@@ -30,12 +35,15 @@ describe('DataGrid', () => {
   it('renders a default state', () => {
     const result = render(
       <DataGrid items={testItems} columns={testColumns}>
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeader, columnId }) => <DataGridCell key={columnId}>{renderHeader()}</DataGridCell>}
+          </DataGridRow>
+        </DataGridHeader>
         <DataGridBody>
           {({ item, rowId }: RowState<Item>) => (
             <DataGridRow key={rowId}>
-              <DataGridCell>{item.first}</DataGridCell>
-              <DataGridCell>{item.second}</DataGridCell>
-              <DataGridCell>{item.third}</DataGridCell>
+              {({ renderCell, columnId }) => <DataGridCell key={columnId}>{renderCell(item)}</DataGridCell>}
             </DataGridRow>
           )}
         </DataGridBody>

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { DataGrid } from './DataGrid';
 import { isConformant } from '../../testing/isConformant';
 import { DataGridProps } from './DataGrid.types';
-import { ColumnDefinition, RowState } from '../../hooks';
+import { ColumnDefinition, createColumn, RowState } from '../../hooks';
 import { DataGridBody } from '../DataGridBody/DataGridBody';
 import { DataGridRow } from '../DataGridRow/DataGridRow';
 import { DataGridCell } from '../DataGridCell/DataGridCell';
@@ -22,9 +22,9 @@ describe('DataGrid', () => {
   }
 
   const testColumns: ColumnDefinition<Item>[] = [
-    { columnId: 'first', renderHeader: () => 'first', renderCell: item => item.first },
-    { columnId: 'second', renderHeader: () => 'second', renderCell: item => item.second },
-    { columnId: 'third', renderHeader: () => 'third', renderCell: item => item.third },
+    createColumn({ columnId: 'first', renderHeaderCell: () => 'first', renderCell: item => item.first }),
+    createColumn({ columnId: 'second', renderHeaderCell: () => 'second', renderCell: item => item.second }),
+    createColumn({ columnId: 'third', renderHeaderCell: () => 'third', renderCell: item => item.third }),
   ];
   const testItems: Item[] = [
     { first: 'first', second: 'second', third: 'third' },
@@ -37,7 +37,7 @@ describe('DataGrid', () => {
       <DataGrid items={testItems} columns={testColumns}>
         <DataGridHeader>
           <DataGridRow>
-            {({ renderHeader, columnId }) => <DataGridCell key={columnId}>{renderHeader()}</DataGridCell>}
+            {({ renderHeaderCell, columnId }) => <DataGridCell key={columnId}>{renderHeaderCell()}</DataGridCell>}
           </DataGridRow>
         </DataGridHeader>
         <DataGridBody>

--- a/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -7,6 +7,34 @@ exports[`DataGrid renders a default state 1`] = `
     role="table"
   >
     <div
+      class="fui-DataGridHeader fui-TableHeader"
+      role="rowgroup"
+    >
+      <div
+        class="fui-DataGridRow fui-TableRow"
+        role="row"
+      >
+        <div
+          class="fui-DataGridCell fui-TableCell"
+          role="cell"
+        >
+          first
+        </div>
+        <div
+          class="fui-DataGridCell fui-TableCell"
+          role="cell"
+        >
+          second
+        </div>
+        <div
+          class="fui-DataGridCell fui-TableCell"
+          role="cell"
+        >
+          third
+        </div>
+      </div>
+    </div>
+    <div
       class="fui-DataGridBody fui-TableBody"
       role="rowgroup"
     >

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.test.tsx
@@ -13,7 +13,7 @@ describe('DataGridRow', () => {
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests
 
   it('renders a default state', () => {
-    const result = render(<DataGridRow>Default DataGridRow</DataGridRow>);
+    const result = render(<DataGridRow>{() => 'foo'}</DataGridRow>);
     expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
@@ -1,11 +1,20 @@
+import * as React from 'react';
+import { ColumnDefinitionRender } from '../../hooks/types';
 import { TableRowProps, TableRowSlots, TableRowState } from '../TableRow/TableRow.types';
 
 export type DataGridRowSlots = TableRowSlots;
 
+// Use any here since we can't know the user types
+// The user is responsible for narrowing the type downstream
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CellRenderFunction = (column: ColumnDefinitionRender<any>) => React.ReactNode;
+
 /**
  * DataGridRow Props
  */
-export type DataGridRowProps = TableRowProps;
+export type DataGridRowProps = Omit<TableRowProps, 'children'> & {
+  children: CellRenderFunction;
+};
 
 /**
  * State used in rendering DataGridRow

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ColumnDefinitionRender } from '../../hooks/types';
+import { ColumnDefinition } from '../../hooks';
 import { TableRowProps, TableRowSlots, TableRowState } from '../TableRow/TableRow.types';
 
 export type DataGridRowSlots = TableRowSlots;
@@ -7,7 +7,7 @@ export type DataGridRowSlots = TableRowSlots;
 // Use any here since we can't know the user types
 // The user is responsible for narrowing the type downstream
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type CellRenderFunction = (column: ColumnDefinitionRender<any>) => React.ReactNode;
+export type CellRenderFunction = (column: ColumnDefinition<any>) => React.ReactNode;
 
 /**
  * DataGridRow Props

--- a/packages/react-components/react-table/src/components/DataGridRow/__snapshots__/DataGridRow.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridRow/__snapshots__/DataGridRow.test.tsx.snap
@@ -5,8 +5,6 @@ exports[`DataGridRow renders a default state 1`] = `
   <div
     class="fui-DataGridRow fui-TableRow"
     role="row"
-  >
-    Default DataGridRow
-  </div>
+  />
 </div>
 `;

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import type { DataGridRowProps, DataGridRowState } from './DataGridRow.types';
 import { useTableRow_unstable } from '../TableRow/useTableRow';
+import { useDataGridContext_unstable } from '../../contexts/dataGridContext';
+import { ColumnDefinitionRender } from '../../hooks/types';
 
 /**
  * Create the state required to render DataGridRow.
@@ -12,5 +14,22 @@ import { useTableRow_unstable } from '../TableRow/useTableRow';
  * @param ref - reference to root HTMLElement of DataGridRow
  */
 export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<HTMLElement>): DataGridRowState => {
-  return useTableRow_unstable({ ...props, as: 'div' }, ref);
+  const columnDefs = useDataGridContext_unstable(ctx => ctx.columns);
+  // Use any here since we can't know the user types
+  // The user is responsible for narrowing the type downstream
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const columnDefsRendered: ColumnDefinitionRender<any>[] = columnDefs.map(columnDef => {
+    return {
+      ...columnDef,
+      renderCell: columnDef.renderCell ?? (() => null),
+      renderHeader: columnDef.renderHeader ?? (() => null),
+    };
+  });
+
+  const cellRenderFunction = props.children;
+  const children = columnDefsRendered.map(columnDefRendered => {
+    return cellRenderFunction(columnDefRendered);
+  });
+
+  return useTableRow_unstable({ ...props, children, as: 'div' }, ref);
 };

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import type { DataGridRowProps, DataGridRowState } from './DataGridRow.types';
 import { useTableRow_unstable } from '../TableRow/useTableRow';
 import { useDataGridContext_unstable } from '../../contexts/dataGridContext';
-import { ColumnDefinitionRender } from '../../hooks/types';
 
 /**
  * Create the state required to render DataGridRow.
@@ -15,20 +14,10 @@ import { ColumnDefinitionRender } from '../../hooks/types';
  */
 export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<HTMLElement>): DataGridRowState => {
   const columnDefs = useDataGridContext_unstable(ctx => ctx.columns);
-  // Use any here since we can't know the user types
-  // The user is responsible for narrowing the type downstream
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const columnDefsRendered: ColumnDefinitionRender<any>[] = columnDefs.map(columnDef => {
-    return {
-      ...columnDef,
-      renderCell: columnDef.renderCell ?? (() => null),
-      renderHeader: columnDef.renderHeader ?? (() => null),
-    };
-  });
 
   const cellRenderFunction = props.children;
-  const children = columnDefsRendered.map(columnDefRendered => {
-    return cellRenderFunction(columnDefRendered);
+  const children = columnDefs.map(columnDef => {
+    return cellRenderFunction(columnDef);
   });
 
   return useTableRow_unstable({ ...props, children, as: 'div' }, ref);

--- a/packages/react-components/react-table/src/hooks/createColumn.ts
+++ b/packages/react-components/react-table/src/hooks/createColumn.ts
@@ -1,0 +1,42 @@
+import { CreateColumnOptions } from './types';
+
+const defaultCompare = () => 0;
+
+const defaultRenderCell = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn('@fluentui/react-table: You are using the default column renderCell function that renders null');
+  }
+
+  return null;
+};
+
+const defaultRenderHeaderCell = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn('@fluentui/react-table: You are using the default column renderHeaderCell function that renders null');
+  }
+
+  return null;
+};
+
+/**
+ * Helper function to create column definition with defaults
+ * @param options - column definition options
+ * @returns - column definition with defaults
+ */
+export function createColumn<TItem>(options: CreateColumnOptions<TItem>) {
+  const {
+    columnId,
+    renderCell = defaultRenderCell,
+    renderHeaderCell = defaultRenderHeaderCell,
+    compare = defaultCompare,
+  } = options;
+
+  return {
+    columnId,
+    renderCell,
+    renderHeaderCell,
+    compare,
+  };
+}

--- a/packages/react-components/react-table/src/hooks/index.ts
+++ b/packages/react-components/react-table/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './useTable';
 export * from './useSort';
 export * from './useSelection';
+export * from './createColumn';

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -10,16 +10,16 @@ export interface SortState {
   sortDirection: SortDirection;
 }
 
-export interface ColumnDefinition<TItem> {
+export interface CreateColumnOptions<TItem> extends Partial<ColumnDefinition<TItem>> {
   columnId: ColumnId;
-  compare?: (a: TItem, b: TItem) => number;
-  renderHeader?: () => React.ReactNode;
-  renderCell?: (item: TItem) => React.ReactNode;
 }
 
-export interface ColumnDefinitionRender<TItem>
-  extends Omit<ColumnDefinition<TItem>, 'renderHeader' | 'renderCell'>,
-    Required<Pick<ColumnDefinition<TItem>, 'renderHeader' | 'renderCell'>> {}
+export interface ColumnDefinition<TItem> {
+  columnId: ColumnId;
+  compare: (a: TItem, b: TItem) => number;
+  renderHeaderCell: () => React.ReactNode;
+  renderCell: (item: TItem) => React.ReactNode;
+}
 
 export type RowEnhancer<TItem, TRowState extends RowState<TItem> = RowState<TItem>> = (
   row: RowState<TItem>,

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { SortDirection } from '../components/Table/Table.types';
 
 export type RowId = string | number;
@@ -12,7 +13,13 @@ export interface SortState {
 export interface ColumnDefinition<TItem> {
   columnId: ColumnId;
   compare?: (a: TItem, b: TItem) => number;
+  renderHeader?: () => React.ReactNode;
+  renderCell?: (item: TItem) => React.ReactNode;
 }
+
+export interface ColumnDefinitionRender<TItem>
+  extends Omit<ColumnDefinition<TItem>, 'renderHeader' | 'renderCell'>,
+    Required<Pick<ColumnDefinition<TItem>, 'renderHeader' | 'renderCell'>> {}
 
 export type RowEnhancer<TItem, TRowState extends RowState<TItem> = RowState<TItem>> = (
   row: RowState<TItem>,

--- a/packages/react-components/react-table/src/hooks/useSort.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.test.ts
@@ -2,10 +2,15 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { ColumnDefinition } from './types';
 import { useSortState } from './useSort';
 import { mockTableState } from '../testing/mockTableState';
+import { createColumn } from './createColumn';
 
 describe('useSortState', () => {
   it('should use default sort state', () => {
-    const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+    const columnDefinition = [
+      createColumn({ columnId: 1 }),
+      createColumn({ columnId: 2 }),
+      createColumn({ columnId: 3 }),
+    ];
     const { result } = renderHook(() =>
       useSortState(mockTableState({ columns: columnDefinition }), {
         defaultSortState: { sortColumn: 2, sortDirection: 'descending' },
@@ -17,7 +22,11 @@ describe('useSortState', () => {
   });
 
   it('should use user sort state', () => {
-    const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+    const columnDefinition = [
+      createColumn({ columnId: 1 }),
+      createColumn({ columnId: 2 }),
+      createColumn({ columnId: 3 }),
+    ];
     const { result } = renderHook(() =>
       useSortState(mockTableState({ columns: columnDefinition }), {
         sortState: { sortColumn: 2, sortDirection: 'descending' },
@@ -30,7 +39,11 @@ describe('useSortState', () => {
 
   describe('toggleColumnSort', () => {
     it('should sort a new column in ascending order', () => {
-      const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+      const columnDefinition = [
+        createColumn({ columnId: 1 }),
+        createColumn({ columnId: 2 }),
+        createColumn({ columnId: 3 }),
+      ];
       const onSortChange = jest.fn();
       const { result } = renderHook(() =>
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
@@ -46,7 +59,11 @@ describe('useSortState', () => {
     });
 
     it('should toggle sort direction on a column', () => {
-      const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+      const columnDefinition = [
+        createColumn({ columnId: 1 }),
+        createColumn({ columnId: 2 }),
+        createColumn({ columnId: 3 }),
+      ];
       const onSortChange = jest.fn();
       const { result } = renderHook(() =>
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
@@ -68,7 +85,11 @@ describe('useSortState', () => {
 
   describe('setColumnSort', () => {
     it('should sort a column in ascending order', () => {
-      const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+      const columnDefinition = [
+        createColumn({ columnId: 1 }),
+        createColumn({ columnId: 2 }),
+        createColumn({ columnId: 3 }),
+      ];
       const onSortChange = jest.fn();
       const { result } = renderHook(() =>
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
@@ -84,7 +105,11 @@ describe('useSortState', () => {
     });
 
     it('should sort a column in descending order', () => {
-      const columnDefinition = [{ columnId: 1 }, { columnId: 2 }, { columnId: 3 }];
+      const columnDefinition = [
+        createColumn({ columnId: 1 }),
+        createColumn({ columnId: 2 }),
+        createColumn({ columnId: 3 }),
+      ];
       const onSortChange = jest.fn();
       const { result } = renderHook(() =>
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
@@ -105,9 +130,9 @@ describe('useSortState', () => {
     it('should use the compare function for the sorted column', () => {
       const compare = createMockCompare();
       const columnDefinition = [
-        { columnId: 1, compare: createMockCompare() },
-        { columnId: 2, compare },
-        { columnId: 3, compare: createMockCompare() },
+        createColumn({ columnId: 1, compare: createMockCompare() }),
+        createColumn({ columnId: 2, compare }),
+        createColumn({ columnId: 3, compare: createMockCompare() }),
       ];
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
@@ -124,7 +149,7 @@ describe('useSortState', () => {
 
     it('should sort ascending', () => {
       const columnDefinition: ColumnDefinition<{ value: number }>[] = [
-        { columnId: 1, compare: (a, b) => a.value - b.value },
+        createColumn({ columnId: 1, compare: (a, b) => a.value - b.value }),
       ];
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
@@ -145,7 +170,7 @@ describe('useSortState', () => {
 
     it('should sort descending', () => {
       const columnDefinition: ColumnDefinition<{ value: number }>[] = [
-        { columnId: 1, compare: (a, b) => a.value - b.value },
+        createColumn({ columnId: 1, compare: (a, b) => a.value - b.value }),
       ];
 
       const items = [{ value: 1 }, { value: 2 }];
@@ -171,7 +196,7 @@ describe('useSortState', () => {
 
   describe('getSortDirection', () => {
     it('should return sort direction for the sorted column', () => {
-      const columnDefinition: ColumnDefinition<{ value: number }>[] = [{ columnId: 1 }];
+      const columnDefinition: ColumnDefinition<{ value: number }>[] = [createColumn({ columnId: 1 })];
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
       act(() => {
@@ -182,7 +207,10 @@ describe('useSortState', () => {
     });
 
     it('should return undefined for unsorted column', () => {
-      const columnDefinition: ColumnDefinition<{ value: number }>[] = [{ columnId: 1 }, { columnId: 2 }];
+      const columnDefinition: ColumnDefinition<{ value: number }>[] = [
+        createColumn({ columnId: 1 }),
+        createColumn({ columnId: 2 }),
+      ];
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
       act(() => {

--- a/packages/react-components/react-table/src/hooks/useTable.test.ts
+++ b/packages/react-components/react-table/src/hooks/useTable.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { createColumn } from './createColumn';
 import { defaultTableSelectionState, useSelection } from './useSelection';
 import { defaultTableSortState, useSort } from './useSort';
 import { useTable } from './useTable';
@@ -8,7 +9,7 @@ describe('useTable', () => {
     const { result } = renderHook(() =>
       useTable(
         {
-          columns: [{ columnId: 1 }],
+          columns: [createColumn({ columnId: 1 })],
           items: [{}, {}, {}],
         },
         [useSort({})],
@@ -32,7 +33,7 @@ describe('useTable', () => {
     const { result } = renderHook(() =>
       useTable(
         {
-          columns: [{ columnId: 1 }],
+          columns: [createColumn({ columnId: 1 })],
           items: [{}, {}, {}],
         },
         [useSelection({ selectionMode: 'multiselect' })],
@@ -56,7 +57,7 @@ describe('useTable', () => {
     it('should enahnce rows', () => {
       const { result } = renderHook(() =>
         useTable({
-          columns: [{ columnId: 1 }],
+          columns: [createColumn({ columnId: 1 })],
           items: [{}, {}, {}],
         }),
       );
@@ -90,7 +91,7 @@ describe('useTable', () => {
     it('should use custom rowId', () => {
       const { result } = renderHook(() =>
         useTable({
-          columns: [{ columnId: 1 }],
+          columns: [createColumn({ columnId: 1 })],
           items: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
           getRowId: item => item.value,
         }),
@@ -103,7 +104,7 @@ describe('useTable', () => {
     it('should return original items', () => {
       const { result } = renderHook(() =>
         useTable({
-          columns: [{ columnId: 1 }],
+          columns: [createColumn({ columnId: 1 })],
           items: [{ value: 1 }, { value: 2 }, { value: 3 }],
         }),
       );

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -1,4 +1,4 @@
-export { useTable, useSelection, useSort } from './hooks';
+export { useTable, useSelection, useSort, createColumn } from './hooks';
 export type {
   UseTableOptions,
   TableState as HeadlessTableState,
@@ -9,6 +9,7 @@ export type {
   RowId,
   ColumnDefinition,
   ColumnId,
+  CreateColumnOptions,
 } from './hooks';
 
 export {
@@ -115,7 +116,7 @@ export {
   useDataGridRow_unstable,
   renderDataGridRow_unstable,
 } from './DataGridRow';
-export type { DataGridRowProps, DataGridRowState, DataGridRowSlots } from './DataGridRow';
+export type { DataGridRowProps, DataGridRowState, DataGridRowSlots, CellRenderFunction } from './DataGridRow';
 
 export {
   DataGridBody,

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -16,6 +16,7 @@ import {
   DataGrid,
   DataGridHeader,
   DataGridHeaderCell,
+  DataGridCell,
   ColumnDefinition,
   RowState,
   createColumn,
@@ -155,7 +156,7 @@ export const Default = () => {
         {({ item, rowId }: RowState<Item>) => (
           <DataGridRow key={rowId}>
             {({ renderCell, columnId }: ColumnDefinition<Item>) => (
-              <DataGridHeaderCell key={columnId}>{renderCell(item)}</DataGridHeaderCell>
+              <DataGridCell key={columnId}>{renderCell(item)}</DataGridCell>
             )}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -12,7 +12,6 @@ import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
-  DataGridCell,
   DataGridRow,
   DataGrid,
   DataGridHeader,
@@ -20,6 +19,7 @@ import {
   ColumnDefinition,
   RowState,
 } from '@fluentui/react-table';
+import { ColumnDefinitionRender } from '../../src/hooks/types';
 
 type FileCell = {
   label: string;
@@ -88,10 +88,57 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  { columnId: 'file' },
-  { columnId: 'author' },
-  { columnId: 'lastUpdated' },
-  { columnId: 'lastUpdate' },
+  {
+    columnId: 'file',
+    compare: (a, b) => {
+      return a.file.label.localeCompare(b.file.label);
+    },
+    renderHeader: () => {
+      return 'File';
+    },
+    renderCell: item => {
+      return <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>;
+    },
+  },
+  {
+    columnId: 'author',
+    compare: (a, b) => {
+      return a.author.label.localeCompare(b.author.label);
+    },
+    renderHeader: () => {
+      return 'Author';
+    },
+    renderCell: item => {
+      return (
+        <TableCellLayout media={<Avatar badge={{ status: item.author.status }} />}>{item.author.label}</TableCellLayout>
+      );
+    },
+  },
+  {
+    columnId: 'lastUpdated',
+    compare: (a, b) => {
+      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
+    },
+    renderHeader: () => {
+      return 'Last updated';
+    },
+
+    renderCell: item => {
+      return item.lastUpdated.label;
+    },
+  },
+  {
+    columnId: 'lastUpdate',
+    compare: (a, b) => {
+      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
+    },
+    renderHeader: () => {
+      return 'Last update';
+    },
+    renderCell: item => {
+      return <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>;
+    },
+  },
 ];
 
 export const Default = () => {
@@ -99,31 +146,17 @@ export const Default = () => {
     <DataGrid items={items} columns={columns}>
       <DataGridHeader>
         <DataGridRow>
-          <DataGridHeaderCell>File</DataGridHeaderCell>
-          <DataGridHeaderCell>Author</DataGridHeaderCell>
-          <DataGridHeaderCell>Last updated</DataGridHeaderCell>
-          <DataGridHeaderCell>Last update</DataGridHeaderCell>
+          {({ renderHeader, columnId }: ColumnDefinitionRender<Item>) => (
+            <DataGridHeaderCell key={columnId}>{renderHeader()}</DataGridHeaderCell>
+          )}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody>
         {({ item, rowId }: RowState<Item>) => (
           <DataGridRow key={rowId}>
-            <DataGridCell>
-              <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
-            </DataGridCell>
-            <DataGridCell>
-              <TableCellLayout
-                media={
-                  <Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />
-                }
-              >
-                {item.author.label}
-              </TableCellLayout>
-            </DataGridCell>
-            <DataGridCell>{item.lastUpdated.label}</DataGridCell>
-            <DataGridCell>
-              <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
-            </DataGridCell>
+            {({ renderCell, columnId }: ColumnDefinitionRender<Item>) => (
+              <DataGridHeaderCell key={columnId}>{renderCell(item)}</DataGridHeaderCell>
+            )}
           </DataGridRow>
         )}
       </DataGridBody>

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -18,8 +18,8 @@ import {
   DataGridHeaderCell,
   ColumnDefinition,
   RowState,
+  createColumn,
 } from '@fluentui/react-table';
-import { ColumnDefinitionRender } from '../../src/hooks/types';
 
 type FileCell = {
   label: string;
@@ -88,24 +88,24 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
     compare: (a, b) => {
       return a.file.label.localeCompare(b.file.label);
     },
-    renderHeader: () => {
+    renderHeaderCell: () => {
       return 'File';
     },
     renderCell: item => {
       return <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>;
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
     compare: (a, b) => {
       return a.author.label.localeCompare(b.author.label);
     },
-    renderHeader: () => {
+    renderHeaderCell: () => {
       return 'Author';
     },
     renderCell: item => {
@@ -113,32 +113,32 @@ const columns: ColumnDefinition<Item>[] = [
         <TableCellLayout media={<Avatar badge={{ status: item.author.status }} />}>{item.author.label}</TableCellLayout>
       );
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
     compare: (a, b) => {
       return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
     },
-    renderHeader: () => {
+    renderHeaderCell: () => {
       return 'Last updated';
     },
 
     renderCell: item => {
       return item.lastUpdated.label;
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
     compare: (a, b) => {
       return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
     },
-    renderHeader: () => {
+    renderHeaderCell: () => {
       return 'Last update';
     },
     renderCell: item => {
       return <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>;
     },
-  },
+  }),
 ];
 
 export const Default = () => {
@@ -146,15 +146,15 @@ export const Default = () => {
     <DataGrid items={items} columns={columns}>
       <DataGridHeader>
         <DataGridRow>
-          {({ renderHeader, columnId }: ColumnDefinitionRender<Item>) => (
-            <DataGridHeaderCell key={columnId}>{renderHeader()}</DataGridHeaderCell>
+          {({ renderHeaderCell, columnId }: ColumnDefinition<Item>) => (
+            <DataGridHeaderCell key={columnId}>{renderHeaderCell()}</DataGridHeaderCell>
           )}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody>
         {({ item, rowId }: RowState<Item>) => (
           <DataGridRow key={rowId}>
-            {({ renderCell, columnId }: ColumnDefinitionRender<Item>) => (
+            {({ renderCell, columnId }: ColumnDefinition<Item>) => (
               <DataGridHeaderCell key={columnId}>{renderCell(item)}</DataGridHeaderCell>
             )}
           </DataGridRow>

--- a/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
@@ -21,6 +21,7 @@ import {
   useTable,
   ColumnDefinition,
   useSelection,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -90,18 +91,18 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
-  },
+  }),
 ];
 
 export const MultipleSelect = () => {
@@ -121,16 +122,20 @@ export const MultipleSelect = () => {
     ],
   );
 
-  const rows = getRows(row => ({
-    ...row,
-    onClick: () => toggleRow(row.rowId),
-    onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'Enter') {
-        toggleRow(row.rowId);
-      }
-    },
-    selected: isRowSelected(row.rowId),
-  }));
+  const rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: () => toggleRow(row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          toggleRow(row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
 
   // eslint-disable-next-line deprecation/deprecation
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
@@ -150,13 +155,13 @@ export const MultipleSelect = () => {
         </TableRow>
       </TableHeader>
       <TableBody {...keyboardNavAttr}>
-        {rows.map(({ item, selected, onClick, onKeyDown }) => (
+        {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
           <TableRow
             key={item.file.label}
             onClick={onClick}
             onKeyDown={onKeyDown}
             aria-selected={selected}
-            appearance={selected ? 'brand' : 'none'}
+            appearance={appearance}
           >
             <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} />
             <TableCell>

--- a/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
@@ -90,22 +90,25 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-  }),
-];
-
 export const MultipleSelect = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+      }),
+    ],
+    [],
+  );
+
   const {
     getRows,
     selection: { allRowsSelected, someRowsSelected, toggleAllRows, toggleRow, isRowSelected },

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -91,22 +91,25 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-  }),
-];
-
 export const MultipleSelectControlled = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+      }),
+    ],
+    [],
+  );
+
   const [selectedRows, setSelectedRows] = React.useState(
     () => new Set<RowId>([0, 1]),
   );

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -22,6 +22,7 @@ import {
   ColumnDefinition,
   RowId,
   useSelection,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -91,18 +92,18 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
-  },
+  }),
 ];
 
 export const MultipleSelectControlled = () => {
@@ -127,16 +128,20 @@ export const MultipleSelectControlled = () => {
     ],
   );
 
-  const rows = getRows(row => ({
-    ...row,
-    onClick: () => toggleRow(row.rowId),
-    onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'Enter') {
-        toggleRow(row.rowId);
-      }
-    },
-    selected: isRowSelected(row.rowId),
-  }));
+  const rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: () => toggleRow(row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          toggleRow(row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
 
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
@@ -155,13 +160,13 @@ export const MultipleSelectControlled = () => {
         </TableRow>
       </TableHeader>
       <TableBody {...keyboardNavAttr}>
-        {rows.map(({ item, selected, onClick, onKeyDown }) => (
+        {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
           <TableRow
             key={item.file.label}
             onClick={onClick}
             onKeyDown={onKeyDown}
             aria-selected={selected}
-            appearance={selected ? 'neutral' : 'none'}
+            appearance={appearance}
           >
             <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} />
             <TableCell>

--- a/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
@@ -21,6 +21,7 @@ import {
   ColumnDefinition,
   useSelection,
   TableCellLayout,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -90,18 +91,18 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
-  },
+  }),
 ];
 
 export const SingleSelect = () => {
@@ -121,16 +122,20 @@ export const SingleSelect = () => {
     ],
   );
 
-  const rows = getRows(row => ({
-    ...row,
-    onClick: () => toggleRow(row.rowId),
-    onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'Enter') {
-        toggleRow(row.rowId);
-      }
-    },
-    selected: isRowSelected(row.rowId),
-  }));
+  const rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: () => toggleRow(row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          toggleRow(row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
@@ -145,13 +150,13 @@ export const SingleSelect = () => {
         </TableRow>
       </TableHeader>
       <TableBody {...keyboardNavAttr}>
-        {rows.map(({ item, selected, onClick, onKeyDown }) => (
+        {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
           <TableRow
             key={item.file.label}
             onClick={onClick}
             onKeyDown={onKeyDown}
             aria-selected={selected}
-            appearance={selected ? 'brand' : 'none'}
+            appearance={appearance}
           >
             <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} type="radio" />
             <TableCell>

--- a/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
@@ -90,22 +90,25 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-  }),
-];
-
 export const SingleSelect = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+      }),
+    ],
+    [],
+  );
+
   const {
     getRows,
     selection: { toggleRow, isRowSelected },

--- a/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
@@ -22,6 +22,7 @@ import {
   RowId,
   useSelection,
   TableCellLayout,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -91,18 +92,18 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
-  },
+  }),
 ];
 
 export const SingleSelectControlled = () => {
@@ -126,16 +127,20 @@ export const SingleSelectControlled = () => {
     ],
   );
 
-  const rows = getRows(row => ({
-    ...row,
-    onClick: () => toggleRow(row.rowId),
-    onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'Enter') {
-        toggleRow(row.rowId);
-      }
-    },
-    selected: isRowSelected(row.rowId),
-  }));
+  const rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: () => toggleRow(row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          toggleRow(row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
 
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
@@ -151,13 +156,13 @@ export const SingleSelectControlled = () => {
         </TableRow>
       </TableHeader>
       <TableBody {...keyboardNavAttr}>
-        {rows.map(({ item, selected, onClick, onKeyDown }) => (
+        {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
           <TableRow
             key={item.file.label}
             onClick={onClick}
             onKeyDown={onKeyDown}
             aria-selected={selected}
-            appearance={selected ? 'neutral' : 'none'}
+            appearance={appearance}
           >
             <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} type="radio" />
             <TableCell>

--- a/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
@@ -91,22 +91,25 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-  }),
-];
-
 export const SingleSelectControlled = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+      }),
+    ],
+    [],
+  );
+
   const [selectedRows, setSelectedRows] = React.useState(
     () => new Set<RowId>([1]),
   );

--- a/packages/react-components/react-table/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Sort.stories.tsx
@@ -90,34 +90,37 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-    compare: (a, b) => {
-      return a.file.label.localeCompare(b.file.label);
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-    compare: (a, b) => {
-      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-    compare: (a, b) => {
-      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
-    },
-  }),
-];
-
 export const Sort = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+        compare: (a, b) => {
+          return a.file.label.localeCompare(b.file.label);
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+        compare: (a, b) => {
+          return a.author.label.localeCompare(b.author.label);
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+        compare: (a, b) => {
+          return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+        compare: (a, b) => {
+          return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
+        },
+      }),
+    ],
+    [],
+  );
+
   const {
     getRows,
     sort: { getSortDirection, toggleColumnSort, sort },

--- a/packages/react-components/react-table/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Sort.stories.tsx
@@ -21,6 +21,7 @@ import {
   ColumnId,
   useSort,
   TableCellLayout,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -90,30 +91,30 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
     compare: (a, b) => {
       return a.file.label.localeCompare(b.file.label);
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
     compare: (a, b) => {
       return a.author.label.localeCompare(b.author.label);
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
     compare: (a, b) => {
       return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
     compare: (a, b) => {
       return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
     },
-  },
+  }),
 ];
 
 export const Sort = () => {

--- a/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
@@ -90,34 +90,37 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-    compare: (a, b) => {
-      return a.file.label.localeCompare(b.file.label);
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-    compare: (a, b) => {
-      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-    compare: (a, b) => {
-      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
-    },
-  }),
-];
-
 export const SortControlled = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+        compare: (a, b) => {
+          return a.file.label.localeCompare(b.file.label);
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+        compare: (a, b) => {
+          return a.author.label.localeCompare(b.author.label);
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+        compare: (a, b) => {
+          return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+        compare: (a, b) => {
+          return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
+        },
+      }),
+    ],
+    [],
+  );
+
   const [sortState, setSortState] = React.useState<{
     sortDirection: 'ascending' | 'descending';
     sortColumn: ColumnId | undefined;

--- a/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
@@ -21,6 +21,7 @@ import {
   ColumnId,
   useSort,
   TableCellLayout,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -90,30 +91,30 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
     compare: (a, b) => {
       return a.file.label.localeCompare(b.file.label);
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
     compare: (a, b) => {
       return a.author.label.localeCompare(b.author.label);
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
     compare: (a, b) => {
       return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
     },
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
     compare: (a, b) => {
       return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
     },
-  },
+  }),
 ];
 
 export const SortControlled = () => {

--- a/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
@@ -90,22 +90,25 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-  }),
-];
-
 export const SubtleSelection = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+      }),
+    ],
+    [],
+  );
+
   const {
     getRows,
     selection: { allRowsSelected, someRowsSelected, toggleAllRows, toggleRow, isRowSelected },

--- a/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
@@ -21,6 +21,7 @@ import {
   useTable,
   ColumnDefinition,
   useSelection,
+  createColumn,
 } from '@fluentui/react-components/unstable';
 
 type FileCell = {
@@ -90,18 +91,18 @@ const items: Item[] = [
 ];
 
 const columns: ColumnDefinition<Item>[] = [
-  {
+  createColumn<Item>({
     columnId: 'file',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'author',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdated',
-  },
-  {
+  }),
+  createColumn<Item>({
     columnId: 'lastUpdate',
-  },
+  }),
 ];
 
 export const SubtleSelection = () => {
@@ -121,16 +122,20 @@ export const SubtleSelection = () => {
     ],
   );
 
-  const rows = getRows(row => ({
-    ...row,
-    onClick: () => toggleRow(row.rowId),
-    onKeyDown: (e: React.KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'Enter') {
-        toggleRow(row.rowId);
-      }
-    },
-    selected: isRowSelected(row.rowId),
-  }));
+  const rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: () => toggleRow(row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          toggleRow(row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
 
   // eslint-disable-next-line deprecation/deprecation
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
@@ -150,8 +155,14 @@ export const SubtleSelection = () => {
         </TableRow>
       </TableHeader>
       <TableBody {...keyboardNavAttr}>
-        {rows.map(({ item, selected, onClick, onKeyDown }) => (
-          <TableRow key={item.file.label} onClick={onClick} onKeyDown={onKeyDown} aria-selected={selected}>
+        {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
+          <TableRow
+            key={item.file.label}
+            onClick={onClick}
+            onKeyDown={onKeyDown}
+            aria-selected={selected}
+            appearance={appearance}
+          >
             <TableSelectionCell tabIndex={0} subtle checked={selected} />
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>


### PR DESCRIPTION
## ⚠️ Breaking Change

This PR makes the `ColumnDefinition` API stricter so that `compare` is now a required property.

### Before

```ts
import { ColumnDefinition } from '@fluentui/react-components/unstable;

// ⚠️ This will now error because of missing properties
const column: ColumnDefinition<Item> = [{ columnId: "column" }];
```

### After

```ts
import { ColumnDefinition, createColumn } from '@fluentui/react-components/unstable;

// ✅ This will create the stricter column definition with defaults
const column: ColumnDefinition<Item> = [createColumn({ columnId: "column" })];
```

Fixes #25458
