### PR TITLE
fix: Various design fixes to Table components

### DIFF
--- a/change/@fluentui-react-table-4fd95b09-8d7a-4443-ab87-47802ed452f6.json
+++ b/change/@fluentui-react-table-4fd95b09-8d7a-4443-ab87-47802ed452f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Various design fixes to Table components",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableCell/useTableCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCellStyles.ts
@@ -1,5 +1,6 @@
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { TableCellSlots, TableCellState } from './TableCell.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
@@ -31,6 +32,14 @@ const useStyles = makeStyles({
   root: {
     position: 'relative',
     ...shorthands.padding('0px', tokens.spacingHorizontalS),
+
+    ...createCustomFocusIndicatorStyle(
+      {
+        ...shorthands.outline('2px', 'solid', tokens.colorStrokeFocus2),
+        ...shorthands.borderRadius(tokens.borderRadiusMedium),
+      },
+      { selector: 'focus', enableOutline: true },
+    ),
   },
 });
 

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
@@ -2,6 +2,7 @@ import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { TableCellLayoutSlots, TableCellLayoutState } from './TableCellLayout.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { typographyStyles } from '@fluentui/react-theme';
 
 export const tableCellLayoutClassNames: SlotClassNames<TableCellLayoutSlots> = {
   root: 'fui-TableCellLayout',
@@ -33,8 +34,8 @@ const useStyles = makeStyles({
 
   mediaPrimary: {
     '& svg': {
-      width: '28px',
-      height: '28px',
+      width: '24px',
+      height: '24px',
     },
   },
 
@@ -43,8 +44,8 @@ const useStyles = makeStyles({
   },
 
   description: {
-    fontSize: tokens.fontSizeBase300,
     color: tokens.colorNeutralForeground2,
+    ...typographyStyles.caption1,
   },
 });
 

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
@@ -66,7 +66,7 @@ const useStyles = makeStyles({
     ),
     ...createCustomFocusIndicatorStyle(
       {
-        ...shorthands.outline('2px', 'solid'),
+        ...shorthands.outline('2px', 'solid', tokens.colorStrokeFocus2),
         ...shorthands.borderRadius(tokens.borderRadiusMedium),
       },
       { selector: 'focus', enableOutline: true },
@@ -82,7 +82,6 @@ const useStyles = makeStyles({
         opacity: 1,
       },
       [`& .${tableSelectionCellClassNames.root}`]: {
-        backgroundColor: tokens.colorSubtleBackgroundHover,
         opacity: 1,
       },
     },
@@ -94,7 +93,6 @@ const useStyles = makeStyles({
         opacity: 1,
       },
       [`& .${tableSelectionCellClassNames.root}`]: {
-        backgroundColor: tokens.colorSubtleBackgroundHover,
         opacity: 1,
       },
     },
@@ -144,9 +142,7 @@ const useStyles = makeStyles({
     },
     backgroundColor: tokens.colorSubtleBackgroundSelected,
     color: tokens.colorNeutralForeground1Hover,
-    ':hover': {
-      backgroundColor: tokens.colorSubtleBackgroundSelected,
-    },
+
     ':active': {
       backgroundColor: tokens.colorSubtleBackgroundSelected,
     },

--- a/packages/react-components/react-table/src/components/TableSelectionCell/useTableSelectionCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableSelectionCell/useTableSelectionCellStyles.ts
@@ -41,10 +41,6 @@ const useStyles = makeStyles({
     flexGrow: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    '& svg': {
-      width: '16px',
-      height: '16px',
-    },
   },
 
   subtle: {

--- a/packages/react-components/react-table/stories/Table/CellActions.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/CellActions.stories.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 import {
   FolderRegular,
   EditRegular,
+  EditFilled,
   OpenRegular,
   DocumentRegular,
   PeopleRegular,
   DocumentPdfRegular,
   VideoRegular,
   MoreHorizontalRegular,
+  MoreHorizontalFilled,
+  bundleIcon,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar, Button } from '@fluentui/react-components';
 import {
@@ -20,6 +23,9 @@ import {
   TableCellActions,
   TableCellLayout,
 } from '@fluentui/react-components/unstable';
+
+const EditIcon = bundleIcon(EditFilled, EditRegular);
+const MoreHorizontalIcon = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
 
 const items = [
   {
@@ -83,8 +89,8 @@ export const CellActions = () => {
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
               <TableCellActions>
-                <Button icon={<EditRegular />} appearance="subtle" />
-                <Button icon={<MoreHorizontalRegular />} appearance="subtle" />
+                <Button icon={<EditIcon />} appearance="subtle" />
+                <Button icon={<MoreHorizontalIcon />} appearance="subtle" />
               </TableCellActions>
             </TableCell>
             <TableCell>

--- a/packages/react-components/react-table/stories/Table/PrimaryCell.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/PrimaryCell.stories.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 import {
   FolderRegular,
   EditRegular,
+  EditFilled,
   OpenRegular,
   DocumentRegular,
   PeopleRegular,
   DocumentPdfRegular,
   VideoRegular,
   MoreHorizontalRegular,
+  MoreHorizontalFilled,
+  bundleIcon,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar, Button } from '@fluentui/react-components';
 import {
@@ -20,6 +23,9 @@ import {
   TableCellActions,
   TableCellLayout,
 } from '@fluentui/react-components/unstable';
+
+const EditIcon = bundleIcon(EditFilled, EditRegular);
+const MoreHorizontalIcon = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
 
 const items = [
   {
@@ -85,8 +91,8 @@ export const PrimaryCell = () => {
                 {item.file.label}
               </TableCellLayout>
               <TableCellActions>
-                <Button icon={<EditRegular />} appearance="subtle" />
-                <Button icon={<MoreHorizontalRegular />} appearance="subtle" />
+                <Button icon={<EditIcon />} appearance="subtle" />
+                <Button icon={<MoreHorizontalIcon />} appearance="subtle" />
               </TableCellActions>
             </TableCell>
 


### PR DESCRIPTION
Various design fixes to Table primitives

- Cell action buttons should be filled on hover/pressed in examples
- Icons in primary cells should be 24px
- Subtitle text in primary cell should be caption 1
- Checkbox/radio cell should not have gray hover state when row is selected
- Circle inside selected radio should match sizing in Radio component
- Focus state should match createFocusOutlineStyle (black border instead of blue)

* Addresses #25706
