### PR TITLE
BREAKING: `sortable` prop no longer enables `TableHeader` navigation

### DIFF
--- a/change/@fluentui-react-table-bfaf115f-c73a-46d6-9aa3-c45d2e3d9aa7.json
+++ b/change/@fluentui-react-table-bfaf115f-c73a-46d6-9aa3-c45d2e3d9aa7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "BREAKING: `sortable` prop no longer enables `TableHeader` navigation",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableHeader/TableHeader.test.tsx
+++ b/packages/react-components/react-table/src/components/TableHeader/TableHeader.test.tsx
@@ -41,26 +41,4 @@ describe('TableHeader', () => {
     expect(container.firstElementChild?.tagName).toEqual('DIV');
     expect(container.firstElementChild?.getAttribute('role')).toEqual('rowgroup');
   });
-
-  it('should use tabster if sortable', () => {
-    const { getByRole } = render(
-      <TableContextProvider value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: true }}>
-        <TableHeader>
-          <div />
-        </TableHeader>
-      </TableContextProvider>,
-    );
-    expect(getByRole('rowgroup').hasAttribute('data-tabster')).toBe(true);
-  });
-
-  it('should not use tabster if not sortable', () => {
-    const { getByRole } = render(
-      <TableContextProvider value={{ ...tableContextDefaultValue, noNativeElements: true, sortable: false }}>
-        <TableHeader>
-          <div />
-        </TableHeader>
-      </TableContextProvider>,
-    );
-    expect(getByRole('rowgroup').hasAttribute('data-tabster')).toBe(false);
-  });
 });

--- a/packages/react-components/react-table/src/components/TableHeader/useTableHeader.ts
+++ b/packages/react-components/react-table/src/components/TableHeader/useTableHeader.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { getNativeElementProps } from '@fluentui/react-utilities';
-import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import type { TableHeaderProps, TableHeaderState } from './TableHeader.types';
 import { useTableContext } from '../../contexts/tableContext';
 
@@ -14,8 +13,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableHeader
  */
 export const useTableHeader_unstable = (props: TableHeaderProps, ref: React.Ref<HTMLElement>): TableHeaderState => {
-  const { noNativeElements, sortable } = useTableContext();
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'horizontal', circular: true });
+  const { noNativeElements } = useTableContext();
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'thead';
   return {
@@ -25,7 +23,6 @@ export const useTableHeader_unstable = (props: TableHeaderProps, ref: React.Ref<
     root: getNativeElementProps(rootComponent, {
       ref,
       role: rootComponent === 'div' ? 'rowgroup' : undefined,
-      ...(sortable && keyboardNavAttr),
       ...props,
     }),
     noNativeElements,

--- a/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
@@ -140,7 +140,6 @@ export const MultipleSelect = () => {
     };
   });
 
-  // eslint-disable-next-line deprecation/deprecation
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (

--- a/packages/react-components/react-table/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Sort.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -132,6 +132,8 @@ export const Sort = () => {
     [useSort({ defaultSortState: { sortColumn: 'file', sortDirection: 'ascending' } })],
   );
 
+  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
+
   const headerSortProps = (columnId: ColumnId) => ({
     onClick: () => {
       toggleColumnSort(columnId);
@@ -142,7 +144,7 @@ export const Sort = () => {
   const rows = sort(getRows());
 
   return (
-    <Table sortable>
+    <Table sortable {...keyboardNavAttr}>
       <TableHeader>
         <TableRow>
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -139,6 +139,7 @@ export const SortControlled = () => {
     },
     [useSort({ sortState, onSortChange: setSortState })],
   );
+  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   const headerSortProps = (columnId: ColumnId) => ({
     onClick: () => toggleColumnSort(columnId),
@@ -148,7 +149,7 @@ export const SortControlled = () => {
   const rows = sort(getRows());
 
   return (
-    <Table sortable>
+    <Table sortable {...keyboardNavAttr}>
       <TableHeader>
         <TableRow>
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>


### PR DESCRIPTION
## ⚠️ BREAKING

Setting the `sortable` prop no longer sets tabster attributes on the `TableHeader`. This reduces the scope of the primitives to have no default focus management. Now there's only one way to do keyboard navigation with primitives.

## Current Behavior

```tsx
{/* sortable will make the cells in TableHeader navigable using arrow keys */}
<Table sortable>
<TableHeader>
  <TableRow>
    <TableHeaderCell />
    <TableHeaderCell />
    <TableHeaderCell />
  </TableRow>
</TableHeader>
{/* ... */}
</Table>
```

## New Behavior

```tsx
const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });

{/* The user will need to apply for management themselves */}
<Table sortable {...keyboardNavAttr}>
<TableHeader>
  <TableRow>
    <TableHeaderCell />
    <TableHeaderCell />
    <TableHeaderCell />
  </TableRow>
</TableHeader>
{/* ... */}
</Table>
```