### PR TITLE
chore(react-theme): do not export spacings

### DIFF
--- a/change/@fluentui-react-theme-a729b272-7bf6-4abe-9372-70300f8e776b.json
+++ b/change/@fluentui-react-theme-a729b272-7bf6-4abe-9372-70300f8e776b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(react-theme): do not export spacings",
+  "packageName": "@fluentui/react-theme",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-theme/src/global/spacings.ts
+++ b/packages/react-components/react-theme/src/global/spacings.ts
@@ -1,6 +1,7 @@
 import type { HorizontalSpacingTokens, SpacingTokens, VerticalSpacingTokens } from '../types';
 
-export const spacings: SpacingTokens = {
+// Intentionally not exported! Use horizontalSpacings and verticalSpacings instead.
+const spacings: SpacingTokens = {
   none: '0',
   xxs: '2px',
   xs: '4px',


### PR DESCRIPTION
## Current Behavior

`spacings` was marked as exported inside the package (**it has never exported out of the package**)

## New Behavior

`spacings` are now internal to the file to avoid confuction

