### PR TITLE
feature(react-menu): improve menu open change data with union types

### DIFF
--- a/change/@fluentui-react-components-ef3d0d2f-e887-444c-90f3-ccd17ce00829.json
+++ b/change/@fluentui-react-components-ef3d0d2f-e887-444c-90f3-ccd17ce00829.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "react-menu: deprecates MenuOpenEvents in favor of MenuOpenEvent",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-7fc995f8-caf5-41d7-8486-131d88c39883.json
+++ b/change/@fluentui-react-menu-7fc995f8-caf5-41d7-8486-131d88c39883.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: menu open change data union types",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -235,6 +235,7 @@ import { MenuListProvider } from '@fluentui/react-menu';
 import { MenuListSlots } from '@fluentui/react-menu';
 import { MenuListState } from '@fluentui/react-menu';
 import { MenuOpenChangeData } from '@fluentui/react-menu';
+import { MenuOpenEvent } from '@fluentui/react-menu';
 import { MenuOpenEvents } from '@fluentui/react-menu';
 import { MenuPopover } from '@fluentui/react-menu';
 import { menuPopoverClassNames } from '@fluentui/react-menu';
@@ -1058,6 +1059,8 @@ export { MenuListSlots }
 export { MenuListState }
 
 export { MenuOpenChangeData }
+
+export { MenuOpenEvent }
 
 export { MenuOpenEvents }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -427,6 +427,9 @@ export type {
   MenuListSlots,
   MenuListState,
   MenuOpenChangeData,
+  MenuOpenEvent,
+  // MenuOpenEvents is deprecated but removing it would be a breaking change
+  // eslint-disable-next-line deprecation/deprecation
   MenuOpenEvents,
   MenuPopoverProps,
   MenuPopoverSlots,

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -220,10 +220,46 @@ export type MenuOpenChangeData = {
     bubble?: boolean;
     keyboard?: boolean;
     open: boolean;
-};
+} & ({
+    type: 'menuTriggerContextMenu';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuTriggerClick';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuTriggerMouseEnter';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuTriggerMouseLeave';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuTriggerMouseMove';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuTriggerKeyDown';
+    event: React_2.KeyboardEvent<HTMLElement>;
+} | {
+    type: 'menuItemClick';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuPopoverMouseEnter';
+    event: React_2.MouseEvent<HTMLElement>;
+} | {
+    type: 'menuPopoverKeyDown';
+    event: React_2.KeyboardEvent<HTMLElement>;
+} | {
+    type: 'clickOutside';
+    event: MouseEvent | TouchEvent;
+} | {
+    type: 'scrollOutside';
+    event: MouseEvent | TouchEvent;
+} | {
+    type: 'menuMouseEnter';
+    event: MouseEvent | TouchEvent;
+});
 
 // @public
-export type MenuOpenEvents = MouseEvent | TouchEvent | React_2.FocusEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.MouseEvent<HTMLElement>;
+export type MenuOpenEvent = MenuOpenChangeData['event'];
 
 // @public
 export const MenuPopover: ForwardRefComponent<MenuPopoverProps>;
@@ -250,7 +286,7 @@ export type MenuProps = ComponentProps<MenuSlots> & Pick<MenuListProps, 'checked
     defaultOpen?: boolean;
     hoverDelay?: number;
     inline?: boolean;
-    onOpenChange?: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
+    onOpenChange?: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
     open?: boolean;
     openOnContext?: boolean;
     openOnHover?: boolean;
@@ -290,7 +326,7 @@ export type MenuState = ComponentState<MenuSlots> & Pick<MenuProps, 'onOpenChang
     menuPopoverRef: React_2.MutableRefObject<HTMLElement>;
     menuTrigger: React_2.ReactNode;
     setContextTarget: SetVirtualMouseTarget;
