### PR TITLE
fix: Table row height is determined by cells

### DIFF
--- a/change/@fluentui-react-table-6c92019b-b4d2-4482-bf0c-e3564c2de0f0.json
+++ b/change/@fluentui-react-table-6c92019b-b4d2-4482-bf0c-e3564c2de0f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Table row height is determined by cells",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -331,7 +331,7 @@ export type TableCellSlots = {
 };
 
 // @public
-export type TableCellState = ComponentState<TableCellSlots> & Pick<TableContextValue, 'noNativeElements'>;
+export type TableCellState = ComponentState<TableCellSlots> & Pick<TableContextValue, 'noNativeElements' | 'size'>;
 
 // @public (undocumented)
 export const tableClassName = "fui-Table";

--- a/packages/react-components/react-table/src/components/TableCell/TableCell.types.ts
+++ b/packages/react-components/react-table/src/components/TableCell/TableCell.types.ts
@@ -13,4 +13,4 @@ export type TableCellProps = ComponentProps<TableCellSlots> & {};
 /**
  * State used in rendering TableCell
  */
-export type TableCellState = ComponentState<TableCellSlots> & Pick<TableContextValue, 'noNativeElements'>;
+export type TableCellState = ComponentState<TableCellSlots> & Pick<TableContextValue, 'noNativeElements' | 'size'>;

--- a/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
@@ -13,7 +13,7 @@ import { useTableContext } from '../../contexts/tableContext';
  * @param ref - reference to root HTMLElement of TableCell
  */
 export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTMLElement>): TableCellState => {
-  const { noNativeElements } = useTableContext();
+  const { noNativeElements, size } = useTableContext();
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'td';
 
@@ -27,5 +27,6 @@ export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTML
       ...props,
     }),
     noNativeElements,
+    size,
   };
 };

--- a/packages/react-components/react-table/src/components/TableCell/useTableCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCellStyles.ts
@@ -13,6 +13,18 @@ const useTableLayoutStyles = makeStyles({
     display: 'table-cell',
     verticalAlign: 'middle',
   },
+
+  medium: {
+    height: '44px',
+  },
+
+  small: {
+    height: '34px',
+  },
+
+  smaller: {
+    height: '24px',
+  },
 });
 
 const useFlexLayoutStyles = makeStyles({
@@ -21,6 +33,18 @@ const useFlexLayoutStyles = makeStyles({
     minWidth: '0px',
     alignItems: 'center',
     ...shorthands.flex(1, 1, '0px'),
+  },
+
+  medium: {
+    minHeight: '44px',
+  },
+
+  small: {
+    minHeight: '34px',
+  },
+
+  smaller: {
+    minHeight: '24px',
   },
 });
 
@@ -47,6 +71,7 @@ export const useTableCellStyles_unstable = (state: TableCellState): TableCellSta
     tableCellClassNames.root,
     styles.root,
     state.noNativeElements ? layoutStyles.flex.root : layoutStyles.table.root,
+    state.noNativeElements ? layoutStyles.flex[state.size] : layoutStyles.table[state.size],
     state.root.className,
   );
   return state;

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCellStyles.ts
@@ -64,7 +64,7 @@ const useStyles = makeStyles({
     height: '100%',
     alignItems: 'center',
     ...shorthands.gap(tokens.spacingHorizontalS),
-    minHeight: '44px',
+    minHeight: '32px',
     ...shorthands.flex(1, 1, '0px'),
   },
   sortable: {

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
@@ -16,36 +16,12 @@ const useTableLayoutStyles = makeStyles({
   root: {
     display: 'table-row',
   },
-
-  medium: {
-    height: '44px',
-  },
-
-  small: {
-    height: '34px',
-  },
-
-  smaller: {
-    height: '24px',
-  },
 });
 
 const useFlexLayoutStyles = makeStyles({
   root: {
     display: 'flex',
     alignItems: 'center',
-  },
-
-  medium: {
-    minHeight: '44px',
-  },
-
-  small: {
-    minHeight: '34px',
-  },
-
-  smaller: {
-    minHeight: '24px',
   },
 });
 
@@ -172,7 +148,6 @@ export const useTableRowStyles_unstable = (state: TableRowState): TableRowState 
     !isHeaderRow && styles.rootInteractive,
     styles[state.size],
     state.noNativeElements ? layoutStyles.flex.root : layoutStyles.table.root,
-    state.noNativeElements ? layoutStyles.flex[state.size] : layoutStyles.table[state.size],
     styles[state.appearance],
     state.root.className,
   );


### PR DESCRIPTION
Table rows no longer determine the row height. The height styles are set of each table cell. This is actually necessary for flex layout so that the cells aren't smaller than the row.

Also fixes a bug where the header should have height 32px

Before

![msedge_outVyG6LJd](https://user-images.githubusercontent.com/20744592/202729072-bad82521-a423-4b1a-990d-816dfd920d3d.gif)

After

![msedge_yUPccgtioR](https://user-images.githubusercontent.com/20744592/202729162-1c60cdc1-087a-4f14-9de9-eba6e8a2da14.gif)



Addresses #25706
