### PR TITLE
bugfix:removed useConstant hook for initial value in timepicker

### DIFF
--- a/change/@fluentui-react-fcd794a8-7856-4526-a422-5594334da599.json
+++ b/change/@fluentui-react-fcd794a8-7856-4526-a422-5594334da599.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "In Timepicker intialValue const used the useConst hook which does not update the initial value of the timepicker if the TimePicker receive updated date via props",
+  "packageName": "@fluentui/react",
+  "email": "harminder_Sethi@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useConst } from '@fluentui/react-hooks';
 import { KeyCodes } from '../../Utilities';
 import {
   TimeConstants,
@@ -52,7 +51,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
 
   const optionsCount = getDropdownOptionsCount(increments, timeRange);
 
-  const initialValue = useConst(defaultValue || new Date());
+  const initialValue = defaultValue || new Date();
   const baseDate: Date = React.useMemo(() => generateBaseDate(increments, timeRange, initialValue), [
     increments,
     timeRange,

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -7,6 +7,7 @@ import {
   ceilMinuteToIncrement,
   getDateFromTimeSelection,
 } from '@fluentui/date-time-utilities';
+import { useControllableValue } from '@fluentui/react-hooks';
 import { ComboBox } from '../../ComboBox';
 import type { IComboBox, IComboBoxOption } from '../../ComboBox';
 import type { ITimePickerProps, ITimeRange, ITimePickerStrings } from './TimePicker.types';
@@ -51,8 +52,8 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
 
   const optionsCount = getDropdownOptionsCount(increments, timeRange);
 
-  const initialValue = defaultValue || new Date();
-  const baseDate: Date = React.useMemo(() => generateBaseDate(increments, timeRange, initialValue), [
+  const [initialValue] = useControllableValue(defaultValue, new Date());
+  const baseDate: Date = React.useMemo(() => generateBaseDate(increments, timeRange, initialValue as Date), [
     increments,
     timeRange,
     initialValue,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
TimePicker when used with DatePicker return the current date with the selected time from TimePicker instead of DatePicker date. This was happeing due to useConst hook which set the current date value at initial render and does not update if the value change


## New Behavior

Removed the useConst hook for initial value which will help the TimePicker date sync with DatePicker selected date

## Related Issue(s)

