### PR TITLE
Hide callout on legend hover

### DIFF
--- a/change/@fluentui-react-charting-f2e133de-6ad2-4585-8f2b-a9115bfa9341.json
+++ b/change/@fluentui-react-charting-f2e133de-6ad2-4585-8f2b-a9115bfa9341.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide callout on legend hover",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -476,6 +476,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
           this._onLegendClick(singleChartData.legend);
         },
         hoverAction: () => {
+          this._handleChartMouseLeave();
           this._onLegendHover(singleChartData.legend);
         },
         onMouseOutAction: () => {

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -201,6 +201,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
             }
           },
           hoverAction: () => {
+            this._handleChartMouseLeave();
             this.setState({ activeLegend: point.legend! });
           },
           onMouseOutAction: () => {

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -475,6 +475,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             this._onLegendClick(point.legend);
           },
           hoverAction: () => {
+            this._handleChartMouseLeave();
             this._onLegendHover(point.legend);
           },
           onMouseOutAction: () => {

--- a/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
+++ b/packages/react-charting/src/components/HeatMapChart/HeatMapChart.base.tsx
@@ -399,6 +399,7 @@ export class HeatMapChartBase extends React.Component<IHeatMapChartProps, IHeatM
           this._onLegendClick(item.legend);
         },
         hoverAction: () => {
+          this._handleChartMouseLeave();
           this._onLegendHover(item.legend);
         },
         onMouseOutAction: () => {

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -383,6 +383,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
           this.setState({ activeLegend: '' });
         },
         hoverAction: () => {
+          this._handleChartMouseLeave();
           this.setState({ activeLegend: point.legend });
         },
         ...(point.legendShape && {
@@ -412,6 +413,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
               this.setState({ activeLegend: '' });
             },
             hoverAction: () => {
+              this._handleChartMouseLeave();
               this.setState({ activeLegend: title });
             },
             opacity: this._getColorFillBarOpacity(colorFillBar),

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -338,6 +338,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
                 this._onClick(point.legend!);
               },
               hoverAction: () => {
+                this._handleChartMouseLeave();
                 this._onHover(point.legend!);
               },
               onMouseOutAction: () => {
@@ -363,6 +364,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
               this._onClick(point.legend!);
             },
             hoverAction: () => {
+              this._handleChartMouseLeave();
               this._onHover(point.legend!);
             },
             onMouseOutAction: () => {

--- a/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -241,6 +241,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         hoverAction:
           total > 0
             ? () => {
+                this._handleChartMouseLeave();
                 this._onHover(point.legend!);
               }
             : undefined,

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -640,6 +640,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           this._onLegendClick(point.legend!);
         },
         hoverAction: () => {
+          this._handleChartMouseLeave();
           this._onLegendHover(point.legend!);
         },
         onMouseOutAction: () => {
@@ -656,6 +657,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           this._onLegendClick(lineLegendText);
         },
         hoverAction: () => {
+          this._handleChartMouseLeave();
           this._onLegendHover(lineLegendText);
         },
         onMouseOutAction: () => {

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -497,7 +497,12 @@ export class VerticalStackedBarChartBase extends React.Component<
           action: () => {
             this._onLegendClick(point.legend);
           },
-          hoverAction: allowHoverOnLegend ? () => this._onLegendHover(point.legend) : undefined,
+          hoverAction: allowHoverOnLegend
+            ? () => {
+                this._handleChartMouseLeave();
+                this._onLegendHover(point.legend);
+              }
+            : undefined,
           onMouseOutAction: allowHoverOnLegend ? () => this._onLegendLeave() : undefined,
         };
 
@@ -514,7 +519,12 @@ export class VerticalStackedBarChartBase extends React.Component<
           action: () => {
             this._onLegendClick(point.title);
           },
-          hoverAction: allowHoverOnLegend ? () => this._onLegendHover(point.title) : undefined,
+          hoverAction: allowHoverOnLegend
+            ? () => {
+                this._handleChartMouseLeave();
+                this._onLegendHover(point.title);
+              }
+            : undefined,
           onMouseOutAction: allowHoverOnLegend ? () => this._onLegendLeave() : undefined,
         };
         legendsOfLine.push(legend);


### PR DESCRIPTION
## Previous Behavior

The callout stays visible when user hovers over legends

## New Behavior

The callout hides when user hovers over legends