### PR TITLE
fix: v8 Modal examples use heading tags

### DIFF
--- a/packages/react-examples/src/react/Modal/Modal.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Modal/Modal.Basic.Example.tsx
@@ -57,7 +57,9 @@ export const ModalBasicExample: React.FunctionComponent = () => {
         dragOptions={isDraggable ? dragOptions : undefined}
       >
         <div className={contentStyles.header}>
-          <span id={titleId}>Lorem Ipsum</span>
+          <h2 className={contentStyles.heading} id={titleId}>
+            Lorem Ipsum
+          </h2>
           <IconButton
             styles={iconButtonStyles}
             iconProps={cancelIcon}
@@ -134,6 +136,12 @@ const contentStyles = mergeStyleSets({
       padding: '12px 12px 14px 24px',
     },
   ],
+  heading: {
+    color: theme.palette.neutralPrimary,
+    fontWeight: FontWeights.semibold,
+    fontSize: 'inherit',
+    margin: '0',
+  },
   body: {
     flex: '4 4 auto',
     padding: '0 24px 24px 24px',

--- a/packages/react-examples/src/react/Modal/Modal.Modeless.Example.tsx
+++ b/packages/react-examples/src/react/Modal/Modal.Modeless.Example.tsx
@@ -48,7 +48,9 @@ export const ModalModelessExample: React.FunctionComponent = () => {
         dragOptions={isDraggable ? dragOptions : undefined}
       >
         <div className={contentStyles.header}>
-          <span id={titleId}>Lorem Ipsum</span>
+          <h2 className={contentStyles.heading} id={titleId}>
+            Lorem Ipsum
+          </h2>
           <IconButton
             styles={iconButtonStyles}
             iconProps={cancelIcon}
@@ -94,6 +96,12 @@ const contentStyles = mergeStyleSets({
       padding: '12px 12px 14px 24px',
     },
   ],
+  heading: {
+    color: theme.palette.neutralPrimary,
+    fontWeight: FontWeights.semibold,
+    fontSize: 'inherit',
+    margin: '0',
+  },
   body: {
     flex: '4 4 auto',
     padding: '0 24px 24px 24px',


### PR DESCRIPTION
Resolves an ADO bug, small example-content-only tag fix.