### PR TITLE
added allowPhoneInitials option in getInitials call for Avatar

### DIFF
--- a/change/@fluentui-react-avatar-4f9a90dd-295b-4417-ab83-f72159b21409.json
+++ b/change/@fluentui-react-avatar-4f9a90dd-295b-4417-ab83-f72159b21409.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added allowPhoneInitials option in getInitials call for Avatar",
+  "packageName": "@fluentui/react-avatar",
+  "email": "kakrookaran@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -48,7 +48,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   let initials: AvatarState['initials'] = resolveShorthand(props.initials, {
     required: true,
     defaultProps: {
-      children: getInitials(name, dir === 'rtl', { firstInitialOnly: size <= 16 }),
+      children: getInitials(name, dir === 'rtl', { allowPhoneInitials: true, firstInitialOnly: size <= 16 }),
       id: baseId + '__initials',
     },
   });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [] Code is up-to-date with the `master` branch
* [] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Avatar doesn't show numbers unless primary field contains at least 1 letter

## New Behavior

Avatar shows numbers even if primary field contains at least 1 letter

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #25704
