### PR TITLE
chore: Add bundle size fixture to create-component template

### DIFF
--- a/scripts/generators/create-component/plop-templates/bundle-size/{{componentName}}.fixture.js.hbs
+++ b/scripts/generators/create-component/plop-templates/bundle-size/{{componentName}}.fixture.js.hbs
@@ -1,0 +1,7 @@
+import { {{componentName}} } from '@fluentui/{{packageName}}';
+
+console.log({{componentName}});
+
+export default {
+  name: '{{componentName}}',
+};

--- a/scripts/generators/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/generators/create-package/plop-templates-react/package.json.hbs
@@ -14,6 +14,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "bundle-size measure",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",


### PR DESCRIPTION
## Previous Behavior

Components created using `yarn create-component` did not include bundle size tests by default.

## New Behavior

Add bundle-size command to packages created with `yarn create-package`, and bundle size fixtures for components created with `yarn create-component`. This will enable bundle size tests by default for new components.

## Related Issue(s)

None
