### PR TITLE
fix: Fixing Slider's programmatic focus

### DIFF
--- a/change/@fluentui-react-45e501d9-d10e-4a7f-af84-bcdb47113bb9.json
+++ b/change/@fluentui-react-45e501d9-d10e-4a7f-af84-bcdb47113bb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing Slider's programmatic focus.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -54,7 +54,7 @@ const getPercent = (value: number, sliderMin: number, sliderMax: number) => {
 
 const useComponentRef = (
   props: ISliderProps,
-  sliderBoxRef: React.RefObject<HTMLElement>,
+  sliderBoxRef: React.RefObject<HTMLDivElement>,
   value: number | undefined,
   range: [number, number] | undefined,
 ) => {
@@ -341,7 +341,7 @@ export const useSlider = (props: ISliderProps, ref: React.ForwardedRef<HTMLDivEl
 
   const lowerValueThumbRef = React.useRef<HTMLElement>(null);
   const thumbRef = React.useRef<HTMLElement>(null);
-  const sliderBoxRef = React.useRef<HTMLElement>(null);
+  const sliderBoxRef = React.useRef<HTMLDivElement>(null);
   useComponentRef(props, sliderBoxRef, value, ranged ? [lowerValue, value] : undefined);
   const getPositionStyles = getSlotStyleFn(vertical ? 'bottom' : getRTL(props.theme) ? 'right' : 'left');
   const getTrackStyles = getSlotStyleFn(vertical ? 'height' : 'width');
@@ -412,7 +412,7 @@ export const useSlider = (props: ISliderProps, ref: React.ForwardedRef<HTMLDivEl
     ...({ 'data-is-focusable': !disabled } as any),
   };
 
-  const sliderBoxProps: React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement> = {
+  const sliderBoxProps: React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLDivElement> = {
     id,
     className: css(classNames.slideBox, buttonProps.className),
     ref: sliderBoxRef,

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -68,7 +68,6 @@ const useComponentRef = (
         return range;
       },
       focus() {
-        console.log(sliderBoxRef.current);
         sliderBoxRef.current?.focus();
       },
     }),

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -412,7 +412,7 @@ export const useSlider = (props: ISliderProps, ref: React.ForwardedRef<HTMLDivEl
     ...({ 'data-is-focusable': !disabled } as any),
   };
 
-  const sliderBoxProps: React.HTMLAttributes<HTMLElement> = {
+  const sliderBoxProps: React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement> = {
     id,
     className: css(classNames.slideBox, buttonProps.className),
     ref: sliderBoxRef,

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -54,7 +54,7 @@ const getPercent = (value: number, sliderMin: number, sliderMax: number) => {
 
 const useComponentRef = (
   props: ISliderProps,
-  thumb: React.RefObject<HTMLSpanElement>,
+  sliderBoxRef: React.RefObject<HTMLElement>,
   value: number | undefined,
   range: [number, number] | undefined,
 ) => {
@@ -68,16 +68,15 @@ const useComponentRef = (
         return range;
       },
       focus() {
-        if (thumb.current) {
-          thumb.current.focus();
-        }
+        console.log(sliderBoxRef.current);
+        sliderBoxRef.current?.focus();
       },
     }),
-    [thumb, value, range],
+    [range, sliderBoxRef, value],
   );
 };
 
-export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) => {
+export const useSlider = (props: ISliderProps, ref: React.ForwardedRef<HTMLDivElement>) => {
   const {
     step = 1,
     className,
@@ -343,12 +342,8 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
 
   const lowerValueThumbRef = React.useRef<HTMLElement>(null);
   const thumbRef = React.useRef<HTMLElement>(null);
-  useComponentRef(
-    props,
-    ranged && !vertical ? lowerValueThumbRef : thumbRef,
-    value,
-    ranged ? [lowerValue, value] : undefined,
-  );
+  const sliderBoxRef = React.useRef<HTMLElement>(null);
+  useComponentRef(props, sliderBoxRef, value, ranged ? [lowerValue, value] : undefined);
   const getPositionStyles = getSlotStyleFn(vertical ? 'bottom' : getRTL(props.theme) ? 'right' : 'left');
   const getTrackStyles = getSlotStyleFn(vertical ? 'height' : 'width');
   const originValue = originFromZero ? 0 : min;
@@ -361,7 +356,7 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
 
   const rootProps: React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement> = {
     className: classNames.root,
-    ref: ref,
+    ref,
   };
 
   const labelProps: ILabelProps = {
@@ -421,10 +416,11 @@ export const useSlider = (props: ISliderProps, ref: React.Ref<HTMLDivElement>) =
   const sliderBoxProps: React.HTMLAttributes<HTMLElement> = {
     id,
     className: css(classNames.slideBox, buttonProps.className),
+    ref: sliderBoxRef,
     ...(!disabled && {
       onMouseDown: onMouseDownOrTouchStart,
       onTouchStart: onMouseDownOrTouchStart,
-      onKeyDown: onKeyDown,
+      onKeyDown,
     }),
     ...(buttonProps &&
       getNativeProps<React.HTMLAttributes<HTMLDivElement>>(buttonProps, divProperties, ['id', 'className'])),


### PR DESCRIPTION
## Previous Behavior

Using programmatic `focus` based on the `componentRef` of a `Slider` would not work correctly, trying and failing to focus on the non-interactive thumb.

![Before](https://user-images.githubusercontent.com/7798177/205178157-809d07e7-bd3a-448d-8103-7181b3a0549b.gif)

## New Behavior

Using programmatic `focus` based on the `componentRef` of a `Slider` now works correctly, focusing on the interactive slider-box as expected.

![After](https://user-images.githubusercontent.com/7798177/205178765-b8b66725-4a55-4790-b427-d3044a7c9209.gif)

## Related Issue(s)

* Fixes #23627
