### PR TITLE
fix: Allow PresenceBadge's icon to be overridden by the user

### DIFF
--- a/change/@fluentui-react-badge-b015aa83-a8a1-4d2d-b21e-6c043231e03f.json
+++ b/change/@fluentui-react-badge-b015aa83-a8a1-4d2d-b21e-6c043231e03f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Allow PresenceBadge's icon to be overridden by the user.",
+  "packageName": "@fluentui/react-badge",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/stories/Avatar/AvatarBadgeIcon.stories.tsx
+++ b/packages/react-components/react-avatar/stories/Avatar/AvatarBadgeIcon.stories.tsx
@@ -2,16 +2,12 @@ import * as React from 'react';
 import { Avatar } from '@fluentui/react-components';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
-export const BadgeIcon = () => (
-  <>
-    <Avatar name="John Doe" badge={{ icon: <CalendarMonthRegular /> }} />
-  </>
-);
+export const BadgeIcon = () => <Avatar name="John Doe" badge={{ icon: <CalendarMonthRegular /> }} />;
 
 BadgeIcon.parameters = {
   docs: {
     description: {
-      story: 'An avatar can have the icon inside the badge customized by the user instead of using the default ones.',
+      story: 'An Avatar can have a custom icon inside the badge.',
     },
   },
 };

--- a/packages/react-components/react-avatar/stories/Avatar/AvatarBadgeIcon.stories.tsx
+++ b/packages/react-components/react-avatar/stories/Avatar/AvatarBadgeIcon.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Avatar } from '@fluentui/react-components';
+import { CalendarMonthRegular } from '@fluentui/react-icons';
+
+export const BadgeIcon = () => (
+  <>
+    <Avatar name="John Doe" badge={{ icon: <CalendarMonthRegular /> }} />
+  </>
+);
+
+BadgeIcon.parameters = {
+  docs: {
+    description: {
+      story: 'An avatar can have the icon inside the badge customized by the user instead of using the default ones.',
+    },
+  },
+};

--- a/packages/react-components/react-avatar/stories/Avatar/index.stories.tsx
+++ b/packages/react-components/react-avatar/stories/Avatar/index.stories.tsx
@@ -7,6 +7,7 @@ export { Name } from './AvatarName.stories';
 export { Image } from './AvatarImage.stories';
 export { Icon } from './AvatarIcon.stories';
 export { Badge } from './AvatarBadge.stories';
+export { BadgeIcon } from './AvatarBadgeIcon.stories';
 export { Square } from './AvatarSquare.stories';
 export { ColorBrand } from './AvatarColorBrand.stories';
 export { ColorColorful } from './AvatarColorColorful.stories';

--- a/packages/react-components/react-badge/src/components/PresenceBadge/presenceIcons.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/presenceIcons.ts
@@ -30,7 +30,7 @@ import {
 } from '@fluentui/react-icons';
 import type { PresenceBadgeState } from './PresenceBadge.types';
 
-export const presenceAwayFilled: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceAwayFilled: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceAway10Filled,
@@ -45,7 +45,7 @@ export const presenceAwayFilled: Record<PresenceBadgeState['size'], React.Functi
   'extra-large': PresenceAway16Filled,
 };
 
-export const presenceAvailableRegular: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceAvailableRegular: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceAvailable10Regular,
@@ -60,7 +60,7 @@ export const presenceAvailableRegular: Record<PresenceBadgeState['size'], React.
   'extra-large': PresenceAvailable16Regular,
 };
 
-export const presenceAvailableFilled: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceAvailableFilled: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceAvailable10Filled,
@@ -75,7 +75,7 @@ export const presenceAvailableFilled: Record<PresenceBadgeState['size'], React.F
   'extra-large': PresenceAvailable16Filled,
 };
 
-export const presenceBusyFilled: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceBusyFilled: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceBusy10Filled,
@@ -90,7 +90,7 @@ export const presenceBusyFilled: Record<PresenceBadgeState['size'], React.Functi
   'extra-large': PresenceBusy16Filled,
 };
 
-export const presenceDndFilled: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceDndFilled: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceDnd10Filled,
@@ -105,7 +105,7 @@ export const presenceDndFilled: Record<PresenceBadgeState['size'], React.Functio
   'extra-large': PresenceDnd16Filled,
 };
 
