### PR TITLE
Expand @fluentui/react root index file's export *s to uncover and fix duplicate exports.

### DIFF
--- a/change/@fluentui-eslint-plugin-ae682cae-04ae-4e42-a4ba-cbf2525ad490.json
+++ b/change/@fluentui-eslint-plugin-ae682cae-04ae-4e42-a4ba-cbf2525ad490.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating react-legacy linting to warn on export star usage.",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-10ceb504-58ea-4967-b2d3-daae2d632740.json
+++ b/change/@fluentui-react-10ceb504-58ea-4967-b2d3-daae2d632740.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "This change removes top-level export * from the index.js of @fluentui/react, which was implicitly exporting duplicates of symbols. Changing to explicit exports means that the export * as the top level barrel file can't introduce duplicate names. This works around an issue identified in esbuild: https://github.com/evanw/esbuild/issues/2658",
+  "packageName": "@fluentui/react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/base-legacy.js
+++ b/packages/eslint-plugin/src/configs/base-legacy.js
@@ -14,5 +14,13 @@ module.exports = {
      */
     ...getNamingConventionRule({ prefixInterface: true }),
   },
-  overrides: [],
+  overrides: [
+    {
+      files: '**/src/index.{ts,tsx,js}',
+      rules: {
+        // TODO: propagate to `error` once all packages barrel files have been fixed
+        '@rnx-kit/no-export-all': ['warn', { expand: 'all' }],
+      },
+    },
+  ],
 };

--- a/packages/eslint-plugin/src/configs/react-legacy.js
+++ b/packages/eslint-plugin/src/configs/react-legacy.js
@@ -10,4 +10,13 @@ module.exports = {
     'jsdoc/check-tag-names': 'off',
     '@griffel/no-shorthands': 'off',
   },
+  overrides: [
+    {
+      files: '**/src/index.{ts,tsx,js}',
+      rules: {
+        // TODO: propagate to `error` once all packages barrel files have been fixed
+        '@rnx-kit/no-export-all': ['warn', { expand: 'all' }],
+      },
+    },
+  ],
 };

--- a/packages/eslint-plugin/src/configs/react-legacy.js
+++ b/packages/eslint-plugin/src/configs/react-legacy.js
@@ -10,13 +10,5 @@ module.exports = {
     'jsdoc/check-tag-names': 'off',
     '@griffel/no-shorthands': 'off',
   },
-  overrides: [
-    {
-      files: '**/src/index.{ts,tsx,js}',
-      rules: {
-        // TODO: propagate to `error` once all packages barrel files have been fixed
-        '@rnx-kit/no-export-all': ['warn', { expand: 'all' }],
-      },
-    },
-  ],
+  overrides: [],
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable deprecation/deprecation */
 export { ActivityItem, getActivityItemClassNames, getActivityItemStyles } from './ActivityItem';
 export type { IActivityItemClassNames, IActivityItemProps, IActivityItemStyles } from './ActivityItem';
 export { Autofill } from './Autofill';
