### PR TITLE
chore: Add Checkbox bundle size test

### DIFF
--- a/change/@fluentui-react-checkbox-f94ea0be-f27d-401f-9810-fdd8c96b2251.json
+++ b/change/@fluentui-react-checkbox-f94ea0be-f27d-401f-9810-fdd8c96b2251.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add Checkbox bundle size test",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-checkbox/bundle-size/Checkbox.fixture.js
+++ b/packages/react-components/react-checkbox/bundle-size/Checkbox.fixture.js
@@ -1,0 +1,7 @@
+import { Checkbox } from '@fluentui/react-checkbox';
+
+console.log(Checkbox);
+
+export default {
+  name: 'Checkbox',
+};

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
## Previous Behavior

Checkbox was missing a bundle size test.

## New Behavior

Add react-checkbox/bundle-size/Checkbox.fixture.js to enable bundle size regression testing in PRs.
