### PR TITLE
fix(storybook): fix theme picker current selection

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/ThemePicker.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/ThemePicker.stories.tsx
@@ -32,15 +32,18 @@ const useStyles = makeStyles({
  */
 export const ThemePicker: React.FC<{ selectedThemeId?: string }> = ({ selectedThemeId }) => {
   const styles = useStyles();
+  const [currentThemeId, setCurrentThemeId] = React.useState(selectedThemeId ?? null);
 
   const setGlobalTheme = (themeId: ThemeIds): void => {
     addons.getChannel().emit('updateGlobals', { globals: { [THEME_ID]: themeId } });
   };
   const onCheckedValueChange: MenuProps['onCheckedValueChange'] = (e, data) => {
-    setGlobalTheme(data.checkedItems[0] as ThemeIds);
+    const newThemeId = data.checkedItems[0] as ThemeIds;
+    setGlobalTheme(newThemeId);
+    setCurrentThemeId(newThemeId);
   };
 
-  const selectedTheme = themes.find(theme => theme.id === selectedThemeId);
+  const selectedTheme = themes.find(theme => theme.id === currentThemeId);
 
   return (
     <Menu


### PR DESCRIPTION
## Current Behavior

Whenever you select a new value in the theme picker in a storybook, the value isn't updated until you switch to another story, most likely caused by 

`addons.getChannel().emit('updateGlobals', { globals: { [THEME_ID]: themeId } });`

not triggering an update at component level.

## New Behavior

Using a local state in the theme switcher for the current value so it always shows what's been currently selected.
