### PR TITLE
chore: upgrade storybook-addon-export-to-codesandbox to patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "screener-storybook": "0.23.0",
     "semver": "^6.2.0",
     "source-map-loader": "4.0.0",
-    "storybook-addon-export-to-codesandbox": "0.7.0",
+    "storybook-addon-export-to-codesandbox": "0.7.1",
     "storybook-addon-performance": "0.16.1",
     "strip-ansi": "6.0.0",
     "style-loader": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24470,10 +24470,10 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
-storybook-addon-export-to-codesandbox@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.7.0.tgz#530d6fa1bbc27a7d93c2909fa21341b75546565b"
-  integrity sha512-euSgOCzFggjl5iDLpq853ygIz/RoyCBHFCo+IFkFkCWbMtP/wHqjR0+fqm/t0iebe4px+L7cfFY/tFC3xsZcyg==
+storybook-addon-export-to-codesandbox@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.7.1.tgz#bdfeddc1bde2cc6178a31298305db5c276bb4127"
+  integrity sha512-ARroFvBylOcyc+XkG0xJmrFo4CokXpKqJVSwLP3ZUSYakqRvqSZaGEefoR5zDFvqZjG7XLX7D6g9cfnId3uUEg==
   dependencies:
     codesandbox-import-utils "^2.2.3"
     pkg-up "^3.1.0"


### PR DESCRIPTION
Bump version of storybook-addon-export-to-codesandbox. This fixes an issue with conditional rendering of a React hook, causing the storybook to crash.

More details: https://github.com/microsoft/fluentui-storybook-addons/pull/22