### PR TITLE
docs(public-docsite-v9): Split Basic and NextJS setups into two pages

### DIFF
--- a/apps/public-docsite-v9/.storybook/preview.js
+++ b/apps/public-docsite-v9/.storybook/preview.js
@@ -25,7 +25,7 @@ export const parameters = {
         [
           'Introduction',
           'Developer',
-          ['Quick Start', 'Styling Components', 'Positioning Components', 'Component Poster'],
+          ['Quick Start', 'Styling Components', 'Positioning Components', 'Component Poster', 'Server-Side Rendering'],
           'Migration',
           [
             'Overview',

--- a/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
@@ -1,0 +1,144 @@
+import { Meta } from '@storybook/addon-docs';
+import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
+
+<Meta title="Concepts/Developer/Server-Side Rendering/NextJS Setup" />
+
+### Next.js
+
+For basic instructions on getting Next.js set up, see [Getting Started](https://nextjs.org/docs/getting-started).
+
+1. Get a basic next.js setup running, rendering a page from the `pages` folder, as guided by the tutorial.
+2. Add the Fluent UI dependencies: `@fluentui/react-components`.
+
+```sh
+yarn add @fluentui/react-components
+```
+
+1. Create a `_document.tsx` file under your `pages` folder with the following content:
+
+```tsx
+import { createDOMRenderer, renderToStyleElements } from '@fluentui/react-components';
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    // 👇 creates a renderer that will be used for SSR
+    const renderer = createDOMRenderer();
+    const originalRenderPage = ctx.renderPage;
+
+    ctx.renderPage = () =>
+      originalRenderPage({
+        enhanceApp: App =>
+          function EnhancedApp(props) {
+            const enhancedProps = {
+              ...props,
+              // 👇 this is required to provide a proper renderer instance
+              renderer,
+            };
+
+            return <App {...enhancedProps} />;
+          },
+      });
+
+    const initialProps = await Document.getInitialProps(ctx);
+    const styles = renderToStyleElements(renderer);
+
+    return {
+      ...initialProps,
+      styles: (
+        <>
+          {initialProps.styles}
+          {/* 👇 adding Fluent UI styles elements to output */}
+          {styles}
+        </>
+      ),
+    };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;
+```
+
+2. Create or modify a `_app.tsx` file under your `pages` folder with the following content:
+
+```tsx
+import {
+  createDOMRenderer,
+  FluentProvider,
+  GriffelRenderer,
+  SSRProvider,
+  RendererProvider,
+  webLightTheme,
+} from '@fluentui/react-components';
+import type { AppProps } from 'next/app';
+
+type EnhancedAppProps = AppProps & { renderer?: GriffelRenderer };
+
+function MyApp({ Component, pageProps, renderer }: EnhancedAppProps) {
+  return (
+    // 👇 Accepts a renderer from <Document /> or creates a default one
+    //    Also triggers rehydration a client
+    <RendererProvider renderer={renderer || createDOMRenderer()}>
+      <SSRProvider>
+        <FluentProvider theme={webLightTheme}>
+          <Component {...pageProps} />
+        </FluentProvider>
+      </SSRProvider>
+    </RendererProvider>
+  );
+}
+
+export default MyApp;
+```
+
+3. You should now be able to server render Fluent UI React components in any of your pages:
+
+```tsx
+import { Button, makeStyles, shorthands, Title1, tokens } from '@fluentui/react-components';
+import type { NextPage } from 'next';
+import Head from 'next/head';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '200px',
+
+    ...shorthands.border('2px', 'dashed', tokens.colorPaletteBerryBorder2),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.gap('5px'),
+    ...shorthands.padding('10px'),
+  },
+});
+
+const Home: NextPage = () => {
+  const styles = useStyles();
+
+  return (
+    <>
+      <Head>
+        <title>My app</title>
+      </Head>
+
+      <div className={styles.container}>
+        <Title1>Hello world!</Title1>
+        <Button>A button</Button>
+      </div>
+    </>
+  );
+};
+
+export default Home;
+```

--- a/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
@@ -10,7 +10,11 @@ For basic instructions on getting Next.js set up, see [Getting Started](https://
 2. Add the Fluent UI dependencies: `@fluentui/react-components`.
 
 ```sh
+// yarn
 yarn add @fluentui/react-components
+
+//npm
+npm install @fluentui/react-components
 ```
 
 1. Create a `_document.tsx` file under your `pages` folder with the following content:

--- a/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/NextJS Setup" />
 
-### Next.js
+## Next.js
 
 For basic instructions on getting Next.js set up, see [Getting Started](https://nextjs.org/docs/getting-started).
 

--- a/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Nextjs.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/addon-docs';
-import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/NextJS Setup" />
 

--- a/apps/public-docsite-v9/src/Concepts/SSR/Portals.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Portals.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
+import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/Portals" />
 

--- a/apps/public-docsite-v9/src/Concepts/SSR/Portals.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Portals.stories.mdx
@@ -3,12 +3,12 @@ import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/Portals" />
 
-### React Portals
+## React Portals
 
 React does not support hydration for portals ([facebook/react#13097](https://github.com/facebook/react/issues/13097)). While Fluent
 UI tries to work out of the box without hydration warnings, some workarounds are required in certain edge cases.
 
-#### Default open
+### Default open
 
 Components like `Menu` or `Popover` have a `defaultOpen` prop that open the positioned surface on mount. These components
 are rendered with React portals. In SSR using the `defaultOpen` on server render will cause a hydration error because

--- a/apps/public-docsite-v9/src/Concepts/SSR/Portals.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Portals.stories.mdx
@@ -1,0 +1,52 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Developer/Server-Side Rendering/Portals" />
+
+### React Portals
+
+React does not support hydration for portals ([facebook/react#13097](https://github.com/facebook/react/issues/13097)). While Fluent
+UI tries to work out of the box without hydration warnings, some workarounds are required in certain edge cases.
+
+#### Default open
+
+Components like `Menu` or `Popover` have a `defaultOpen` prop that open the positioned surface on mount. These components
+are rendered with React portals. In SSR using the `defaultOpen` on server render will cause a hydration error because
+React does not support hydration for portals.
+
+The below example shows how to use the `useIsSSR` hook to implement a `Menu` that is open by default on the first render.
+Toggle the checkbox to mount/unmount the component.
+
+<SSRDefaultOpen />
+
+```tsx
+import * as React from 'react';
+import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, useIsSSR, Button } from '@fluentui/react-components';
+
+const DefaultOpenMenu = () => {
+  const [open, setOpen] = React.useState(false);
+  const isSSR = useIsSSR();
+
+  React.useEffect(() => {
+    if (!isSSR) {
+      setOpen(true);
+    }
+  }, [isSSR]);
+
+  return (
+    <Menu open={open} onOpenChange={(e, data) => setOpen(data.open)}>
+      <MenuTrigger>
+        <Button>SSR Default open</Button>
+      </MenuTrigger>
+
+      <MenuPopover>
+        <MenuList>
+          <MenuItem>New </MenuItem>
+          <MenuItem>New Window</MenuItem>
+          <MenuItem disabled>Open File</MenuItem>
+          <MenuItem>Open Folder</MenuItem>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
+```

--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/addon-docs';
-import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/Basic Setup" />
 
@@ -9,7 +8,7 @@ Fluent UI React v9 fully supports Server-Side Rendering.
 
 ### Basic setup
 
-For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `FluentProvider` in the root file of your app. If these providers are not added, there will be issues when hydrating. See the following example:
+For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `FluentProvider` in the root of your app. If these providers are not added, there will be issues when hydrating. See the following example:
 
 ```tsx
 import express from 'express';
@@ -20,7 +19,7 @@ import {
   RendererProvider,
   renderToStyleElements,
   FluentProvider,
-  teamsDarkTheme,
+  webLightTheme,
   SSRProvider,
 } from '@fluentui/react-components';
 
@@ -44,20 +43,21 @@ server.get('/', (req, res) => {
   const html = ReactDOMServer.renderToString(
     <RendererProvider renderer={renderer}>
       <SSRProvider>
-        <FluentProvider theme={teamsDarkTheme}>
+        <FluentProvider theme={webLightTheme}>
           <ExampleComponent />
         </FluentProvider>
       </SSRProvider>
     </RendererProvider>,
   );
 
-  // Converting our styles to style elements and then rendering them to add them into our code.
+  // Converting Fluent UI styles to style elements. 👇
   const style = ReactDOMServer.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>);
 
   res.write(`
   <!DOCTYPE html>
   <html>
     <head>
+      ${/* 👇 adding Fluent UI styles elements to output */}
       ${style}
     </head>
     <body>
@@ -69,53 +69,4 @@ server.get('/', (req, res) => {
 });
 
 server.listen(3000, 'localhost');
-```
-
-### React Portals
-
-React does not support hydration for portals ([facebook/react#13097](https://github.com/facebook/react/issues/13097)). While Fluent
-UI tries to work out of the box without hydration warnings, some workarounds are required in certain edge cases.
-
-#### Default open
-
-Components like `Menu` or `Popover` have a `defaultOpen` prop that open the positioned surface on mount. These components
-are rendered with React portals. In SSR using the `defaultOpen` on server render will cause a hydration error because
-React does not support hydration for portals.
-
-The below example shows how to use the `useIsSSR` hook to implement a `Menu` that is open by default on the first render.
-Toggle the checkbox to mount/unmount the component.
-
-<SSRDefaultOpen />
-
-```tsx
-import { Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, useIsSSR, Button } from '@fluentui/react-components';
-import * as React from 'react';
-
-const DefaultOpenMenu = () => {
-  const [open, setOpen] = React.useState(false);
-  const isSSR = useIsSSR();
-
-  React.useEffect(() => {
-    if (!isSSR) {
-      setOpen(true);
-    }
-  }, [isSSR]);
-
-  return (
-    <Menu open={open} onOpenChange={(e, data) => setOpen(data.open)}>
-      <MenuTrigger>
-        <Button>SSR Default open</Button>
-      </MenuTrigger>
-
-      <MenuPopover>
-        <MenuList>
-          <MenuItem>New </MenuItem>
-          <MenuItem>New Window</MenuItem>
-          <MenuItem disabled>Open File</MenuItem>
-          <MenuItem>Open Folder</MenuItem>
-        </MenuList>
-      </MenuPopover>
-    </Menu>
-  );
-};
 ```

--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/addon-docs';
-import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/Basic Setup" />
 

--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
-<Meta title="Concepts/Developer/Server-Side Rendering" />
+<Meta title="Concepts/Developer/Server-Side Rendering/Basic Setup" />
 
 ## Server-Side Rendering
 
@@ -9,19 +9,19 @@ Fluent UI React v9 fully supports Server-Side Rendering.
 
 ### Basic setup
 
-For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `ThemeProvider` in the root file of your app. If these providers are not added, there will be issues when hydrating. See the following example:
+For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `FluentProvider` in the root file of your app. If these providers are not added, there will be issues when hydrating. See the following example:
 
 ```tsx
-import * as React from 'react';
-import * as ReactDOM from 'react-dom/server';
+import express from 'express';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import {
   createDOMRenderer,
-  FluentProvider,
-  makeStyles,
   RendererProvider,
   renderToStyleElements,
+  FluentProvider,
+  teamsDarkTheme,
   SSRProvider,
-  webLightTheme,
 } from '@fluentui/react-components';
 
 const useExampleStyles = makeStyles({
@@ -41,169 +41,34 @@ const server = express();
 server.get('/', (req, res) => {
   const renderer = createDOMRenderer();
 
-  const html = ReactDOM.renderToString(
+  const html = ReactDOMServer.renderToString(
     <RendererProvider renderer={renderer}>
       <SSRProvider>
-        <FluentProvider theme={webLightTheme}>
+        <FluentProvider theme={teamsDarkTheme}>
           <ExampleComponent />
         </FluentProvider>
       </SSRProvider>
     </RendererProvider>,
   );
 
-  res.send(`
-    <html>
-      <head>
-        ${renderToStyleElements(renderer)}
-      </head>
-      <body>
-        <div id="root">${html}</div>
-      </body>
-    </html>
+  // Converting our styles to style elements and then rendering them to add them into our code.
+  const style = ReactDOMServer.renderToStaticMarkup(<>{renderToStyleElements(renderer)}</>);
+
+  res.write(`
+  <!DOCTYPE html>
+  <html>
+    <head>
+      ${style}
+    </head>
+    <body>
+      <div id="root">${html}</div>
+    </body>
+  </html>
   `);
+  res.end();
 });
 
 server.listen(3000, 'localhost');
-```
-
-### Next.js
-
-For basic instructions on getting Next.js set up, see [Getting Started](https://nextjs.org/docs/getting-started).
-
-1. Get a basic next.js setup running, rendering a page from the `pages` folder, as guided by the tutorial.
-2. Add the Fluent UI dependencies: `@fluentui/react-components`.
-
-```sh
-yarn add @fluentui/react-components
-```
-
-1. Create a `_document.tsx` file under your `pages` folder with the following content:
-
-```tsx
-import { createDOMRenderer, renderToStyleElements } from '@fluentui/react-components';
-import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
-
-class MyDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext) {
-    // 👇 creates a renderer that will be used for SSR
-    const renderer = createDOMRenderer();
-    const originalRenderPage = ctx.renderPage;
-
-    ctx.renderPage = () =>
-      originalRenderPage({
-        enhanceApp: App =>
-          function EnhancedApp(props) {
-            const enhancedProps = {
-              ...props,
-              // 👇 this is required to provide a proper renderer instance
-              renderer,
-            };
-
-            return <App {...enhancedProps} />;
-          },
-      });
-
-    const initialProps = await Document.getInitialProps(ctx);
-    const styles = renderToStyleElements(renderer);
-
-    return {
-      ...initialProps,
-      styles: (
-        <>
-          {initialProps.styles}
-          {/* 👇 adding Fluent UI styles elements to output */}
-          {styles}
-        </>
-      ),
-    };
-  }
-
-  render() {
-    return (
-      <Html>
-        <Head />
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
-}
-
-export default MyDocument;
-```
-
-2. Create or modify a `_app.tsx` file under your `pages` folder with the following content:
-
-```tsx
-import {
-  createDOMRenderer,
-  FluentProvider,
-  GriffelRenderer,
-  SSRProvider,
-  RendererProvider,
-  webLightTheme,
-} from '@fluentui/react-components';
-import type { AppProps } from 'next/app';
-
-type EnhancedAppProps = AppProps & { renderer?: GriffelRenderer };
-
-function MyApp({ Component, pageProps, renderer }: EnhancedAppProps) {
-  return (
-    // 👇 Accepts a renderer from <Document /> or creates a default one
-    //    Also triggers rehydration a client
-    <RendererProvider renderer={renderer || createDOMRenderer()}>
-      <SSRProvider>
-        <FluentProvider theme={webLightTheme}>
-          <Component {...pageProps} />
-        </FluentProvider>
-      </SSRProvider>
-    </RendererProvider>
-  );
-}
-
-export default MyApp;
-```
-
-3. You should now be able to server render Fluent UI React components in any of your pages:
-
-```tsx
-import { Button, makeStyles, shorthands, Title1, tokens } from '@fluentui/react-components';
-import type { NextPage } from 'next';
-import Head from 'next/head';
-
-const useStyles = makeStyles({
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    width: '200px',
-
-    ...shorthands.border('2px', 'dashed', tokens.colorPaletteBerryBorder2),
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    ...shorthands.gap('5px'),
-    ...shorthands.padding('10px'),
-  },
-});
-
-const Home: NextPage = () => {
-  const styles = useStyles();
-
-  return (
-    <>
-      <Head>
-        <title>My app</title>
-      </Head>
-
-      <div className={styles.container}>
-        <Title1>Hello world!</Title1>
-        <Button>A button</Button>
-      </div>
-    </>
-  );
-};
-
-export default Home;
 ```
 
 ### React Portals

--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
+import { SSRDefaultOpen } from './MenuSSRDefaultOpen.stories';
 
 <Meta title="Concepts/Developer/Server-Side Rendering/Basic Setup" />
 

--- a/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/SSR.stories.mdx
@@ -8,6 +8,16 @@ Fluent UI React v9 fully supports Server-Side Rendering.
 
 ### Basic setup
 
+Add `@fluentui/react-components` dependency:
+
+```sh
+// yarn
+yarn add @fluentui/react-components
+
+//npm
+npm install @fluentui/react-components
+```
+
 For any setup using SSR, you need to provide a `RendererProvider`, `SSRProvider` and `FluentProvider` in the root of your app. If these providers are not added, there will be issues when hydrating. See the following example:
 
 ```tsx


### PR DESCRIPTION
This PR adds the following:
* Updates basic setup code with comments.
* Adds a folder for SSR.
* Splits the basic setup and NextJS setup.
  * This is needed since we'll add more platform setups like Gatsby.
* Splits Portal section into its own page for better visibility.