### PR TITLE
fix(scripts): copy amd files for ts-solution projects if they exist

### DIFF
--- a/scripts/tasks/copy.ts
+++ b/scripts/tasks/copy.ts
@@ -83,6 +83,10 @@ export function copyCompiled() {
       ),
       out: path.join(packageDir, path.dirname(packageJson.main)),
     },
+    amd: {
+      in: path.join(packageDir, tsConfig.compilerOptions.outDir as string, 'lib-amd', projectMetadata.sourceRoot),
+      out: path.join(packageDir, 'lib-amd'),
+    },
   };
 
   const tasks = [
@@ -97,6 +101,12 @@ export function copyCompiled() {
 
       dest: paths.commonJs.out,
     }),
+    fs.existsSync(paths.amd.in)
+      ? copyTask({
+          paths: [paths.amd.in],
+          dest: paths.amd.out,
+        })
+      : null,
   ].filter(Boolean) as TaskFunction[];
 
   return series(...tasks);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

After https://github.com/microsoft/fluentui/pull/25609, v9 packages that need to ship AMD will not ship it

## New Behavior

v9 packages ship AMD if they have it setup

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows https://github.com/microsoft/fluentui/pull/25609
