### PR TITLE
stress-test: add "afterframe" dependency

### DIFF
--- a/apps/stress-test/package.json
+++ b/apps/stress-test/package.json
@@ -15,6 +15,7 @@
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/web-components": "^2.5.8",
     "@microsoft/fast-element": "^1.10.4",
+    "afterframe": "1.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "random-seedable": "1.0.8"

--- a/apps/stress-test/src/shared/react/TestMount.tsx
+++ b/apps/stress-test/src/shared/react/TestMount.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { styleInjector } from '../css/injectStyles';
-// import { requestPostAnimationFrame } from '../utils/requestPostAnimationFrame';
 import { ReactSelectorTree } from './ReactSelectorTree';
 import type { TestProps } from './types';
 

--- a/apps/stress-test/src/shared/utils/performanceMeasure.ts
+++ b/apps/stress-test/src/shared/utils/performanceMeasure.ts
@@ -1,11 +1,11 @@
-import { requestPostAnimationFrame } from './requestPostAnimationFrame';
+import afterframe from 'afterframe';
 
 export type PerformanceMeasureFn = (measureName?: string, startMark?: string) => void;
 
 export const performanceMeasure: PerformanceMeasureFn = (measureName = 'stress', startMark = 'start') => {
   performance.mark(startMark);
 
-  requestPostAnimationFrame(() => {
+  afterframe(() => {
     performance.measure(measureName, startMark);
   });
 };

--- a/apps/stress-test/src/shared/utils/requestPostAnimationFrame.ts
+++ b/apps/stress-test/src/shared/utils/requestPostAnimationFrame.ts
@@ -1,6 +1,0 @@
-export const requestPostAnimationFrame = (callback: Function): void => {
-  requestAnimationFrame(() => {
-    addEventListener('message', _ => callback(), { once: true });
-    postMessage('', '*');
-  });
-};

--- a/apps/stress-test/src/shared/vanilla/TestMount.ts
+++ b/apps/stress-test/src/shared/vanilla/TestMount.ts
@@ -3,7 +3,7 @@ import { SelectorTreeNode } from '../tree/types';
 import { DOMSelectorTreeComponentRenderer } from './types';
 import { renderVanillaSelectorTree } from './VanillaSelectorTree';
 import { styleInjector } from '../css/injectStyles';
-import { requestPostAnimationFrame } from '../utils/requestPostAnimationFrame';
+import afterframe from 'afterframe';
 
 export const testMount = (
   tree: SelectorTreeNode,
@@ -19,7 +19,7 @@ export const testMount = (
 
   const vanillaTree = renderVanillaSelectorTree(tree, selectors, componentRenderer, testOptions);
 
-  requestPostAnimationFrame(() => {
+  afterframe(() => {
     performance.measure('stress', 'start');
   });
   return vanillaTree;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6778,6 +6778,11 @@ adm-zip@0.5.9:
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
   integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
 
+afterframe@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/afterframe/-/afterframe-1.0.2.tgz#c63e17cdb29e4e60be2e618a315caf5ab5ade0c0"
+  integrity sha512-0JeMZI7dIfVs5guqLgidQNV7c6jBC2HO0QNSekAUB82Hr7PdU9QXNAF3kpFkvATvHYDDTGto7FPsRu1ey+aKJQ==
+
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"


### PR DESCRIPTION
## Current Behavior

`stress-test` has a function called `requestPostAnimationFrame` that allows us to measure the time between the start of the browser rendering a frame and the end. This is useful for measure style recalculation, layout and paint.

## New Behavior

Drop `requestPostAnimationFrame` in favor of taking a dependency on `afterframe`, a library that does the same thing. This reduces the amount of code in the `stress-test` app itself and allows us to focus on the features of the tool itself.