### PR TITLE
fix: Carousel fix for FZ - Adding data-is-visible prop

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -17,6 +17,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- `Carousel` fix for FZ - Adding data-is-visible prop #25973 @kolaps33 ([#25973](https://github.com/microsoft/fluentui/pull/25973))
 
 <!--------------------------------[ v0.65.0 ]------------------------------- -->
 ## [v0.65.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.65.0) (2022-10-31)

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
@@ -10,6 +10,8 @@ import { keyboardKey, SpacebarKey } from '../../keyboard-key';
  * Adds attribute 'aria-label' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'role=region' to 'itemsContainer' slot if 'navigation' property is true.  Set 'role=none' otherwise.
  * Adds attribute 'tabIndex=-1' to 'itemsContainer' slot if 'navigation' property is false. Does not set the attribute otherwise.
+ * Adds attribute 'data-is-visible=false' to 'paddleNext' slot if 'paddleNextHidden' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'data-is-visible=false' to 'paddlePrevious' slot if 'paddlePreviousHidden' property is false. Does not set the attribute otherwise.
  * @specification
  * Adds attribute 'role=region' to 'root' slot.
  * Adds attribute 'aria-live=polite' to 'itemsContainerWrapper' slot if 'ariaLiveOn' property is true. Sets the attribute to 'off' otherwise.
@@ -46,6 +48,7 @@ export const carouselBehavior: Accessibility<CarouselBehaviorProps> = props => (
         'aria-hidden': 'true',
       }),
       ...(props.paddleNextHidden && {
+        // we need the attribute when carousel is inside FZ
         'data-is-visible': 'false',
       }),
     },
@@ -55,6 +58,7 @@ export const carouselBehavior: Accessibility<CarouselBehaviorProps> = props => (
         'aria-hidden': 'true',
       }),
       ...(props.paddlePreviousHidden && {
+        // we need the attribute when carousel is inside FZ
         'data-is-visible': 'false',
       }),
     },

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
@@ -45,11 +45,17 @@ export const carouselBehavior: Accessibility<CarouselBehaviorProps> = props => (
         tabIndex: -1,
         'aria-hidden': 'true',
       }),
+      ...(props.paddleNextHidden && {
+        'data-is-visible': 'false',
+      }),
     },
     paddlePrevious: {
       ...(props.navigation && {
         tabIndex: -1,
         'aria-hidden': 'true',
+      }),
+      ...(props.paddlePreviousHidden && {
+        'data-is-visible': 'false',
       }),
     },
   },
@@ -80,6 +86,8 @@ export type CarouselBehaviorProps = {
   /** Element type. */
   navigation: Object | Object[];
   ariaLiveOn: boolean;
+  paddleNextHidden: boolean;
+  paddlePreviousHidden: boolean;
   'aria-roledescription'?: string;
   'aria-label'?: string;
 };

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -2,6 +2,7 @@ import { carouselBehavior } from '@fluentui/accessibility';
 
 const roleDescription = 'carousel';
 const label = 'portrait collection';
+// set both props to false, as tests are writen in 'Carousel-test.tsx' file
 const paddleHiddenProps = {
   paddlePreviousHidden: false,
   paddleNextHidden: false,

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -2,11 +2,15 @@ import { carouselBehavior } from '@fluentui/accessibility';
 
 const roleDescription = 'carousel';
 const label = 'portrait collection';
+const paddleHiddenProps = {
+  paddlePreviousHidden: false,
+  paddleNextHidden: false,
+};
 
 describe('carouselBehavior.ts', () => {
   describe('root', () => {
     test(`sets "role=region" when carousel has NO navigation`, () => {
-      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false, ...paddleHiddenProps });
       expect(expectedResult.attributes.root.role).toEqual('region');
     });
 
@@ -15,6 +19,7 @@ describe('carouselBehavior.ts', () => {
         ariaLiveOn: false,
         navigation: false,
         'aria-roledescription': roleDescription,
+        ...paddleHiddenProps,
       });
       expect(expectedResult.attributes.root['aria-roledescription']).toEqual(roleDescription);
     });
@@ -24,6 +29,7 @@ describe('carouselBehavior.ts', () => {
         ariaLiveOn: false,
         navigation: false,
         'aria-label': label,
+        ...paddleHiddenProps,
       });
       expect(expectedResult.attributes.root['aria-label']).toEqual(label);
     });
