### PR TITLE
fix: Picker infinite loop on itemLimit=0 (#25550)

### DIFF
--- a/change/@fluentui-react-f52f6ff4-6134-461e-adfb-0138a31c60d8.json
+++ b/change/@fluentui-react-f52f6ff4-6134-461e-adfb-0138a31c60d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent infinite loop when Picker has itemLimit=0",
+  "packageName": "@fluentui/react",
+  "email": "r.vanbaaren@link-it.nl",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -599,7 +599,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
    * Resets focus to last element in wrapper div if clicking back into Picker that has hit item limit
    */
   protected onWrapperClick = (ev: React.MouseEvent<HTMLInputElement>): void => {
-    if (!this.canAddItems()) {
+    if (this.state.items.length && !this.canAddItems()) {
       this.resetFocus(this.state.items.length - 1);
     }
   };

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -413,7 +413,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
       if (newEl) {
         newEl.focus();
       }
-    } else if (!this.canAddItems()) {
+    } else if (items.length && !this.canAddItems()) {
       this.resetFocus(items.length - 1);
     } else {
       if (this.input.current) {


### PR DESCRIPTION
## Current Behavior

When setting the `itemLimit` on a picker to 0 and erasing all the items will cause an infinite loop.

## New Behavior

When setting a `itemLimit` of 0 on the picker will not cause an infinite loop.

> I was unable to create a test for this. Even before my change I couldn't get a test to fail on this.

## Related Issue(s)

Fixes #25550 
