### PR TITLE
feat: DataGrid supports custom row Ids

### DIFF
--- a/change/@fluentui-react-table-ce22b634-8d6d-4bbd-b632-7749310f0bf6.json
+++ b/change/@fluentui-react-table-ce22b634-8d6d-4bbd-b632-7749310f0bf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: DataGrid supports custom row Ids",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -133,7 +133,7 @@ export type DataGridHeaderSlots = TableHeaderSlots;
 export type DataGridHeaderState = TableHeaderState;
 
 // @public
-export type DataGridProps = TableProps & Pick<DataGridContextValue, 'items' | 'columns'> & Pick<Partial<DataGridContextValue>, 'focusMode' | 'subtleSelection' | 'selectionAppearance'> & Pick<UseTableSortOptions, 'sortState' | 'defaultSortState'> & Pick<UseTableSelectionOptions, 'defaultSelectedItems' | 'selectedItems'> & {
+export type DataGridProps = TableProps & Pick<DataGridContextValue, 'items' | 'columns' | 'getRowId'> & Pick<Partial<DataGridContextValue>, 'focusMode' | 'subtleSelection' | 'selectionAppearance'> & Pick<UseTableSortOptions, 'sortState' | 'defaultSortState'> & Pick<UseTableSelectionOptions, 'defaultSelectedItems' | 'selectedItems'> & {
     onSortChange?: (e: React_2.MouseEvent, sortState: SortState) => void;
     onSelectionChange?: (e: React_2.MouseEvent | React_2.KeyboardEvent, data: OnSelectionChangeData) => void;
     selectionMode?: SelectionMode_2;
@@ -179,7 +179,7 @@ export type DataGridSlots = TableSlots;
 // @public
 export type DataGridState = TableState & {
     tableState: HeadlessTableState<unknown>;
-} & Pick<DataGridContextValue, 'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance'>;
+} & Pick<DataGridContextValue, 'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance' | 'getRowId'>;
 
 // @public (undocumented)
 export type FocusMode = 'none' | 'cell';

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
@@ -51,7 +51,7 @@ export type DataGridContextValue = HeadlessTableState<any> & {
  * DataGrid Props
  */
 export type DataGridProps = TableProps &
-  Pick<DataGridContextValue, 'items' | 'columns'> &
+  Pick<DataGridContextValue, 'items' | 'columns' | 'getRowId'> &
   Pick<Partial<DataGridContextValue>, 'focusMode' | 'subtleSelection' | 'selectionAppearance'> &
   Pick<UseTableSortOptions, 'sortState' | 'defaultSortState'> &
   Pick<UseTableSelectionOptions, 'defaultSelectedItems' | 'selectedItems'> & {
@@ -69,5 +69,5 @@ export type DataGridProps = TableProps &
  */
 export type DataGridState = TableState & { tableState: HeadlessTableState<unknown> } & Pick<
     DataGridContextValue,
-    'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance'
+    'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance' | 'getRowId'
   >;

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
@@ -27,12 +27,13 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     defaultSelectedItems,
     subtleSelection = false,
     selectionAppearance = 'brand',
+    getRowId,
   } = props;
 
   const navigable = focusMode !== 'none';
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
-  const tableState = useTableFeatures({ items, columns }, [
+  const tableState = useTableFeatures({ items, columns, getRowId }, [
     useTableSort({
       defaultSortState,
       sortState,

--- a/packages/react-components/react-table/stories/DataGrid/CustomRowId.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/CustomRowId.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar, Checkbox } from '@fluentui/react-components';
 import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
@@ -20,6 +20,8 @@ import {
   ColumnDefinition,
   RowState,
   createColumn,
+  RowId,
+  DataGridProps,
 } from '@fluentui/react-table';
 
 type FileCell = {
@@ -88,7 +90,7 @@ const items: Item[] = [
   },
 ];
 
-export const Default = () => {
+export const CustomRowId = () => {
   const columns: ColumnDefinition<Item>[] = React.useMemo(
     () => [
       createColumn<Item>({
@@ -148,30 +150,58 @@ export const Default = () => {
     [],
   );
 
-  return (
-    <DataGrid
-      items={items}
-      columns={columns}
-      focusMode="cell"
-      sortable
-      selectionMode="multiselect"
-      getRowId={item => item.file.label}
-      onSelectionChange={(e, data) => console.log(data)}
-    >
-      <DataGridHeader>
-        <DataGridRow>
-          {({ renderHeaderCell }: ColumnDefinition<Item>) => (
-            <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
-          )}
-        </DataGridRow>
-      </DataGridHeader>
-      <DataGridBody>
-        {({ item, rowId }: RowState<Item>) => (
-          <DataGridRow key={rowId}>
-            {({ renderCell }: ColumnDefinition<Item>) => <DataGridCell>{renderCell(item)}</DataGridCell>}
-          </DataGridRow>
-        )}
-      </DataGridBody>
-    </DataGrid>
+  const [selectedRows, setSelectedRows] = React.useState(
+    new Set<RowId>(['Thursday presentation']),
   );
+  const onSelectionChange: DataGridProps['onSelectionChange'] = (e, data) => {
+    setSelectedRows(data.selectedItems);
+  };
+
+  return (
+    <>
+      <ul>
+        {items.map(item => (
+          <li key={item.file.label}>
+            <Checkbox label={item.file.label} checked={selectedRows.has(item.file.label)} />
+          </li>
+        ))}
+      </ul>
+
+      <DataGrid
+        items={items}
+        columns={columns}
+        focusMode="cell"
+        selectionMode="multiselect"
+        selectedItems={selectedRows}
+        onSelectionChange={onSelectionChange}
+        getRowId={item => item.file.label}
+      >
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell }: ColumnDefinition<Item>) => (
+              <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
+            )}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody>
+          {({ item, rowId }: RowState<Item>) => (
+            <DataGridRow key={rowId}>
+              {({ renderCell }: ColumnDefinition<Item>) => <DataGridCell>{renderCell(item)}</DataGridCell>}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>
+    </>
+  );
+};
+
+CustomRowId.parameters = {
+  docs: {
+    description: {
+      story: [
+        'By default row Ids are the index of the item in the collection. In order to use a row Id based on the data',
+        'use the `getRowId` prop.',
+      ].join('\n'),
+    },
+  },
 };

--- a/packages/react-components/react-table/stories/DataGrid/index.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/index.stories.tsx
@@ -19,6 +19,7 @@ export { SingleSelect } from './SingleSelect.stories';
 export { SingleSelectControlled } from './SingleSelectControlled.stories';
 export { SubtleSelection } from './SubtleSelection.stories';
 export { SelectionAppearance } from './SelectionAppearance.stories';
+export { CustomRowId } from './CustomRowId.stories';
 export default {
   title: 'Preview Components/DataGrid',
   component: DataGrid,


### PR DESCRIPTION
Add the `getRowId` prop to the `DataGrid` component with usage example and documentation.
