### PR TITLE
[v8] fix: TooltipHost calls onRenderContent without passing props

### DIFF
--- a/change/@fluentui-react-4e35ca8e-0664-4585-9bba-af7c3bd689eb.json
+++ b/change/@fluentui-react-4e35ca8e-0664-4585-9bba-af7c3bd689eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: TooltipHost calls onRenderContent without passing props",
+  "packageName": "@fluentui/react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -80,7 +80,29 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
 
     const { isTooltipVisible } = this.state;
     const tooltipId = id || this._defaultTooltipId;
-    const tooltipContent = tooltipProps?.onRenderContent ? tooltipProps.onRenderContent() : content;
+
+    const tooltipRenderProps = {
+      id: `${tooltipId}--tooltip`,
+      content,
+      targetElement: this._getTargetElement(),
+      directionalHint,
+      directionalHintForRTL,
+      calloutProps: assign({}, calloutProps, {
+        onDismiss: this._hideTooltip,
+        onFocus: this._onTooltipContentFocus,
+        onMouseEnter: this._onTooltipMouseEnter,
+        onMouseLeave: this._onTooltipMouseLeave,
+      }),
+      onMouseEnter: this._onTooltipMouseEnter,
+      onMouseLeave: this._onTooltipMouseLeave,
+      ...getNativeProps(this.props, divProperties, ['id']), // Make sure we use the id above
+      ...tooltipProps,
+    };
+
+    // Get the content of the tooltip for use in the hidden div used for screen readers
+    const tooltipContent = tooltipProps?.onRenderContent
+      ? tooltipProps.onRenderContent(tooltipRenderProps, props => (props?.content ? <>{props.content}</> : null))
+      : content;
     const showTooltip = isTooltipVisible && !!tooltipContent;
     const ariaDescribedBy = setAriaDescribedBy && isTooltipVisible && !!tooltipContent ? tooltipId : undefined;
 
@@ -98,25 +120,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
         aria-describedby={ariaDescribedBy}
       >
         {children}
-        {showTooltip && (
-          <Tooltip
-            id={`${tooltipId}--tooltip`}
-            content={content}
-            targetElement={this._getTargetElement()}
-            directionalHint={directionalHint}
-            directionalHintForRTL={directionalHintForRTL}
-            calloutProps={assign({}, calloutProps, {
-              onDismiss: this._hideTooltip,
-              onFocus: this._onTooltipContentFocus,
-              onMouseEnter: this._onTooltipMouseEnter,
-              onMouseLeave: this._onTooltipMouseLeave,
-            })}
-            onMouseEnter={this._onTooltipMouseEnter}
-            onMouseLeave={this._onTooltipMouseLeave}
-            {...getNativeProps(this.props, divProperties, ['id'])} // Make sure we use the id above
-            {...tooltipProps}
-          />
-        )}
+        {showTooltip && <Tooltip {...tooltipRenderProps} />}
         <div hidden={true} id={tooltipId} style={hiddenContentStyle as React.CSSProperties}>
           {tooltipContent}
         </div>

--- a/packages/react/src/components/Tooltip/TooltipHost.test.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.test.tsx
@@ -119,4 +119,14 @@ describe('TooltipHost', () => {
     const descriptionText = component.find('#tooltipId').at(0).text();
     expect(descriptionText).toEqual('test');
   });
+
+  it('passes props and render function to onRenderContent', () => {
+    const tooltipProps: ITooltipProps = {
+      onRenderContent: (props, render) => render?.({ ...props, content: props?.content + ' suffix' }) || null,
+    };
+
+    const component = mount(<TooltipHost content={'prefix'} id="tooltipId" tooltipProps={tooltipProps} />);
+    const descriptionText = component.find('#tooltipId').at(0).text();
+    expect(descriptionText).toEqual('prefix suffix');
+  });
 });


### PR DESCRIPTION
## Previous Behavior

TooltipHost calls `onRenderContent` to generate the content used for aria-describedby, but does not pass in props or a default render function. 

It appears that this was a longstanding bug, but a recent PR #24037 caused it to be hit in more cases.

## New Behavior

TooltipHost passes props and a default render function when it calls the Tooltip's `onRenderContent` function to generate the description.

## Related Issue(s)

* Fixes #24107
