### PR TITLE
chore: Update Checkbox and Radio to use griffel reset styles

### DIFF
--- a/change/@fluentui-react-checkbox-a337788c-cf01-4300-b7e9-9cfccba53f4c.json
+++ b/change/@fluentui-react-checkbox-a337788c-cf01-4300-b7e9-9cfccba53f4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update Checkbox to use griffel reset styles",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-3244b173-95d4-4d07-aaf7-21e05ff4234a.json
+++ b/change/@fluentui-react-radio-3244b173-95d4-4d07-aaf7-21e05ff4234a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Update Radio to use griffel reset styles",
+  "packageName": "@fluentui/react-radio",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 import { CheckboxSlots, CheckboxState } from './Checkbox.types';
@@ -15,133 +15,134 @@ export const checkboxClassNames: SlotClassNames<CheckboxSlots> = {
 const indicatorSizeMedium = '16px';
 const indicatorSizeLarge = '20px';
 
-const useRootStyles = makeStyles({
-  base: {
-    position: 'relative',
-    display: 'inline-flex',
-    ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
+const useRootBaseClassName = makeResetStyles({
+  position: 'relative',
+  display: 'inline-flex',
+  ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
+});
+
+const useInputBaseClassName = makeResetStyles({
+  boxSizing: 'border-box',
+  cursor: 'pointer',
+  height: '100%',
+  margin: 0,
+  opacity: 0,
+  position: 'absolute',
+  top: 0,
+  // Calculate the width of the hidden input by taking into account the size of the indicator + the padding around it.
+  // This is done so that clicking on that "empty space" still toggles the checkbox.
+  width: `calc(${indicatorSizeMedium} + 2 * ${tokens.spacingHorizontalS})`,
+
+  // When unchecked, hide the the checkmark icon (child of the indicator slot)
+  [`:not(:checked):not(:indeterminate) ~ .${checkboxClassNames.indicator} > *`]: {
+    opacity: 0,
+  },
+
+  // Colors for the unchecked state
+  ':enabled:not(:checked):not(:indeterminate)': {
+    [`& ~ .${checkboxClassNames.label}`]: {
+      color: tokens.colorNeutralForeground3,
+    },
+    [`& ~ .${checkboxClassNames.indicator}`]: {
+      borderColor: tokens.colorNeutralStrokeAccessible,
+    },
+
+    ':hover': {
+      [`& ~ .${checkboxClassNames.label}`]: {
+        color: tokens.colorNeutralForeground2,
+      },
+      [`& ~ .${checkboxClassNames.indicator}`]: {
+        borderColor: tokens.colorNeutralStrokeAccessibleHover,
+      },
+    },
+
+    ':active:hover': {
+      [`& ~ .${checkboxClassNames.label}`]: {
+        color: tokens.colorNeutralForeground1,
+      },
+      [`& ~ .${checkboxClassNames.indicator}`]: {
+        borderColor: tokens.colorNeutralStrokeAccessiblePressed,
+      },
+    },
+  },
+
+  // Colors for the checked state
+  ':enabled:checked:not(:indeterminate)': {
+    [`& ~ .${checkboxClassNames.label}`]: {
+      color: tokens.colorNeutralForeground1,
+    },
+    [`& ~ .${checkboxClassNames.indicator}`]: {
+      backgroundColor: tokens.colorCompoundBrandBackground,
+      color: tokens.colorNeutralForegroundInverted,
+      borderColor: tokens.colorCompoundBrandBackground,
+    },
+
+    ':hover': {
+      [`& ~ .${checkboxClassNames.indicator}`]: {
+        backgroundColor: tokens.colorCompoundBrandBackgroundHover,
+        borderColor: tokens.colorCompoundBrandBackgroundHover,
+      },
+    },
+
+    ':active:hover': {
+      [`& ~ .${checkboxClassNames.indicator}`]: {
+        backgroundColor: tokens.colorCompoundBrandBackgroundPressed,
+        borderColor: tokens.colorCompoundBrandBackgroundPressed,
+      },
+    },
+  },
+
+  // Colors for the mixed state
+  ':enabled:indeterminate': {
+    [`& ~ .${checkboxClassNames.label}`]: {
+      color: tokens.colorNeutralForeground1,
+    },
+    [`& ~ .${checkboxClassNames.indicator}`]: {
+      borderColor: tokens.colorCompoundBrandStroke,
+      color: tokens.colorCompoundBrandForeground1,
+    },
+
+    ':hover': {
+      [`& ~ .${checkboxClassNames.indicator}`]: {
+        borderColor: tokens.colorCompoundBrandStrokeHover,
+        color: tokens.colorCompoundBrandForeground1Hover,
+      },
+    },
+
+    ':active:hover': {
+      [`& ~ .${checkboxClassNames.indicator}`]: {
+        borderColor: tokens.colorCompoundBrandStrokePressed,
+        color: tokens.colorCompoundBrandForeground1Pressed,
+      },
+    },
+  },
+
+  ':disabled': {
+    cursor: 'default',
+
+    [`& ~ .${checkboxClassNames.label}`]: {
+      cursor: 'default',
+      color: tokens.colorNeutralForegroundDisabled,
+      '@media (forced-colors: active)': {
+        color: 'GrayText',
+      },
+    },
+    [`& ~ .${checkboxClassNames.indicator}`]: {
+      borderColor: tokens.colorNeutralStrokeDisabled,
+      color: tokens.colorNeutralForegroundDisabled,
+      '@media (forced-colors: active)': {
+        color: 'GrayText',
+      },
+    },
+    [`& ~ .${checkboxClassNames.indicator} svg`]: {
+      '@media (forced-colors: active)': {
+        color: 'GrayText',
+      },
+    },
   },
 });
 
 const useInputStyles = makeStyles({
-  base: {
-    boxSizing: 'border-box',
-    cursor: 'pointer',
-    height: '100%',
-    ...shorthands.margin(0),
-    opacity: 0,
-    position: 'absolute',
-    top: 0,
-
-    // When unchecked, hide the the checkmark icon (child of the indicator slot)
-    [`:not(:checked):not(:indeterminate) ~ .${checkboxClassNames.indicator} > *`]: {
-      opacity: 0,
-    },
-
-    // Colors for the unchecked state
-    ':enabled:not(:checked):not(:indeterminate)': {
-      [`& ~ .${checkboxClassNames.label}`]: {
-        color: tokens.colorNeutralForeground3,
-      },
-      [`& ~ .${checkboxClassNames.indicator}`]: {
-        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessible),
-      },
-
-      ':hover': {
-        [`& ~ .${checkboxClassNames.label}`]: {
-          color: tokens.colorNeutralForeground2,
-        },
-        [`& ~ .${checkboxClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
-        },
-      },
-
-      ':active:hover': {
-        [`& ~ .${checkboxClassNames.label}`]: {
-          color: tokens.colorNeutralForeground1,
-        },
-        [`& ~ .${checkboxClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorNeutralStrokeAccessiblePressed),
-        },
-      },
-    },
-
-    // Colors for the checked state
-    ':enabled:checked:not(:indeterminate)': {
-      [`& ~ .${checkboxClassNames.label}`]: {
-        color: tokens.colorNeutralForeground1,
-      },
-      [`& ~ .${checkboxClassNames.indicator}`]: {
-        backgroundColor: tokens.colorCompoundBrandBackground,
-        color: tokens.colorNeutralForegroundInverted,
-        ...shorthands.borderColor(tokens.colorCompoundBrandBackground),
-      },
-
-      ':hover': {
-        [`& ~ .${checkboxClassNames.indicator}`]: {
-          backgroundColor: tokens.colorCompoundBrandBackgroundHover,
-          ...shorthands.borderColor(tokens.colorCompoundBrandBackgroundHover),
-        },
-      },
-
-      ':active:hover': {
-        [`& ~ .${checkboxClassNames.indicator}`]: {
-          backgroundColor: tokens.colorCompoundBrandBackgroundPressed,
-          ...shorthands.borderColor(tokens.colorCompoundBrandBackgroundPressed),
-        },
-      },
-    },
-
-    // Colors for the mixed state
-    ':enabled:indeterminate': {
-      [`& ~ .${checkboxClassNames.label}`]: {
-        color: tokens.colorNeutralForeground1,
-      },
-      [`& ~ .${checkboxClassNames.indicator}`]: {
-        ...shorthands.borderColor(tokens.colorCompoundBrandStroke),
-        color: tokens.colorCompoundBrandForeground1,
-      },
-
-      ':hover': {
-        [`& ~ .${checkboxClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorCompoundBrandStrokeHover),
-          color: tokens.colorCompoundBrandForeground1Hover,
-        },
-      },
-
-      ':active:hover': {
-        [`& ~ .${checkboxClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorCompoundBrandStrokePressed),
-          color: tokens.colorCompoundBrandForeground1Pressed,
-        },
-      },
-    },
-
-    ':disabled': {
-      cursor: 'default',
-
-      [`& ~ .${checkboxClassNames.label}`]: {
-        cursor: 'default',
-        color: tokens.colorNeutralForegroundDisabled,
-        '@media (forced-colors: active)': {
-          color: 'GrayText',
-        },
-      },
-      [`& ~ .${checkboxClassNames.indicator}`]: {
-        ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
-        color: tokens.colorNeutralForegroundDisabled,
-        '@media (forced-colors: active)': {
-          color: 'GrayText',
-        },
-      },
-      [`& ~ .${checkboxClassNames.indicator} svg`]: {
-        '@media (forced-colors: active)': {
-          color: 'GrayText',
-        },
-      },
-    },
-  },
-
   before: {
     right: 0,
   },
@@ -149,40 +150,34 @@ const useInputStyles = makeStyles({
     left: 0,
   },
 
-  // Calculate the width of the hidden input by taking into account the size of the indicator + the padding around it.
-  // This is done so that clicking on that "empty space" still toggles the checkbox.
-  medium: {
-    width: `calc(${indicatorSizeMedium} + 2 * ${tokens.spacingHorizontalS})`,
-  },
   large: {
     width: `calc(${indicatorSizeLarge} + 2 * ${tokens.spacingHorizontalS})`,
   },
 });
 
+const useIndicatorBaseClassName = makeResetStyles({
+  alignSelf: 'flex-start',
+  boxSizing: 'border-box',
+  flexShrink: 0,
+
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+
+  borderWidth: tokens.strokeWidthThin,
+  borderStyle: 'solid',
+  borderRadius: tokens.borderRadiusSmall,
+  margin: tokens.spacingVerticalS + ' ' + tokens.spacingHorizontalS,
+  fill: 'currentColor',
+  pointerEvents: 'none',
+
+  fontSize: '12px',
+  height: indicatorSizeMedium,
+  width: indicatorSizeMedium,
+});
+
 const useIndicatorStyles = makeStyles({
-  base: {
-    alignSelf: 'flex-start',
-    boxSizing: 'border-box',
-    flexShrink: 0,
-
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...shorthands.overflow('hidden'),
-
-    ...shorthands.border(tokens.strokeWidthThin, 'solid'),
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
-    ...shorthands.margin(tokens.spacingVerticalS, tokens.spacingHorizontalS),
-    fill: 'currentColor',
-    pointerEvents: 'none',
-  },
-
-  medium: {
-    fontSize: '12px',
-    height: indicatorSizeMedium,
-    width: indicatorSizeMedium,
-  },
-
   large: {
     fontSize: '16px',
     height: indicatorSizeLarge,
@@ -194,10 +189,10 @@ const useIndicatorStyles = makeStyles({
   },
 });
 
+// Can't use makeResetStyles for Label because Label is a component that uses makeResetStyles.
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
-    color: 'inherit',
     cursor: 'pointer',
     ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalS),
   },
@@ -225,26 +220,28 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Checkbox slots based on the state
  */
 export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState => {
-  const rootStyles = useRootStyles();
-  state.root.className = mergeClasses(checkboxClassNames.root, rootStyles.base, state.root.className);
-
   const { labelPosition, shape, size } = state;
 
+  const rootBaseClassName = useRootBaseClassName();
+  state.root.className = mergeClasses(checkboxClassNames.root, rootBaseClassName, state.root.className);
+
+  const inputBaseClassName = useInputBaseClassName();
   const inputStyles = useInputStyles();
   state.input.className = mergeClasses(
     checkboxClassNames.input,
-    inputStyles.base,
-    inputStyles[size],
+    inputBaseClassName,
+    size === 'large' && inputStyles.large,
     inputStyles[labelPosition],
     state.input.className,
   );
 
+  const indicatorBaseClassName = useIndicatorBaseClassName();
   const indicatorStyles = useIndicatorStyles();
   if (state.indicator) {
     state.indicator.className = mergeClasses(
       checkboxClassNames.indicator,
-      indicatorStyles.base,
-      indicatorStyles[size],
+      indicatorBaseClassName,
+      size === 'large' && indicatorStyles.large,
       shape === 'circular' && indicatorStyles.circular,
       state.indicator.className,
     );

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -165,8 +165,7 @@ const useIndicatorBaseClassName = makeResetStyles({
   justifyContent: 'center',
   overflow: 'hidden',
 
-  borderWidth: tokens.strokeWidthThin,
-  borderStyle: 'solid',
+  border: tokens.strokeWidthThin + ' solid',
   borderRadius: tokens.borderRadiusSmall,
   margin: tokens.spacingVerticalS + ' ' + tokens.spacingHorizontalS,
   fill: 'currentColor',

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -189,7 +189,7 @@ const useIndicatorStyles = makeStyles({
   },
 });
 
-// Can't use makeResetStyles for Label because Label is a component that uses makeResetStyles.
+// Can't use makeResetStyles here because Label is a component that may itself use makeResetStyles.
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -1,6 +1,6 @@
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { RadioSlots, RadioState } from './Radio.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
@@ -14,145 +14,138 @@ export const radioClassNames: SlotClassNames<RadioSlots> = {
 // The indicator size is used by the indicator and label styles
 const indicatorSize = '16px';
 
-/**
- * Styles for the root slot
- */
-const useRootStyles = makeStyles({
-  base: {
-    display: 'inline-flex',
-    position: 'relative',
-  },
+const useRootBaseClassName = makeResetStyles({
+  display: 'inline-flex',
+  position: 'relative',
+  ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
+});
 
+const useRootStyles = makeStyles({
   vertical: {
     flexDirection: 'column',
     alignItems: 'center',
   },
-
-  focusIndicator: createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
 });
 
-const useInputStyles = makeStyles({
-  base: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    width: '100%',
-    height: '100%',
-    boxSizing: 'border-box',
-    ...shorthands.margin(0),
-    opacity: 0,
+const useInputBaseClassName = makeResetStyles({
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  width: `calc(${indicatorSize} + 2 * ${tokens.spacingHorizontalS})`,
+  height: '100%',
+  boxSizing: 'border-box',
+  margin: 0,
+  opacity: 0,
 
-    ':enabled': {
+  ':enabled': {
+    cursor: 'pointer',
+    [`& ~ .${radioClassNames.label}`]: {
       cursor: 'pointer',
-      [`& ~ .${radioClassNames.label}`]: {
-        cursor: 'pointer',
-      },
+    },
+  },
+
+  // When unchecked, hide the circle icon (child of the indicator)
+  [`:not(:checked) ~ .${radioClassNames.indicator} > *`]: {
+    opacity: '0',
+  },
+
+  // Colors for the unchecked state
+  ':enabled:not(:checked)': {
+    [`& ~ .${radioClassNames.label}`]: {
+      color: tokens.colorNeutralForeground3,
+    },
+    [`& ~ .${radioClassNames.indicator}`]: {
+      borderColor: tokens.colorNeutralStrokeAccessible,
     },
 
-    // When unchecked, hide the circle icon (child of the indicator)
-    [`:not(:checked) ~ .${radioClassNames.indicator} > *`]: {
-      opacity: '0',
-    },
-
-    // Colors for the unchecked state
-    ':enabled:not(:checked)': {
+    ':hover': {
       [`& ~ .${radioClassNames.label}`]: {
-        color: tokens.colorNeutralForeground3,
+        color: tokens.colorNeutralForeground2,
       },
       [`& ~ .${radioClassNames.indicator}`]: {
-        ...shorthands.borderColor(tokens.colorNeutralStrokeAccessible),
-      },
-
-      ':hover': {
-        [`& ~ .${radioClassNames.label}`]: {
-          color: tokens.colorNeutralForeground2,
-        },
-        [`& ~ .${radioClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorNeutralStrokeAccessibleHover),
-        },
-      },
-
-      ':hover:active': {
-        [`& ~ .${radioClassNames.label}`]: {
-          color: tokens.colorNeutralForeground1,
-        },
-        [`& ~ .${radioClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorNeutralStrokeAccessiblePressed),
-        },
+        borderColor: tokens.colorNeutralStrokeAccessibleHover,
       },
     },
 
-    // Colors for the checked state
-    ':enabled:checked': {
+    ':hover:active': {
       [`& ~ .${radioClassNames.label}`]: {
         color: tokens.colorNeutralForeground1,
       },
       [`& ~ .${radioClassNames.indicator}`]: {
-        ...shorthands.borderColor(tokens.colorCompoundBrandStroke),
-        color: tokens.colorCompoundBrandForeground1,
-      },
-
-      ':hover': {
-        [`& ~ .${radioClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorCompoundBrandStrokeHover),
-          color: tokens.colorCompoundBrandForeground1Hover,
-        },
-      },
-
-      ':hover:active': {
-        [`& ~ .${radioClassNames.indicator}`]: {
-          ...shorthands.borderColor(tokens.colorCompoundBrandStrokePressed),
-          color: tokens.colorCompoundBrandForeground1Pressed,
-        },
+        borderColor: tokens.colorNeutralStrokeAccessiblePressed,
       },
     },
+  },
 
-    // Colors for the disabled state
-    ':disabled': {
-      [`& ~ .${radioClassNames.label}`]: {
-        color: tokens.colorNeutralForegroundDisabled,
-        cursor: 'default',
-      },
+  // Colors for the checked state
+  ':enabled:checked': {
+    [`& ~ .${radioClassNames.label}`]: {
+      color: tokens.colorNeutralForeground1,
+    },
+    [`& ~ .${radioClassNames.indicator}`]: {
+      borderColor: tokens.colorCompoundBrandStroke,
+      color: tokens.colorCompoundBrandForeground1,
+    },
+
+    ':hover': {
       [`& ~ .${radioClassNames.indicator}`]: {
-        ...shorthands.borderColor(tokens.colorNeutralStrokeDisabled),
-        color: tokens.colorNeutralForegroundDisabled,
+        borderColor: tokens.colorCompoundBrandStrokeHover,
+        color: tokens.colorCompoundBrandForeground1Hover,
+      },
+    },
+
+    ':hover:active': {
+      [`& ~ .${radioClassNames.indicator}`]: {
+        borderColor: tokens.colorCompoundBrandStrokePressed,
+        color: tokens.colorCompoundBrandForeground1Pressed,
       },
     },
   },
 
-  after: {
-    width: `calc(${indicatorSize} + 2 * ${tokens.spacingHorizontalS})`,
+  // Colors for the disabled state
+  ':disabled': {
+    [`& ~ .${radioClassNames.label}`]: {
+      color: tokens.colorNeutralForegroundDisabled,
+      cursor: 'default',
+    },
+    [`& ~ .${radioClassNames.indicator}`]: {
+      borderColor: tokens.colorNeutralStrokeDisabled,
+      color: tokens.colorNeutralForegroundDisabled,
+    },
   },
+});
+
+const useInputStyles = makeStyles({
   below: {
+    width: '100%',
     height: `calc(${indicatorSize} + 2 * ${tokens.spacingVerticalS})`,
   },
 });
 
-const useIndicatorStyles = makeStyles({
-  base: {
-    width: indicatorSize,
-    height: indicatorSize,
-    fontSize: '12px',
-    boxSizing: 'border-box',
-    flexShrink: 0,
+const useIndicatorBaseClassName = makeResetStyles({
+  width: indicatorSize,
+  height: indicatorSize,
+  fontSize: '12px',
+  boxSizing: 'border-box',
+  flexShrink: 0,
 
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...shorthands.overflow('hidden'),
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
 
-    ...shorthands.border(tokens.strokeWidthThin, 'solid'),
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    ...shorthands.margin(tokens.spacingVerticalS, tokens.spacingHorizontalS),
-    fill: 'currentColor',
-    pointerEvents: 'none',
-  },
+  borderWidth: tokens.strokeWidthThin,
+  borderStyle: 'solid',
+  borderRadius: tokens.borderRadiusCircular,
+  margin: tokens.spacingVerticalS + ' ' + tokens.spacingHorizontalS,
+  fill: 'currentColor',
+  pointerEvents: 'none',
 });
 
+// Can't use makeResetStyles for Label because Label is a component that could itself use makeResetStyles.
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',
-
     ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalS),
   },
 
@@ -177,25 +170,30 @@ const useLabelStyles = makeStyles({
 export const useRadioStyles_unstable = (state: RadioState) => {
   const { labelPosition } = state;
 
+  const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
   state.root.className = mergeClasses(
     radioClassNames.root,
-    rootStyles.base,
-    rootStyles.focusIndicator,
+    rootBaseClassName,
     labelPosition === 'below' && rootStyles.vertical,
     state.root.className,
   );
 
+  const inputBaseClassName = useInputBaseClassName();
   const inputStyles = useInputStyles();
   state.input.className = mergeClasses(
     radioClassNames.input,
-    inputStyles.base,
-    inputStyles[labelPosition],
+    inputBaseClassName,
+    labelPosition === 'below' && inputStyles.below,
     state.input.className,
   );
 
-  const indicatorStyles = useIndicatorStyles();
-  state.indicator.className = mergeClasses(radioClassNames.indicator, indicatorStyles.base, state.indicator.className);
+  const indicatorBaseClassName = useIndicatorBaseClassName();
+  state.indicator.className = mergeClasses(
+    radioClassNames.indicator,
+    indicatorBaseClassName,
+    state.indicator.className,
+  );
 
   const labelStyles = useLabelStyles();
   if (state.label) {

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -134,8 +134,7 @@ const useIndicatorBaseClassName = makeResetStyles({
   justifyContent: 'center',
   overflow: 'hidden',
 
-  borderWidth: tokens.strokeWidthThin,
-  borderStyle: 'solid',
+  border: tokens.strokeWidthThin + ' solid',
   borderRadius: tokens.borderRadiusCircular,
   margin: tokens.spacingVerticalS + ' ' + tokens.spacingHorizontalS,
   fill: 'currentColor',

--- a/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
+++ b/packages/react-components/react-radio/src/components/Radio/useRadioStyles.ts
@@ -142,7 +142,7 @@ const useIndicatorBaseClassName = makeResetStyles({
   pointerEvents: 'none',
 });
 
-// Can't use makeResetStyles for Label because Label is a component that could itself use makeResetStyles.
+// Can't use makeResetStyles here because Label is a component that may itself use makeResetStyles.
 const useLabelStyles = makeStyles({
   base: {
     alignSelf: 'center',


### PR DESCRIPTION
## Previous Behavior

Checkbox and Radio's styles include all of the styles for the checked, hover, etc. states in the base styles, and use CSS selectors to conditionally apply the styles.
* This results in a large number of classes being added to the default checkbox, because Griffel styles use a separate class for each combination of selector & property. As shown below, there are a total of **154** css classes across all of Checkbox's slots.
* This affects performance because chromium's css performance degrades with the number of classes.

<img width="435" alt="Checkbox class counts" src="https://user-images.githubusercontent.com/48106640/207474764-b9e052ea-0c3f-4d15-9a8c-a7ca2930a85b.png">

## New Behavior

Use Griffel's `makeResetStyles` to combine all of the base styles for each of Checkbox and Radio's slots into a single CSS class. Also, merge the styles for the default state into the base styles (`size: medium`, `labelPosition: after`). 
* For Checkbox, this results in an **85%** reduction in the number of CSS classes across all slots: down to **23** from 154 before.
* The stress test for Checkbox shows a roughly **12%** improvement in performance for applying styling.

<img width="435" alt="Checkbox class counts" src="https://user-images.githubusercontent.com/48106640/207475042-9092b219-f63d-446b-8c75-3e43b60df8a2.png">

<img width="703" alt="Checkbox perf test results" src="https://user-images.githubusercontent.com/48106640/207543844-6abec370-0d1d-4516-913c-af46db32eb9f.png">

## Related Issue(s)

* Partial fix for: #25483
  * This fixes the **CSS class bloat** part but does not fix the **Override specificity** concern in that issue.
