### PR TITLE
fix(react-persona): Make Persona's text wrap when overflowing its container

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Persona.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Persona.stories.tsx
@@ -98,4 +98,15 @@ storiesOf('Persona Converged', module)
         />
       ))}
     </div>
+  ))
+  .addStory('textWrap', () => (
+    <div className="testWrapper" style={{ padding: '10px', width: '200px' }}>
+      <Persona
+        presence={{ status: 'available' }}
+        name="Do in incididunt ea minim laboris et est do consequat."
+        secondaryText="Ea cupidatat esse ullamco velit officia sint ea sit duis id ea id eu."
+        tertiaryText="Eiusmod mollit labore cupidatat enim amet dolor dolor."
+        quaternaryText="Commodo est aute sunt eiusmod sint elit irure incididunt reprehenderit culpa."
+      />
+    </div>
   ));

--- a/change/@fluentui-react-persona-d51509e5-3996-4e3e-b326-3e4135b5b8e6.json
+++ b/change/@fluentui-react-persona-d51509e5-3996-4e3e-b326-3e4135b5b8e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Make Persona's text wrap when overflowing its container.",
+  "packageName": "@fluentui/react-persona",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
+++ b/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
@@ -21,7 +21,6 @@ const avatarSpacing = `--fui-Persona__avatar--spacing`;
 const useStyles = makeStyles({
   base: {
     display: 'inline-grid',
-    gridAutoColumns: 'max-content',
     gridAutoRows: 'max-content',
   },
   after: {
@@ -48,7 +47,7 @@ const useStyles = makeStyles({
 
   // These alignToPrimary styles are needed due to presence being too small to center with the primary text.
   alignToPrimary: {
-    gridTemplateColumns: `max-content [middle] max-content`,
+    gridTemplateColumns: `auto [middle] auto`,
   },
   afterAlignToPrimary: {
     alignSelf: 'center',

--- a/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
+++ b/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
@@ -23,13 +23,16 @@ const useStyles = makeStyles({
     display: 'inline-grid',
     gridAutoRows: 'max-content',
   },
+
   after: {
     gridAutoFlow: 'column',
     justifyItems: 'start',
+    gridTemplateColumns: 'max-content [middle] auto',
   },
   before: {
     gridAutoFlow: 'column',
     justifyItems: 'end',
+    gridTemplateColumns: 'auto [middle] max-content',
   },
   below: {
     justifyItems: 'center',
@@ -45,10 +48,6 @@ const useStyles = makeStyles({
     alignSelf: 'center',
   },
 
-  // These alignToPrimary styles are needed due to presence being too small to center with the primary text.
-  alignToPrimary: {
-    gridTemplateColumns: `auto [middle] auto`,
-  },
   afterAlignToPrimary: {
     alignSelf: 'center',
     gridRowStart: 'unset',
@@ -101,21 +100,16 @@ const usePresenceSpacingStyles = makeStyles({
  * Apply styling to the Persona slots based on the state
  */
 export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => {
-  const { size, textAlignment, textPosition } = state;
-  const alignToPrimary = textAlignment === 'start' && size !== 'extra-large' && size !== 'huge';
+  const { presenceOnly, size, textAlignment, textPosition } = state;
+
+  const alignToPrimary = presenceOnly && textAlignment === 'start' && size !== 'extra-large' && size !== 'huge';
   const { primaryTextClassName, optionalTextClassName } = useTextClassNames(state, alignToPrimary);
 
   const styles = useStyles();
   const avatarSpacingStyles = useAvatarSpacingStyles();
   const presenceSpacingStyles = { ...avatarSpacingStyles, ...usePresenceSpacingStyles() };
 
-  state.root.className = mergeClasses(
-    personaClassNames.root,
-    styles.base,
-    styles[textPosition],
-    textPosition !== 'below' && alignToPrimary && styles.alignToPrimary,
-    state.root.className,
-  );
+  state.root.className = mergeClasses(personaClassNames.root, styles.base, styles[textPosition], state.root.className);
 
   if (state.avatar) {
     state.avatar.className = mergeClasses(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Persona's text did not wrap when overflowing its container due to using `gridAutoColumns: max-content`.

## New Behavior

Persona's text now wraps when overflowing its container.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Related #25698 
* Fixes #25698
