### PR TITLE
Fix wrong narration in browse mode

### DIFF
--- a/change/@fluentui-react-charting-35e5b80b-88cd-4032-9bfe-42cdeca3337c.json
+++ b/change/@fluentui-react-charting-35e5b80b-88cd-4032-9bfe-42cdeca3337c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix wrong narration in browse mode",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
@@ -58,8 +58,8 @@ export class Arc extends React.Component<IArcProps, IArcState> {
           onBlur={this._onBlur}
           opacity={opacity}
           onClick={href ? this._redirectToUrl.bind(this, href) : this.props.data?.data.onClick}
-          aria-labelledby={this.props.calloutId}
-          role="text"
+          aria-label={this._getAriaLabel()}
+          role="img"
         />
         <text textAnchor={'middle'} className={classNames.insideDonutString} y={5}>
           {this.props.valueInsideDonut!}
@@ -100,6 +100,13 @@ export class Arc extends React.Component<IArcProps, IArcState> {
   private _redirectToUrl(href: string | undefined): void {
     href ? (window.location.href = href) : '';
   }
+
+  private _getAriaLabel = (): string => {
+    const point = this.props.data!.data;
+    const legend = point.xAxisCalloutData || point.legend;
+    const yValue = point.yAxisCalloutData || point.data || 0;
+    return point.callOutAccessibilityData?.ariaLabel || (legend ? `${legend}, ` : '') + `${yValue}.`;
+  };
 }
 
 function _updateChart(newProps: IArcProps): void {

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
         >
           <g>
             <path
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -68,7 +68,7 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -86,7 +86,7 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
           </g>
           <g>
             <path
-              aria-labelledby="callout0"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -107,7 +107,7 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -590,7 +590,7 @@ exports[`DonutChart - mouse events Should render customized callout on mouseover
         >
           <g>
             <path
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -611,7 +611,7 @@ exports[`DonutChart - mouse events Should render customized callout on mouseover
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -629,7 +629,7 @@ exports[`DonutChart - mouse events Should render customized callout on mouseover
           </g>
           <g>
             <path
-              aria-labelledby="callout0"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -650,7 +650,7 @@ exports[`DonutChart - mouse events Should render customized callout on mouseover
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1049,7 +1049,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -1070,7 +1070,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1088,7 +1088,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout0"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -1109,7 +1109,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1429,7 +1429,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
         >
           <g>
             <path
-              aria-labelledby="callout11"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -1450,7 +1450,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1468,7 +1468,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
           </g>
           <g>
             <path
-              aria-labelledby="callout11"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -1489,7 +1489,7 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1809,7 +1809,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout4"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -1830,7 +1830,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1848,7 +1848,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout4"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -1869,7 +1869,7 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1940,7 +1940,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout7"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -1961,7 +1961,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -1979,7 +1979,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout7"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -2000,7 +2000,7 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -2320,7 +2320,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
         >
           <g>
             <path
-              aria-labelledby="callout15"
+              aria-label="2020/04/30, 20000."
               className=
 
                   {
@@ -2341,7 +2341,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=
@@ -2361,7 +2361,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
           </g>
           <g>
             <path
-              aria-labelledby="callout15"
+              aria-label="2020/04/20, 39000."
               className=
 
                   {
@@ -2382,7 +2382,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
               onMouseMove={[Function]}
               onMouseOver={[Function]}
               opacity={1}
-              role="text"
+              role="img"
             />
             <text
               className=

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -338,8 +338,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
             onFocus={this._onBarFocus.bind(this, pointData, singleSet, refIndexNumber)}
             onBlur={this._onBarLeave}
             onClick={this.props.href ? this._redirectToUrl.bind(this, this.props.href!) : pointData.onClick}
-            aria-labelledby={`toolTip${this._calloutId}`}
-            role="text"
+            aria-label={this._getAriaLabel(pointData, singleSet.xAxisPoint)}
+            role="img"
           />,
         );
     });
@@ -521,5 +521,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
    */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
+  };
+
+  private _getAriaLabel = (point: IGVBarChartSeriesPoint, xAxisPoint: string): string => {
+    const xValue = point.xAxisCalloutData || xAxisPoint;
+    const legend = point.legend;
+    const yValue = point.yAxisCalloutData || point.data;
+    return point.callOutAccessibilityData?.ariaLabel || `${xValue}. ${legend}, ${yValue}.`;
   };
 }

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -119,13 +119,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -141,13 +141,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -163,7 +163,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -174,7 +174,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -190,13 +190,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -212,13 +212,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -234,7 +234,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -851,7 +851,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -867,13 +867,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -889,13 +889,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -911,7 +911,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -922,7 +922,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -938,13 +938,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -960,13 +960,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -982,7 +982,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -1518,7 +1518,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -1533,13 +1533,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -1554,13 +1554,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -1575,7 +1575,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -1585,7 +1585,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -1600,13 +1600,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -1621,13 +1621,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -1642,7 +1642,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -2098,7 +2098,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout14"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -2113,13 +2113,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout14"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -2134,13 +2134,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout14"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -2155,7 +2155,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -2165,7 +2165,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout14"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -2180,13 +2180,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout14"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -2201,13 +2201,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout14"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -2222,7 +2222,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -2658,7 +2658,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout5"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -2673,13 +2673,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout5"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -2694,13 +2694,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout5"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -2715,7 +2715,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -2725,7 +2725,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout5"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -2740,13 +2740,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout5"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -2761,13 +2761,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout5"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -2782,7 +2782,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -2899,7 +2899,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout9"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -2914,13 +2914,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout9"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -2935,13 +2935,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout9"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -2956,7 +2956,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -2966,7 +2966,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout9"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -2981,13 +2981,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout9"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -3002,13 +3002,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout9"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -3023,7 +3023,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -3479,7 +3479,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout19"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -3494,13 +3494,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout19"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -3515,13 +3515,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout19"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -3536,7 +3536,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -3546,7 +3546,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout19"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -3561,13 +3561,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout19"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -3582,13 +3582,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout19"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -3603,7 +3603,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -4059,7 +4059,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout24"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -4074,13 +4074,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout24"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -4095,13 +4095,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout24"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -4116,7 +4116,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -4126,7 +4126,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout24"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -4141,13 +4141,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout24"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -4162,13 +4162,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout24"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -4183,7 +4183,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -4639,7 +4639,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
           transform="translate(11.42857142857143, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout29"
+            aria-label="2000. MetaData1, 66."
             className=
 
                 {
@@ -4654,13 +4654,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={4.45652173913043}
           />
           <rect
-            aria-labelledby="toolTipcallout29"
+            aria-label="2000. MetaData2, 13."
             className=
 
                 {
@@ -4675,13 +4675,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout29"
+            aria-label="2000. MetaData3, 34."
             className=
 
                 {
@@ -4696,7 +4696,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}
@@ -4706,7 +4706,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
           transform="translate(-17.14285714285714, 0)"
         >
           <rect
-            aria-labelledby="toolTipcallout29"
+            aria-label="2010. MetaData1, 14."
             className=
 
                 {
@@ -4721,13 +4721,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={0.42154566744730637}
             y={0}
           />
           <rect
-            aria-labelledby="toolTipcallout29"
+            aria-label="2010. MetaData2, 90."
             className=
 
                 {
@@ -4742,13 +4742,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={8.852459016393441}
             y={18.80434782608696}
           />
           <rect
-            aria-labelledby="toolTipcallout29"
+            aria-label="2010. MetaData3, 33."
             className=
 
                 {
@@ -4763,7 +4763,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             onMouseOut={[Function]}
             onMouseOver={[Function]}
             opacity=""
-            role="text"
+            role="img"
             width={8.009367681498828}
             x={17.283372365339574}
             y={0}

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -311,9 +311,8 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
         const rectElement: JSX.Element = (
           <g
             key={id}
-            {...(this.state.calloutId && {
-              'aria-labelledby': `${this.state.calloutId}`,
-            })}
+            role="img"
+            aria-label={this._getAriaLabel(dataPointObject)}
             data-is-focusable={true}
             fillOpacity={this._getOpacity(dataPointObject.legend)}
             transform={`translate(${this._xAxisScale(dataPointObject.x)}, ${this._yAxisScale(dataPointObject.y)})`}
@@ -676,5 +675,17 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
    */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
+  };
+
+  private _getAriaLabel = (point: FlattenData): string => {
+    const xValue = point.x;
+    const yValue = point.y;
+    const legend = point.legend;
+    const zValue = point.ratio ? `${point.ratio[0]}/${point.ratio[1]}` : point.rectText || point.value;
+    const description = point.descriptionMessage;
+    return (
+      point.callOutAccessibilityData?.ariaLabel ||
+      `${xValue}, ${yValue}. ${legend}, ${zValue}.` + (description ? ` ${description}.` : '')
+    );
   };
 }

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -98,7 +98,8 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
         transform="translate(40, 0)"
       />
       <g
-        aria-labelledby="10"
+        aria-label="Mar/04, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+        off and people of alaska are hoping for more of this days."
         data-is-focusable={true}
         fillOpacity="1"
         key="00"
@@ -106,6 +107,7 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(-19.405940594059405, -7.227722772277229)"
       >
         <rect
@@ -133,7 +135,7 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
         </text>
       </g>
       <g
-        aria-labelledby="10"
+        aria-label="Mar/03, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
         data-is-focusable={true}
         fillOpacity="1"
         key="10"
@@ -141,6 +143,7 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(10.297029702970299, -34.45544554455446)"
       >
         <rect
@@ -648,12 +651,15 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
         transform="translate(40, 0)"
       />
       <g
+        aria-label="Mar/04, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+        off and people of alaska are hoping for more of this days."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(-19.405940594059405, -7.227722772277229)"
       >
         <rect
@@ -681,12 +687,14 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
         </text>
       </g>
       <g
+        aria-label="Mar/03, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(10.297029702970299, -34.45544554455446)"
       >
         <rect
@@ -978,12 +986,15 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
         transform="translate(40, 0)"
       />
       <g
+        aria-label="Mar/04, p2. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+      off and people of alaska are hoping for more of this days."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(-19.405940594059405, -7.227722772277229)"
       >
         <rect
@@ -1011,12 +1022,14 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
         </text>
       </g>
       <g
+        aria-label="Mar/03, p1. Nasty, 50/2391. a good day to start with in Texas with best air quality."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(10.297029702970299, -34.45544554455446)"
       >
         <rect
@@ -1398,12 +1411,15 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
         transform="translate(40, 0)"
       />
       <g
+        aria-label="Mar/04, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+        off and people of alaska are hoping for more of this days."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(-19.405940594059405, -7.227722772277229)"
       >
         <rect
@@ -1431,12 +1447,14 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
         </text>
       </g>
       <g
+        aria-label="Mar/03, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(10.297029702970299, -34.45544554455446)"
       >
         <rect
@@ -1569,12 +1587,15 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
         transform="translate(40, 0)"
       />
       <g
+        aria-label="Mar/04, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+        off and people of alaska are hoping for more of this days."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(-19.405940594059405, -7.227722772277229)"
       >
         <rect
@@ -1602,12 +1623,14 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
         </text>
       </g>
       <g
+        aria-label="Mar/03, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(10.297029702970299, -34.45544554455446)"
       >
         <rect
@@ -1899,12 +1922,15 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
         transform="translate(40, 0)"
       />
       <g
+        aria-label="Mar/04, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+        off and people of alaska are hoping for more of this days."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(-19.405940594059405, -7.227722772277229)"
       >
         <rect
@@ -1932,12 +1958,14 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
         </text>
       </g>
       <g
+        aria-label="Mar/03, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
         data-is-focusable={true}
         fillOpacity="1"
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
+        role="img"
         transform="translate(10.297029702970299, -34.45544554455446)"
       >
         <rect

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -322,9 +322,8 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
           fill={color}
           onMouseOver={point.legend !== '' ? this._hoverOn.bind(this, xValue, point) : undefined}
           onFocus={point.legend !== '' ? this._hoverOn.bind(this, xValue, point) : undefined}
-          aria-labelledby={this._calloutId}
           role="img"
-          aria-label="Horizontal bar chart"
+          aria-label={this._getAriaLabel(point)}
           onBlur={this._hoverOff}
           onMouseLeave={this._hoverOff}
         />
@@ -337,5 +336,13 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     this.setState({
       isCalloutVisible: false,
     });
+  };
+
+  private _getAriaLabel = (point: IChartDataPoint): string => {
+    const legend = point.xAxisCalloutData || point.legend;
+    const yValue =
+      point.yAxisCalloutData ||
+      (point.horizontalBarChartdata ? `${point.horizontalBarChartdata.x}/${point.horizontalBarChartdata.y}` : 0);
+    return point.callOutAccessibilityData?.ariaLabel || (legend ? `${legend}, ` : '') + `${yValue}.`;
   };
 }

--- a/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -143,8 +143,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             onClick={[Function]}
           >
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 94%."
               data-is-focusable={true}
               fill="#004b50"
               height={8}
@@ -159,8 +158,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
               y={0}
             />
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="13457/15000."
               data-is-focusable={false}
               fill="#c8c6c4"
               height={8}
@@ -309,8 +307,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             onClick={[Function]}
           >
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 19%."
               data-is-focusable={true}
               fill="#5c2d91"
               height={8}
@@ -325,8 +322,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
               y={0}
             />
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="14200/15000."
               data-is-focusable={false}
               fill="#c8c6c4"
               height={8}
@@ -651,8 +647,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             onClick={[Function]}
           >
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 94%."
               data-is-focusable={true}
               fill="#004b50"
               height={8}
@@ -667,8 +662,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
               y={0}
             />
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="13457/15000."
               data-is-focusable={false}
               fill="#c8c6c4"
               height={8}
@@ -817,8 +811,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             onClick={[Function]}
           >
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 19%."
               data-is-focusable={true}
               fill="#5c2d91"
               height={8}
@@ -833,8 +826,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
               y={0}
             />
             <rect
-              aria-label="Horizontal bar chart"
-              aria-labelledby="callout0"
+              aria-label="14200/15000."
               data-is-focusable={false}
               fill="#c8c6c4"
               height={8}

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -202,9 +202,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
-          aria-labelledby={this._calloutId}
           role="img"
-          aria-label="Multi stacked bar chart"
+          aria-label={this._getAriaLabel(point)}
           onMouseOver={point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point)}
           onMouseMove={point.placeHolder ? undefined : this._onBarHover.bind(this, pointData, color, point)}
           onMouseLeave={point.placeHolder ? undefined : this._onBarLeave}
@@ -460,5 +459,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
    */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
+  };
+
+  private _getAriaLabel = (point: IChartDataPoint): string => {
+    const legend = point.xAxisCalloutData || point.legend;
+    const yValue = point.yAxisCalloutData || point.data || 0;
+    return point.callOutAccessibilityData?.ariaLabel || (legend ? `${legend}, ` : '') + `${yValue}.`;
   };
 }

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -280,9 +280,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           data-is-focusable={!this.props.hideTooltip}
           onFocus={this._onBarFocus.bind(this, pointData, color, point)}
           onBlur={this._onBarLeave}
