### PR TITLE
fix: Grouped Detailslist's collapseAllVisibility=hidden needs correct spacers and role=cell nodes

### DIFF
--- a/change/@fluentui-react-36e9af14-473b-452c-8618-929be8d3f6a4.json
+++ b/change/@fluentui-react-36e9af14-473b-452c-8618-929be8d3f6a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Grouped DetailsList alignment and cell count when CollapseAllVisibility is hidden",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
@@ -10,7 +10,6 @@ import {
   IToggleStyles,
   mergeStyles,
   Toggle,
-  CollapseAllVisibility,
 } from '@fluentui/react';
 import { DefaultButton, IButtonStyles } from '@fluentui/react/lib/Button';
 

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Grouped.Example.tsx
@@ -10,6 +10,7 @@ import {
   IToggleStyles,
   mergeStyles,
   Toggle,
+  CollapseAllVisibility,
 } from '@fluentui/react';
 import { DefaultButton, IButtonStyles } from '@fluentui/react/lib/Button';
 
@@ -19,10 +20,10 @@ const controlWrapperClass = mergeStyles({
   flexWrap: 'wrap',
 });
 const toggleStyles: Partial<IToggleStyles> = {
-  root: { margin: margin },
+  root: { margin },
   label: { marginLeft: 10 },
 };
-const addItemButtonStyles: Partial<IButtonStyles> = { root: { margin: margin } };
+const addItemButtonStyles: Partial<IButtonStyles> = { root: { margin } };
 
 export interface IDetailsListGroupedExampleItem {
   key: string;

--- a/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -202,9 +202,9 @@ export class DetailsHeaderBase
 
     const classNames = this._classNames;
     const IconComponent = useFastIcons ? FontIcon : Icon;
-    const showGroupExpander =
-      groupNestingDepth! > 0 && this.props.collapseAllVisibility === CollapseAllVisibility.visible;
-    const columnIndexOffset = 1 + (showCheckbox ? 1 : 0) + (showGroupExpander ? 1 : 0);
+    const hasGroupExpander = groupNestingDepth! > 0;
+    const showGroupExpander = hasGroupExpander && this.props.collapseAllVisibility === CollapseAllVisibility.visible;
+    const columnIndexOffset = 1 + (showCheckbox ? 1 : 0) + (hasGroupExpander ? 1 : 0);
 
     const isRTL = getRTL(theme);
     return (
@@ -294,6 +294,10 @@ export class DetailsHeaderBase
             />
             {/* Use this span in addition to aria-label, otherwise VoiceOver ignores the column */}
             <span className={classNames.accessibleLabel}>{ariaLabelForToggleAllGroupsButton}</span>
+          </div>
+        ) : hasGroupExpander ? (
+          <div className={classNames.cellIsGroupExpander} data-is-focusable={false} role="columnheader">
+            {/* Empty placeholder cell when CollapseAllVisibility is hidden */}
           </div>
         ) : null}
         <GroupSpacer indentWidth={indentWidth} role="gridcell" count={groupNestingDepth! - 1} />
@@ -405,7 +409,7 @@ export class DetailsHeaderBase
         if (columnReorderProps.onColumnDrop) {
           const dragDropDetails: IColumnDragDropDetails = {
             draggedIndex: this._draggedColumnIndex,
-            targetIndex: targetIndex,
+            targetIndex,
           };
           columnReorderProps.onColumnDrop(dragDropDetails);
           /* eslint-disable deprecation/deprecation */
@@ -717,7 +721,7 @@ export class DetailsHeaderBase
 
     this.setState({
       columnResizeDetails: {
-        columnIndex: columnIndex,
+        columnIndex,
         columnMinWidth: columns[columnIndex].calculatedWidth!,
         originX: ev.clientX,
       },
@@ -752,7 +756,7 @@ export class DetailsHeaderBase
       if (ev.which === KeyCodes.enter) {
         this.setState({
           columnResizeDetails: {
-            columnIndex: columnIndex,
+            columnIndex,
             columnMinWidth: columns[columnIndex].calculatedWidth!,
           },
         });
@@ -880,7 +884,7 @@ export class DetailsHeaderBase
 
     if (this.state.isAllSelected !== isAllSelected) {
       this.setState({
-        isAllSelected: isAllSelected,
+        isAllSelected,
       });
     }
   }

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -363,7 +363,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         <GroupSpacer
           indentWidth={indentWidth}
           role="gridcell"
-          count={groupNestingDepth! - (this.props.collapseAllVisibility === CollapseAllVisibility.hidden ? 1 : 0)}
+          count={groupNestingDepth! === 0 ? -1 : groupNestingDepth!}
         />
 
         {item && rowFields}

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -14,7 +14,6 @@ import { GroupSpacer } from '../GroupedList/GroupSpacer';
 import { DetailsRowFields } from './DetailsRowFields';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { SelectionMode, SELECTION_CHANGE } from '../../Selection';
-import { CollapseAllVisibility } from '../../GroupedList';
 import { classNamesFunction } from '../../Utilities';
 import type { IDisposable } from '../../Utilities';
 import type { IColumn } from './DetailsList.types';


### PR DESCRIPTION
Fixes [15721](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15721)

## Previous Behavior

Previously, we fully removed the header cell with the collapse all button when the `collapseAllVisibility` was set to hidden, which resulted in an incorrect number of column headers for the content, as well as misaligned content cells, both visually and semantically.

![screenshot of grouped detailsList showing group headers misaligned with the column headers](https://user-images.githubusercontent.com/3819570/206809455-c8737573-9b56-4fb5-84e5-0f4fc993ee04.png)


## New Behavior

Now when `collapseAllVisibility` is hidden, the header's collapse all button is gone, but an empty cell is present to ensure the correct number of column headers, and to have the column headers line up with their columns.

Cells in each row are also given the correct spacing and empty cells.

![screenshot of grouped detailsList showing no header expand button, but correct spacing](https://user-images.githubusercontent.com/3819570/206809107-e1decb2b-75dc-4a0f-a70a-482fad15daee.png)

