### PR TITLE
feat: Implement `focusMode` prop for DataGrid, apply role="grid" correctly

### DIFF
--- a/change/@fluentui-react-table-7398941b-ae22-4a18-878d-1ac8e853c6ee.json
+++ b/change/@fluentui-react-table-7398941b-ae22-4a18-878d-1ac8e853c6ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: DataGrid cells navigable by default, apply role=\"grid\" correctly",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-7398941b-ae22-4a18-878d-1ac8e853c6ee.json
+++ b/change/@fluentui-react-table-7398941b-ae22-4a18-878d-1ac8e853c6ee.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "feat: DataGrid cells navigable by default, apply role=\"grid\" correctly",
+  "comment": "feat: Implement `focusMode` prop for DataGrid, apply role=\"grid\" correctly",
   "packageName": "@fluentui/react-table",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -90,7 +90,9 @@ export type DataGridCellState = TableCellState;
 export const dataGridClassNames: SlotClassNames<DataGridSlots>;
 
 // @public (undocumented)
-export type DataGridContextValue = HeadlessTableState<any>;
+export type DataGridContextValue = HeadlessTableState<any> & {
+    focusMode: FocusMode;
+};
 
 // @public (undocumented)
 export type DataGridContextValues = TableContextValues & {
@@ -128,7 +130,7 @@ export type DataGridHeaderSlots = TableHeaderSlots;
 export type DataGridHeaderState = TableHeaderState;
 
 // @public
-export type DataGridProps = TableProps & Pick<DataGridContextValue, 'items' | 'columns'>;
+export type DataGridProps = TableProps & Pick<DataGridContextValue, 'items' | 'columns'> & Pick<Partial<DataGridContextValue>, 'focusMode'>;
 
 // @public
 export const DataGridRow: ForwardRefComponent<DataGridRowProps>;
@@ -168,7 +170,10 @@ export type DataGridSlots = TableSlots;
 // @public
 export type DataGridState = TableState & {
     tableState: HeadlessTableState<unknown>;
-};
+} & Pick<DataGridContextValue, 'focusMode'>;
+
+// @public (undocumented)
+export type FocusMode = 'none' | 'cell';
 
 // @public (undocumented)
 export interface HeadlessTableState<TItem> extends Pick<UseTableOptions<TItem>, 'items' | 'getRowId'> {

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
@@ -51,4 +51,69 @@ describe('DataGrid', () => {
     );
     expect(result.container).toMatchSnapshot();
   });
+
+  it('should render tabster attributes when `focusMode` has value `cell`', () => {
+    const result = render(
+      <DataGrid items={testItems} columns={testColumns} focusMode="cell">
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell, columnId }) => <DataGridCell key={columnId}>{renderHeaderCell()}</DataGridCell>}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody>
+          {({ item, rowId }: RowState<Item>) => (
+            <DataGridRow key={rowId}>
+              {({ renderCell, columnId }) => <DataGridCell key={columnId}>{renderCell(item)}</DataGridCell>}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>,
+    );
+
+    expect(result.getByRole('grid').getAttribute('data-tabster')).toMatchInlineSnapshot(
+      `"{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3}}"`,
+    );
+  });
+
+  it('should not render tabster attributes when `focusMode` has value `none`', () => {
+    const result = render(
+      <DataGrid items={testItems} columns={testColumns} focusMode="none">
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell, columnId }) => <DataGridCell key={columnId}>{renderHeaderCell()}</DataGridCell>}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody>
+          {({ item, rowId }: RowState<Item>) => (
+            <DataGridRow key={rowId}>
+              {({ renderCell, columnId }) => <DataGridCell key={columnId}>{renderCell(item)}</DataGridCell>}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>,
+    );
+
+    expect(result.getByRole('grid').hasAttribute('data-tabster')).toBe(false);
+  });
+
+  it('should not render tabster attributes when `focusMode` prop is not set', () => {
+    const result = render(
+      <DataGrid items={testItems} columns={testColumns}>
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell, columnId }) => <DataGridCell key={columnId}>{renderHeaderCell()}</DataGridCell>}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody>
+          {({ item, rowId }: RowState<Item>) => (
+            <DataGridRow key={rowId}>
+              {({ renderCell, columnId }) => <DataGridCell key={columnId}>{renderCell(item)}</DataGridCell>}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>,
+    );
+
+    expect(result.getByRole('grid').hasAttribute('data-tabster')).toBe(false);
+  });
 });

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
@@ -3,6 +3,8 @@ import { TableState as HeadlessTableState } from '../../hooks';
 
 export type DataGridSlots = TableSlots;
 
+export type FocusMode = 'none' | 'cell';
+
 export type DataGridContextValues = TableContextValues & {
   dataGrid: DataGridContextValue;
 };
