### PR TITLE
docs: a11y fixes for `Table` examples

### DIFF
--- a/packages/react-components/react-table/stories/Table/CellActions.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/CellActions.stories.tsx
@@ -75,7 +75,7 @@ const columns = [
 
 export const CellActions = () => {
   return (
-    <Table>
+    <Table aria-label="Table with cell actions">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/CellNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/CellNavigation.stories.tsx
@@ -69,7 +69,7 @@ export const CellNavigation = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr}>
+    <Table {...keyboardNavAttr} aria-label="Table with grid keyboard navigation">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/DataGrid.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/DataGrid.stories.tsx
@@ -169,7 +169,7 @@ export const DataGrid = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr} sortable>
+    <Table {...keyboardNavAttr} sortable aria-label="DataGrid implementation with Table primitives">
       <TableHeader>
         <TableRow>
           <TableSelectionCell

--- a/packages/react-components/react-table/stories/Table/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Default.stories.tsx
@@ -67,7 +67,7 @@ const columns = [
 
 export const Default = () => {
   return (
-    <Table>
+    <Table arial-label="Default table">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
@@ -141,10 +141,20 @@ export const MultipleSelect = () => {
     };
   });
 
+  const toggleAllKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ') {
+        toggleAllRows(e);
+        e.preventDefault();
+      }
+    },
+    [toggleAllRows],
+  );
+
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr}>
+    <Table {...keyboardNavAttr} aria-label="Table with multiselect">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
@@ -152,6 +162,7 @@ export const MultipleSelect = () => {
             checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
+            onKeyDown={toggleAllKeydown}
           />
           <TableHeaderCell>File</TableHeaderCell>
           <TableHeaderCell>Author</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -147,10 +147,20 @@ export const MultipleSelectControlled = () => {
     };
   });
 
+  const toggleAllKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ') {
+        toggleAllRows(e);
+        e.preventDefault();
+      }
+    },
+    [toggleAllRows],
+  );
+
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr}>
+    <Table {...keyboardNavAttr} aria-lable="Table with controlled multiselect">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
@@ -158,6 +168,7 @@ export const MultipleSelectControlled = () => {
             checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
+            onKeyDown={toggleAllKeydown}
           />
           <TableHeaderCell>File</TableHeaderCell>
           <TableHeaderCell>Author</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -160,7 +160,7 @@ export const MultipleSelectControlled = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr} aria-lable="Table with controlled multiselect">
+    <Table {...keyboardNavAttr} aria-label="Table with controlled multiselect">
       <TableHeader>
         <TableRow>
           <TableSelectionCell

--- a/packages/react-components/react-table/stories/Table/NonNativeElements.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/NonNativeElements.stories.tsx
@@ -67,7 +67,7 @@ const columns = [
 
 export const NonNativeElements = () => {
   return (
-    <Table noNativeElements>
+    <Table noNativeElements aria-label="Table without semantic HTML elements">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/PrimaryCell.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/PrimaryCell.stories.tsx
@@ -75,7 +75,7 @@ const columns = [
 
 export const PrimaryCell = () => {
   return (
-    <Table>
+    <Table aria-label="Table with primary cell layout">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
@@ -143,7 +143,7 @@ export const SingleSelect = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table>
+    <Table aria-label="Table with single selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell type="radio" hidden />

--- a/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
@@ -149,7 +149,7 @@ export const SingleSelectControlled = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table>
+    <Table aria-label="Table with controlled single selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell type="radio" hidden />

--- a/packages/react-components/react-table/stories/Table/SizeExtraSmall.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SizeExtraSmall.stories.tsx
@@ -67,7 +67,7 @@ const columns = [
 
 export const SizeExtraSmall = () => {
   return (
-    <Table size="extra-small">
+    <Table size="extra-small" aria-label="Table with extra-small size">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/SizeSmall.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SizeSmall.stories.tsx
@@ -67,7 +67,7 @@ const columns = [
 
 export const SizeSmall = () => {
   return (
-    <Table size="small">
+    <Table size="small" aria-label="Table with small size">
       <TableHeader>
         <TableRow>
           {columns.map(column => (

--- a/packages/react-components/react-table/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Sort.stories.tsx
@@ -144,7 +144,7 @@ export const Sort = () => {
   const rows = sort(getRows());
 
   return (
-    <Table sortable {...keyboardNavAttr}>
+    <Table sortable {...keyboardNavAttr} aria-label="Table with sort">
       <TableHeader>
         <TableRow>
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
@@ -149,7 +149,7 @@ export const SortControlled = () => {
   const rows = sort(getRows());
 
   return (
-    <Table sortable {...keyboardNavAttr}>
+    <Table sortable {...keyboardNavAttr} aria-label="Table with controlled sort">
       <TableHeader>
         <TableRow>
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
@@ -154,7 +154,7 @@ export const SubtleSelection = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr} aria-lable="Table with subtle selection">
+    <Table {...keyboardNavAttr} aria-label="Table with subtle selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell

--- a/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
@@ -132,6 +132,7 @@ export const SubtleSelection = () => {
       onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === ' ') {
+          e.preventDefault();
           toggleRow(e, row.rowId);
         }
       },
@@ -140,10 +141,20 @@ export const SubtleSelection = () => {
     };
   });
 
+  const toggleAllKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ') {
+        toggleAllRows(e);
+        e.preventDefault();
+      }
+    },
+    [toggleAllRows],
+  );
+
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr}>
+    <Table {...keyboardNavAttr} aria-lable="Table with subtle selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
@@ -151,6 +162,7 @@ export const SubtleSelection = () => {
             checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
+            onKeyDown={toggleAllKeydown}
           />
           <TableHeaderCell>File</TableHeaderCell>
           <TableHeaderCell>Author</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/Virtualization.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Virtualization.stories.tsx
@@ -151,8 +151,18 @@ export const Virtualization = () => {
     };
   });
 
+  const toggleAllKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ') {
+        toggleAllRows(e);
+        e.preventDefault();
+      }
+    },
+    [toggleAllRows],
+  );
+
   return (
-    <Table noNativeElements {...keyboardNavAttr}>
+    <Table noNativeElements {...keyboardNavAttr} aria-label="Table with selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
@@ -160,6 +170,7 @@ export const Virtualization = () => {
             checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
+            onKeyDown={toggleAllKeydown}
           />
           <TableHeaderCell>File</TableHeaderCell>
           <TableHeaderCell>Author</TableHeaderCell>
@@ -175,6 +186,8 @@ export const Virtualization = () => {
             const { item, selected, appearance, onClick, onKeyDown } = data[index];
             return (
               <TableRow
+                aria-rowindex={index}
+                aria-rowcount={data.length}
                 style={style}
                 key={item.file.label}
                 onKeyDown={onKeyDown}


### PR DESCRIPTION
- Add `e.preventDefault` for some spacebar selection examples that were missing
- Adds aria-labels to table examples
- Adds `aria-rowindex` and `aria-rowcount` to virtualized table example