### PR TITLE
fix: Making Stack properly render non-ReactElement children

### DIFF
--- a/change/@fluentui-react-164cba30-514e-4d2d-b6b7-d65448342050.json
+++ b/change/@fluentui-react-164cba30-514e-4d2d-b6b7-d65448342050.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Making Stack properly render non-ReactElement children.",
+  "packageName": "@fluentui/react",
+  "email": "humberto_makoto@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -46,7 +46,7 @@ function _processStackChildren(
 
   childrenArray = React.Children.map(childrenArray, child => {
     if (!child || !React.isValidElement(child)) {
-      return null;
+      return child;
     }
 
     if (child.type === React.Fragment) {


### PR DESCRIPTION
## PR Description

PR #25397 introduced a way to scope the `Stack's` child selectors so they wouldn't be as expensive for performance when recalculating styles. However, it seems that, in the process, we restricted `Stack` to work only with `children` that are React elements. This PR fixes the issue so that `Stack` works with any element (with the same restrictions to using `enableScopedSelectors` still in place).

## Related Issue(s)

Fixes #25653
