### PR TITLE
fix(Popover): always invoke onOpenChange regardless of prev state 

### DIFF
--- a/change/@fluentui-react-popover-b28938cd-f8d9-4551-8695-cead5e5bbff3.json
+++ b/change/@fluentui-react-popover-b28938cd-f8d9-4551-8695-cead5e5bbff3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Invoke `onOpenChange` callback without checking if open state has flipped",
+  "comment": "fix: Invoke `onOpenChange` callback without checking if open state has flipped",
   "packageName": "@fluentui/react-popover",
   "email": "yuanboxue@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-popover-b28938cd-f8d9-4551-8695-cead5e5bbff3.json
+++ b/change/@fluentui-react-popover-b28938cd-f8d9-4551-8695-cead5e5bbff3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Invoke `onOpenChange` callback without checking if open state has flipped",
+  "packageName": "@fluentui/react-popover",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -169,15 +169,8 @@ function useOpenState(
         setContextTarget(undefined);
       }
 
-      setOpenState(prevOpen => {
-        // More than one event (mouse, focus, keyboard) can request the Popover to close
-        // We assume the first event is the correct one
-        if (prevOpen !== shouldOpen) {
-          onOpenChange?.(e, { open: shouldOpen });
-        }
-
-        return shouldOpen;
-      });
+      setOpenState(shouldOpen);
+      onOpenChange?.(e, { open: shouldOpen });
     },
     [setOpenState, onOpenChange, setContextTarget],
   );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Popover only invokes `onOpenChange` when the state is flipped (true -> false or vice versa).

It seems to be the correct thing to do, however it breaks in this example: https://codesandbox.io/s/determined-lalande-75x1i7?file=/example.tsx
Popover has controlled `open` state because the example tries to keep it open when pressing ESC key.
But after pressing ESC, Popover cannot be closed by clicking outside of it.

Popover uses `useControllableState`, which is not able to sync the prev state in callback setter with user state (#25748).
When pressing ESC, the user state is `open=true`, but the internal state in `useControllableState` is still `open=false`. Therefore when clicking outside, both the current and next state is `open=false`, and `onOpenChange` is not invoked. 

## New Behavior

Always invoke `onOpenChange`, regardless of the previous state.  