@@ -34,6 +40,7 @@ describe('carouselBehavior.ts', () => {
         navigation: true,
         'aria-roledescription': roleDescription,
         'aria-label': label,
+        ...paddleHiddenProps,
       });
       expect(expectedResult.attributes.root['aria-roledescription']).toBeUndefined();
       expect(expectedResult.attributes.root['aria-label']).toBeUndefined();
@@ -43,7 +50,7 @@ describe('carouselBehavior.ts', () => {
 
   describe('itemsContainer', () => {
     test(`sets "role=region" when carousel has navigation`, () => {
-      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: true });
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: true, ...paddleHiddenProps });
       expect(expectedResult.attributes.itemsContainer.role).toEqual('region');
     });
 
@@ -52,6 +59,7 @@ describe('carouselBehavior.ts', () => {
         ariaLiveOn: false,
         navigation: true,
         'aria-roledescription': roleDescription,
+        ...paddleHiddenProps,
       });
       expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toEqual(roleDescription);
     });
@@ -61,6 +69,7 @@ describe('carouselBehavior.ts', () => {
         ariaLiveOn: false,
         navigation: true,
         'aria-label': label,
+        ...paddleHiddenProps,
       });
       expect(expectedResult.attributes.itemsContainer['aria-label']).toEqual(label);
     });
@@ -71,18 +80,19 @@ describe('carouselBehavior.ts', () => {
         navigation: false,
         'aria-roledescription': roleDescription,
         'aria-label': label,
+        ...paddleHiddenProps,
       });
       expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toBeUndefined();
       expect(expectedResult.attributes.itemsContainer['aria-label']).toBeUndefined();
     });
 
     test(`sets "role=none" when carousel has NO navigation`, () => {
-      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false, ...paddleHiddenProps });
       expect(expectedResult.attributes.itemsContainer.role).toEqual('none');
     });
 
     test(`sets "tabindex=-1" when carousel has NO navigation`, () => {
-      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false, ...paddleHiddenProps });
       expect(expectedResult.attributes.itemsContainer.tabIndex).toEqual(-1);
     });
   });

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -225,6 +225,9 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
     [items?.length],
   );
 
