### PR TITLE
feat: add `applyStylesToPortals` prop to FluentProvider

### DIFF
--- a/apps/vr-tests-react-components/.storybook/preview.js
+++ b/apps/vr-tests-react-components/.storybook/preview.js
@@ -25,12 +25,16 @@ setAddon({
    */
   addStory(storyName, storyFn, config = {}) {
     this.add(storyName, (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
-      return <FluentProvider theme={webLightTheme}>{storyFn(context)}</FluentProvider>;
+      return (
+        <FluentProvider passStylesToPortals={false} theme={webLightTheme}>
+          {storyFn(context)}
+        </FluentProvider>
+      );
     });
     if (config.includeRtl) {
       this.add(storyName + ' - RTL', (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
         return (
-          <FluentProvider theme={webLightTheme} dir="rtl">
+          <FluentProvider passStylesToPortals={false} theme={webLightTheme} dir="rtl">
             {storyFn(context)}
           </FluentProvider>
         );
@@ -38,14 +42,22 @@ setAddon({
     }
     if (config.includeDarkMode) {
       this.add(storyName + ' - Dark Mode', (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
-        return <FluentProvider theme={webDarkTheme}>{storyFn(context)}</FluentProvider>;
+        return (
+          <FluentProvider passStylesToPortals={false} theme={webDarkTheme}>
+            {storyFn(context)}
+          </FluentProvider>
+        );
       });
     }
     if (config.includeHighContrast) {
       this.add(storyName + ' - High Contrast', (
         /** @type {import('../src/utilities/types').StoryContext} */ context,
       ) => {
-        return <FluentProvider theme={teamsHighContrastTheme}>{storyFn(context)}</FluentProvider>;
+        return (
+          <FluentProvider passStylesToPortals={false} theme={teamsHighContrastTheme}>
+            {storyFn(context)}
+          </FluentProvider>
+        );
       });
     }
 

--- a/apps/vr-tests-react-components/.storybook/preview.js
+++ b/apps/vr-tests-react-components/.storybook/preview.js
@@ -26,7 +26,7 @@ setAddon({
   addStory(storyName, storyFn, config = {}) {
     this.add(storyName, (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
       return (
-        <FluentProvider passStylesToPortals={false} theme={webLightTheme}>
+        <FluentProvider applyStylesToPortals={false} theme={webLightTheme}>
           {storyFn(context)}
         </FluentProvider>
       );
@@ -34,7 +34,7 @@ setAddon({
     if (config.includeRtl) {
       this.add(storyName + ' - RTL', (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
         return (
-          <FluentProvider passStylesToPortals={false} theme={webLightTheme} dir="rtl">
+          <FluentProvider applyStylesToPortals={false} theme={webLightTheme} dir="rtl">
             {storyFn(context)}
           </FluentProvider>
         );
@@ -43,7 +43,7 @@ setAddon({
     if (config.includeDarkMode) {
       this.add(storyName + ' - Dark Mode', (/** @type {import('../src/utilities/types').StoryContext} */ context) => {
         return (
-          <FluentProvider passStylesToPortals={false} theme={webDarkTheme}>
+          <FluentProvider applyStylesToPortals={false} theme={webDarkTheme}>
             {storyFn(context)}
           </FluentProvider>
         );
@@ -54,7 +54,7 @@ setAddon({
         /** @type {import('../src/utilities/types').StoryContext} */ context,
       ) => {
         return (
-          <FluentProvider passStylesToPortals={false} theme={teamsHighContrastTheme}>
+          <FluentProvider applyStylesToPortals={false} theme={teamsHighContrastTheme}>
             {storyFn(context)}
           </FluentProvider>
         );

--- a/change/@fluentui-react-menu-2cb39518-350f-471e-aeac-f4077d6fe085.json
+++ b/change/@fluentui-react-menu-2cb39518-350f-471e-aeac-f4077d6fe085.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: always apply typography styles in MenuPopover",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-0462ea09-ba7e-4205-a8e5-17e62603e5de.json
+++ b/change/@fluentui-react-popover-0462ea09-ba7e-4205-a8e5-17e62603e5de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: always apply typography styles in PopoverSurface",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-f154ffd0-53f9-4a00-98fd-60f928e80590.json
+++ b/change/@fluentui-react-provider-f154ffd0-53f9-4a00-98fd-60f928e80590.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "add \"passStylesToPortals\" prop",
+  "comment": "add \"applyStylesToPortals\" prop",
   "packageName": "@fluentui/react-provider",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-provider-f154ffd0-53f9-4a00-98fd-60f928e80590.json
+++ b/change/@fluentui-react-provider-f154ffd0-53f9-4a00-98fd-60f928e80590.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add \"passStylesToPortals\" prop",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
@@ -1,5 +1,5 @@
 import { shorthands, mergeClasses, makeStyles } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 import type { MenuPopoverSlots, MenuPopoverState } from './MenuPopover.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
@@ -11,12 +11,14 @@ const useStyles = makeStyles({
   root: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     backgroundColor: tokens.colorNeutralBackground1,
+    color: tokens.colorNeutralForeground1,
     minWidth: '128px',
     maxWidth: '300px',
     width: 'max-content',
     boxShadow: `${tokens.shadow16}`,
     ...shorthands.padding('4px'),
     ...shorthands.border('1px', 'solid', tokens.colorTransparentStroke),
+    ...typographyStyles.body1,
   },
 });
 

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.ts
@@ -1,6 +1,6 @@
 import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createArrowHeightStyles, createArrowStyles } from '@fluentui/react-positioning';
-import { tokens } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 import type { PopoverSize } from '../Popover/Popover.types';
 import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -20,10 +20,12 @@ export const arrowHeights: Record<PopoverSize, number> = {
  */
 const useStyles = makeStyles({
   root: {
+    color: tokens.colorNeutralForeground1,
     backgroundColor: tokens.colorNeutralBackground1,
     boxShadow: tokens.shadow16,
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     ...shorthands.border('1px', 'solid', tokens.colorTransparentStroke),
+    ...typographyStyles.body1,
   },
 
   inverted: {

--- a/packages/react-components/react-provider/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/etc/react-provider.api.md
@@ -19,6 +19,7 @@ import type { TooltipVisibilityContextValue_unstable } from '@fluentui/react-sha
 // @public (undocumented)
 export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots, "root">, "dir"> & {
     dir?: "ltr" | "rtl" | undefined;
+    passStylesToPortals?: boolean | undefined;
     targetDocument?: Document | undefined;
     theme?: Partial<Theme> | undefined;
 } & React_2.RefAttributes<HTMLElement>>;
@@ -37,6 +38,7 @@ export type FluentProviderContextValues = Pick<FluentProviderState, 'theme'> & {
 // @public (undocumented)
 export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir'> & {
     dir?: 'ltr' | 'rtl';
+    passStylesToPortals?: boolean;
     targetDocument?: Document;
     theme?: PartialTheme;
 };
@@ -47,7 +49,7 @@ export type FluentProviderSlots = {
 };
 
 // @public (undocumented)
-export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'dir'>> & {
+export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'dir' | 'passStylesToPortals'>> & {
     theme: ThemeContextValue_unstable;
     themeClassName: string;
 };

--- a/packages/react-components/react-provider/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/etc/react-provider.api.md
@@ -18,8 +18,8 @@ import type { TooltipVisibilityContextValue_unstable } from '@fluentui/react-sha
 
 // @public (undocumented)
 export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots, "root">, "dir"> & {
+    applyStylesToPortals?: boolean | undefined;
     dir?: "ltr" | "rtl" | undefined;
-    passStylesToPortals?: boolean | undefined;
     targetDocument?: Document | undefined;
     theme?: Partial<Theme> | undefined;
 } & React_2.RefAttributes<HTMLElement>>;
@@ -37,8 +37,8 @@ export type FluentProviderContextValues = Pick<FluentProviderState, 'theme'> & {
 
 // @public (undocumented)
 export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir'> & {
+    applyStylesToPortals?: boolean;
     dir?: 'ltr' | 'rtl';
-    passStylesToPortals?: boolean;
     targetDocument?: Document;
     theme?: PartialTheme;
 };
@@ -49,7 +49,7 @@ export type FluentProviderSlots = {
 };
 
 // @public (undocumented)
-export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'dir' | 'passStylesToPortals'>> & {
+export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'applyStylesToPortals' | 'dir'>> & {
     theme: ThemeContextValue_unstable;
     themeClassName: string;
 };

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -15,15 +15,22 @@ export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir
   /** Sets the direction of text & generated styles. */
   dir?: 'ltr' | 'rtl';
 
+  /**
+   * Passes styles applied to a component down to portals if enabled.
+   * @default true
+   */
+  passStylesToPortals?: boolean;
+
   /** Provides the document, can be undefined during SSR render. */
   targetDocument?: Document;
 
+  /** Sets the theme used in a scope. */
   theme?: PartialTheme;
 };
 
 export type FluentProviderState = ComponentState<FluentProviderSlots> &
   Pick<FluentProviderProps, 'targetDocument'> &
-  Required<Pick<FluentProviderProps, 'dir'>> & {
+  Required<Pick<FluentProviderProps, 'dir' | 'passStylesToPortals'>> & {
     theme: ThemeContextValue;
     themeClassName: string;
   };

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -12,14 +12,14 @@ export type FluentProviderSlots = {
 };
 
 export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir'> & {
-  /** Sets the direction of text & generated styles. */
-  dir?: 'ltr' | 'rtl';
-
   /**
    * Passes styles applied to a component down to portals if enabled.
    * @default true
    */
-  passStylesToPortals?: boolean;
+  applyStylesToPortals?: boolean;
+
+  /** Sets the direction of text & generated styles. */
+  dir?: 'ltr' | 'rtl';
 
   /** Provides the document, can be undefined during SSR render. */
   targetDocument?: Document;
@@ -30,7 +30,7 @@ export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir
 
 export type FluentProviderState = ComponentState<FluentProviderSlots> &
   Pick<FluentProviderProps, 'targetDocument'> &
-  Required<Pick<FluentProviderProps, 'dir' | 'passStylesToPortals'>> & {
+  Required<Pick<FluentProviderProps, 'applyStylesToPortals' | 'dir'>> & {
     theme: ThemeContextValue;
     themeClassName: string;
   };

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -31,8 +31,8 @@ export const useFluentProvider_unstable = (
    * see https://github.com/microsoft/fluentui/blob/0dc74a19f3aa5a058224c20505016fbdb84db172/packages/fluentui/react-northstar/src/utils/mergeProviderContexts.ts#L89-L93
    */
   const {
+    applyStylesToPortals = true,
     dir = parentContext.dir,
-    passStylesToPortals = true,
     targetDocument = parentContext.targetDocument,
     theme,
   } = props;
@@ -51,8 +51,8 @@ export const useFluentProvider_unstable = (
   }, []);
 
   return {
+    applyStylesToPortals,
     dir,
-    passStylesToPortals,
     targetDocument,
     theme: mergedTheme,
     themeClassName: useFluentProviderThemeStyleTag({ theme: mergedTheme, targetDocument }),

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -30,7 +30,12 @@ export const useFluentProvider_unstable = (
    * nesting providers with the same "dir" should not add additional attributes to DOM
    * see https://github.com/microsoft/fluentui/blob/0dc74a19f3aa5a058224c20505016fbdb84db172/packages/fluentui/react-northstar/src/utils/mergeProviderContexts.ts#L89-L93
    */
-  const { dir = parentContext.dir, targetDocument = parentContext.targetDocument, theme } = props;
+  const {
+    dir = parentContext.dir,
+    passStylesToPortals = true,
+    targetDocument = parentContext.targetDocument,
+    theme,
+  } = props;
   const mergedTheme = mergeThemes(parentTheme, theme);
 
   React.useEffect(() => {
@@ -47,6 +52,7 @@ export const useFluentProvider_unstable = (
 
   return {
     dir,
+    passStylesToPortals,
     targetDocument,
     theme: mergedTheme,
     themeClassName: useFluentProviderThemeStyleTag({ theme: mergedTheme, targetDocument }),

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.test.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.test.ts
@@ -69,11 +69,11 @@ describe('useFluentProviderContextValues_unstable', () => {
       expect(result.current.themeClassName).toBe('foo');
     });
 
-    it('passes classes only from "themeClassName" when "passStylesToPortals" is false', () => {
+    it('passes classes only from "themeClassName" when "applyStylesToPortals" is false', () => {
       const { result } = renderHook(() => {
         const state = {
           ...useFluentProvider_unstable({}, React.createRef()),
-          passStylesToPortals: false,
+          applyStylesToPortals: false,
           root: { className: 'foo' },
           themeClassName: 'bar',
         };

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.test.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.test.ts
@@ -54,13 +54,34 @@ describe('useFluentProviderContextValues_unstable', () => {
     expect(result.current.theme).toEqual({ colorBrandBackground: '#fff' });
   });
 
-  it('should return a value for "themeClassname"', () => {
-    const { result } = renderHook(() => {
-      const state = useFluentProvider_unstable({ className: 'foo' }, React.createRef());
+  describe('themeClassname', () => {
+    it('passes classes from "root" slot by default', () => {
+      const { result } = renderHook(() => {
+        const state = {
+          ...useFluentProvider_unstable({}, React.createRef()),
+          root: { className: 'foo' },
+          themeClassName: 'bar',
+        };
 
-      return useFluentProviderContextValues_unstable(state);
+        return useFluentProviderContextValues_unstable(state);
+      });
+
+      expect(result.current.themeClassName).toBe('foo');
     });
 
-    expect(result.current.themeClassName).toBe('foo');
+    it('passes classes only from "themeClassName" when "passStylesToPortals" is false', () => {
+      const { result } = renderHook(() => {
+        const state = {
+          ...useFluentProvider_unstable({}, React.createRef()),
+          passStylesToPortals: false,
+          root: { className: 'foo' },
+          themeClassName: 'bar',
+        };
+
+        return useFluentProviderContextValues_unstable(state);
+      });
+
+      expect(result.current.themeClassName).toBe('bar');
+    });
   });
 });

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { FluentProviderContextValues, FluentProviderState } from './FluentProvider.types';
 
 export function useFluentProviderContextValues_unstable(state: FluentProviderState): FluentProviderContextValues {
-  const { dir, passStylesToPortals, root, targetDocument, theme, themeClassName } = state;
+  const { applyStylesToPortals, dir, root, targetDocument, theme, themeClassName } = state;
 
   const provider = React.useMemo(() => ({ dir, targetDocument }), [dir, targetDocument]);
   // "Tooltip" component mutates an object in this context, instance should be stable
@@ -13,6 +13,6 @@ export function useFluentProviderContextValues_unstable(state: FluentProviderSta
     textDirection: dir,
     tooltip,
     theme,
-    themeClassName: passStylesToPortals ? root.className! : themeClassName,
+    themeClassName: applyStylesToPortals ? root.className! : themeClassName,
   };
 }

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { FluentProviderContextValues, FluentProviderState } from './FluentProvider.types';
 
 export function useFluentProviderContextValues_unstable(state: FluentProviderState): FluentProviderContextValues {
-  const { root, dir, targetDocument, theme } = state;
+  const { dir, passStylesToPortals, root, targetDocument, theme, themeClassName } = state;
 
   const provider = React.useMemo(() => ({ dir, targetDocument }), [dir, targetDocument]);
   // "Tooltip" component mutates an object in this context, instance should be stable
@@ -13,6 +13,6 @@ export function useFluentProviderContextValues_unstable(state: FluentProviderSta
     textDirection: dir,
     tooltip,
     theme,
-    themeClassName: root.className!,
+    themeClassName: passStylesToPortals ? root.className! : themeClassName,
   };
 }

--- a/packages/react-components/react-provider/stories/Provider/FluentProviderApplyStylesToPortals.stories.tsx
+++ b/packages/react-components/react-provider/stories/Provider/FluentProviderApplyStylesToPortals.stories.tsx
@@ -53,7 +53,7 @@ const FrameRenderer: React.FunctionComponent<FrameRendererProps> = ({ children }
   );
 };
 
-const PassStylesToPortalsExample: React.FC<{ targetDocument?: Document }> = ({ targetDocument }) => {
+const ApplyStylesToPortalsExample: React.FC<{ targetDocument?: Document }> = ({ targetDocument }) => {
   const styles = useStyles();
 
   return (
@@ -62,17 +62,17 @@ const PassStylesToPortalsExample: React.FC<{ targetDocument?: Document }> = ({ t
         <div>An element inside a provider</div>
         <Portal>
           <div className={styles.portal}>
-            A portal created by FluentProvider with <code>passStylesToPortals={`{true}`}</code>. Styles from
+            A portal created by FluentProvider with <code>applyStylesToPortals={`{true}`}</code>. Styles from
             FluentProvider are applied
           </div>
         </Portal>
       </FluentProvider>
 
-      <FluentProvider className={styles.provider} passStylesToPortals={false} targetDocument={targetDocument}>
+      <FluentProvider className={styles.provider} applyStylesToPortals={false} targetDocument={targetDocument}>
         <div>An element inside a provider</div>
         <Portal>
           <div className={styles.portal}>
-            A portal created by FluentProvider with <code>passStylesToPortals={`{false}`}</code>. Styles from
+            A portal created by FluentProvider with <code>applyStylesToPortals={`{false}`}</code>. Styles from
             FluentProvider are not applied
           </div>
         </Portal>
@@ -81,24 +81,24 @@ const PassStylesToPortalsExample: React.FC<{ targetDocument?: Document }> = ({ t
   );
 };
 
-export const PassStylesToPortals = () => (
+export const ApplyStylesToPortals = () => (
   // FrameRenderer is redundant this example, it's used only to render portals inside an iframe
   // to make them visible in Storybook
   <FrameRenderer>
     {(externalDocument, renderer) => (
       <RendererProvider renderer={renderer} targetDocument={externalDocument}>
-        <PassStylesToPortalsExample targetDocument={externalDocument} />
+        <ApplyStylesToPortalsExample targetDocument={externalDocument} />
       </RendererProvider>
     )}
   </FrameRenderer>
 );
 
-PassStylesToPortals.parameters = {
+ApplyStylesToPortals.parameters = {
   docs: {
     description: {
       story: [
-        '`passStylesToPortals` controls if styles from FluentProvider should be applied to components that use Portal ',
-        'component.',
+        '`applyStylesToPortals` controls if styles from FluentProvider should be applied to components that use ',
+        'Portal component.',
       ].join(''),
     },
   },

--- a/packages/react-components/react-provider/stories/Provider/FluentProviderFrame.stories.tsx
+++ b/packages/react-components/react-provider/stories/Provider/FluentProviderFrame.stories.tsx
@@ -92,9 +92,11 @@ export const Frame = () => {
 Frame.parameters = {
   docs: {
     description: {
-      story:
-        'A Fluent provider does not cross an iframee boundary.' +
-        'Renderer provider supports Fluent provider within the iframe.',
+      story: [
+        'A FluentProvider does not cross an iframe boundary.',
+        'To render into iframes pass a proper `Document` instance to `targetDocument` prop on',
+        'FluentProvider & RendererProvider.',
+      ].join(' '),
     },
   },
 };

--- a/packages/react-components/react-provider/stories/Provider/FluentProviderPassStylesToPortals.stories.tsx
+++ b/packages/react-components/react-provider/stories/Provider/FluentProviderPassStylesToPortals.stories.tsx
@@ -1,0 +1,105 @@
+import {
+  createDOMRenderer,
+  makeStyles,
+  shorthands,
+  tokens,
+  FluentProvider,
+  Portal,
+  RendererProvider,
+} from '@fluentui/react-components';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+const useStyles = makeStyles({
+  provider: {
+    ...shorthands.border('3px', 'solid', tokens.colorBrandForeground2),
+    ...shorthands.borderRadius('5px'),
+    ...shorthands.padding('5px'),
+
+    backgroundColor: tokens.colorBrandBackground2,
+    marginBottom: '20px',
+  },
+  portal: {
+    ...shorthands.border('3x', 'dotted', tokens.colorPaletteDarkOrangeBorder2),
+    ...shorthands.padding('5px'),
+  },
+});
+
+type FrameRendererProps = {
+  children: (externalDocument: Document, renderer: ReturnType<typeof createDOMRenderer>) => React.ReactElement;
+};
+
+const FrameRenderer: React.FunctionComponent<FrameRendererProps> = ({ children }) => {
+  const [frameRef, setFrameRef] = React.useState<HTMLIFrameElement | null>(null);
+  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+
+  const contentDocument = frameRef ? (frameRef.contentDocument as Document) : undefined;
+  const renderer = React.useMemo(() => createDOMRenderer(contentDocument), [contentDocument]);
+
+  React.useEffect(() => {
+    if (contentDocument) {
+      const el = contentDocument.createElement('div');
+      contentDocument.body.appendChild(el);
+
+      setContainer(el);
+    }
+  }, [contentDocument]);
+
+  return (
+    <>
+      <iframe ref={setFrameRef} style={{ height: 300, width: 700, border: 'none' }} />
+      {contentDocument && container && ReactDOM.createPortal(children(contentDocument, renderer), container)}
+    </>
+  );
+};
+
+const PassStylesToPortalsExample: React.FC<{ targetDocument?: Document }> = ({ targetDocument }) => {
+  const styles = useStyles();
+
+  return (
+    <>
+      <FluentProvider className={styles.provider} targetDocument={targetDocument}>
+        <div>An element inside a provider</div>
+        <Portal>
+          <div className={styles.portal}>
+            A portal created by FluentProvider with <code>passStylesToPortals={`{true}`}</code>. Styles from
+            FluentProvider are applied
+          </div>
+        </Portal>
+      </FluentProvider>
+
+      <FluentProvider className={styles.provider} passStylesToPortals={false} targetDocument={targetDocument}>
+        <div>An element inside a provider</div>
+        <Portal>
+          <div className={styles.portal}>
+            A portal created by FluentProvider with <code>passStylesToPortals={`{false}`}</code>. Styles from
+            FluentProvider are not applied
+          </div>
+        </Portal>
+      </FluentProvider>
+    </>
+  );
+};
+
+export const PassStylesToPortals = () => (
+  // FrameRenderer is redundant this example, it's used only to render portals inside an iframe
+  // to make them visible in Storybook
+  <FrameRenderer>
+    {(externalDocument, renderer) => (
+      <RendererProvider renderer={renderer} targetDocument={externalDocument}>
+        <PassStylesToPortalsExample targetDocument={externalDocument} />
+      </RendererProvider>
+    )}
+  </FrameRenderer>
+);
+
+PassStylesToPortals.parameters = {
+  docs: {
+    description: {
+      story: [
+        '`passStylesToPortals` controls if styles from FluentProvider should be applied to components that use Portal ',
+        'component.',
+      ].join(''),
+    },
+  },
+};

--- a/packages/react-components/react-provider/stories/Provider/index.stories.tsx
+++ b/packages/react-components/react-provider/stories/Provider/index.stories.tsx
@@ -6,7 +6,7 @@ import bestPracticesMd from './FluentProviderBestPractices.md';
 
 export { Default } from './FluentProviderDefault.stories';
 export { Dir } from './FluentProviderDir.stories';
-export { PassStylesToPortals } from './FluentProviderPassStylesToPortals.stories';
+export { ApplyStylesToPortals } from './FluentProviderApplyStylesToPortals.stories';
 export { Nested } from './FluentProviderNested.stories';
 export { Frame } from './FluentProviderFrame.stories';
 

--- a/packages/react-components/react-provider/stories/Provider/index.stories.tsx
+++ b/packages/react-components/react-provider/stories/Provider/index.stories.tsx
@@ -6,6 +6,7 @@ import bestPracticesMd from './FluentProviderBestPractices.md';
 
 export { Default } from './FluentProviderDefault.stories';
 export { Dir } from './FluentProviderDir.stories';
+export { PassStylesToPortals } from './FluentProviderPassStylesToPortals.stories';
 export { Nested } from './FluentProviderNested.stories';
 export { Frame } from './FluentProviderFrame.stories';
 


### PR DESCRIPTION
## New Behavior

Fixes #25528.

This PR adds `applyStylesToPortals` to `FluentProvider` that defines to whether to pass styles applied to a component down to portals or not. Before this behavior was not configurable.

I also added `applyStylesToPortals` to `apps/vr-tests-react-components/.storybook/preview.js` to ensure that our components apply proper styles and don't rely on styles from `FluentProvider`. `MenuPopover` & `PopoverSurface` have been update to include typography styles.