### PR TITLE
fix: Pickers limit keyboard nav to resultsMaximumNumber

### DIFF
--- a/change/@fluentui-react-bfd757de-4aad-4e5a-a85d-943c1e0b6859.json
+++ b/change/@fluentui-react-bfd757de-4aad-4e5a-a85d-943c1e0b6859.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "fix: pickers limit keyboard navivation to resultsMaximumNumber\"",
+  "comment": "fix: pickers limit keyboard navigation to resultsMaximumNumber.",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-bfd757de-4aad-4e5a-a85d-943c1e0b6859.json
+++ b/change/@fluentui-react-bfd757de-4aad-4e5a-a85d-943c1e0b6859.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: pickers limit keyboard navivation to resultsMaximumNumber\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -11016,7 +11016,7 @@ export class SuggestionsController<T> {
     // (undocumented)
     suggestions: ISuggestionModel<T>[];
     // (undocumented)
-    updateSuggestions(newSuggestions: T[], selectedIndex?: number): void;
+    updateSuggestions(newSuggestions: T[], selectedIndex?: number, maxCount?: number): void;
 }
 
 // @public

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -137,7 +137,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
     this.selection = new Selection({ onSelectionChanged: () => this.onSelectionChange() });
     this.selection.setItems(items);
     this.state = {
-      items: items,
+      items,
       suggestedDisplayValue: '',
       isMostRecentlyUsedVisible: false,
       moreSuggestionsAvailable: false,
@@ -393,9 +393,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
         key: item.key ? item.key : index,
         selected: selectedIndices!.indexOf(index) !== -1,
         onRemoveItem: () => this.removeItem(item),
-        disabled: disabled,
+        disabled,
         onItemChange: this.onItemChange,
-        removeButtonAriaLabel: removeButtonAriaLabel,
+        removeButtonAriaLabel,
         removeButtonIconProps,
       }),
     );
@@ -437,7 +437,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
   }
 
   protected updateSuggestions(suggestions: any[]) {
-    this.suggestionStore.updateSuggestions(suggestions, 0);
+    const maxSuggestionsCount = this.props.pickerSuggestionsProps?.resultsMaximumNumber;
+    this.suggestionStore.updateSuggestions(suggestions, 0, maxSuggestionsCount);
     this.forceUpdate();
   }
 
@@ -962,7 +963,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
     if (updatedValue !== undefined) {
       this.resolveNewValue(updatedValue, newSuggestions);
     } else {
-      this.suggestionStore.updateSuggestions(newSuggestions, -1);
+      const maxSuggestionsCount = this.props.pickerSuggestionsProps?.resultsMaximumNumber;
+      this.suggestionStore.updateSuggestions(newSuggestions, -1, maxSuggestionsCount);
       if (this.state.suggestionsLoading) {
         this.setState({
           suggestionsLoading: false,
@@ -981,7 +983,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
       // If the component is a controlled component then the controlling component will need to add or remove the items.
       this.onChange(items);
     } else {
-      this.setState({ items: items }, () => {
+      this.setState({ items }, () => {
         this._onSelectedItemsUpdated(items);
       });
     }

--- a/packages/react/src/components/pickers/Suggestions/SuggestionsController.ts
+++ b/packages/react/src/components/pickers/Suggestions/SuggestionsController.ts
@@ -13,8 +13,12 @@ export class SuggestionsController<T> {
     this.currentIndex = -1;
   }
 
-  public updateSuggestions(newSuggestions: T[], selectedIndex?: number): void {
+  public updateSuggestions(newSuggestions: T[], selectedIndex?: number, maxCount?: number): void {
     if (newSuggestions && newSuggestions.length > 0) {
+      if (maxCount && newSuggestions.length > maxCount) {
+        const startIndex = selectedIndex && selectedIndex > maxCount ? selectedIndex + 1 - maxCount : 0;
+        newSuggestions = newSuggestions.slice(startIndex, startIndex + maxCount - 1);
+      }
       this.suggestions = this.convertSuggestionsToSuggestionItems(newSuggestions);
       this.currentIndex = selectedIndex ? selectedIndex : 0;
       if (selectedIndex! === -1) {


### PR DESCRIPTION
Fixes #25438

The `resultsMaximumNumber` prop should limit the number of items present in the picker, even if there are more matching items for a given search string.

Currently, `resultsMaximumNumber` limits the number of items displayed for mouse users, but still allows arrow keys to access the full set of matching options.

This PR makes the following changes to fix that:
- The SuggestionsController now accepts a `maxCount` argument in its `updateSuggestions`. This keeps the 0-length check and resolving selectedIndex vs. maxCount in one place
- When BasePicker calls SuggestionsController's `updateSuggestions`, it passes in `resultsMaximumNumber` as the maxCount

The limited suggestions array needs to be reflected within SuggestionsController because that is where the nextSuggestion/previousSuggestion logic lives, which is used by up/down arrow keys.