### PR TITLE
BREAKING(useTable): `onSelectionChange` returns data object

### DIFF
--- a/change/@fluentui-react-table-32493410-892f-4f58-95e3-f38c054ae05c.json
+++ b/change/@fluentui-react-table-32493410-892f-4f58-95e3-f38c054ae05c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "BREAKING(useTable): `onSelectionChange` returns data object",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -10,6 +10,10 @@ export interface SortState {
   sortDirection: SortDirection;
 }
 
+export interface OnSelectionChangeData {
+  selectedItems: Set<RowId>;
+}
+
 export interface CreateColumnOptions<TItem> extends Partial<ColumnDefinition<TItem>> {
   columnId: ColumnId;
 }
@@ -158,7 +162,7 @@ export interface UseSelectionOptions {
   /**
    * Called when selection changes
    */
-  onSelectionChange?: (e: React.SyntheticEvent, selectedItems: Set<RowId>) => void;
+  onSelectionChange?: (e: React.SyntheticEvent, data: OnSelectionChangeData) => void;
 }
 
 export interface UseTableOptions<TItem> {

--- a/packages/react-components/react-table/src/hooks/useSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.test.ts
@@ -58,7 +58,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.size).toBe(items.length);
         expect(Array.from(result.current.selection.selectedRows)).toEqual(items.map((_, i) => i));
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([0, 1, 2, 3]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, { selectedItems: new Set([0, 1, 2, 3]) });
       });
 
       it('should deselect all rows', () => {
@@ -77,7 +77,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set() });
       });
     });
     describe('clearRows', () => {
@@ -96,7 +96,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set() });
       });
     });
 
@@ -113,7 +113,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, { selectedItems: new Set([1]) });
       });
 
       it('should select multiple rows', () => {
@@ -134,7 +134,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([1, 2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set([1, 2]) });
       });
     });
 
@@ -155,7 +155,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set() });
       });
     });
 
@@ -173,7 +173,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, { selectedItems: new Set([1]) });
       });
 
       it('should deselect selected row', () => {
@@ -193,7 +193,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(result.current.selection.selectedRows.has(1)).toBe(false);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set() });
       });
 
       it('should select another unselected row', () => {
@@ -214,7 +214,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([1, 2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set([1, 2]) });
       });
     });
 
@@ -327,7 +327,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set() });
       });
     });
 
@@ -344,7 +344,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, { selectedItems: new Set([1]) });
       });
 
       it('should select another row', () => {
@@ -364,7 +364,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set([2]) });
       });
     });
 
@@ -385,7 +385,7 @@ describe('useSelectionState', () => {
 
         expect(result.current.selection.selectedRows.size).toBe(0);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set());
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set() });
       });
     });
 
@@ -403,7 +403,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith({}, new Set([1]));
+        expect(onSelectionChange).toHaveBeenCalledWith({}, { selectedItems: new Set([1]) });
       });
 
       it('should deselect selected row', () => {
@@ -423,7 +423,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.size).toBe(1);
         expect(result.current.selection.selectedRows.has(1)).toBe(false);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set([2]) });
       });
 
       it('should select another unselected row', () => {
@@ -444,7 +444,7 @@ describe('useSelectionState', () => {
         expect(result.current.selection.selectedRows.has(1)).toBe(false);
         expect(result.current.selection.selectedRows.has(2)).toBe(true);
         expect(onSelectionChange).toHaveBeenCalledTimes(2);
-        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, new Set([2]));
+        expect(onSelectionChange).toHaveBeenNthCalledWith(2, {}, { selectedItems: new Set([2]) });
       });
     });
 

--- a/packages/react-components/react-table/src/hooks/useSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useSelection.ts
@@ -39,7 +39,7 @@ export function useSelectionState<TItem>(
   const selectionManager = React.useMemo(() => {
     return createSelectionManager(selectionMode, (e, newSelectedItems) => {
       setSelected(() => {
-        onSelectionChange?.(e as React.SyntheticEvent, newSelectedItems);
+        onSelectionChange?.(e as React.SyntheticEvent, { selectedItems: newSelectedItems });
         return newSelectedItems;
       });
     });

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -126,7 +126,7 @@ export const MultipleSelectControlled = () => {
       useSelection({
         selectionMode: 'multiselect',
         selectedItems: selectedRows,
-        onSelectionChange: (e, nextSelelectedRows) => setSelectedRows(nextSelelectedRows),
+        onSelectionChange: (e, data) => setSelectedRows(data.selectedItems),
       }),
     ],
   );

--- a/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
@@ -125,7 +125,7 @@ export const SingleSelectControlled = () => {
       useSelection({
         selectionMode: 'single',
         selectedItems: selectedRows,
-        onSelectionChange: (e, nextSelectedRows) => setSelectedRows(nextSelectedRows),
+        onSelectionChange: (e, data) => setSelectedRows(data.selectedItems),
       }),
     ],
   );


### PR DESCRIPTION
## ⚠️ Breaking change

Modifies `onSelectionChange` to be more consistent with component change callbacks since it will be used in `DataGrid`

## Previous Behavior

```ts
useSelection({
  selectionMode: 'multiselect',
  onSelectionChange: (e, newSelectedItems) =>
    setSelectedRows(newSelectedItems),
}),
```

## New Behavior

```ts
useSelection({
  selectionMode: 'multiselect',
  onSelectionChange: (e, data) => 
    setSelectedRows(data.selectedItems),
}),
```
