### PR TITLE
feat(react-utilities): generalize is HTMLElement attribute to unknown

### DIFF
--- a/change/@fluentui-react-utilities-7cc076d6-144c-497a-9432-7ed6e01735ae.json
+++ b/change/@fluentui-react-utilities-7cc076d6-144c-497a-9432-7ed6e01735ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: generalize is HTMLElement attribute to unknown",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -73,10 +73,10 @@ export function getTriggerChild<TriggerChildProps>(children: TriggerProps<Trigge
 export function isFluentTrigger(element: React_2.ReactElement): element is React_2.ReactElement<TriggerProps>;
 
 // @internal
-export function isHTMLElement(element?: Node | null | undefined): element is HTMLElement;
+export function isHTMLElement(element?: unknown): element is HTMLElement;
 
 // @internal
-export function isInteractiveHTMLElement(element: Node | null | undefined): boolean;
+export function isInteractiveHTMLElement(element: unknown): boolean;
 
 // @public
 export function isResolvedShorthand<Shorthand extends Slot<UnknownSlotProps>>(shorthand?: Shorthand): shorthand is ExtractSlotProps<Shorthand>;

--- a/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
+++ b/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
@@ -7,10 +7,11 @@
  * might be problematic while operating with [multiple realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms)
  *
  */
-export function isHTMLElement(element?: Node | null | undefined): element is HTMLElement {
+export function isHTMLElement(element?: unknown): element is HTMLElement {
+  const typedElement = element as Node | null | undefined;
   return Boolean(
-    element !== null &&
-      element?.ownerDocument?.defaultView &&
-      element instanceof element.ownerDocument.defaultView.HTMLElement,
+    typedElement !== null &&
+      typedElement?.ownerDocument?.defaultView &&
+      typedElement instanceof typedElement.ownerDocument.defaultView.HTMLElement,
   );
 }

--- a/packages/react-components/react-utilities/src/utils/isInteractiveHTMLElement.ts
+++ b/packages/react-components/react-utilities/src/utils/isInteractiveHTMLElement.ts
@@ -4,7 +4,7 @@ import { isHTMLElement } from './isHTMLElement';
  * @internal
  * Checks that the element has default behaviour from user input on click or 'Enter'/'Space' keys
  */
-export function isInteractiveHTMLElement(element: Node | null | undefined) {
+export function isInteractiveHTMLElement(element: unknown) {
   if (!isHTMLElement(element)) {
     return false;
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behaviour

Converts guard type method `isHTMLElement` and `isInteractiveHTMLElement` to accept any kind of argument by converting it's type from `Node` to `unknown`.

Some use cases while dealing with `event.target` might require this conversion, as `event.target` typings provided by react normally are simplified to `EventTarget`
