### PR TITLE
BREAKING: Headless table callbacks require event

### DIFF
--- a/change/@fluentui-react-table-edbad8fb-57a4-46a3-94ba-b8d0e38a1944.json
+++ b/change/@fluentui-react-table-edbad8fb-57a4-46a3-94ba-b8d0e38a1944.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "BREAKING: Headless table callbacks require event",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -449,14 +449,14 @@ export type TableSelectionCellState = ComponentState<TableSelectionCellSlots> & 
 // @public (undocumented)
 export interface TableSelectionState {
     allRowsSelected: boolean;
-    clearRows: () => void;
-    deselectRow: (rowId: RowId) => void;
+    clearRows: (e: React_2.SyntheticEvent) => void;
+    deselectRow: (e: React_2.SyntheticEvent, rowId: RowId) => void;
     isRowSelected: (rowId: RowId) => boolean;
     selectedRows: Set<RowId>;
-    selectRow: (rowId: RowId) => void;
+    selectRow: (e: React_2.SyntheticEvent, rowId: RowId) => void;
     someRowsSelected: boolean;
-    toggleAllRows: () => void;
-    toggleRow: (rowId: RowId) => void;
+    toggleAllRows: (e: React_2.SyntheticEvent) => void;
+    toggleRow: (e: React_2.SyntheticEvent, rowId: RowId) => void;
 }
 
 // @public (undocumented)
