### PR TITLE
chore: Updating Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,4 @@ PR flow tips:
 
 <!-- Please link the issue being fixed so it gets closed when this is merged. -->
 
-Fixes #
+* Fixes #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ PR flow tips:
 * [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
 -->
 
-## Current Behavior
+## Previous Behavior
 
 <!-- This is the behavior we have today -->
 


### PR DESCRIPTION
## PR Description

This PR updates the PR Template so that it reads `## Previous Behavior` instead of `## Current Behavior` when referring to the behavior that existed before the changes in the PR. This makes it less ambiguous as `Current` could mean the behavior before or after the PR depending on how it's used.
