### PR TITLE
fix: prevent selected items to be interactive when dropdown is disabled

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -842,6 +842,7 @@ export const Dropdown = (React.forwardRef<HTMLDivElement, DropdownProps>((props,
         defaultProps: () => ({
           className: dropdownSlotClassNames.selectedItem,
           active: isSelectedItemActive(index),
+          disabled,
           variables,
           ...(typeof item === 'object' &&
             !item.hasOwnProperty('key') && {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -55,6 +55,9 @@ export interface DropdownSelectedItemProps extends UIComponentProps<DropdownSele
   /** Image of the selected item. */
   image?: ShorthandValue<ImageProps>;
 
+  /** A dropdown selected item can show that it cannot be interacted with. */
+  disabled?: boolean;
+
   /**
    * Called on selected item click.
    *
@@ -97,7 +100,7 @@ export const DropdownSelectedItem = (React.forwardRef<HTMLSpanElement, DropdownS
   const { setStart, setEnd } = useTelemetry(DropdownSelectedItem.displayName, context.telemetry);
   setStart();
 
-  const { active, header, icon, image, className, design, styles, variables } = props;
+  const { active, header, icon, image, className, design, styles, variables, disabled } = props;
 
   const itemRef = React.useRef<HTMLElement>();
   const ElementType = getElementType(props);
@@ -136,21 +139,25 @@ export const DropdownSelectedItem = (React.forwardRef<HTMLSpanElement, DropdownS
   );
 
   const handleClick = (e: React.SyntheticEvent) => {
+    if (disabled) return;
     _.invoke(props, 'onClick', e, props);
   };
 
   const handleKeyDown = (e: React.SyntheticEvent) => {
+    if (disabled) return;
     _.invoke(props, 'onKeyDown', e, props);
   };
 
   const handleIconOverrides = iconProps => ({
     ...iconProps,
     onClick: (e: React.SyntheticEvent, iconProps: BoxProps) => {
+      if (disabled) return;
       e.stopPropagation();
       _.invoke(props, 'onRemove', e, iconProps);
       _.invoke(props, 'onClick', e, iconProps);
     },
     onKeyDown: (e: React.KeyboardEvent, iconProps: BoxProps) => {
+      if (disabled) return;
       e.stopPropagation();
       if (getCode(e) === keyboardKey.Enter) {
         _.invoke(props, 'onRemove', e, iconProps);

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -1873,6 +1873,14 @@ describe('Dropdown', () => {
       expect(getSelectedItemNodes()).toHaveLength(1);
       expect(getItemNodes()).toHaveLength(items.length - 1);
     });
+
+    it('should not call onRemove when dropdown is disabled', () => {
+      const onRemove = jest.fn();
+      const value = { header: items[0], onRemove };
+      const { clickOnSelectedItemAtIndex } = renderDropdown({ multiple: true, value, disabled: true });
+      clickOnSelectedItemAtIndex(0);
+      expect(onRemove).not.toHaveBeenCalled();
+    });
   });
 
   describe('items', () => {


### PR DESCRIPTION
### Overview

`disabled`  prop wasn't being forwarded to `DropdownSelectedItem`  therefore it was interactive while the dropdown itself was `disabled`. To fix it we are passing it forward and preventing the callbacks to be invoked when disabled. 