### PR TITLE
fix: Respecting user-provided ids in ComboBox options

### DIFF
--- a/change/@fluentui-react-a5c36bc6-3f4e-4de1-91a8-8d2407288c7c.json
+++ b/change/@fluentui-react-a5c36bc6-3f4e-4de1-91a8-8d2407288c7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Respecting user-provided ids in ComboBox options.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -165,6 +165,28 @@ describe('ComboBox', () => {
     expect(getByRole('combobox').getAttribute('value')).toEqual('');
   });
 
+  it('Respects a user provided id for an option', () => {
+    const options: IComboBoxOption[] = [
+      { key: 0, text: 'zero' },
+      { key: 1, text: 'one', id: 'one' },
+      { key: 2, text: 'two' },
+    ];
+
+    const { getByRole, getAllByRole } = render(<ComboBox options={options} />);
+    const combobox = getByRole('combobox');
+    // open combobox
+    userEvent.click(combobox);
+
+    const optionArray = getAllByRole('option');
+    expect(optionArray.length).toEqual(3);
+
+    const regex = new RegExp(/ComboBox[0-9]+-list[0-9]+/);
+    expect(regex.test(optionArray[0].getAttribute('id')!)).toEqual(true);
+    expect(regex.test(optionArray[1].getAttribute('id')!)).toEqual(false);
+    expect(optionArray[1].getAttribute('id')).toEqual('one');
+    expect(regex.test(optionArray[2].getAttribute('id')!)).toEqual(true);
+  });
+
   it('Applies correct attributes to the selected option', () => {
     const { getByRole, getAllByRole } = render(<ComboBox options={DEFAULT_OPTIONS} defaultSelectedKey="2" />);
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -486,7 +486,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
               onRenderList,
               onRenderItem,
               onRenderOption,
-              options: currentOptions.map((item, index) => ({ ...item, index: index })),
+              options: currentOptions.map((item, index) => ({ ...item, index })),
               onDismiss: this._onDismiss,
             },
             this._onRenderContainer,
@@ -1493,7 +1493,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const getOptionComponent = () => {
       return !this.props.multiSelect ? (
         <CommandButton
-          id={id + '-list' + item.index}
+          id={item.id ?? id + '-list' + item.index}
           key={item.key}
           data-index={item.index}
           styles={optionStyles}
@@ -1520,7 +1520,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         </CommandButton>
       ) : (
         <Checkbox
-          id={id + '-list' + item.index}
+          id={item.id ?? id + '-list' + item.index}
           ariaLabel={item.ariaLabel}
           key={item.key}
           styles={optionStyles}
@@ -1848,7 +1848,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     this.props.hoisted.setSuggestedDisplayValue(suggestedDisplayValue);
     this.setState({
       currentPendingValue: normalizeToString(currentPendingValue),
-      currentPendingValueValidIndex: currentPendingValueValidIndex,
+      currentPendingValueValidIndex,
       currentPendingValueValidIndexOnHover: HoverStatus.default,
     });
   }
@@ -1951,9 +1951,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    */
   private _setOpenStateAndFocusOnClose(isOpen: boolean, focusInputAfterClose: boolean): void {
     this._focusInputAfterClose = focusInputAfterClose;
-    this.setState({
-      isOpen: isOpen,
-    });
+    this.setState({ isOpen });
   }
 
   /**
@@ -2359,11 +2357,15 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * null otherwise
    */
   private _getAriaActiveDescendantValue(): string | undefined {
-    const { selectedIndices } = this.props.hoisted;
+    const { currentOptions, selectedIndices } = this.props.hoisted;
     const { isOpen, currentPendingValueValidIndex } = this.state;
-    let descendantText = isOpen && selectedIndices?.length ? this._id + '-list' + selectedIndices[0] : undefined;
+    const options = currentOptions.map((item, index) => ({ ...item, index }));
+    let descendantText =
+      isOpen && selectedIndices?.length
+        ? options[selectedIndices[0]].id ?? this._id + '-list' + selectedIndices[0]
+        : undefined;
     if (isOpen && this._hasFocus() && currentPendingValueValidIndex !== -1) {
-      descendantText = this._id + '-list' + currentPendingValueValidIndex;
+      descendantText = options[currentPendingValueValidIndex].id ?? this._id + '-list' + currentPendingValueValidIndex;
     }
     return descendantText;
   }


### PR DESCRIPTION
## Previous Behavior

Passing `id` as part of a `ComboBoxOption` would not be respected, and it would instead be overridden by the automatically generated one.

## New Behavior

Passing `id` as part of a `ComboBoxOption` is now respected over the automatically generated one. We made sure to propagate the correct value to `aria-activedescendant` when this happens. A test has been added to ensure this behavior is not broken in the future.

## Related Issue(s)

* Fixes #25857
