### PR TITLE
fix: FloatingPeoplePicker roles should be listbox/option

### DIFF
--- a/change/@fluentui-react-21d08d17-38f6-4bdf-8d0e-383125edda19.json
+++ b/change/@fluentui-react-21d08d17-38f6-4bdf-8d0e-383125edda19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: FloatingPeoplePicker roles should be listbox/option",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -72,7 +72,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
   public onQueryStringChanged = (queryString: string): void => {
     if (queryString !== this.state.queryString) {
       this.setState({
-        queryString: queryString,
+        queryString,
       });
 
       if (this.props.onInputChanged) {
@@ -281,7 +281,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
         if (
           this.props.onRemoveSuggestion &&
           this.suggestionsControl.current &&
-          this.suggestionsControl.current.hasSuggestionSelected &&
+          this.suggestionsControl.current.hasSuggestionSelected() &&
           this.suggestionsControl.current.currentSuggestion &&
           ev.shiftKey
         ) {

--- a/packages/react/src/components/FloatingPicker/Suggestions/SuggestionsCore.tsx
+++ b/packages/react/src/components/FloatingPicker/Suggestions/SuggestionsCore.tsx
@@ -138,7 +138,7 @@ export class SuggestionsCore<T> extends React.Component<ISuggestionsCoreProps<T>
       <div
         className={css('ms-Suggestions-container', styles.suggestionsContainer)}
         id="suggestion-list"
-        role="list"
+        role="listbox"
         aria-label={suggestionsContainerAriaLabel}
       >
         {suggestions.map((suggestion: ISuggestionModel<T>, index: number) => (
@@ -146,8 +146,6 @@ export class SuggestionsCore<T> extends React.Component<ISuggestionsCoreProps<T>
             ref={suggestion.selected || index === this.currentIndex ? this._selectedElement : undefined}
             key={(suggestion.item as any).key ? (suggestion.item as any).key : index}
             id={'sug-' + index}
-            role="listitem"
-            aria-label={suggestion.ariaLabel}
           >
             <TypedSuggestionsItem
               id={'sug-item' + index}


### PR DESCRIPTION
Fixes #25538

Previously, the FloatingPeoplePicker had this role structure:

- list
  - listitem
    - option
  - listitem
    - option
  - etc.

We want just a plain:
- listbox
  - option
  - option
  - etc.

The `option` role already comes from the `SuggestionsItem` used internally, so this PR updates the floating control to just wrap SuggestionsItems in a `listbox` with no list/listitem roles.