### PR TITLE
fix:  v9 docs Theme link points to correct url

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Theming.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Theming.stories.mdx
@@ -14,7 +14,7 @@ const exampleTheme = {
 };
 ```
 
-You can browse all the available tokens in **[Theme](/docs/theme-colors--colors)** section of the docs.
+You can browse all the available tokens in **[Theme](/docs/theme-color--page)** section of the docs.
 
 ## How theme is applied
 


### PR DESCRIPTION
Fixes #25436

One-line URL change, now points to the Theme Colors page.