### PR TITLE
fix(loadWorkspaceAddon): Create dist path recursively

### DIFF
--- a/scripts/storybook/utils.js
+++ b/scripts/storybook/utils.js
@@ -105,7 +105,7 @@ function loadWorkspaceAddon(addonName, options = {}) {
   `;
 
   if (!fs.existsSync(tsConfigDistPath)) {
-    fs.mkdirSync(tsConfigDistPath);
+    fs.mkdirSync(tsConfigDistPath, { recursive: true });
   }
 
   fs.writeFileSync(presetMockedSourcePath, modifiedPresetContent, { encoding: 'utf-8' });


### PR DESCRIPTION
By default [recursive creation](https://nodejs.org/api/fs.html#fsmkdirsyncpath-options) is not enabled. The path being created is `dist/out-tsc`. In nix systems this seems to work even without `recursive`, however if the `dist` folder does not exist on windows this call will fail:

```shell
Error: ENOENT: no such file or directory, mkdir '/home/lingga/fluentui/dist/out-tsc'
    at Object.mkdirSync (node:fs:1349:3)
    at loadWorkspaceAddon (/home/lingga/fluentui/scripts/storybook/utils.js:108:8)
    at Object.<anonymous> (/home/lingga/fluentui/.storybook/main.js:52:5)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/lingga/fluentui/packages/react-components/react-components/.storybook/main.js:1:18)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18) {
  errno: -2,
  syscall: 'mkdir',
  code: 'ENOENT',
  path: '/home/lingga/fluentui/dist/out-tsc'
}
```

