### PR TITLE
feat: add allowSpaceAsCharacter prop to Combobox

### DIFF
--- a/change/@fluentui-react-combobox-eebfd08a-8c5a-4912-80a7-732ab92a9d09.json
+++ b/change/@fluentui-react-combobox-eebfd08a-8c5a-4912-80a7-732ab92a9d09.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add allowSpaceAsCharacter prop to Combobox",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -49,8 +49,9 @@ export type ComboboxOpenEvents = ComboboxBaseOpenEvents;
 
 // @public
 export type ComboboxProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> & ComboboxBaseProps & {
-    freeform?: boolean;
     children?: React_2.ReactNode;
+    freeform?: boolean;
+    allowSpaceAsCharacter?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -377,6 +377,23 @@ describe('Combobox', () => {
     expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Green');
   });
 
+  it('does not select with space if allowSpaceAsCharacter is true', () => {
+    const { getByTestId, getByText } = render(
+      <Combobox open allowSpaceAsCharacter data-testid="combobox">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    const combobox = getByTestId('combobox');
+
+    userEvent.type(combobox, 'gre ');
+
+    expect((combobox as HTMLInputElement).value).toEqual('gre ');
+    expect(getByText('Green').getAttribute('aria-selected')).toEqual('false');
+  });
+
   it('does not select a disabled option with the keyboard', () => {
     const { getByTestId, getByRole } = render(
       <Combobox open data-testid="combobox">

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -29,14 +29,21 @@ export type ComboboxSlots = {
 export type ComboboxProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> &
   ComboboxBaseProps & {
     /*
+     * The primary slot, `<input>`, does not support children so we need to explicitly include it here.
+     */
+    children?: React.ReactNode;
+
+    /*
      * Whether the ComboBox allows freeform user input, rather than restricting to the provided options.
      */
     freeform?: boolean;
 
-    /*
-     * The primary slot, `<input>`, does not support children so we need to explicitly include it here.
+    /**
+     * When true, space will insert a character into the text field instead of selecting options.
+     * This is not recommended for most scenarios, but is useful in special cases where typing a space is necessary.
+     * @default false
      */
-    children?: React.ReactNode;
+    allowSpaceAsCharacter?: boolean;
   };
 
 /**


### PR DESCRIPTION
Part of the fixes in #25724

## Previous Behavior

The space key selects options (or opens the listbox popup) by default, which is overwhelmingly what was shown to be expected by people in the user study.

## New Behavior

Space-to-select is still the default behavior, but this adds an `allowSpaceAsCharacter` prop that allows insertion of space characters instead of selection for use cases where that isn't desired (some cases full name selection is one of the scenarios that has come up).
