### PR TITLE
chore(react-positioning, theme-sass, utilities): migrate to new package structure

### DIFF
--- a/change/@fluentui-react-positioning-a44227d8-ace2-477c-98b6-7b239f164aaa.json
+++ b/change/@fluentui-react-positioning-a44227d8-ace2-477c-98b6-7b239f164aaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-sass-1f5563cb-f045-4787-ace7-3c2f1f6c51cb.json
+++ b/change/@fluentui-react-theme-sass-1f5563cb-f045-4787-ace7-3c2f1f6c51cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-9077d172-d3c7-4615-b176-4696e60a97c4.json
+++ b/change/@fluentui-react-utilities-9077d172-d3c7-4615-b176-4696e60a97c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Migrate to new package structure.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-positioning/.npmignore
+++ b/packages/react-components/react-positioning/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/react-theme-sass/.npmignore
+++ b/packages/react-components/react-theme-sass/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 

--- a/packages/react-components/react-utilities/.npmignore
+++ b/packages/react-components/react-utilities/.npmignore
@@ -3,10 +3,11 @@
 bundle-size/
 config/
 coverage/
-e2e/
+docs/
 etc/
 node_modules/
 src/
+stories/
 dist/types/
 temp/
 __fixtures__
@@ -16,7 +17,7 @@ __tests__
 *.api.json
 *.log
 *.spec.*
-*.stories.*
+*.cy.*
 *.test.*
 *.yml
 


### PR DESCRIPTION
## Changes:
- Runs `migrate-converged-pkg` which reflects updates made in #24458.
	- Moves stories to `stories/` folder in the root of the package.
	- Collocates any e2e tests with the component implementation and jest tests.
	- removes `common/` folder and moves contents to new `testing/` folder 
	- adds `docs/` folder to package root.

## Issue:
- Part of #24129