### PR TITLE
feat: update Listbox and Option to use menu and menuitemcheckbox semantics for multiselect

### DIFF
--- a/change/@fluentui-react-combobox-701e29a2-ac8a-4be4-bfa7-44fb3466a96f.json
+++ b/change/@fluentui-react-combobox-701e29a2-ac8a-4be4-bfa7-44fb3466a96f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: update Listbox and Option to use menu and menuitemcheckbox semantics for multiselect",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -273,9 +273,9 @@ describe('Combobox', () => {
       </Combobox>,
     );
 
-    expect(getByTestId('green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('blue').getAttribute('aria-selected')).toEqual('false');
+    expect(getByTestId('green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('red').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('blue').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('should set defaultSelectedOptions based on Option `value`', () => {
@@ -291,8 +291,8 @@ describe('Combobox', () => {
       </Combobox>,
     );
 
-    expect(getByTestId('green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('blue').getAttribute('aria-selected')).toEqual('true');
+    expect(getByTestId('green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('blue').getAttribute('aria-checked')).toEqual('true');
   });
 
   it('should set selectedOptions', () => {
@@ -322,9 +322,9 @@ describe('Combobox', () => {
       </Combobox>,
     );
 
-    expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('blue').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('green').getAttribute('aria-selected')).toEqual('false');
+    expect(getByTestId('red').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('blue').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('green').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('should change defaultSelectedOptions on click', () => {
@@ -419,9 +419,9 @@ describe('Combobox', () => {
 
     userEvent.click(getByText('Green'));
 
-    expect(getByText('Red', { selector: '[role=menuitemcheckbox]' }).getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Blue').getAttribute('aria-selected')).toEqual('false');
+    expect(getByText('Red', { selector: '[role=menuitemcheckbox]' }).getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Blue').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('stays open on click for multiselect', () => {

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -419,7 +419,7 @@ describe('Combobox', () => {
 
     userEvent.click(getByText('Green'));
 
-    expect(getByText('Red', { selector: '[role=option]' }).getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Red', { selector: '[role=menuitemcheckbox]' }).getAttribute('aria-selected')).toEqual('true');
     expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
     expect(getByText('Blue').getAttribute('aria-selected')).toEqual('false');
   });
@@ -435,7 +435,7 @@ describe('Combobox', () => {
 
     userEvent.click(getByText('Green'));
 
-    expect(getByRole('listbox')).not.toBeNull();
+    expect(getByRole('menu')).not.toBeNull();
   });
 
   it('should respect value over selected options', () => {

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -209,9 +209,9 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
 
-    expect(getByTestId('green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('blue').getAttribute('aria-selected')).toEqual('false');
+    expect(getByTestId('green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('red').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('blue').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('should set defaultSelectedOptions based on Option `value`', () => {
@@ -227,8 +227,8 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
 
-    expect(getByTestId('green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('blue').getAttribute('aria-selected')).toEqual('true');
+    expect(getByTestId('green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('blue').getAttribute('aria-checked')).toEqual('true');
   });
 
   it('should set selectedOptions', () => {
@@ -258,9 +258,9 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
 
-    expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('blue').getAttribute('aria-selected')).toEqual('true');
-    expect(getByTestId('green').getAttribute('aria-selected')).toEqual('false');
+    expect(getByTestId('red').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('blue').getAttribute('aria-checked')).toEqual('true');
+    expect(getByTestId('green').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('should change defaultSelectedOptions on click', () => {
@@ -355,9 +355,9 @@ describe('Dropdown', () => {
 
     fireEvent.click(getByText('Green'));
 
-    expect(getByText('Red', { selector: '[role=menuitemcheckbox]' }).getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Blue').getAttribute('aria-selected')).toEqual('false');
+    expect(getByText('Red', { selector: '[role=menuitemcheckbox]' }).getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Blue').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('calls onOptionSelect with correct data for single-select', () => {

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -355,7 +355,7 @@ describe('Dropdown', () => {
 
     fireEvent.click(getByText('Green'));
 
-    expect(getByText('Red', { selector: '[role=option]' }).getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Red', { selector: '[role=menuitemcheckbox]' }).getAttribute('aria-selected')).toEqual('true');
     expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
     expect(getByText('Blue').getAttribute('aria-selected')).toEqual('false');
   });
@@ -443,7 +443,7 @@ describe('Dropdown', () => {
 
     fireEvent.click(getByText('Green'));
 
-    expect(getByRole('listbox')).not.toBeNull();
+    expect(getByRole('menu')).not.toBeNull();
   });
 
   it('should respect value over selected options', () => {

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
@@ -32,6 +32,30 @@ describe('Listbox', () => {
     expect(result.container).toMatchSnapshot();
   });
 
+  it('uses lisbox/option semantics for single-select', () => {
+    const { getAllByRole } = render(
+      <Listbox>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Listbox>,
+    );
+    expect(getAllByRole('listbox').length).toEqual(1);
+    expect(getAllByRole('option').length).toEqual(3);
+  });
+
+  it('uses menu/menuitemcheckbox semantics for multi-select', () => {
+    const { getAllByRole } = render(
+      <Listbox multiselect>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Listbox>,
+    );
+    expect(getAllByRole('menu').length).toEqual(1);
+    expect(getAllByRole('menuitemcheckbox').length).toEqual(3);
+  });
+
   /* Moving activeOption */
   it('should set active option on click', () => {
     const { getByTestId } = render(

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
@@ -182,9 +182,9 @@ describe('Listbox', () => {
       </Listbox>,
     );
 
-    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Red').getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Blue').getAttribute('aria-selected')).toEqual('false');
+    expect(getByText('Green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Red').getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Blue').getAttribute('aria-checked')).toEqual('false');
   });
 
   it('should set selectedOptions', () => {
@@ -225,8 +225,8 @@ describe('Listbox', () => {
 
     fireEvent.click(getByText('Red'));
 
-    expect(getByText('Green').getAttribute('aria-selected')).toEqual('true');
-    expect(getByText('Red').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Green').getAttribute('aria-checked')).toEqual('true');
+    expect(getByText('Red').getAttribute('aria-checked')).toEqual('true');
   });
 
   it('should fire onChange when an option is selected', () => {

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -89,7 +89,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     },
     root: getNativeElementProps('div', {
       ref,
-      role: 'listbox',
+      role: multiselect ? 'menu' : 'listbox',
       'aria-activedescendant': hasComboboxContext ? undefined : activeOption?.id,
       'aria-multiselectable': multiselect,
       tabIndex: 0,

--- a/packages/react-components/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Option renders a default multi-select state 1`] = `
     aria-selected="false"
     class="fui-Option"
     id="fluent-option1"
-    role="option"
+    role="menuitemcheckbox"
   >
     <span
       aria-hidden="true"
@@ -70,7 +70,7 @@ exports[`Option renders a selected multi-select state 1`] = `
     aria-selected="true"
     class="fui-Option"
     id="fluent-option1"
-    role="option"
+    role="menuitemcheckbox"
   >
     <span
       aria-hidden="true"

--- a/packages/react-components/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Option/__snapshots__/Option.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Option renders a default multi-select state 1`] = `
 <div>
   <div
-    aria-selected="false"
+    aria-checked="false"
     class="fui-Option"
     id="fluent-option1"
     role="menuitemcheckbox"
@@ -67,7 +67,7 @@ exports[`Option renders a default single-select state 1`] = `
 exports[`Option renders a selected multi-select state 1`] = `
 <div>
   <div
-    aria-selected="true"
+    aria-checked="true"
     class="fui-Option"
     id="fluent-option1"
     role="menuitemcheckbox"

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -108,6 +108,10 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
     }
   }, [id, optionData, registerOption]);
 
+  const semanticProps = multiselect
+    ? { role: 'menuitemcheckbox', 'aria-checked': selected }
+    : { role: 'option', 'aria-selected': selected };
+
   return {
     components: {
       root: 'div',
@@ -115,10 +119,9 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
     },
     root: getNativeElementProps('div', {
       ref: useMergedRefs(ref, optionRef),
-      role: multiselect ? 'menuitemcheckbox' : 'option',
       'aria-disabled': disabled ? 'true' : undefined,
-      'aria-selected': `${selected}`,
       id,
+      ...semanticProps,
       ...props,
       onClick,
     }),

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -115,7 +115,7 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
     },
     root: getNativeElementProps('div', {
       ref: useMergedRefs(ref, optionRef),
-      role: 'option',
+      role: multiselect ? 'menuitemcheckbox' : 'option',
       'aria-disabled': disabled ? 'true' : undefined,
       'aria-selected': `${selected}`,
       id,


### PR DESCRIPTION
Part of the changes in #25724

## Previous Behavior

We currently use listbox/option for both single-select and mutli-select Combobox, Listbox, and Dropdown. Based on the usability study, menu/menuitemcheckbox semantics significantly improved screen reader usability for multiselect Combo/Dropdown, with no drawbacks.

## New Behavior

Single-select keeps the listbox/option semantics, while multi-select uses menu/menuitemcheckbox. This change only affects screen reader (and SR + braille) users.
