### PR TITLE
feat(react-dialog): removes `aria-haspopup`

### DIFF
--- a/change/@fluentui-react-dialog-cfbd0be5-81c5-4351-9f00-8931078078c2.json
+++ b/change/@fluentui-react-dialog-cfbd0be5-81c5-4351-9f00-8931078078c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: removes aria-haspopup",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -29,6 +29,7 @@ import {
   dialogSurfaceSelector,
   dialogTriggerCloseId,
   dialogTriggerCloseSelector,
+  dialogTriggerOpenId,
   dialogTriggerOpenSelector,
 } from '../../testing/selectors';
 
@@ -39,7 +40,7 @@ describe('Dialog', () => {
     mount(
       <Dialog>
         <DialogTrigger disableButtonEnhancement>
-          <Button>Open dialog</Button>
+          <Button id={dialogTriggerOpenId}>Open dialog</Button>
         </DialogTrigger>
         <DialogSurface>
           <DialogBody>
@@ -51,7 +52,9 @@ describe('Dialog', () => {
             </DialogContent>
             <DialogActions>
               <DialogTrigger disableButtonEnhancement>
-                <Button appearance="secondary">Close</Button>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
               </DialogTrigger>
               <Button appearance="primary">Do Something</Button>
             </DialogActions>
@@ -66,7 +69,7 @@ describe('Dialog', () => {
     mount(
       <Dialog>
         <DialogTrigger disableButtonEnhancement>
-          <Button>Open dialog</Button>
+          <Button id={dialogTriggerOpenId}>Open dialog</Button>
         </DialogTrigger>
         <DialogSurface>
           <DialogBody>
@@ -78,7 +81,9 @@ describe('Dialog', () => {
             </DialogContent>
             <DialogActions>
               <DialogTrigger disableButtonEnhancement>
-                <Button appearance="secondary">Close</Button>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
               </DialogTrigger>
               <Button appearance="primary">Do Something</Button>
             </DialogActions>
@@ -93,7 +98,7 @@ describe('Dialog', () => {
     mount(
       <Dialog>
         <DialogTrigger disableButtonEnhancement>
-          <Button>Open dialog</Button>
+          <Button id={dialogTriggerOpenId}>Open dialog</Button>
         </DialogTrigger>
         <DialogSurface>
           <DialogBody>
@@ -122,7 +127,7 @@ describe('Dialog', () => {
     mount(
       <Dialog>
         <DialogTrigger disableButtonEnhancement>
-          <Button>Open dialog</Button>
+          <Button id={dialogTriggerOpenId}>Open dialog</Button>
         </DialogTrigger>
         <DialogSurface id="dialog-surface">
           <DialogBody>
@@ -143,7 +148,7 @@ describe('Dialog', () => {
     mount(
       <Dialog>
         <DialogTrigger disableButtonEnhancement>
-          <Button>Open dialog</Button>
+          <Button id={dialogTriggerOpenId}>Open dialog</Button>
         </DialogTrigger>
         <DialogSurface>
           <DialogBody>
@@ -182,7 +187,7 @@ describe('Dialog', () => {
         //eslint-disable-next-line react/jsx-no-bind
         <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -212,7 +217,7 @@ describe('Dialog', () => {
     mount(
       <Dialog modalType="non-modal">
         <DialogTrigger disableButtonEnhancement>
-          <Button>Open dialog</Button>
+          <Button id={dialogTriggerOpenId}>Open dialog</Button>
         </DialogTrigger>
         <DialogSurface>
           <DialogBody>
@@ -270,7 +275,7 @@ describe('Dialog', () => {
       mount(
         <Dialog modalType="modal">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -282,7 +287,9 @@ describe('Dialog', () => {
               </DialogContent>
               <DialogActions>
                 <DialogTrigger disableButtonEnhancement>
-                  <Button appearance="secondary">Close</Button>
+                  <Button id={dialogTriggerCloseId} appearance="secondary">
+                    Close
+                  </Button>
                 </DialogTrigger>
                 <Button appearance="primary">Do Something</Button>
               </DialogActions>
@@ -298,7 +305,7 @@ describe('Dialog', () => {
       mount(
         <Dialog modalType="modal">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogTitle>Dialog title</DialogTitle>
@@ -309,7 +316,9 @@ describe('Dialog', () => {
             </DialogBody>
             <DialogActions>
               <DialogTrigger disableButtonEnhancement>
-                <Button appearance="secondary">Close</Button>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
               </DialogTrigger>
               <Button appearance="primary">Do Something</Button>
             </DialogActions>
@@ -325,7 +334,7 @@ describe('Dialog', () => {
       mount(
         <Dialog modalType="non-modal">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -337,7 +346,9 @@ describe('Dialog', () => {
               </DialogContent>
               <DialogActions>
                 <DialogTrigger disableButtonEnhancement>
-                  <Button appearance="secondary">Close</Button>
+                  <Button id={dialogTriggerCloseId} appearance="secondary">
+                    Close
+                  </Button>
                 </DialogTrigger>
                 <Button appearance="primary">Do Something</Button>
               </DialogActions>
@@ -353,7 +364,7 @@ describe('Dialog', () => {
       mount(
         <Dialog modalType="non-modal">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -365,7 +376,9 @@ describe('Dialog', () => {
               </DialogContent>
               <DialogActions>
                 <DialogTrigger disableButtonEnhancement>
-                  <Button appearance="secondary">Close</Button>
+                  <Button id={dialogTriggerCloseId} appearance="secondary">
+                    Close
+                  </Button>
                 </DialogTrigger>
                 <Button appearance="primary">Do Something</Button>
               </DialogActions>
@@ -382,7 +395,7 @@ describe('Dialog', () => {
       mount(
         <Dialog modalType="alert">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -394,7 +407,9 @@ describe('Dialog', () => {
               </DialogContent>
               <DialogActions>
                 <DialogTrigger disableButtonEnhancement>
-                  <Button appearance="secondary">Close</Button>
+                  <Button id={dialogTriggerCloseId} appearance="secondary">
+                    Close
+                  </Button>
                 </DialogTrigger>
                 <Button appearance="primary">Do Something</Button>
               </DialogActions>
@@ -410,7 +425,7 @@ describe('Dialog', () => {
       mount(
         <Dialog modalType="alert">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -422,7 +437,9 @@ describe('Dialog', () => {
               </DialogContent>
               <DialogActions>
                 <DialogTrigger disableButtonEnhancement>
-                  <Button appearance="secondary">Close</Button>
+                  <Button id={dialogTriggerCloseId} appearance="secondary">
+                    Close
+                  </Button>
                 </DialogTrigger>
                 <Button appearance="primary">Do Something</Button>
               </DialogActions>

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -54,7 +54,6 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     content: open ? content : null,
     trigger,
     requestOpenChange,
-    dialogContentId: useId('dialog-content-'),
     dialogTitleId: useId('dialog-title-'),
     isNestedDialog: useHasParentContext(DialogContext),
     dialogRef: focusRef,

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
@@ -2,7 +2,7 @@ import type { DialogContextValue, DialogSurfaceContextValue } from '../../contex
 import type { DialogContextValues, DialogState } from './Dialog.types';
 
 export function useDialogContextValues_unstable(state: DialogState): DialogContextValues {
-  const { modalType, open, dialogContentId, dialogRef, dialogTitleId, isNestedDialog, requestOpenChange } = state;
+  const { modalType, open, dialogRef, dialogTitleId, isNestedDialog, requestOpenChange } = state;
 
   /**
    * This context is created with "@fluentui/react-context-selector",
@@ -12,7 +12,6 @@ export function useDialogContextValues_unstable(state: DialogState): DialogConte
     open,
     modalType,
     dialogRef,
-    dialogContentId,
     dialogTitleId,
     isNestedDialog,
     requestOpenChange,

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContent.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContent.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getNativeElementProps } from '@fluentui/react-utilities';
-import { useDialogContext_unstable } from '../../contexts';
 import { DialogContentProps, DialogContentState } from './DialogContent.types';
 
 /**
@@ -16,14 +15,12 @@ export const useDialogContent_unstable = (
   props: DialogContentProps,
   ref: React.Ref<HTMLElement>,
 ): DialogContentState => {
-  const dialogContentId = useDialogContext_unstable(ctx => ctx.dialogContentId);
   return {
     components: {
       root: 'div',
     },
     root: getNativeElementProps(props.as ?? 'div', {
       ref,
-      id: dialogContentId,
       ...props,
     }),
   };

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -35,7 +35,6 @@ export const useDialogSurface_unstable = (
   const open = useDialogContext_unstable(ctx => ctx.open);
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
   const dialogTitleID = useDialogContext_unstable(ctx => ctx.dialogTitleId);
-  const dialogContentId = useDialogContext_unstable(ctx => ctx.dialogContentId);
 
   const handledBackdropClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (isResolvedShorthand(props.backdrop)) {
@@ -83,7 +82,6 @@ export const useDialogSurface_unstable = (
       tabIndex: -1, // https://github.com/microsoft/fluentui/issues/25150
       'aria-modal': modalType !== 'non-modal',
       role: modalType === 'alert' ? 'alertdialog' : 'dialog',
-      'aria-describedby': dialogContentId,
       'aria-labelledby': props['aria-label'] ? undefined : dialogTitleID,
       ...props,
       ...modalAttributes,

--- a/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.cy.tsx
@@ -14,7 +14,7 @@ import {
   DialogTrigger,
 } from '@fluentui/react-dialog';
 import { Button } from '@fluentui/react-components';
-import { dialogActionSelector, dialogTriggerOpenSelector } from '../../testing/selectors';
+import { dialogActionSelector, dialogTriggerOpenId, dialogTriggerOpenSelector } from '../../testing/selectors';
 
 const mount = (element: JSX.Element) => mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
 
@@ -24,7 +24,7 @@ describe('DialogTitle', () => {
       mount(
         <Dialog modalType="modal">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -53,7 +53,7 @@ describe('DialogTitle', () => {
       mount(
         <Dialog modalType="non-modal">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>
@@ -82,7 +82,7 @@ describe('DialogTitle', () => {
       mount(
         <Dialog modalType="alert">
           <DialogTrigger disableButtonEnhancement>
-            <Button>Open dialog</Button>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
           </DialogTrigger>
           <DialogSurface>
             <DialogBody>

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/DialogTrigger.test.tsx
@@ -56,7 +56,7 @@ describe('DialogTrigger', () => {
     expect(ref.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         <button
-          aria-haspopup="dialog"
+          aria-expanded="false"
           data-tabster="{\\"deloser\\":{}}"
         >
           Trigger
@@ -86,7 +86,7 @@ describe('DialogTrigger', () => {
     expect(cb.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         <button
-          aria-haspopup="dialog"
+          aria-expanded="false"
           data-tabster="{\\"deloser\\":{}}"
         >
           Trigger

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/__snapshots__/DialogTrigger.test.tsx.snap
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/__snapshots__/DialogTrigger.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DialogTrigger renders a default state 1`] = `
 <button
-  aria-haspopup="dialog"
+  aria-expanded={false}
   data-tabster="{\\"deloser\\":{}}"
   onClick={[Function]}
 >

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
@@ -19,6 +19,7 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
   const child = getTriggerChild(children);
 
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
+  const open = useDialogContext_unstable(ctx => ctx.open);
 
   const { triggerAttributes } = useModalAttributes();
 
@@ -37,7 +38,7 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
 
   const triggerChildProps = {
     ...child?.props,
-    'aria-haspopup': action === 'close' ? undefined : 'dialog',
+    'aria-expanded': open,
     ref: child?.ref,
     onClick: handleClick,
     ...triggerAttributes,

--- a/packages/react-components/react-dialog/src/contexts/dialogContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogContext.ts
@@ -6,7 +6,6 @@ import type { DialogModalType, DialogOpenChangeData } from '../Dialog';
 
 export type DialogContextValue = {
   open: boolean;
-  dialogContentId?: string;
   dialogTitleId?: string;
   isNestedDialog: boolean;
   dialogRef: React.Ref<DialogSurfaceElement>;

--- a/packages/react-components/react-dialog/src/testing/selectors.ts
+++ b/packages/react-components/react-dialog/src/testing/selectors.ts
@@ -1,10 +1,11 @@
 import { dialogSurfaceClassNames, dialogTitleClassNames } from '@fluentui/react-dialog';
 
+export const dialogTriggerOpenId = 'open-btn';
 export const dialogTriggerCloseId = 'close-btn';
 
 export const dialogBackdropSelector = `.${dialogSurfaceClassNames.backdrop}`;
 export const dialogSurfaceSelector = `.${dialogSurfaceClassNames.root}`;
-export const dialogTriggerOpenSelector = `[aria-haspopup="dialog"]`;
+export const dialogTriggerOpenSelector = `#${dialogTriggerOpenId}`;
 export const dialogTriggerCloseSelector = `#${dialogTriggerCloseId}`;
 export const dialogTitleSelector = `.${dialogTitleClassNames.root}`;
 export const dialogActionSelector = `.${dialogTitleClassNames.action}`;

--- a/packages/react-components/react-dialog/stories/Dialog/DialogBestPractices.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogBestPractices.md
@@ -8,7 +8,7 @@
 - Dialog boxes consist of a header (`DialogTitle`), content (`DialogContent`), and footer (`DialogActions`), which should all be included inside a body (`DialogBody`).
 - Validate that people’s entries are acceptable before closing the dialog. Show an inline validation error near the field they must correct.
 - Modal dialogs should be used very sparingly—only when it’s critical that people make a choice or provide information before they can proceed. Thee dialogs are generally used for irreversible or potentially destructive tasks. They’re typically paired with an backdrop without a light dismiss.
-- `DialogSurface` by default has `aria-describedby="dialog-content-id"`, which might not be ideal with complex `DialogContent`, on those scenarios (for example on [with form](#with-form)), it is recommended to set `aria-describedby={undefined}`
+- Add a `aria-describedby` attribute on `DialogSurface` pointing to the dialog content on short confirmation like dialogs.
 
 ### Don't
 

--- a/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.md
@@ -1,3 +1,8 @@
-`DialogTrigger` can be outside `Dialog`, in this case Dialog `open` state should be controlled by the user, as `DialogTrigger` doesn't have access to `Dialog` context anymore.
+There's absolutely no benefit in using `DialogTrigger` outside of `Dialog`, using a simple `Button` with `aria-expanded` properly set would be equivalent.
 
-> ⚠️ It is still advised to use `DialogTrigger` instead of simply using a `Button`, since `DialogTrigger` provides ARIA attributes required for a modal trigger
+Some disadvantages of not having the `DialogTrigger` inside the `Dialog`:
+
+1. `aria-expanded` should be manually configured
+2. `onOpenChange` callback won't fire `triggerClick` events, since there is not trigger to be clicked in context.
+
+> ⚠️ Do not forget to manually add `aria-expanded` attributes to ensure accessibility

--- a/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.stories.tsx
@@ -15,9 +15,9 @@ export const TriggerOutsideDialog = () => {
   const [open, setOpen] = React.useState(false);
   return (
     <>
-      <DialogTrigger disableButtonEnhancement>
-        <Button onClick={() => setOpen(true)}>Open Dialog</Button>
-      </DialogTrigger>
+      <Button aria-expanded={open} onClick={() => setOpen(true)}>
+        Open Dialog
+      </Button>
       <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
         <DialogSurface>
           <DialogBody>

--- a/packages/react-components/react-dialog/stories/Dialog/DialogWithForm.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogWithForm.md
@@ -1,5 +1,3 @@
 Having a `form` inside the `Dialog` its quite simple, you simply add a `<form>` element between `DialogSurface` and `DialogBody` to ensure all the content between them are properly wrapped inside the formulary. This allows a button inside `DialogActions` to be properly used as submission button.
 
 > Keep in mind that controlling the `open` state of the `Dialog` might be ideal in this scenario, since validation and submission are possibly synchronous activities. For example, closing the `Dialog` only after the submission is successful would require control of the `open` state, to properly set `open` to `false` only once the submission has succeeded.
-
-> ⚠️ Don't forget to set `aria-describedby={undefined}` for `DialogSurface` to ensure the formulary is not automatically narrated by screen readers.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently `DialogTrigger` introduces `aria-haspopup` to it's child to ensure `accessibility`.

## New Behavior

As stated  in https://github.com/microsoft/fluentui/issues/25151, we should be using `aria-expanded` instead of `aria-haspopup`

1. removes `aria-haspopup` for `DialogTrigger`
2. adds `aria-expanded` for `DialogTrigger`
3. updates stories to reflect change
4. removes `aria-describedby` from `DialogSurface`
5. adds best practices on how to properly use `aria-describedby`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/25151
