### PR TITLE
feat: add support for nonce in Fela renderer

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,10 +18,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- `createFelaRenderer` is now a function @layershifter ([#25992](https://github.com/microsoft/fluentui/pull/25992))
+
 ### Fixes
 - `Carousel` fix for FZ - Adding data-is-visible prop #25973 @kolaps33 ([#25973](https://github.com/microsoft/fluentui/pull/25973))
 - Fix `Dropdown` allowing interaction with selected items when disabled @chpalac ([#25954](https://github.com/microsoft/fluentui/pull/25954))
 - Fix `Button` styles for `disabledFocusable` when `text` @chpalac ([#26012](https://github.com/microsoft/fluentui/pull/26012))
+
+### Features
+- `nonce` can be configured for Fela renderer @layershifter ([#25992](https://github.com/microsoft/fluentui/pull/25992))
 
 <!--------------------------------[ v0.65.0 ]------------------------------- -->
 ## [v0.65.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.65.0) (2022-10-31)

--- a/packages/fluentui/docs/src/app.tsx
+++ b/packages/fluentui/docs/src/app.tsx
@@ -38,7 +38,7 @@ const themes = {
 };
 
 function useRendererFactory(): CreateRenderer {
-  const rendererFactory = localStorage.fluentRenderer === 'emotion' ? createEmotionRenderer() : createFelaRenderer;
+  const rendererFactory = localStorage.fluentRenderer === 'emotion' ? createEmotionRenderer() : createFelaRenderer();
 
   React.useEffect(() => {
     (window as any).setFluentRenderer = (rendererName: 'fela' | 'emotion') => {

--- a/packages/fluentui/react-bindings/src/renderer/RendererContext.ts
+++ b/packages/fluentui/react-bindings/src/renderer/RendererContext.ts
@@ -2,4 +2,4 @@ import { createFelaRenderer } from '@fluentui/react-northstar-fela-renderer';
 import { CreateRenderer } from '@fluentui/react-northstar-styles-renderer';
 import * as React from 'react';
 
-export const RendererContext = React.createContext<CreateRenderer>(createFelaRenderer);
+export const RendererContext = React.createContext<CreateRenderer>(createFelaRenderer());

--- a/packages/fluentui/react-northstar-fela-renderer/package.json
+++ b/packages/fluentui/react-northstar-fela-renderer/package.json
@@ -9,21 +9,22 @@
     "@fluentui/styles": "^0.65.0",
     "css-in-js-utils": "^3.0.0",
     "fela": "^10.6.1",
+    "fela-dom": "^11.7.0",
     "fela-plugin-embedded": "^10.6.1",
     "fela-plugin-fallback-value": "^10.6.1",
     "fela-plugin-placeholder-prefixer": "^10.6.1",
     "fela-plugin-rtl": "^10.6.1",
     "fela-tools": "^10.6.1",
-    "fela-utils": "^10.6.1",
+    "fela-utils": "^11.7.0",
     "inline-style-expand-shorthand": "^1.2.0",
     "lodash": "^4.17.15",
-    "react-fela": "^10.6.1",
     "stylis": "^3.5.4"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts": "^1.0.0",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "react-fela": "^10.6.1"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-northstar-fela-renderer/src/RendererProvider.tsx
+++ b/packages/fluentui/react-northstar-fela-renderer/src/RendererProvider.tsx
@@ -1,0 +1,64 @@
+import { render, rehydrate } from 'fela-dom';
+import * as React from 'react';
+
+import { FelaRenderer } from './types';
+
+// Copied from https://github.com/robinweser/fela/blob/master/packages/fela-bindings/src/RendererProviderFactory.js
+
+function hasDOM(renderer: FelaRenderer, targetDocument: Document | undefined) {
+  // ensure we're on a browser by using document since window is defined in e.g. React Native
+  // see https://github.com/robinweser/fela/issues/736
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  const doc = targetDocument || document;
+
+  return renderer && doc && doc.createElement;
+}
+
+function hasServerRenderedStyle(targetDocument = document) {
+  return targetDocument.querySelectorAll('[data-fela-type]').length > 0;
+}
+
+type RendererProviderProps = {
+  renderer: FelaRenderer;
+  rehydrate?: boolean;
+  targetDocument?: Document;
+};
+
+// Typings provided by "fela" package are outdated, this overrides provides proper definition
+declare module 'fela-dom' {
+  function render(renderer: FelaRenderer, targetDocument?: Document): void;
+  function rehydrate(renderer: FelaRenderer, targetDocument?: Document): void;
+}
+
+export class RendererProvider extends React.Component<RendererProviderProps, Record<string, unknown>> {
+  constructor(props: RendererProviderProps) {
+    super(props);
+    this._renderStyle();
+  }
+
+  componentDidUpdate(prevProps: RendererProviderProps) {
+    if (prevProps.renderer !== this.props.renderer) {
+      // add warning that renderer is changed
+      this._renderStyle();
+    }
+  }
+
+  _renderStyle() {
+    const { renderer, rehydrate: shouldRehydrate, targetDocument } = this.props;
+
+    if (hasDOM(renderer, targetDocument)) {
+      if (shouldRehydrate && hasServerRenderedStyle(targetDocument)) {
+        rehydrate(renderer, targetDocument);
+      } else {
+        render(renderer, targetDocument);
+      }
+    }
+  }
+
+  render() {
+    return <>{this.props.children}</>;
+  }
+}

--- a/packages/fluentui/react-northstar-fela-renderer/src/createFelaRenderer.tsx
+++ b/packages/fluentui/react-northstar-fela-renderer/src/createFelaRenderer.tsx
@@ -5,7 +5,6 @@ import felaPluginFallbackValue from 'fela-plugin-fallback-value';
 import felaPluginPlaceholderPrefixer from 'fela-plugin-placeholder-prefixer';
 import felaPluginRtl from 'fela-plugin-rtl';
 import * as React from 'react';
-import { RendererProvider } from 'react-fela';
 
 import { felaDisableAnimationsPlugin } from './felaDisableAnimationsPlugin';
 import { felaExpandCssShorthandsPlugin } from './felaExpandCssShorthandsPlugin';
@@ -14,7 +13,8 @@ import { felaInvokeKeyframesPlugin } from './felaInvokeKeyframesPlugin';
 import { felaPerformanceEnhancer } from './felaPerformanceEnhancer';
 import { felaSanitizeCssPlugin } from './felaSanitizeCssPlugin';
 import { felaStylisEnhancer } from './felaStylisEnhancer';
-import { FelaRendererParam } from './types';
+import { RendererProvider } from './RendererProvider';
+import { FelaRenderer, FelaRendererParam } from './types';
 
 let felaDevMode = false;
 
@@ -92,58 +92,72 @@ const rendererConfig = {
   ],
 };
 
-export const createFelaRenderer: CreateRenderer = () => {
-  const felaRenderer = createRenderer(rendererConfig) as IRenderer & {
-    listeners: [];
-    nodes: Record<string, HTMLStyleElement>;
-    updateSubscription: Function | undefined;
-  };
-  let usedRenderers: number = 0;
-
-  // rehydration disabled to avoid leaking styles between renderers
-  // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
-  const Provider: Renderer['Provider'] = props => (
-    <RendererProvider renderer={felaRenderer} {...{ rehydrate: false, targetDocument: props.target }}>
-      {props.children}
-    </RendererProvider>
-  );
-
-  return {
-    registerUsage: () => {
-      usedRenderers += 1;
-    },
-    unregisterUsage: () => {
-      usedRenderers -= 1;
-
-      if (usedRenderers === 0) {
-        felaRenderer.listeners = [];
-        felaRenderer.nodes = {};
-        felaRenderer.updateSubscription = undefined;
-      }
-    },
-
-    renderFont: font => {
-      felaRenderer.renderFont(font.name, font.paths, font.props);
-    },
-    renderGlobal: felaRenderer.renderStatic,
-    renderRule: (styles, param) => {
-      const felaParam: FelaRendererParam = {
-        ...param,
-        theme: { direction: param.direction },
-      };
-
-      return felaRenderer.renderRule(() => (styles as unknown) as IStyle, felaParam);
-    },
-
-    // getOriginalRenderer() is implemented only for tests to be compatible with jest-react-fela expectations.
-    getOriginalRenderer: (): IRenderer => {
-      if (process.env.NODE_ENV !== 'test') {
-        throw new Error('This method implements private API and can be used only in tests');
-      }
-
-      return felaRenderer;
-    },
-
-    Provider,
-  };
+export type CreateFelaRendererOptions = {
+  nonce?: string;
 };
+
+export function createFelaRenderer(options: CreateFelaRendererOptions = {}): CreateRenderer {
+  const { nonce } = options;
+
+  return () => {
+    const felaRenderer = createRenderer(rendererConfig) as FelaRenderer & {
+      listeners: [];
+      nodes: Record<string, HTMLStyleElement>;
+      updateSubscription: Function | undefined;
+    };
+    let usedRenderers: number = 0;
+
+    if (nonce) {
+      felaRenderer.styleNodeAttributes = {
+        nonce,
+      };
+    }
+
+    // rehydration disabled to avoid leaking styles between renderers
+    // https://github.com/rofrischmann/fela/blob/master/docs/api/fela-dom/rehydrate.md
+    const Provider: Renderer['Provider'] = props => (
+      <RendererProvider renderer={felaRenderer} rehydrate={false} targetDocument={props.target}>
+        {props.children}
+      </RendererProvider>
+    );
+
+    return {
+      registerUsage: () => {
+        usedRenderers += 1;
+      },
+      unregisterUsage: () => {
+        usedRenderers -= 1;
+
+        if (usedRenderers === 0) {
+          felaRenderer.listeners = [];
+          felaRenderer.nodes = {};
+          felaRenderer.updateSubscription = undefined;
+        }
+      },
+
+      renderFont: font => {
+        felaRenderer.renderFont(font.name, font.paths, font.props);
+      },
+      renderGlobal: felaRenderer.renderStatic,
+      renderRule: (styles, param) => {
+        const felaParam: FelaRendererParam = {
+          ...param,
+          theme: { direction: param.direction },
+        };
+
+        return felaRenderer.renderRule(() => (styles as unknown) as IStyle, felaParam);
+      },
+
+      // getOriginalRenderer() is implemented only for tests to be compatible with jest-react-fela expectations.
+      getOriginalRenderer: (): IRenderer => {
+        if (process.env.NODE_ENV !== 'test') {
+          throw new Error('This method implements private API and can be used only in tests');
+        }
+
+        return felaRenderer;
+      },
+
+      Provider,
+    };
+  };
+}

--- a/packages/fluentui/react-northstar-fela-renderer/src/types.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/src/types.ts
@@ -16,6 +16,8 @@ export type FelaRenderer = IRenderer & {
     media?: string,
     support?: string,
   ): string;
+
+  styleNodeAttributes: Record<string, string | number | boolean>;
 };
 
 export type FelaRendererChange = {

--- a/packages/fluentui/react-northstar-fela-renderer/test/felaRenderer-test.tsx
+++ b/packages/fluentui/react-northstar-fela-renderer/test/felaRenderer-test.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { FelaComponent, RendererProvider, ThemeProvider } from 'react-fela';
 
-const felaRenderer = (createFelaRenderer() as any).getOriginalRenderer();
+const felaRenderer = (createFelaRenderer()() as any).getOriginalRenderer();
 
 function createSnapshot(component: JSX.Element, theme = {}) {
   const div = document.createElement('div');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7403,7 +7403,7 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@^2.0.0, asap@~2.0.3, asap@~2.0.6:
+asap@^2.0.0, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -10050,11 +10050,6 @@ core-js@3, core-js@^3.0.4, core-js@^3.3.2, core-js@^3.6.5, core-js@^3.8.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.2.tgz#740660d2ff55ef34ce664d7e2455119c5bdd3d61"
   integrity sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -11664,7 +11659,7 @@ encodeurl@^1.0.2, encodeurl@~1.0.1, encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11, encoding@^0.1.12, encoding@^0.1.13:
+encoding@^0.1.12, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -12941,19 +12936,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.4:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
-
 fclone@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
@@ -12985,6 +12967,16 @@ fela-dom@^10.6.1:
     css-in-js-utils "^3.0.0"
     fast-loops "^1.0.1"
     fela-utils "^10.6.1"
+
+fela-dom@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/fela-dom/-/fela-dom-11.7.0.tgz#8706aaedf348af6e2d761d38c0f97d8d6607a99b"
+  integrity sha512-mYboADGGQc/EihhyPOs8Xo2aJ0cOQI4q3+aWQ11KPzaCAT3TTVdXuTslT5QeXoE6cT6nS77GvvrRzXb3U/gY6Q==
+  dependencies:
+    css-in-js-utils "^3.0.0"
+    fast-loops "^1.0.1"
+    fela-utils "^11.7.0"
+    sort-css-media-queries "^1.4.3"
 
 fela-plugin-custom-property@^10.6.1:
   version "10.8.2"
@@ -13039,6 +13031,14 @@ fela-utils@^10.6.1:
   version "10.8.2"
   resolved "https://registry.yarnpkg.com/fela-utils/-/fela-utils-10.8.2.tgz#b9d38e043aaf5d3d48012686ffb84e6378f24a35"
   integrity sha512-RmoDOIby14Zb3Xn03noLolyMC2528xcNO5KcNCaznyByd1Acq8DnvQn91Ph9nBLcLqdC1rGme5HwRcrCOHG+kA==
+  dependencies:
+    css-in-js-utils "^3.0.0"
+    fast-loops "^1.0.0"
+
+fela-utils@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/fela-utils/-/fela-utils-11.7.0.tgz#ad91df64320d005ae131a8ad72f9ce7454198428"
+  integrity sha512-s/3QJtkCesH+2/yJDpedHVAvMgKy9hSt2++6l7Xjio5BixiUnvkwbqdCV/fcAb4E3reJLNzYeatgPdcw4HVXRQ==
   dependencies:
     css-in-js-utils "^3.0.0"
     fast-loops "^1.0.0"
@@ -16068,7 +16068,7 @@ is-ssh@^1.4.0:
   dependencies:
     protocols "^2.0.1"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -16231,14 +16231,6 @@ isobject@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isomorphic-unfetch@^2.0.0:
   version "2.1.1"
@@ -19665,14 +19657,6 @@ node-fetch@2.6.7, node-fetch@^2.1.2, node-fetch@^2.6.0, node-fetch@^2.6.1, node-
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 node-forge@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
@@ -21736,13 +21720,6 @@ promise.prototype.finally@^3.1.0:
     es-abstract "^1.9.0"
     function-bind "^1.1.1"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 promise@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -22068,11 +22045,10 @@ react-ace@^5.1.2:
     prop-types "^15.5.8"
 
 react-addons-shallow-compare@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
-  integrity sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz#28a94b0dfee71530852c66a69053d59a1baf04cb"
+  integrity sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==
   dependencies:
-    fbjs "^0.8.4"
     object-assign "^4.1.0"
 
 react-app-polyfill@2.0.0:
@@ -24170,6 +24146,11 @@ socks@^2.3.3, socks@^2.6.2:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
 
+sort-css-media-queries@^1.4.3:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/sort-css-media-queries/-/sort-css-media-queries-1.5.4.tgz#24182b12002a13d01ba943ddf74f5098d7c244ce"
+  integrity sha512-YP5W/h4Sid/YP7Lp87ejJ5jP13/Mtqt2vx33XyhO+IAugKlufRPbOrPlIiEUuxmpNBSBd3EeeQpFhdu3RfI2Ag==
+
 sort-keys-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sort-keys-length/-/sort-keys-length-1.0.1.tgz#9cb6f4f4e9e48155a6aa0671edd336ff1479a188"
@@ -25950,7 +25931,7 @@ typical@^5.2.0:
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
-ua-parser-js@^0.7.18, ua-parser-js@^0.7.30:
+ua-parser-js@^0.7.30:
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
@@ -27115,7 +27096,7 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.4.1:
+whatwg-fetch@^3.4.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==


### PR DESCRIPTION
Fixes #25583.

# BREAKING CHANGES

This PR contains a breaking change in `@fluentui/react-northstar-fela-renderer` to allow configure `nonce` property on style tags. `createFelaRenderer()` now is a factory that accepts options:

```tsx
createFelaRenderer();
// or
createFelaRenderer({ nonce: '' })
```

## Before

```tsx
import { RendererContext } from "@fluentui/react-northstar";
import { createFelaRenderer } from "@fluentui/react-northstar-fela-renderer";

function App() {
  return <RendererContext.Provider value={createFelaRenderer} />;
}
```

## After

```tsx
import { RendererContext } from "@fluentui/react-northstar";
import { createFelaRenderer } from "@fluentui/react-northstar-fela-renderer";

function App() {
  return <RendererContext.Provider value={createFelaRenderer()} />; // 👈 change is there
}
```

### Notes

I didn't bump Fela fully as we have enhancers that should be update for a newer version. Instead I copied `RendererProvider` from `react-fela` (actually `fela-bindings`) and bumped `fela-dom` to a version that supports `styleAttributes` feature (https://github.com/robinweser/fela/pull/768).
