### PR TITLE
chore(react-menu): removes prop spreading on MenuList state

### DIFF
--- a/change/@fluentui-react-components-dbb0daa2-367e-4700-8822-0755f7033c6c.json
+++ b/change/@fluentui-react-components-dbb0daa2-367e-4700-8822-0755f7033c6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: deprecates unused type UninitializedMenuListState",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-0855b482-9526-40c3-9209-9f961f2e8e1b.json
+++ b/change/@fluentui-react-menu-0855b482-9526-40c3-9209-9f961f2e8e1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: removes prop spreading on MenuList state",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -482,6 +482,8 @@ export type {
   MenuTriggerProps,
   MenuTriggerState,
   SelectableHandler,
+  // UninitializedMenuListState is deprecated but removing it would be a breaking change
+  // eslint-disable-next-line deprecation/deprecation
   UninitializedMenuListState,
 } from '@fluentui/react-menu';
 export {

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -35,9 +35,10 @@ export type MenuCheckedValueChangeData = {
 export type MenuCheckedValueChangeEvent = React_2.MouseEvent | React_2.KeyboardEvent;
 
 // @public
-export type MenuContextValue = Pick<MenuState, 'openOnHover' | 'openOnContext' | 'triggerRef' | 'menuPopoverRef' | 'setOpen' | 'isSubmenu' | 'triggerId' | 'hasIcons' | 'hasCheckmarks' | 'persistOnItemClick' | 'inline' | 'checkedValues' | 'onCheckedValueChange' | 'defaultCheckedValues'> & {
+export type MenuContextValue = Pick<MenuState, 'openOnHover' | 'openOnContext' | 'triggerRef' | 'menuPopoverRef' | 'setOpen' | 'isSubmenu' | 'triggerId' | 'hasIcons' | 'hasCheckmarks' | 'persistOnItemClick' | 'inline' | 'checkedValues' | 'onCheckedValueChange'> & {
     open: boolean;
     triggerId: string;
+    defaultCheckedValues?: Record<string, string[]>;
 };
 
 // @public (undocumented)
@@ -180,10 +181,11 @@ export const MenuList: ForwardRefComponent<MenuListProps>;
 export const menuListClassNames: SlotClassNames<MenuListSlots>;
 
 // @public
-export type MenuListContextValue = Pick<MenuListProps, 'checkedValues' | 'onCheckedValueChange' | 'hasIcons' | 'hasCheckmarks'> & {
+export type MenuListContextValue = Pick<MenuListProps, 'checkedValues' | 'hasIcons' | 'hasCheckmarks'> & {
     setFocusByFirstCharacter?: (e: React_2.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => void;
     toggleCheckbox?: SelectableHandler;
     selectRadio?: SelectableHandler;
+    onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
 };
 
 // @public (undocumented)
@@ -209,10 +211,12 @@ export type MenuListSlots = {
 };
 
 // @public (undocumented)
-export type MenuListState = ComponentState<MenuListSlots> & Pick<MenuListProps, 'defaultCheckedValues' | 'onCheckedValueChange'> & Required<Pick<MenuListProps, 'checkedValues' | 'hasCheckmarks' | 'hasIcons'>> & {
+export type MenuListState = ComponentState<MenuListSlots> & Required<Pick<MenuListProps, 'checkedValues' | 'hasCheckmarks' | 'hasIcons'>> & {
     selectRadio: SelectableHandler;
     setFocusByFirstCharacter: NonNullable<MenuListContextValue['setFocusByFirstCharacter']>;
     toggleCheckbox: SelectableHandler;
+    defaultCheckedValues?: Record<string, string[]>;
+    onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
 };
 
 // @public
@@ -286,11 +290,11 @@ export type MenuPopoverState = ComponentState<MenuPopoverSlots> & {
 // @public
 export type MenuProps = ComponentProps<MenuSlots> & Pick<MenuListProps, 'checkedValues' | 'defaultCheckedValues' | 'hasCheckmarks' | 'hasIcons' | 'onCheckedValueChange'> & {
     children: [JSX.Element, JSX.Element] | JSX.Element;
-    defaultOpen?: boolean;
     hoverDelay?: number;
     inline?: boolean;
     onOpenChange?: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
     open?: boolean;
+    defaultOpen?: boolean;
     openOnContext?: boolean;
     openOnHover?: boolean;
     persistOnItemClick?: boolean;
@@ -322,7 +326,7 @@ export type MenuSplitGroupSlots = {
 export type MenuSplitGroupState = ComponentState<MenuSplitGroupSlots>;
 
 // @public (undocumented)
-export type MenuState = ComponentState<MenuSlots> & Pick<MenuProps, 'onOpenChange' | 'defaultCheckedValues'> & Required<Pick<MenuProps, 'hasCheckmarks' | 'hasIcons' | 'inline' | 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover' | 'closeOnScroll' | 'hoverDelay' | 'openOnContext' | 'persistOnItemClick'>> & {
+export type MenuState = ComponentState<MenuSlots> & Required<Pick<MenuProps, 'hasCheckmarks' | 'hasIcons' | 'inline' | 'checkedValues' | 'onCheckedValueChange' | 'open' | 'openOnHover' | 'closeOnScroll' | 'hoverDelay' | 'openOnContext' | 'persistOnItemClick'>> & {
     contextTarget?: PositioningVirtualElement;
     isSubmenu: boolean;
     menuPopover: React_2.ReactNode;
@@ -332,6 +336,8 @@ export type MenuState = ComponentState<MenuSlots> & Pick<MenuProps, 'onOpenChang
     setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
     triggerId: string;
     triggerRef: React_2.MutableRefObject<HTMLElement>;
+    onOpenChange?: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
+    defaultCheckedValues?: Record<string, string[]>;
 };
 
 // @public
@@ -399,7 +405,7 @@ export const renderMenuTrigger_unstable: (state: MenuTriggerState) => JSX.Elemen
 // @public (undocumented)
 export type SelectableHandler = (e: React_2.MouseEvent | React_2.KeyboardEvent, name: string, value: string, checked: boolean) => void;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type UninitializedMenuListState = Omit<MenuListState, 'checkedValues' | 'selectRadio' | 'setFocusByFirstCharacter' | 'toggleCheckbox'> & Partial<Pick<MenuListState, 'checkedValues'>>;
 
 // @public

--- a/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
@@ -22,13 +22,6 @@ export type MenuProps = ComponentProps<MenuSlots> &
     children: [JSX.Element, JSX.Element] | JSX.Element;
 
     /**
-     * Whether the popup is open by default
-     *
-     * @default false
-     */
-    defaultOpen?: boolean;
-
-    /**
      * Sets the delay for mouse open/close for the popover one mouse enter/leave
      */
     hoverDelay?: number;
@@ -53,6 +46,13 @@ export type MenuProps = ComponentProps<MenuSlots> &
      * @default false
      */
     open?: boolean;
+
+    /**
+     * Whether the popup is open by default
+     *
+     * @default false
+     */
+    defaultOpen?: boolean;
 
     /**
      * Opens the menu on right click (context menu), removes all other menu open interactions
@@ -89,7 +89,6 @@ export type MenuProps = ComponentProps<MenuSlots> &
   };
 
 export type MenuState = ComponentState<MenuSlots> &
-  Pick<MenuProps, 'onOpenChange' | 'defaultCheckedValues'> &
   Required<
     Pick<
       MenuProps,
@@ -150,6 +149,20 @@ export type MenuState = ComponentState<MenuSlots> &
      * The ref for the MenuTrigger, used for popup positioning
      */
     triggerRef: React.MutableRefObject<HTMLElement>;
+
+    /**
+     * Call back when the component requests to change value
+     * The `open` value is used as a hint when directly controlling the component
+     * @deprecated this property is not used internally anymore,
+     * the signature remains just to avoid breaking changes
+     */
+    onOpenChange?: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
+    /**
+     * Default values to be checked on mount
+     @deprecated this property is not used internally anymore,
+     * the signature remains just to avoid breaking changes
+     */
+    defaultCheckedValues?: Record<string, string[]>;
   };
 
 export type MenuContextValues = {

--- a/packages/react-components/react-menu/src/components/Menu/useMenuContextValues.test.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenuContextValues.test.tsx
@@ -15,7 +15,6 @@ describe('useMenuContextValues_unstable', () => {
     expect(result.current.menu).toMatchInlineSnapshot(`
       Object {
         "checkedValues": Object {},
-        "defaultCheckedValues": undefined,
         "hasCheckmarks": false,
         "hasIcons": false,
         "inline": false,

--- a/packages/react-components/react-menu/src/components/Menu/useMenuContextValues.ts
+++ b/packages/react-components/react-menu/src/components/Menu/useMenuContextValues.ts
@@ -3,7 +3,6 @@ import type { MenuContextValues, MenuState } from './Menu.types';
 export function useMenuContextValues_unstable(state: MenuState): MenuContextValues {
   const {
     checkedValues,
-    defaultCheckedValues,
     hasCheckmarks,
     hasIcons,
     inline,
@@ -22,7 +21,6 @@ export function useMenuContextValues_unstable(state: MenuState): MenuContextValu
   // This context is created with "@fluentui/react-context-selector", these is no sense to memoize it
   const menu = {
     checkedValues,
-    defaultCheckedValues,
     hasCheckmarks,
     hasIcons,
     inline,

--- a/packages/react-components/react-menu/src/components/MenuGroup/useMenuGroup.ts
+++ b/packages/react-components/react-menu/src/components/MenuGroup/useMenuGroup.ts
@@ -18,6 +18,6 @@ export function useMenuGroup_unstable(props: MenuGroupProps, ref: React.Ref<HTML
       role: 'group',
       ...props,
     }),
-    headerId: headerId,
+    headerId,
   };
 }

--- a/packages/react-components/react-menu/src/components/MenuList/MenuList.types.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/MenuList.types.ts
@@ -47,7 +47,6 @@ export type MenuListProps = ComponentProps<MenuListSlots> & {
 };
 
 export type MenuListState = ComponentState<MenuListSlots> &
-  Pick<MenuListProps, 'defaultCheckedValues' | 'onCheckedValueChange'> &
   Required<Pick<MenuListProps, 'checkedValues' | 'hasCheckmarks' | 'hasIcons'>> & {
     /**
      * Selects a radio item, will de-select the currently selected ratio item
@@ -63,12 +62,31 @@ export type MenuListState = ComponentState<MenuListSlots> &
      * Toggles the state of a checkbox item
      */
     toggleCheckbox: SelectableHandler;
+
+    /**
+     * Default values to be checked on mount
+     * @deprecated this property is not used internally anymore,
+     * the signature remains just to avoid breaking changes
+     */
+    defaultCheckedValues?: Record<string, string[]>;
+    /**
+     * Callback when checked items change for value with a name
+     *
+     * @param event - React's original SyntheticEvent
+     * @param data - A data object with relevant information
+     * @deprecated this property is not used internally anymore,
+     * the signature remains just to avoid breaking changes
+     */
+    onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
   };
 
 export type MenuListContextValues = {
   menuList: MenuListContextValue;
 };
 
+/**
+ * @deprecated
+ */
 export type UninitializedMenuListState = Omit<
   MenuListState,
   'checkedValues' | 'selectRadio' | 'setFocusByFirstCharacter' | 'toggleCheckbox'

--- a/packages/react-components/react-menu/src/components/MenuList/MenuList.types.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/MenuList.types.ts
@@ -85,7 +85,7 @@ export type MenuListContextValues = {
 };
 
 /**
- * @deprecated
+ * @deprecated this type is not being used internally anymore
  */
 export type UninitializedMenuListState = Omit<
   MenuListState,

--- a/packages/react-components/react-menu/src/components/MenuList/useMenuList.test.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/useMenuList.test.ts
@@ -122,16 +122,21 @@ describe('useMenuList_unstable', () => {
       const name = 'test';
       const value = '1';
 
+      const handleCheckedValueChange = jest.fn();
+
       // Act
       const { result } = renderHook(() =>
-        useMenuList_unstable({ onCheckedValueChange: jest.fn(), checkedValues: { [name]: checkedItems } }, null),
+        useMenuList_unstable(
+          { onCheckedValueChange: handleCheckedValueChange, checkedValues: { [name]: checkedItems } },
+          null,
+        ),
       );
       const state = result.current;
       act(() => state.toggleCheckbox(({} as unknown) as React.MouseEvent, name, value, checked));
 
       // Assert
-      expect(state.onCheckedValueChange).toHaveBeenCalledTimes(1);
-      expect(state.onCheckedValueChange).toHaveBeenCalledWith(
+      expect(handleCheckedValueChange).toHaveBeenCalledTimes(1);
+      expect(handleCheckedValueChange).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ name, checkedItems: expectedResult }),
       );
@@ -163,16 +168,22 @@ describe('useMenuList_unstable', () => {
       // Arrange
       const name = 'test';
       const value = '1';
+
+      const handleCheckedValueChange = jest.fn();
+
       // Act
       const { result } = renderHook(() =>
-        useMenuList_unstable({ onCheckedValueChange: jest.fn(), checkedValues: { [name]: checkedItems } }, null),
+        useMenuList_unstable(
+          { onCheckedValueChange: handleCheckedValueChange, checkedValues: { [name]: checkedItems } },
+          null,
+        ),
       );
       const state = result.current;
       act(() => state.selectRadio(({} as unknown) as React.MouseEvent, name, value, true));
 
       // Assert
-      expect(state.onCheckedValueChange).toHaveBeenCalledTimes(1);
-      expect(state.onCheckedValueChange).toHaveBeenCalledWith(
+      expect(handleCheckedValueChange).toHaveBeenCalledTimes(1);
+      expect(handleCheckedValueChange).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ name, checkedItems: expectedResult }),
       );

--- a/packages/react-components/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/useMenuList.ts
@@ -9,7 +9,7 @@ import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabste
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
 import { MenuContext } from '../../contexts/menuContext';
-import type { MenuListProps, MenuListState, UninitializedMenuListState } from './MenuList.types';
+import type { MenuListProps, MenuListState } from './MenuList.types';
 
 /**
  * Returns the props and state required to render the component
@@ -27,22 +27,6 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
   }
 
   const innerRef = React.useRef<HTMLElement>(null);
-  const initialState: UninitializedMenuListState = {
-    components: {
-      root: 'div',
-    },
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, innerRef),
-      role: 'menu',
-      'aria-labelledby': menuContext.triggerId,
-      ...focusAttributes,
-      ...props,
-    }),
-    hasIcons: menuContext.hasIcons || false,
-    hasCheckmarks: menuContext.hasCheckmarks || false,
-    ...(hasMenuContext && menuContext),
-    ...props,
-  };
 
   const setFocusByFirstCharacter = React.useCallback(
     (e: React.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => {
@@ -91,12 +75,13 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
   );
 
   const [checkedValues, setCheckedValues] = useControllableState({
-    state: initialState.checkedValues,
-    defaultState: initialState.defaultCheckedValues,
+    state: hasMenuContext ? menuContext.checkedValues : props.checkedValues,
+    defaultState: props.defaultCheckedValues,
     initialState: {},
   });
 
-  const { onCheckedValueChange } = initialState;
+  const handleCheckedValueChange = hasMenuContext ? menuContext.onCheckedValueChange : props.onCheckedValueChange;
+
   const toggleCheckbox = useEventCallback(
     (e: React.MouseEvent | React.KeyboardEvent, name: string, value: string, checked: boolean) => {
       const checkedItems = checkedValues?.[name] || [];
@@ -107,7 +92,7 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
         newCheckedItems.push(value);
       }
 
-      onCheckedValueChange?.(e, { name, checkedItems: newCheckedItems });
+      handleCheckedValueChange?.(e, { name, checkedItems: newCheckedItems });
       setCheckedValues(s => ({ ...s, [name]: newCheckedItems }));
     },
   );
@@ -115,18 +100,27 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
   const selectRadio = useEventCallback((e: React.MouseEvent | React.KeyboardEvent, name: string, value: string) => {
     const newCheckedItems = [value];
     setCheckedValues(s => ({ ...s, [name]: newCheckedItems }));
-    onCheckedValueChange?.(e, { name, checkedItems: newCheckedItems });
+    handleCheckedValueChange?.(e, { name, checkedItems: newCheckedItems });
   });
 
-  const state = {
-    ...initialState,
+  return {
+    components: {
+      root: 'div',
+    },
+    root: getNativeElementProps('div', {
+      ref: useMergedRefs(ref, innerRef),
+      role: 'menu',
+      'aria-labelledby': menuContext.triggerId,
+      ...focusAttributes,
+      ...props,
+    }),
+    hasIcons: menuContext.hasIcons || false,
+    hasCheckmarks: menuContext.hasCheckmarks || false,
+    checkedValues,
     setFocusByFirstCharacter,
     selectRadio,
     toggleCheckbox,
-    checkedValues: checkedValues ?? {},
   };
-
-  return state;
 };
 
 /**
@@ -135,7 +129,6 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
 const useMenuContextSelectors = () => {
   const checkedValues = useMenuContext_unstable(context => context.checkedValues);
   const onCheckedValueChange = useMenuContext_unstable(context => context.onCheckedValueChange);
-  const defaultCheckedValues = useMenuContext_unstable(context => context.defaultCheckedValues);
   const triggerId = useMenuContext_unstable(context => context.triggerId);
   const hasIcons = useMenuContext_unstable(context => context.hasIcons);
   const hasCheckmarks = useMenuContext_unstable(context => context.hasCheckmarks);
@@ -143,7 +136,6 @@ const useMenuContextSelectors = () => {
   return {
     checkedValues,
     onCheckedValueChange,
-    defaultCheckedValues,
     triggerId,
     hasIcons,
     hasCheckmarks,

--- a/packages/react-components/react-menu/src/components/MenuList/useMenuListContextValues.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/useMenuListContextValues.ts
@@ -1,22 +1,13 @@
 import type { MenuListContextValues, MenuListState } from './MenuList.types';
 
 export function useMenuListContextValues_unstable(state: MenuListState): MenuListContextValues {
-  const {
-    checkedValues,
-    hasCheckmarks,
-    hasIcons,
-    onCheckedValueChange,
-    selectRadio,
-    setFocusByFirstCharacter,
-    toggleCheckbox,
-  } = state;
+  const { checkedValues, hasCheckmarks, hasIcons, selectRadio, setFocusByFirstCharacter, toggleCheckbox } = state;
 
   // This context is created with "@fluentui/react-context-selector", these is no sense to memoize it
   const menuList = {
     checkedValues,
     hasCheckmarks,
     hasIcons,
-    onCheckedValueChange,
     selectRadio,
     setFocusByFirstCharacter,
     toggleCheckbox,

--- a/packages/react-components/react-menu/src/contexts/menuContext.ts
+++ b/packages/react-components/react-menu/src/contexts/menuContext.ts
@@ -12,7 +12,6 @@ const menuContextDefaultValue: MenuContextValue = {
   setOpen: () => false,
   checkedValues: {},
   onCheckedValueChange: () => null,
-  defaultCheckedValues: {},
   isSubmenu: false,
   triggerRef: ({ current: null } as unknown) as React.MutableRefObject<HTMLElement>,
   menuPopoverRef: ({ current: null } as unknown) as React.MutableRefObject<HTMLElement>,
@@ -45,10 +44,15 @@ export type MenuContextValue = Pick<
   | 'inline'
   | 'checkedValues'
   | 'onCheckedValueChange'
-  | 'defaultCheckedValues'
 > & {
   open: boolean;
   triggerId: string;
+  /**
+   * Default values to be checked on mount
+   * @deprecated this property is not used internally anymore,
+   * the signature remains just to avoid breaking changes
+   */
+  defaultCheckedValues?: Record<string, string[]>;
 };
 
 export const MenuProvider = MenuContext.Provider;

--- a/packages/react-components/react-menu/src/contexts/menuListContext.tsx
+++ b/packages/react-components/react-menu/src/contexts/menuListContext.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createContext, useContextSelector } from '@fluentui/react-context-selector';
 import type { ContextSelector, Context } from '@fluentui/react-context-selector';
 import type { SelectableHandler } from '../selectable/index';
-import type { MenuListProps } from '../components/index';
+import type { MenuCheckedValueChangeData, MenuCheckedValueChangeEvent, MenuListProps } from '../components/index';
 
 export const MenuListContext: Context<MenuListContextValue> = createContext<MenuListContextValue | undefined>(
   undefined,
@@ -10,7 +10,6 @@ export const MenuListContext: Context<MenuListContextValue> = createContext<Menu
 
 const menuListContextDefaultValue: MenuListContextValue = {
   checkedValues: {},
-  onCheckedValueChange: () => null,
   setFocusByFirstCharacter: () => null,
   toggleCheckbox: () => null,
   selectRadio: () => null,
@@ -21,13 +20,20 @@ const menuListContextDefaultValue: MenuListContextValue = {
 /**
  * Context shared between MenuList and its children components
  */
-export type MenuListContextValue = Pick<
-  MenuListProps,
-  'checkedValues' | 'onCheckedValueChange' | 'hasIcons' | 'hasCheckmarks'
-> & {
+export type MenuListContextValue = Pick<MenuListProps, 'checkedValues' | 'hasIcons' | 'hasCheckmarks'> & {
   setFocusByFirstCharacter?: (e: React.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => void;
   toggleCheckbox?: SelectableHandler;
   selectRadio?: SelectableHandler;
+  /**
+   * Callback when checked items change for value with a name
+   *
+   * @param event - React's original SyntheticEvent
+   * @param data - A data object with relevant information
+   *
+   * @deprecated this property is not used internally anymore,
+   * the signature remains just to avoid breaking changes
+   */
+  onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
 };
 
 export const MenuListProvider = MenuListContext.Provider;

--- a/packages/react-components/react-menu/src/index.ts
+++ b/packages/react-components/react-menu/src/index.ts
@@ -82,6 +82,8 @@ export type {
   MenuListProps,
   MenuListSlots,
   MenuListState,
+  // UninitializedMenuListState is deprecated but removing it would be a breaking change
+  // eslint-disable-next-line deprecation/deprecation
   UninitializedMenuListState,
 } from './MenuList';
 export {

--- a/packages/react-components/react-menu/src/testing/mockUseMenuContext.ts
+++ b/packages/react-components/react-menu/src/testing/mockUseMenuContext.ts
@@ -17,7 +17,6 @@ export const mockUseMenuContext = (options: Partial<MenuContextValue> = {}) => {
     openOnHover: false,
     isSubmenu: false,
     checkedValues: {},
-    defaultCheckedValues: undefined,
     hasCheckmarks: false,
     hasIcons: false,
     inline: false,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Main changes

1. Removes the spreading of `props` into `MenuList` state declaration. 
2. Updates types accordingly, deprecating unnecessary properties passing down for the state
3. deprecates unused type `UninitializedMenuListState`

#### This PR is a code maintenance

Together with type casting, spreading props at state is not ideal as it obscures what properties are actually required to maintain the proper usage of internal state, therefore spreading props at state should be avoided.
