### PR TITLE
fix: Allow data-selection-disabled to be respected by DetailsRow

### DIFF
--- a/change/@fluentui-react-5ad3027a-0dd8-4a63-bb67-aa14172f043f.json
+++ b/change/@fluentui-react-5ad3027a-0dd8-4a63-bb67-aa14172f043f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Allow data-selection-disabled to be respected by DetailsRow.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -327,7 +327,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         className={this._classNames.root}
         data-selection-index={itemIndex}
         data-selection-touch-invoke={true}
-        data-selection-disabled={disabled || undefined}
+        data-selection-disabled={(this.props as any)['data-selection-disabled'] ?? disabled ?? undefined}
         data-item-index={itemIndex}
         aria-rowindex={ariaPositionInSet === undefined ? itemIndex + flatIndexOffset : undefined}
         data-automationid="DetailsRow"
@@ -354,7 +354,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
               className: this._classNames.check,
               theme,
               isVisible: checkboxVisibility === CheckboxVisibility.always,
-              onRenderDetailsCheckbox: onRenderDetailsCheckbox,
+              onRenderDetailsCheckbox,
               useFastIcons,
             })}
           </div>
@@ -432,9 +432,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     const selectionState = getSelectionState(this.props);
 
     if (!shallowCompare(selectionState, this.state.selectionState)) {
-      this.setState({
-        selectionState: selectionState,
-      });
+      this.setState({ selectionState });
     }
   };
 

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -327,7 +327,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         className={this._classNames.root}
         data-selection-index={itemIndex}
         data-selection-touch-invoke={true}
-        data-selection-disabled={(this.props as any)['data-selection-disabled'] ?? disabled ?? undefined}
+        data-selection-disabled={(this.props as any)['data-selection-disabled'] ?? (disabled || undefined)}
         data-item-index={itemIndex}
         aria-rowindex={ariaPositionInSet === undefined ? itemIndex + flatIndexOffset : undefined}
         data-automationid="DetailsRow"


### PR DESCRIPTION
## Previous Behavior

Passing `data-selection-disabled` to `DetailsRow` was being overridden by internal behavior.

## New Behavior

Passing `data-selection-disabled` to `DetailsRow` is now respected instead of being overridden by internal behavior.

## Related Issue(s)

* Fixes #25824
