### PR TITLE
fix(react-table): supports colSpan property for `th`

### DIFF
--- a/change/@fluentui-react-utilities-4d6f852b-64d8-4458-a485-11c9bf778ac0.json
+++ b/change/@fluentui-react-utilities-4d6f852b-64d8-4458-a485-11c9bf778ac0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: supports colSpan property for th",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -327,6 +327,7 @@ export const trProperties = htmlElementProperties;
  * @public
  */
 export const thProperties = toObjectMap(htmlElementProperties, [
+  'colSpan', // td, th
   'rowSpan', // td, th
   'scope', // th
 ]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Seems like `colSpan` is not included as supported attribute for `getNativeElementProps` with `th`.

https://github.com/microsoft/fluentui/blob/d1228a137bb5f28014bad869d88584ae95ba46da/packages/react-components/react-utilities/src/utils/properties.ts#L329-L332

## New Behavior

1. Adds `colSpan` as a valid property.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/25612
