### PR TITLE
feat: add allowFreeInput to v8 ComboBox to allow typing while the combobox is in focus

### DIFF
--- a/change/@fluentui-react-a50694ba-a465-4888-a8e1-81e560c8d563.json
+++ b/change/@fluentui-react-a50694ba-a465-4888-a8e1-81e560c8d563.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: add allowFreeSearch to ComboBox, to allow typing while the combobox is in focus",
+  "comment": "feat: add allowFreeInput to ComboBox, to allow typing while the combobox is in focus",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-a50694ba-a465-4888-a8e1-81e560c8d563.json
+++ b/change/@fluentui-react-a50694ba-a465-4888-a8e1-81e560c8d563.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add allowFreeSearch to ComboBox, to allow typing while the combobox is in focus",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
-import { ComboBox, SelectableOptionMenuItemType } from '@fluentui/react';
+import { ComboBox } from '@fluentui/react';
 import type { IComboBoxOption, IComboBoxStyles } from '@fluentui/react';
 
 const options: IComboBoxOption[] = [
-  { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
-  { key: 'A', text: 'Option A' },
-  { key: 'B', text: 'Option B' },
-  { key: 'C', text: 'Option C' },
-  { key: 'D', text: 'Option D' },
-  { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },
-  { key: 'Header2', text: 'Second heading', itemType: SelectableOptionMenuItemType.Header },
-  { key: 'E', text: 'Option E' },
-  { key: 'F', text: 'Option F', disabled: true },
-  { key: 'G', text: 'Option G' },
-  { key: 'H', text: 'Option H' },
-  { key: 'I', text: 'Option I' },
-  { key: 'J', text: 'Option J' },
+  { key: 'black', text: 'Black' },
+  { key: 'blue', text: 'Blue' },
+  { key: 'brown', text: 'Brown' },
+  { key: 'cyan', text: 'Cyan' },
+  { key: 'green', text: 'Green' },
+  { key: 'magenta', text: 'Magenta', disabled: true },
+  { key: 'mauve', text: 'Mauve' },
+  { key: 'orange', text: 'Orange' },
+  { key: 'pink', text: 'Pink' },
+  { key: 'purple', text: 'Purple' },
+  { key: 'red', text: 'Red' },
+  { key: 'rose', text: 'Rose' },
+  { key: 'violet', text: 'Violet' },
+  { key: 'white', text: 'White' },
+  { key: 'yellow', text: 'Yellow' },
 ];
 // Optional styling to make the example look nicer
 const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };

--- a/packages/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { ComboBox, IComboBoxOption, IComboBoxStyles, SelectableOptionMenuItemType } from '@fluentui/react';
+import { ComboBox, SelectableOptionMenuItemType } from '@fluentui/react';
+import type { IComboBoxOption, IComboBoxStyles } from '@fluentui/react';
 
 const options: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