-    setOpen: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
+    setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
     triggerId: string;
     triggerRef: React_2.MutableRefObject<HTMLElement>;
 };

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -261,6 +261,9 @@ export type MenuOpenChangeData = {
 // @public
 export type MenuOpenEvent = MenuOpenChangeData['event'];
 
+// @public @deprecated (undocumented)
+export type MenuOpenEvents = MenuOpenEvent;
+
 // @public
 export const MenuPopover: ForwardRefComponent<MenuPopoverProps>;
 

--- a/packages/react-components/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.test.tsx
@@ -9,6 +9,7 @@ import { MenuItem } from '../MenuItem/index';
 import { MenuItemCheckbox } from '../MenuItemCheckbox/index';
 import { MenuItemRadio } from '../MenuItemRadio/index';
 import { MenuPopover } from '../MenuPopover/index';
+import { MenuOpenChangeData } from './Menu.types';
 
 describe('Menu', () => {
   isConformant({
@@ -20,6 +21,9 @@ describe('Menu', () => {
       'component-has-static-classnames-object',
       // Menu does not have own styles
       'make-styles-overrides-win',
+      // TODO:
+      // onOpenChange: A second (data) argument cannot be a union
+      'consistent-callback-args',
     ],
     Component: Menu,
     displayName: 'Menu',
@@ -82,7 +86,12 @@ describe('Menu', () => {
 
     // Assert
     expect(onOpenChange).toHaveBeenCalledTimes(1);
-    expect(onOpenChange).toHaveBeenLastCalledWith(expect.anything(), { open: !open, keyboard: false });
+    expect(onOpenChange).toHaveBeenLastCalledWith(expect.anything(), {
+      open: !open,
+      keyboard: false,
+      type: 'menuTriggerClick',
+      event: expect.anything(),
+    } as MenuOpenChangeData);
   });
 
   it('should call onOpenChange when menu is opened and closed', () => {
@@ -107,8 +116,19 @@ describe('Menu', () => {
 
     // Assert
     expect(onOpenChange).toHaveBeenCalledTimes(2);
-    expect(onOpenChange).toHaveBeenNthCalledWith(1, expect.anything(), { open: true, keyboard: false });
-    expect(onOpenChange).toHaveBeenNthCalledWith(2, expect.anything(), { open: false, keyboard: false, bubble: true });
+    expect(onOpenChange).toHaveBeenNthCalledWith(1, expect.anything(), {
+      open: true,
+      keyboard: false,
+      type: 'menuTriggerClick',
+      event: expect.anything(),
+    });
+    expect(onOpenChange).toHaveBeenNthCalledWith(2, expect.anything(), {
+      open: false,
+      keyboard: false,
+      bubble: true,
+      type: 'menuItemClick',
+      event: expect.anything(),
+    });
   });
 
   it.each([

--- a/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
@@ -160,6 +160,10 @@ export type MenuContextValues = {
  * The supported events that will trigger open/close of the menu
  */
 export type MenuOpenEvent = MenuOpenChangeData['event'];
+/**
+ * @deprecated use MenuOpenEvent instead
+ */
+export type MenuOpenEvents = MenuOpenEvent;
 
 /**
  * Data attached to open/close events

--- a/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
@@ -45,7 +45,7 @@ export type MenuProps = ComponentProps<MenuSlots> &
      * Call back when the component requests to change value
      * The `open` value is used as a hint when directly controlling the component
      */
-    onOpenChange?: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
+    onOpenChange?: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
 
     /**
      * Whether the popup is open
@@ -139,7 +139,7 @@ export type MenuState = ComponentState<MenuSlots> &
     /**
      * Callback to open/close the popup
      */
-    setOpen: (e: MenuOpenEvents, data: MenuOpenChangeData) => void;
+    setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
 
     /**
      * Id for the MenuTrigger element for aria relationship
@@ -151,6 +151,15 @@ export type MenuState = ComponentState<MenuSlots> &
      */
     triggerRef: React.MutableRefObject<HTMLElement>;
   };
+
+export type MenuContextValues = {
+  menu: MenuContextValue;
+};
+
+/**
+ * The supported events that will trigger open/close of the menu
+ */
+export type MenuOpenEvent = MenuOpenChangeData['event'];
 
 /**
  * Data attached to open/close events
@@ -167,18 +176,53 @@ export type MenuOpenChangeData = {
    */
   keyboard?: boolean;
   open: boolean;
-};
-
-export type MenuContextValues = {
-  menu: MenuContextValue;
-};
-
-/**
- * The supported events that will trigger open/close of the menu
- */
-export type MenuOpenEvents =
-  | MouseEvent
-  | TouchEvent
-  | React.FocusEvent<HTMLElement>
-  | React.KeyboardEvent<HTMLElement>
-  | React.MouseEvent<HTMLElement>;
+} & (
+  | {
+      type: 'menuTriggerContextMenu';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuTriggerClick';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuTriggerMouseEnter';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuTriggerMouseLeave';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuTriggerMouseMove';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuTriggerKeyDown';
+      event: React.KeyboardEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuItemClick';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuPopoverMouseEnter';
+      event: React.MouseEvent<HTMLElement>;
+    }
+  | {
+      type: 'menuPopoverKeyDown';
+      event: React.KeyboardEvent<HTMLElement>;
+    }
+  | {
+      type: 'clickOutside';
+      event: MouseEvent | TouchEvent;
+    }
+  | {
+      type: 'scrollOutside';
+      event: MouseEvent | TouchEvent;
+    }
+  | {
+      type: 'menuMouseEnter';
+      event: MouseEvent | TouchEvent;
+    }
+);

--- a/packages/react-components/react-menu/src/components/MenuItem/MenuItem.test.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItem/MenuItem.test.tsx
@@ -176,7 +176,13 @@ describe('MenuItem', () => {
 
     // Assert
     expect(setOpen).toHaveBeenCalledTimes(1);
-    expect(setOpen).toHaveBeenCalledWith(expect.anything(), { open: false, bubble: true, keyboard: false });
+    expect(setOpen).toHaveBeenCalledWith(expect.anything(), {
+      open: false,
+      bubble: true,
+      keyboard: false,
+      type: 'menuItemClick',
+      event: expect.anything(),
+    });
   });
 
   it('should not call setOpen if persistOnItemClick is true in context', () => {

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -79,7 +79,13 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
             }),
             onClick: useEventCallback(event => {
               if (!hasSubmenu && !persistOnClick) {
-                setOpen(event, { open: false, keyboard: dismissedWithKeyboardRef.current, bubble: true });
+                setOpen(event, {
+                  open: false,
+                  keyboard: dismissedWithKeyboardRef.current,
+                  bubble: true,
+                  type: 'menuItemClick',
+                  event,
+                });
                 dismissedWithKeyboardRef.current = false;
               }
 

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -63,32 +63,32 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
 
   const { onMouseEnter: onMouseEnterOriginal, onKeyDown: onKeyDownOriginal } = rootProps;
 
-  rootProps.onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
+  rootProps.onMouseEnter = useEventCallback((event: React.MouseEvent<HTMLElement>) => {
     if (openOnHover) {
-      setOpen(e, { open: true, keyboard: false });
+      setOpen(event, { open: true, keyboard: false, type: 'menuPopoverMouseEnter', event });
     }
 
-    onMouseEnterOriginal?.(e);
+    onMouseEnterOriginal?.(event);
   });
 
-  rootProps.onKeyDown = useEventCallback((e: React.KeyboardEvent<HTMLElement>) => {
-    const key = e.key;
+  rootProps.onKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLElement>) => {
+    const key = event.key;
 
     if (key === Escape || (isSubmenu && key === CloseArrowKey)) {
-      if (open && popoverRef.current?.contains(e.target as HTMLElement)) {
-        setOpen(e, { open: false, keyboard: true });
+      if (open && popoverRef.current?.contains(event.target as HTMLElement)) {
+        setOpen(event, { open: false, keyboard: true, type: 'menuPopoverKeyDown', event });
         // stop propagation to avoid conflicting with other elements that listen for `Escape`
         // e,g: Dialog, Popover and Tooltip
-        e.stopPropagation();
+        event.stopPropagation();
       }
     }
 
     if (key === Tab) {
-      setOpen(e, { open: false, keyboard: true });
-      e.preventDefault();
+      setOpen(event, { open: false, keyboard: true, type: 'menuPopoverKeyDown', event });
+      event.preventDefault();
     }
 
-    onKeyDownOriginal?.(e);
+    onKeyDownOriginal?.(event);
   });
 
   return {

--- a/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -47,41 +47,41 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
 
   const child = getTriggerChild(children);
 
-  const onContextMenu = (e: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(e)) {
+  const onContextMenu = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
+    if (isTargetDisabled(event)) {
       return;
     }
 
     if (openOnContext) {
-      e.preventDefault();
-      setOpen(e, { open: true, keyboard: false });
+      event.preventDefault();
+      setOpen(event, { open: true, keyboard: false, type: 'menuTriggerContextMenu', event });
     }
   };
 
-  const onClick = (e: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(e)) {
+  const onClick = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
+    if (isTargetDisabled(event)) {
       return;
     }
 
     if (!openOnContext) {
-      setOpen(e, { open: !open, keyboard: openedWithKeyboardRef.current });
+      setOpen(event, { open: !open, keyboard: openedWithKeyboardRef.current, type: 'menuTriggerClick', event });
       openedWithKeyboardRef.current = false;
     }
   };
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(e)) {
+  const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
+    if (isTargetDisabled(event)) {
       return;
     }
 
-    const key = e.key;
+    const key = event.key;
 
     if (!openOnContext && ((isSubmenu && key === OpenArrowKey) || (!isSubmenu && key === ArrowDown))) {
-      setOpen(e, { open: true, keyboard: true });
+      setOpen(event, { open: true, keyboard: true, type: 'menuTriggerKeyDown', event });
     }
 
     if (key === Escape && !isSubmenu) {
-      setOpen(e, { open: false, keyboard: true });
+      setOpen(event, { open: false, keyboard: true, type: 'menuTriggerKeyDown', event });
     }
 
     // if menu is already open, can't rely on effects to focus
@@ -90,34 +90,34 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     }
   };
 
-  const onMouseEnter = (e: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(e)) {
+  const onMouseEnter = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
+    if (isTargetDisabled(event)) {
       return;
     }
     if (openOnHover && hasMouseMoved.current) {
-      setOpen(e, { open: true, keyboard: false });
+      setOpen(event, { open: true, keyboard: false, type: 'menuTriggerMouseEnter', event });
     }
   };
 
   // Opening a menu when a mouse hasn't moved and just entering the trigger is a bad a11y experience
   // First time open the mouse using mousemove and then continue with mouseenter
   // Only use once to determine that the user is using the mouse since it is an expensive event to handle
-  const onMouseMove = (e: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(e)) {
+  const onMouseMove = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
+    if (isTargetDisabled(event)) {
       return;
     }
     if (openOnHover && !hasMouseMoved.current) {
-      setOpen(e, { open: true, keyboard: false });
+      setOpen(event, { open: true, keyboard: false, type: 'menuTriggerMouseMove', event });
       hasMouseMoved.current = true;
     }
   };
 
-  const onMouseLeave = (e: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(e)) {
+  const onMouseLeave = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
+    if (isTargetDisabled(event)) {
       return;
     }
     if (openOnHover) {
-      setOpen(e, { open: false, keyboard: false });
+      setOpen(event, { open: false, keyboard: false, type: 'menuTriggerMouseLeave', event });
     }
   };
 

--- a/packages/react-components/react-menu/src/index.ts
+++ b/packages/react-components/react-menu/src/index.ts
@@ -7,7 +7,17 @@ export { MenuListProvider, useMenuListContext_unstable } from './contexts/menuLi
 export type { MenuListContextValue } from './contexts/menuListContext';
 
 export { Menu, renderMenu_unstable, useMenuContextValues_unstable, useMenu_unstable } from './Menu';
-export type { MenuContextValues, MenuOpenChangeData, MenuOpenEvent, MenuProps, MenuSlots, MenuState } from './Menu';
+export type {
+  MenuContextValues,
+  MenuOpenChangeData,
+  MenuOpenEvent,
+  // MenuOpenEvents is deprecated but removing it would be a breaking change
+  // eslint-disable-next-line deprecation/deprecation
+  MenuOpenEvents,
+  MenuProps,
+  MenuSlots,
+  MenuState,
+} from './Menu';
 export {
   MenuDivider,
   menuDividerClassNames,

--- a/packages/react-components/react-menu/src/index.ts
+++ b/packages/react-components/react-menu/src/index.ts
@@ -7,7 +7,7 @@ export { MenuListProvider, useMenuListContext_unstable } from './contexts/menuLi
 export type { MenuListContextValue } from './contexts/menuListContext';
 
 export { Menu, renderMenu_unstable, useMenuContextValues_unstable, useMenu_unstable } from './Menu';
-export type { MenuContextValues, MenuOpenChangeData, MenuOpenEvents, MenuProps, MenuSlots, MenuState } from './Menu';
+export type { MenuContextValues, MenuOpenChangeData, MenuOpenEvent, MenuProps, MenuSlots, MenuState } from './Menu';
 export {
   MenuDivider,
   menuDividerClassNames,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently `MenuOpenChangeData` doesn't provide a proper type system to identify which kind of event generated the request for change.

## New Behavior

By introducing a union of types of events we're able to create a filtering mechanism that allows further customisation from the user side and a more granular knowledge of what causes the change request on a menu open event.

This approach follows a similar pattern described on `react-dialog` `DialogOpenChangeData` type.
https://github.com/microsoft/fluentui/blob/6ce378e366246cc7504a7adc7a49ad5c06c11f1e/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts#L10-L33


### Extra

1. Deprecates `MenuOpenEvents` in favor of `MenuOpenEvent` type.
   a. The `MenuOpenEvents` is an union of all possible event types, the plural suggests multiplicity, not necessarily an union, converting it to `MenuOpenEvent` indicates that its a single event.
