### PR TITLE
chore(react-dialog): removes unnecessary union case for DialogOpenChangeData

### DIFF
--- a/change/@fluentui-react-dialog-64415a56-f53d-498c-8000-38ce9610b103.json
+++ b/change/@fluentui-react-dialog-64415a56-f53d-498c-8000-38ce9610b103.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: removes unnecessary union case for DialogOpenChangeData",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -81,10 +81,6 @@ export type DialogContentState = ComponentState<DialogContentSlots>;
 
 // @public (undocumented)
 export type DialogOpenChangeData = {
-    type: 'dialogCancel';
-    open: boolean;
-    event: React_2.SyntheticEvent<DialogSurfaceElement>;
-} | {
     type: 'escapeKeyDown';
     open: boolean;
     event: React_2.KeyboardEvent<DialogSurfaceElement>;

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -9,14 +9,6 @@ export type DialogOpenChangeEvent = DialogOpenChangeData['event'];
 
 export type DialogOpenChangeData =
   | {
-      /**
-       * triggered when Escape key is pressed in a native `dialog`
-       */
-      type: 'dialogCancel';
-      open: boolean;
-      event: React.SyntheticEvent<DialogSurfaceElement>;
-    }
-  | {
       type: 'escapeKeyDown';
       open: boolean;
       event: React.KeyboardEvent<DialogSurfaceElement>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

https://github.com/microsoft/fluentui/blob/6ce378e366246cc7504a7adc7a49ad5c06c11f1e/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts#L10-L33

`dialogCancel` data type refers to a scenario involving native dialog.

## New Behavior

Since native dialogs are not supported anymore this union case becomes irrelevant. This PR removes that case.