### PR TITLE
remove the unecessary extra specificity and styles in hover and focus styles

### DIFF
--- a/change/@fluentui-react-596053a1-fb7a-4795-9268-88f2dd1fa249.json
+++ b/change/@fluentui-react-596053a1-fb7a-4795-9268-88f2dd1fa249.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove the unecessary extra specificity and styles in hover and focus styles",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/react/src/components/SpinButton/SpinButton.styles.ts
@@ -133,7 +133,6 @@ export const getStyles = (props: ISpinButtonStyleProps): ISpinButtonStyles => {
   const SpinButtonInputTextColorSelected = palette.white;
   const SpinButtonInputBackgroundColorSelected = semanticColors.inputBackgroundChecked;
   const SpinButtonIconDisabledColor = semanticColors.disabledText;
-
   return {
     root: [
       fonts.medium,
@@ -192,49 +191,34 @@ export const getStyles = (props: ISpinButtonStyleProps): ISpinButtonStyles => {
         boxSizing: 'border-box',
         height: DEFAULT_HEIGHT,
         minWidth: DEFAULT_MIN_WIDTH,
-        selectors: {
-          // setting border using pseudo-element here in order to prevent:
-          // input and chevron buttons to overlap border under certain resolutions
-          ':after': {
-            pointerEvents: 'none',
-            content: "''",
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            bottom: 0,
-            right: 0,
-            borderWidth: '1px',
-            borderStyle: 'solid',
-            borderColor: SpinButtonRootBorderColor,
-            borderRadius: effects.roundedCorner2,
+        ...getInputFocusStyle(SpinButtonRootBorderColor, effects.roundedCorner2),
+        ':after': {
+          borderWidth: '1px',
+          [HighContrastSelector]: {
+            borderColor: 'GrayText',
           },
         },
       },
       (labelPosition === Position.top || labelPosition === Position.bottom) && {
         width: '100%',
       },
+
       !disabled && [
         {
-          selectors: {
-            ':hover': {
-              selectors: {
-                ':after': {
-                  borderColor: SpinButtonRootBorderColorHovered,
-                },
-                [HighContrastSelector]: {
-                  selectors: {
-                    ':after': {
-                      borderColor: 'Highlight',
-                    },
-                  },
-                },
-              },
+          ':hover:after': {
+            borderColor: SpinButtonRootBorderColorHovered,
+            [HighContrastSelector]: {
+              borderColor: 'Highlight',
             },
           },
         },
         isFocused && {
-          selectors: {
-            '&&': getInputFocusStyle(SpinButtonRootBorderColorFocused, effects.roundedCorner2),
+          ':hover:after, :after': {
+            borderColor: SpinButtonRootBorderColorFocused,
+            borderWidth: '2px',
+            [HighContrastSelector]: {
+              borderColor: 'Highlight',
+            },
           },
         },
       ],

--- a/packages/react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/react/src/components/SpinButton/SpinButton.styles.ts
@@ -191,7 +191,7 @@ export const getStyles = (props: ISpinButtonStyleProps): ISpinButtonStyles => {
         boxSizing: 'border-box',
         height: DEFAULT_HEIGHT,
         minWidth: DEFAULT_MIN_WIDTH,
-        ...getInputFocusStyle(SpinButtonRootBorderColor, effects.roundedCorner2),
+        ...getInputFocusStyle(SpinButtonRootBorderColor, effects.roundedCorner2, 'border', 0),
         ':after': {
           borderWidth: '1px',
           [HighContrastSelector]: {

--- a/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`SpinButton snapshots renders correctly 1`] = `
     className=
 
         {
+          border-color: #605e5c;
           box-sizing: border-box;
           display: flex;
           height: 32px;
@@ -69,17 +70,19 @@ exports[`SpinButton snapshots renders correctly 1`] = `
           position: relative;
         }
         &:after {
-          border-color: #605e5c;
           border-radius: 2px;
-          border-style: solid;
           border-width: 1px;
-          bottom: 0px;
+          border: 2px solid #605e5c;
+          bottom: -1px;
           content: '';
-          left: 0px;
+          left: -1px;
           pointer-events: none;
           position: absolute;
-          right: 0px;
-          top: 0px;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
+          border-color: GrayText;
         }
         &:hover:after {
           border-color: #323130;
@@ -503,6 +506,7 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
     className=
 
         {
+          border-color: #605e5c;
           box-sizing: border-box;
           display: flex;
           height: 32px;
@@ -510,17 +514,19 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
           position: relative;
         }
         &:after {
-          border-color: #605e5c;
           border-radius: 2px;
-          border-style: solid;
           border-width: 1px;
-          bottom: 0px;
+          border: 2px solid #605e5c;
+          bottom: -1px;
           content: '';
-          left: 0px;
+          left: -1px;
           pointer-events: none;
           position: absolute;
-          right: 0px;
-          top: 0px;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
+          border-color: GrayText;
         }
         &:hover:after {
           border-color: #323130;

--- a/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -73,13 +73,13 @@ exports[`SpinButton snapshots renders correctly 1`] = `
           border-radius: 2px;
           border-width: 1px;
           border: 2px solid #605e5c;
-          bottom: -1px;
+          bottom: 0px;
           content: '';
-          left: -1px;
+          left: 0px;
           pointer-events: none;
           position: absolute;
-          right: -1px;
-          top: -1px;
+          right: 0px;
+          top: 0px;
         }
         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
           border-color: GrayText;
@@ -517,13 +517,13 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
           border-radius: 2px;
           border-width: 1px;
           border: 2px solid #605e5c;
-          bottom: -1px;
+          bottom: 0px;
           content: '';
-          left: -1px;
+          left: 0px;
           pointer-events: none;
           position: absolute;
-          right: -1px;
-          top: -1px;
+          right: 0px;
+          top: 0px;
         }
         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:after {
           border-color: GrayText;


### PR DESCRIPTION
In the past, the only way to change the focus state color was to know that a double class was used, and to know HOW to write styles that duplicated the className

```
isFocused && {
  '&&:after': { borderColor: 'green' }
} 
```


Spin button focus was a bit duplicative and double classes were used for specificity. This change simplifies the styles, reduces the need for additional classes for specificity, and aligns the button with other inputs in high contrast mode.
![hcm](https://user-images.githubusercontent.com/1434956/204649549-e341e105-0dda-42f6-9632-5a609b6a5a3f.gif)
