### PR TITLE
fix: Pressed and Hover states for toolbar buttons

### DIFF
--- a/change/@fluentui-react-toolbar-79a4ea5f-680e-49e7-a6ca-5348689f03d7.json
+++ b/change/@fluentui-react-toolbar-79a4ea5f-680e-49e7-a6ca-5348689f03d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update default button appearance for toolbar",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "chassunc@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-toolbar/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/react-components/react-toolbar/src/components/ToolbarButton/ToolbarButton.tsx
@@ -8,7 +8,7 @@ import { renderButton_unstable, useButtonStyles_unstable, useButton_unstable } f
  * which will respect toolbar props such as `size`
  */
 export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps> = React.forwardRef((props, ref) => {
-  const state = useButton_unstable({ appearance: 'transparent', ...props }, ref);
+  const state = useButton_unstable({ appearance: 'subtle', ...props }, ref);
   useButtonStyles_unstable(state);
   return renderButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react


### PR DESCRIPTION
## Overview

Fixes: #25802 

The correct default appearance from `react-button` to be used for `ToolbarButton` is the subtle one which will respect the `pressed` and `hover` states. 

![0ttn29RF7S](https://user-images.githubusercontent.com/86579954/204651484-3c5d3ced-85e5-4e9b-bc96-6ba1592c0b7d.gif)

