### PR TITLE
fix(react-overflow): Remove cypress test line causing intermittent CI failures

### DIFF
--- a/change/@fluentui-react-overflow-d916857c-b536-467d-ba22-cdd6246254c2.json
+++ b/change/@fluentui-react-overflow-d916857c-b536-467d-ba22-cdd6246254c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: Remove cypress test line causing intermittent CI failures.",
+  "packageName": "@fluentui/react-overflow",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -405,7 +405,6 @@ describe('Overflow', () => {
     );
 
     setContainerSize(350);
-    cy.get(`[${selectors.divider}="4"]`);
     cy.get(`[${selectors.divider}="4"]`).should('not.exist');
     cy.get(`[${selectors.divider}]`).should('have.length', 3);
     setContainerSize(250);


### PR DESCRIPTION
### Issue:
- We have been getting intermittent CI failures with a specific `Overflow` cypress test (`should notify group visibility changes correctly`).
	- Examples: 
	- https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=274551&view=logs&j=be0e6c0b-16d6-5408-4b39-461952619dc9&t=95e57134-5ddb-52ed-4fd2-92e8f59f6f0f
	- https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=275173&view=logs&j=be0e6c0b-16d6-5408-4b39-461952619dc9&t=95e57134-5ddb-52ed-4fd2-92e8f59f6f0f

## Changes: 
- removes a test with no assertion which seems to be the root cause of the intermittent CI failures. This removed line is trying to select a Divider that is **NOT** supposed to exist (the line after it asserting that it shouldn't exist confirms this) which is why cypress keeps timing out since it's looking for an element that isn't there. 