### PR TITLE
fix(DataGridSelectionCell): should render `aria-selected` on the cell

### DIFF
--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/DataGridSelectionCell.test.tsx
@@ -73,6 +73,36 @@ describe('DataGridSelectionCell', () => {
     expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
   });
 
+  it('should render aria-selected=true on cell if row is selected', () => {
+    const isRowSelected = () => true;
+    const ctx = mockDataGridContext(
+      { selectableRows: true },
+      { selection: { isRowSelected, selectionMode: 'multiselect' } },
+    );
+    const { getByRole } = render(
+      <DataGridContextProvider value={ctx}>
+        <DataGridSelectionCell />
+      </DataGridContextProvider>,
+    );
+
+    expect(getByRole('gridcell').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('should render aria-selected=false on cell if row is not selected', () => {
+    const isRowSelected = () => false;
+    const ctx = mockDataGridContext(
+      { selectableRows: true },
+      { selection: { isRowSelected, selectionMode: 'multiselect' } },
+    );
+    const { getByRole } = render(
+      <DataGridContextProvider value={ctx}>
+        <DataGridSelectionCell />
+      </DataGridContextProvider>,
+    );
+
+    expect(getByRole('gridcell').getAttribute('aria-selected')).toBe('false');
+  });
+
   describe('in header', () => {
     it('should render indeterminate checkbox if some rows are selected in multiselect mode', () => {
       const someRowsSelected = true;
@@ -125,6 +155,54 @@ describe('DataGridSelectionCell', () => {
 
       fireEvent.click(getByRole('checkbox'));
       expect(toggleAllRows).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render aria-checked false if no rows are selected', () => {
+      const ctx = mockDataGridContext(
+        { selectableRows: true },
+        { selection: { allRowsSelected: false, someRowsSelected: false, selectionMode: 'multiselect' } },
+      );
+      const { getByRole } = render(
+        <DataGridHeader>
+          <DataGridContextProvider value={ctx}>
+            <DataGridSelectionCell />
+          </DataGridContextProvider>
+        </DataGridHeader>,
+      );
+
+      expect(getByRole('gridcell').getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('should render aria-checked mixed if some rows are selected', () => {
+      const ctx = mockDataGridContext(
+        { selectableRows: true },
+        { selection: { allRowsSelected: false, someRowsSelected: true, selectionMode: 'multiselect' } },
+      );
+      const { getByRole } = render(
+        <DataGridHeader>
+          <DataGridContextProvider value={ctx}>
+            <DataGridSelectionCell />
+          </DataGridContextProvider>
+        </DataGridHeader>,
+      );
+
+      expect(getByRole('gridcell').getAttribute('aria-checked')).toBe('mixed');
+    });
+
+    it('should render aria-checked true if all rows are selected', () => {
+      const ctx = mockDataGridContext(
+        { selectableRows: true },
+        { selection: { allRowsSelected: true, someRowsSelected: true, selectionMode: 'multiselect' } },
+      );
+      const { getByRole } = render(
+        <DataGridHeader>
+          <DataGridContextProvider value={ctx}>
+            <DataGridSelectionCell />
+          </DataGridContextProvider>
+        </DataGridHeader>,
+      );
+
+      expect(getByRole('gridcell').getAttribute('aria-checked')).toBe('true');
     });
   });
 });

--- a/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
@@ -21,10 +21,9 @@ export const useDataGridSelectionCell_unstable = (
 ): DataGridSelectionCellState => {
   const isHeader = useIsInTableHeader();
   const rowId = useRowIdContext();
-  const multiselect = useDataGridContext_unstable(ctx => ctx.selection.selectionMode === 'multiselect');
   const subtle = useDataGridContext_unstable(ctx => ctx.subtleSelection);
   const checked = useDataGridContext_unstable(ctx => {
-    if (isHeader && multiselect) {
+    if (isHeader && ctx.selection.selectionMode === 'multiselect') {
       return ctx.selection.allRowsSelected ? true : ctx.selection.someRowsSelected ? 'mixed' : false;
     }
 
@@ -51,7 +50,9 @@ export const useDataGridSelectionCell_unstable = (
       checked,
       type,
       tabIndex: 0,
-      hidden: isHeader && !multiselect,
+      hidden: isHeader && type === 'radio',
+      'aria-checked': isHeader ? checked : undefined,
+      'aria-selected': isHeader || checked === 'mixed' ? undefined : checked,
       subtle,
       checkboxIndicator: { tabIndex: -1 },
       ...props,

--- a/packages/react-components/react-table/stories/Table/DataGrid.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/DataGrid.stories.tsx
@@ -202,7 +202,7 @@ export const DataGrid = () => {
               aria-selected={selected}
               checked={selected}
             />
-            <TableCell tabIndex={0} role="gridcell">
+            <TableCell tabIndex={0} role="gridcell" aria-selected={selected}>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>
             <TableCell tabIndex={0} role="gridcell">


### PR DESCRIPTION
According to [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) and [aria spec](https://www.w3.org/TR/wai-aria-1.1/#aria-selected), `aria-selected` should be used on elements with `role="gridcell"` to indicate selection.


