### PR TITLE
fix: remove unnecessary selectable ref and add support for aria-describedby on card preview

### DIFF
--- a/change/@fluentui-react-card-9d79f524-9dc5-44c5-ab24-44afd1ece6ff.json
+++ b/change/@fluentui-react-card-9d79f524-9dc5-44c5-ab24-44afd1ece6ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unnecessary selectable ref and add support for aria-describedby on card preview",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -66,23 +66,13 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLDivElement
   const [referenceLabel, setReferenceLabel] = React.useState(cardContextDefaultValue.selectableA11yProps.referenceId);
 
   const cardBaseRef = useFocusWithin<HTMLDivElement>();
-  const { selectable, selected, selectableRef, selectableCardProps, selectFocused, checkboxSlot } = useCardSelectable(
+  const { selectable, selected, selectableCardProps, selectFocused, checkboxSlot } = useCardSelectable(
     props,
     { referenceId, referenceLabel },
     cardBaseRef,
   );
 
   const cardRef = useMergedRefs(cardBaseRef, ref);
-
-  const floatingActionSlot = React.useMemo(
-    () =>
-      resolveShorthand(floatingAction, {
-        defaultProps: {
-          ref: selectableRef,
-        },
-      }),
-    [floatingAction, selectableRef],
-  );
 
   const { interactive, focusAttributes } = useCardInteractive(props);
 
@@ -115,7 +105,7 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLDivElement
       ...selectableCardProps,
     }),
 
-    floatingAction: floatingActionSlot,
+    floatingAction: resolveShorthand(floatingAction),
     checkbox: checkboxSlot,
   };
 };

--- a/packages/react-components/react-card/src/components/CardPreview/useCardPreview.ts
+++ b/packages/react-components/react-card/src/components/CardPreview/useCardPreview.ts
@@ -17,12 +17,12 @@ export const useCardPreview_unstable = (props: CardPreviewProps, ref: React.Ref<
   const { logo } = props;
 
   const {
-    selectableA11yProps: { referenceLabel, setReferenceLabel },
+    selectableA11yProps: { referenceLabel, referenceId, setReferenceLabel, setReferenceId },
   } = useCardContext_unstable();
   const previewRef = useMergedRefs(ref, React.useRef<HTMLDivElement>(null));
 
   React.useEffect(() => {
-    if (referenceLabel) {
+    if (referenceLabel && referenceId) {
       return;
     }
 
@@ -31,15 +31,18 @@ export const useCardPreview_unstable = (props: CardPreviewProps, ref: React.Ref<
 
       if (img) {
         const ariaLabel = img.getAttribute('aria-label');
+        const ariaDescribedby = img.getAttribute('aria-describedby');
 
-        if (img.alt) {
+        if (ariaDescribedby) {
+          setReferenceId(ariaDescribedby);
+        } else if (img.alt) {
           setReferenceLabel(img.alt);
         } else if (ariaLabel) {
           setReferenceLabel(ariaLabel);
         }
       }
     }
-  }, [setReferenceLabel, referenceLabel, previewRef]);
+  }, [setReferenceLabel, referenceLabel, previewRef, referenceId, setReferenceId]);
 
   return {
     components: {

--- a/packages/react-components/react-card/stories/Card/CardSelectableIndicator.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardSelectableIndicator.stories.tsx
@@ -64,19 +64,21 @@ export const SelectableIndicator = () => {
   const [selected3, setSelected3] = React.useState(false);
   const [selected4, setSelected4] = React.useState(false);
 
-  const onFirstCardSelected = React.useCallback((_, { selected }) => setSelected1(selected), [setSelected1]);
-  const onSecondCardSelected = React.useCallback((_, { selected }) => setSelected2(selected), [setSelected2]);
-  const onThirdCardSelected = React.useCallback((_, { selected }) => setSelected3(selected), [setSelected3]);
-  const onForthCardSelected = React.useCallback((_, { selected }) => setSelected4(selected), [setSelected4]);
+  const setCheckboxState = React.useCallback(({ selected, checked }, setFn) => setFn(!!(selected || checked)), []);
+
+  const onSelected1Change = React.useCallback((_, state) => setCheckboxState(state, setSelected1), [setCheckboxState]);
+  const onSelected2Change = React.useCallback((_, state) => setCheckboxState(state, setSelected2), [setCheckboxState]);
+  const onSelected3Change = React.useCallback((_, state) => setCheckboxState(state, setSelected3), [setCheckboxState]);
+  const onSelected4Change = React.useCallback((_, state) => setCheckboxState(state, setSelected4), [setCheckboxState]);
 
   return (
     <div className={styles.main}>
       <div className={styles.row}>
         <Card
           className={styles.card}
-          floatingAction={<Checkbox checked={selected1} />}
+          floatingAction={<Checkbox onChange={onSelected1Change} checked={selected1} />}
           selected={selected1}
-          onSelectionChange={onFirstCardSelected}
+          onSelectionChange={onSelected1Change}
         >
           <CardPreview
             className={styles.grayBackground}
@@ -94,9 +96,9 @@ export const SelectableIndicator = () => {
 
         <Card
           className={styles.card}
-          floatingAction={<Checkbox checked={selected2} />}
+          floatingAction={<Checkbox onChange={onSelected2Change} checked={selected2} />}
           selected={selected2}
-          onSelectionChange={onSecondCardSelected}
+          onSelectionChange={onSelected2Change}
         >
           <CardPreview
             className={styles.grayBackground}
@@ -114,31 +116,21 @@ export const SelectableIndicator = () => {
       </div>
 
       <div className={styles.row}>
-        <Card className={styles.card} selected={selected3} onSelectionChange={onThirdCardSelected}>
+        <Card className={styles.card} selected={selected3} onSelectionChange={onSelected3Change}>
           <CardHeader
             image={<img src={resolveAsset('word_logo.svg')} alt="Microsoft Word Logo" />}
             header={<Text weight="semibold">Secret Project Briefing</Text>}
             description={<Caption1 className={styles.caption}>OneDrive &gt; Documents</Caption1>}
-            action={
-              <div className={styles.actions}>
-                <Button appearance="transparent" icon={<MoreHorizontal20Filled />} aria-label="More actions" />
-                <Checkbox checked={selected3} />
-              </div>
-            }
+            action={<Checkbox onChange={onSelected3Change} checked={selected3} />}
           />
         </Card>
 
-        <Card className={styles.card} selected={selected4} onSelectionChange={onForthCardSelected}>
+        <Card className={styles.card} selected={selected4} onSelectionChange={onSelected4Change}>
           <CardHeader
             image={<img src={resolveAsset('excel_logo.svg')} alt="Microsoft Excel Logo" />}
             header={<Text weight="semibold">Team Budget</Text>}
             description={<Caption1 className={styles.caption}>OneDrive &gt; Spreadsheets</Caption1>}
-            action={
-              <div className={styles.actions}>
-                <Button appearance="transparent" icon={<MoreHorizontal20Filled />} aria-label="More actions" />
-                <Checkbox checked={selected4} />
-              </div>
-            }
+            action={<Checkbox onChange={onSelected4Change} checked={selected4} />}
           />
         </Card>
       </div>


### PR DESCRIPTION
## New Behavior
Card had support for some a11y attributes, and this PR adds also `aria-describedby` to this list. By default, we try to guess and correctly set the accessible tags to the selectable cards.