-          aria-label="Stacked bar chart"
+          aria-label={this._getAriaLabel(point)}
           role="img"
-          aria-labelledby={this._calloutId}
           onMouseOver={this._onBarHover.bind(this, pointData, color, point)}
           onMouseMove={this._onBarHover.bind(this, pointData, color, point)}
           onMouseLeave={this._onBarLeave}
@@ -449,5 +448,11 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
    */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
+  };
+
+  private _getAriaLabel = (point: IChartDataPoint): string => {
+    const legend = point.xAxisCalloutData || point.legend;
+    const yValue = point.yAxisCalloutData || point.data || 0;
+    return point.callOutAccessibilityData?.ariaLabel || (legend ? `${legend}, ` : '') + `${yValue}.`;
   };
 }

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -132,8 +132,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -165,8 +164,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -318,8 +316,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -351,8 +348,7 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -755,8 +751,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -788,8 +783,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -941,8 +935,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -974,8 +967,7 @@ exports[`MultiStackedBarChart - mouse events Should render customized callout on
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -1295,8 +1287,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -1326,8 +1317,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -1475,8 +1465,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -1506,8 +1495,7 @@ exports[`MultiStackedBarChart snapShot testing renders MultiStackedBarChart corr
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout0"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -1743,8 +1731,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout31"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -1774,8 +1761,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout31"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -1919,8 +1905,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout31"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -1950,8 +1935,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideDenominator correctly
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout31"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -2191,8 +2175,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout8"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -2222,8 +2205,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout8"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -2371,8 +2353,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout8"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -2402,8 +2383,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideLegend correctly 1`] 
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout8"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -2561,8 +2541,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -2592,8 +2571,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -2741,8 +2719,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -2772,8 +2749,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideRatio correctly 1`] =
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout23"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -3194,8 +3170,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-label="2020/04/30, 40%."
               className=
 
                   {
@@ -3225,8 +3200,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-label="2020/04/30, 23%."
               className=
 
                   {
@@ -3374,8 +3348,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
                 }
           >
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {
@@ -3405,8 +3378,7 @@ exports[`MultiStackedBarChart snapShot testing renders hideTooltip correctly 1`]
               />
             </g>
             <g
-              aria-label="Multi stacked bar chart"
-              aria-labelledby="callout15"
+              aria-label="2020/04/30, 87%."
               className=
 
                   {

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -139,8 +139,7 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout0"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -173,8 +172,7 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout0"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -514,8 +512,7 @@ exports[`StackedBarChart - mouse events Should render customized callout on mous
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout0"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -548,8 +545,7 @@ exports[`StackedBarChart - mouse events Should render customized callout on mous
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout0"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -806,8 +802,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout0"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -838,8 +833,7 @@ exports[`StackedBarChart snapShot testing renders StackedBarChart correctly 1`] 
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout0"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -1018,8 +1012,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout25"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -1050,8 +1043,7 @@ exports[`StackedBarChart snapShot testing renders enabledLegendsWrapLines correc
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout25"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -1216,8 +1208,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout16"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -1248,8 +1239,7 @@ exports[`StackedBarChart snapShot testing renders hideDenominator correctly 1`] 
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout16"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -1428,8 +1418,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout4"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -1460,8 +1449,7 @@ exports[`StackedBarChart snapShot testing renders hideLegend correctly 1`] = `
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout4"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -1610,8 +1598,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout12"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -1642,8 +1629,7 @@ exports[`StackedBarChart snapShot testing renders hideNumberDisplay correctly 1`
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout12"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -1822,8 +1808,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout8"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -1854,8 +1839,7 @@ exports[`StackedBarChart snapShot testing renders hideTooltip correctly 1`] = `
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout8"
+            aria-label="Winter is coming, 23."
             className=
 
                 {
@@ -2004,8 +1988,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
       >
         <g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout20"
+            aria-label="first Lorem ipsum dolor sit amet, 40."
             className=
 
                 {
@@ -2036,8 +2019,7 @@ exports[`StackedBarChart snapShot testing renders ignoreFixStyle correctly 1`] =
             />
           </g>
           <g
-            aria-label="Stacked bar chart"
-            aria-labelledby="callout20"
+            aria-label="Winter is coming, 23."
             className=
 
                 {

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -506,9 +506,8 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           }}
           onClick={point.onClick}
           onMouseOver={this._onBarHover.bind(this, point, colorScale(point.y))}
-          aria-label="Vertical bar chart"
-          role="text"
-          aria-labelledby={`toolTip${this._calloutId}`}
+          aria-label={this._getAriaLabel(point)}
+          role="img"
           onMouseLeave={this._onBarLeave}
           onFocus={this._onBarFocus.bind(this, point, index, colorScale(point.y))}
           onBlur={this._onBarLeave}
@@ -555,9 +554,8 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           y={containerHeight - this.margins.bottom! - yBarScale(point.y)}
           width={this._barWidth}
           height={barHeight}
-          aria-label="Vertical bar chart"
-          role="text"
-          aria-labelledby={`toolTip${this._calloutId}`}
+          aria-label={this._getAriaLabel(point)}
+          role="img"
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend!);
           }}
@@ -705,5 +703,20 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
    */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
+  };
+
+  private _getAriaLabel = (point: IVerticalBarChartDataPoint): string => {
+    const xValue = point.xAxisCalloutData || point.x;
+    const legend = point.legend;
+    const yValue = point.yAxisCalloutData || point.y;
+    const lineLegend = this.props.lineLegendText || 'Line';
+    const lineYValue = point.lineData?.yAxisCalloutData || point.lineData?.y;
+    return (
+      point.callOutAccessibilityData?.ariaLabel ||
+      `${xValue}. ` +
+        (legend ? `${legend}, ` : '') +
+        `${yValue}.` +
+        (typeof lineYValue !== 'undefined' ? ` ${lineLegend}, ${lineYValue}.` : '')
+    );
   };
 }

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -99,8 +99,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
       />
       <g>
         <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
+          aria-label="2020/04/30. First, 10%."
           className=
 
               {
@@ -114,14 +113,13 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
           width={32}
           x={56}
           y={224}
         />
         <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
+          aria-label="2020/04/30. Second, 20%."
           className=
 
               {
@@ -135,14 +133,13 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
+          aria-label="2020/04/30. Third, 37%."
           className=
 
               {
@@ -156,7 +153,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={122}
@@ -751,8 +748,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
       />
       <g>
         <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
+          aria-label="2020/04/30. First, 10%."
           className=
 
               {
@@ -766,14 +762,13 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
           width={32}
           x={56}
           y={224}
         />
         <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
+          aria-label="2020/04/30. Second, 20%."
           className=
 
               {
@@ -787,14 +782,13 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
           width={32}
           x={8.30769230769231}
           y={20}
         />
         <rect
-          aria-label="Vertical bar chart"
-          aria-labelledby="toolTipcallout0"
+          aria-label="2020/04/30. Third, 37%."
           className=
 
               {
@@ -808,7 +802,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
           width={32}
           x={-63.23076923076923}
           y={122}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -724,7 +724,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         });
         const rectFocusProps = !shouldFocusWholeStack && {
           'data-is-focusable': !this.props.hideTooltip,
-          'aria-labelledby': `toolTip${this._calloutId}`,
+          'aria-label': this._getAriaLabel(singleChartData, point),
           onMouseOver: this._onRectHover.bind(this, singleChartData.xAxisPoint, point, color),
           onMouseMove: this._onRectHover.bind(this, singleChartData.xAxisPoint, point, color),
           onMouseLeave: this._handleMouseOut,
@@ -777,7 +777,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             fill={color}
             ref={e => (ref.refElement = e)}
             {...rectFocusProps}
-            role="text"
+            role="img"
             transform={`translate(${xScaleBandwidthTranslate}, 0)`}
           />
         );
@@ -785,14 +785,14 @@ export class VerticalStackedBarChartBase extends React.Component<
       const groupRef: IRefArrayData = {};
       const stackFocusProps = shouldFocusWholeStack && {
         'data-is-focusable': !this.props.hideTooltip,
-        'aria-labelledby': `toolTip${this._calloutId}`,
+        'aria-label': this._getAriaLabel(singleChartData),
         onMouseOver: this._onStackHover.bind(this, singleChartData),
         onMouseMove: this._onStackHover.bind(this, singleChartData),
         onMouseLeave: this._handleMouseOut,
         onFocus: this._onStackFocus.bind(this, singleChartData, groupRef),
         onBlur: this._handleMouseOut,
         onClick: this._onClick.bind(this, singleChartData),
-        role: 'text',
+        role: 'img',
       };
       return (
         <g
@@ -925,5 +925,35 @@ export class VerticalStackedBarChartBase extends React.Component<
    */
   private _noLegendHighlighted = () => {
     return this.state.selectedLegend === '' && this.state.activeLegend === '';
+  };
+
+  private _getAriaLabel = (singleChartData: IVerticalStackedChartProps, point?: IVSChartDataPoint): string => {
+    if (!point) {
+      /** if shouldFocusWholeStack is true */
+      const xValue = singleChartData.xAxisCalloutData || singleChartData.xAxisPoint;
+      const pointValues = singleChartData.chartData
+        .map(pt => {
+          const legend = pt.legend;
+          const yValue = pt.yAxisCalloutData || pt.data;
+          return `${legend}, ${yValue}.`;
+        })
+        .join(' ');
+      const lineValues = singleChartData.lineData
+        ?.map(ln => {
+          const legend = ln.legend;
+          const yValue = ln.yAxisCalloutData || ln.data || ln.y;
+          return `${legend}, ${yValue}.`;
+        })
+        .join(' ');
+      return (
+        singleChartData.stackCallOutAccessibilityData?.ariaLabel ||
+        `${xValue}. ${pointValues}` + (lineValues ? ` ${lineValues}` : '')
+      );
+    }
+    /** if shouldFocusWholeStack is false */
+    const xValue = singleChartData.xAxisCalloutData || point.xAxisCalloutData || singleChartData.xAxisPoint;
+    const legend = point.legend;
+    const yValue = point.yAxisCalloutData || point.data;
+    return point.callOutAccessibilityData?.ariaLabel || `${xValue}. ${legend}, ${yValue}.`;
   };
 }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           key="0false"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata1, 40%."
             className=
 
                 {
@@ -120,14 +120,14 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
             y={78.84615384615384}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata2, 5%."
             className=
 
                 {
@@ -144,7 +144,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
@@ -156,7 +156,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           key="1false"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata1, 30%."
             className=
 
                 {
@@ -173,14 +173,14 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}
             y={127.88461538461539}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata2, 20%."
             className=
 
                 {
@@ -197,7 +197,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}
@@ -708,7 +708,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           key="0false"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata1, 40%."
             className=
 
                 {
@@ -725,14 +725,14 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
             y={78.84615384615384}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata2, 5%."
             className=
 
                 {
@@ -749,7 +749,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
@@ -761,7 +761,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           key="1false"
         >
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata1, 30%."
             className=
 
                 {
@@ -778,14 +778,14 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}
             y={127.88461538461539}
           />
           <rect
-            aria-labelledby="toolTipcallout0"
+            aria-label="2020/04/30. Metadata2, 20%."
             className=
 
                 {
@@ -802,7 +802,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             onMouseLeave={[Function]}
             onMouseMove={[Function]}
             onMouseOver={[Function]}
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}
@@ -1227,7 +1227,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       />
       <g>
         <g
-          aria-labelledby="toolTipcallout0"
+          aria-label="0. Metadata1, 40%. Metadata2, 5%. Line1, 15."
           data-is-focusable={true}
           id="0-singleBar"
           key="0true"
@@ -1237,7 +1237,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           onMouseLeave={[Function]}
           onMouseMove={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
         >
           <rect
             className=
@@ -1249,7 +1249,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#0078d4"
             height={196.15384615384616}
             key="0"
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
@@ -1265,7 +1265,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#00188f"
             height={24.51923076923077}
             key="1"
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
@@ -1273,7 +1273,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           />
         </g>
         <g
-          aria-labelledby="toolTipcallout0"
+          aria-label="20. Metadata1, 30%. Metadata2, 20%. Line1, 30."
           data-is-focusable={true}
           id="1-singleBar"
           key="1true"
@@ -1283,7 +1283,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           onMouseLeave={[Function]}
           onMouseMove={[Function]}
           onMouseOver={[Function]}
-          role="text"
+          role="img"
         >
           <rect
             className=
@@ -1295,7 +1295,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#0078d4"
             height={147.1153846153846}
             key="1"
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}
@@ -1311,7 +1311,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#00188f"
             height={98.07692307692308}
             key="2"
-            role="text"
+            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}


### PR DESCRIPTION
## Current Behavior

In browse mode, screen reader announces same information for all focusable SVG shapes

## New Behavior

In browse mode, screen reader announces respective information for the SVG shapes