### PR TITLE
chore: Add documentation to Progress about reduced-motion

### DIFF
--- a/packages/react-components/react-progress/Spec.md
+++ b/packages/react-components/react-progress/Spec.md
@@ -121,3 +121,4 @@ The Progress is non-interactive.
 ## Accessibility
 
 - The `determinate` Progress has the proper `aria` attributes assigned to the element that will allow screen readers to get the `max` and current `value` of the `Progress`.
+- When `reduced-motion` is active, the `indeterminate` `Progress` will animate only once. Use `ProgressField` to add a `description` and `hint` message to the `Progress` bar.

--- a/packages/react-components/react-progress/src/components/Progress/useProgressStyles.ts
+++ b/packages/react-components/react-progress/src/components/Progress/useProgressStyles.ts
@@ -98,6 +98,10 @@ const useBarStyles = makeStyles({
     animationName: indeterminateProgress,
     animationDuration: '3s',
     animationIterationCount: 'infinite',
+    '@media screen and (prefers-reduced-motion: reduce)': {
+      animationDuration: '0.01ms',
+      animationIterationCount: '1',
+    },
   },
 
   rtl: {

--- a/packages/react-components/react-progress/src/stories/Progress/ProgressBestPractices.md
+++ b/packages/react-components/react-progress/src/stories/Progress/ProgressBestPractices.md
@@ -6,6 +6,7 @@
 - Display operation description
 - Show text above and/or below the bar
 - Combine steps of a single operation into one bar
+- Use `ProgressField` to add a `description` and `hint` message for the `indeterminate` `Progress` when `reduced-motion` is active
 
 ### Don't
 


### PR DESCRIPTION
This PR adds styling and documentation to the `Progress` component about the behavior when `reduced-motion` is active. Fixes #25450 