### PR TITLE
V8 Button: Remove deprecation warning around elementRef, and use elementRef in Panel example

### DIFF
--- a/change/@fluentui-react-70986d46-e165-4e23-86cd-807da4359fca.json
+++ b/change/@fluentui-react-70986d46-e165-4e23-86cd-807da4359fca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix deprecation warning on Buttons elementRef and fix PanelConfirm example to use element ref for focus",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/Panel/Panel.ConfirmDismiss.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.ConfirmDismiss.Example.tsx
@@ -16,7 +16,7 @@ const dialogModalProps = {
 export const PanelConfirmDismissExample: React.FunctionComponent = () => {
   const [isPanelOpen, setIsPanelOpen] = React.useState(false);
   const [isDialogVisible, setIsDialogVisible] = React.useState(false);
-  const buttonElRef = React.useRef<HTMLElement>(null);
+  const buttonRef = React.useRef<HTMLElement>(null);
 
   const openPanel = React.useCallback(() => setIsPanelOpen(true), []);
   const onDismiss = React.useCallback((ev?: React.SyntheticEvent | KeyboardEvent) => {
@@ -29,6 +29,7 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
 
   const hideDialog = React.useCallback(() => setIsDialogVisible(false), []);
   const hideDialogAndPanel = React.useCallback(() => {
+    setIsPanelOpen(false);
     setIsDialogVisible(false);
   }, []);
 
@@ -37,7 +38,7 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
       {explanation}
       <br />
       <br />
-      <DefaultButton elementRef={buttonElRef} text="Open panel" onClick={openPanel} />
+      <DefaultButton elementRef={buttonRef} text="Open panel" onClick={openPanel} />
       <Panel
         headerText="Panel with custom close behavior"
         isOpen={isPanelOpen}
@@ -51,7 +52,7 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
         onDismiss={hideDialog}
         dialogContentProps={dialogContentProps}
         modalProps={dialogModalProps}
-        elementToFocusOnDismiss={buttonElRef.current || undefined}
+        elementToFocusOnDismiss={buttonRef.current || undefined}
       >
         <DialogFooter>
           <PrimaryButton onClick={hideDialogAndPanel} text="Yes" />

--- a/packages/react-examples/src/react/Panel/Panel.ConfirmDismiss.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.ConfirmDismiss.Example.tsx
@@ -16,6 +16,7 @@ const dialogModalProps = {
 export const PanelConfirmDismissExample: React.FunctionComponent = () => {
   const [isPanelOpen, setIsPanelOpen] = React.useState(false);
   const [isDialogVisible, setIsDialogVisible] = React.useState(false);
+  const buttonElRef = React.useRef<HTMLElement>(null);
 
   const openPanel = React.useCallback(() => setIsPanelOpen(true), []);
   const onDismiss = React.useCallback((ev?: React.SyntheticEvent | KeyboardEvent) => {
@@ -28,7 +29,6 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
 
   const hideDialog = React.useCallback(() => setIsDialogVisible(false), []);
   const hideDialogAndPanel = React.useCallback(() => {
-    setIsPanelOpen(false);
     setIsDialogVisible(false);
   }, []);
 
@@ -37,7 +37,7 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
       {explanation}
       <br />
       <br />
-      <DefaultButton text="Open panel" onClick={openPanel} />
+      <DefaultButton elementRef={buttonElRef} text="Open panel" onClick={openPanel} />
       <Panel
         headerText="Panel with custom close behavior"
         isOpen={isPanelOpen}
@@ -51,6 +51,7 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
         onDismiss={hideDialog}
         dialogContentProps={dialogContentProps}
         modalProps={dialogModalProps}
+        elementToFocusOnDismiss={buttonElRef.current || undefined}
       >
         <DialogFooter>
           <PrimaryButton onClick={hideDialogAndPanel} text="Yes" />

--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -55,8 +55,7 @@ export interface IButtonProps
   componentRef?: IRefObject<IButton>;
 
   /**
-   * Optional callback to access the root DOM element.
-   * @deprecated Temporary solution which will be replaced with ref in the V8 release.
+   * Optional callback to access the root DOM element as an HTMLElement.
    */
   elementRef?: React.Ref<HTMLElement>;
 


### PR DESCRIPTION
We had the best of intentions to remove elementRef in v8, but the move from class to functional component just didn't happen for button. I ran across this in trying to update the Panel example to make sure that focus was returned to the button on the page, because when the dialog closed, focus was trying to go back to the panel, but it being closed, focus just went to the page root.

