### PR TITLE
GroupedListV2: update aria-posinset and aria-rowindex

### DIFF
--- a/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/public-docsite/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -58,6 +58,8 @@ export const categories: { Other?: ICategory; [name: string]: ICategory } = {
         Compact: {},
         Grouped: {},
         LargeGrouped: { title: 'Large Grouped' },
+        GroupedV2: { title: 'Grouped V2' },
+        LargeGroupedV2: { title: 'Large Grouped V2' },
         CustomColumns: { title: 'Custom Item Columns', url: 'customitemcolumns' },
         CustomRows: { title: 'Custom Item Rows', url: 'customitemrows' },
         CustomFooter: { title: 'Custom Footer' },

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListGroupedV2Page.doc.ts
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListGroupedV2Page.doc.ts
@@ -1,0 +1,10 @@
+import { TFabricPlatformPageProps } from '../../../interfaces/Platforms';
+import { DetailsListSimpleGroupedV2PageProps as ExternalProps } from '@fluentui/react-examples/lib/react/DetailsList/DetailsList.doc';
+
+export const DetailsListGroupedV2PageProps: TFabricPlatformPageProps = {
+  web: {
+    ...(ExternalProps as any),
+    title: 'DetailsList - Grouped V2',
+    isFeedbackVisible: false,
+  },
+};

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListGroupedV2Page.tsx
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListGroupedV2Page.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
+import { DetailsListGroupedV2PageProps } from './DetailsListGroupedV2Page.doc';
+
+export const DetailsListGroupedV2Page: React.FunctionComponent<IControlsPageProps> = props => {
+  return <ControlsAreaPage {...props} {...DetailsListGroupedV2PageProps[props.platform]} />;
+};

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListLargeGroupedV2Page.doc.ts
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListLargeGroupedV2Page.doc.ts
@@ -1,0 +1,10 @@
+import { TFabricPlatformPageProps } from '../../../interfaces/Platforms';
+import { DetailsListLargeGroupedPageProps as ExternalProps } from '@fluentui/react-examples/lib/react/DetailsList/DetailsList.doc';
+
+export const DetailsListLargeGroupedV2PageProps: TFabricPlatformPageProps = {
+  web: {
+    ...(ExternalProps as any),
+    title: 'DetailsList - Large Grouped V2',
+    isFeedbackVisible: false,
+  },
+};

--- a/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListLargeGroupedV2Page.tsx
+++ b/apps/public-docsite/src/pages/Controls/DetailsListPage/DetailsListLargeGroupedV2Page.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
+import { DetailsListLargeGroupedV2PageProps } from './DetailsListLargeGroupedV2Page.doc';
+
+export const DetailsListLargeGroupedV2Page: React.FunctionComponent<IControlsPageProps> = props => {
+  return <ControlsAreaPage {...props} {...DetailsListLargeGroupedV2PageProps[props.platform]} />;
+};

--- a/change/@fluentui-react-8cc34e48-8e55-4e4c-9ddb-f1f9cd3b0f3f.json
+++ b/change/@fluentui-react-8cc34e48-8e55-4e4c-9ddb-f1f9cd3b0f3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: set correct aria-posinset and aria-rowindex values on GroupedListV2",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.GroupedV2.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.GroupedV2.Example.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import {
+  DetailsHeader,
+  DetailsList,
+  IColumn,
+  IDetailsHeaderProps,
+  IDetailsList,
+  IGroup,
+  IRenderFunction,
+  IToggleStyles,
+  mergeStyles,
+  Toggle,
+  GroupedListV2_unstable as GroupedListV2,
+} from '@fluentui/react';
+import { DefaultButton, IButtonStyles } from '@fluentui/react/lib/Button';
+
+const margin = '0 20px 20px 0';
+const controlWrapperClass = mergeStyles({
+  display: 'flex',
+  flexWrap: 'wrap',
+});
+const toggleStyles: Partial<IToggleStyles> = {
+  root: { margin },
+  label: { marginLeft: 10 },
+};
+const addItemButtonStyles: Partial<IButtonStyles> = { root: { margin } };
+
+export interface IDetailsListGroupedExampleItem {
+  key: string;
+  name: string;
+  color: string;
+}
+
+export interface IDetailsListGroupedExampleState {
+  items: IDetailsListGroupedExampleItem[];
+  groups: IGroup[];
+  showItemIndexInView: boolean;
+  isCompactMode: boolean;
+}
+const _blueGroupIndex = 2;
+
+const onRenderColumn = (item: IDetailsListGroupedExampleItem, index: number, column: IColumn) => {
+  const value =
+    item && column && column.fieldName ? item[column.fieldName as keyof IDetailsListGroupedExampleItem] || '' : '';
+
+  return <div data-is-focusable={true}>{value}</div>;
+};
+
+const onRenderDetailsHeader = (props: IDetailsHeaderProps, _defaultRender?: IRenderFunction<IDetailsHeaderProps>) => {
+  return <DetailsHeader {...props} ariaLabelForToggleAllGroupsButton={'Expand collapse groups'} />;
+};
+
+// export class DetailsListGroupedV2Example extends React.Component<{}, IDetailsListGroupedExampleState> {
+export const DetailsListGroupedV2Example: React.FC = () => {
+  const root = React.useRef<IDetailsList>(null);
+  const [columns] = React.useState<IColumn[]>([
+    { key: 'name', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+    { key: 'color', name: 'Color', fieldName: 'color', minWidth: 100, maxWidth: 200 },
+  ]);
+
+  const [items, setItems] = React.useState<IDetailsListGroupedExampleItem[]>([
+    { key: 'a', name: 'a', color: 'red' },
+    { key: 'b', name: 'b', color: 'red' },
+    { key: 'c', name: 'c', color: 'blue' },
+    { key: 'd', name: 'd', color: 'blue' },
+    { key: 'e', name: 'e', color: 'blue' },
+  ]);
+
+  const [groups, setGroups] = React.useState<IGroup[]>([
+    { key: 'groupred0', name: 'Color: "red"', startIndex: 0, count: 2, level: 0 },
+    { key: 'groupgreen2', name: 'Color: "green"', startIndex: 2, count: 0, level: 0 },
+    { key: 'groupblue2', name: 'Color: "blue"', startIndex: 2, count: 3, level: 0 },
+  ]);
+
+  const [isCompactMode, setIsCompactMode] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    root.current?.focusIndex(items.length - 1, true);
+  }, [items]);
+
+  const addItem = React.useCallback((): void => {
+    const newGroups = [...groups];
+    newGroups[_blueGroupIndex].count++;
+
+    setItems(
+      items.concat([
+        {
+          key: 'item-' + items.length,
+          name: 'New item ' + items.length,
+          color: 'blue',
+        },
+      ]),
+    );
+
+    setGroups(newGroups);
+  }, [items, groups]);
+
+  const onChangeCompactMode = (ev: React.MouseEvent<HTMLElement>, checked: boolean): void => {
+    setIsCompactMode(checked);
+  };
+
+  return (
+    <div>
+      <div className={controlWrapperClass}>
+        <DefaultButton onClick={addItem} text="Add an item" styles={addItemButtonStyles} />
+        <Toggle
+          label="Compact mode"
+          inlineLabel
+          checked={isCompactMode}
+          // eslint-disable-next-line react/jsx-no-bind
+          onChange={onChangeCompactMode}
+          styles={toggleStyles}
+        />
+      </div>
+      <DetailsList
+        componentRef={root}
+        items={items}
+        groups={groups}
+        columns={columns}
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        ariaLabelForSelectionColumn="Toggle selection"
+        checkButtonAriaLabel="select row"
+        checkButtonGroupAriaLabel="select section"
+        onRenderDetailsHeader={onRenderDetailsHeader}
+        groupProps={{
+          showEmptyGroups: true,
+          groupedListAs: GroupedListV2,
+        }}
+        onRenderItemColumn={onRenderColumn}
+        compact={isCompactMode}
+      />
+    </div>
+  );
+};
+
+// @ts-expect-error Storybook
+DetailsListGroupedV2Example.storyName = 'V2 Grouped';

