### PR TITLE
stress-test: disable CSS transitions on injected styles

### DIFF
--- a/apps/stress-test/src/shared/css/injectStyles.ts
+++ b/apps/stress-test/src/shared/css/injectStyles.ts
@@ -158,7 +158,7 @@ export const randomCssFromSelectors = (selectors: string[]): string => {
   let css = '';
 
   selectors.forEach(selector => {
-    css += `${selector} { background-color: ${choice(colors)}; }\n`;
+    css += `${selector} { background-color: ${choice(colors)}; transition-duration: 0ms; }\n`;
   });
 
   return css;


### PR DESCRIPTION
## Current Behavior

When controls under test in `stress-test` have CSS `transition` styles the style recalculation measurement becomes unreliable in Firefox. Sometimes the measurement includes the transition time (i.e., we add something like 100ms to the style recalc time) and sometimes it does not. Chromium browsers remain stable on this measurement and never measure the transition time.

## New Behavior

Transition styles are disabled on any DOM node that matches a style injected by `stress-test`. This stabilizes Firefox's measurement and aligns it with Chromium so we're measuring the same thing in both engines.

## More Details

### With `transition`

#### Chromium Before

This is taken from Chrome but Edge gives the same results.
![chromium_profiler](https://user-images.githubusercontent.com/93940821/200376855-9cc06d54-da7a-4cca-9f1e-899d9af88a5f.png)

#### Firefox Before 

This aligns with Chromium 👍
![firefox_profiler_bad_but_accurate](https://user-images.githubusercontent.com/93940821/200376965-bb855435-7b86-470b-8a78-8f783ef38d3f.png)

This does not ☹️
![firefox_profiler_bad_and_not_accurate](https://user-images.githubusercontent.com/93940821/200377044-ab19961f-1289-49d4-8b32-3d248fda7373.png)

### Without `transition`

#### Chromium After

![chromium_profiler_after](https://user-images.githubusercontent.com/93940821/200377268-d0626379-9898-4198-b4ec-2ee453925d32.png)

#### Firefox After
![firefox_profiler_after](https://user-images.githubusercontent.com/93940821/200377314-ece13b59-ab92-40b8-9d20-5b17889e696c.png)

### Analysis

Measuring style recalc and layout in browsers is [somewhat challenging](https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/) as there isn't an API to query for this information in the browser itself. It seems what is happening in Firefox is that engine has some logic that sometimes splits the transition styles into two frame and sometimes merges (leaves them as?) a single frame. Chromium appears to always have two frames in this situation.

Ideally I think we'd measure the transition styles as it seems more correct to take into account all styles that appear on a given control. However, I've not been able to work out a reliable way to achieve this in a cross-browser way that also takes into account that some controls do not have transition styles. Basically, trying to support `transition` styles makes style recalc measurements less stable across the board.

Since an important quality of performance measurement tools is consistency and stability of measurements and since we want to make "apples-to-apples" comparisons across browsers as best we can, removing transition styles feels like the correct choice at this time. This change stabilizes Firefox's measurements and ensures we're measuring the same thing in Firefox and Chromium browsers.