### PR TITLE
fix: Removing weird hover style on first option in multiselect Comboboxes

### DIFF
--- a/change/@fluentui-react-3a53c3c8-e896-4cd0-9227-2979ec7a93c7.json
+++ b/change/@fluentui-react-3a53c3c8-e896-4cd0-9227-2979ec7a93c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Removing weird hover style on first option in multiselect Comboboxes.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1660,7 +1660,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       (includeCurrentPendingValue && currentPendingValue !== null && currentPendingValue !== undefined)
       ? currentPendingValueValidIndex
       : this.props.multiSelect
-      ? 0
+      ? -1
       : this._getFirstSelectedIndex();
   }
 


### PR DESCRIPTION
## Previous Behavior

The first option in multiselect `Comboboxes` had a hover style applied that wasn't applied to any other option.

![Before](https://user-images.githubusercontent.com/7798177/206557805-70ef5f40-8b4b-41ce-b10b-efb299a067c7.gif)

## New Behavior

The first option in multiselect `Comboboxes` no longer has a unique hover style applied.

![After](https://user-images.githubusercontent.com/7798177/206557824-7be5b897-308f-4fda-9ac3-5162a7992690.gif)

## Related Issue(s)

* Fixes #23645
