### PR TITLE
fix(react-menu): remove unwanted aria attributes on context menu

### DIFF
--- a/change/@fluentui-react-menu-18f45b88-3199-463a-8745-635943d6bccb.json
+++ b/change/@fluentui-react-menu-18f45b88-3199-463a-8745-635943d6bccb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unwanted aria attributes on context menu",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -300,7 +300,7 @@ export const MenuTrigger: React_2.FC<MenuTriggerProps>;
 
 // @public
 export type MenuTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType, Props = {}> = ARIAButtonResultProps<Type, Props & {
-    'aria-haspopup': 'menu';
+    'aria-haspopup'?: 'menu';
     'aria-expanded'?: boolean;
     id: string;
     ref: React_2.Ref<never>;

--- a/packages/react-components/react-menu/src/components/Menu/Menu.cy.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.cy.tsx
@@ -10,6 +10,7 @@ import {
   menuTriggerSelector,
   menuItemSelector,
   menuSelector,
+  menuTriggerId,
 } from '../../testing/selectors';
 
 import {
@@ -34,7 +35,7 @@ describe('MenuTrigger', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -55,7 +56,7 @@ describe('MenuTrigger', () => {
     mount(
       <Menu openOnHover hoverDelay={1}>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -77,7 +78,7 @@ describe('MenuTrigger', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -101,7 +102,7 @@ describe('MenuTrigger', () => {
       mount(
         <Menu>
           <MenuTrigger disableButtonEnhancement>
-            <button>Menu</button>
+            <button id={menuTriggerId}>Menu</button>
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
@@ -120,7 +121,7 @@ describe('MenuTrigger', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -136,7 +137,7 @@ describe('MenuTrigger', () => {
 describe('Custom Trigger', () => {
   const CustomMenuTrigger = React.forwardRef<HTMLButtonElement, {}>((props, ref) => {
     return (
-      <button {...props} ref={ref}>
+      <button id={menuTriggerId} {...props} ref={ref}>
         Custom Trigger
       </button>
     );
@@ -181,7 +182,7 @@ describe('MenuItem', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -203,7 +204,7 @@ describe('MenuItem', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -225,7 +226,7 @@ describe('MenuItem', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -248,7 +249,7 @@ describe('MenuItemCheckbox', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -272,7 +273,7 @@ describe('MenuItemCheckbox', () => {
       mount(
         <Menu>
           <MenuTrigger disableButtonEnhancement>
-            <button>Menu</button>
+            <button id={menuTriggerId}>Menu</button>
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
@@ -298,7 +299,7 @@ describe('MenuItemRadio', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -323,7 +324,7 @@ describe('MenuItemRadio', () => {
       mount(
         <Menu>
           <MenuTrigger disableButtonEnhancement>
-            <button>Menu</button>
+            <button id={menuTriggerId}>Menu</button>
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
@@ -351,7 +352,7 @@ describe('MenuItemRadio', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -395,7 +396,7 @@ describe('Menu', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -418,7 +419,7 @@ describe('Menu', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -434,7 +435,7 @@ describe('Menu', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -450,7 +451,7 @@ describe('Menu', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -466,7 +467,7 @@ describe('Menu', () => {
     mount(
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -491,7 +492,7 @@ describe('Menu', () => {
     mount(
       <Menu closeOnScroll>
         <MenuTrigger disableButtonEnhancement>
-          <button>Menu</button>
+          <button id={menuTriggerId}>Menu</button>
         </MenuTrigger>
         <MenuPopover>
           <MenuList>
@@ -515,7 +516,7 @@ describe('Menu', () => {
       <>
         <Menu closeOnScroll>
           <MenuTrigger disableButtonEnhancement>
-            <button>Menu</button>
+            <button id={menuTriggerId}>Menu</button>
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
@@ -537,7 +538,7 @@ describe('Menu', () => {
         <button>Before</button>
         <Menu closeOnScroll>
           <MenuTrigger disableButtonEnhancement>
-            <button>Menu</button>
+            <button id={menuTriggerId}>Menu</button>
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
@@ -557,7 +558,7 @@ describe('Menu', () => {
       mount(
         <Menu>
           <MenuTrigger>
-            <button>Menu</button>
+            <button id={menuTriggerId}>Menu</button>
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
@@ -577,7 +578,7 @@ describe('SplitMenuItem', () => {
   const example = (
     <Menu>
       <MenuTrigger disableButtonEnhancement>
-        <button>Menu</button>
+        <button id={menuTriggerId}>Menu</button>
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
@@ -691,7 +692,7 @@ describe(`Nested Menus`, () => {
   const UncontrolledExample = () => (
     <Menu>
       <MenuTrigger disableButtonEnhancement>
-        <button>Toggle menu</button>
+        <button id={menuTriggerId}>Toggle menu</button>
       </MenuTrigger>
 
       <MenuPopover>
@@ -785,7 +786,7 @@ describe(`Nested Menus`, () => {
     return (
       <Menu>
         <MenuTrigger disableButtonEnhancement>
-          <button>Toggle menu</button>
+          <button id={menuTriggerId}>Toggle menu</button>
         </MenuTrigger>
 
         <MenuPopover>
@@ -811,7 +812,7 @@ describe(`Nested Menus`, () => {
           .click()
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).trigger('mousemove');
+            cy.get(menuItemSelector).eq(4).trigger('mousemove');
           })
           .get(menuSelector)
           .should('have.length', 2)
@@ -829,7 +830,7 @@ describe(`Nested Menus`, () => {
             .click()
             .get(menuSelector)
             .within(() => {
-              cy.get(menuTriggerSelector).focus().type(key);
+              cy.get(menuItemSelector).eq(4).focus().type(key);
             })
             .get(menuSelector)
             .eq(1)
@@ -846,7 +847,7 @@ describe(`Nested Menus`, () => {
         cy.get(menuTriggerSelector).click();
 
         cy.get(menuSelector).within(() => {
-          cy.get(menuTriggerSelector).trigger('mousemove');
+          cy.get(menuItemSelector).eq(4).trigger('mousemove');
         });
         cy.get(menuSelector).should('have.length', 2);
 
@@ -854,7 +855,7 @@ describe(`Nested Menus`, () => {
         cy.get(menuSelector)
           .eq(0)
           .within(() => {
-            cy.get(menuTriggerSelector).trigger('mouseout');
+            cy.get(menuItemSelector).eq(4).trigger('mouseout');
           });
 
         // move mouse over first element in nested menu
@@ -875,7 +876,7 @@ describe(`Nested Menus`, () => {
           .click()
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).click().focus().type('{rightarrow}');
+            cy.get(menuItemSelector).eq(4).click().focus().type('{rightarrow}');
           })
           .get(menuSelector)
           .eq(1)
@@ -893,7 +894,7 @@ describe(`Nested Menus`, () => {
             .click()
             .get(menuSelector)
             .within(() => {
-              cy.get(menuTriggerSelector).focus().type('{rightarrow}').focused().type(key);
+              cy.get(menuItemSelector).eq(4).focus().type('{rightarrow}').focused().type(key);
             })
             .get(menuSelector)
             .should('have.length', 1);
@@ -906,7 +907,7 @@ describe(`Nested Menus`, () => {
           .click()
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).type('{rightarrow}');
+            cy.get(menuItemSelector).eq(4).type('{rightarrow}');
           })
           .get(menuSelector)
           .eq(1)
@@ -929,7 +930,7 @@ describe(`Nested Menus`, () => {
           .click()
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).type('{rightarrow}');
+            cy.get(menuItemSelector).eq(4).type('{rightarrow}');
           })
           .get(menuSelector)
           .eq(1)
@@ -949,7 +950,7 @@ describe(`Nested Menus`, () => {
           .click()
           .get(menuSelector)
           .within(() => {
-            cy.get(menuTriggerSelector).type('{rightarrow}');
+            cy.get(menuItemSelector).eq(4).type('{rightarrow}');
           })
           .get(menuSelector)
           .eq(1)
@@ -964,7 +965,7 @@ describe('Context menu', () => {
   const ContextMenuExample = () => (
     <Menu openOnContext>
       <MenuTrigger disableButtonEnhancement>
-        <button>trigger</button>
+        <button id={menuTriggerId}>trigger</button>
       </MenuTrigger>
       <MenuPopover>
         <MenuList>

--- a/packages/react-components/react-menu/src/components/MenuList/MenuList.cy.tsx
+++ b/packages/react-components/react-menu/src/components/MenuList/MenuList.cy.tsx
@@ -4,7 +4,7 @@ import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';
 import { teamsLightTheme } from '@fluentui/react-theme';
 
-import { menuTriggerSelector, menuItemSelector, menuSelector } from '../../testing/selectors';
+import { menuItemSelector, menuSelector } from '../../testing/selectors';
 
 import { MenuList, MenuItem, Menu, MenuTrigger, MenuPopover } from '@fluentui/react-menu';
 const mount = (element: JSX.Element) => {
@@ -53,19 +53,19 @@ describe('MenuList', () => {
 
     it('should not open a menu trigger with ArrowDown', () => {
       mount(<Example />);
-      cy.get(menuTriggerSelector).focus().type('{downarrow}').get(menuSelector).should('have.length', 1);
+      cy.get(menuItemSelector).eq(3).focus().type('{downarrow}').get(menuSelector).should('have.length', 1);
     });
 
     it('should focus next menuitem from a menu trigger with ArrowDown', () => {
       mount(<Example />);
-      cy.get('body').click().get(menuTriggerSelector).focus().type('{downarrow}');
+      cy.get('body').click().get(menuItemSelector).eq(3).focus().type('{downarrow}');
 
       cy.focused().get(menuItemSelector).first().should('be.focused');
     });
 
     it('should open a menu trigger with ArrowRight', () => {
       mount(<Example />);
-      cy.get(menuTriggerSelector).focus().type('{rightarrow}').get(menuSelector).should('have.length', 2);
+      cy.get(menuItemSelector).eq(3).focus().type('{rightarrow}').get(menuSelector).should('have.length', 2);
     });
   });
 });

--- a/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -16,7 +16,7 @@ export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps> & {
 export type MenuTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType, Props = {}> = ARIAButtonResultProps<
   Type,
   Props & {
-    'aria-haspopup': 'menu';
+    'aria-haspopup'?: 'menu';
     'aria-expanded'?: boolean;
     id: string;
     ref: React.Ref<never>;

--- a/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -122,8 +122,6 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   };
 
   const contextMenuProps = {
-    'aria-haspopup': 'menu',
-    'aria-expanded': !open && !isSubmenu ? undefined : open,
     id: triggerId,
     ...child?.props,
     ref: useMergedRefs(triggerRef, child?.ref),
@@ -131,13 +129,15 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     onMouseLeave: useEventCallback(mergeCallbacks(child?.props.onMouseLeave, onMouseLeave)),
     onContextMenu: useEventCallback(mergeCallbacks(child?.props.onContextMenu, onContextMenu)),
     onMouseMove: useEventCallback(mergeCallbacks(child?.props.onMouseMove, onMouseMove)),
-  } as const;
+  };
 
   const triggerChildProps = {
+    'aria-haspopup': 'menu',
+    'aria-expanded': !open && !isSubmenu ? undefined : open,
     ...contextMenuProps,
     onClick: useEventCallback(mergeCallbacks(child?.props.onClick, onClick)),
     onKeyDown: useEventCallback(mergeCallbacks(child?.props.onKeyDown, onKeyDown)),
-  };
+  } as const;
 
   const ariaButtonTriggerChildProps = useARIAButtonProps(
     child?.type === 'button' || child?.type === 'a' ? child.type : 'div',

--- a/packages/react-components/react-menu/src/testing/selectors.ts
+++ b/packages/react-components/react-menu/src/testing/selectors.ts
@@ -1,4 +1,6 @@
-export const menuTriggerSelector = '[aria-haspopup="menu"]';
+export const menuTriggerId = 'menu-trigger';
+
+export const menuTriggerSelector = `#${menuTriggerId}`;
 export const menuItemSelector = '[role="menuitem"]';
 export const menuItemCheckboxSelector = '[role="menuitemcheckbox"]';
 export const menuItemRadioSelector = '[role="menuitemradio"]';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

Currently `aria-haspopup` and `aria-expanded` are being added on 2 scenarios:

1. a button trigger
2. a context menu trigger (which normally isn't a button)

## New Behavior

This PR ensure the aria attributes are only added on the first scenario (the one of a button trigger).

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/microsoft/fluentui/issues/25607
Fixes https://github.com/microsoft/fluentui/issues/24902