-export const presenceDndRegular: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceDndRegular: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceDnd10Regular,
@@ -120,7 +120,7 @@ export const presenceDndRegular: Record<PresenceBadgeState['size'], React.Functi
   'extra-large': PresenceDnd16Regular,
 };
 
-export const presenceOofRegular: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceOofRegular: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceOof10Regular,
@@ -135,7 +135,7 @@ export const presenceOofRegular: Record<PresenceBadgeState['size'], React.Functi
   'extra-large': PresenceOof16Regular,
 };
 
-export const presenceOfflineRegular: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceOfflineRegular: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceOffline10Regular,
@@ -150,7 +150,7 @@ export const presenceOfflineRegular: Record<PresenceBadgeState['size'], React.Fu
   'extra-large': PresenceOffline16Regular,
 };
 
-export const presenceUnknownRegular: Record<PresenceBadgeState['size'], React.FunctionComponent | null> = {
+export const presenceUnknownRegular: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   tiny: PresenceUnknown10Regular,

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -83,10 +83,5 @@ export const usePresenceBadge_unstable = (
     outOfOffice,
   };
 
-  // const IconElement = iconMap(status, outOfOffice, state.size);
-  // if (IconElement) {
-  //   state.icon!.children = <IconElement />;
-  // }
-
   return state;
 };

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -14,11 +14,7 @@ import {
 import { useBadge_unstable } from '../Badge/index';
 import type { PresenceBadgeProps, PresenceBadgeState } from './PresenceBadge.types';
 
-const iconMap = (
-  status: PresenceBadgeState['status'],
-  outOfOffice: boolean,
-  size: PresenceBadgeState['size'],
-): React.FunctionComponent | null => {
+const iconMap = (status: PresenceBadgeState['status'], outOfOffice: boolean, size: PresenceBadgeState['size']) => {
   switch (status) {
     case 'available':
       return outOfOffice ? presenceAvailableRegular[size] : presenceAvailableFilled[size];
@@ -54,9 +50,7 @@ export const usePresenceBadge_unstable = (
   props: PresenceBadgeProps,
   ref: React.Ref<HTMLElement>,
 ): PresenceBadgeState => {
-  const size = props.size ?? 'medium';
-  const status = props.status ?? 'available';
-  const outOfOffice = props.outOfOffice ?? false;
+  const { size = 'medium', status = 'available', outOfOffice = false } = props;
 
   const statusText = DEFAULT_STRINGS[status];
   const oofText = props.outOfOffice && props.status !== 'out-of-office' ? ` ${DEFAULT_STRINGS['out-of-office']}` : '';

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -54,29 +54,39 @@ export const usePresenceBadge_unstable = (
   props: PresenceBadgeProps,
   ref: React.Ref<HTMLElement>,
 ): PresenceBadgeState => {
-  const statusText = DEFAULT_STRINGS[props.status ?? 'available'];
+  const size = props.size ?? 'medium';
+  const status = props.status ?? 'available';
+  const outOfOffice = props.outOfOffice ?? false;
+
+  const statusText = DEFAULT_STRINGS[status];
   const oofText = props.outOfOffice && props.status !== 'out-of-office' ? ` ${DEFAULT_STRINGS['out-of-office']}` : '';
+
+  const IconElement = iconMap(status, outOfOffice, size);
+
   const state: PresenceBadgeState = {
     ...useBadge_unstable(
       {
-        size: 'medium',
         'aria-label': statusText + oofText,
         role: 'img',
         ...props,
+        size,
         icon: resolveShorthand(props.icon, {
+          defaultProps: {
+            children: IconElement ? <IconElement /> : null,
+          },
           required: true,
         }),
       },
       ref,
     ),
-    status: props.status ?? 'available',
-    outOfOffice: props.outOfOffice ?? false,
+    status,
+    outOfOffice,
   };
 
-  const IconElement = iconMap(state.status, state.outOfOffice, state.size);
-  if (IconElement) {
-    state.icon!.children = <IconElement />;
-  }
+  // const IconElement = iconMap(status, outOfOffice, state.size);
+  // if (IconElement) {
+  //   state.icon!.children = <IconElement />;
+  // }
 
   return state;
 };


### PR DESCRIPTION
## Previous Behavior

The icons used in `PresenceBadge` cannot be overridden by the user, not even when overriding the `icon` slot.

## New Behavior

The icons used in `PresenceBadge` are now only used by default but can be overridden by the user through the `icon` slot.