### PR TITLE
fix: SSRProvider TypeScript definitions

### DIFF
--- a/change/@fluentui-react-utilities-9259798e-d6da-420f-8da3-3bf377f4825b.json
+++ b/change/@fluentui-react-utilities-9259798e-d6da-420f-8da3-3bf377f4825b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update definitions for SSRProvider",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -131,7 +131,9 @@ export type Slots<S extends SlotPropsRecord> = {
 export type SlotShorthandValue = React_2.ReactChild | React_2.ReactNode[] | React_2.ReactPortal;
 
 // @public
-export const SSRProvider: React_2.FC;
+export const SSRProvider: React_2.FC<{
+    children: React_2.ReactNode;
+}>;
 
 // @public
 export type TriggerProps<TriggerChildProps = unknown> = {

--- a/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
@@ -35,7 +35,7 @@ export function useSSRContext(): SSRContextValue {
  *
  * @public
  */
-export const SSRProvider: React.FC = props => {
+export const SSRProvider: React.FC<{ children: React.ReactNode }> = props => {
   const [value] = React.useState<SSRContextValue>(() => ({ current: 0 }));
 
   return <SSRContext.Provider value={value}>{props.children}</SSRContext.Provider>;


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior
![image](https://user-images.githubusercontent.com/1209159/200735199-8158cc4d-7d57-472b-a46a-ce7e86be9a75.png)

## New Behavior

* fix the issue
## Related Issue(s)

* children prop now needs to be listed explicitly when defining props in React 18
* [How to Upgrade to React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions)
