### PR TITLE
Fix: Update tabs to remain the same size between unselected and selected states

### DIFF
--- a/change/@fluentui-react-tabs-5857fdb2-8ae6-4796-9d11-757f662e5046.json
+++ b/change/@fluentui-react-tabs-5857fdb2-8ae6-4796-9d11-757f662e5046.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added support for reserving space for selected state",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/etc/react-tabs.api.md
+++ b/packages/react-components/react-tabs/etc/react-tabs.api.md
@@ -44,7 +44,7 @@ export const TabList: ForwardRefComponent<TabListProps>;
 export const tabListClassNames: SlotClassNames<TabListSlots>;
 
 // @public (undocumented)
-export type TabListContextValue = Pick<TabListProps, 'onTabSelect' | 'selectedValue'> & Required<Pick<TabListProps, 'appearance' | 'disabled' | 'size' | 'vertical'>> & {
+export type TabListContextValue = Pick<TabListProps, 'onTabSelect' | 'selectedValue' | 'reserveSelectedTabSpace'> & Required<Pick<TabListProps, 'appearance' | 'disabled' | 'size' | 'vertical'>> & {
     onRegister: RegisterTabEventHandler;
     onUnregister: RegisterTabEventHandler;
     onSelect: SelectTabEventHandler;
@@ -63,6 +63,7 @@ export type TabListContextValues = {
 // @public
 export type TabListProps = ComponentProps<TabListSlots> & {
     appearance?: 'transparent' | 'subtle';
+    reserveSelectedTabSpace?: boolean;
     defaultSelectedValue?: TabValue;
     disabled?: boolean;
     onTabSelect?: SelectTabEventHandler;
@@ -103,6 +104,7 @@ export type TabState = ComponentState<TabSlots> & Pick<TabProps, 'value'> & Requ
     appearance?: 'transparent' | 'subtle';
     iconOnly: boolean;
     selected: boolean;
+    contentReservedSpaceClassName?: string;
     size: 'small' | 'medium';
     vertical: boolean;
 };

--- a/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
@@ -60,7 +60,7 @@ export type TabState = ComponentState<TabSlots> &
      * When defined, tab content with selected style is rendered hidden to reserve space.
      * This keeps consistent content size between unselected and selected states.
      */
-    selectedTabContentClassName?: string;
+    contentReservedSpaceClassName?: string;
     /**
      * A tab can be either 'small' or 'medium' size.
      */

--- a/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
@@ -57,6 +57,11 @@ export type TabState = ComponentState<TabSlots> &
      */
     selected: boolean;
     /**
+     * When defined, tab content with selected style is rendered hidden to reserve space.
+     * This keeps consistent content size between unselected and selected states.
+     */
+    selectedTabContentClassName?: string;
+    /**
      * A tab can be either 'small' or 'medium' size.
      */
     size: 'small' | 'medium';

--- a/packages/react-components/react-tabs/src/components/Tab/renderTab.tsx
+++ b/packages/react-components/react-tabs/src/components/Tab/renderTab.tsx
@@ -12,6 +12,9 @@ export const renderTab_unstable = (state: TabState) => {
     <slots.root {...slotProps.root}>
       {slots.icon && <slots.icon {...slotProps.icon} />}
       {!state.iconOnly && <slots.content {...slotProps.content} />}
+      {!state.selected && !state.iconOnly && state.selectedTabContentClassName !== undefined && (
+        <slots.content {...slotProps.content} className={state.selectedTabContentClassName} />
+      )}
     </slots.root>
   );
 };

--- a/packages/react-components/react-tabs/src/components/Tab/renderTab.tsx
+++ b/packages/react-components/react-tabs/src/components/Tab/renderTab.tsx
@@ -12,8 +12,8 @@ export const renderTab_unstable = (state: TabState) => {
     <slots.root {...slotProps.root}>
       {slots.icon && <slots.icon {...slotProps.icon} />}
       {!state.iconOnly && <slots.content {...slotProps.content} />}
-      {!state.selected && !state.iconOnly && state.selectedTabContentClassName !== undefined && (
-        <slots.content {...slotProps.content} className={state.selectedTabContentClassName} />
+      {!state.selected && !state.iconOnly && state.contentReservedSpaceClassName !== undefined && (
+        <slots.content {...slotProps.content} className={state.contentReservedSpaceClassName} />
       )}
     </slots.root>
   );

--- a/packages/react-components/react-tabs/src/components/Tab/useTab.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTab.ts
@@ -18,6 +18,7 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
   const { content, disabled: tabDisabled = false, icon, value } = props;
 
   const appearance = useContextSelector(TabListContext, ctx => ctx.appearance);
+  const consistentTabSize = useContextSelector(TabListContext, ctx => ctx.keepTabSizeConsistent);
   const listDisabled = useContextSelector(TabListContext, ctx => ctx.disabled);
   const selected = useContextSelector(TabListContext, ctx => ctx.selectedValue === value);
   const onRegister = useContextSelector(TabListContext, ctx => ctx.onRegister);
@@ -64,6 +65,7 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
     iconOnly: Boolean(iconShorthand?.children && !contentShorthand.children),
     content: contentShorthand,
     appearance,
+    selectedTabContentClassName: consistentTabSize ? '' : undefined,
     disabled,
     selected,
     size,

--- a/packages/react-components/react-tabs/src/components/Tab/useTab.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTab.ts
@@ -18,7 +18,7 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
   const { content, disabled: tabDisabled = false, icon, value } = props;
 
   const appearance = useContextSelector(TabListContext, ctx => ctx.appearance);
-  const consistentTabSize = useContextSelector(TabListContext, ctx => ctx.keepTabSizeConsistent);
+  const reserveSelectedTabSpace = useContextSelector(TabListContext, ctx => ctx.reserveSelectedTabSpace);
   const listDisabled = useContextSelector(TabListContext, ctx => ctx.disabled);
   const selected = useContextSelector(TabListContext, ctx => ctx.selectedValue === value);
   const onRegister = useContextSelector(TabListContext, ctx => ctx.onRegister);
@@ -65,7 +65,7 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
     iconOnly: Boolean(iconShorthand?.children && !contentShorthand.children),
     content: contentShorthand,
     appearance,
-    selectedTabContentClassName: consistentTabSize ? '' : undefined,
+    contentReservedSpaceClassName: reserveSelectedTabSpace ? '' : undefined,
     disabled,
     selected,
     size,

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
@@ -12,6 +12,10 @@ export const tabClassNames: SlotClassNames<TabSlots> = {
   content: 'fui-Tab__content',
 };
 
+const reservedSpaceClassNames = {
+  content: 'fui-Tab__content--reserved-space',
+};
+
 /**
  * Styles for the root slot
  */
@@ -406,9 +410,9 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
   }
 
   // This needs to be before state.content.className is updated
-  if (state.selectedTabContentClass !== undefined) {
-    state.selectedTabContentClass = mergeClasses(
-      tabClassNames.content,
+  if (state.contentReservedSpaceClassName !== undefined) {
+    state.contentReservedSpaceClassName = mergeClasses(
+      reservedSpaceClassNames.content,
       contentStyles.base,
       contentStyles.selected,
       state.icon ? contentStyles.iconBefore : contentStyles.noIconBefore,

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
@@ -309,6 +309,8 @@ const useActiveIndicatorStyles = makeStyles({
  */
 const useIconStyles = makeStyles({
   base: {
+    gridColumnStart: 1,
+    gridRowStart: 1,
     alignItems: 'center',
     display: 'inline-flex',
     justifyContent: 'center',
@@ -340,6 +342,17 @@ const useContentStyles = makeStyles({
   },
   selected: {
     ...typographyStyles.body1Strong,
+  },
+  noIconBefore: {
+    gridColumnStart: 1,
+    gridRowStart: 1,
+  },
+  iconBefore: {
+    gridColumnStart: 2,
+    gridRowStart: 1,
+  },
+  placeholder: {
+    visibility: 'hidden',
   },
 });
 
@@ -384,6 +397,7 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
       size === 'small' &&
       (vertical ? activeIndicatorStyles.smallVertical : activeIndicatorStyles.smallHorizontal),
     selected && disabled && activeIndicatorStyles.disabled,
+
     state.root.className,
   );
 
@@ -391,10 +405,23 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
     state.icon.className = mergeClasses(tabClassNames.icon, iconStyles.base, iconStyles[size], state.icon.className);
   }
 
+  // This needs to be before state.content.className is updated
+  if (state.selectedTabContentClass !== undefined) {
+    state.selectedTabContentClass = mergeClasses(
+      tabClassNames.content,
+      contentStyles.base,
+      contentStyles.selected,
+      state.icon ? contentStyles.iconBefore : contentStyles.noIconBefore,
+      contentStyles.placeholder,
+      state.content.className,
+    );
+  }
+
   state.content.className = mergeClasses(
     tabClassNames.content,
     contentStyles.base,
     selected && contentStyles.selected,
+    state.icon ? contentStyles.iconBefore : contentStyles.noIconBefore,
     state.content.className,
   );
 

--- a/packages/react-components/react-tabs/src/components/TabList/TabList.types.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/TabList.types.ts
@@ -49,13 +49,12 @@ export type TabListProps = ComponentProps<TabListSlots> & {
 
   /**
    * Tab size may change between unselected and selected states.
-   * The default scenario is the selected tab has bold text.
+   * The default scenario is a selected tab has bold text.
    *
-   * When true, this property causes unselected tabs to be the same size as when selected.
-   * This is done by rendering the content again with the selected styles and visibility:hidden.
+   * When true, this property requests tabs be the same size whether unselected or selected.
    * @default 'true'
    */
-  keepTabSizeConsistent?: boolean;
+  reserveSelectedTabSpace?: boolean;
 
   /**
    * The value of the tab to be selected by default.
@@ -92,8 +91,8 @@ export type TabListProps = ComponentProps<TabListSlots> & {
   vertical?: boolean;
 };
 
-export type TabListContextValue = Pick<TabListProps, 'onTabSelect' | 'selectedValue'> &
-  Required<Pick<TabListProps, 'appearance' | 'disabled' | 'size' | 'vertical' | 'keepTabSizeConsistent'>> & {
+export type TabListContextValue = Pick<TabListProps, 'onTabSelect' | 'selectedValue' | 'reserveSelectedTabSpace'> &
+  Required<Pick<TabListProps, 'appearance' | 'disabled' | 'size' | 'vertical'>> & {
     /** A callback to allow a tab to register itself with the tab list. */
     onRegister: RegisterTabEventHandler;
 

--- a/packages/react-components/react-tabs/src/components/TabList/TabList.types.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/TabList.types.ts
@@ -48,6 +48,16 @@ export type TabListProps = ComponentProps<TabListSlots> & {
   appearance?: 'transparent' | 'subtle';
 
   /**
+   * Tab size may change between unselected and selected states.
+   * The default scenario is the selected tab has bold text.
+   *
+   * When true, this property causes unselected tabs to be the same size as when selected.
+   * This is done by rendering the content again with the selected styles and visibility:hidden.
+   * @default 'true'
+   */
+  keepTabSizeConsistent?: boolean;
+
+  /**
    * The value of the tab to be selected by default.
    * Typically useful when the selectedValue is uncontrolled.
    */
@@ -83,7 +93,7 @@ export type TabListProps = ComponentProps<TabListSlots> & {
 };
 
 export type TabListContextValue = Pick<TabListProps, 'onTabSelect' | 'selectedValue'> &
-  Required<Pick<TabListProps, 'appearance' | 'disabled' | 'size' | 'vertical'>> & {
+  Required<Pick<TabListProps, 'appearance' | 'disabled' | 'size' | 'vertical' | 'keepTabSizeConsistent'>> & {
     /** A callback to allow a tab to register itself with the tab list. */
     onRegister: RegisterTabEventHandler;
 

--- a/packages/react-components/react-tabs/src/components/TabList/TabList.types.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/TabList.types.ts
@@ -52,7 +52,7 @@ export type TabListProps = ComponentProps<TabListSlots> & {
    * The default scenario is a selected tab has bold text.
    *
    * When true, this property requests tabs be the same size whether unselected or selected.
-   * @default 'true'
+   * @default true
    */
   reserveSelectedTabSpace?: boolean;
 

--- a/packages/react-components/react-tabs/src/components/TabList/TabListContext.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/TabListContext.ts
@@ -5,6 +5,7 @@ import { TabListContextValue } from './TabList.types';
 // eslint-disable-next-line @fluentui/no-context-default-value
 export const TabListContext: Context<TabListContextValue> = createContext<TabListContextValue>({
   appearance: 'transparent',
+  keepTabSizeConsistent: true,
   disabled: false,
   selectedValue: undefined,
   onRegister: () => {

--- a/packages/react-components/react-tabs/src/components/TabList/TabListContext.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/TabListContext.ts
@@ -5,7 +5,7 @@ import { TabListContextValue } from './TabList.types';
 // eslint-disable-next-line @fluentui/no-context-default-value
 export const TabListContext: Context<TabListContextValue> = createContext<TabListContextValue>({
   appearance: 'transparent',
-  keepTabSizeConsistent: true,
+  reserveSelectedTabSpace: true,
   disabled: false,
   selectedValue: undefined,
   onRegister: () => {

--- a/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
@@ -19,6 +19,11 @@ exports[`TabList renders tabs when disabled 1`] = `
       >
         First
       </span>
+      <span
+        class="fui-Tab__content--reserved-space"
+      >
+        First
+      </span>
     </button>
     <button
       class="fui-Tab"
@@ -42,6 +47,11 @@ exports[`TabList renders tabs when disabled 1`] = `
     >
       <span
         class="fui-Tab__content"
+      >
+        Third
+      </span>
+      <span
+        class="fui-Tab__content--reserved-space"
       >
         Third
       </span>
@@ -70,6 +80,11 @@ exports[`TabList renders tabs with default selected tab 1`] = `
       >
         First
       </span>
+      <span
+        class="fui-Tab__content--reserved-space"
+      >
+        First
+      </span>
     </button>
     <button
       aria-selected="true"
@@ -95,6 +110,11 @@ exports[`TabList renders tabs with default selected tab 1`] = `
     >
       <span
         class="fui-Tab__content"
+      >
+        Third
+      </span>
+      <span
+        class="fui-Tab__content--reserved-space"
       >
         Third
       </span>
@@ -133,6 +153,11 @@ exports[`TabList renders with tabs 1`] = `
       >
         First
       </span>
+      <span
+        class="fui-Tab__content--reserved-space"
+      >
+        First
+      </span>
     </button>
     <button
       aria-selected="false"
@@ -147,6 +172,11 @@ exports[`TabList renders with tabs 1`] = `
       >
         Second
       </span>
+      <span
+        class="fui-Tab__content--reserved-space"
+      >
+        Second
+      </span>
     </button>
     <button
       aria-selected="false"
@@ -158,6 +188,11 @@ exports[`TabList renders with tabs 1`] = `
     >
       <span
         class="fui-Tab__content"
+      >
+        Third
+      </span>
+      <span
+        class="fui-Tab__content--reserved-space"
       >
         Third
       </span>

--- a/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
@@ -21,7 +21,7 @@ import { TabValue } from '../Tab/Tab.types';
 export const useTabList_unstable = (props: TabListProps, ref: React.Ref<HTMLElement>): TabListState => {
   const {
     appearance = 'transparent',
-    keepTabSizeConsistent = true,
+    reserveSelectedTabSpace = true,
     disabled = false,
     onTabSelect,
     size = 'medium',
@@ -88,7 +88,7 @@ export const useTabList_unstable = (props: TabListProps, ref: React.Ref<HTMLElem
       ...props,
     }),
     appearance,
-    keepTabSizeConsistent,
+    reserveSelectedTabSpace,
     disabled,
     selectedValue,
     size,

--- a/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
@@ -19,7 +19,14 @@ import { TabValue } from '../Tab/Tab.types';
  * @param ref - reference to root HTMLElement of TabList
  */
 export const useTabList_unstable = (props: TabListProps, ref: React.Ref<HTMLElement>): TabListState => {
-  const { appearance = 'transparent', disabled = false, onTabSelect, size = 'medium', vertical = false } = props;
+  const {
+    appearance = 'transparent',
+    keepTabSizeConsistent = true,
+    disabled = false,
+    onTabSelect,
+    size = 'medium',
+    vertical = false,
+  } = props;
 
   const innerRef = React.useRef<HTMLElement>(null);
 
@@ -81,6 +88,7 @@ export const useTabList_unstable = (props: TabListProps, ref: React.Ref<HTMLElem
       ...props,
     }),
     appearance,
+    keepTabSizeConsistent,
     disabled,
     selectedValue,
     size,

--- a/packages/react-components/react-tabs/src/components/TabList/useTabListContextValues.tsx
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabListContextValues.tsx
@@ -3,7 +3,7 @@ import { TabListContextValue, TabListContextValues, TabListState } from './TabLi
 export function useTabListContextValues(state: TabListState): TabListContextValues {
   const {
     appearance,
-    reserveSelectedTabSpace: keepTabSizeConsistent,
+    reserveSelectedTabSpace,
     disabled,
     selectedValue: selectedKey,
     onRegister,
@@ -16,7 +16,7 @@ export function useTabListContextValues(state: TabListState): TabListContextValu
 
   const tabList: TabListContextValue = {
     appearance,
-    reserveSelectedTabSpace: keepTabSizeConsistent,
+    reserveSelectedTabSpace,
     disabled,
     selectedValue: selectedKey,
     onSelect,

--- a/packages/react-components/react-tabs/src/components/TabList/useTabListContextValues.tsx
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabListContextValues.tsx
@@ -3,6 +3,7 @@ import { TabListContextValue, TabListContextValues, TabListState } from './TabLi
 export function useTabListContextValues(state: TabListState): TabListContextValues {
   const {
     appearance,
+    keepTabSizeConsistent,
     disabled,
     selectedValue: selectedKey,
     onRegister,
@@ -15,6 +16,7 @@ export function useTabListContextValues(state: TabListState): TabListContextValu
 
   const tabList: TabListContextValue = {
     appearance,
+    keepTabSizeConsistent,
     disabled,
     selectedValue: selectedKey,
     onSelect,

--- a/packages/react-components/react-tabs/src/components/TabList/useTabListContextValues.tsx
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabListContextValues.tsx
@@ -3,7 +3,7 @@ import { TabListContextValue, TabListContextValues, TabListState } from './TabLi
 export function useTabListContextValues(state: TabListState): TabListContextValues {
   const {
     appearance,
-    keepTabSizeConsistent,
+    reserveSelectedTabSpace: keepTabSizeConsistent,
     disabled,
     selectedValue: selectedKey,
     onRegister,
@@ -16,7 +16,7 @@ export function useTabListContextValues(state: TabListState): TabListContextValu
 
   const tabList: TabListContextValue = {
     appearance,
-    keepTabSizeConsistent,
+    reserveSelectedTabSpace: keepTabSizeConsistent,
     disabled,
     selectedValue: selectedKey,
     onSelect,


### PR DESCRIPTION
## Fix
Currently tab size is based on the content within.  When a tab is selected, a bold font is used.  This causes tabs to be different sizes between unselected and selected states creating a visual movement of tabs.

This updates TabList and Tab to reserve space in unselected tabs to the content is the same size for both states.  This eliminates the visual movements of tabs.

## Changes
- Added reserveSelectedTabSpace to TabList context
- Added contentReservedSpaceClassName to TabState
- Updated useTab to set contentReservedSpaceClassName based on context reserveSelectedTabSpace
- Updated useTabStyles to set contentReservedSpaceClassName style to match selected tab content style
- Updated renderTab to render content slot again with with selected tab content style and visibility:hidden
- Updates test snapshots

## Issues
Fixes #23947

## Open issues
Need to measure perf impact of rendering content twice in every tab.

## Screenshots

### Before
See associated issue.

### After
https://user-images.githubusercontent.com/28762486/200083589-b01f4332-6d06-4d6e-8f46-6e0e81ea7f3a.mov

