### PR TITLE
fix(TableCellLayout): Icon sizes in should match design spec

### DIFF
--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -322,7 +322,7 @@ export type TableCellLayoutSlots = {
 // @public
 export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> & Pick<TableCellLayoutProps, 'appearance'> & {
     avatarSize: AvatarSizes | undefined;
-};
+} & Pick<TableContextValue, 'size'>;
 
 // @public
 export type TableCellProps = ComponentProps<TableCellSlots> & {};

--- a/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
@@ -1,5 +1,6 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { AvatarSizes } from '@fluentui/react-avatar';
+import { TableContextValue } from '../Table/Table.types';
 
 export type TableCellLayoutContextValues = {
   avatar: {
@@ -42,4 +43,4 @@ export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>>
  * State used in rendering TableCellLayout
  */
 export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> &
-  Pick<TableCellLayoutProps, 'appearance'> & { avatarSize: AvatarSizes | undefined };
+  Pick<TableCellLayoutProps, 'appearance'> & { avatarSize: AvatarSizes | undefined } & Pick<TableContextValue, 'size'>;

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
@@ -39,5 +39,6 @@ export const useTableCellLayout_unstable = (
     description: resolveShorthand(props.description),
     wrapper: resolveShorthand(props.wrapper, { required: !!props.description || !!props.children }),
     avatarSize: tableAvatarSizeMap[size],
+    size,
   };
 };

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
@@ -32,11 +32,16 @@ const useStyles = makeStyles({
     alignItems: 'center',
   },
 
+  mediaExtraSmall: {
+    fontSize: '16px',
+  },
+
+  mediaSmallAndMedium: {
+    fontSize: '20px',
+  },
+
   mediaPrimary: {
-    '& svg': {
-      width: '24px',
-      height: '24px',
-    },
+    fontSize: '24px',
   },
 
   mainPrimary: {
@@ -58,9 +63,16 @@ export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): 
   const primary = state.appearance === 'primary';
 
   if (state.media) {
+    const mediaSizedStyles = {
+      small: styles.mediaSmallAndMedium,
+      medium: styles.mediaSmallAndMedium,
+      'extra-small': styles.mediaExtraSmall,
+    };
+
     state.media.className = mergeClasses(
       tableCellLayoutClassNames.media,
       styles.media,
+      mediaSizedStyles[state.size],
       primary && styles.mediaPrimary,
       state.media.className,
     );


### PR DESCRIPTION
- `small` and `medium`table will have 20px icons
- `extra-small` table will have 16px icons
- `primary` cell will have 24px icons

Icon styling is now achieved with `fontSize` which avoids nested selectors to improve perf and reduce css rule output.

Fixes #25706
