### PR TITLE
fix(react-components): stories for migrated v9 packages are included again

### DIFF
--- a/change/@fluentui-react-components-ba631a4c-e394-4ffa-b4f3-e84de4f8c733.json
+++ b/change/@fluentui-react-components-ba631a4c-e394-4ffa-b4f3-e84de4f8c733.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: stories from migrated v9 packages are now included.",
+  "packageName": "@fluentui/react-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/.storybook/main.utils.js
+++ b/packages/react-components/react-components/.storybook/main.utils.js
@@ -19,9 +19,14 @@ function getVnextStories() {
     .filter(pkgName => pkgName.startsWith('@fluentui/') && !excludedDependencies.includes(pkgName))
     .map(pkgName => {
       const name = pkgName.replace('@fluentui/', '');
-      const storiesGlob = '/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
+      const storiesGlob = '**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
 
-      return `../../${name}${storiesGlob}`;
+      //TODO: simplify once v9 migration [https://github.com/microsoft/fluentui/issues/24129] is complete.
+      if (fs.existsSync(`../${name}/stories/`)) {
+        return `../../${name}/stories/${storiesGlob}`;
+      } else {
+        return `../../${name}/src/${storiesGlob}`;
+      }
     });
 }
 

--- a/packages/react-components/react-components/.storybook/main.utils.test.js
+++ b/packages/react-components/react-components/.storybook/main.utils.test.js
@@ -14,7 +14,7 @@ describe(`main utils`, () => {
 
       const first = actual[0];
       expect(first.startsWith('../../react-')).toBeTruthy();
-      expect(first.endsWith('/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)')).toBeTruthy();
+      expect(first.endsWith('/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->
- stories of migrated v9 packages as part of #24129 don't load when running `yarn workspace @fluentui/react-components start`
## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- stories of migrated v9 packages are now included

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Part of #24129 
