### PR TITLE
chore: Add reduced-motion documentation to Spinner

### DIFF
--- a/change/@fluentui-react-spinner-9b660086-15f0-4220-970b-d21b6a1e0ed4.json
+++ b/change/@fluentui-react-spinner-9b660086-15f0-4220-970b-d21b6a1e0ed4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add documentation for Spinner when reduced-motion is active",
+  "packageName": "@fluentui/react-spinner",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinner/Spec.md
+++ b/packages/react-components/react-spinner/Spec.md
@@ -118,3 +118,5 @@ The Spinner is non-interactive.
 - **Touch** - Nothing
 
 ## Accessibility
+
+When reduced motion, is active the `indeterminate` `Spinner` will rotate once and then stop animating.

--- a/packages/react-components/react-spinner/src/stories/Spinner/SpinnerBestPractices.md
+++ b/packages/react-components/react-spinner/src/stories/Spinner/SpinnerBestPractices.md
@@ -10,6 +10,7 @@
 - Use one Spinner at a time.
 - Descriptive verbs are appropriate under a Spinner to help the user understand what's happening. Ie: Saving, processing, updating.
 - Use a Spinner when confirming a change has been made or a task is being processed.
+- Add a description to a Spinner when reduced-motion is active
 
 ### Don't
 


### PR DESCRIPTION
This PR is to add more documentation about the `Spinner` behavior when `reduced-motion` is active. Fixes #25449 