### PR TITLE
simplify component main.js by using root main.js as an addon

### DIFF
--- a/change/@fluentui-react-accordion-304a3d66-9235-4a50-879a-6b082eb8a4d5.json
+++ b/change/@fluentui-react-accordion-304a3d66-9235-4a50-879a-6b082eb8a4d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-accordion",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-alert-8e592d90-ce04-4d7a-837c-71a609cc36f7.json
+++ b/change/@fluentui-react-alert-8e592d90-ce04-4d7a-837c-71a609cc36f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-alert",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-53d763c3-bee9-4728-83bc-24273d3ee208.json
+++ b/change/@fluentui-react-aria-53d763c3-bee9-4728-83bc-24273d3ee208.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-aria",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-9344c38e-126e-4411-8e1f-d1e066ce3908.json
+++ b/change/@fluentui-react-avatar-9344c38e-126e-4411-8e1f-d1e066ce3908.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-avatar",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-c1ba9c9f-e204-4e31-9482-feaa5b6d0531.json
+++ b/change/@fluentui-react-badge-c1ba9c9f-e204-4e31-9482-feaa5b6d0531.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-badge",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-0bc9bc14-233f-4e43-ad39-00dfa94705ca.json
+++ b/change/@fluentui-react-button-0bc9bc14-233f-4e43-ad39-00dfa94705ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-button",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-06d4e295-2c69-4736-aedc-fc534ed91cdb.json
+++ b/change/@fluentui-react-card-06d4e295-2c69-4736-aedc-fc534ed91cdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-card",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-18f22809-b33a-4c40-a19d-84130a471e56.json
+++ b/change/@fluentui-react-checkbox-18f22809-b33a-4c40-a19d-84130a471e56.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-dialog-dc602396-e654-4f61-bb88-4617999bc415.json
+++ b/change/@fluentui-react-dialog-dc602396-e654-4f61-bb88-4617999bc415.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-dialog",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-2fd22709-d21c-4ada-bd27-6b37ba576d89.json
+++ b/change/@fluentui-react-divider-2fd22709-d21c-4ada-bd27-6b37ba576d89.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-divider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-field-2056a3e1-88ab-4e5e-be62-315190344836.json
+++ b/change/@fluentui-react-field-2056a3e1-88ab-4e5e-be62-315190344836.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-field",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-299cc317-d718-458c-b013-de4d588fe856.json
+++ b/change/@fluentui-react-image-299cc317-d718-458c-b013-de4d588fe856.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-image",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-f5c92a85-66eb-4187-a348-9e4bdd2597c0.json
+++ b/change/@fluentui-react-input-f5c92a85-66eb-4187-a348-9e4bdd2597c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-input",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-42667945-daae-421f-9be1-1128a10c00ab.json
+++ b/change/@fluentui-react-label-42667945-daae-421f-9be1-1128a10c00ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-label",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-d40b2d55-4fe3-4f80-9edd-516b162e4b6a.json
+++ b/change/@fluentui-react-link-d40b2d55-4fe3-4f80-9edd-516b162e4b6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-link",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-2935496e-aebb-4f72-83fb-ceef97786697.json
+++ b/change/@fluentui-react-menu-2935496e-aebb-4f72-83fb-ceef97786697.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-menu",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-8628899d-2718-410b-b5bb-0857057bfd21.json
+++ b/change/@fluentui-react-overflow-8628899d-2718-410b-b5bb-0857057bfd21.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-overflow",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-persona-e6d5573b-1f0e-456e-bab0-a70d51687466.json
+++ b/change/@fluentui-react-persona-e6d5573b-1f0e-456e-bab0-a70d51687466.json
@@ -1,0 +1,10 @@
+{
+  "type": "none",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@fluentui/react-persona",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-34fbced6-c00d-4026-adc4-48c96cf91eb9.json
+++ b/change/@fluentui-react-popover-34fbced6-c00d-4026-adc4-48c96cf91eb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-popover",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-9268f708-bb77-4aa6-af8f-9baa8c2cbb2d.json
+++ b/change/@fluentui-react-portal-9268f708-bb77-4aa6-af8f-9baa8c2cbb2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-portal",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-progress-f0ca885c-2816-4682-b524-c167009c381b.json
+++ b/change/@fluentui-react-progress-f0ca885c-2816-4682-b524-c167009c381b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-progress",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-dc4d17f5-1320-432d-a037-76500c414bd9.json
+++ b/change/@fluentui-react-provider-dc4d17f5-1320-432d-a037-76500c414bd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-provider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-e1eb9966-7802-4589-86a0-d81ede127a63.json
+++ b/change/@fluentui-react-radio-e1eb9966-7802-4589-86a0-d81ede127a63.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-radio",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-select-15685396-9ba9-4c2d-a836-9648ba86cbc5.json
+++ b/change/@fluentui-react-select-15685396-9ba9-4c2d-a836-9648ba86cbc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-select",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-ed758af5-c200-4807-85d0-8ce3ff2517b4.json
+++ b/change/@fluentui-react-slider-ed758af5-c200-4807-85d0-8ce3ff2517b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-slider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinbutton-c91e3776-48f8-46a6-994e-6237f6e876e0.json
+++ b/change/@fluentui-react-spinbutton-c91e3776-48f8-46a6-994e-6237f6e876e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinner-fe9a4ce5-e171-4b13-b9a3-35046bb35e61.json
+++ b/change/@fluentui-react-spinner-fe9a4ce5-e171-4b13-b9a3-35046bb35e61.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-spinner",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-5811e74f-d556-4c64-9bbe-52ccd68192b4.json
+++ b/change/@fluentui-react-switch-5811e74f-d556-4c64-9bbe-52ccd68192b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-switch",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-table-52ab49bb-2f7b-4536-aa5b-fa01f81a095f.json
+++ b/change/@fluentui-react-table-52ab49bb-2f7b-4536-aa5b-fa01f81a095f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-table",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-3f55b2e4-7e7b-4b94-ae1c-a8591c96d4d7.json
+++ b/change/@fluentui-react-tabs-3f55b2e4-7e7b-4b94-ae1c-a8591c96d4d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-tabs",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-9d297d25-1bd6-4099-ae84-7fd8e2648e09.json
+++ b/change/@fluentui-react-text-9d297d25-1bd6-4099-ae84-7fd8e2648e09.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-text",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-textarea-8333317c-cd0f-4b3f-b0ab-b26ec10c48a2.json
+++ b/change/@fluentui-react-textarea-8333317c-cd0f-4b3f-b0ab-b26ec10c48a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-textarea",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-855e67f8-9702-49a8-9c38-c4d822077a02.json
+++ b/change/@fluentui-react-theme-855e67f8-9702-49a8-9c38-c4d822077a02.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-theme",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-6b9c4a8c-b391-43f5-b641-fbec892406fe.json
+++ b/change/@fluentui-react-tooltip-6b9c4a8c-b391-43f5-b641-fbec892406fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "simplify component main.js by using root main.js as an addon",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-accordion/.storybook/main.js
+++ b/packages/react-components/react-accordion/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-alert/.storybook/main.js
+++ b/packages/react-components/react-alert/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-aria/.storybook/main.js
+++ b/packages/react-components/react-aria/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-avatar/.storybook/main.js
+++ b/packages/react-components/react-avatar/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-badge/.storybook/main.js
+++ b/packages/react-components/react-badge/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-button/.storybook/main.js
+++ b/packages/react-components/react-button/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-card/.storybook/main.js
+++ b/packages/react-components/react-card/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-checkbox/.storybook/main.js
+++ b/packages/react-components/react-checkbox/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-dialog/.storybook/main.js
+++ b/packages/react-components/react-dialog/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-divider/.storybook/main.js
+++ b/packages/react-components/react-divider/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-field/.storybook/main.js
+++ b/packages/react-components/react-field/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-image/.storybook/main.js
+++ b/packages/react-components/react-image/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-input/.storybook/main.js
+++ b/packages/react-components/react-input/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-label/.storybook/main.js
+++ b/packages/react-components/react-label/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-link/.storybook/main.js
+++ b/packages/react-components/react-link/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-menu/.storybook/main.js
+++ b/packages/react-components/react-menu/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-overflow/.storybook/main.js
+++ b/packages/react-components/react-overflow/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-persona/.storybook/main.js
+++ b/packages/react-components/react-persona/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-popover/.storybook/main.js
+++ b/packages/react-components/react-popover/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-portal/.storybook/main.js
+++ b/packages/react-components/react-portal/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-progress/.storybook/main.js
+++ b/packages/react-components/react-progress/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-provider/.storybook/main.js
+++ b/packages/react-components/react-provider/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-radio/.storybook/main.js
+++ b/packages/react-components/react-radio/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-select/.storybook/main.js
+++ b/packages/react-components/react-select/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-slider/.storybook/main.js
+++ b/packages/react-components/react-slider/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-spinbutton/.storybook/main.js
+++ b/packages/react-components/react-spinbutton/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-spinner/.storybook/main.js
+++ b/packages/react-components/react-spinner/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-storybook-addon/.storybook/main.js
+++ b/packages/react-components/react-storybook-addon/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-switch/.storybook/main.js
+++ b/packages/react-components/react-switch/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-table/.storybook/main.js
+++ b/packages/react-components/react-table/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-tabs/.storybook/main.js
+++ b/packages/react-components/react-tabs/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-text/.storybook/main.js
+++ b/packages/react-components/react-text/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-textarea/.storybook/main.js
+++ b/packages/react-components/react-textarea/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-theme/.storybook/main.js
+++ b/packages/react-components/react-theme/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-tooltip/.storybook/main.js
+++ b/packages/react-components/react-tooltip/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};

--- a/packages/react-components/react-tree/.storybook/main.js
+++ b/packages/react-components/react-tree/.storybook/main.js
@@ -1,14 +1,4 @@
-const rootMain = require('../../../../.storybook/main');
-
-module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
-  ...rootMain,
-  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
-  addons: [...rootMain.addons],
-  webpackFinal: (config, options) => {
-    const localConfig = { ...rootMain.webpackFinal(config, options) };
-
-    // add your own webpack tweaks if needed
-
-    return localConfig;
-  },
-});
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: ['../../../../.storybook/main'],
+};


### PR DESCRIPTION
Storybook already merges in the main.js data of an addon, so we don't need to spread each part in if we use it as a addon. This also future proofs components in case we add another top-level item to main.js that isn't properly spread.

I only replaced the obvious ones (with main.js identical to each other). We can clean up the others over time.