### PR TITLE
8.0 Azure Theme ActionButton style bug fix

### DIFF
--- a/change/@fluentui-azure-themes-fe64290b-3f2d-41ad-9969-5a64dfabe50c.json
+++ b/change/@fluentui-azure-themes-fe64290b-3f2d-41ad-9969-5a64dfabe50c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "action button fix",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -119,7 +119,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   controlOutlineDisabled: DarkSemanticColors.controlOutlines.disabled,
   controlOutlineHovered: DarkSemanticColors.controlOutlines.hover,
   iconButtonFill: DarkSemanticColors.primaryButton.rest.background,
-  iconButtonFillHovered: DarkSemanticColors.primaryButton.hover.background,
+  iconButtonFillHovered: DarkSemanticColors.commandBar.button.hover.icon,
   labelText: DarkSemanticColors.text.label,
   sliderActiveBackground: DarkSemanticColors.slider.activeBackground,
   sliderInActiveHover: DarkSemanticColors.slider.inactiveBackgroundHovered,

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -6,6 +6,7 @@ import {
 } from '@fluentui/react/lib/Styling';
 
 export const inputHeight = '18px';
+export const commandBarHeight = '36px';
 export const buttonPadding = '0px 16px';
 export const borderWidth = '1px';
 export const borderRadius = '3px';

--- a/packages/azure-themes/src/azure/styles/ActionButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ActionButton.styles.ts
@@ -16,8 +16,8 @@ export const ActionButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
   return {
     root: {
       fontSize: theme.fonts.medium.fontSize,
+      height: StyleConstants.commandBarHeight,
       backgroundColor: semanticColors.buttonBackground,
-      border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
       color: semanticColors.buttonText,
       ...iconColor(extendedSemanticColors.iconButtonFill),
     },
@@ -28,7 +28,6 @@ export const ActionButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       ...iconColor(semanticColors.primaryButtonTextDisabled),
     },
     rootHovered: {
-      border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorderHovered}`,
       backgroundColor: semanticColors.buttonBackgroundHovered,
       color: semanticColors.buttonTextHovered,
       selectors: {
@@ -38,7 +37,6 @@ export const ActionButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       },
     },
     rootPressed: {
-      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.inputBorderPressed}`,
       backgroundColor: semanticColors.buttonBackgroundPressed,
       color: semanticColors.buttonTextPressed,
       selectors: {
@@ -46,6 +44,9 @@ export const ActionButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
           ...iconColor(extendedSemanticColors.iconButtonFillHovered),
         },
       },
+    },
+    rootFocused: {
+      border: `${StyleConstants.borderWidth} solid ${extendedSemanticColors.inputBorderPressed}`,
     },
     rootChecked: {
       border: `${StyleConstants.borderWidth} solid ${semanticColors.buttonTextPressed}`,

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -64,7 +64,6 @@ const Example = () => (
       <ButtonIconWithTooltipExample />
       <ButtonContextualMenuExample />
       <ButtonActionExample />
-
       <Label>Toggle button</Label>
       <ButtonToggleExample />
       <ButtonSplitExample checked={false} />


### PR DESCRIPTION
## Previous Behavior
<img width="121" alt="image" src="https://user-images.githubusercontent.com/30805892/205827022-750db365-93ff-4945-985e-b94b2633c172.png">

## New Behavior
Removed border from rest & hover state
Reduce height to 36px
<img width="241" alt="image" src="https://user-images.githubusercontent.com/30805892/205826529-49d7ee7d-8978-4859-a4b1-e1d0afe46f28.png">

<img width="120" alt="image" src="https://user-images.githubusercontent.com/30805892/205827258-479b7ef7-9b40-4d51-865c-e82a96e9a20f.png">

**rest**
<img width="115" alt="image" src="https://user-images.githubusercontent.com/30805892/205827511-3aa2b68b-c49b-47ed-a610-c4f83a410c68.png">


**hovered**
<img width="111" alt="image" src="https://user-images.githubusercontent.com/30805892/205827451-7ad76b5e-7dff-46bf-bb38-300bb084b015.png">

**pressed**
<img width="126" alt="image" src="https://user-images.githubusercontent.com/30805892/205828428-f2aa607a-cb7d-4d66-a1ce-03e03217c30b.png">

**focus**
<img width="105" alt="image" src="https://user-images.githubusercontent.com/30805892/205828635-55827f99-570e-4775-aae0-da1cb0cfbf28.png">

dark: rest, hover, pressed, focus
<img width="122" alt="image" src="https://user-images.githubusercontent.com/30805892/205830972-b6f64912-1d8f-4d2d-a0a0-1999f8027ba5.png">
<img width="118" alt="image" src="https://user-images.githubusercontent.com/30805892/205831139-b1c45af0-9a12-423e-a408-4adf683c5458.png">
<img width="118" alt="image" src="https://user-images.githubusercontent.com/30805892/205831662-bcbabc27-fe5f-4d62-94f5-ad8477cdbbe2.png">
<img width="113" alt="image" src="https://user-images.githubusercontent.com/30805892/205831286-1fb375cc-65b1-42b0-b1d6-e4aabc738102.png">