--- a/packages/react-examples/src/react/DetailsList/DetailsList.GroupedV2.Large.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.GroupedV2.Large.Example.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { DetailsHeader, DetailsList, IColumn, IDetailsHeaderProps, IGroup } from '@fluentui/react/lib/DetailsList';
+import { GroupedListV2_unstable as GroupedListV2 } from '@fluentui/react/lib/GroupedListV2';
+
+interface IDetailsListGroupedLargeExampleItem {
+  key: string;
+  name: string;
+  value: string;
+}
+
+const getInitialItems = () => {
+  const items = [];
+  for (let i = 0; i < 1000; i++) {
+    items.push({
+      key: i.toString(),
+      name: 'Item ' + i,
+      value: i.toString(),
+    });
+  }
+
+  return items;
+};
+
+const getInitialGroups = () => {
+  const groups = [];
+  for (let i = 0; i < 10; i++) {
+    groups.push({
+      key: i.toString(),
+      name: i.toString(),
+      startIndex: i * 100,
+      count: 100,
+      level: 0,
+    });
+  }
+
+  return groups;
+};
+
+const onRenderDetailsHeader = (props: IDetailsHeaderProps) => {
+  return <DetailsHeader {...props} ariaLabelForToggleAllGroupsButton={'Expand collapse groups'} />;
+};
+
+export const DetailsListGroupedV2LargeExmaple: React.FC = () => {
+  const [items] = React.useState<IDetailsListGroupedLargeExampleItem[]>(() => getInitialItems());
+  const [groups] = React.useState<IGroup[]>(() => getInitialGroups());
+  const [columns] = React.useState<IColumn[]>([
+    { key: 'name', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+    { key: 'value', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true },
+  ]);
+
+  return (
+    <DetailsList
+      items={items}
+      groups={groups}
+      columns={columns}
+      ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+      ariaLabelForSelectionColumn="Toggle selection"
+      checkButtonAriaLabel="select row"
+      checkButtonGroupAriaLabel="select section"
+      onRenderDetailsHeader={onRenderDetailsHeader}
+      groupProps={{
+        groupedListAs: GroupedListV2,
+      }}
+    />
+  );
+};
+
+// @ts-expect-error Storybook
+DetailsListGroupedV2LargeExmaple.storyName = 'V2 Grouped Large';

--- a/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.doc.tsx
@@ -29,8 +29,14 @@ const DetailsListProportionalColumnsCode = require('!raw-loader?esModule=false!@
 import { DetailsListGroupedExample } from './DetailsList.Grouped.Example';
 const DetailsListGroupedExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx') as string;
 
+import { DetailsListGroupedV2Example } from './DetailsList.GroupedV2.Example';
+const DetailsListGroupedV2ExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.GroupedV2.Example.tsx') as string;
+
 import { DetailsListGroupedLargeExample } from './DetailsList.Grouped.Large.Example';
 const DetailsListGroupedLargeExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.Grouped.Large.Example.tsx') as string;
+
+import { DetailsListGroupedV2LargeExmaple } from './DetailsList.GroupedV2.Large.Example';
+const DetailsListGroupedV2LargeExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.GroupedV2.Large.Example.tsx') as string;
 
 import { DetailsListDragDropExample } from './DetailsList.DragDrop.Example';
 const DetailsListDragDropExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/DetailsList/DetailsList.DragDrop.Example.tsx') as string;
@@ -104,10 +110,22 @@ export const DetailsListSimpleGroupedPageProps: IDocPageProps = generateProps({
   view: <DetailsListGroupedExample />,
 });
 
+export const DetailsListSimpleGroupedV2PageProps: IDocPageProps = generateProps({
+  title: 'Simple grouped DetailsList V2',
+  code: DetailsListGroupedV2ExampleCode,
+  view: <DetailsListGroupedV2Example />,
+});
+
 export const DetailsListLargeGroupedPageProps: IDocPageProps = generateProps({
   title: 'Large grouped DetailsList',
   code: DetailsListGroupedLargeExampleCode,
   view: <DetailsListGroupedLargeExample />,
+});
+
+export const DetailsListLargeGroupedV2PageProps: IDocPageProps = generateProps({
+  title: 'Large grouped DetailsList V2',
+  code: DetailsListGroupedV2LargeExampleCode,
+  view: <DetailsListGroupedV2LargeExmaple />,
 });
 
 export const DetailsListCustomColumnsPageProps: IDocPageProps = generateProps({

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2012,8 +2012,10 @@ export class GroupedListSection extends React_2.Component<IGroupedListSectionPro
     render(): JSX.Element;
 }
 
+// Warning: (ae-forgotten-export) The symbol "IGroupedListV2Props" needs to be exported by the entry point index.d.ts
+//
 // @public
-export const GroupedListV2_unstable: React_2.FunctionComponent<IGroupedListProps>;
+export const GroupedListV2_unstable: React_2.FunctionComponent<IGroupedListV2Props>;
 
 // @public (undocumented)
 export const GroupFooter: React_2.FunctionComponent<IGroupFooterProps>;

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
@@ -7488,7 +7488,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={2}
+                      aria-rowindex={3}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -7790,7 +7790,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={3}
+                      aria-rowindex={4}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -8317,7 +8317,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={4}
+                      aria-rowindex={6}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -8619,7 +8619,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={5}
+                      aria-rowindex={7}
                       aria-selected={false}
                       className=
                           ms-FocusZone
@@ -8921,7 +8921,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                     role="presentation"
                   >
                     <div
-                      aria-rowindex={6}
+                      aria-rowindex={8}
                       aria-selected={false}
                       className=
                           ms-FocusZone

--- a/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
@@ -15,12 +15,12 @@ import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import type { IProcessedStyleSet } from '../../Styling';
 import type {
   IGroupedList,
-  IGroupedListProps,
   IGroup,
   IGroupRenderProps,
   IGroupedListStyleProps,
   IGroupedListStyles,
 } from './GroupedList.types';
+import type { IGroupedListV2Props } from './GroupedListV2.types';
 import { GroupHeader } from './GroupHeader';
 import { GroupShowAll } from './GroupShowAll';
 import { GroupFooter } from './GroupFooter';
@@ -29,17 +29,11 @@ import type { IGroupShowAllProps } from './GroupShowAll.styles';
 import type { IGroupFooterProps } from './GroupFooter.types';
 
 export interface IGroupedListV2State {
-  selectionMode?: IGroupedListProps['selectionMode'];
-  compact?: IGroupedListProps['compact'];
+  selectionMode?: IGroupedListV2Props['selectionMode'];
+  compact?: IGroupedListV2Props['compact'];
   groups?: IGroup[];
-  items?: IGroupedListProps['items'];
-  listProps?: IGroupedListProps['listProps'];
-  version: {};
-  groupExpandedVersion: {};
-}
-
-export interface IGroupedListV2Props extends IGroupedListProps {
-  listRef: React.Ref<List>;
+  items?: IGroupedListV2Props['items'];
+  listProps?: IGroupedListV2Props['listProps'];
   version: {};
   groupExpandedVersion: {};
 }
@@ -472,7 +466,7 @@ export const GroupedListV2FC: React.FC<IGroupedListV2Props> = props => {
       return renderFooter(item, flattenedIndex);
     } else {
       const level = item.group.level ? item.group.level + 1 : 1;
-      return onRenderCell(level, item.item, item.itemIndex ?? flattenedIndex);
+      return onRenderCell(level, item.item, item.itemIndex ?? flattenedIndex, item.group);
     }
   };
 
@@ -532,13 +526,13 @@ const GroupItem = <T,>({
 };
 
 export class GroupedListV2Wrapper
-  extends React.Component<IGroupedListProps, IGroupedListV2State>
+  extends React.Component<IGroupedListV2Props, IGroupedListV2State>
   implements IGroupedList {
   public static displayName: string = 'GroupedListV2';
   private _list = React.createRef<List>();
 
   public static getDerivedStateFromProps(
-    nextProps: IGroupedListProps,
+    nextProps: IGroupedListV2Props,
     previousState: IGroupedListV2State,
   ): IGroupedListV2State {
     const { groups, selectionMode, compact, items, listProps } = nextProps;
@@ -562,7 +556,7 @@ export class GroupedListV2Wrapper
     return nextState;
   }
 
-  constructor(props: IGroupedListProps) {
+  constructor(props: IGroupedListV2Props) {
     super(props);
     initializeComponentRef(this);
 

--- a/packages/react/src/components/GroupedList/GroupedListV2.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { styled } from '../../Utilities';
 import { getStyles } from './GroupedList.styles';
 import { GroupedListV2Wrapper } from './GroupedListV2.base';
-import type { IGroupedListProps, IGroupedListStyles, IGroupedListStyleProps } from './GroupedList.types';
+import type { IGroupedListStyles, IGroupedListStyleProps } from './GroupedList.types';
+import type { IGroupedListV2Props } from './GroupedListV2.types';
 
 /**
  * NOTE: GroupedListV2 is "unstable" and meant for preview use. It passes
@@ -13,8 +14,8 @@ import type { IGroupedListProps, IGroupedListStyles, IGroupedListStyleProps } fr
  * that addresses issues GroupedList has with virtualizing nested lists under certain
  * conditions.
  */
-const GroupedListV2: React.FunctionComponent<IGroupedListProps> = styled<
-  IGroupedListProps,
+const GroupedListV2: React.FunctionComponent<IGroupedListV2Props> = styled<
+  IGroupedListV2Props,
   IGroupedListStyleProps,
   IGroupedListStyles
 >(GroupedListV2Wrapper, getStyles, undefined, {

--- a/packages/react/src/components/GroupedList/GroupedListV2.types.ts
+++ b/packages/react/src/components/GroupedList/GroupedListV2.types.ts
@@ -4,7 +4,7 @@ import { List } from '../../List';
 import type { IGroup } from './GroupedList.types';
 
 export interface IGroupedListV2Props extends IGroupedListProps {
-  /** Ref to the underlying List controle */
+  /** Ref to the underlying List control */
   listRef?: React.Ref<List>;
 
   /**
@@ -15,7 +15,7 @@ export interface IGroupedListV2Props extends IGroupedListProps {
   version?: {};
 
   /**
-   * For perf reasons, GrouopedList avoids re-rendering unless certain props have changed.
+   * For perf reasons, GroupedList avoids re-rendering unless certain props have changed.
    * Use this prop if you need to force it to re-render when a group has expanded or collapsed.
    * You can pass any type of value as long as it only changes (`===` comparison)
    * when a re-render should happen.

--- a/packages/react/src/components/GroupedList/GroupedListV2.types.ts
+++ b/packages/react/src/components/GroupedList/GroupedListV2.types.ts
@@ -5,14 +5,14 @@ import type { IGroup } from './GroupedList.types';
 
 export interface IGroupedListV2Props extends IGroupedListProps {
   /** Ref to the underlying List controle */
-  listRef: React.Ref<List>;
+  listRef?: React.Ref<List>;
 
   /**
    * For perf reasons, GroupedList avoids re-rendering unless certain props have changed.
    * Use this prop if you need to force it to re-render in other cases. You can pass any type of
    * value as long as it only changes (`===` comparison) when a re-render should happen.
    */
-  version: {};
+  version?: {};
 
   /**
    * For perf reasons, GrouopedList avoids re-rendering unless certain props have changed.
@@ -20,7 +20,7 @@ export interface IGroupedListV2Props extends IGroupedListProps {
    * You can pass any type of value as long as it only changes (`===` comparison)
    * when a re-render should happen.
    */
-  groupExpandedVersion: {};
+  groupExpandedVersion?: {};
 
   /** Rendering callback to render the group items. */
   onRenderCell: (nestingDepth?: number, item?: any, index?: number, group?: IGroup) => React.ReactNode;

--- a/packages/react/src/components/GroupedList/GroupedListV2.types.ts
+++ b/packages/react/src/components/GroupedList/GroupedListV2.types.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import type { IGroupedListProps } from './GroupedList.types';
+import { List } from '../../List';
+import type { IGroup } from './GroupedList.types';
+
+export interface IGroupedListV2Props extends IGroupedListProps {
+  /** Ref to the underlying List controle */
+  listRef: React.Ref<List>;
+
+  /**
+   * For perf reasons, GroupedList avoids re-rendering unless certain props have changed.
+   * Use this prop if you need to force it to re-render in other cases. You can pass any type of
+   * value as long as it only changes (`===` comparison) when a re-render should happen.
+   */
+  version: {};
+
+  /**
+   * For perf reasons, GrouopedList avoids re-rendering unless certain props have changed.
+   * Use this prop if you need to force it to re-render when a group has expanded or collapsed.
+   * You can pass any type of value as long as it only changes (`===` comparison)
+   * when a re-render should happen.
+   */
+  groupExpandedVersion: {};
+
+  /** Rendering callback to render the group items. */
+  onRenderCell: (nestingDepth?: number, item?: any, index?: number, group?: IGroup) => React.ReactNode;
+}


### PR DESCRIPTION
## Current Behavior

The incorrect value for `aria-posinset` was set on GroupedListV2. When used in `DetailsList` `aria-rowindex` was not set and `aria-level` and `aria-posinset` were incorrectly set.

## New Behavior

Set the correct `aria-posinset` and `aria-rowindex` values on GroupedListV2 depending on `role`.

## Related Issue(s)


Fixes #24795
