### PR TITLE
docs(public-docsite-v9): Adding a basic setup section to the SSR docs

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -7,30 +7,63 @@ import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 Fluent UI React v9 fully supports Server-Side Rendering.
 
-## Basic setup
+### Basic setup
 
 For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `ThemeProvider` in the root file of your app. If these providers are not added, there will be issues when hydrating. See the following example:
 
 ```tsx
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/server';
 import {
   createDOMRenderer,
   FluentProvider,
-  SSRProvider,
+  makeStyles,
   RendererProvider,
+  renderToStyleElements,
+  SSRProvider,
   webLightTheme,
 } from '@fluentui/react-components';
 
-function App() {
-  return (
-    <RendererProvider renderer={createDOMRenderer()}>
+const useExampleStyles = makeStyles({
+  root: {
+    color: 'red',
+  },
+});
+
+const ExampleComponent: React.FC = () => {
+  const classes = useExampleStyles();
+
+  return <div className={classes.root}>Hello world</div>;
+};
+
+const server = express();
+
+server.get('/', (req, res) => {
+  const renderer = createDOMRenderer();
+
+  const html = ReactDOM.renderToString(
+    <RendererProvider renderer={renderer}>
       <SSRProvider>
         <FluentProvider theme={webLightTheme}>
-          <div className="App">{/* ... */}</div>
+          <ExampleComponent />
         </FluentProvider>
       </SSRProvider>
-    </RendererProvider>
+    </RendererProvider>,
   );
-}
+
+  res.send(`
+    <html>
+      <head>
+        ${renderToStyleElements(renderer)}
+      </head>
+      <body>
+        <div id="root">${html}</div>
+      </body>
+    </html>
+  `);
+});
+
+server.listen(3000, 'localhost');
 ```
 
 ### Next.js

--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -7,6 +7,32 @@ import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 Fluent UI React v9 fully supports Server-Side Rendering.
 
+## Basic setup
+
+For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `ThemeProvider` in the root file of your app. If these providers are not added, there will be issues when hydrating. See the following example:
+
+```tsx
+import {
+  createDOMRenderer,
+  FluentProvider,
+  SSRProvider,
+  RendererProvider,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+function App() {
+  return (
+    <RendererProvider renderer={createDOMRenderer()}>
+      <SSRProvider>
+        <FluentProvider theme={webLightTheme}>
+          <div className="App">{/* ... */}</div>
+        </FluentProvider>
+      </SSRProvider>
+    </RendererProvider>
+  );
+}
+```
+
 ### Next.js
 
 For basic instructions on getting Next.js set up, see [Getting Started](https://nextjs.org/docs/getting-started).


### PR DESCRIPTION
We noticed that since the docs only mention NextJS, it can be confusing how to setup SSR with Fluent UI v9. The most important part being that a `SSRProvider`, `FluentProvider`, and a `RendererProvider` are needed to avoid hydration issues among others. This PR adds a `Basic setup` section to the SSR docs and mentions how to add these.
