### PR TITLE
Update EP04 video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following table will help you navigate the 3 projects and understand their d
 
 |                                                                              EP04: Foundational APIs                                                                               |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| <a href="https://youtu.be/uxuIJlYmKGk?utm_source=github" target="_blank"><img src="ghdocs/medias/fluentui-ep04-preview.gif" alt="Watch EP04: Foundational APIs" width="240" /></a> |
+| <a href="https://learn.microsoft.com/en-us/shows/fluent-ui-insights/fluent-ui-insights-apis-in-v9-slots-jsx-children-triggers?utm_source=github" target="_blank"><img src="ghdocs/medias/fluentui-ep04-preview.gif" alt="Watch EP04: Foundational APIs" width="240" /></a> |
 
 ## Licenses
 


### PR DESCRIPTION
It's only a reference URL

## Previous Behavior

EP04: Foundational APIs was sending viewers to **YouTube** to watch the video

## New Behavior

EP04: Foundational APIs is sending viewers to **Learn** to watch the video


