### PR TITLE
fix: button styles for disabledFocusable and text variation

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - `Carousel` fix for FZ - Adding data-is-visible prop #25973 @kolaps33 ([#25973](https://github.com/microsoft/fluentui/pull/25973))
 - Fix `Dropdown` allowing interaction with selected items when disabled @chpalac ([#25954](https://github.com/microsoft/fluentui/pull/25954))
+- Fix `Button` styles for `disabledFocusable` when `text` @chpalac ([#26012](https://github.com/microsoft/fluentui/pull/26012))
 
 <!--------------------------------[ v0.65.0 ]------------------------------- -->
 ## [v0.65.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.65.0) (2022-10-31)

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -235,6 +235,9 @@ export const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, Button
           ':hover': {
             color: v.textColorDisabled,
           },
+          ':active': {
+            color: v.textColorDisabled,
+          },
         }),
 
         ...(!p.text && {


### PR DESCRIPTION
## Overview

Fix styles for the color when the button is `disabledFocusable` and `text`, currently when pressed it makes the color like this: 

![1JTwzjycku](https://user-images.githubusercontent.com/86579954/207888237-4cf2b098-d59d-4103-aa99-36df03d2a23c.gif)

This PR implements the fix adding the correct styles for `active`