### PR TITLE
feat(scripts): remove @internal stripping and enable no deps build needed for api generation

### DIFF
--- a/scripts/api-extractor/api-extractor.common.v-next.json
+++ b/scripts/api-extractor/api-extractor.common.v-next.json
@@ -9,10 +9,7 @@
   },
   "dtsRollup": {
     "enabled": true,
-    // TODO: replace following line with these 2 commented ones after all v9 is migrated to new build and .d.ts API stripping
     "untrimmedFilePath": "<projectFolder>/dist/index.d.ts",
-    // "untrimmedFilePath": "<projectFolder>/dist/untrimmed.d.ts",
-    // "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts",
     "omitTrimmingComments": false
   },
   "compiler": {

--- a/scripts/tasks/api-extractor.ts
+++ b/scripts/tasks/api-extractor.ts
@@ -147,6 +147,7 @@ export function apiExtractor() {
                   tsConfig,
                   tsConfigPath,
                   packageJson,
+                  definitionsRootPath: 'dist/out-tsc/types',
                 });
 
                 config.compiler = compilerConfig;

--- a/scripts/tasks/ts.ts
+++ b/scripts/tasks/ts.ts
@@ -34,7 +34,7 @@ function prepareTsTaskConfig(options: TscTaskOptions) {
     if (hasNewCompilationSetup) {
       options.outDir = `${tsConfigOutDir}/${options.outDir}`;
     } else {
-      // TODO: remove after all v9 is migrated to new build and .d.ts API stripping
+      // TODO: remove after all v9 is migrated to new tsc processing
       options.baseUrl = '.';
       options.rootDir = './src';
     }

--- a/scripts/tasks/utils.spec.ts
+++ b/scripts/tasks/utils.spec.ts
@@ -1,0 +1,53 @@
+import { getTsPathAliasesApiExtractorConfig } from './utils';
+
+type DeepPartial<T> = Partial<{ [P in keyof T]: DeepPartial<T[P]> }>;
+describe(`utils`, () => {
+  describe(`#getTsPathAliasesApiExtractorConfig`, () => {
+    type Options = Parameters<typeof getTsPathAliasesApiExtractorConfig>[0];
+    function setup(options: DeepPartial<Options> = {}) {
+      const defaults = {
+        tsConfig: {
+          compilerOptions: {
+            outDir: '../../dist/out-tsc',
+            ...options.tsConfig?.compilerOptions,
+          },
+        },
+        tsConfigPath: 'tsconfig.lib.json',
+        packageJson: {
+          name: '@proj/one',
+          version: '0.0.1',
+          main: 'lib/index.js',
+          dependencies: { ...options.packageJson?.dependencies },
+          peerDependencies: { ...options.packageJson?.peerDependencies },
+        },
+        definitionsRootPath: options.definitionsRootPath ?? 'dist/types',
+      };
+
+      return getTsPathAliasesApiExtractorConfig(defaults as Options);
+    }
+
+    it(`should set compilerOptions`, () => {
+      const actual = setup();
+
+      expect(actual.overrideTsconfig.compilerOptions).toEqual(
+        expect.objectContaining({ isolatedModules: false, skipLibCheck: false }),
+      );
+    });
+
+    it(`should override path aliases to emitted declaration files instead of source files`, () => {
+      const actual = setup({ definitionsRootPath: 'dist/for/types' });
+
+      const newPaths = (actual.overrideTsconfig.compilerOptions.paths as unknown) as Record<string, string[]>;
+
+      const newPath = Object.values(newPaths)[0][0];
+      expect(newPath).toMatch(new RegExp('^dist/for/types.+src/index.d.ts$', 'i'));
+    });
+
+    it(`should set allowSyntheticDefaultImports if package has invalid deps/peerDeps`, () => {
+      const actual = setup({ packageJson: { dependencies: { '@storybook/api': '6.5.0' } } });
+      expect(actual.overrideTsconfig.compilerOptions).toEqual(
+        expect.objectContaining({ allowSyntheticDefaultImports: true }),
+      );
+    });
+  });
+});

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -853,11 +853,6 @@ describe('migrate-converged-pkg generator', () => {
       expect(readJson(tree, apiExtractorConfigPath)).toMatchInlineSnapshot(`
         Object {
           "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-          "dtsRollup": Object {
-            "enabled": true,
-            "publicTrimmedFilePath": "<projectFolder>/dist/index.d.ts",
-            "untrimmedFilePath": "",
-          },
           "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
         }
       `);
@@ -1493,8 +1488,7 @@ describe('migrate-converged-pkg generator', () => {
             },
             "dtsRollup": Object {
               "enabled": true,
-              "publicTrimmedFilePath": "<projectFolder>/dist/unstable.d.ts",
-              "untrimmedFilePath": "<projectFolder>/dist/unstable-untrimmed.d.ts",
+              "untrimmedFilePath": "<projectFolder>/dist/unstable.d.ts",
             },
             "extends": "@fluentui/scripts/api-extractor/api-extractor.common.v-next.json",
             "mainEntryPointFilePath": "<projectFolder>/../../../dist/out-tsc/types/packages/react-components/<unscopedPackageName>/src/unstable/index.d.ts",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

- apis marked with `@internal` are physically removed from rollup-ed `index.d.ts`
- `api.md` generation works differently on CI and Local
  - ci triggers it under the hood as part of `just-scripts build` 
  - locally one needs to execute `build:local` or `lage build --to`
- `api.md` generation needs all dependencies to have api generated

## New Behavior

- no apis are physically removed from rollup-ed `index.d.ts` as that adds hard to reason about issues in user land
  - will be replaced by lint rule  
- `api.md` generation works the same on CI and Local
- `api.md` generation doesn't need to to generate apis for dependencies 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Replaces https://github.com/microsoft/fluentui/pull/23369
Closes https://github.com/microsoft/fluentui/issues/19360

## Follow up

- [x] apply new config on all packages https://github.com/microsoft/fluentui/pull/25609

💡 Note that this PR was merged after the declared followup. 

**Why?**

Turns out our pipelines ran into race conditions which ended up in unexpected `build` followed by `test` task execution failures caused by hybrid state of tsc processing and api-extractor 🚨. Last but not least, we need to act on those Test memory leaks which will cause us a lot of issues when migrating to node 16 (that will fail on unhandled rejection promises ) 