@@ -19,23 +20,23 @@ const options: IComboBoxOption[] = [
 // Optional styling to make the example look nicer
 const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
 
-export const ComboBoxFreeSearchExample: React.FunctionComponent = () => {
+export const ComboBoxFreeInputExample: React.FunctionComponent = () => {
   return (
     <div>
       <ComboBox
-        label="ComboBox with allowFreeSearch and autocomplete"
+        label="ComboBox with allowFreeInput and autocomplete"
         options={options}
         styles={comboBoxStyles}
-        allowFreeSearch
-        autoComplete="off"
+        allowFreeInput
+        autoComplete="on"
       />
       <ComboBox
         defaultSelectedKey="C"
-        label="ComboBox with allowFreeSearch without autocomplete"
+        label="ComboBox with allowFreeInput without autocomplete"
         options={options}
         styles={comboBoxStyles}
-        allowFreeSearch
-        autoComplete="on"
+        allowFreeInput
+        autoComplete="off"
       />
     </div>
   );

--- a/packages/react-examples/src/react/ComboBox/ComboBox.FreeSearch.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.FreeSearch.Example.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { ComboBox, IComboBoxOption, IComboBoxStyles, SelectableOptionMenuItemType } from '@fluentui/react';
+
+const options: IComboBoxOption[] = [
+  { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'A', text: 'Option A' },
+  { key: 'B', text: 'Option B' },
+  { key: 'C', text: 'Option C' },
+  { key: 'D', text: 'Option D' },
+  { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },
+  { key: 'Header2', text: 'Second heading', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'E', text: 'Option E' },
+  { key: 'F', text: 'Option F', disabled: true },
+  { key: 'G', text: 'Option G' },
+  { key: 'H', text: 'Option H' },
+  { key: 'I', text: 'Option I' },
+  { key: 'J', text: 'Option J' },
+];
+// Optional styling to make the example look nicer
+const comboBoxStyles: Partial<IComboBoxStyles> = { root: { maxWidth: 300 } };
+
+export const ComboBoxFreeSearchExample: React.FunctionComponent = () => {
+  return (
+    <div>
+      <ComboBox
+        label="ComboBox with allowFreeSearch and autocomplete"
+        options={options}
+        styles={comboBoxStyles}
+        allowFreeSearch
+        autoComplete="off"
+      />
+      <ComboBox
+        defaultSelectedKey="C"
+        label="ComboBox with allowFreeSearch without autocomplete"
+        options={options}
+        styles={comboBoxStyles}
+        allowFreeSearch
+        autoComplete="on"
+      />
+    </div>
+  );
+};

--- a/packages/react-examples/src/react/ComboBox/ComboBox.doc.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.doc.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ComboBoxBasicExample } from './ComboBox.Basic.Example';
+import { ComboBoxFreeSearchExample } from './ComboBox.FreeSearch.Example';
 import { ComboBoxInlineExample } from './ComboBox.Inline.Example';
 import { ComboBoxTogglesExample } from './ComboBox.Toggles.Example';
 import { ComboBoxControlledExample } from './ComboBox.Controlled.Example';
@@ -12,6 +13,7 @@ import { ComboBoxCustomStyledExample } from './ComboBox.CustomStyled.Example';
 import { IDocPageProps } from '@fluentui/react/lib/common/DocPage.types';
 
 const ComboBoxBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Basic.Example.tsx') as string;
+const ComboBoxFreeSearchExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.FreeSearch.Example.tsx') as string;
 const ComboBoxInlineExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx') as string;
 const ComboBoxTogglesExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Toggles.Example.tsx') as string;
 const ComboBoxControlledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Controlled.Example.tsx') as string;
@@ -30,6 +32,11 @@ export const ComboBoxPageProps: IDocPageProps = {
       title: 'Basic uncontrolled ComboBox',
       code: ComboBoxBasicExampleCode,
       view: <ComboBoxBasicExample />,
+    },
+    {
+      title: 'ComboBox with allowFreeSearch',
+      code: ComboBoxFreeSearchExampleCode,
+      view: <ComboBoxFreeSearchExample />,
     },
     {
       title: 'ComboBox with inline dropdown',

--- a/packages/react-examples/src/react/ComboBox/ComboBox.doc.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.doc.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ComboBoxBasicExample } from './ComboBox.Basic.Example';
-import { ComboBoxFreeSearchExample } from './ComboBox.FreeSearch.Example';
+import { ComboBoxFreeInputExample } from './ComboBox.FreeInput.Example';
 import { ComboBoxInlineExample } from './ComboBox.Inline.Example';
 import { ComboBoxTogglesExample } from './ComboBox.Toggles.Example';
 import { ComboBoxControlledExample } from './ComboBox.Controlled.Example';
@@ -13,7 +13,7 @@ import { ComboBoxCustomStyledExample } from './ComboBox.CustomStyled.Example';
 import { IDocPageProps } from '@fluentui/react/lib/common/DocPage.types';
 
 const ComboBoxBasicExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Basic.Example.tsx') as string;
-const ComboBoxFreeSearchExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.FreeSearch.Example.tsx') as string;
+const ComboBoxFreeInputExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx') as string;
 const ComboBoxInlineExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Inline.Example.tsx') as string;
 const ComboBoxTogglesExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Toggles.Example.tsx') as string;
 const ComboBoxControlledExampleCode = require('!raw-loader?esModule=false!@fluentui/react-examples/src/react/ComboBox/ComboBox.Controlled.Example.tsx') as string;
@@ -34,9 +34,9 @@ export const ComboBoxPageProps: IDocPageProps = {
       view: <ComboBoxBasicExample />,
     },
     {
-      title: 'ComboBox with allowFreeSearch',
-      code: ComboBoxFreeSearchExampleCode,
-      view: <ComboBoxFreeSearchExample />,
+      title: 'ComboBox with allowFreeInput',
+      code: ComboBoxFreeInputExampleCode,
+      view: <ComboBoxFreeInputExample />,
     },
     {
       title: 'ComboBox with inline dropdown',

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3901,6 +3901,7 @@ export interface IComboBoxOptionStyles extends IButtonStyles {
 // @public (undocumented)
 export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox, IComboBox>, React_2.RefAttributes<HTMLDivElement> {
     allowFreeform?: boolean;
+    allowFreeSearch?: boolean;
     ariaDescribedBy?: string;
     autoComplete?: 'on' | 'off';
     autofill?: IAutofillProps;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3901,7 +3901,7 @@ export interface IComboBoxOptionStyles extends IButtonStyles {
 // @public (undocumented)
 export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox, IComboBox>, React_2.RefAttributes<HTMLDivElement> {
     allowFreeform?: boolean;
-    allowFreeSearch?: boolean;
+    allowFreeInput?: boolean;
     ariaDescribedBy?: string;
     autoComplete?: 'on' | 'off';
     autofill?: IAutofillProps;

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -279,9 +279,9 @@ describe('ComboBox', () => {
     expect(combobox.getAttribute('value')).toEqual('Foo');
   });
 
-  it('Can insert text in uncontrolled case with autoComplete and allowFreeSearch on', () => {
+  it('Can insert text in uncontrolled case with autoComplete and allowFreeInput on', () => {
     const { getByRole } = render(
-      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="on" allowFreeSearch />,
+      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="on" allowFreeInput />,
     );
 
     const combobox = getByRole('combobox');
@@ -315,9 +315,9 @@ describe('ComboBox', () => {
     expect(combobox.getAttribute('value')).toEqual('f');
   });
 
-  it('Can insert text in uncontrolled case with autoComplete off and allowFreeSearch on', () => {
+  it('Can insert text in uncontrolled case with autoComplete off and allowFreeInput on', () => {
     const { getByRole } = render(
-      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="off" allowFreeSearch />,
+      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="off" allowFreeInput />,
     );
 
     const combobox = getByRole('combobox');
@@ -609,14 +609,14 @@ describe('ComboBox', () => {
     expect(changedValue).toEqual('');
   });
 
-  it('onInputValueChange is called when the input changes with allowFreeSearch', () => {
+  it('onInputValueChange is called when the input changes with allowFreeInput', () => {
     let changedValue: string | undefined = undefined;
     const onInputValueChangeHandler = (value: string) => {
       changedValue = value;
     };
 
     const { getByRole } = render(
-      <ComboBox options={DEFAULT_OPTIONS} allowFreeSearch onInputValueChange={onInputValueChangeHandler} />,
+      <ComboBox options={DEFAULT_OPTIONS} allowFreeInput onInputValueChange={onInputValueChangeHandler} />,
     );
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'a');
@@ -629,10 +629,10 @@ describe('ComboBox', () => {
     expect(changedValue).toEqual('');
   });
 
-  it('onChange is called when a full matching option is typed and submitted with allowFreeSearch', () => {
+  it('onChange is called when a full matching option is typed and submitted with allowFreeInput', () => {
     const onChange = jest.fn();
 
-    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS2} allowFreeSearch onChange={onChange} />);
+    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS2} allowFreeInput onChange={onChange} />);
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'foo');
     expect(onChange).not.toHaveBeenCalled();
@@ -641,20 +641,20 @@ describe('ComboBox', () => {
     expect(onChange).toHaveBeenCalledWith(expect.anything(), DEFAULT_OPTIONS2[1], 1, 'Foo');
   });
 
-  it('onChange is not called when a non-matching is typed and submitted with allowFreeSearch', () => {
+  it('onChange is not called when a non-matching string is typed and submitted with allowFreeInput', () => {
     const onChange = jest.fn();
 
-    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS2} allowFreeSearch onChange={onChange} />);
+    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS2} allowFreeInput onChange={onChange} />);
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'abc{enter}');
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('onPendingValueChanged is called when a full matching option is typed with allowFreeSearch', () => {
+  it('onPendingValueChanged is called when a full matching option is typed with allowFreeInput', () => {
     const onPendingValueChanged = jest.fn();
 
     const { getByRole } = render(
-      <ComboBox options={DEFAULT_OPTIONS2} allowFreeSearch onPendingValueChanged={onPendingValueChanged} />,
+      <ComboBox options={DEFAULT_OPTIONS2} allowFreeInput onPendingValueChanged={onPendingValueChanged} />,
     );
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'foo');

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -279,6 +279,16 @@ describe('ComboBox', () => {
     expect(combobox.getAttribute('value')).toEqual('Foo');
   });
 
+  it('Can insert text in uncontrolled case with autoComplete and allowFreeSearch on', () => {
+    const { getByRole } = render(
+      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="on" allowFreeSearch />,
+    );
+
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'f');
+    expect(combobox.getAttribute('value')).toEqual('Foo');
+  });
+
   it('Can insert text in uncontrolled case with autoComplete on and allowFreeform off', () => {
     const { getByRole } = render(<ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="on" />);
 
@@ -303,6 +313,16 @@ describe('ComboBox', () => {
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'f');
     expect(combobox.getAttribute('value')).toEqual('f');
+  });
+
+  it('Can insert text in uncontrolled case with autoComplete off and allowFreeSearch on', () => {
+    const { getByRole } = render(
+      <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} autoComplete="off" allowFreeSearch />,
+    );
+
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'xyz');
+    expect(combobox.getAttribute('value')).toEqual('xyz');
   });
 
   it('Can insert text in uncontrolled case with autoComplete and allowFreeform off', () => {
@@ -587,6 +607,58 @@ describe('ComboBox', () => {
 
     userEvent.clear(combobox);
     expect(changedValue).toEqual('');
+  });
+
+  it('onInputValueChange is called when the input changes with allowFreeSearch', () => {
+    let changedValue: string | undefined = undefined;
+    const onInputValueChangeHandler = (value: string) => {
+      changedValue = value;
+    };
+
+    const { getByRole } = render(
+      <ComboBox options={DEFAULT_OPTIONS} allowFreeSearch onInputValueChange={onInputValueChangeHandler} />,
+    );
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'a');
+    expect(changedValue).toEqual('a');
+
+    userEvent.type(combobox, 'bcd');
+    expect(changedValue).toEqual('abcd');
+
+    userEvent.clear(combobox);
+    expect(changedValue).toEqual('');
+  });
+
+  it('onChange is called when a full matching option is typed and submitted with allowFreeSearch', () => {
+    const onChange = jest.fn();
+
+    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS2} allowFreeSearch onChange={onChange} />);
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'foo');
+    expect(onChange).not.toHaveBeenCalled();
+
+    userEvent.type(combobox, '{enter}');
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), DEFAULT_OPTIONS2[1], 1, 'Foo');
+  });
+
+  it('onChange is not called when a non-matching is typed and submitted with allowFreeSearch', () => {
+    const onChange = jest.fn();
+
+    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS2} allowFreeSearch onChange={onChange} />);
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'abc{enter}');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('onPendingValueChanged is called when a full matching option is typed with allowFreeSearch', () => {
+    const onPendingValueChanged = jest.fn();
+
+    const { getByRole } = render(
+      <ComboBox options={DEFAULT_OPTIONS2} allowFreeSearch onPendingValueChanged={onPendingValueChanged} />,
+    );
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'foo');
+    expect(onPendingValueChanged).toHaveBeenCalledWith(DEFAULT_OPTIONS2[1], 1, undefined);
   });
 
   it('suggestedDisplayValue is set to undefined when the selected input is cleared', () => {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -712,7 +712,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       // Single-select
       let index: number = this._getFirstSelectedIndex();
       if (allowFreeform || allowFreeInput) {
-        // If we are allowing freeform/free search and autocomplete is also true
+        // If we are allowing freeform/free input and autocomplete is also true
         // and we've got a pending value that matches an option, remember
         // the matched option's index
         if (autoComplete === 'on' && currentPendingIndexValid) {
@@ -2135,7 +2135,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           return;
         }
 
-        // If we are not allowing freeform or free search and
+        // If we are not allowing freeform or free input and
         // allowing autoComplete, handle the input here
         if (!allowFreeform && !allowFreeInput && autoComplete === 'on') {
           this._onInputChange(ev.key);

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -343,6 +343,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   public componentDidUpdate(prevProps: IComboBoxInternalProps, prevState: IComboBoxState) {
     const {
       allowFreeform,
+      allowFreeSearch,
       text,
       onMenuOpen,
       onMenuDismissed,
@@ -388,7 +389,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
             prevProps.hoisted.selectedIndices &&
             selectedIndices &&
             prevProps.hoisted.selectedIndices[0] !== selectedIndices[0]) ||
-            !allowFreeform ||
+            (!allowFreeform && !allowFreeSearch) ||
             text !== prevProps.text)))
     ) {
       this._onFocus();
@@ -554,12 +555,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       return null;
     }
 
-    const visibleValue = normalizeToString(this._currentVisibleValue);
-    if (comboBox.value !== visibleValue) {
-      return visibleValue;
-    }
-
-    return comboBox.value;
+    return normalizeToString(this._currentVisibleValue);
   };
 
   private _renderComboBoxWrapper = (
@@ -683,6 +679,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const {
       text,
       allowFreeform,
+      allowFreeSearch,
       autoComplete,
       hoisted: { suggestedDisplayValue, selectedIndices, currentOptions },
     } = this.props;
@@ -714,8 +711,8 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     } else {
       // Single-select
       let index: number = this._getFirstSelectedIndex();
-      if (allowFreeform) {
-        // If we are allowing freeform and autocomplete is also true
+      if (allowFreeform || allowFreeSearch) {
+        // If we are allowing freeform/free search and autocomplete is also true
         // and we've got a pending value that matches an option, remember
         // the matched option's index
         if (autoComplete === 'on' && currentPendingIndexValid) {
@@ -796,7 +793,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       this.props.onInputValueChange(updatedValue);
     }
 
-    this.props.allowFreeform
+    this.props.allowFreeform || this.props.allowFreeSearch
       ? this._processInputChangeWithFreeform(updatedValue)
       : this._processInputChangeWithoutFreeform(updatedValue);
   };
@@ -911,7 +908,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       }
     }
 
-    // If we get here, either autoComplete is on or we did not find a match with autoComplete on.
+    // If we get here, either autoComplete is off or we did not find a match with autoComplete on.
     // Remember we are not allowing freeform, so at this point, if we have a pending valid value index
     // use that; otherwise use the selectedIndex
     const index = currentPendingValueValidIndex >= 0 ? currentPendingValueValidIndex : this._getFirstSelectedIndex();
@@ -1967,6 +1964,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const {
       disabled,
       allowFreeform,
+      allowFreeSearch,
       autoComplete,
       hoisted: { currentOptions },
     } = this.props;
@@ -2095,7 +2093,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
       case KeyCodes.home:
       case KeyCodes.end:
-        if (allowFreeform) {
+        if (allowFreeform || allowFreeSearch) {
           return;
         }
 
@@ -2118,7 +2116,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       /* eslint-disable no-fallthrough */
       case KeyCodes.space:
         // event handled in _onComboBoxKeyUp
-        if (!allowFreeform && autoComplete === 'off') {
+        if (!allowFreeform && !allowFreeSearch && autoComplete === 'off') {
           break;
         }
 
@@ -2137,12 +2135,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           return;
         }
 
-        // If we are not allowing freeform and
+        // If we are not allowing freeform or free search and
         // allowing autoComplete, handle the input here
-        // since we have marked the input as readonly
-        if (!allowFreeform && autoComplete === 'on') {
+        if (!allowFreeform && !allowFreeSearch && autoComplete === 'on') {
           this._onInputChange(ev.key);
-          break;
+          return;
         }
 
         // allow the key to propagate by default
@@ -2158,7 +2155,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * @param ev - the keyboard event that was fired
    */
   private _onInputKeyUp = (ev: React.KeyboardEvent<HTMLElement | Autofill>): void => {
-    const { disabled, allowFreeform, autoComplete } = this.props;
+    const { disabled, allowFreeform, allowFreeSearch, autoComplete } = this.props;
     const isOpen = this.state.isOpen;
 
     // We close the menu on key up only if ALL of the following are true:
@@ -2183,7 +2180,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         // If we are not allowing freeform and are not autoComplete
         // make space expand/collapse the combo box
         // and allow the event to propagate
-        if (!allowFreeform && autoComplete === 'off') {
+        if (!allowFreeform && !allowFreeSearch && autoComplete === 'off') {
           this._setOpenStateAndFocusOnClose(!isOpen, !!isOpen);
         }
         return;

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -343,7 +343,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   public componentDidUpdate(prevProps: IComboBoxInternalProps, prevState: IComboBoxState) {
     const {
       allowFreeform,
-      allowFreeSearch,
+      allowFreeInput,
       text,
       onMenuOpen,
       onMenuDismissed,
@@ -377,7 +377,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     //   just opened/closed the menu OR
     //   are focused AND
     //     updated the selectedIndex with the menu closed OR
-    //     are not allowing freeform OR
+    //     are not allowing freeform or free input OR
     //     the value changed
     // we need to set selection
     if (
@@ -389,7 +389,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
             prevProps.hoisted.selectedIndices &&
             selectedIndices &&
             prevProps.hoisted.selectedIndices[0] !== selectedIndices[0]) ||
-            (!allowFreeform && !allowFreeSearch) ||
+            (!allowFreeform && !allowFreeInput) ||
             text !== prevProps.text)))
     ) {
       this._onFocus();
@@ -679,7 +679,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const {
       text,
       allowFreeform,
-      allowFreeSearch,
+      allowFreeInput,
       autoComplete,
       hoisted: { suggestedDisplayValue, selectedIndices, currentOptions },
     } = this.props;
@@ -711,7 +711,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     } else {
       // Single-select
       let index: number = this._getFirstSelectedIndex();
-      if (allowFreeform || allowFreeSearch) {
+      if (allowFreeform || allowFreeInput) {
         // If we are allowing freeform/free search and autocomplete is also true
         // and we've got a pending value that matches an option, remember
         // the matched option's index
@@ -793,7 +793,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       this.props.onInputValueChange(updatedValue);
     }
 
-    this.props.allowFreeform || this.props.allowFreeSearch
+    this.props.allowFreeform || this.props.allowFreeInput
       ? this._processInputChangeWithFreeform(updatedValue)
       : this._processInputChangeWithoutFreeform(updatedValue);
   };
@@ -1964,7 +1964,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const {
       disabled,
       allowFreeform,
-      allowFreeSearch,
+      allowFreeInput,
       autoComplete,
       hoisted: { currentOptions },
     } = this.props;
@@ -2093,7 +2093,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
       case KeyCodes.home:
       case KeyCodes.end:
-        if (allowFreeform || allowFreeSearch) {
+        if (allowFreeform || allowFreeInput) {
           return;
         }
 
@@ -2116,7 +2116,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       /* eslint-disable no-fallthrough */
       case KeyCodes.space:
         // event handled in _onComboBoxKeyUp
-        if (!allowFreeform && !allowFreeSearch && autoComplete === 'off') {
+        if (!allowFreeform && !allowFreeInput && autoComplete === 'off') {
           break;
         }
 
@@ -2137,7 +2137,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
         // If we are not allowing freeform or free search and
         // allowing autoComplete, handle the input here
-        if (!allowFreeform && !allowFreeSearch && autoComplete === 'on') {
+        if (!allowFreeform && !allowFreeInput && autoComplete === 'on') {
           this._onInputChange(ev.key);
           break;
         }
@@ -2155,7 +2155,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * @param ev - the keyboard event that was fired
    */
   private _onInputKeyUp = (ev: React.KeyboardEvent<HTMLElement | Autofill>): void => {
-    const { disabled, allowFreeform, allowFreeSearch, autoComplete } = this.props;
+    const { disabled, allowFreeform, allowFreeInput, autoComplete } = this.props;
     const isOpen = this.state.isOpen;
 
     // We close the menu on key up only if ALL of the following are true:
@@ -2177,10 +2177,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     // eslint-disable-next-line deprecation/deprecation
     switch (ev.which) {
       case KeyCodes.space:
-        // If we are not allowing freeform and are not autoComplete
+        // If we are not allowing freeform or free input, and autoComplete is off
         // make space expand/collapse the combo box
         // and allow the event to propagate
-        if (!allowFreeform && !allowFreeSearch && autoComplete === 'off') {
+        if (!allowFreeform && !allowFreeInput && autoComplete === 'off') {
           this._setOpenStateAndFocusOnClose(!isOpen, !!isOpen);
         }
         return;

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -2139,7 +2139,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         // allowing autoComplete, handle the input here
         if (!allowFreeform && !allowFreeSearch && autoComplete === 'on') {
           this._onInputChange(ev.key);
-          return;
+          break;
         }
 
         // allow the key to propagate by default

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -139,6 +139,13 @@ export interface IComboBoxProps
   allowFreeform?: boolean;
 
   /**
+   * When true, the Combobox will allow the user to type freely while the Combobox is focused.
+   * On Blur, the value will be set to the matching option, or the previous selection.
+   * @defaultvalue false
+   */
+  allowFreeSearch?: boolean;
+
+  /**
    * Whether the ComboBox auto completes. As the user is entering text, potential matches will be
    * suggested from the list of options. If the ComboBox is expanded, this will also scroll to the
    * suggested option and give it a selected style.

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -140,10 +140,10 @@ export interface IComboBoxProps
 
   /**
    * When true, the Combobox will allow the user to type freely while the Combobox is focused.
-   * On Blur, the value will be set to the matching option, or the previous selection.
+   * On Blur, the value will be set to the matching option, or the previous selection if there is no match.
    * @defaultvalue false
    */
-  allowFreeSearch?: boolean;
+  allowFreeInput?: boolean;
 
   /**
    * Whether the ComboBox auto completes. As the user is entering text, potential matches will be


### PR DESCRIPTION
Resolves #19379

## Current Behavior

The current v8 combobox will never allow the user to enter text that does not match an existing option unless `allowFreeform=true`. This leaves out use cases where the combobox should not allow freeform text strings to be submitted, but allowing free user search while open/focused is still desired.

This also addresses the many quirks around autocomplete without allowFreeform.

## New Behavior

If `allowFreeInput` is set to `true`, ComboBox allows freeform typing and backspace within the input. When the field is blurred, the value resets to the last selected value, if the string does not match an option. This matches the current behavior of the field if you type with `allowFreeform=false` without opening the listbox for the first time -- the only time free typing was allowed previously.


Example 

https://fluentuipr.z22.web.core.windows.net/pull/25602/react/storybook/index.html?path=/story/components-combobox--free-input