@@ -467,11 +467,11 @@ export type TableSlots = {
 // @public (undocumented)
 export interface TableSortState<TItem> {
     getSortDirection: (columnId: ColumnId) => SortDirection | undefined;
-    setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
+    setColumnSort: (event: React_2.SyntheticEvent, columnId: ColumnId, sortDirection: SortDirection) => void;
     sort: <TRowState extends RowState<TItem>>(rows: TRowState[]) => TRowState[];
     sortColumn: ColumnId | undefined;
     sortDirection: SortDirection;
-    toggleColumnSort: (columnId: ColumnId) => void;
+    toggleColumnSort: (event: React_2.SyntheticEvent, columnId: ColumnId) => void;
 }
 
 // @public

--- a/packages/react-components/react-table/src/hooks/selectionManager.ts
+++ b/packages/react-components/react-table/src/hooks/selectionManager.ts
@@ -1,14 +1,19 @@
+import * as React from 'react';
 import { SelectionMode } from './types';
 
-type OnSelectionChangeCallback = (selectedItems: Set<SelectionItemId>) => void;
+type OnSelectionChangeCallback = (e: React.SyntheticEvent | Event, selectedItems: Set<SelectionItemId>) => void;
 
 export interface SelectionManager {
-  toggleItem(id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
-  selectItem(id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
-  deselectItem(id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
-  clearItems(): void;
+  toggleItem(e: React.SyntheticEvent | Event, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  selectItem(e: React.SyntheticEvent | Event, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  deselectItem(e: React.SyntheticEvent | Event, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  clearItems(e: React.SyntheticEvent | Event): void;
   isSelected(id: SelectionItemId, selectedItems: Set<SelectionItemId>): boolean;
-  toggleAllItems(itemIds: SelectionItemId[], selectedItems: Set<SelectionItemId>): void;
+  toggleAllItems(
+    e: React.SyntheticEvent | Event,
+    itemIds: SelectionItemId[],
+    selectedItems: Set<SelectionItemId>,
+  ): void;
 }
 
 export type SelectionItemId = string | number;
@@ -23,7 +28,7 @@ export function createSelectionManager(
 }
 
 function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCallback): SelectionManager {
-  const toggleAllItems = (itemIds: SelectionItemId[], selectedItems: Set<SelectionItemId>) => {
+  const toggleAllItems: SelectionManager['toggleAllItems'] = (e, itemIds, selectedItems) => {
     const allItemsSelected = itemIds.every(itemId => selectedItems.has(itemId));
 
     if (allItemsSelected) {
@@ -32,31 +37,31 @@ function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCall
       itemIds.forEach(itemId => selectedItems.add(itemId));
     }
 
-    onSelectionChange(new Set(selectedItems));
+    onSelectionChange(e, new Set(selectedItems));
   };
 
-  const toggleItem = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
+  const toggleItem: SelectionManager['toggleItem'] = (e, itemId, selectedItems) => {
     if (selectedItems.has(itemId)) {
       selectedItems.delete(itemId);
     } else {
       selectedItems.add(itemId);
     }
 
-    onSelectionChange(new Set(selectedItems));
+    onSelectionChange(e, new Set(selectedItems));
   };
 
-  const selectItem = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
+  const selectItem: SelectionManager['selectItem'] = (e, itemId, selectedItems) => {
     selectedItems.add(itemId);
-    onSelectionChange(new Set(selectedItems));
+    onSelectionChange(e, new Set(selectedItems));
   };
 
-  const deselectItem = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
+  const deselectItem: SelectionManager['deselectItem'] = (e, itemId, selectedItems) => {
     selectedItems.delete(itemId);
-    onSelectionChange(new Set(selectedItems));
+    onSelectionChange(e, new Set(selectedItems));
   };
 
-  const clearItems = () => {
-    onSelectionChange(new Set());
+  const clearItems: SelectionManager['clearItems'] = e => {
+    onSelectionChange(e, new Set());
   };
 
   const isSelected = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
@@ -74,20 +79,20 @@ function createMultipleSelectionManager(onSelectionChange: OnSelectionChangeCall
 }
 
 function createSingleSelectionManager(onSelectionChange: OnSelectionChangeCallback): SelectionManager {
-  const toggleItem = (itemId: SelectionItemId) => {
-    onSelectionChange(new Set([itemId]));
+  const toggleItem: SelectionManager['toggleItem'] = (e, itemId) => {
+    onSelectionChange(e, new Set([itemId]));
   };
 
-  const clearItems = () => {
-    onSelectionChange(new Set<SelectionItemId>());
+  const clearItems: SelectionManager['clearItems'] = e => {
+    onSelectionChange(e, new Set<SelectionItemId>());
   };
 
   const isSelected = (itemId: SelectionItemId, selectedItems: Set<SelectionItemId>) => {
     return selectedItems.has(itemId);
   };
 
-  const selectItem = (itemId: SelectionItemId) => {
-    onSelectionChange(new Set([itemId]));
+  const selectItem: SelectionManager['selectItem'] = (e, itemId) => {
+    onSelectionChange(e, new Set([itemId]));
   };
 
   return {

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -37,11 +37,11 @@ export interface TableSortState<TItem> {
   /**
    * Set the sort direction for the specified column
    */
-  setColumnSort: (columnId: ColumnId, sortDirection: SortDirection) => void;
+  setColumnSort: (event: React.SyntheticEvent, columnId: ColumnId, sortDirection: SortDirection) => void;
   /**
    * Toggles the sort direction for specified column
    */
-  toggleColumnSort: (columnId: ColumnId) => void;
+  toggleColumnSort: (event: React.SyntheticEvent, columnId: ColumnId) => void;
   /**
    * Returns the sort direction if a column is sorted,
    * returns undefined if the column is not sorted
@@ -58,23 +58,23 @@ export interface TableSelectionState {
   /**
    * Clears all selected rows
    */
-  clearRows: () => void;
+  clearRows: (e: React.SyntheticEvent) => void;
   /**
    * Selects single row
    */
-  selectRow: (rowId: RowId) => void;
+  selectRow: (e: React.SyntheticEvent, rowId: RowId) => void;
   /**
    * De-selects single row
    */
-  deselectRow: (rowId: RowId) => void;
+  deselectRow: (e: React.SyntheticEvent, rowId: RowId) => void;
   /**
    * Toggle selection of all rows
    */
-  toggleAllRows: () => void;
+  toggleAllRows: (e: React.SyntheticEvent) => void;
   /**
    * Toggle selection of single row
    */
-  toggleRow: (rowId: RowId) => void;
+  toggleRow: (e: React.SyntheticEvent, rowId: RowId) => void;
   /**
    * Collection of row ids corresponding to selected rows
    */
@@ -139,7 +139,7 @@ export interface UseSortOptions {
   /**
    * Called when sort changes
    */
-  onSortChange?: (state: SortState) => void;
+  onSortChange?: (e: React.SyntheticEvent, state: SortState) => void;
 }
 
 export interface UseSelectionOptions {
@@ -158,7 +158,7 @@ export interface UseSelectionOptions {
   /**
    * Called when selection changes
    */
-  onSelectionChange?: (selectedItems: Set<RowId>) => void;
+  onSelectionChange?: (e: React.SyntheticEvent, selectedItems: Set<RowId>) => void;
 }
 
 export interface UseTableOptions<TItem> {

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useSelectionState } from './useSelection';
 import { mockTableState } from '../testing/mockTableState';
+import { mockSyntheticEvent } from '../testing/mockSyntheticEvent';
 
 describe('useSelectionState', () => {
   const items = [{ value: 'a' }, { value: 'b' }, { value: 'c' }, { value: 'd' }];
@@ -38,7 +39,7 @@ describe('useSelectionState', () => {
         ),
       );
       act(() => {
-        result.current.selection.toggleAllRows();
+        result.current.selection.toggleAllRows(mockSyntheticEvent());
       });
 
       expect(Array.from(result.current.selection.selectedRows)).toEqual(items.map(item => item.value));
@@ -52,12 +53,12 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleAllRows();
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
         });
         expect(result.current.selection.selectedRows.size).toBe(items.length);
         expect(Array.from(result.current.selection.selectedRows)).toEqual(items.map((_, i) => i));
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith(new Set([0, 1, 2, 3]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([0, 1, 2, 3]));
       });
 
       it('should deselect all rows', () => {
@@ -67,16 +68,16 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleAllRows();
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
         });
 
         act(() => {
-          result.current.selection.toggleAllRows();
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
         });
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
       });
     });
     describe('clearRows', () => {
@@ -87,15 +88,15 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleAllRows();
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
         });
         act(() => {
-          result.current.selection.clearRows();
+          result.current.selection.clearRows(mockSyntheticEvent());
         });
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
       });
     });
 
@@ -107,12 +108,12 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
       });
 
       it('should select multiple rows', () => {
@@ -122,18 +123,18 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.selectRow(2);
+          result.current.selection.selectRow(mockSyntheticEvent(), 2);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(2);
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([1, 2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([1, 2]));
       });
     });
 
@@ -145,16 +146,16 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.deselectRow(1);
+          result.current.selection.deselectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
       });
     });
 
