### PR TITLE
fix(DataGridRow): `children` type should only be render function

### DIFF
--- a/change/@fluentui-react-table-6f2d8d51-2a06-4d30-84bb-01051233a5fe.json
+++ b/change/@fluentui-react-table-6f2d8d51-2a06-4d30-84bb-01051233a5fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(DataGridRow): `children` type should only be render function",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -146,7 +146,7 @@ export const DataGridRow: ForwardRefComponent<DataGridRowProps>;
 export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots>;
 
 // @public
-export type DataGridRowProps = Omit<TableRowProps, 'children'> & ComponentProps<DataGridRowSlots> & {
+export type DataGridRowProps = Omit<TableRowProps, 'children'> & Omit<ComponentProps<DataGridRowSlots>, 'children'> & {
     children: CellRenderFunction;
 };
 

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
@@ -21,7 +21,7 @@ export type CellRenderFunction = (column: ColumnDefinition<any>) => React.ReactN
  * DataGridRow Props
  */
 export type DataGridRowProps = Omit<TableRowProps, 'children'> &
-  ComponentProps<DataGridRowSlots> & {
+  Omit<ComponentProps<DataGridRowSlots>, 'children'> & {
     children: CellRenderFunction;
   };
 


### PR DESCRIPTION
## Previous Behavior

The `children` type from `ComponentProps` was being intersected with the explicit `children` type declared in props, so the expected type was actually `string & CellRenderFunction | false & CellRenderFunction...`

## New Behavior

The `children` type can only be of `CellRenderFunction`

