### PR TITLE
fix: handle null and undefined in @fluentui/utilities shallowCompare

### DIFF
--- a/change/@fluentui-utilities-6d708b55-ae70-43d3-bae5-d23b00ab9b73.json
+++ b/change/@fluentui-utilities-6d708b55-ae70-43d3-bae5-d23b00ab9b73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle null and undefined in shallowCompare, add tests",
+  "packageName": "@fluentui/utilities",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/object.test.ts
+++ b/packages/utilities/src/object.test.ts
@@ -1,4 +1,55 @@
-import { assign, filteredAssign, mapEnumByName, values, omit } from './object';
+import { assign, filteredAssign, mapEnumByName, values, omit, shallowCompare } from './object';
+
+describe('shallowCompare', () => {
+  it('returns true for matching objects', () => {
+    const a = {
+      a: 1,
+      b: 'string',
+      c: {
+        d: 2,
+      },
+    };
+
+    const b = { ...a };
+
+    expect(shallowCompare(a, b)).toBeTruthy();
+  });
+
+  it('returns false when one object is a superset of the other', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a: { [key: string]: any } = {
+      a: 1,
+      b: 'string',
+      c: {
+        d: 2,
+      },
+    };
+
+    const b = { ...a, e: 'extra' };
+
+    expect(shallowCompare(a, b)).toBeFalsy();
+
+    a.e = 'extra';
+    a.f = 3;
+
+    expect(shallowCompare(a, b)).toBeFalsy();
+  });
+
+  it('returns true for two empty objects', () => {
+    expect(shallowCompare({}, {})).toBeTruthy();
+  });
+
+  it('returns true for two null or undefined objects', () => {
+    expect(shallowCompare(null, null)).toBeTruthy();
+    expect(shallowCompare(undefined, undefined)).toBeTruthy();
+    expect(shallowCompare(null, undefined)).toBeTruthy();
+  });
+
+  it('returns false when comparing null or undefined against an object', () => {
+    expect(shallowCompare(null, { a: 1 })).toBeFalsy();
+    expect(shallowCompare(undefined, { a: 1 })).toBeFalsy();
+  });
+});
 
 describe('assign', () => {
   it('can copy an object', () => {

--- a/packages/utilities/src/object.test.ts
+++ b/packages/utilities/src/object.test.ts
@@ -35,14 +35,32 @@ describe('shallowCompare', () => {
     expect(shallowCompare(a, b)).toBeFalsy();
   });
 
+  it('returns false when nested objects are not strictly equal', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a: { [key: string]: any } = {
+      a: 1,
+      b: 'string',
+      c: {
+        d: 2,
+      },
+    };
+
+    const b = { ...a, c: { ...a.c } };
+
+    expect(shallowCompare(a, b)).toBeFalsy();
+  });
+
   it('returns true for two empty objects', () => {
     expect(shallowCompare({}, {})).toBeTruthy();
   });
 
-  it('returns true for two null or undefined objects', () => {
+  it('returns true for two falsy values', () => {
     expect(shallowCompare(null, null)).toBeTruthy();
     expect(shallowCompare(undefined, undefined)).toBeTruthy();
     expect(shallowCompare(null, undefined)).toBeTruthy();
+    expect(shallowCompare(0, '')).toBeTruthy();
+    expect(shallowCompare(null, '')).toBeTruthy();
+    expect(shallowCompare(0, undefined)).toBeTruthy();
   });
 
   it('returns false when comparing null or undefined against an object', () => {

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -5,6 +5,11 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function shallowCompare<TA extends any, TB extends any>(a: TA, b: TB): boolean {
+  if (!a || !b) {
+    // only return true if both a and b are falsy
+    return !a && !b;
+  }
+
   for (let propName in a) {
     if ((a as Object).hasOwnProperty(propName)) {
       if (!(b as Object).hasOwnProperty(propName) || (b as { [key: string]: unknown })[propName] !== a[propName]) {


### PR DESCRIPTION
Fixes #25371

Updates the `shallowCompare` in `@fluentui/utilities` to handle falsy values.

Previously, `shallowCompare(null, {a: 'b'})` would throw an error for trying to access `.hasOwnProperty` of `null`.

Now it does the following:
- If both compared variables are falsy it returns true regardless of if they're the same value, to preserve existing behavior. So `shallowCompare(null, undefined)` will return true (this was the case before the change).
- If one of the compared variables is falsy and the other is not, it will return false
- When both variables are truthy, the behavior is not changed

I also added some tests for `shallowCompare`, since it had none previously