### PR TITLE
chore(WebComponents v3): Enable bundlesize pipeline

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -4,6 +4,7 @@ pr:
 
 trigger:
   - master
+  - web-components-v3 # Remove before merging to master
 
 variables:
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/')) }}:


### PR DESCRIPTION
I enabled the bundle size pipeline for PRs to web-components-v3 in #25529.
Unfortunately I forgot to enable it on the branch itself. For that reason the branch is missing baseline measurements.

This PR enables the pipeline on the branch.