### PR TITLE
chore: Replace use of fontSize tokens with typographyStyles in input controls

### DIFF
--- a/change/@fluentui-react-combobox-9a7d0c49-3100-4295-a3c5-4a8a3095fc80.json
+++ b/change/@fluentui-react-combobox-9a7d0c49-3100-4295-a3c5-4a8a3095fc80.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "packageName": "@fluentui/react-combobox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-9a7d0c49-3100-4295-a3c5-4a8a3095fc80.json
+++ b/change/@fluentui-react-combobox-9a7d0c49-3100-4295-a3c5-4a8a3095fc80.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "comment": "chore: Replace use of fontSize tokens with typographyStyles",
   "packageName": "@fluentui/react-combobox",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-input-6fe37858-c97b-497a-97e4-5e16767361bf.json
+++ b/change/@fluentui-react-input-6fe37858-c97b-497a-97e4-5e16767361bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "packageName": "@fluentui/react-input",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-6fe37858-c97b-497a-97e4-5e16767361bf.json
+++ b/change/@fluentui-react-input-6fe37858-c97b-497a-97e4-5e16767361bf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "comment": "chore: Replace use of fontSize tokens with typographyStyles",
   "packageName": "@fluentui/react-input",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-select-5be7fa6b-231e-4073-a8ee-b288f6d0e4ef.json
+++ b/change/@fluentui-react-select-5be7fa6b-231e-4073-a8ee-b288f6d0e4ef.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "comment": "chore: Replace use of fontSize tokens with typographyStyles",
   "packageName": "@fluentui/react-select",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-select-5be7fa6b-231e-4073-a8ee-b288f6d0e4ef.json
+++ b/change/@fluentui-react-select-5be7fa6b-231e-4073-a8ee-b288f6d0e4ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "packageName": "@fluentui/react-select",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-b18f2623-cf8d-4372-a75d-ceb940e78e1e.json
+++ b/change/@fluentui-react-textarea-b18f2623-cf8d-4372-a75d-ceb940e78e1e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "comment": "chore: Replace use of fontSize tokens with typographyStyles",
   "packageName": "@fluentui/react-textarea",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-textarea-b18f2623-cf8d-4372-a75d-ceb940e78e1e.json
+++ b/change/@fluentui-react-textarea-b18f2623-cf8d-4372-a75d-ceb940e78e1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Replace fontSizeBase400 styles with body2",
+  "packageName": "@fluentui/react-textarea",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
@@ -1,4 +1,4 @@
-import { tokens } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { iconSizes } from '../../utils/internalTokens';
@@ -169,21 +169,18 @@ const useInputStyles = makeStyles({
 
   // size variants
   small: {
-    fontSize: tokens.fontSizeBase200,
     height: fieldHeights.small,
-    lineHeight: tokens.lineHeightBase200,
+    ...typographyStyles.caption1,
     ...shorthands.padding(0, 0, 0, `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`),
   },
   medium: {
-    fontSize: tokens.fontSizeBase300,
     height: fieldHeights.medium,
-    lineHeight: tokens.lineHeightBase300,
+    ...typographyStyles.body1,
     ...shorthands.padding(0, 0, 0, `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`),
   },
   large: {
-    fontSize: tokens.fontSizeBase400,
     height: fieldHeights.large,
-    lineHeight: tokens.lineHeightBase400,
+    ...typographyStyles.body2,
     ...shorthands.padding(0, 0, 0, `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalSNudge})`),
   },
   disabled: {

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
@@ -1,4 +1,4 @@
-import { tokens } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { iconSizes } from '../../utils/internalTokens';
@@ -100,8 +100,7 @@ const useStyles = makeStyles({
 
   // size variants
   small: {
-    fontSize: tokens.fontSizeBase200,
-    lineHeight: tokens.lineHeightBase200,
+    ...typographyStyles.caption1,
     ...shorthands.padding(
       '3px',
       tokens.spacingHorizontalSNudge,
@@ -110,8 +109,7 @@ const useStyles = makeStyles({
     ),
   },
   medium: {
-    fontSize: tokens.fontSizeBase300,
-    lineHeight: tokens.lineHeightBase300,
+    ...typographyStyles.body1,
     ...shorthands.padding(
       '5px',
       tokens.spacingHorizontalMNudge,
@@ -121,8 +119,7 @@ const useStyles = makeStyles({
   },
   large: {
     columnGap: tokens.spacingHorizontalSNudge,
-    fontSize: tokens.fontSizeBase400,
-    lineHeight: tokens.lineHeightBase400,
+    ...typographyStyles.body2,
     ...shorthands.padding(
       '7px',
       tokens.spacingHorizontalM,

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -10,15 +10,6 @@ export const inputClassNames: SlotClassNames<InputSlots> = {
   contentAfter: 'fui-Input__contentAfter',
 };
 
-// TODO(sharing) use theme values once available
-const contentSizes = {
-  // TODO: This 400 style is not in the typography styles.
-  // May need a design change
-  400: {
-    fontSize: tokens.fontSizeBase400,
-    lineHeight: tokens.lineHeightBase400,
-  },
-};
 // TODO(sharing) should these be shared somewhere?
 const fieldHeights = {
   small: '24px',
@@ -109,7 +100,7 @@ const useRootStyles = makeStyles({
   large: {
     minHeight: fieldHeights.large,
     ...shorthands.padding('0', tokens.spacingHorizontalM),
-    ...contentSizes[400],
+    ...typographyStyles.body2,
     ...shorthands.gap(tokens.spacingHorizontalSNudge),
   },
   outline: {
@@ -208,7 +199,7 @@ const useInputElementStyles = makeStyles({
     ...typographyStyles.body1,
   },
   large: {
-    ...contentSizes[400],
+    ...typographyStyles.body2,
     ...shorthands.padding('0', tokens.spacingHorizontalSNudge),
   },
   disabled: {

--- a/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
+++ b/packages/react-components/react-select/src/components/Select/useSelectStyles.ts
@@ -15,15 +15,6 @@ const iconSizes = {
   large: '24px',
 };
 
-// This 400 style is not in the typography styles.
-// May need a design change
-const contentSizes = {
-  400: {
-    fontSize: tokens.fontSizeBase400,
-    lineHeight: tokens.lineHeightBase400,
-  },
-};
-
 //TODO: Should fieldHeights be a set of global design tokens or constants?
 const fieldHeights = {
   small: '24px',
@@ -166,7 +157,7 @@ const useSelectStyles = makeStyles({
     height: fieldHeights.large,
     paddingLeft: paddingLeft.large,
     paddingRight: paddingRight.large,
-    ...contentSizes[400],
+    ...typographyStyles.body2,
   },
   outline: {
     backgroundColor: tokens.colorNeutralBackground1,

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -209,8 +209,7 @@ const useTextareaStyles = makeStyles({
       tokens.spacingVerticalS,
       `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalXXS})`,
     ),
-    fontSize: tokens.fontSizeBase400,
-    lineHeight: tokens.lineHeightBase400,
+    ...typographyStyles.body2,
   },
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

There was no typography token for `fontSizeBase400` and regular weight, so it was manually specified in several components.

## New Behavior

Replace uses of `fontSizeBase400` with `typographyStyles.body2`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #23617