@@ -7,6 +6,7 @@ export { Announced, AnnouncedBase } from './Announced';
 export type { IAnnouncedProps, IAnnouncedStyleProps, IAnnouncedStyles } from './Announced';
 export { Breadcrumb, BreadcrumbBase } from './Breadcrumb';
 export type {
+  // eslint-disable-next-line deprecation/deprecation
   IBreadCrumbData,
   IBreadcrumb,
   IBreadcrumbData,
@@ -19,6 +19,7 @@ export type {
 export {
   ActionButton,
   BaseButton,
+  // eslint-disable-next-line deprecation/deprecation
   Button,
   ButtonGlobalClassNames,
   ButtonType,
@@ -57,6 +58,7 @@ export {
   FirstWeekOfYear,
   defaultCalendarNavigationIcons,
   defaultCalendarStrings,
+  // eslint-disable-next-line deprecation/deprecation
   defaultDayPickerStrings,
 } from './Calendar';
 export type {
@@ -69,7 +71,9 @@ export type {
   ICalendarDayProps,
   ICalendarDayStyleProps,
   ICalendarDayStyles,
+  // eslint-disable-next-line deprecation/deprecation
   ICalendarFormatDateCallbacks,
+  // eslint-disable-next-line deprecation/deprecation
   ICalendarIconStrings,
   ICalendarMonth,
   ICalendarMonthProps,
@@ -122,6 +126,7 @@ export type {
   ICoachmarkProps,
   ICoachmarkStyleProps,
   ICoachmarkStyles,
+  // eslint-disable-next-line deprecation/deprecation
   ICoachmarkTypes,
   IEntityRect,
 } from './Coachmark';
@@ -130,6 +135,7 @@ export {
   MAX_COLOR_ALPHA,
   MAX_COLOR_HUE,
   MAX_COLOR_RGB,
+  // eslint-disable-next-line deprecation/deprecation
   MAX_COLOR_RGBA,
   MAX_COLOR_SATURATION,
   MAX_COLOR_VALUE,
@@ -212,6 +218,7 @@ export {
   ContextualMenuItemBase,
   ContextualMenuItemType,
   canAnyMenuItemsCheck,
+  // eslint-disable-next-line deprecation/deprecation
   getContextualMenuItemClassNames,
   getContextualMenuItemStyles,
   getMenuItemStyles,
@@ -219,6 +226,7 @@ export {
 } from './ContextualMenu';
 export type {
   IContextualMenu,
+  // eslint-disable-next-line deprecation/deprecation
   IContextualMenuClassNames,
   IContextualMenuItem,
   IContextualMenuItemProps,
@@ -233,6 +241,7 @@ export type {
   IContextualMenuStyleProps,
   IContextualMenuStyles,
   IContextualMenuSubComponentStyles,
+  // eslint-disable-next-line deprecation/deprecation
   IMenuItemClassNames,
   IMenuItemStyles,
 } from './ContextualMenu';
@@ -392,6 +401,7 @@ export type {
 } from './Dialog';
 export { VerticalDivider } from './Divider';
 export type {
+  // eslint-disable-next-line deprecation/deprecation
   IVerticalDividerClassNames,
   IVerticalDividerProps,
   IVerticalDividerPropsStyles,
@@ -474,7 +484,11 @@ export type {
   IExtendedPeoplePickerProps,
   IPeoplePickerItemProps,
 } from './ExtendedPicker';
-export { Fabric, FabricBase } from './Fabric';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  Fabric,
+  FabricBase,
+} from './Fabric';
 export type { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric';
 export { Facepile, FacepileBase, OverflowButtonType } from './Facepile';
 export type { IFacepile, IFacepilePersona, IFacepileProps, IFacepileStyleProps, IFacepileStyles } from './Facepile';
@@ -529,7 +543,9 @@ export type {
   IGroupShowAllStyleProps,
   IGroupShowAllStyles,
   IGroupSpacerProps,
+  // eslint-disable-next-line deprecation/deprecation
   IGroupSpacerStyleProps,
+  // eslint-disable-next-line deprecation/deprecation
   IGroupSpacerStyles,
   IGroupedListSectionProps,
   IGroupedListSectionState,
@@ -562,7 +578,16 @@ export type {
   IPlainCardStyleProps,
   IPlainCardStyles,
 } from './HoverCard';
-export { FontIcon, Icon, IconBase, IconType, ImageIcon, getFontIcon, getIconContent } from './Icon';
+export {
+  FontIcon,
+  Icon,
+  IconBase,
+  // eslint-disable-next-line deprecation/deprecation
+  IconType,
+  ImageIcon,
+  getFontIcon,
+  getIconContent,
+} from './Icon';
 export type {
   IFontIconProps,
   IIconContent,
@@ -573,7 +598,10 @@ export type {
   IImageIconProps,
 } from './Icon';
 export { initializeIcons } from './Icons';
-export type { IconNames } from './Icons';
+export type {
+  // eslint-disable-next-line deprecation/deprecation
+  IconNames,
+} from './Icons';
 export { Image, ImageBase, ImageCoverStyle, ImageFit, ImageLoadState } from './Image';
 export type { IImage, IImageProps, IImageState, IImageStyleProps, IImageStyles } from './Image';
 export {
@@ -641,7 +669,14 @@ export {
 } from './Layer';
 export type { ILayer, ILayerHost, ILayerHostProps, ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer';
 export { Link, LinkBase } from './Link';
-export type { ILink, ILinkHTMLAttributes, ILinkProps, ILinkStyleProps, ILinkStyles } from './Link';
+export type {
+  ILink,
+  // eslint-disable-next-line deprecation/deprecation
+  ILinkHTMLAttributes,
+  ILinkProps,
+  ILinkStyleProps,
+  ILinkStyles,
+} from './Link';
 export { List, ScrollToMode } from './List';
 export type {
   IList,
@@ -775,8 +810,10 @@ export type {
   IPeoplePickerItemSuggestionProps,
   IPeoplePickerItemSuggestionStyleProps,
   IPeoplePickerItemSuggestionStyles,
+  // eslint-disable-next-line deprecation/deprecation
   IPeoplePickerItemWithMenuProps,
   IPeoplePickerProps,
+  // eslint-disable-next-line deprecation/deprecation
   IPersonaWithMenu,
   IPickerAriaIds,
   IPickerItem,
@@ -801,7 +838,15 @@ export type {
   ITagItemSuggestionStyles,
   ITagPickerProps,
 } from './Pickers';
-export { Pivot, PivotBase, PivotItem, PivotLinkFormat, PivotLinkSize } from './Pivot';
+export {
+  Pivot,
+  PivotBase,
+  PivotItem,
+  // eslint-disable-next-line deprecation/deprecation
+  PivotLinkFormat,
+  // eslint-disable-next-line deprecation/deprecation
+  PivotLinkSize,
+} from './Pivot';
 export type {
   IPivot,
   IPivotItemProps,
@@ -829,6 +874,7 @@ export type {
   ICalloutPositionedInfo,
   IElementPosition,
   IElementPositionInfo,
+  // eslint-disable-next-line deprecation/deprecation
   IPoint,
   IPosition,
   IPositionDirectionalHintData,
@@ -842,6 +888,7 @@ export { PositioningContainer, useHeightOffset } from './PositioningContainer';
 export type {
   IPositioningContainer,
   IPositioningContainerProps,
+  // eslint-disable-next-line deprecation/deprecation
   IPositioningContainerTypes,
 } from './PositioningContainer';
 export { ProgressIndicator, ProgressIndicatorBase } from './ProgressIndicator';
@@ -874,9 +921,13 @@ export {
   initializeResponsiveMode,
   setResponsiveMode,
   useResponsiveMode,
+  // eslint-disable-next-line deprecation/deprecation
   withResponsiveMode,
 } from './ResponsiveMode';
-export type { IWithResponsiveModeState } from './ResponsiveMode';
+export type {
+  // eslint-disable-next-line deprecation/deprecation
+  IWithResponsiveModeState,
+} from './ResponsiveMode';
 export { ScrollablePane, ScrollablePaneBase, ScrollablePaneContext, ScrollbarVisibility } from './ScrollablePane';
 export type {
   IScrollablePane,
@@ -961,7 +1012,13 @@ export { Slider, SliderBase } from './Slider';
 export type { ISlider, ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider';
 export { KeyboardSpinDirection, SpinButton } from './SpinButton';
 export type { ISpinButton, ISpinButtonProps, ISpinButtonStyleProps, ISpinButtonStyles } from './SpinButton';
-export { Spinner, SpinnerBase, SpinnerSize, SpinnerType } from './Spinner';
+export {
+  Spinner,
+  SpinnerBase,
+  SpinnerSize,
+  // eslint-disable-next-line deprecation/deprecation
+  SpinnerType,
+} from './Spinner';
 export type { ISpinner, ISpinnerProps, ISpinnerStyleProps, ISpinnerStyles, SpinnerLabelPosition } from './Spinner';
 export { Stack, StackItem } from './Stack';
 export type {
@@ -993,6 +1050,7 @@ export {
   DefaultEffects,
   DefaultFontStyles,
   DefaultPalette,
+  // eslint-disable-next-line deprecation/deprecation
   EdgeChromiumHighContrastSelector,
   FontClassNames,
   FontSizes,
@@ -1025,9 +1083,11 @@ export {
   createTheme,
   focusClear,
   fontFace,
+  // eslint-disable-next-line deprecation/deprecation
   getEdgeChromiumNoHighContrastAdjustSelector,
   getFadedOverflowStyle,
   getFocusOutlineStyle,
+  // eslint-disable-next-line deprecation/deprecation
   getFocusStyle,
   getGlobalClassNames,
   getHighContrastNoAdjustStyle,
@@ -1154,8 +1214,10 @@ export type {
 export {
   Async,
   AutoScroll,
+  // eslint-disable-next-line deprecation/deprecation
   BaseComponent,
   Customizations,
+  // eslint-disable-next-line deprecation/deprecation
   Customizer,
   CustomizerContext,
   DATA_IS_SCROLLABLE_ATTRIBUTE,
@@ -1236,6 +1298,7 @@ export {
   getRTL,
   getRTLSafeKeyCode,
   getRect,
+  // eslint-disable-next-line deprecation/deprecation
   getResourceUrl,
   getScrollbarWidth,
   getVirtualParent,
@@ -1247,9 +1310,11 @@ export {
   hoistStatics,
   htmlElementProperties,
   iframeProperties,
+  // eslint-disable-next-line deprecation/deprecation
   imageProperties,
   imgProperties,
   initializeComponentRef,
+  // eslint-disable-next-line deprecation/deprecation
   initializeFocusRects,
   inputProperties,
   isControlled,
@@ -1281,6 +1346,7 @@ export {
   optionProperties,
   portalContainsElement,
   precisionRound,
+  // eslint-disable-next-line deprecation/deprecation
   raiseClick,
   removeDirectionalKeyCode,
   removeIndex,
@@ -1291,12 +1357,15 @@ export {
   safeRequestAnimationFrame,
   safeSetTimeout,
   selectProperties,
+  // eslint-disable-next-line deprecation/deprecation
   setBaseUrl,
   setFocusVisibility,
+  // eslint-disable-next-line deprecation/deprecation
   setLanguage,
   setMemoizeWeakMap,
   setPortalAttribute,
   setRTL,
+  // eslint-disable-next-line deprecation/deprecation
   setSSR,
   setVirtualParent,
   setWarningCallback,
@@ -1327,6 +1396,7 @@ export type {
   ICancelable,
   IChangeDescription,
   IChangeEventCallback,
+  // eslint-disable-next-line deprecation/deprecation
   IClassNames,
   IClassNamesFunctionOptions,
   IComponentAs,
@@ -1364,9 +1434,12 @@ export type {
   IStyleFunctionOrObject,
   IVirtualElement,
   IWarnControlledUsageParams,
+  // eslint-disable-next-line deprecation/deprecation
   Omit,
   RefObject,
+  // eslint-disable-next-line deprecation/deprecation
   Settings,
+  // eslint-disable-next-line deprecation/deprecation
   SettingsFunction,
   StyleFunction,
 } from './Utilities';
@@ -1392,8 +1465,19 @@ export type { WindowProviderProps } from './WindowProvider';
  * Styles and Theme both exported the same names which causes conflicting
  * star exports with webpack5. See here: https://github.com/microsoft/fluentui/issues/21601.
  */
-export { ThemeContext, ThemeProvider, makeStyles, useTheme } from './utilities/ThemeProvider/index';
-export type { StylesClassMapping, ThemeProviderProps, UseStylesOptions } from './utilities/ThemeProvider/index';
+export {
+  ThemeContext,
+  ThemeProvider,
+  // eslint-disable-next-line deprecation/deprecation
+  makeStyles,
+  useTheme,
+} from './utilities/ThemeProvider/index';
+export type {
+  StylesClassMapping,
+  ThemeProviderProps,
+  // eslint-disable-next-line deprecation/deprecation
+  UseStylesOptions,
+} from './utilities/ThemeProvider/index';
 export {
   CommunicationColors,
   DefaultSpacing,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,100 +1,1399 @@
-export * from './ActivityItem';
-export * from './Autofill';
-export * from './Announced';
-export * from './Breadcrumb';
-export * from './Button';
-export * from './ButtonGrid';
-export * from './Calendar';
-export * from './Callout';
-export * from './Check';
-export * from './Checkbox';
-export * from './ChoiceGroup';
+/* eslint-disable deprecation/deprecation */
+export { ActivityItem, getActivityItemClassNames, getActivityItemStyles } from './ActivityItem';
+export type { IActivityItemClassNames, IActivityItemProps, IActivityItemStyles } from './ActivityItem';
+export { Autofill } from './Autofill';
+export type { IAutofill, IAutofillProps, IAutofillState } from './Autofill';
+export { Announced, AnnouncedBase } from './Announced';
+export type { IAnnouncedProps, IAnnouncedStyleProps, IAnnouncedStyles } from './Announced';
+export { Breadcrumb, BreadcrumbBase } from './Breadcrumb';
+export type {
+  IBreadCrumbData,
+  IBreadcrumb,
+  IBreadcrumbData,
+  IBreadcrumbItem,
+  IBreadcrumbProps,
+  IBreadcrumbStyleProps,
+  IBreadcrumbStyles,
+  IDividerAsProps,
+} from './Breadcrumb';
+export {
+  ActionButton,
+  BaseButton,
+  Button,
+  ButtonGlobalClassNames,
+  ButtonType,
+  CommandBarButton,
+  CommandButton,
+  CompoundButton,
+  DefaultButton,
+  ElementType,
+  IconButton,
+  MessageBarButton,
+  PrimaryButton,
+  getSplitButtonClassNames,
+} from './Button';
+export type {
+  IBaseButtonProps,
+  IBaseButtonState,
+  IButton,
+  IButtonClassNames,
+  IButtonProps,
+  IButtonStyles,
+  ISplitButtonClassNames,
+} from './Button';
+export { ButtonGrid, ButtonGridCell } from './ButtonGrid';
+export type {
+  IButtonGrid,
+  IButtonGridCellProps,
+  IButtonGridProps,
+  IButtonGridStyleProps,
+  IButtonGridStyles,
+} from './ButtonGrid';
+export {
+  AnimationDirection,
+  Calendar,
+  DateRangeType,
+  DayOfWeek,
+  FirstWeekOfYear,
+  defaultCalendarNavigationIcons,
+  defaultCalendarStrings,
+  defaultDayPickerStrings,
+} from './Calendar';
+export type {
+  ICalendar,
+  ICalendarDay,
+  ICalendarDayGrid,
+  ICalendarDayGridProps,
+  ICalendarDayGridStyleProps,
+  ICalendarDayGridStyles,
+  ICalendarDayProps,
+  ICalendarDayStyleProps,
+  ICalendarDayStyles,
+  ICalendarFormatDateCallbacks,
+  ICalendarIconStrings,
+  ICalendarMonth,
+  ICalendarMonthProps,
+  ICalendarMonthStyleProps,
+  ICalendarMonthStyles,
+  ICalendarNavigationIcons,
+  ICalendarPickerStyleProps,
+  ICalendarPickerStyles,
+  ICalendarProps,
+  ICalendarStrings,
+  ICalendarStyleProps,
+  ICalendarStyles,
+  ICalendarYear,
+  ICalendarYearHeaderProps,
+  ICalendarYearProps,
+  ICalendarYearRange,
+  ICalendarYearRangeToString,
+  ICalendarYearStrings,
+  ICalendarYearStyleProps,
+  ICalendarYearStyles,
+  IDateFormatting,
+} from './Calendar';
+export { Callout, CalloutContent, CalloutContentBase, DirectionalHint, FocusTrapCallout } from './Callout';
+export type {
+  ICalloutContentStyleProps,
+  ICalloutContentStyles,
+  ICalloutProps,
+  IFocusTrapCalloutProps,
+  Target,
+} from './Callout';
+export { Check, CheckBase } from './Check';
+export type { ICheckProps, ICheckStyleProps, ICheckStyles } from './Check';
+export { Checkbox, CheckboxBase } from './Checkbox';
+export type { ICheckbox, ICheckboxProps, ICheckboxStyleProps, ICheckboxStyles } from './Checkbox';
+export { ChoiceGroup, ChoiceGroupBase, ChoiceGroupOption } from './ChoiceGroup';
+export type {
+  IChoiceGroup,
+  IChoiceGroupOption,
+  IChoiceGroupOptionProps,
+  IChoiceGroupOptionStyleProps,
+  IChoiceGroupOptionStyles,
+  IChoiceGroupProps,
+  IChoiceGroupStyleProps,
+  IChoiceGroupStyles,
+} from './ChoiceGroup';
 // export * from './ChoiceGroupOption'; // exported by ChoiceGroup
-export * from './Coachmark';
-export * from './Color';
-export * from './ColorPicker';
-export * from './ComboBox';
-export * from './CommandBar';
-export * from './ContextualMenu';
-export * from './DatePicker';
-export * from './DateTimeUtilities';
-export * from './DetailsList';
-export * from './Dialog';
-export * from './Divider';
-export * from './DocumentCard';
-export * from './DragDrop';
-export * from './Dropdown';
-export * from './ExtendedPicker';
-export * from './Fabric';
-export * from './Facepile';
-export * from './FloatingPicker';
-export * from './FocusTrapZone';
-export * from './FocusZone';
-export * from './Grid';
-export * from './GroupedList';
-export * from './HoverCard';
-export * from './Icon';
-export * from './Icons';
-export * from './Image';
-export * from './Keytips';
-export * from './Keytip';
-export * from './KeytipData';
-export * from './KeytipLayer';
-export * from './Label';
-export * from './Layer';
-export * from './Link';
-export * from './List';
-export * from './MarqueeSelection';
-export * from './MessageBar';
-export * from './Modal';
-export * from './Nav';
-export * from './OverflowSet';
-export * from './Overlay';
-export * from './Panel';
-export * from './Persona';
-export * from './PersonaCoin';
-// export * from './PersonaPresence'; (Exported as part of Persona)
-export * from './Pickers';
-export * from './Pivot';
-export * from './Popup';
-export * from './Positioning';
-export * from './PositioningContainer';
-export * from './ProgressIndicator';
-export * from './Rating';
-export * from './ResizeGroup';
-export * from './ResponsiveMode';
-export * from './ScrollablePane';
-export * from './SearchBox';
-export * from './SelectableOption';
-export * from './SelectedItemsList';
-export * from './Selection';
-export * from './Separator';
-export * from './Shimmer';
-export * from './ShimmeredDetailsList';
-export * from './Slider';
-export * from './SpinButton';
-export * from './Spinner';
-export * from './Stack';
-export * from './Sticky';
-export * from './Styling';
-export * from './SwatchColorPicker';
-export * from './TeachingBubble';
-export * from './Text';
-export * from './TextField';
-export * from './ThemeGenerator';
-export * from './TimePicker';
-export * from './Toggle';
-export * from './Tooltip';
-export * from './Utilities';
-export * from './Viewport';
-export * from './WeeklyDayPicker';
-export * from './WindowProvider';
+export { COACHMARK_ATTRIBUTE_NAME, Coachmark, CoachmarkBase } from './Coachmark';
+export type {
+  ICoachmark,
+  ICoachmarkProps,
+  ICoachmarkStyleProps,
+  ICoachmarkStyles,
+  ICoachmarkTypes,
+  IEntityRect,
+} from './Coachmark';
+export {
+  HEX_REGEX,
+  MAX_COLOR_ALPHA,
+  MAX_COLOR_HUE,
+  MAX_COLOR_RGB,
+  MAX_COLOR_RGBA,
+  MAX_COLOR_SATURATION,
+  MAX_COLOR_VALUE,
+  MAX_HEX_LENGTH,
+  MAX_RGBA_LENGTH,
+  MIN_HEX_LENGTH,
+  MIN_RGBA_LENGTH,
+  RGBA_REGEX,
+  Shade,
+  clamp,
+  correctHSV,
+  correctHex,
+  correctRGB,
+  cssColor,
+  getBackgroundShade,
+  getColorFromHSV,
+  getColorFromRGBA,
+  getColorFromString,
+  getContrastRatio,
+  getFullColorString,
+  getShade,
+  hsl2hsv,
+  hsl2rgb,
+  hsv2hex,
+  hsv2hsl,
+  hsv2rgb,
+  isDark,
+  isValidShade,
+  rgb2hex,
+  rgb2hsv,
+  updateA,
+  updateH,
+  updateRGB,
+  updateSV,
+  updateT,
+} from './Color';
+export type { IColor, IHSL, IHSV, IRGB } from './Color';
+export { ColorPicker, ColorPickerBase } from './ColorPicker';
+export type {
+  IColorPicker,
+  IColorPickerProps,
+  IColorPickerState,
+  IColorPickerStrings,
+  IColorPickerStyleProps,
+  IColorPickerStyles,
+  IColorRectangle,
+  IColorRectangleProps,
+  IColorRectangleStyleProps,
+  IColorRectangleStyles,
+  IColorSlider,
+  IColorSliderProps,
+  IColorSliderStyleProps,
+  IColorSliderStyles,
+} from './ColorPicker';
+export { ComboBox, VirtualizedComboBox } from './ComboBox';
+export type {
+  IComboBox,
+  IComboBoxClassNames,
+  IComboBoxOption,
+  IComboBoxOptionClassNames,
+  IComboBoxOptionStyles,
+  IComboBoxProps,
+  IComboBoxState,
+  IComboBoxStyles,
+  IOnRenderComboBoxLabelProps,
+} from './ComboBox';
+export { CommandBar, CommandBarBase, getCommandBarStyles, getCommandButtonStyles } from './CommandBar';
+export type {
+  ICommandBar,
+  ICommandBarData,
+  ICommandBarItemProps,
+  ICommandBarProps,
+  ICommandBarStyleProps,
+  ICommandBarStyles,
+} from './CommandBar';
+export {
+  ContextualMenu,
+  ContextualMenuBase,
+  ContextualMenuItem,
+  ContextualMenuItemBase,
+  ContextualMenuItemType,
+  canAnyMenuItemsCheck,
+  getContextualMenuItemClassNames,
+  getContextualMenuItemStyles,
+  getMenuItemStyles,
+  getSubmenuItems,
+} from './ContextualMenu';
+export type {
+  IContextualMenu,
+  IContextualMenuClassNames,
+  IContextualMenuItem,
+  IContextualMenuItemProps,
+  IContextualMenuItemRenderFunctions,
+  IContextualMenuItemRenderProps,
+  IContextualMenuItemStyleProps,
+  IContextualMenuItemStyles,
+  IContextualMenuListProps,
+  IContextualMenuProps,
+  IContextualMenuRenderItem,
+  IContextualMenuSection,
+  IContextualMenuStyleProps,
+  IContextualMenuStyles,
+  IContextualMenuSubComponentStyles,
+  IMenuItemClassNames,
+  IMenuItemStyles,
+} from './ContextualMenu';
+export { DatePicker, DatePickerBase, defaultDatePickerStrings } from './DatePicker';
+export type {
+  IDatePicker,
+  IDatePickerProps,
+  IDatePickerStrings,
+  IDatePickerStyleProps,
+  IDatePickerStyles,
+} from './DatePicker';
+export {
+  DAYS_IN_WEEK,
+  MonthOfYear,
+  TimeConstants,
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  compareDatePart,
+  compareDates,
+  getDatePartHashValue,
+  getDateRangeArray,
+  getEndDateOfWeek,
+  getMonthEnd,
+  getMonthStart,
+  getStartDateOfWeek,
+  getWeekNumber,
+  getWeekNumbersInMonth,
+  getYearEnd,
+  getYearStart,
+  isInDateRangeArray,
+  setMonth,
+} from './DateTimeUtilities';
+export {
+  CHECK_CELL_WIDTH,
+  CheckboxVisibility,
+  CollapseAllVisibility,
+  ColumnActionsMode,
+  ColumnDragEndLocation,
+  ConstrainMode,
+  DEFAULT_CELL_STYLE_PROPS,
+  DEFAULT_ROW_HEIGHTS,
+  DetailsColumn,
+  DetailsColumnBase,
+  DetailsHeader,
+  DetailsHeaderBase,
+  DetailsList,
+  DetailsListBase,
+  DetailsListLayoutMode,
+  DetailsRow,
+  DetailsRowBase,
+  DetailsRowCheck,
+  DetailsRowFields,
+  DetailsRowGlobalClassNames,
+  HEADER_HEIGHT,
+  SELECTION_CHANGE,
+  SelectAllVisibility,
+  Selection,
+  SelectionDirection,
+  SelectionMode,
+  SelectionZone,
+  buildColumns,
+  getCellStyles,
+  getDetailsColumnStyles,
+  getDetailsHeaderStyles,
+  getDetailsListStyles,
+  getDetailsRowCheckStyles,
+  getDetailsRowStyles,
+} from './DetailsList';
+export type {
+  ICellStyleProps,
+  IColumn,
+  IColumnDragDropDetails,
+  IColumnReorderHeaderProps,
+  IColumnReorderOptions,
+  IColumnResizeDetails,
+  IDetailsCheckboxProps,
+  IDetailsColumnFieldProps,
+  IDetailsColumnFilterIconProps,
+  IDetailsColumnProps,
+  IDetailsColumnRenderTooltipProps,
+  IDetailsColumnStyleProps,
+  IDetailsColumnStyles,
+  IDetailsFooterBaseProps,
+  IDetailsFooterProps,
+  IDetailsGroupDividerProps,
+  IDetailsGroupRenderProps,
+  IDetailsHeader,
+  IDetailsHeaderBaseProps,
+  IDetailsHeaderProps,
+  IDetailsHeaderState,
+  IDetailsHeaderStyleProps,
+  IDetailsHeaderStyles,
+  IDetailsItemProps,
+  IDetailsList,
+  IDetailsListCheckboxProps,
+  IDetailsListProps,
+  IDetailsListState,
+  IDetailsListStyleProps,
+  IDetailsListStyles,
+  IDetailsRow,
+  IDetailsRowBaseProps,
+  IDetailsRowCheckProps,
+  IDetailsRowCheckStyleProps,
+  IDetailsRowCheckStyles,
+  IDetailsRowFieldsProps,
+  IDetailsRowProps,
+  IDetailsRowSelectionState,
+  IDetailsRowState,
+  IDetailsRowStyleProps,
+  IDetailsRowStyles,
+  IDragDropContext,
+  IDragDropEvents,
+  IDragDropHelper,
+  IDragDropOptions,
+  IDropHintDetails,
+  IGroup,
+  IGroupDividerProps,
+  IGroupRenderProps,
+  IGroupedList,
+  IGroupedListProps,
+  IGroupedListStyleProps,
+  IGroupedListStyles,
+  IObjectWithKey,
+  IOverrideColumnRenderProps,
+  ISelection,
+  ISelectionOptions,
+  ISelectionZone,
+  ISelectionZoneProps,
+  ISelectionZoneState,
+  IViewport,
+  IWithViewportProps,
+} from './DetailsList';
+export {
+  Dialog,
+  DialogBase,
+  DialogContent,
+  DialogContentBase,
+  DialogFooter,
+  DialogFooterBase,
+  DialogType,
+} from './Dialog';
+export type {
+  IDialog,
+  IDialogContent,
+  IDialogContentProps,
+  IDialogContentStyleProps,
+  IDialogContentStyles,
+  IDialogFooter,
+  IDialogFooterProps,
+  IDialogFooterStyleProps,
+  IDialogFooterStyles,
+  IDialogProps,
+  IDialogStyleProps,
+  IDialogStyles,
+} from './Dialog';
+export { VerticalDivider } from './Divider';
+export type {
+  IVerticalDividerClassNames,
+  IVerticalDividerProps,
+  IVerticalDividerPropsStyles,
+  IVerticalDividerStyles,
+} from './Divider';
+export {
+  DocumentCard,
+  DocumentCardActions,
+  DocumentCardActivity,
+  DocumentCardDetails,
+  DocumentCardImage,
+  DocumentCardLocation,
+  DocumentCardLogo,
+  DocumentCardPreview,
+  DocumentCardStatus,
+  DocumentCardTitle,
+  DocumentCardType,
+} from './DocumentCard';
+export type {
+  IDocumentCard,
+  IDocumentCardActions,
+  IDocumentCardActionsProps,
+  IDocumentCardActionsStyleProps,
+  IDocumentCardActionsStyles,
+  IDocumentCardActivity,
+  IDocumentCardActivityPerson,
+  IDocumentCardActivityProps,
+  IDocumentCardActivityStyleProps,
+  IDocumentCardActivityStyles,
+  IDocumentCardContext,
+  IDocumentCardDetails,
+  IDocumentCardDetailsProps,
+  IDocumentCardDetailsStyleProps,
+  IDocumentCardDetailsStyles,
+  IDocumentCardImage,
+  IDocumentCardImageProps,
+  IDocumentCardImageStyleProps,
+  IDocumentCardImageStyles,
+  IDocumentCardLocation,
+  IDocumentCardLocationProps,
+  IDocumentCardLocationStyleProps,
+  IDocumentCardLocationStyles,
+  IDocumentCardLogo,
+  IDocumentCardLogoProps,
+  IDocumentCardLogoStyleProps,
+  IDocumentCardLogoStyles,
+  IDocumentCardPreview,
+  IDocumentCardPreviewImage,
+  IDocumentCardPreviewProps,
+  IDocumentCardPreviewStyleProps,
+  IDocumentCardPreviewStyles,
+  IDocumentCardProps,
+  IDocumentCardStatus,
+  IDocumentCardStatusProps,
+  IDocumentCardStatusStyleProps,
+  IDocumentCardStatusStyles,
+  IDocumentCardStyleProps,
+  IDocumentCardStyles,
+  IDocumentCardTitle,
+  IDocumentCardTitleProps,
+  IDocumentCardTitleStyleProps,
+  IDocumentCardTitleStyles,
+} from './DocumentCard';
+export { DragDropHelper } from './DragDrop';
+export type { IDragDropEvent, IDragDropHelperParams, IDragDropTarget } from './DragDrop';
+export { Dropdown, DropdownBase, DropdownMenuItemType } from './Dropdown';
+export type {
+  IDropdown,
+  IDropdownOption,
+  IDropdownProps,
+  IDropdownStyleProps,
+  IDropdownStyles,
+  IDropdownSubComponentStyles,
+} from './Dropdown';
+export { BaseExtendedPeoplePicker, BaseExtendedPicker, ExtendedPeoplePicker } from './ExtendedPicker';
+export type {
+  IBaseExtendedPicker,
+  IBaseExtendedPickerProps,
+  IBaseExtendedPickerState,
+  IExtendedPeoplePickerProps,
+  IPeoplePickerItemProps,
+} from './ExtendedPicker';
+export { Fabric, FabricBase } from './Fabric';
+export type { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric';
+export { Facepile, FacepileBase, OverflowButtonType } from './Facepile';
+export type { IFacepile, IFacepilePersona, IFacepileProps, IFacepileStyleProps, IFacepileStyles } from './Facepile';
+export {
+  BaseFloatingPeoplePicker,
+  BaseFloatingPicker,
+  FloatingPeoplePicker,
+  SuggestionItemType,
+  SuggestionsControl,
+  SuggestionsCore,
+  SuggestionsHeaderFooterItem,
+  SuggestionsStore,
+  createItem,
+} from './FloatingPicker';
+export type {
+  IBaseFloatingPicker,
+  IBaseFloatingPickerProps,
+  IBaseFloatingPickerState,
+  IBaseFloatingPickerSuggestionProps,
+  IPeopleFloatingPickerProps,
+  ISuggestionsControlProps,
+  ISuggestionsControlState,
+  ISuggestionsCoreProps,
+  ISuggestionsHeaderFooterItemProps,
+  ISuggestionsHeaderFooterProps,
+  SuggestionsStoreOptions,
+} from './FloatingPicker';
+export { FocusTrapZone } from './FocusTrapZone';
+export type { IFocusTrapZone, IFocusTrapZoneProps } from './FocusTrapZone';
+export { FocusZone, FocusZoneDirection, FocusZoneTabbableElements } from './FocusZone';
+export type { IFocusZone, IFocusZoneProps } from './FocusZone';
+export {
+  GetGroupCount,
+  GroupFooter,
+  GroupHeader,
+  GroupShowAll,
+  GroupSpacer,
+  GroupedList,
+  GroupedListBase,
+  GroupedListSection,
+  GroupedListV2_unstable,
+} from './GroupedList';
+export type {
+  IGroupFooterProps,
+  IGroupFooterStyleProps,
+  IGroupFooterStyles,
+  IGroupHeaderCheckboxProps,
+  IGroupHeaderProps,
+  IGroupHeaderStyleProps,
+  IGroupHeaderStyles,
+  IGroupShowAllProps,
+  IGroupShowAllStyleProps,
+  IGroupShowAllStyles,
+  IGroupSpacerProps,
+  IGroupSpacerStyleProps,
+  IGroupSpacerStyles,
+  IGroupedListSectionProps,
+  IGroupedListSectionState,
+  IGroupedListState,
+} from './GroupedList';
+export {
+  ExpandingCard,
+  ExpandingCardBase,
+  ExpandingCardMode,
+  HoverCard,
+  HoverCardBase,
+  HoverCardType,
+  OpenCardMode,
+  PlainCard,
+  PlainCardBase,
+} from './HoverCard';
+export type {
+  IExpandingCard,
+  IExpandingCardProps,
+  IExpandingCardState,
+  IExpandingCardStyleProps,
+  IExpandingCardStyles,
+  IHoverCard,
+  IHoverCardProps,
+  IHoverCardState,
+  IHoverCardStyleProps,
+  IHoverCardStyles,
+  IPlainCard,
+  IPlainCardProps,
+  IPlainCardStyleProps,
+  IPlainCardStyles,
+} from './HoverCard';
+export { FontIcon, Icon, IconBase, IconType, ImageIcon, getFontIcon, getIconContent } from './Icon';
+export type {
+  IFontIconProps,
+  IIconContent,
+  IIconProps,
+  IIconState,
+  IIconStyleProps,
+  IIconStyles,
+  IImageIconProps,
+} from './Icon';
+export { initializeIcons } from './Icons';
+export type { IconNames } from './Icons';
+export { Image, ImageBase, ImageCoverStyle, ImageFit, ImageLoadState } from './Image';
+export type { IImage, IImageProps, IImageState, IImageStyleProps, IImageStyles } from './Image';
+export {
+  DATAKTP_ARIA_TARGET,
+  DATAKTP_EXECUTE_TARGET,
+  DATAKTP_TARGET,
+  KTP_ARIA_SEPARATOR,
+  KTP_FULL_PREFIX,
+  KTP_LAYER_ID,
+  KTP_PREFIX,
+  KTP_SEPARATOR,
+  Keytip,
+  KeytipData,
+  KeytipEvents,
+  KeytipLayer,
+  KeytipLayerBase,
+  KeytipManager,
+  buildKeytipConfigMap,
+  constructKeytip,
+  getAriaDescribedBy,
+  ktpTargetFromId,
+  ktpTargetFromSequences,
+  mergeOverflows,
+  sequencesToID,
+  transitionKeysAreEqual,
+  transitionKeysContain,
+  useKeytipRef,
+} from './Keytips';
+export type {
+  IKeytipConfig,
+  IKeytipConfigItem,
+  IKeytipConfigMap,
+  IKeytipDataProps,
+  IKeytipLayer,
+  IKeytipLayerProps,
+  IKeytipLayerState,
+  IKeytipLayerStyleProps,
+  IKeytipLayerStyles,
+  IKeytipProps,
+  IKeytipStyleProps,
+  IKeytipStyles,
+  IKeytipTransitionKey,
+  IUniqueKeytip,
+  KeytipDataOptions,
+  KeytipTransitionModifier,
+} from './Keytips';
+export { Label, LabelBase } from './Label';
+export type { ILabel, ILabelProps, ILabelStyleProps, ILabelStyles } from './Label';
+export {
+  Layer,
+  LayerBase,
+  LayerHost,
+  cleanupDefaultLayerHost,
+  createDefaultLayerHost,
+  getLayerCount,
+  getLayerHost,
+  getLayerHostSelector,
+  getLayerStyles,
+  notifyHostChanged,
+  registerLayer,
+  registerLayerHost,
+  setLayerHostSelector,
+  unregisterLayer,
+  unregisterLayerHost,
+} from './Layer';
+export type { ILayer, ILayerHost, ILayerHostProps, ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer';
+export { Link, LinkBase } from './Link';
+export type { ILink, ILinkHTMLAttributes, ILinkProps, ILinkStyleProps, ILinkStyles } from './Link';
+export { List, ScrollToMode } from './List';
+export type {
+  IList,
+  IListOnRenderRootProps,
+  IListOnRenderSurfaceProps,
+  IListProps,
+  IListState,
+  IPage,
+  IPageProps,
+  IPageSpecification,
+} from './List';
+export { MarqueeSelection } from './MarqueeSelection';
+export type {
+  IMarqueeSelection,
+  IMarqueeSelectionProps,
+  IMarqueeSelectionStyleProps,
+  IMarqueeSelectionStyles,
+} from './MarqueeSelection';
+export { MessageBar, MessageBarBase, MessageBarType } from './MessageBar';
+export type { IMessageBar, IMessageBarProps, IMessageBarStyleProps, IMessageBarStyles } from './MessageBar';
+export { Modal, ModalBase } from './Modal';
+export type { IAccessiblePopupProps, IDragOptions, IModal, IModalProps, IModalStyleProps, IModalStyles } from './Modal';
+export { Nav, NavBase, isRelativeUrl } from './Nav';
+export type {
+  INav,
+  INavButtonProps,
+  INavLink,
+  INavLinkGroup,
+  INavProps,
+  INavState,
+  INavStyleProps,
+  INavStyles,
+  IRenderGroupHeaderProps,
+} from './Nav';
+export { OverflowSet, OverflowSetBase } from './OverflowSet';
+export type {
+  IOverflowSet,
+  IOverflowSetItemProps,
+  IOverflowSetProps,
+  IOverflowSetStyleProps,
+  IOverflowSetStyles,
+} from './OverflowSet';
+export { Overlay, OverlayBase } from './Overlay';
+export type { IOverlay, IOverlayProps, IOverlayStyleProps, IOverlayStyles } from './Overlay';
+export { Panel, PanelBase, PanelType } from './Panel';
+export type {
+  IPanel,
+  IPanelHeaderRenderer,
+  IPanelProps,
+  IPanelStyleProps,
+  IPanelStyles,
+  IPanelSubComponentStyles,
+} from './Panel';
+export {
+  Persona,
+  PersonaBase,
+  PersonaCoin,
+  PersonaCoinBase,
+  PersonaInitialsColor,
+  PersonaPresence,
+  PersonaSize,
+  getPersonaInitialsColor,
+  personaPresenceSize,
+  personaSize,
+  presenceBoolean,
+  sizeBoolean,
+  sizeToPixels,
+} from './Persona';
+export type {
+  IPersona,
+  IPersonaCoinProps,
+  IPersonaCoinStyleProps,
+  IPersonaCoinStyles,
+  IPersonaPresenceProps,
+  IPersonaPresenceStyleProps,
+  IPersonaPresenceStyles,
+  IPersonaProps,
+  IPersonaSharedProps,
+  IPersonaStyleProps,
+  IPersonaStyles,
+} from './Persona';
+export {
+  BasePeoplePicker,
+  BasePicker,
+  BasePickerListBelow,
+  CompactPeoplePicker,
+  CompactPeoplePickerBase,
+  ListPeoplePicker,
+  ListPeoplePickerBase,
+  MemberListPeoplePicker,
+  NormalPeoplePicker,
+  NormalPeoplePickerBase,
+  PeoplePickerItem,
+  PeoplePickerItemBase,
+  PeoplePickerItemSuggestion,
+  PeoplePickerItemSuggestionBase,
+  SuggestionActionType,
+  Suggestions,
+  SuggestionsController,
+  SuggestionsItem,
+  TagItem,
+  TagItemBase,
+  TagItemSuggestion,
+  TagItemSuggestionBase,
+  TagPicker,
+  TagPickerBase,
+  ValidationState,
+  createGenericItem,
+  getBasePickerStyles,
+  getPeoplePickerItemStyles,
+  getPeoplePickerItemSuggestionStyles,
+  getSuggestionsItemStyles,
+  getSuggestionsStyles,
+  getTagItemStyles,
+  getTagItemSuggestionStyles,
+} from './Pickers';
+export type {
+  IBasePicker,
+  IBasePickerProps,
+  IBasePickerState,
+  IBasePickerStyleProps,
+  IBasePickerStyles,
+  IBasePickerSuggestionsProps,
+  IGenericItem,
+  IInputProps,
+  IPeoplePickerItemSelectedProps,
+  IPeoplePickerItemSelectedStyleProps,
+  IPeoplePickerItemSelectedStyles,
+  IPeoplePickerItemSelectedSubComponentStyles,
+  IPeoplePickerItemSharedProps,
+  IPeoplePickerItemSuggestionProps,
+  IPeoplePickerItemSuggestionStyleProps,
+  IPeoplePickerItemSuggestionStyles,
+  IPeoplePickerItemWithMenuProps,
+  IPeoplePickerProps,
+  IPersonaWithMenu,
+  IPickerAriaIds,
+  IPickerItem,
+  IPickerItemProps,
+  ISuggestionItemProps,
+  ISuggestionModel,
+  ISuggestions,
+  ISuggestionsItem,
+  ISuggestionsItemStyleProps,
+  ISuggestionsItemStyles,
+  ISuggestionsProps,
+  ISuggestionsState,
+  ISuggestionsStyleProps,
+  ISuggestionsStyles,
+  ISuggestionsSubComponentStyles,
+  ITag,
+  ITagItemProps,
+  ITagItemStyleProps,
+  ITagItemStyles,
+  ITagItemSuggestionProps,
+  ITagItemSuggestionStyleProps,
+  ITagItemSuggestionStyles,
+  ITagPickerProps,
+} from './Pickers';
+export { Pivot, PivotBase, PivotItem, PivotLinkFormat, PivotLinkSize } from './Pivot';
+export type {
+  IPivot,
+  IPivotItemProps,
+  IPivotProps,
+  IPivotStyleProps,
+  IPivotStyles,
+  PivotLinkFormatType,
+  PivotLinkSizeType,
+} from './Pivot';
+export { Popup } from './Popup';
+export type { IPopupProps, IPopupRestoreFocusParams } from './Popup';
+export {
+  Position,
+  RectangleEdge,
+  getBoundsFromTargetWindow,
+  getMaxHeight,
+  getOppositeEdge,
+  positionCallout,
+  positionCard,
+  positionElement,
+} from './Positioning';
+export type {
+  ICalloutBeakPositionedInfo,
+  ICalloutPositionProps,
+  ICalloutPositionedInfo,
+  IElementPosition,
+  IElementPositionInfo,
+  IPoint,
+  IPosition,
+  IPositionDirectionalHintData,
+  IPositionProps,
+  IPositionedData,
+  IRelativePositions,
+  IWindowWithSegments,
+  Point,
+} from './Positioning';
+export { PositioningContainer, useHeightOffset } from './PositioningContainer';
+export type {
+  IPositioningContainer,
+  IPositioningContainerProps,
+  IPositioningContainerTypes,
+} from './PositioningContainer';
+export { ProgressIndicator, ProgressIndicatorBase } from './ProgressIndicator';
+export type {
+  IProgressIndicatorProps,
+  IProgressIndicatorStyleProps,
+  IProgressIndicatorStyles,
+} from './ProgressIndicator';
+export { Rating, RatingBase, RatingSize } from './Rating';
+export type { IRating, IRatingProps, IRatingStarProps, IRatingStyleProps, IRatingStyles } from './Rating';
+export {
+  MeasuredContext,
+  ResizeGroup,
+  ResizeGroupBase,
+  ResizeGroupDirection,
+  getMeasurementCache,
+  getNextResizeGroupStateProvider,
+} from './ResizeGroup';
+export type {
+  IResizeGroup,
+  IResizeGroupProps,
+  IResizeGroupState,
+  IResizeGroupStyleProps,
+  IResizeGroupStyles,
+} from './ResizeGroup';
+export {
+  ResponsiveMode,
+  getInitialResponsiveMode,
+  getResponsiveMode,
+  initializeResponsiveMode,
+  setResponsiveMode,
+  useResponsiveMode,
+  withResponsiveMode,
+} from './ResponsiveMode';
+export type { IWithResponsiveModeState } from './ResponsiveMode';
+export { ScrollablePane, ScrollablePaneBase, ScrollablePaneContext, ScrollbarVisibility } from './ScrollablePane';
+export type {
+  IScrollablePane,
+  IScrollablePaneContext,
+  IScrollablePaneProps,
+  IScrollablePaneState,
+  IScrollablePaneStyleProps,
+  IScrollablePaneStyles,
+} from './ScrollablePane';
+export { SearchBox, SearchBoxBase } from './SearchBox';
+export type { ISearchBox, ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox';
+export { SelectableOptionMenuItemType, getAllSelectedOptions } from './SelectableOption';
+export type { ISelectableDroppableTextProps, ISelectableOption } from './SelectableOption';
+export {
+  BasePeopleSelectedItemsList,
+  BaseSelectedItemsList,
+  ExtendedSelectedItem,
+  SelectedPeopleList,
+} from './SelectedItemsList';
+export type {
+  IBaseSelectedItemsList,
+  IBaseSelectedItemsListProps,
+  IBaseSelectedItemsListState,
+  IEditingSelectedPeopleItemProps,
+  IEditingSelectedPeopleItemStyles,
+  IEditingSelectedPeopleItemStylesProps,
+  IExtendedPersonaProps,
+  IPeoplePickerItemState,
+  ISelectedItemProps,
+  ISelectedPeopleItemProps,
+  ISelectedPeopleProps,
+} from './SelectedItemsList';
+export { Separator, SeparatorBase } from './Separator';
+export type { ISeparator, ISeparatorProps, ISeparatorStyleProps, ISeparatorStyles } from './Separator';
+export {
+  Shimmer,
+  ShimmerBase,
+  ShimmerCircle,
+  ShimmerCircleBase,
+  ShimmerElementType,
+  ShimmerElementsDefaultHeights,
+  ShimmerElementsGroup,
+  ShimmerElementsGroupBase,
+  ShimmerGap,
+  ShimmerGapBase,
+  ShimmerLine,
+  ShimmerLineBase,
+} from './Shimmer';
+export type {
+  ICircle,
+  IGap,
+  ILine,
+  IShimmerCircle,
+  IShimmerCircleProps,
+  IShimmerCircleStyleProps,
+  IShimmerCircleStyles,
+  IShimmerColors,
+  IShimmerElement,
+  IShimmerElementsGroup,
+  IShimmerElementsGroupProps,
+  IShimmerElementsGroupStyleProps,
+  IShimmerElementsGroupStyles,
+  IShimmerGap,
+  IShimmerGapProps,
+  IShimmerGapStyleProps,
+  IShimmerGapStyles,
+  IShimmerLine,
+  IShimmerLineProps,
+  IShimmerLineStyleProps,
+  IShimmerLineStyles,
+  IShimmerProps,
+  IShimmerStyleProps,
+  IShimmerStyles,
+} from './Shimmer';
+export { ShimmeredDetailsList, ShimmeredDetailsListBase, getShimmeredDetailsListStyles } from './ShimmeredDetailsList';
+export type {
+  IShimmeredDetailsListProps,
+  IShimmeredDetailsListStyleProps,
+  IShimmeredDetailsListStyles,
+} from './ShimmeredDetailsList';
+export { Slider, SliderBase } from './Slider';
+export type { ISlider, ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider';
+export { KeyboardSpinDirection, SpinButton } from './SpinButton';
+export type { ISpinButton, ISpinButtonProps, ISpinButtonStyleProps, ISpinButtonStyles } from './SpinButton';
+export { Spinner, SpinnerBase, SpinnerSize, SpinnerType } from './Spinner';
+export type { ISpinner, ISpinnerProps, ISpinnerStyleProps, ISpinnerStyles, SpinnerLabelPosition } from './Spinner';
+export { Stack, StackItem } from './Stack';
+export type {
+  Alignment,
+  IStackComponent,
+  IStackItemComponent,
+  IStackItemProps,
+  IStackItemSlot,
+  IStackItemSlots,
+  IStackItemStyles,
+  IStackItemStylesReturnType,
+  IStackItemTokenReturnType,
+  IStackItemTokens,
+  IStackProps,
+  IStackSlot,
+  IStackSlots,
+  IStackStyles,
+  IStackStylesReturnType,
+  IStackTokenReturnType,
+  IStackTokens,
+} from './Stack';
+export { Sticky, StickyPositionType } from './Sticky';
+export type { IStickyProps, IStickyState } from './Sticky';
+export {
+  AnimationClassNames,
+  AnimationStyles,
+  AnimationVariables,
+  ColorClassNames,
+  DefaultEffects,
+  DefaultFontStyles,
+  DefaultPalette,
+  EdgeChromiumHighContrastSelector,
+  FontClassNames,
+  FontSizes,
+  FontWeights,
+  HighContrastSelector,
+  HighContrastSelectorBlack,
+  HighContrastSelectorWhite,
+  IconFontSizes,
+  InjectionMode,
+  PulsingBeaconAnimationStyles,
+  ScreenWidthMaxLarge,
+  ScreenWidthMaxMedium,
+  ScreenWidthMaxSmall,
+  ScreenWidthMaxXLarge,
+  ScreenWidthMaxXXLarge,
+  ScreenWidthMinLarge,
+  ScreenWidthMinMedium,
+  ScreenWidthMinSmall,
+  ScreenWidthMinUhfMobile,
+  ScreenWidthMinXLarge,
+  ScreenWidthMinXXLarge,
+  ScreenWidthMinXXXLarge,
+  Stylesheet,
+  ThemeSettingName,
+  ZIndexes,
+  buildClassMap,
+  concatStyleSets,
+  concatStyleSetsWithProps,
+  createFontStyles,
+  createTheme,
+  focusClear,
+  fontFace,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+  getFadedOverflowStyle,
+  getFocusOutlineStyle,
+  getFocusStyle,
+  getGlobalClassNames,
+  getHighContrastNoAdjustStyle,
+  getIcon,
+  getIconClassName,
+  getInputFocusStyle,
+  getPlaceholderStyles,
+  getScreenSelector,
+  getTheme,
+  getThemedContext,
+  hiddenContentStyle,
+  keyframes,
+  loadTheme,
+  mergeStyleSets,
+  mergeStyles,
+  noWrap,
+  normalize,
+  registerDefaultFontFaces,
+  registerIconAlias,
+  registerIcons,
+  registerOnThemeChangeCallback,
+  removeOnThemeChangeCallback,
+  setIconOptions,
+  unregisterIcons,
+} from './Styling';
+export type {
+  GlobalClassNames,
+  IAnimationStyles,
+  IAnimationVariables,
+  ICSPSettings,
+  IEffects,
+  IFontFace,
+  IFontStyles,
+  IFontWeight,
+  IGetFocusStylesOptions,
+  IIconOptions,
+  IIconRecord,
+  IIconSubset,
+  IIconSubsetRecord,
+  IPalette,
+  IPartialTheme,
+  IProcessedStyleSet,
+  IRawStyle,
+  IScheme,
+  ISchemeNames,
+  ISemanticColors,
+  ISemanticTextColors,
+  ISpacing,
+  IStyle,
+  IStyleSet,
+  IStyleSheetConfig,
+  ITheme,
+} from './Styling';
+export {
+  ColorPickerGridCell,
+  ColorPickerGridCellBase,
+  SwatchColorPicker,
+  SwatchColorPickerBase,
+} from './SwatchColorPicker';
+export type {
+  IColorCellProps,
+  IColorPickerGridCellProps,
+  IColorPickerGridCellStyleProps,
+  IColorPickerGridCellStyles,
+  ISwatchColorPickerProps,
+  ISwatchColorPickerStyleProps,
+  ISwatchColorPickerStyles,
+} from './SwatchColorPicker';
+export { TeachingBubble, TeachingBubbleBase, TeachingBubbleContent, TeachingBubbleContentBase } from './TeachingBubble';
+export type {
+  ITeachingBubble,
+  ITeachingBubbleProps,
+  ITeachingBubbleStyleProps,
+  ITeachingBubbleStyles,
+  ITeachingBubbleSubComponentStyles,
+} from './TeachingBubble';
+export { Text, TextStyles, TextView } from './Text';
+export type {
+  ITextComponent,
+  ITextProps,
+  ITextSlot,
+  ITextSlots,
+  ITextStyles,
+  ITextStylesReturnType,
+  ITextTokenReturnType,
+  ITextTokens,
+} from './Text';
+export { DEFAULT_MASK_CHAR, MaskedTextField, TextField, TextFieldBase, getTextFieldStyles } from './TextField';
+export type {
+  IMaskedTextField,
+  IMaskedTextFieldProps,
+  ITextField,
+  ITextFieldProps,
+  ITextFieldSnapshot,
+  ITextFieldState,
+  ITextFieldStyleProps,
+  ITextFieldStyles,
+  ITextFieldSubComponentStyles,
+} from './TextField';
+export {
+  BaseSlots,
+  FabricSlots,
+  SemanticColorSlots,
+  ThemeGenerator,
+  themeRulesStandardCreator,
+} from './ThemeGenerator';
+export type { IThemeRules, IThemeSlotRule } from './ThemeGenerator';
+export { TimePicker } from './TimePicker';
+export type { ITimePickerProps, ITimePickerStrings, ITimeRange } from './TimePicker';
+export { Toggle, ToggleBase } from './Toggle';
+export type { IToggle, IToggleProps, IToggleStyleProps, IToggleStyles } from './Toggle';
+export { Tooltip, TooltipBase, TooltipDelay, TooltipHost, TooltipHostBase, TooltipOverflowMode } from './Tooltip';
+export type {
+  ITooltip,
+  ITooltipHost,
+  ITooltipHostProps,
+  ITooltipHostState,
+  ITooltipHostStyleProps,
+  ITooltipHostStyles,
+  ITooltipProps,
+  ITooltipStyleProps,
+  ITooltipStyles,
+} from './Tooltip';
+export {
+  Async,
+  AutoScroll,
+  BaseComponent,
+  Customizations,
+  Customizer,
+  CustomizerContext,
+  DATA_IS_SCROLLABLE_ATTRIBUTE,
+  DATA_PORTAL_ATTRIBUTE,
+  DelayedRender,
+  EventGroup,
+  FabricPerformance,
+  FocusRects,
+  FocusRectsContext,
+  FocusRectsProvider,
+  GlobalSettings,
+  IsFocusVisibleClassName,
+  KeyCodes,
+  Rectangle,
+  addDirectionalKeyCode,
+  addElementAtIndex,
+  allowOverscrollOnElement,
+  allowScrollOnElement,
+  anchorProperties,
+  appendFunction,
+  arraysEqual,
+  asAsync,
+  assertNever,
+  assign,
+  audioProperties,
+  baseElementEvents,
+  baseElementProperties,
+  buttonProperties,
+  calculatePrecision,
+  canUseDOM,
+  classNamesFunction,
+  colGroupProperties,
+  colProperties,
+  composeComponentAs,
+  composeRenderFunction,
+  createArray,
+  createMemoizer,
+  createMergedRef,
+  css,
+  customizable,
+  disableBodyScroll,
+  divProperties,
+  doesElementContainFocus,
+  elementContains,
+  elementContainsAttribute,
+  enableBodyScroll,
+  extendComponent,
+  filteredAssign,
+  find,
+  findElementRecursive,
+  findIndex,
+  findScrollableParent,
+  fitContentToBounds,
+  flatten,
+  focusAsync,
+  focusFirstChild,
+  formProperties,
+  format,
+  getChildren,
+  getDistanceBetweenPoints,
+  getDocument,
+  getElementIndexPath,
+  getFirstFocusable,
+  getFirstTabbable,
+  getFirstVisibleElementFromSelector,
+  getFocusableByIndexPath,
+  getId,
+  getInitials,
+  getLanguage,
+  getLastFocusable,
+  getLastTabbable,
+  getNativeElementProps,
+  getNativeProps,
+  getNextElement,
+  getParent,
+  getPreviousElement,
+  getPropsWithDefaults,
+  getRTL,
+  getRTLSafeKeyCode,
+  getRect,
+  getResourceUrl,
+  getScrollbarWidth,
+  getVirtualParent,
+  getWindow,
+  hasHorizontalOverflow,
+  hasOverflow,
+  hasVerticalOverflow,
+  hoistMethods,
+  hoistStatics,
+  htmlElementProperties,
+  iframeProperties,
+  imageProperties,
+  imgProperties,
+  initializeComponentRef,
+  initializeFocusRects,
+  inputProperties,
+  isControlled,
+  isDirectionalKeyCode,
+  isElementFocusSubZone,
+  isElementFocusZone,
+  isElementTabbable,
+  isElementVisible,
+  isElementVisibleAndNotHidden,
+  isIE11,
+  isIOS,
+  isMac,
+  isVirtualElement,
+  labelProperties,
+  liProperties,
+  mapEnumByName,
+  memoize,
+  memoizeFunction,
+  merge,
+  mergeAriaAttributeValues,
+  mergeCustomizations,
+  mergeScopedSettings,
+  mergeSettings,
+  modalize,
+  nullRender,
+  olProperties,
+  omit,
+  on,
+  optionProperties,
+  portalContainsElement,
+  precisionRound,
+  raiseClick,
+  removeDirectionalKeyCode,
+  removeIndex,
+  replaceElement,
+  resetControlledWarnings,
+  resetIds,
+  resetMemoizations,
+  safeRequestAnimationFrame,
+  safeSetTimeout,
+  selectProperties,
+  setBaseUrl,
+  setFocusVisibility,
+  setLanguage,
+  setMemoizeWeakMap,
+  setPortalAttribute,
+  setRTL,
+  setSSR,
+  setVirtualParent,
+  setWarningCallback,
+  shallowCompare,
+  shouldWrapFocus,
+  styled,
+  tableProperties,
+  tdProperties,
+  textAreaProperties,
+  thProperties,
+  toMatrix,
+  trProperties,
+  unhoistMethods,
+  useCustomizationSettings,
+  useFocusRects,
+  values,
+  videoProperties,
+  warn,
+  warnConditionallyRequiredProps,
+  warnControlledUsage,
+  warnDeprecations,
+  warnMutuallyExclusive,
+} from './Utilities';
+export type {
+  FitMode,
+  IAsAsyncOptions,
+  IBaseProps,
+  ICancelable,
+  IChangeDescription,
+  IChangeEventCallback,
+  IClassNames,
+  IClassNamesFunctionOptions,
+  IComponentAs,
+  IComponentAsProps,
+  ICssInput,
+  ICustomizableProps,
+  ICustomizations,
+  ICustomizerContext,
+  ICustomizerProps,
+  IDeclaredEventsByName,
+  IDelayedRenderProps,
+  IDelayedRenderState,
+  IDictionary,
+  IDisposable,
+  IEventRecord,
+  IEventRecordList,
+  IEventRecordsByName,
+  IFitContentToBoundsOptions,
+  IFocusRectsContext,
+  IPerfData,
+  IPerfMeasurement,
+  IPerfSummary,
+  IPropsWithStyles,
+  IRectangle,
+  IRefObject,
+  IRenderComponent,
+  IRenderFunction,
+  ISelectionOptionsWithRequiredGetKey,
+  ISerializableObject,
+  ISettings,
+  ISettingsFunction,
+  ISettingsMap,
+  ISize,
+  IStyleFunction,
+  IStyleFunctionOrObject,
+  IVirtualElement,
+  IWarnControlledUsageParams,
+  Omit,
+  RefObject,
+  Settings,
+  SettingsFunction,
+  StyleFunction,
+} from './Utilities';
+export { withViewport } from './Viewport';
+export type { IWithViewportState } from './Viewport';
+export {
+  WeeklyDayPicker,
+  defaultWeeklyDayPickerNavigationIcons,
+  defaultWeeklyDayPickerStrings,
+} from './WeeklyDayPicker';
+export type {
+  IWeeklyDayPicker,
+  IWeeklyDayPickerNavigationIcons,
+  IWeeklyDayPickerProps,
+  IWeeklyDayPickerStrings,
+  IWeeklyDayPickerStyleProps,
+  IWeeklyDayPickerStyles,
+} from './WeeklyDayPicker';
+export { WindowContext, WindowProvider, useDocument, useWindow } from './WindowProvider';
+export type { WindowProviderProps } from './WindowProvider';
 /**
  * Now explicitly declaring Theme exports that are NOT already being exported from Styles.
  * Styles and Theme both exported the same names which causes conflicting
  * star exports with webpack5. See here: https://github.com/microsoft/fluentui/issues/21601.
  */
-export * from './utilities/ThemeProvider/index';
+export { ThemeContext, ThemeProvider, makeStyles, useTheme } from './utilities/ThemeProvider/index';
+export type { StylesClassMapping, ThemeProviderProps, UseStylesOptions } from './utilities/ThemeProvider/index';
 export {
   CommunicationColors,
   DefaultSpacing,


### PR DESCRIPTION
## Repro

1. Using esbuild, bundle @fluentui/react/lib/index.js with esbuild, but externalize `date-time-utilities`.
2. Try to import `DayOfWeek` from bundle.

## Current Behavior

It's not exported because there are multiple paths to the external library, and esbuild gives up trying to dedupe across external boundaries.

## New Behavior

Due to expanding the root barrel index.ts star exports, paths to the exported things are now straightened out and you can now import `DayOfWeek` from the resulting bundle.

## Notes

* The api extractor result validated no api shift
* There were a number of duplicates in the exports that I removed by manually removing red squiggles.
* It is possible but very unlikely that importing `{namedThing} from './SomeTopLevelThing'` could translate to more nested export * ambiguity deeper int the tree, without getting rid of all export *s in sub-level barrel files. I'm minimizing the change here, and so far I don't see a need to go beyond the root. In v9 hopefully export * is totally disallowed, because it causes problems downstream. Better to be explicit.

## Related Issue(s)

See issue: https://github.com/evanw/esbuild/issues/2658