@@ -10,14 +12,25 @@ export type DataGridContextValues = TableContextValues & {
 // Use any here since we can't know the user types
 // The user is responsible for narrowing the type downstream
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type DataGridContextValue = HeadlessTableState<any>;
+export type DataGridContextValue = HeadlessTableState<any> & {
+  /**
+   * How focus navigation will work in the datagrid
+   * @default none
+   */
+  focusMode: FocusMode;
+};
 
 /**
  * DataGrid Props
  */
-export type DataGridProps = TableProps & Pick<DataGridContextValue, 'items' | 'columns'>;
+export type DataGridProps = TableProps &
+  Pick<DataGridContextValue, 'items' | 'columns'> &
+  Pick<Partial<DataGridContextValue>, 'focusMode'>;
 
 /**
  * State used in rendering DataGrid
  */
-export type DataGridState = TableState & { tableState: HeadlessTableState<unknown> };
+export type DataGridState = TableState & { tableState: HeadlessTableState<unknown> } & Pick<
+    DataGridContextValue,
+    'focusMode'
+  >;

--- a/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`DataGrid renders a default state 1`] = `
 <div>
   <div
     class="fui-DataGrid fui-Table"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3}}"
     role="grid"
   >
     <div
@@ -18,21 +17,18 @@ exports[`DataGrid renders a default state 1`] = `
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           third
         </div>
@@ -49,21 +45,18 @@ exports[`DataGrid renders a default state 1`] = `
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           third
         </div>
@@ -75,21 +68,18 @@ exports[`DataGrid renders a default state 1`] = `
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           third
         </div>
@@ -101,21 +91,18 @@ exports[`DataGrid renders a default state 1`] = `
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
           role="gridcell"
-          tabindex="0"
         >
           third
         </div>

--- a/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -4,7 +4,8 @@ exports[`DataGrid renders a default state 1`] = `
 <div>
   <div
     class="fui-DataGrid fui-Table"
-    role="table"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3}}"
+    role="grid"
   >
     <div
       class="fui-DataGridHeader fui-TableHeader"
@@ -16,19 +17,22 @@ exports[`DataGrid renders a default state 1`] = `
       >
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           third
         </div>
@@ -44,19 +48,22 @@ exports[`DataGrid renders a default state 1`] = `
       >
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           third
         </div>
@@ -67,19 +74,22 @@ exports[`DataGrid renders a default state 1`] = `
       >
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           third
         </div>
@@ -90,19 +100,22 @@ exports[`DataGrid renders a default state 1`] = `
       >
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           first
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           second
         </div>
         <div
           class="fui-DataGridCell fui-TableCell"
-          role="cell"
+          role="gridcell"
+          tabindex="0"
         >
           third
         </div>

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import type { DataGridProps, DataGridState } from './DataGrid.types';
 import { useTable_unstable } from '../Table/useTable';
 import { useTable } from '../../hooks/useTable';
@@ -14,8 +15,9 @@ import { useTable } from '../../hooks/useTable';
  */
 export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLElement>): DataGridState => {
   const { items, columns } = props;
+  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
   const tableState = useTable({ items, columns }, []);
-  const baseTableState = useTable_unstable({ ...props, as: 'div' }, ref);
+  const baseTableState = useTable_unstable({ role: 'grid', as: 'div', ...keyboardNavAttr, ...props }, ref);
 
   return {
     ...baseTableState,

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
@@ -14,13 +14,18 @@ import { useTable } from '../../hooks/useTable';
  * @param ref - reference to root HTMLElement of DataGrid
  */
 export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLElement>): DataGridState => {
-  const { items, columns } = props;
+  const { items, columns, focusMode = 'none' } = props;
+  const navigable = focusMode !== 'none';
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
   const tableState = useTable({ items, columns }, []);
-  const baseTableState = useTable_unstable({ role: 'grid', as: 'div', ...keyboardNavAttr, ...props }, ref);
+  const baseTableState = useTable_unstable(
+    { role: 'grid', as: 'div', ...(navigable && keyboardNavAttr), ...props },
+    ref,
+  );
 
   return {
     ...baseTableState,
+    focusMode,
     tableState,
   };
 };

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGridContextValues.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGridContextValues.ts
@@ -7,6 +7,7 @@ export function useDataGridContextValues_unstable(state: DataGridState): DataGri
     ...tableContextValues,
     dataGrid: {
       ...state.tableState,
+      focusMode: state.focusMode,
     },
   };
 }

--- a/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridCell/DataGridCell.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 import { DataGridCell } from './DataGridCell';
 import { isConformant } from '../../testing/isConformant';
 import { DataGridCellProps } from './DataGridCell.types';
