### PR TITLE
Change website language around strict mode

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
@@ -42,13 +42,14 @@ import { Button } from '@fluentui/react-components';
 export default () => <Button appearance="primary">Get started</Button>;
 ```
 
-### Strict mode
+### StrictMode
 
-Strict mode is currently not supported. Plese remove any `React.StrictMode` wrappers from your app.
+We are aware of some strict mode bugs when using Fluent UI v9 in React 18. These bugs only show up in strict mode, and they will not stop the rest of your app from running.
+You can [track the bugs on Github](https://github.com/microsoft/fluentui/issues?q=is%3Aopen+is%3Aissue+label%3A%22Area%3A+Strict+Mode%22+label%3A%22React+18%22) and learn how they will affect your application.
 
 #### SSR with Next.js
 
-To avoid hydration issues, disable strict mode in your app by adding the following configuration to your `next.config.js` file:
+To avoid strict mode hydration issues, you can disable strict mode in your app by adding the following configuration to your `next.config.js` file:
 
 ```js
 module.exports = {

--- a/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
@@ -42,7 +42,7 @@ import { Button } from '@fluentui/react-components';
 export default () => <Button appearance="primary">Get started</Button>;
 ```
 
-### StrictMode
+### Strict mode
 
 We are aware of some strict mode bugs when using Fluent UI v9 in React 18. These bugs only show up in strict mode, and they will not stop the rest of your app from running.
 You can [track the bugs on Github](https://github.com/microsoft/fluentui/issues?q=is%3Aopen+is%3Aissue+label%3A%22Area%3A+Strict+Mode%22+label%3A%22React+18%22) and learn how they will affect your application.

--- a/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
@@ -49,7 +49,7 @@ You can [track the bugs on Github](https://github.com/microsoft/fluentui/issues?
 
 #### SSR with Next.js
 
-To avoid strict mode hydration issues, you can disable strict mode in your app by adding the following configuration to your `next.config.js` file:
+To avoid strict mode hydration issues, you can disable strict mode in your Next.js app by adding the following configuration to your `next.config.js` file:
 
 ```js
 module.exports = {


### PR DESCRIPTION
Changed some language in our docs that were causing confusion around the state of Fluent v9 in strict mode. Original docs sounded like you had to turn off strict mode in your entire app to use v9 (which is a blocker for many adopters). 

The truth is that the issues in strict mode are mostly limited to react 18 (the SSR issue is 17/18 but almost fixed), and even in react 18, your app will still work, with the exception of the existing bugs. 