### PR TITLE
chore(eslint config v9): turn off react/jsx-no-bind rule for cypress tests

### DIFF
--- a/change/@fluentui-eslint-plugin-83433d10-e2cd-4770-9d92-67bb16949a8a.json
+++ b/change/@fluentui-eslint-plugin-83433d10-e2cd-4770-9d92-67bb16949a8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Turn off react/jsx-no-bind rule for cypress component test files.",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-dialog-79b6c18e-0e77-459b-bb58-b56343e43485.json
+++ b/change/@fluentui-react-dialog-79b6c18e-0e77-459b-bb58-b56343e43485.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove unneeded eslint rule line disables.",
+  "packageName": "@fluentui/react-dialog",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-a5ada429-92db-4447-a6db-e909b652516e.json
+++ b/change/@fluentui-react-menu-a5ada429-92db-4447-a6db-e909b652516e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove unneeded eslint rule line disables.",
+  "packageName": "@fluentui/react-menu",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-23aa3f07-0bc1-4817-bd9d-677738de8781.json
+++ b/change/@fluentui-react-popover-23aa3f07-0bc1-4817-bd9d-677738de8781.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove unneeded eslint rule line disables.",
+  "packageName": "@fluentui/react-popover",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -48,6 +48,7 @@ module.exports = {
       files: ['**/*.cy.{ts,tsx,js}', 'isConformant.{ts,tsx,js}'],
       rules: {
         'import/no-extraneous-dependencies': 'off',
+        'react-jsx-no-bind': 'off',
       },
     },
   ],

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -48,7 +48,7 @@ module.exports = {
       files: ['**/*.cy.{ts,tsx,js}', 'isConformant.{ts,tsx,js}'],
       rules: {
         'import/no-extraneous-dependencies': 'off',
-        'react-jsx-no-bind': 'off',
+        'react/jsx-no-bind': 'off',
       },
     },
   ],

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -184,7 +184,6 @@ describe('Dialog', () => {
         }
       }, [open]);
       return (
-        //eslint-disable-next-line react/jsx-no-bind
         <Dialog open={open} onOpenChange={(event, data) => setOpen(data.open)}>
           <DialogTrigger disableButtonEnhancement>
             <Button id={dialogTriggerOpenId}>Open dialog</Button>

--- a/packages/react-components/react-menu/src/components/Menu/Menu.cy.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.cy.tsx
@@ -150,7 +150,6 @@ describe('Custom Trigger', () => {
     };
 
     return (
-      // eslint-disable-next-line react/jsx-no-bind
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger disableButtonEnhancement>
           <CustomMenuTrigger />
@@ -714,7 +713,6 @@ describe(`Nested Menus`, () => {
     };
 
     return (
-      // eslint-disable-next-line react/jsx-no-bind
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger disableButtonEnhancement>
           <MenuItem>Editor Layout</MenuItem>
@@ -738,7 +736,6 @@ describe(`Nested Menus`, () => {
     };
 
     return (
-      // eslint-disable-next-line react/jsx-no-bind
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger disableButtonEnhancement>
           <MenuItem>Appearance</MenuItem>
@@ -763,7 +760,6 @@ describe(`Nested Menus`, () => {
     };
 
     return (
-      // eslint-disable-next-line react/jsx-no-bind
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger disableButtonEnhancement>
           <MenuItem>Preferences</MenuItem>

--- a/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
@@ -29,7 +29,6 @@ describe('Popover', () => {
       const [open, setOpen] = React.useState(false);
 
       return (
-        // eslint-disable-next-line react/jsx-no-bind
         <Popover open={open} onOpenChange={(e, data) => setOpen(data.open)}>
           <PopoverTrigger disableButtonEnhancement>
             <button>Trigger</button>
@@ -297,7 +296,6 @@ describe('Popover', () => {
       };
 
       return (
-        // eslint-disable-next-line react/jsx-no-bind
         <Popover onOpenChange={onOpenChange}>
           <PopoverTrigger disableButtonEnhancement>
             <button>Popover trigger</button>


### PR DESCRIPTION
## Changes:
- turns off `react/jsx-no-bind` rule for cypress test files.
- removes one line comments disabling said rule in a couple of v9 cypress tests.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #25576
