### PR TITLE
fix: Explicit focus outline for TableHeaderCell and TableSelectionCell

### DIFF
--- a/change/@fluentui-react-table-1c69ba37-4433-4fe5-917e-0580a0f84821.json
+++ b/change/@fluentui-react-table-1c69ba37-4433-4fe5-917e-0580a0f84821.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Explicit focus outline for TableHeaderCell and TableSelectionCell",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
+import { useFocusWithin } from '@fluentui/react-tabster';
 import { ArrowUpRegular, ArrowDownRegular } from '@fluentui/react-icons';
 import type { TableHeaderCellProps, TableHeaderCellState } from './TableHeaderCell.types';
 import { useTableContext } from '../../contexts/tableContext';
@@ -33,7 +34,7 @@ export const useTableHeaderCell_unstable = (
       sortIcon: 'span',
     },
     root: getNativeElementProps(rootComponent, {
-      ref,
+      ref: useMergedRefs(ref, useFocusWithin()),
       role: rootComponent === 'div' ? 'columnheader' : undefined,
       'aria-sort': sortable ? props.sortDirection ?? 'none' : undefined,
       ...props,

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCellStyles.ts
@@ -74,6 +74,7 @@ const useStyles = makeStyles({
     ...shorthands.gap(tokens.spacingHorizontalXS),
     minHeight: '32px',
     ...shorthands.flex(1, 1, '0px'),
+    outlineStyle: 'none',
   },
   sortable: {
     cursor: 'pointer',

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCellStyles.ts
@@ -1,6 +1,7 @@
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { TableHeaderCellSlots, TableHeaderCellState } from './TableHeaderCell.types';
 
 export const tableHeaderCellClassName = 'fui-TableHeaderCell';
@@ -31,6 +32,13 @@ const useFlexLayoutStyles = makeStyles({
 const useStyles = makeStyles({
   root: {
     ...shorthands.padding('0px', tokens.spacingHorizontalS),
+    ...createCustomFocusIndicatorStyle(
+      {
+        ...shorthands.outline('2px', 'solid', tokens.colorStrokeFocus2),
+        ...shorthands.borderRadius(tokens.borderRadiusMedium),
+      },
+      { selector: 'focus-within', enableOutline: true },
+    ),
   },
 
   rootInteractive: {

--- a/packages/react-components/react-table/src/components/TableSelectionCell/useTableSelectionCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableSelectionCell/useTableSelectionCellStyles.ts
@@ -2,6 +2,7 @@ import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { TableSelectionCellSlots, TableSelectionCellState } from './TableSelectionCell.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+import { tokens } from '@fluentui/react-theme';
 
 export const tableSelectionCellClassNames: SlotClassNames<TableSelectionCellSlots> = {
   root: 'fui-TableSelectionCell',
@@ -34,6 +35,13 @@ const useStyles = makeStyles({
     textAlign: 'center',
     whiteSpace: 'nowrap',
     ...shorthands.padding(0),
+    ...createCustomFocusIndicatorStyle(
+      {
+        ...shorthands.outline('2px', 'solid', tokens.colorStrokeFocus2),
+        ...shorthands.borderRadius(tokens.borderRadiusMedium),
+      },
+      { selector: 'focus', enableOutline: true },
+    ),
   },
 
   radioIndicator: {


### PR DESCRIPTION
## Previous Behavior

Focus outlines can be different colours on browsers (i.e. blue in Firefox)

## New Behavior

Focus outlines will follow design spec