+  const isNextPaddleHidden = (): boolean => items !== undefined && !circular && activeIndex === items.length - 1;
+  const isPreviousPaddleHidden = (): boolean => items !== undefined && !circular && activeIndex === 0;
+
   const unhandledProps = useUnhandledProps(Carousel.handledProps, props);
   const getA11yProps = useAccessibility<CarouselBehaviorProps>(accessibility, {
     debugName: Carousel.displayName,
@@ -249,6 +252,8 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
       },
     },
     mapPropsToBehavior: () => ({
+      paddlePreviousHidden: isPreviousPaddleHidden(),
+      paddleNextHidden: isNextPaddleHidden(),
       navigation,
       ariaLiveOn,
       'aria-roledescription': ariaRoleDescription,
@@ -428,7 +433,7 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
             getA11yProps('paddlePrevious', {
               className: carouselSlotClassNames.paddlePrevious,
               previous: true,
-              hidden: items !== undefined && !circular && activeIndex === 0,
+              hidden: isPreviousPaddleHidden(),
               disableClickableNav,
             }),
           overrideProps: (predefinedProps: CarouselPaddleProps) =>
@@ -441,7 +446,7 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
             getA11yProps('paddleNext', {
               className: carouselSlotClassNames.paddleNext,
               next: true,
-              hidden: items !== undefined && !circular && activeIndex === items.length - 1,
+              hidden: isNextPaddleHidden(),
               disableClickableNav,
             }),
           overrideProps: (predefinedProps: CarouselPaddleProps) => handlePaddleOverrides(predefinedProps, 'paddleNext'),

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -225,8 +225,8 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
     [items?.length],
   );
 
-  const isNextPaddleHidden = (): boolean => items !== undefined && !circular && activeIndex === items.length - 1;
-  const isPreviousPaddleHidden = (): boolean => items !== undefined && !circular && activeIndex === 0;
+  const nextPaddleHidden = items !== undefined && !circular && activeIndex === items.length - 1;
+  const previousPaddleHidden = items !== undefined && !circular && activeIndex === 0;
 
   const unhandledProps = useUnhandledProps(Carousel.handledProps, props);
   const getA11yProps = useAccessibility<CarouselBehaviorProps>(accessibility, {
@@ -252,8 +252,8 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
       },
     },
     mapPropsToBehavior: () => ({
-      paddlePreviousHidden: isPreviousPaddleHidden(),
-      paddleNextHidden: isNextPaddleHidden(),
+      paddlePreviousHidden: previousPaddleHidden,
+      paddleNextHidden: nextPaddleHidden,
       navigation,
       ariaLiveOn,
       'aria-roledescription': ariaRoleDescription,
@@ -433,7 +433,7 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
             getA11yProps('paddlePrevious', {
               className: carouselSlotClassNames.paddlePrevious,
               previous: true,
-              hidden: isPreviousPaddleHidden(),
+              hidden: previousPaddleHidden,
               disableClickableNav,
             }),
           overrideProps: (predefinedProps: CarouselPaddleProps) =>
@@ -446,7 +446,7 @@ export const Carousel = (React.forwardRef<HTMLDivElement, CarouselProps>((props,
             getA11yProps('paddleNext', {
               className: carouselSlotClassNames.paddleNext,
               next: true,
-              hidden: isNextPaddleHidden(),
+              hidden: nextPaddleHidden,
               disableClickableNav,
             }),
           overrideProps: (predefinedProps: CarouselPaddleProps) => handlePaddleOverrides(predefinedProps, 'paddleNext'),

--- a/packages/fluentui/react-northstar/test/specs/components/Carousel/Carousel-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Carousel/Carousel-test.tsx
@@ -344,4 +344,26 @@ describe('Carousel', () => {
       ).toBe(animationEnterFromNext);
     });
   });
+
+  describe('focus zone "visible" attribute', () => {
+    it('should has data-is-visible=false when previous paddle is hidden', () => {
+      const wrapper = renderCarousel({ defaultActiveIndex: 0 });
+      const paddlePrevios = getPaddlePreviousWrapper(wrapper).getDOMNode();
+      const paddleNext = getPaddleNextWrapper(wrapper).getDOMNode();
+
+      expect(paddlePrevios).toHaveAttribute('data-is-visible');
+      expect(paddlePrevios.getAttribute('data-is-visible')).toEqual('false');
+      expect(paddleNext).not.toHaveAttribute('data-is-visible');
+    });
+
+    it('should has data-is-visible=false when next paddle is hidden', () => {
+      const wrapper = renderCarousel({ defaultActiveIndex: 3 });
+      const paddleNext = getPaddleNextWrapper(wrapper).getDOMNode();
+      const paddlePrevios = getPaddlePreviousWrapper(wrapper).getDOMNode();
+
+      expect(paddleNext).toHaveAttribute('data-is-visible');
+      expect(paddleNext.getAttribute('data-is-visible')).toEqual('false');
+      expect(paddlePrevios).not.toHaveAttribute('data-is-visible');
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
## Description 
When carousel component is used inside the focus zone, then navigation go into paddle which is not visible in the UI. 
Paddle is hidden only with CSS visibility prop:
https://www.w3schools.com/cssref/pr_class_visibility.php  

Focus zone(FZ) has function isElementVisible() in the "focusUtilities.js", but this function doesn't evaluate CSS visibility prop. 
But FZ has attribute  'data-is-visible' which should indicate if element is visible for navigation or not. 
Adding the attribute to make element not visible for FZ. 

## Previous Behavior
there was not  'data-is-visible' attribute

## New Behavior
there is 'data-is-visible=false' attribute added when paddle is hidden 

![image](https://user-images.githubusercontent.com/22620150/207535161-9cbaba55-02e7-4b18-8d33-d901722da684.png)




