### PR TITLE
support cross story linking and create example in Menu story

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -38,6 +38,7 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
+    '@storybook/addon-links',
     '@storybook/addon-knobs/preset',
     'storybook-addon-performance',
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import 'cypress-storybook/react';
 import * as dedent from 'dedent';
 import './docs-root.css';
+import { withLinks } from '@storybook/addon-links';
 
 // This patches globals set up by cypress-storybook to work around its usage of the deprecated
 // forceReRender API that no longer works with storyStoreV7
@@ -22,7 +23,7 @@ window.__setCurrentStory = function (categorization, story) {
 };
 
 /** @type {NonNullable<import('@storybook/react').Story['decorators']>} */
-export const decorators = [];
+export const decorators = [withLinks];
 
 /** @type {import('@storybook/addons').Parameters} */
 export const parameters = {

--- a/change/@fluentui-react-menu-44cbedde-a909-4161-9fc6-2431911a35a0.json
+++ b/change/@fluentui-react-menu-44cbedde-a909-4161-9fc6-2431911a35a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added a link in the docs to the MenuButton",
+  "packageName": "@fluentui/react-menu",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@storybook/addon-docs": "6.5.5",
     "@storybook/addon-essentials": "6.5.5",
     "@storybook/addon-knobs": "6.4.0",
+    "@storybook/addon-links": "6.5.5",
     "@storybook/addons": "6.5.5",
     "@storybook/api": "6.5.5",
     "@storybook/builder-webpack5": "6.5.5",

--- a/packages/react-components/react-menu/stories/Menu/MenuDescription.md
+++ b/packages/react-components/react-menu/stories/Menu/MenuDescription.md
@@ -1,2 +1,4 @@
 A menu displays a list of actions. The Menu component handles the
 state management of the passed in list of actions.
+
+See also <a href="#" data-sb-kind="components-button-menubutton--default">MenuButton</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,6 +3972,24 @@
     react-lifecycles-compat "^3.0.4"
     react-select "^3.2.0"
 
+"@storybook/addon-links@6.5.5":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.5.5.tgz#1f5aeac63f526f7cf802d2921fe3ff7013213a8b"
+  integrity sha512-0UrlCtlhZouM7KREgEnLqvW0jfJfg9rXs9AcVBSrpvh8NL0OM9D9K1zqN+prxKcmTzWAmCU+9QXVZNTnyLrhEQ==
+  dependencies:
+    "@storybook/addons" "6.5.5"
+    "@storybook/client-logger" "6.5.5"
+    "@storybook/core-events" "6.5.5"
+    "@storybook/csf" "0.0.2--canary.4566f4d.1"
+    "@storybook/router" "6.5.5"
+    "@types/qs" "^6.9.5"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    prop-types "^15.7.2"
+    qs "^6.10.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-measure@6.5.5":
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-6.5.5.tgz#19165fc24c3b24a7ec31480a6a1a7fd5d333c774"


### PR DESCRIPTION
since URLs are hosted inside of an iframe, any anchor tag is going to be relative to that iframe...just doesn't work.

with addon-links, and the decorator, we can use link in markdown, or in examples via buttons or anchor tags. 

```
<a href="#" data-sb-kind="components-button-menubutton--default">MenuButton</a>
<button data-sb-kind="components-button-menubutton--default">MenuButton</button>
// note that we use data-sb-kind and not data-sb-story
```
https://storybook.js.org/addons/@storybook/addon-links