### PR TITLE
Allow focus navigation with tab key in donut chart

### DIFF
--- a/change/@fluentui-react-charting-ccfd96da-8e65-4550-b18b-3c45ca241de3.json
+++ b/change/@fluentui-react-charting-ccfd96da-8e65-4550-b18b-3c45ca241de3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow focus navigation with tab key in donut chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -3,7 +3,7 @@ import { classNamesFunction, getId } from '@fluentui/react/lib/Utilities';
 import * as scale from 'd3-scale';
 import { IProcessedStyleSet, IPalette } from '@fluentui/react/lib/Styling';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
-import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
+import { FocusZone, FocusZoneDirection, FocusZoneTabbableElements } from '@fluentui/react-focus';
 import { IAccessibilityProps, ChartHoverCard, ILegend, Legends } from '../../index';
 import { Pie } from './Pie/index';
 import { IChartDataPoint, IChartProps, IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles } from './index';
@@ -104,7 +104,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
         ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}
         onMouseLeave={this._handleChartMouseLeave}
       >
-        <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
+        <FocusZone direction={FocusZoneDirection.horizontal} handleTabKey={FocusZoneTabbableElements.all}>
           <div>
             <svg
               className={this._classNames.chart}


### PR DESCRIPTION
## Current Behavior

Cannot focus arcs in donut chart using tab key

## New Behavior

Can focus arcs in donut chart using tab key