+import { DataGridContextProvider } from '../../contexts/dataGridContext';
+import { mockDataGridContext } from '../../testing/mockDataGridContext';
 
 describe('DataGridCell', () => {
   isConformant<DataGridCellProps>({
@@ -10,10 +12,31 @@ describe('DataGridCell', () => {
     displayName: 'DataGridCell',
   });
 
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
   it('renders a default state', () => {
     const result = render(<DataGridCell>Default DataGridCell</DataGridCell>);
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('should set tabindex="0" when focusMode is cell', () => {
+    const context = mockDataGridContext({ focusMode: 'cell' });
+    const result = render(
+      <DataGridContextProvider value={context}>
+        <DataGridCell>Default DataGridCell</DataGridCell>
+      </DataGridContextProvider>,
+    );
+
+    expect(result.getByRole('gridcell').tabIndex).toBe(0);
+  });
+
+  it('should not set tabindex when focusMode is none', () => {
+    const context = mockDataGridContext({ focusMode: 'none' });
+    const result = render(
+      <DataGridContextProvider value={context}>
+        <DataGridCell>Default DataGridCell</DataGridCell>
+      </DataGridContextProvider>,
+    );
+
+    expect(result.getByRole('gridcell').tabIndex).toBe(-1);
+    expect(result.getByRole('gridcell').hasAttribute('tabindex')).toBe(false);
   });
 });

--- a/packages/react-components/react-table/src/components/DataGridCell/__snapshots__/DataGridCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridCell/__snapshots__/DataGridCell.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`DataGridCell renders a default state 1`] = `
   <div
     class="fui-DataGridCell fui-TableCell"
     role="gridcell"
-    tabindex="0"
   >
     Default DataGridCell
   </div>

--- a/packages/react-components/react-table/src/components/DataGridCell/__snapshots__/DataGridCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridCell/__snapshots__/DataGridCell.test.tsx.snap
@@ -4,7 +4,8 @@ exports[`DataGridCell renders a default state 1`] = `
 <div>
   <div
     class="fui-DataGridCell fui-TableCell"
-    role="cell"
+    role="gridcell"
+    tabindex="0"
   >
     Default DataGridCell
   </div>

--- a/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { DataGridCellProps, DataGridCellState } from './DataGridCell.types';
 import { useTableCell_unstable } from '../TableCell/useTableCell';
+import { useDataGridContext_unstable } from '../../contexts/dataGridContext';
 
 /**
  * Create the state required to render DataGridCell.
@@ -12,5 +13,6 @@ import { useTableCell_unstable } from '../TableCell/useTableCell';
  * @param ref - reference to root HTMLElement of DataGridCell
  */
 export const useDataGridCell_unstable = (props: DataGridCellProps, ref: React.Ref<HTMLElement>): DataGridCellState => {
-  return useTableCell_unstable({ as: 'div', role: 'gridcell', tabIndex: 0, ...props }, ref);
+  const tabbable = useDataGridContext_unstable(ctx => ctx.focusMode !== 'none');
+  return useTableCell_unstable({ as: 'div', role: 'gridcell', tabIndex: tabbable ? 0 : undefined, ...props }, ref);
 };

--- a/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
@@ -12,5 +12,5 @@ import { useTableCell_unstable } from '../TableCell/useTableCell';
  * @param ref - reference to root HTMLElement of DataGridCell
  */
 export const useDataGridCell_unstable = (props: DataGridCellProps, ref: React.Ref<HTMLElement>): DataGridCellState => {
-  return useTableCell_unstable({ ...props, as: 'div' }, ref);
+  return useTableCell_unstable({ as: 'div', role: 'gridcell', tabIndex: 0, ...props }, ref);
 };

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/__snapshots__/DataGridSelectionCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/__snapshots__/DataGridSelectionCell.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DataGridSelectionCell renders a default state 1`] = `
 <div>
   <div
     class="fui-DataGridSelectionCell fui-TableSelectionCell"
-    role="cell"
+    role="gridcell"
   >
     <span
       class="fui-Checkbox fui-DataGridSelectionCell__checkboxIndicator fui-TableSelectionCell__checkboxIndicator"

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
@@ -15,5 +15,5 @@ export const useDataGridSelectionCell_unstable = (
   props: DataGridSelectionCellProps,
   ref: React.Ref<HTMLElement>,
 ): DataGridSelectionCellState => {
-  return useTableSelectionCell_unstable({ ...props, as: 'div' }, ref);
+  return useTableSelectionCell_unstable({ as: 'div', role: 'gridcell', ...props }, ref);
 };

--- a/packages/react-components/react-table/src/contexts/dataGridContext.ts
+++ b/packages/react-components/react-table/src/contexts/dataGridContext.ts
@@ -7,6 +7,7 @@ const dataGridContext = createContext<DataGridContextValue | undefined>(undefine
 
 const dataGridContextDefaultValue: DataGridContextValue = {
   ...defaultTableState,
+  focusMode: 'none',
 };
 
 export const DataGridContextProvider = dataGridContext.Provider;

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -140,6 +140,7 @@ export type {
   DataGridState,
   DataGridContextValues,
   DataGridContextValue,
+  FocusMode,
 } from './DataGrid';
 
 export {

--- a/packages/react-components/react-table/src/testing/mockDataGridContext.ts
+++ b/packages/react-components/react-table/src/testing/mockDataGridContext.ts
@@ -1,0 +1,34 @@
+import { DataGridContextValue } from '../components/DataGrid/DataGrid.types';
+import { ColumnDefinition, createColumn, defaultTableSelectionState, defaultTableSortState } from '../hooks';
+
+interface Item {
+  first: string;
+  second: string;
+  third: string;
+}
+
+const testColumns: ColumnDefinition<Item>[] = [
+  createColumn({ columnId: 'first', renderHeaderCell: () => 'first', renderCell: item => item.first }),
+  createColumn({ columnId: 'second', renderHeaderCell: () => 'second', renderCell: item => item.second }),
+  createColumn({ columnId: 'third', renderHeaderCell: () => 'third', renderCell: item => item.third }),
+];
+const testItems: Item[] = [
+  { first: 'first', second: 'second', third: 'third' },
+  { first: 'first', second: 'second', third: 'third' },
+  { first: 'first', second: 'second', third: 'third' },
+];
+
+export function mockDataGridContext(options: Partial<DataGridContextValue> = {}) {
+  const mockContext: DataGridContextValue = {
+    columns: testColumns,
+    items: testItems,
+    focusMode: 'none',
+    getRowId: () => '',
+    getRows: () => [],
+    selection: defaultTableSelectionState,
+    sort: defaultTableSortState,
+    ...options,
+  };
+
+  return mockContext;
+}

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -149,7 +149,7 @@ export const Default = () => {
   );
 
   return (
-    <DataGrid items={items} columns={columns}>
+    <DataGrid items={items} columns={columns} focusMode="cell">
       <DataGridHeader>
         <DataGridRow>
           {({ renderHeaderCell, columnId }: ColumnDefinition<Item>) => (

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -88,61 +88,66 @@ const items: Item[] = [
   },
 ];
 
-const columns: ColumnDefinition<Item>[] = [
-  createColumn<Item>({
-    columnId: 'file',
-    compare: (a, b) => {
-      return a.file.label.localeCompare(b.file.label);
-    },
-    renderHeaderCell: () => {
-      return 'File';
-    },
-    renderCell: item => {
-      return <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>;
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
-    renderHeaderCell: () => {
-      return 'Author';
-    },
-    renderCell: item => {
-      return (
-        <TableCellLayout media={<Avatar badge={{ status: item.author.status }} />}>{item.author.label}</TableCellLayout>
-      );
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdated',
-    compare: (a, b) => {
-      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
-    },
-    renderHeaderCell: () => {
-      return 'Last updated';
-    },
-
-    renderCell: item => {
-      return item.lastUpdated.label;
-    },
-  }),
-  createColumn<Item>({
-    columnId: 'lastUpdate',
-    compare: (a, b) => {
-      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
-    },
-    renderHeaderCell: () => {
-      return 'Last update';
-    },
-    renderCell: item => {
-      return <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>;
-    },
-  }),
-];
-
 export const Default = () => {
+  const columns: ColumnDefinition<Item>[] = React.useMemo(
+    () => [
+      createColumn<Item>({
+        columnId: 'file',
+        compare: (a, b) => {
+          return a.file.label.localeCompare(b.file.label);
+        },
+        renderHeaderCell: () => {
+          return 'File';
+        },
+        renderCell: item => {
+          return <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>;
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'author',
+        compare: (a, b) => {
+          return a.author.label.localeCompare(b.author.label);
+        },
+        renderHeaderCell: () => {
+          return 'Author';
+        },
+        renderCell: item => {
+          return (
+            <TableCellLayout media={<Avatar badge={{ status: item.author.status }} />}>
+              {item.author.label}
+            </TableCellLayout>
+          );
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdated',
+        compare: (a, b) => {
+          return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
+        },
+        renderHeaderCell: () => {
+          return 'Last updated';
+        },
+
+        renderCell: item => {
+          return item.lastUpdated.label;
+        },
+      }),
+      createColumn<Item>({
+        columnId: 'lastUpdate',
+        compare: (a, b) => {
+          return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
+        },
+        renderHeaderCell: () => {
+          return 'Last update';
+        },
+        renderCell: item => {
+          return <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>;
+        },
+      }),
+    ],
+    [],
+  );
+
   return (
     <DataGrid items={items} columns={columns}>
       <DataGridHeader>


### PR DESCRIPTION
Applies `useArrowNagivationGroup` by default to `DataGrid` when the `focusMode` prop is set. Also sets correct roles for `grid

Fixes #25478 
Fixes #25477
