### PR TITLE
docs: Table examples generally navigate with tab

### DIFF
--- a/change/@fluentui-react-table-8a90996b-247e-47ef-9827-afa7c5daee47.json
+++ b/change/@fluentui-react-table-8a90996b-247e-47ef-9827-afa7c5daee47.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Table examples generally navigate with tab",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-table/stories/Table/CellNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/CellNavigation.stories.tsx
@@ -69,7 +69,7 @@ export const CellNavigation = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr} aria-label="Table with grid keyboard navigation">
+    <Table {...keyboardNavAttr} role="grid" aria-label="Table with grid keyboard navigation">
       <TableHeader>
         <TableRow>
           {columns.map(column => (
@@ -81,10 +81,10 @@ export const CellNavigation = () => {
       <TableBody>
         {items.map(item => (
           <TableRow key={item.file.label}>
-            <TableCell tabIndex={0}>
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>
-            <TableCell tabIndex={0}>
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout
                 media={
                   <Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />
@@ -93,11 +93,13 @@ export const CellNavigation = () => {
                 {item.author.label}
               </TableCellLayout>
             </TableCell>
-            <TableCell tabIndex={0}>{item.lastUpdated.label}</TableCell>
-            <TableCell tabIndex={0}>
+            <TableCell tabIndex={0} role="gridcell">
+              {item.lastUpdated.label}
+            </TableCell>
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
             </TableCell>
-            <TableCell>
+            <TableCell role="gridcell">
               <TableCellLayout>
                 <Button icon={<EditRegular />}>Edit</Button>
               </TableCellLayout>
@@ -115,6 +117,9 @@ CellNavigation.parameters = {
       story: [
         'The `Table` primitive components do not support keyboard navigation. This should be added by users.',
         'Cell navigation can be achieved simply using the `useArrowNavigationGroup` utility provided by the Library.',
+        '',
+        '>⚠️ Once there is any kind of keyboard navigation on the component it must follow the',
+        '>[aria role="grid" pattern](https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids).',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-table/stories/Table/DataGrid.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/DataGrid.stories.tsx
@@ -169,13 +169,15 @@ export const DataGrid = () => {
   const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <Table {...keyboardNavAttr} sortable aria-label="DataGrid implementation with Table primitives">
+    <Table {...keyboardNavAttr} role="grid" sortable aria-label="DataGrid implementation with Table primitives">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
+            checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
+            aria-checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             tabIndex={0}
             checkboxIndicator={{ tabIndex: -1 }}
-            checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
+            role="checkbox"
             onClick={toggleAllRows}
           />
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>
@@ -193,17 +195,25 @@ export const DataGrid = () => {
             aria-selected={selected}
             appearance={appearance}
           >
-            <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} />
-            <TableCell tabIndex={0}>
+            <TableSelectionCell
+              tabIndex={0}
+              checkboxIndicator={{ tabIndex: -1 }}
+              role="gridcell"
+              aria-selected={selected}
+              checked={selected}
+            />
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>
-            <TableCell tabIndex={0}>
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout media={<Avatar badge={{ status: item.author.status }} />}>
                 {item.author.label}
               </TableCellLayout>
             </TableCell>
-            <TableCell tabIndex={0}>{item.lastUpdated.label}</TableCell>
-            <TableCell tabIndex={0}>
+            <TableCell tabIndex={0} role="gridcell">
+              {item.lastUpdated.label}
+            </TableCell>
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
             </TableCell>
           </TableRow>

--- a/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelect.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -151,15 +151,11 @@ export const MultipleSelect = () => {
     [toggleAllRows],
   );
 
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
-
   return (
-    <Table {...keyboardNavAttr} aria-label="Table with multiselect">
+    <Table aria-label="Table with multiselect">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
-            tabIndex={0}
-            checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
             onKeyDown={toggleAllKeydown}
@@ -179,7 +175,7 @@ export const MultipleSelect = () => {
             aria-selected={selected}
             appearance={appearance}
           >
-            <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} />
+            <TableSelectionCell checked={selected} />
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>

--- a/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/MultipleSelectControlled.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -157,15 +157,11 @@ export const MultipleSelectControlled = () => {
     [toggleAllRows],
   );
 
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
-
   return (
-    <Table {...keyboardNavAttr} aria-label="Table with controlled multiselect">
+    <Table aria-label="Table with controlled multiselect">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
-            tabIndex={0}
-            checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
             onKeyDown={toggleAllKeydown}
@@ -185,7 +181,7 @@ export const MultipleSelectControlled = () => {
             aria-selected={selected}
             appearance={appearance}
           >
-            <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} />
+            <TableSelectionCell checked={selected} />
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>

--- a/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelect.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -140,7 +140,6 @@ export const SingleSelect = () => {
       appearance: selected ? ('brand' as const) : ('none' as const),
     };
   });
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
     <Table aria-label="Table with single selection">
@@ -153,7 +152,7 @@ export const SingleSelect = () => {
           <TableHeaderCell>Last update</TableHeaderCell>
         </TableRow>
       </TableHeader>
-      <TableBody {...keyboardNavAttr}>
+      <TableBody>
         {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
           <TableRow
             key={item.file.label}
@@ -162,7 +161,7 @@ export const SingleSelect = () => {
             aria-selected={selected}
             appearance={appearance}
           >
-            <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} type="radio" />
+            <TableSelectionCell checked={selected} type="radio" />
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>

--- a/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SingleSelectControlled.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -146,8 +146,6 @@ export const SingleSelectControlled = () => {
     };
   });
 
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
-
   return (
     <Table aria-label="Table with controlled single selection">
       <TableHeader>
@@ -159,7 +157,7 @@ export const SingleSelectControlled = () => {
           <TableHeaderCell>Last update</TableHeaderCell>
         </TableRow>
       </TableHeader>
-      <TableBody {...keyboardNavAttr}>
+      <TableBody>
         {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
           <TableRow
             key={item.file.label}
@@ -168,7 +166,7 @@ export const SingleSelectControlled = () => {
             aria-selected={selected}
             appearance={appearance}
           >
-            <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} type="radio" />
+            <TableSelectionCell checked={selected} type="radio" />
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>

--- a/packages/react-components/react-table/stories/Table/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Sort.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -132,8 +132,6 @@ export const Sort = () => {
     [useTableSort({ defaultSortState: { sortColumn: 'file', sortDirection: 'ascending' } })],
   );
 
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
-
   const headerSortProps = (columnId: ColumnId) => ({
     onClick: (e: React.MouseEvent) => {
       toggleColumnSort(e, columnId);
@@ -144,7 +142,7 @@ export const Sort = () => {
   const rows = sort(getRows());
 
   return (
-    <Table sortable {...keyboardNavAttr} aria-label="Table with sort">
+    <Table sortable aria-label="Table with sort">
       <TableHeader>
         <TableRow>
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SortControlled.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -139,7 +139,6 @@ export const SortControlled = () => {
     },
     [useTableSort({ sortState, onSortChange: (e, nextSortState) => setSortState(nextSortState) })],
   );
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
 
   const headerSortProps = (columnId: ColumnId) => ({
     onClick: (e: React.MouseEvent) => toggleColumnSort(e, columnId),
@@ -149,7 +148,7 @@ export const SortControlled = () => {
   const rows = sort(getRows());
 
   return (
-    <Table sortable {...keyboardNavAttr} aria-label="Table with controlled sort">
+    <Table sortable aria-label="Table with controlled sort">
       <TableHeader>
         <TableRow>
           <TableHeaderCell {...headerSortProps('file')}>File</TableHeaderCell>

--- a/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SubtleSelection.stories.tsx
@@ -8,7 +8,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -151,15 +151,11 @@ export const SubtleSelection = () => {
     [toggleAllRows],
   );
 
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
-
   return (
-    <Table {...keyboardNavAttr} aria-label="Table with subtle selection">
+    <Table aria-label="Table with subtle selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
-            tabIndex={0}
-            checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
             onKeyDown={toggleAllKeydown}
@@ -179,7 +175,7 @@ export const SubtleSelection = () => {
             aria-selected={selected}
             appearance={appearance}
           >
-            <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} subtle checked={selected} />
+            <TableSelectionCell subtle checked={selected} />
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>

--- a/packages/react-components/react-table/stories/Table/TableDescription.md
+++ b/packages/react-components/react-table/stories/Table/TableDescription.md
@@ -24,3 +24,6 @@ The `useTableFeatures` hook was designed with feature composition in mind. This 
 plugins hooks such as `useTableSort` and `useTableSelection` as a part of `useTableFeatures`. This means
 that as the feature set expands, users will not need to pay the bundle size price for features that they do not intend
 to use. Please consult the usage examples below for more details.
+
+> ⚠️ Once there is any kind of keyboard navigation on the component it must follow the
+> [aria role="grid" pattern](https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids)

--- a/packages/react-components/react-table/stories/Table/Virtualization.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Virtualization.stories.tsx
@@ -9,7 +9,7 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import { PresenceBadgeStatus, Avatar, useArrowNavigationGroup } from '@fluentui/react-components';
+import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
 import {
   TableBody,
   TableCell,
@@ -133,8 +133,6 @@ export const Virtualization = () => {
     ],
   );
 
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
-
   const rows: RowState[] = getRows(row => {
     const selected = isRowSelected(row.rowId);
     return {
@@ -162,12 +160,10 @@ export const Virtualization = () => {
   );
 
   return (
-    <Table noNativeElements {...keyboardNavAttr} aria-label="Table with selection">
+    <Table noNativeElements aria-label="Table with selection">
       <TableHeader>
         <TableRow>
           <TableSelectionCell
-            tabIndex={0}
-            checkboxIndicator={{ tabIndex: -1 }}
             checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
             onClick={toggleAllRows}
             onKeyDown={toggleAllKeydown}
@@ -194,7 +190,7 @@ export const Virtualization = () => {
                 onClick={onClick}
                 appearance={appearance}
               >
-                <TableSelectionCell tabIndex={0} checkboxIndicator={{ tabIndex: -1 }} checked={selected} />
+                <TableSelectionCell checked={selected} />
                 <TableCell>
                   <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
                 </TableCell>


### PR DESCRIPTION
All Table examples will navigate with tab. Added warnings to keyboard navigation examples that any keyboard navigation on the primitives must use the `role="grid"` pattern.
