### PR TITLE
fix(v7 codesandbox): fix broken codesandbox CI 

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "build:min",
   "packages": ["packages/office-ui-fabric-react", "packages/react-icons"],
-  "sandboxes": ["u0e3w", "/apps/codesandbox-react-template", "/apps/codesandbox-react-next-template"]
+  "sandboxes": ["u0e3w", "/apps/codesandbox-react-template", "/apps/codesandbox-react-next-template"],
+  "node": "14"
 }


### PR DESCRIPTION
## Issue:
- Codesandbox CI constantly fails for v7 PRs because #25618 introduced a dependency (`d3-scale@4.0.2`) which explicitly requires the use of a `node` version >= 12. 
### Error: 
```
yarn install v1.22.17

$ node ./scripts/use-yarn-please.js
[1/4] Resolving packages...
[2/4] Fetching packages...
error d3-scale@4.0.2: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.24.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
{ Error: Process rejected with status code 1
    at ChildProcess.<anonymous> (/app/dist/utils/exec.js:20:27)
    at ChildProcess.emit (events.js:198:13)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12) code: 1 }

```
**Codesandbox error**: https://ci.codesandbox.io/status/microsoft/fluentui/pr/25618/builds/314653

## Changes:
- Since the `node` version is not explicitly defined, it defaults to `10.24.1`([source](https://codesandbox.io/docs/learn/sandboxes/ci#configuration-format)). This PR explicitly declares the `node` version for the codesandbox-ci to use `14` to fix the issue above and to also match the version used for v8.

