### PR TITLE
fix: MenuDivider thickness should be `strokeWidthThin`

### DIFF
--- a/change/@fluentui-react-menu-13a26a1d-d2f6-4a55-9113-a1a7996739d1.json
+++ b/change/@fluentui-react-menu-13a26a1d-d2f6-4a55-9113-a1a7996739d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuDivider thickness should be `strokeWidthThin`",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
+++ b/packages/react-components/react-menu/src/components/MenuDivider/useMenuDividerStyles.ts
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
   root: {
     ...shorthands.margin('4px', '-5px', '4px', '-5px'),
     width: 'auto',
-    ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStroke2),
+    ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke2),
   },
 });
 


### PR DESCRIPTION
Updates the border style of `MenuDivider` to use `strokeWidthThin` design token

* Fixes #25097
