### PR TITLE
fix: Avatar shouldn't render an icon when displaying an image

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Avatar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Avatar.stories.tsx
@@ -243,4 +243,5 @@ storiesOf('Avatar Converged', module)
     includeHighContrast: true,
     includeDarkMode: true,
   })
-  .addStory('image-bad-url', () => <Avatar name="Broken Image" image={{ src: `${imageRoot}/bad_image_url.jpg` }} />);
+  .addStory('image-bad-url', () => <Avatar name="Broken Image" image={{ src: `${imageRoot}/bad_image_url.jpg` }} />)
+  .addStory('image-bad-url+icon', () => <Avatar image={{ src: `${imageRoot}/bad_image_url.jpg` }} />);

--- a/change/@fluentui-react-avatar-34fac678-ed67-41e8-b561-e6b3e88ada07.json
+++ b/change/@fluentui-react-avatar-34fac678-ed67-41e8-b561-e6b3e88ada07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Avatar shouldn't render an icon when displaying an image (performance)",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -26,15 +26,11 @@ describe('Avatar', () => {
         },
         {
           props: {
-            image: { src: 'avatar.png', alt: 'test-image' },
             icon: 'Test Icon',
-            badge: 'Test Badge',
           },
           expectedClassNames: {
             root: avatarClassNames.root,
-            image: avatarClassNames.image,
             icon: avatarClassNames.icon,
-            badge: avatarClassNames.badge,
           },
         },
       ],
@@ -108,13 +104,11 @@ describe('Avatar', () => {
     );
   });
 
-  it('prioritizes image over icon', () => {
+  it('does not render the icon when there is an image', () => {
     render(<Avatar icon={<img src="i.svg" alt="test-icon" />} image={{ src: 'avatar.png', alt: 'test-image' }} />);
 
-    // Both are rendered, but the icon precedes the image, and are hidden by it
-    expect(screen.getByAltText('test-image').compareDocumentPosition(screen.getByAltText('test-icon'))).toBe(
-      Node.DOCUMENT_POSITION_PRECEDING,
-    );
+    expect(screen.getByAltText('test-image')).toBeTruthy();
+    expect(screen.queryByAltText('test-icon')).toBeFalsy();
   });
 
   it('prioritizes image over initials and icon', () => {

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -44,28 +44,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     /* excludedPropNames: */ ['name'],
   );
 
-  // Resolve the initials slot, defaulted to getInitials.
-  let initials: AvatarState['initials'] = resolveShorthand(props.initials, {
-    required: true,
-    defaultProps: {
-      children: getInitials(name, dir === 'rtl', { firstInitialOnly: size <= 16 }),
-      id: baseId + '__initials',
-    },
-  });
-
-  // Render the icon slot *only if* there aren't any initials to display.
-  let icon: AvatarState['icon'] = undefined;
-  if (!initials?.children) {
-    initials = undefined;
-    icon = resolveShorthand(props.icon, {
-      required: true,
-      defaultProps: {
-        children: <PersonRegular />,
-        'aria-hidden': true,
-      },
-    });
-  }
-
   const [imageHidden, setImageHidden] = React.useState<true | undefined>(undefined);
   const image: AvatarState['image'] = resolveShorthand(props.image, {
     defaultProps: {
@@ -80,6 +58,32 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   if (image) {
     image.onError = mergeCallbacks(image.onError, () => setImageHidden(true));
     image.onLoad = mergeCallbacks(image.onLoad, () => setImageHidden(undefined));
+  }
+
+  // Resolve the initials slot, defaulted to getInitials.
+  let initials: AvatarState['initials'] = resolveShorthand(props.initials, {
+    required: true,
+    defaultProps: {
+      children: getInitials(name, dir === 'rtl', { firstInitialOnly: size <= 16 }),
+      id: baseId + '__initials',
+    },
+  });
+
+  // Don't render the initials slot if it's empty
+  if (!initials?.children) {
+    initials = undefined;
+  }
+
+  // Render the icon slot *only if* there aren't any initials or image to display
+  let icon: AvatarState['icon'] = undefined;
+  if (!initials && (!image || imageHidden)) {
+    icon = resolveShorthand(props.icon, {
+      required: true,
+      defaultProps: {
+        children: <PersonRegular />,
+        'aria-hidden': true,
+      },
+    });
   }
 
   const badge: AvatarState['badge'] = resolveShorthand(props.badge, {


### PR DESCRIPTION
## Previous Behavior

When an Avatar is displaying only an image and isn't displaying initials, it also renders the icon behind the image. This was done to ensure that something is displayed while the image is loading, or if the image fails to load. However, it causes performance issues by always rendering both the icon and image.

These are the results when running the perf tests from @ling1726's PR #25776. Note: **⭐ AvatarTestV9.perf.tsx** is the one testing the scenario in the bug; the others are for comparison.

| Example                     | avg       | description                               |
| --------------------------- | --------- | ----------------------------------------- |
| ⭐ AvatarTestV9.perf.tsx   | 🟥 58.84  | v9 Avatar with `image`                    |
| AvatarTestV9NoIcon.perf.tsx | 🟩 37.93     | v9 Avatar with `image`, and `icon={null}` |
| AvatarTestv9Image.perf.tsx  | 🟩  27.84     | just an `img` (no Avatar)                 |
| AvatarTestV0.perf.tsx       | 🟧 52.54     | v0 Avatar                                 |

## New Behavior

Don't render the icon if there is an image, unless the image fails to load.

Note: This only affects Avatars that don't have the `name` or `initials` properties set: if either of those is set, then the initials will always render behind the image, and they will be visible while the image is loading.

The runtime of **⭐ AvatarTestV9.perf.tsx** from @ling1726's PR #25776 is improved to 38.15 (down from 58.84). Here are the full results:

| Example                     | avg       | description                               |
| --------------------------- | --------- | ----------------------------------------- |
| ⭐ AvatarTestV9.perf.tsx   | 🟩 38.15  | v9 Avatar with `image`                    |
| AvatarTestV9NoIcon.perf.tsx | 🟩 38.89     | v9 Avatar with `image`, and `icon={null}` |
| AvatarTestv9Image.perf.tsx  | 🟩 27.33     | just an `img` (no Avatar)                 |
| AvatarTestV0.perf.tsx       | 🟧 52.15     | v0 Avatar                                 |

## Related Issue(s)

* Fixes #25777
