### PR TITLE
fix: Make Buttons align correctly when put inside of DialogFooter

### DIFF
--- a/change/@fluentui-react-4962bfe2-335e-4e07-8fc7-036ba5850f69.json
+++ b/change/@fluentui-react-4962bfe2-335e-4e07-8fc7-036ba5850f69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make Buttons align correctly when put inside of DialogFooter.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dialog/DialogFooter.styles.ts
+++ b/packages/react/src/components/Dialog/DialogFooter.styles.ts
@@ -42,9 +42,10 @@ export const getStyles = (props: IDialogFooterStyleProps): IDialogFooterStyles =
     actionsRight: [
       classNames.actionsRight,
       {
-        textAlign: 'right',
-        marginRight: '-4px',
+        display: 'flex',
         fontSize: '0',
+        justifyContent: 'flex-end',
+        marginRight: '-4px',
       },
     ],
   };

--- a/packages/react/src/components/Dialog/DialogFooter.styles.ts
+++ b/packages/react/src/components/Dialog/DialogFooter.styles.ts
@@ -26,6 +26,7 @@ export const getStyles = (props: IDialogFooterStyleProps): IDialogFooterStyles =
         selectors: {
           '.ms-Button': {
             lineHeight: 'normal',
+            verticalAlign: 'middle',
           },
         },
       },
@@ -42,6 +43,7 @@ export const getStyles = (props: IDialogFooterStyleProps): IDialogFooterStyles =
     actionsRight: [
       classNames.actionsRight,
       {
+        alignItems: 'center',
         display: 'flex',
         fontSize: '0',
         justifyContent: 'flex-end',


### PR DESCRIPTION
## Previous Behavior

When having a button with an icon and a button without one in `DialogFooter`, the buttons would be misaligned.

![image](https://user-images.githubusercontent.com/7798177/205415446-92069d33-f4d5-4de2-9b77-ec98bece01ea.png)

## New Behavior

When having a button with an icon and a button without one in `DialogFooter`, the buttons are no longer misaligned.

![image](https://user-images.githubusercontent.com/7798177/205415466-4d705a17-722f-4bb5-8bf9-e4bc7ef50252.png)

## Related Issue(s)

* Fixes #25873
