### PR TITLE
feat: Multiselect Combobox does not display selected options in the input value

### DIFF
--- a/change/@fluentui-react-combobox-fe274c54-be7a-4171-b120-9f9043f09cc4.json
+++ b/change/@fluentui-react-combobox-fe274c54-be7a-4171-b120-9f9043f09cc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: multiselect Combobox does not display selected options in the text field",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -124,7 +124,7 @@ export type ListboxSlots = {
 };
 
 // @public
-export type ListboxState = ComponentState<ListboxSlots> & OptionCollectionState & SelectionState & {
+export type ListboxState = ComponentState<ListboxSlots> & OptionCollectionState & Pick<SelectionProps, 'multiselect'> & SelectionState & {
     activeOption?: OptionValue;
     focusVisible: boolean;
     selectOption(event: SelectionEvents, option: OptionValue): void;

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -452,7 +452,7 @@ describe('Combobox', () => {
     userEvent.type(combobox, 'gr');
     userEvent.click(getByText('Green'));
 
-    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Green').getAttribute('aria-checked')).toEqual('true');
     expect((combobox as HTMLInputElement).value).toEqual('');
   });
 

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -440,7 +440,7 @@ describe('Combobox', () => {
 
   it('clears typed characters after selection for multiselect', () => {
     const { getByRole, getByText } = render(
-      <Combobox defaultOpen multiselect>
+      <Combobox open multiselect>
         <Option>Red</Option>
         <Option>Green</Option>
         <Option>Blue</Option>
@@ -450,7 +450,7 @@ describe('Combobox', () => {
     const combobox = getByRole('combobox');
 
     userEvent.type(combobox, 'gr');
-    userEvent.type(combobox, '{Enter}');
+    userEvent.click(getByText('Green'));
 
     expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
     expect((combobox as HTMLInputElement).value).toEqual('');

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -438,6 +438,24 @@ describe('Combobox', () => {
     expect(getByRole('menu')).not.toBeNull();
   });
 
+  it('clears typed characters after selection for multiselect', () => {
+    const { getByRole, getByText } = render(
+      <Combobox defaultOpen multiselect>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    const combobox = getByRole('combobox');
+
+    userEvent.type(combobox, 'gr');
+    userEvent.type(combobox, '{Enter}');
+
+    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
+    expect((combobox as HTMLInputElement).value).toEqual('');
+  });
+
   it('should respect value over selected options', () => {
     const { getByRole } = render(
       <Combobox value="foo" selectedOptions={['Green']}>

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -27,7 +27,7 @@ import type { ComboboxProps, ComboboxState } from './Combobox.types';
  * @param ref - reference to root HTMLElement of Combobox
  */
 export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLInputElement>): ComboboxState => {
-  const baseState = useComboboxBaseState(props);
+  const baseState = useComboboxBaseState(props, true);
   const {
     activeOption,
     clearSelection,
@@ -61,17 +61,9 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     setPopupWidth(width);
   }, [open]);
 
-  // handle input type-to-select
-  const getSearchString = (inputValue: string): string => {
-    // if there are commas in the value string, take the text after the last comma
-    const searchString = inputValue.split(',').pop();
-
-    return searchString?.trim().toLowerCase() || '';
-  };
-
   // set active option and selection based on typing
   const getOptionFromInput = (inputValue: string): OptionValue | undefined => {
-    const searchString = getSearchString(inputValue);
+    const searchString = inputValue.trim().toLowerCase();
 
     if (searchString.length === 0) {
       return;
@@ -102,7 +94,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     // handle selection and updating value if freeform is false
     if (!baseState.open && !freeform) {
       // select matching option, if the value fully matches
-      if (value && activeOption && getSearchString(value) === activeOption?.value.toLowerCase()) {
+      if (value && activeOption && value.trim().toLowerCase() === activeOption?.value.toLowerCase()) {
         baseState.selectOption(ev, activeOption);
       }
 

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -27,7 +27,7 @@ import type { ComboboxProps, ComboboxState } from './Combobox.types';
  * @param ref - reference to root HTMLElement of Combobox
  */
 export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLInputElement>): ComboboxState => {
-  const baseState = useComboboxBaseState(props, true);
+  const baseState = useComboboxBaseState({ ...props, editable: true });
   const {
     activeOption,
     clearSelection,
@@ -63,9 +63,9 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
 
   // set active option and selection based on typing
   const getOptionFromInput = (inputValue: string): OptionValue | undefined => {
-    const searchString = inputValue.trim().toLowerCase();
+    const searchString = inputValue?.trim().toLowerCase();
 
-    if (searchString.length === 0) {
+    if (!searchString || searchString.length === 0) {
       return;
     }
 

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -472,7 +472,22 @@ describe('Dropdown', () => {
     expect(getByRole('combobox').textContent).toEqual('Green');
   });
 
-  it('should not change value on select', () => {
+  it('should update value after selection for multiselect', () => {
+    const { getByRole, getByText } = render(
+      <Dropdown defaultOpen defaultSelectedOptions={['Red']} multiselect>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    fireEvent.click(getByText('Green'));
+
+    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
+    expect(getByRole('combobox').textContent).toEqual('Red, Green');
+  });
+
+  it('should not change controlled value on select', () => {
     const { getByRole, getByText } = render(
       <Dropdown value="Red" defaultOpen>
         <Option>Red</Option>

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -483,7 +483,7 @@ describe('Dropdown', () => {
 
     fireEvent.click(getByText('Green'));
 
-    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Green').getAttribute('aria-checked')).toEqual('true');
     expect(getByRole('combobox').textContent).toEqual('Red, Green');
   });
 

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.types.ts
@@ -18,6 +18,7 @@ export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps;
  */
 export type ListboxState = ComponentState<ListboxSlots> &
   OptionCollectionState &
+  Pick<SelectionProps, 'multiselect'> &
   SelectionState & {
     /* Option data for the currently highlighted option (not the selected option) */
     activeOption?: OptionValue;

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -23,7 +23,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   const optionCollection = useOptionCollection();
   const { getCount, getOptionAtIndex, getIndexOfId } = optionCollection;
 
-  const { selectedOptions, selectOption } = useSelection(props);
+  const { clearSelection, selectedOptions, selectOption } = useSelection(props);
 
   const [activeOption, setActiveOption] = React.useState<OptionValue | undefined>();
 
@@ -96,6 +96,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
       ...props,
     }),
     multiselect,
+    clearSelection,
     ...optionCollection,
     ...optionContextValues,
   };

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselect.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselect.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { typographyStyles } from '@fluentui/react-components';
 import { makeStyles, shorthands, useId } from '@fluentui/react-components';
 import { Combobox, Option } from '@fluentui/react-combobox';
 import type { ComboboxProps } from '@fluentui/react-combobox';
@@ -12,22 +13,45 @@ const useStyles = makeStyles({
     ...shorthands.gap('2px'),
     maxWidth: '400px',
   },
+  description: {
+    ...typographyStyles.caption1,
+  },
 });
 
 export const Multiselect = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-multi');
+  const selectedListId = `${comboId}-selection`;
+  const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
   const styles = useStyles();
+
+  const onSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
+    setSelectedOptions(data.selectedOptions);
+  };
+
+  const labelledBy = selectedOptions.length > 0 ? `${comboId} ${selectedListId}` : comboId;
+
   return (
     <div className={styles.root}>
-      <label id={comboId}>Best pet</label>
-      <Combobox aria-labelledby={comboId} multiselect={true} placeholder="Select an animal" {...props}>
+      <label id={comboId}>Best pets</label>
+      <Combobox
+        aria-labelledby={labelledBy}
+        multiselect={true}
+        placeholder="Select one or more animals"
+        onOptionSelect={onSelect}
+        {...props}
+      >
         {options.map(option => (
           <Option key={option} disabled={option === 'Ferret'}>
             {option}
           </Option>
         ))}
       </Combobox>
+      {selectedOptions.length ? (
+        <span id={selectedListId} className={styles.description}>
+          Chosen pets: {selectedOptions.join(', ')}
+        </span>
+      ) : null}
     </div>
   );
 };

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithTags.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithTags.stories.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { Button, makeStyles, shorthands, tokens, useId } from '@fluentui/react-components';
+import { Dismiss12Regular } from '@fluentui/react-icons';
+import { Combobox, Option } from '@fluentui/react-combobox';
+import type { ComboboxProps } from '@fluentui/react-combobox';
+
+const useStyles = makeStyles({
+  root: {
+    // Stack the label above the field with a gap
+    display: 'grid',
+    gridTemplateRows: 'repeat(1fr)',
+    justifyItems: 'start',
+    ...shorthands.gap('2px'),
+    maxWidth: '400px',
+  },
+  tagsList: {
+    listStyleType: 'none',
+    marginBottom: tokens.spacingVerticalXXS,
+    marginTop: 0,
+    paddingLeft: 0,
+    display: 'flex',
+    gridGap: tokens.spacingHorizontalXXS,
+  },
+});
+
+export const MultiselectWithTags = (props: Partial<ComboboxProps>) => {
+  // generate ids for handling labelling
+  const comboId = useId('combo-multi');
+  const selectedListId = `${comboId}-selection`;
+
+  // refs for managing focus when removing tags
+  const selectedListRef = React.useRef<HTMLUListElement>(null);
+  const comboboxInputRef = React.useRef<HTMLInputElement>(null);
+
+  const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
+  const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const styles = useStyles();
+
+  const onSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
+    setSelectedOptions(data.selectedOptions);
+  };
+
+  const onTagClick = (option: string, index: number) => {
+    // remove selected option
+    setSelectedOptions(selectedOptions.filter(o => o !== option));
+
+    // focus previous or next option, defaulting to focusing back to the combo input
+    const indexToFocus = index === 0 ? 1 : index - 1;
+    const optionToFocus = selectedListRef.current?.querySelector(`#${comboId}-remove-${indexToFocus}`);
+    if (optionToFocus) {
+      (optionToFocus as HTMLButtonElement).focus();
+    } else {
+      comboboxInputRef.current?.focus();
+    }
+  };
+
+  const labelledBy = selectedOptions.length > 0 ? `${comboId} ${selectedListId}` : comboId;
+
+  return (
+    <div className={styles.root}>
+      <label id={comboId}>Best pets</label>
+      {selectedOptions.length ? (
+        <ul id={selectedListId} className={styles.tagsList} ref={selectedListRef}>
+          {/* The "Remove" span is used for naming the buttons without affecting the Combobox name */}
+          <span id={`${comboId}-remove`} hidden>
+            Remove
+          </span>
+          {selectedOptions.map((option, i) => (
+            <li key={option}>
+              <Button
+                size="small"
+                shape="circular"
+                appearance="primary"
+                icon={<Dismiss12Regular />}
+                iconPosition="after"
+                onClick={() => onTagClick(option, i)}
+                id={`${comboId}-remove-${i}`}
+                aria-labelledby={`${comboId}-remove ${comboId}-remove-${i}`}
+              >
+                {option}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <Combobox
+        aria-labelledby={labelledBy}
+        multiselect={true}
+        placeholder="Select one or more animals"
+        selectedOptions={selectedOptions}
+        onOptionSelect={onSelect}
+        ref={comboboxInputRef}
+        {...props}
+      >
+        {options.map(option => (
+          <Option key={option}>{option}</Option>
+        ))}
+      </Combobox>
+    </div>
+  );
+};
+
+MultiselectWithTags.parameters = {
+  docs: {
+    description: {
+      story:
+        'Combobox can display multiselect values in custom tags. ' +
+        'This example uses a controlled selection so the tags can be used to remove selected options.',
+    },
+  },
+};

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithTags.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithTags.stories.tsx
@@ -32,9 +32,12 @@ export const MultiselectWithTags = (props: Partial<ComboboxProps>) => {
   const selectedListRef = React.useRef<HTMLUListElement>(null);
   const comboboxInputRef = React.useRef<HTMLInputElement>(null);
 
-  const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
   const styles = useStyles();
+
+  // Handle selectedOptions both when an option is selected or deselected in the Combobox,
+  // and when an option is removed by clicking on a tag
+  const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
 
   const onSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
     setSelectedOptions(data.selectedOptions);

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithValueString.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithValueString.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, typographyStyles, useId } from '@fluentui/react-components';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
 import { Combobox, Option } from '@fluentui/react-combobox';
 import type { ComboboxProps } from '@fluentui/react-combobox';
 
@@ -11,9 +11,6 @@ const useStyles = makeStyles({
     justifyItems: 'start',
     ...shorthands.gap('2px'),
     maxWidth: '400px',
-  },
-  description: {
-    ...typographyStyles.caption1,
   },
 });
 

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithValueString.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxMultiselectWithValueString.stories.tsx
@@ -17,48 +17,62 @@ const useStyles = makeStyles({
   },
 });
 
-export const Multiselect = (props: Partial<ComboboxProps>) => {
+export const MultiselectWithValueString = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-multi');
-  const selectedListId = `${comboId}-selection`;
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
+  const [value, setValue] = React.useState('');
   const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
   const styles = useStyles();
 
   const onSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
+    // update selectedOptions
     setSelectedOptions(data.selectedOptions);
+
+    // reset value to an empty string after selection
+    setValue('');
   };
 
-  const labelledBy = selectedOptions.length > 0 ? `${comboId} ${selectedListId}` : comboId;
+  // clear value on focus
+  const onFocus = () => {
+    setValue('');
+  };
+
+  // update value to selected options on blur
+  const onBlur = () => {
+    setValue(selectedOptions.join(', '));
+  };
+
+  // update value on input change
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+  };
 
   return (
     <div className={styles.root}>
       <label id={comboId}>Best pets</label>
       <Combobox
-        aria-labelledby={labelledBy}
+        aria-labelledby={comboId}
         multiselect={true}
         placeholder="Select one or more animals"
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
         onOptionSelect={onSelect}
         {...props}
       >
         {options.map(option => (
-          <Option key={option} disabled={option === 'Ferret'}>
-            {option}
-          </Option>
+          <Option key={option}>{option}</Option>
         ))}
       </Combobox>
-      {selectedOptions.length ? (
-        <span id={selectedListId} className={styles.description}>
-          Chosen pets: {selectedOptions.join(', ')}
-        </span>
-      ) : null}
     </div>
   );
 };
 
-Multiselect.parameters = {
+MultiselectWithValueString.parameters = {
   docs: {
     description: {
-      story: 'Combobox supports multiselect, and options within a multiselect will display checkbox icons.',
+      story: 'Multiselect Combobox supports using a controlled value to display selected options when not in focus.',
     },
   },
 };

--- a/packages/react-components/react-combobox/src/stories/Combobox/index.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/index.stories.tsx
@@ -9,6 +9,8 @@ export { ComplexOptions } from './ComboboxComplexOptions.stories';
 export { CustomOptions } from './ComboboxCustomOptions.stories';
 export { Freeform } from './ComboboxFreeform.stories';
 export { Multiselect } from './ComboboxMultiselect.stories';
+export { MultiselectWithTags } from './ComboboxMultiselectWithTags.stories';
+export { MultiselectWithValueString } from './ComboboxMultiselectWithValueString.stories';
 export { Grouped } from './ComboboxGrouped.stories';
 export { Appearance } from './ComboboxAppearance.stories';
 export { Size } from './ComboboxSize.stories';

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import type { ComboboxContextValue } from '../contexts/ComboboxContext';
 import type { OptionValue, OptionCollectionState } from '../utils/OptionCollection.types';
-import { SelectionEvents, SelectionProps, SelectionState } from '../utils/Selection.types';
+import { SelectionProps, SelectionState } from '../utils/Selection.types';
 
 /**
  * ComboboxBase Props
@@ -71,7 +71,7 @@ export type ComboboxBaseProps = SelectionProps & {
  * State used in rendering Combobox
  */
 export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 'open' | 'inlinePopup' | 'size'>> &
-  Pick<ComboboxBaseProps, 'placeholder' | 'value'> &
+  Pick<ComboboxBaseProps, 'placeholder' | 'value' | 'multiselect'> &
   OptionCollectionState &
   SelectionState & {
     /* Option data for the currently highlighted option (not the selected option) */
@@ -86,8 +86,6 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     /* Whether the next blur event should be ignored, and the combobox/dropdown will not close.*/
     ignoreNextBlur: React.MutableRefObject<boolean>;
 
-    selectOption(event: SelectionEvents, option: OptionValue): void;
-
     setActiveOption(option?: OptionValue): void;
 
     setFocusVisible(focusVisible: boolean): void;
@@ -96,7 +94,7 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
 
     setOpen(event: ComboboxBaseOpenEvents, newState: boolean): void;
 
-    setValue(newValue: string): void;
+    setValue(newValue: string | undefined): void;
   };
 
 /**

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -23,10 +23,8 @@ export type SelectionProps = {
   selectedOptions?: string[];
 };
 
-export type SelectionState = Required<Pick<SelectionProps, 'selectedOptions'>> & Pick<SelectionProps, 'multiselect'>;
-
 /* Values returned by the useSelection hook */
-export type SelectionValue = {
+export type SelectionState = {
   clearSelection: (event: SelectionEvents) => void;
   selectedOptions: string[];
   selectOption: (event: SelectionEvents, option: OptionValue) => void;

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -3,12 +3,12 @@ import { useControllableState, useFirstMount } from '@fluentui/react-utilities';
 import { useOptionCollection } from '../utils/useOptionCollection';
 import { OptionValue } from '../utils/OptionCollection.types';
 import { useSelection } from '../utils/useSelection';
-import type { ComboboxBaseProps, ComboboxBaseOpenEvents } from './ComboboxBase.types';
+import type { ComboboxBaseProps, ComboboxBaseOpenEvents, ComboboxBaseState } from './ComboboxBase.types';
 
 /**
  * State shared between Combobox and Dropdown components
  */
-export const useComboboxBaseState = (props: ComboboxBaseProps) => {
+export const useComboboxBaseState = (props: ComboboxBaseProps, editable = false): ComboboxBaseState => {
   const { appearance = 'outline', inlinePopup = false, multiselect, onOpenChange, size = 'medium' } = props;
 
   const optionCollection = useOptionCollection();
@@ -47,11 +47,12 @@ export const useComboboxBaseState = (props: ComboboxBaseProps) => {
     }
 
     if (multiselect) {
-      return selectedOptions.join(', ');
+      // editable inputs should not display multiple selected options in the input as text
+      return editable ? '' : selectedOptions.join(', ');
     }
 
     return selectedOptions[0];
-  }, [controllableValue, isFirstMount, multiselect, props.defaultValue, selectedOptions]);
+  }, [controllableValue, editable, isFirstMount, multiselect, props.defaultValue, selectedOptions]);
 
   // Handle open state, which is shared with options in context
   const [open, setOpenState] = useControllableState({

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -8,8 +8,15 @@ import type { ComboboxBaseProps, ComboboxBaseOpenEvents, ComboboxBaseState } fro
 /**
  * State shared between Combobox and Dropdown components
  */
-export const useComboboxBaseState = (props: ComboboxBaseProps, editable = false): ComboboxBaseState => {
-  const { appearance = 'outline', inlinePopup = false, multiselect, onOpenChange, size = 'medium' } = props;
+export const useComboboxBaseState = (props: ComboboxBaseProps & { editable?: boolean }): ComboboxBaseState => {
+  const {
+    appearance = 'outline',
+    editable = false,
+    inlinePopup = false,
+    multiselect,
+    onOpenChange,
+    size = 'medium',
+  } = props;
 
   const optionCollection = useOptionCollection();
   const { getOptionAtIndex, getOptionsMatchingText } = optionCollection;

--- a/packages/react-components/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-components/react-combobox/src/utils/useSelection.ts
@@ -1,8 +1,8 @@
 import { useControllableState } from '@fluentui/react-utilities';
 import { OptionValue } from './OptionCollection.types';
-import { SelectionEvents, SelectionProps, SelectionValue } from './Selection.types';
+import { SelectionEvents, SelectionProps, SelectionState } from './Selection.types';
 
-export const useSelection = (props: SelectionProps): SelectionValue => {
+export const useSelection = (props: SelectionProps): SelectionState => {
   const { defaultSelectedOptions, multiselect, onOptionSelect } = props;
 
   const [selectedOptions, setSelectedOptions] = useControllableState({

--- a/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
@@ -145,7 +145,7 @@ export function useTriggerListboxSlots(
           event.preventDefault();
           break;
         case 'Tab':
-          activeOption && selectOption(event, activeOption);
+          !multiselect && activeOption && selectOption(event, activeOption);
           break;
         default:
           newIndex = getIndexFromAction(action, activeIndex, maxIndex);


### PR DESCRIPTION
Related to #25724, fixes the item on clearing multiselect combo's input value

## Previous Behavior

We currently show the selected options as part of the input's value string, which makes typing and editing confusing at best:

![screenshot of an open multiselect combobox with cat and fish selected, and the word "Hamster" typed in the input immediately after fish, with no space between the two](https://user-images.githubusercontent.com/3819570/205776230-fcab7627-9433-4617-9527-5c41fdab3131.png)

## New Behavior

Now the input value is only used for the user to type to search for options in the multiselect combobox, not for displaying the current selection:

![Screenshot of an open multiselect combobox with hamster and dog selected, and only the typed letters 'ca' in the input](https://user-images.githubusercontent.com/3819570/205785843-38b5e6f8-ab2c-4d91-9837-33a8850f7353.png)

I also added two examples showing how to create multiselect combos with custom tags (probably can be replaced when we release the taglist/pickers), and how to put the selected options in the value string, similar to the v8 behavior:

![screenshot of the multiselect with tags and multiselect with value string examples](https://user-images.githubusercontent.com/3819570/205786147-e28e8739-b6ca-4b95-b094-2eac218066a6.png)
