### PR TITLE
fix: Autofill only sets selectionRange when in focus

### DIFF
--- a/change/@fluentui-react-8cfa6416-9eea-4573-8625-3a956ca1b0a7.json
+++ b/change/@fluentui-react-8cfa6416-9eea-4573-8625-3a956ca1b0a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Autofill only sets input selectionRange if input is in focus\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -110,8 +110,8 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
         shouldSelectFullRange = shouldSelectFullInputValueInComponentDidUpdate();
       }
 
-      if (shouldSelectFullRange && this._inputElement.current) {
-        this._inputElement.current.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
+      if (shouldSelectFullRange) {
+        this._inputElement.current!.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
       } else {
         while (
           differenceIndex < this.value.length &&
@@ -119,8 +119,8 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
         ) {
           differenceIndex++;
         }
-        if (differenceIndex > 0 && this._inputElement.current) {
-          this._inputElement.current.setSelectionRange(
+        if (differenceIndex > 0) {
+          this._inputElement.current!.setSelectionRange(
             differenceIndex,
             suggestedDisplayValue.length,
             SELECTION_BACKWARD,

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -95,7 +95,10 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
       return;
     }
 
+    const isFocused = this._inputElement.current && this._inputElement.current === document.activeElement;
+
     if (
+      isFocused &&
       this._autoFillEnabled &&
       this.value &&
       suggestedDisplayValue &&


### PR DESCRIPTION
Fixes [14918](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/14918)

It appears iOS VoiceOver's cursor jumps to an input based on changing the selection range, even if focus is not set to the input. In practice, that meant that it was impossible to move the VO cursor away Autofill with a selection, since it would update and re-set the selection range on blur, pulling the VO cursor back to the input.

This fix only allows the selectionRange to be set when the input is in focus. This should not make a practical difference outside of VoiceOver, since the visual selection and keyboard interaction only take show up when in focus.