### PR TITLE
Enable build pipeline for web-components-v3 branch

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -1,5 +1,6 @@
 pr:
   - master
+  - web-components-v3
 
 trigger:
   - master

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -1,6 +1,6 @@
 pr:
   - master
-  - web-components-v3
+  - web-components-v3 # Remove before merging to master
 
 trigger:
   - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 pr:
   - master
+  - web-components-v3
 
 # There's a separate pipeline for CI which also uses this file, but with a trigger override in the UI
 # https://dev.azure.com/uifabric/fabricpublic/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=164&view=Tab_Triggers

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 pr:
   - master
-  - web-components-v3
+  - web-components-v3 # Remove before merging to master
 
 # There's a separate pipeline for CI which also uses this file, but with a trigger override in the UI
 # https://dev.azure.com/uifabric/fabricpublic/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=164&view=Tab_Triggers


### PR DESCRIPTION
Enable build pipeline for `web-components-v3` branch so that PRs to that branch must pass the build before merging.