### PR TITLE
chore: enable proper type checking within all just.config.ts and its dependents

### DIFF
--- a/apps/perf-test-react-components/src/scenarioIterations.ts
+++ b/apps/perf-test-react-components/src/scenarioIterations.ts
@@ -1,7 +1,5 @@
 // You don't have to add scenarios to this structure unless you want their iterations to differ from the default.
-const scenarioIterations = {
+export const scenarioIterations = {
   MakeStyles: 50000,
   FluentProviderWithTheme: 10,
 };
-
-module.exports = scenarioIterations;

--- a/apps/perf-test-react-components/src/scenarioNames.ts
+++ b/apps/perf-test-react-components/src/scenarioNames.ts
@@ -1,5 +1,3 @@
 // You don't have to add scenarios to this structure unless you want their display name to differ
 // from their scenario name.
-const scenarioNames = {};
-
-module.exports = scenarioNames;
+export const scenarioNames = {};

--- a/apps/perf-test-react-components/src/scenarioRenderTypes.ts
+++ b/apps/perf-test-react-components/src/scenarioRenderTypes.ts
@@ -9,15 +9,8 @@
  */
 
 const AllRenderTypes = ['mount', 'virtual-rerender', 'virtual-rerender-with-unmount'];
-const DefaultRenderTypes = ['mount'];
+export const DefaultRenderTypes = ['mount'];
 
-const scenarioRenderTypes = {
-  ThemeProvider: AllRenderTypes,
-  GroupedList: AllRenderTypes,
-  GroupedListV2: AllRenderTypes,
-};
-
-module.exports = {
-  scenarioRenderTypes,
-  DefaultRenderTypes,
+export const scenarioRenderTypes = {
+  FluentProviderWithTheme: AllRenderTypes,
 };

--- a/apps/perf-test-react-components/tasks/perf-test.ts
+++ b/apps/perf-test-react-components/tasks/perf-test.ts
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import flamegrill, { CookResults, Scenarios, ScenarioConfig, CookResult } from 'flamegrill';
-import scenarioIterations from '../src/scenarioIterations';
+import { scenarioIterations } from '../src/scenarioIterations';
 import { scenarioRenderTypes, DefaultRenderTypes } from '../src/scenarioRenderTypes';
 import { argv } from '@fluentui/scripts';
+
+type ScenarioSetting = Record<string, { scenarioName: string; iterations: number; renderType: string }>;
 
 // TODO: consolidate with newer version of fluent perf-test
 
@@ -145,13 +147,15 @@ export async function getPerfRegressions() {
   const scenarioList = scenariosArg.length > 0 ? scenariosArg : scenariosAvailable;
 
   const scenarios: Scenarios = {};
-  const scenarioSettings = {};
+  const scenarioSettings: ScenarioSetting = {};
   scenarioList.forEach(scenarioName => {
     if (!scenariosAvailable.includes(scenarioName)) {
       throw new Error(`Invalid scenario: ${scenarioName}.`);
     }
-    const iterations = iterationsArg || scenarioIterations[scenarioName] || iterationsDefault;
-    const renderTypes = scenarioRenderTypes[scenarioName] || DefaultRenderTypes;
+    const iterations =
+      iterationsArg || scenarioIterations[scenarioName as keyof typeof scenarioIterations] || iterationsDefault;
+    const renderTypes: string[] =
+      scenarioRenderTypes[scenarioName as keyof typeof scenarioRenderTypes] || DefaultRenderTypes;
 
     renderTypes.forEach(renderType => {
       const scenarioKey = `${scenarioName}-${renderType}`;
@@ -221,7 +225,7 @@ export async function getPerfRegressions() {
 /**
  * Create test summary based on test results.
  */
-function createReport(scenarioSettings, testResults: CookResults) {
+function createReport(scenarioSettings: ScenarioSetting, testResults: CookResults) {
   const report = '## [Perf Analysis (`@fluentui/react-components`)](https://github.com/microsoft/fluentui/wiki/Perf-Testing)\n'
 
     // Show only significant changes by default.
@@ -239,13 +243,13 @@ function createReport(scenarioSettings, testResults: CookResults) {
  * Create a table of scenario results.
  * @param showAll Show only significant results by default.
  */
-function createScenarioTable(scenarioSettings, testResults: CookResults, showAll: boolean) {
+function createScenarioTable(scenarioSettings: ScenarioSetting, testResults: CookResults, showAll: boolean) {
   const resultsToDisplay = Object.keys(testResults).filter(
     key =>
       showAll ||
       (testResults[key].analysis &&
-        testResults[key].analysis.regression &&
-        testResults[key].analysis.regression.isRegression),
+        testResults[key].analysis?.regression &&
+        testResults[key].analysis?.regression?.isRegression),
   );
 
   if (resultsToDisplay.length === 0) {

--- a/apps/perf-test-react-components/tasks/perf-test.ts
+++ b/apps/perf-test-react-components/tasks/perf-test.ts
@@ -245,11 +245,7 @@ function createReport(scenarioSettings: ScenarioSetting, testResults: CookResult
  */
 function createScenarioTable(scenarioSettings: ScenarioSetting, testResults: CookResults, showAll: boolean) {
   const resultsToDisplay = Object.keys(testResults).filter(
-    key =>
-      showAll ||
-      (testResults[key].analysis &&
-        testResults[key].analysis?.regression &&
-        testResults[key].analysis?.regression?.isRegression),
+    key => showAll || testResults[key].analysis?.regression?.isRegression,
   );
 
   if (resultsToDisplay.length === 0) {

--- a/apps/perf-test-react-components/tsconfig.json
+++ b/apps/perf-test-react-components/tsconfig.json
@@ -6,16 +6,10 @@
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
-    "sourceMap": true,
     "experimentalDecorators": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
     "preserveConstEnums": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "lib": ["es2016", "dom"],
-    "types": ["webpack-env"],
-    "skipLibCheck": true
+    "lib": ["ES2015", "DOM"],
+    "types": ["webpack-env"]
   },
   "include": ["src"]
 }

--- a/apps/perf-test/src/scenarioIterations.ts
+++ b/apps/perf-test/src/scenarioIterations.ts
@@ -1,5 +1,5 @@
 // You don't have to add scenarios to this structure unless you want their iterations to differ from the default.
-const scenarioIterations = {
+export const scenarioIterations = {
   DocumentCardTitle: 1000,
   Breadcrumb: 1000,
   CommandBar: 1000,
@@ -17,5 +17,3 @@ const scenarioIterations = {
   GroupedList: 2,
   GroupedListV2: 2,
 };
-
-module.exports = scenarioIterations;

--- a/apps/perf-test/src/scenarioNames.ts
+++ b/apps/perf-test/src/scenarioNames.ts
@@ -1,11 +1,9 @@
 // You don't have to add scenarios to this structure unless you want their display name to differ
 // from their scenario name.
-const scenarioNames = {
+export const scenarioNames = {
   DetailsRowFast: 'DetailsRow (fast icons)',
   DetailsRowNoStyles: 'DetailsRow without styles',
   DocumentCardTitle: 'DocumentCardTitle with truncation',
   StackWithIntrinsicChildren: 'Stack with Intrinsic children',
   StackWithTextChildren: 'Stack with Text children',
 };
-
-module.exports = scenarioNames;

--- a/apps/perf-test/src/scenarioRenderTypes.ts
+++ b/apps/perf-test/src/scenarioRenderTypes.ts
@@ -9,13 +9,10 @@
  */
 
 const AllRenderTypes = ['mount', 'virtual-rerender', 'virtual-rerender-with-unmount'];
-const DefaultRenderTypes = ['mount'];
+export const DefaultRenderTypes = ['mount'];
 
-const scenarioRenderTypes = {
-  FluentProviderWithTheme: AllRenderTypes,
-};
-
-module.exports = {
-  scenarioRenderTypes,
-  DefaultRenderTypes,
+export const scenarioRenderTypes = {
+  ThemeProvider: AllRenderTypes,
+  GroupedList: AllRenderTypes,
+  GroupedListV2: AllRenderTypes,
 };

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -1,10 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import flamegrill, { CookResults, Scenarios, ScenarioConfig, CookResult } from 'flamegrill';
-import scenarioIterations from '../src/scenarioIterations';
+import { scenarioIterations } from '../src/scenarioIterations';
 import { scenarioRenderTypes, DefaultRenderTypes } from '../src/scenarioRenderTypes';
 import { argv } from '@fluentui/scripts';
 
+type ScenarioSetting = Record<string, { scenarioName: string; iterations: number; renderType: string }>;
 // TODO: consolidate with newer version of fluent perf-test
 
 // A high number of iterations are needed to get visualization of lower level calls that are infrequently hit by ticks.
@@ -143,13 +144,15 @@ export async function getPerfRegressions() {
   const scenarioList = scenariosArg.length > 0 ? scenariosArg : scenariosAvailable;
 
   const scenarios: Scenarios = {};
-  const scenarioSettings = {};
+  const scenarioSettings: ScenarioSetting = {};
   scenarioList.forEach(scenarioName => {
     if (!scenariosAvailable.includes(scenarioName)) {
       throw new Error(`Invalid scenario: ${scenarioName}.`);
     }
-    const iterations = iterationsArg || scenarioIterations[scenarioName] || iterationsDefault;
-    const renderTypes = scenarioRenderTypes[scenarioName] || DefaultRenderTypes;
+    const iterations: number =
+      iterationsArg || scenarioIterations[scenarioName as keyof typeof scenarioIterations] || iterationsDefault;
+    const renderTypes: string[] =
+      scenarioRenderTypes[scenarioName as keyof typeof scenarioRenderTypes] || DefaultRenderTypes;
 
     renderTypes.forEach(renderType => {
       const scenarioKey = `${scenarioName}-${renderType}`;
@@ -217,7 +220,7 @@ export async function getPerfRegressions() {
 /**
  * Create test summary based on test results.
  */
-function createReport(scenarioSettings, testResults: CookResults) {
+function createReport(scenarioSettings: ScenarioSetting, testResults: CookResults) {
   const report = '## [Perf Analysis (`@fluentui/react`)](https://github.com/microsoft/fluentui/wiki/Perf-Testing)\n'
 
     // Show only significant changes by default.
@@ -235,13 +238,13 @@ function createReport(scenarioSettings, testResults: CookResults) {
  * Create a table of scenario results.
  * @param showAll Show only significant results by default.
  */
-function createScenarioTable(scenarioSettings, testResults: CookResults, showAll: boolean) {
+function createScenarioTable(scenarioSettings: ScenarioSetting, testResults: CookResults, showAll: boolean) {
   const resultsToDisplay = Object.keys(testResults).filter(
     key =>
       showAll ||
       (testResults[key].analysis &&
-        testResults[key].analysis.regression &&
-        testResults[key].analysis.regression.isRegression),
+        testResults[key].analysis?.regression &&
+        testResults[key].analysis?.regression?.isRegression),
   );
 
   if (resultsToDisplay.length === 0) {

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -240,11 +240,7 @@ function createReport(scenarioSettings: ScenarioSetting, testResults: CookResult
  */
 function createScenarioTable(scenarioSettings: ScenarioSetting, testResults: CookResults, showAll: boolean) {
   const resultsToDisplay = Object.keys(testResults).filter(
-    key =>
-      showAll ||
-      (testResults[key].analysis &&
-        testResults[key].analysis?.regression &&
-        testResults[key].analysis?.regression?.isRegression),
+    key => showAll || testResults[key].analysis?.regression?.isRegression,
   );
 
   if (resultsToDisplay.length === 0) {

--- a/apps/public-docsite-resources/just.config.ts
+++ b/apps/public-docsite-resources/just.config.ts
@@ -6,5 +6,5 @@ preset();
 task('generate-json', () => generatePageJsonFiles(require('./config/api-docs')));
 
 // copied from scripts/just.config.js with addition of generate-json
-task('build', series('clean', 'copy', 'sass', 'generate-json', 'ts')).cached();
+task('build', series('clean', 'copy', 'sass', 'generate-json', 'ts')).cached!();
 task('dev', series('copy', 'sass', 'generate-json', 'webpack-dev-server'));

--- a/apps/public-docsite-v9/just.config.ts
+++ b/apps/public-docsite-v9/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/apps/test-bundles/just.config.ts
+++ b/apps/test-bundles/just.config.ts
@@ -1,4 +1,6 @@
 import { preset, task, resolveCwd } from '@fluentui/scripts';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - parallel-webpack has no types
 import { run } from 'parallel-webpack';
 
 preset();

--- a/apps/ts-minbar-test-react-components/just.config.ts
+++ b/apps/ts-minbar-test-react-components/just.config.ts
@@ -1,4 +1,4 @@
 import { preset, task } from '@fluentui/scripts';
 
 preset();
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/apps/ts-minbar-test-react/just.config.ts
+++ b/apps/ts-minbar-test-react/just.config.ts
@@ -1,4 +1,4 @@
 import { preset, task } from '@fluentui/scripts';
 
 preset();
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/apps/vr-tests/just.config.ts
+++ b/apps/vr-tests/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,8 @@ jobs:
         displayName: NX workspace lint
 
       - script: |
+          # @fluentui/api-docs is used within apps/public-docsite-resources/just.config.ts thus it needs to be build in advance
+          yarn workspace @fluentui/api-docs build
           yarn tsc -p ./tsconfig.json
         displayName: Type-check just.config.ts files
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,10 @@ jobs:
         displayName: NX workspace lint
 
       - script: |
+          yarn tsc -p ./tsconfig.json
+        displayName: Type-check just.config.ts files
+
+      - script: |
           yarn check:installed-dependencies-versions
         displayName: 'check packages: installed dependencies versions'
 

--- a/change/@fluentui-api-docs-92e04fd9-6009-4a8a-b9fc-70465db82c86.json
+++ b/change/@fluentui-api-docs-92e04fd9-6009-4a8a-b9fc-70465db82c86.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/api-docs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-azure-themes-46dc9e54-66bb-49eb-8a35-6fb688ed4883.json
+++ b/change/@fluentui-azure-themes-46dc9e54-66bb-49eb-8a35-6fb688ed4883.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/azure-themes",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-783c87e1-0943-4ca0-abc6-df50fcf142fc.json
+++ b/change/@fluentui-codemods-783c87e1-0943-4ca0-abc6-df50fcf142fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/codemods",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-common-styles-feda0877-487b-470e-8617-90e833a5d5b2.json
+++ b/change/@fluentui-common-styles-feda0877-487b-470e-8617-90e833a5d5b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/common-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-fluent2-theme-7bdd3951-c89e-4c61-9d9b-7865cac27b3f.json
+++ b/change/@fluentui-fluent2-theme-7bdd3951-c89e-4c61-9d9b-7865cac27b3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-7a452355-6ad8-4b97-a872-a1531a9408e1.json
+++ b/change/@fluentui-jest-serializer-merge-styles-7a452355-6ad8-4b97-a872-a1531a9408e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-monaco-editor-307b595f-d6ef-4a44-a259-7d892c25a7a3.json
+++ b/change/@fluentui-monaco-editor-307b595f-d6ef-4a44-a259-7d892c25a7a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-2fd82f7c-be34-4f95-9d67-b4230429502e.json
+++ b/change/@fluentui-react-conformance-2fd82f7c-be34-4f95-9d67-b4230429502e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-griffel-e65abd9a-8cc3-4caa-9818-fa09a2a303cd.json
+++ b/change/@fluentui-react-conformance-griffel-e65abd9a-8cc3-4caa-9818-fa09a2a303cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-b8892d0b-54b4-4c74-8871-18f1a9e76854.json
+++ b/change/@fluentui-react-monaco-editor-b8892d0b-54b4-4c74-8871-18f1a9e76854.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-5d1987a1-5323-4157-b59c-1b0a1412f3f4.json
+++ b/change/@fluentui-test-utilities-5d1987a1-5323-4157-b59c-1b0a1412f3f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: enable strict checking in all just-config files and their dependencies",
+  "packageName": "@fluentui/test-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/a11y-testing/just.config.ts
+++ b/packages/a11y-testing/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/packages/api-docs/just.config.ts
+++ b/packages/api-docs/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/packages/azure-themes/just.config.ts
+++ b/packages/azure-themes/just.config.ts
@@ -1,3 +1,3 @@
-import { preset, just } from '@fluentui/scripts';
+import { preset } from '@fluentui/scripts';
 
 preset();

--- a/packages/codemods/just.config.ts
+++ b/packages/codemods/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/packages/common-styles/just.config.ts
+++ b/packages/common-styles/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task, series } from '@fluentui/scripts';
 
 preset();
 
-task('build', series('clean', 'copy')).cached();
+task('build', series('clean', 'copy')).cached!();

--- a/packages/fluent2-theme/just.config.ts
+++ b/packages/fluent2-theme/just.config.ts
@@ -1,3 +1,3 @@
-import { preset, just } from '@fluentui/scripts';
+import { preset } from '@fluentui/scripts';
 
 preset();

--- a/packages/jest-serializer-merge-styles/just.config.ts
+++ b/packages/jest-serializer-merge-styles/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/packages/monaco-editor/just.config.ts
+++ b/packages/monaco-editor/just.config.ts
@@ -25,6 +25,6 @@ task('ts:postprocess', postprocessTask([...defaultLibPaths, 'esm/**/*.d.ts']));
 task('ts', series(parallel('ts:esm', 'ts:commonjs'), 'ts:postprocess'));
 task('eslint', eslint);
 
-task('build', series('clean', 'copy', 'transform-css', 'ts')).cached();
+task('build', series('clean', 'copy', 'transform-css', 'ts')).cached!();
 
 task('lint', 'eslint');

--- a/packages/monaco-editor/tasks/transformCssTask.ts
+++ b/packages/monaco-editor/tasks/transformCssTask.ts
@@ -1,10 +1,8 @@
-// @ts-check
-const fs = require('fs');
-const glob = require('glob');
+import * as fs from 'fs';
+import glob from 'glob';
+import { splitStyles } from '@microsoft/load-themed-styles';
 
-function createEsm(css) {
-  const { splitStyles } = require('@microsoft/load-themed-styles');
-
+function createEsm(css: string) {
   // Create a source file.
   const source = [
     `/* eslint-disable */`,
@@ -15,10 +13,10 @@ function createEsm(css) {
   return source.join('\n');
 }
 
-exports.transformCssTask = function () {
+export function transformCssTask() {
   const cssFiles = glob.sync('esm/**/*.css');
-  for (let cssFile of cssFiles) {
+  for (const cssFile of cssFiles) {
     fs.writeFileSync(`${cssFile}.js`, createEsm(fs.readFileSync(cssFile, 'utf-8')));
     fs.unlinkSync(cssFile);
   }
-};
+}

--- a/packages/react-components/react-conformance-griffel/just.config.ts
+++ b/packages/react-components/react-conformance-griffel/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/packages/react-conformance/just.config.ts
+++ b/packages/react-conformance/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/packages/react-monaco-editor/just.config.ts
+++ b/packages/react-monaco-editor/just.config.ts
@@ -8,4 +8,4 @@ task('copy-types', copyTypes);
 // These have to be manually re-defined because we need to chain copy-types after copy, and
 // chain() doesn't work if the task chained against is in the middle of the series...
 task('dev', series('clean', 'copy', 'copy-types', 'sass', 'webpack-dev-server'));
-task('build', series('clean', 'copy', 'copy-types', 'ts')).cached();
+task('build', series('clean', 'copy', 'copy-types', 'ts')).cached!();

--- a/packages/react-monaco-editor/scripts/copyTypes.ts
+++ b/packages/react-monaco-editor/scripts/copyTypes.ts
@@ -8,14 +8,14 @@ import * as path from 'path';
 export function copyTypes() {
   const packagesToResolve = ['@fluentui/react', '@fluentui/react-hooks', '@fluentui/example-data'];
   const resolvedPackages = [];
-  const pathsToCopy = [];
+  const pathsToCopy: string[] = [];
 
   while (packagesToResolve.length) {
-    const pkg = packagesToResolve.shift();
+    const pkg = packagesToResolve.shift() as string;
     resolvedPackages.push(pkg);
 
     const packageMatch = pkg.match(/^@fluentui\/([\w-]+)/);
-    const dtsPath = expandSourcePath(`${pkg}/dist/${packageMatch[1]}.d.ts`);
+    const dtsPath = (packageMatch ? expandSourcePath(`${pkg}/dist/${packageMatch[1]}.d.ts`) : '') as string;
 
     if (fs.existsSync(dtsPath)) {
       // copy this .d.ts

--- a/packages/react-monaco-editor/scripts/copyTypes.ts
+++ b/packages/react-monaco-editor/scripts/copyTypes.ts
@@ -7,15 +7,15 @@ import * as path from 'path';
 // so we can more easily load them into the editor later.
 export function copyTypes() {
   const packagesToResolve = ['@fluentui/react', '@fluentui/react-hooks', '@fluentui/example-data'];
-  const resolvedPackages = [];
+  const resolvedPackages: string[] = [];
   const pathsToCopy: string[] = [];
 
-  while (packagesToResolve.length) {
-    const pkg = packagesToResolve.shift() as string;
-    resolvedPackages.push(pkg);
+  let pkg: string | undefined;
+  while ((pkg = packagesToResolve.shift())) {
+    const [, packageNameWithoutScope] = pkg.match(/^@fluentui\/([\w-]+)/) as RegExpMatchArray;
+    const dtsPath = expandSourcePath(`${pkg}/dist/${packageNameWithoutScope}.d.ts`) as string;
 
-    const packageMatch = pkg.match(/^@fluentui\/([\w-]+)/);
-    const dtsPath = (packageMatch ? expandSourcePath(`${pkg}/dist/${packageMatch[1]}.d.ts`) : '') as string;
+    resolvedPackages.push(pkg);
 
     if (fs.existsSync(dtsPath)) {
       // copy this .d.ts

--- a/packages/test-utilities/just.config.ts
+++ b/packages/test-utilities/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts';
 
 preset();
 
-task('build', 'build:node-lib').cached();
+task('build', 'build:node-lib').cached!();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
-  "include": ["./{apps,packages}/*/just.config.ts"]
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./apps/*/just.config.ts", "./packages/**/just.config.ts"],
+  "files": ["./typings/find-free-port/index.d.ts"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

**Pre-requirement:**

- [x] https://github.com/microsoft/fluentui/pull/25851

## Previous Behavior

- `just.config.ts` with all its dep tree is not giving proper DX/is not validated against anything

## New Behavior

- all just configs with its logic is being type-checked on CI and also users get correct DX in their IDEs/editors
- new ci step added to PR pipelines

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes partially https://github.com/microsoft/fluentui/issues/24349