@@ -166,13 +167,13 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
       });
 
       it('should deselect selected row', () => {
@@ -182,17 +183,17 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(result.current.selection.selectedRows.has(1)).toBe(false);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
       });
 
       it('should select another unselected row', () => {
@@ -202,18 +203,18 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.toggleRow(2);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 2);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(2);
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([1, 2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([1, 2]));
       });
     });
 
@@ -224,7 +225,7 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleAllRows();
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
         });
 
         expect(result.current.selection.allRowsSelected).toBe(true);
@@ -245,11 +246,11 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleAllRows();
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
         });
 
         act(() => {
-          result.current.selection.deselectRow(1);
+          result.current.selection.deselectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(3);
@@ -264,7 +265,7 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
@@ -318,15 +319,15 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
         act(() => {
-          result.current.selection.clearRows();
+          result.current.selection.clearRows(mockSyntheticEvent());
         });
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
       });
     });
 
@@ -338,12 +339,12 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
       });
 
       it('should select another row', () => {
@@ -353,17 +354,17 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.selectRow(2);
+          result.current.selection.selectRow(mockSyntheticEvent(), 2);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([2]));
       });
     });
 
@@ -375,16 +376,16 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.deselectRow(1);
+          result.current.selection.deselectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
       });
     });
 
@@ -396,13 +397,13 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith(new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
       });
 
       it('should deselect selected row', () => {
@@ -412,17 +413,17 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.toggleRow(2);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 2);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(false);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([2]));
       });
 
       it('should select another unselected row', () => {
@@ -432,18 +433,18 @@ describe('useSelectionState', () => {
         );
 
         act(() => {
-          result.current.selection.toggleRow(1);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 1);
         });
 
         act(() => {
-          result.current.selection.toggleRow(2);
+          result.current.selection.toggleRow(mockSyntheticEvent(), 2);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(false);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, new Set([2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([2]));
       });
     });
 
@@ -452,7 +453,7 @@ describe('useSelectionState', () => {
         const { result } = renderHook(() => useSelectionState(mockTableState({ items }), { selectionMode: 'single' }));
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);
@@ -472,7 +473,7 @@ describe('useSelectionState', () => {
         const { result } = renderHook(() => useSelectionState(mockTableState({ items }), { selectionMode: 'single' }));
 
         act(() => {
-          result.current.selection.selectRow(1);
+          result.current.selection.selectRow(mockSyntheticEvent(), 1);
         });
 
         expect(result.current.selection.selectedRows.size).toBe(1);

--- a/packages/react-components/react-table/src/hooks/useSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.ts
@@ -37,31 +37,32 @@ export function useSelectionState<TItem>(
   });
 
   const selectionManager = React.useMemo(() => {
-    return createSelectionManager(selectionMode, newSelectedItems => {
+    return createSelectionManager(selectionMode, (e, newSelectedItems) => {
       setSelected(() => {
-        onSelectionChange?.(newSelectedItems);
+        onSelectionChange?.(e as React.SyntheticEvent, newSelectedItems);
         return newSelectedItems;
       });
     });
   }, [onSelectionChange, selectionMode, setSelected]);
 
-  const toggleAllRows: TableSelectionState['toggleAllRows'] = useEventCallback(() => {
+  const toggleAllRows: TableSelectionState['toggleAllRows'] = useEventCallback(e => {
     selectionManager.toggleAllItems(
+      e,
       items.map((item, i) => getRowId?.(item) ?? i),
       selected,
     );
   });
 
-  const toggleRow: TableSelectionState['toggleRow'] = useEventCallback((rowId: RowId) =>
-    selectionManager.toggleItem(rowId, selected),
+  const toggleRow: TableSelectionState['toggleRow'] = useEventCallback((e, rowId: RowId) =>
+    selectionManager.toggleItem(e, rowId, selected),
   );
 
-  const deselectRow: TableSelectionState['deselectRow'] = useEventCallback((rowId: RowId) =>
-    selectionManager.deselectItem(rowId, selected),
+  const deselectRow: TableSelectionState['deselectRow'] = useEventCallback((e, rowId: RowId) =>
+    selectionManager.deselectItem(e, rowId, selected),
   );
 
-  const selectRow: TableSelectionState['selectRow'] = useEventCallback((rowId: RowId) =>
-    selectionManager.selectItem(rowId, selected),
+  const selectRow: TableSelectionState['selectRow'] = useEventCallback((e, rowId: RowId) =>
+    selectionManager.selectItem(e, rowId, selected),
   );
 
   const isRowSelected: TableSelectionState['isRowSelected'] = (rowId: RowId) =>

--- a/packages/react-components/react-table/src/hooks/useSort.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.test.ts
@@ -3,6 +3,7 @@ import { ColumnDefinition } from './types';
 import { useSortState } from './useSort';
 import { mockTableState } from '../testing/mockTableState';
 import { createColumn } from './createColumn';
+import { mockSyntheticEvent } from '../testing/mockSyntheticEvent';
 
 describe('useSortState', () => {
   it('should use default sort state', () => {
@@ -49,13 +50,13 @@ describe('useSortState', () => {
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
       );
       act(() => {
-        result.current.sort.toggleColumnSort(1);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 1);
       });
 
       expect(result.current.sort.sortColumn).toBe(1);
       expect(result.current.sort.sortDirection).toBe('ascending');
       expect(onSortChange).toHaveBeenCalledTimes(1);
-      expect(onSortChange).toHaveBeenCalledWith({ sortColumn: 1, sortDirection: 'ascending' });
+      expect(onSortChange).toHaveBeenCalledWith({}, { sortColumn: 1, sortDirection: 'ascending' });
     });
 
     it('should toggle sort direction on a column', () => {
@@ -69,17 +70,17 @@ describe('useSortState', () => {
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
       );
       act(() => {
-        result.current.sort.toggleColumnSort(1);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 1);
       });
 
       act(() => {
-        result.current.sort.toggleColumnSort(1);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 1);
       });
 
       expect(result.current.sort.sortColumn).toBe(1);
       expect(result.current.sort.sortDirection).toBe('descending');
       expect(onSortChange).toHaveBeenCalledTimes(2);
-      expect(onSortChange).toHaveBeenNthCalledWith(2, { sortColumn: 1, sortDirection: 'descending' });
+      expect(onSortChange).toHaveBeenNthCalledWith(2, {}, { sortColumn: 1, sortDirection: 'descending' });
     });
   });
 
@@ -95,13 +96,13 @@ describe('useSortState', () => {
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
       );
       act(() => {
-        result.current.sort.setColumnSort(1, 'ascending');
+        result.current.sort.setColumnSort(mockSyntheticEvent(), 1, 'ascending');
       });
 
       expect(result.current.sort.sortColumn).toBe(1);
       expect(result.current.sort.sortDirection).toBe('ascending');
       expect(onSortChange).toHaveBeenCalledTimes(1);
-      expect(onSortChange).toHaveBeenCalledWith({ sortColumn: 1, sortDirection: 'ascending' });
+      expect(onSortChange).toHaveBeenCalledWith({}, { sortColumn: 1, sortDirection: 'ascending' });
     });
 
     it('should sort a column in descending order', () => {
@@ -115,13 +116,13 @@ describe('useSortState', () => {
         useSortState(mockTableState({ columns: columnDefinition }), { onSortChange }),
       );
       act(() => {
-        result.current.sort.setColumnSort(1, 'descending');
+        result.current.sort.setColumnSort(mockSyntheticEvent(), 1, 'descending');
       });
 
       expect(result.current.sort.sortColumn).toBe(1);
       expect(result.current.sort.sortDirection).toBe('descending');
       expect(onSortChange).toHaveBeenCalledTimes(1);
-      expect(onSortChange).toHaveBeenCalledWith({ sortColumn: 1, sortDirection: 'descending' });
+      expect(onSortChange).toHaveBeenCalledWith({}, { sortColumn: 1, sortDirection: 'descending' });
     });
   });
 
@@ -137,7 +138,7 @@ describe('useSortState', () => {
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
       act(() => {
-        result.current.sort.toggleColumnSort(2);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 2);
       });
 
       result.current.sort.sort([
@@ -154,7 +155,7 @@ describe('useSortState', () => {
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
       act(() => {
-        result.current.sort.toggleColumnSort(1);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 1);
       });
 
       const rows = [
@@ -176,10 +177,10 @@ describe('useSortState', () => {
       const items = [{ value: 1 }, { value: 2 }];
       const { result } = renderHook(() => useSortState(mockTableState({ items, columns: columnDefinition }), {}));
       act(() => {
-        result.current.sort.toggleColumnSort(1);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 1);
       });
       act(() => {
-        result.current.sort.toggleColumnSort(1);
+        result.current.sort.toggleColumnSort(mockSyntheticEvent(), 1);
       });
 
       const rows = [
@@ -200,7 +201,7 @@ describe('useSortState', () => {
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
       act(() => {
-        result.current.sort.setColumnSort(1, 'descending');
+        result.current.sort.setColumnSort(mockSyntheticEvent(), 1, 'descending');
       });
 
       expect(result.current.sort.getSortDirection(1)).toEqual('descending');
@@ -214,7 +215,7 @@ describe('useSortState', () => {
 
       const { result } = renderHook(() => useSortState(mockTableState({ columns: columnDefinition }), {}));
       act(() => {
-        result.current.sort.setColumnSort(1, 'descending');
+        result.current.sort.setColumnSort(mockSyntheticEvent(), 1, 'descending');
       });
 
       expect(result.current.sort.getSortDirection(2)).toBeUndefined();

--- a/packages/react-components/react-table/src/hooks/useSort.ts
+++ b/packages/react-components/react-table/src/hooks/useSort.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useControllableState } from '@fluentui/react-utilities';
 import type { ColumnId, RowState, SortState, TableSortState, TableState, UseSortOptions } from './types';
 
@@ -33,7 +34,7 @@ export function useSortState<TItem>(tableState: TableState<TItem>, options: UseS
 
   const { sortColumn, sortDirection } = sorted;
 
-  const toggleColumnSort = (columnId: ColumnId | undefined) => {
+  const toggleColumnSort = (e: React.SyntheticEvent, columnId: ColumnId | undefined) => {
     setSorted(s => {
       const newState = { ...s, sortColumn: columnId };
       if (s.sortColumn === columnId) {
@@ -42,14 +43,14 @@ export function useSortState<TItem>(tableState: TableState<TItem>, options: UseS
         newState.sortDirection = 'ascending';
       }
 
-      onSortChange?.(newState);
+      onSortChange?.(e, newState);
       return newState;
     });
   };
 
-  const setColumnSort: TableSortState<TItem>['setColumnSort'] = (nextSortColumn, nextSortDirection) => {
+  const setColumnSort: TableSortState<TItem>['setColumnSort'] = (e, nextSortColumn, nextSortDirection) => {
     const newState = { sortColumn: nextSortColumn, sortDirection: nextSortDirection };
-    onSortChange?.(newState);
+    onSortChange?.(e, newState);
     setSorted(newState);
   };
 

--- a/packages/react-components/react-table/src/testing/mockSyntheticEvent.ts
+++ b/packages/react-components/react-table/src/testing/mockSyntheticEvent.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export function mockSyntheticEvent() {
+  return ({} as unknown) as React.SyntheticEvent;
+}

--- a/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
@@ -129,10 +129,10 @@ export const MultipleSelect = () => {
     const selected = isRowSelected(row.rowId);
     return {
       ...row,
-      onClick: () => toggleRow(row.rowId),
+      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === ' ' || e.key === 'Enter') {
-          toggleRow(row.rowId);
+          toggleRow(e, row.rowId);
         }
       },
       selected,

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -126,7 +126,7 @@ export const MultipleSelectControlled = () => {
       useSelection({
         selectionMode: 'multiselect',
         selectedItems: selectedRows,
-        onSelectionChange: setSelectedRows,
+        onSelectionChange: (e, nextSelelectedRows) => setSelectedRows(nextSelelectedRows),
       }),
     ],
   );
@@ -135,10 +135,10 @@ export const MultipleSelectControlled = () => {
     const selected = isRowSelected(row.rowId);
     return {
       ...row,
-      onClick: () => toggleRow(row.rowId),
+      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === ' ' || e.key === 'Enter') {
-          toggleRow(row.rowId);
+          toggleRow(e, row.rowId);
         }
       },
       selected,

--- a/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
@@ -129,10 +129,10 @@ export const SingleSelect = () => {
     const selected = isRowSelected(row.rowId);
     return {
       ...row,
-      onClick: () => toggleRow(row.rowId),
+      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === ' ' || e.key === 'Enter') {
-          toggleRow(row.rowId);
+          toggleRow(e, row.rowId);
         }
       },
       selected,

--- a/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
@@ -125,7 +125,7 @@ export const SingleSelectControlled = () => {
       useSelection({
         selectionMode: 'single',
         selectedItems: selectedRows,
-        onSelectionChange: setSelectedRows,
+        onSelectionChange: (e, nextSelectedRows) => setSelectedRows(nextSelectedRows),
       }),
     ],
   );
@@ -134,10 +134,10 @@ export const SingleSelectControlled = () => {
     const selected = isRowSelected(row.rowId);
     return {
       ...row,
-      onClick: () => toggleRow(row.rowId),
+      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === ' ' || e.key === 'Enter') {
-          toggleRow(row.rowId);
+          toggleRow(e, row.rowId);
         }
       },
       selected,

--- a/packages/react-components/react-table/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Sort.stories.tsx
@@ -133,8 +133,8 @@ export const Sort = () => {
   );
 
   const headerSortProps = (columnId: ColumnId) => ({
-    onClick: () => {
-      toggleColumnSort(columnId);
+    onClick: (e: React.MouseEvent) => {
+      toggleColumnSort(e, columnId);
     },
     sortDirection: getSortDirection(columnId),
   });

--- a/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
@@ -137,11 +137,11 @@ export const SortControlled = () => {
       columns,
       items,
     },
-    [useSort({ sortState, onSortChange: setSortState })],
+    [useSort({ sortState, onSortChange: (e, nextSortState) => setSortState(nextSortState) })],
   );
 
   const headerSortProps = (columnId: ColumnId) => ({
-    onClick: () => toggleColumnSort(columnId),
+    onClick: (e: React.MouseEvent) => toggleColumnSort(e, columnId),
     sortDirection: getSortDirection(columnId),
   });
 

--- a/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
@@ -129,10 +129,10 @@ export const SubtleSelection = () => {
     const selected = isRowSelected(row.rowId);
     return {
       ...row,
-      onClick: () => toggleRow(row.rowId),
+      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === ' ' || e.key === 'Enter') {
-          toggleRow(row.rowId);
+          toggleRow(e, row.rowId);
         }
       },
       selected,
@@ -140,7 +140,6 @@ export const SubtleSelection = () => {
     };
   });
 
-  // eslint-disable-next-line deprecation/deprecation
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

In order to support `DataGrid` easily and also conform to current library patterns, all headless table callbacks should be called with an event as first argument.

**The other arguments remain unchanged, the event argument is pushed to first place**

Affected callbacks:
* clearRows
* deselectRow
* selectRow
* toggleAllRows
* toggleRow
* setColumnSort
* toggleColumnSort
* onSelectionChange
* onSortChange

## Current Behavior

```ts
const onClick = () => {
  clearRows();
  deselectRow(rowId);
  selectRow(rowId);
  toggleAllRows();
  toggleRow(rowId);
  setColumnSort(columnId, 'ascending');
  toggleColumnSort(columnId);
}

useTable({
    items,
    columns,
  },
  [
    useSort({ onSortChange: (sortState) => console.log(sortState) }),
    useSelection({ onSelectionChange: (selectedRows) => console.log(selectedRows })
  ]
)

```

## New Behavior

```ts
const onClick = (e: React.MouseEvent) => {
  clearRows(e);
  deselectRow(e, rowId);
  selectRow(e, rowId);
  toggleAllRows(e);
  toggleRow(e, rowId);
  setColumnSort(e, columnId, 'ascending');
  toggleColumnSort(e, columnId);
}

useTable({
    items,
    columns,
  },
  [
    useSort({ onSortChange: (e, sortState) => console.log(sortState) }),
    useSelection({ onSelectionChange: (e, selectedRows) => console.log(selectedRows })
  ]
)
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
