### PR TITLE
Match hover background colors b/t table row and cell actions

### DIFF
--- a/change/@fluentui-react-table-cff42d31-144a-4400-9165-d98d429d1abd.json
+++ b/change/@fluentui-react-table-cff42d31-144a-4400-9165-d98d429d1abd.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Match hover background colors b/t table row and cell actions",
+  "comment": "fix: Match hover background colors between table row and cell actions",
   "packageName": "@fluentui/react-table",
   "email": "tigeroakes@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-table-cff42d31-144a-4400-9165-d98d429d1abd.json
+++ b/change/@fluentui-react-table-cff42d31-144a-4400-9165-d98d429d1abd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Match hover background colors b/t table row and cell actions",
+  "packageName": "@fluentui/react-table",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
@@ -82,7 +82,7 @@ const useStyles = makeStyles({
         opacity: 1,
       },
       [`& .${tableSelectionCellClassNames.root}`]: {
-        backgroundColor: tokens.colorNeutralBackground1Hover,
+        backgroundColor: tokens.colorSubtleBackgroundHover,
         opacity: 1,
       },
     },
@@ -90,11 +90,11 @@ const useStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundHover,
       color: tokens.colorNeutralForeground1Hover,
       [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorNeutralBackground1Hover,
+        backgroundColor: tokens.colorSubtleBackgroundHover,
         opacity: 1,
       },
       [`& .${tableSelectionCellClassNames.root}`]: {
-        backgroundColor: tokens.colorNeutralBackground1Hover,
+        backgroundColor: tokens.colorSubtleBackgroundHover,
         opacity: 1,
       },
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

<!-- This is the behavior we have today -->

Currently, in light mode both TableCellActions and TableSelectionCell match the color of the table row on hover. TableSelectionCell keeps the hover style when the row is clicked on, and TableCellActions matches the pressed background color.

In dark mode, both of these elements have different background colors on hover and press.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
The tokens have been updated to match what the table row uses. The light mode behaviour was used as a template.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #25627
