### PR TITLE
bugfix(react-switch): adds line-height=0 to switch indicator slot

### DIFF
--- a/change/@fluentui-react-switch-478e98a6-f6a5-411e-bcea-50c112ce9e77.json
+++ b/change/@fluentui-react-switch-478e98a6-f6a5-411e-bcea-50c112ce9e77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: adds line-height=0 to switch indicator slot",
+  "packageName": "@fluentui/react-switch",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -42,6 +42,7 @@ const useIndicatorStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
     ...shorthands.borderStyle('solid'),
     ...shorthands.borderWidth('1px'),
+    lineHeight: 0,
     boxSizing: 'border-box',
     fill: 'currentColor',
     flexShrink: 0,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Since line height is not provided internally, it'll be inherited from parent, and that might cause some visual issues

![image](https://user-images.githubusercontent.com/5483269/199776585-d1ae1a91-63b7-4706-8136-60b53c71ea39.png)

https://codesandbox.io/s/react-switch-line-height-issue-5cd2w9

## New Behavior

Introduces a line height value of `0` to `indicator` slot, to ensure this visual issue won't happen.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #25505
