### PR TITLE
Azure Theme Constants Clean Up

### DIFF
--- a/change/@fluentui-azure-themes-7e56ebb2-3674-4f55-af98-41b8ced3ceb2.json
+++ b/change/@fluentui-azure-themes-7e56ebb2-3674-4f55-af98-41b8ced3ceb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "alphabetized azure theme constants, renamed choicegroup to choicefield",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -5,25 +5,22 @@ import {
   getScreenSelector,
 } from '@fluentui/react/lib/Styling';
 
-export const inputHeight = '18px';
-export const commandBarHeight = '36px';
-export const buttonPadding = '0px 16px';
-export const borderWidth = '1px';
-export const borderRadius = '3px';
-export const borderWidthError = '1px';
-export const borderSolid = 'solid';
 export const borderNone = 'none';
+export const borderRadius = '3px';
+export const borderSolid = 'solid';
+export const borderWidth = '1px';
+export const buttonPadding = '0px 16px';
+export const choiceFieldHeight = '18px';
+export const commandBarHeight = '36px';
 export const dropDownItemHeight = '32px';
 export const fontFamily =
   // eslint-disable-next-line @fluentui/max-len
   'Segoe UI, "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue",sans-serif';
 export const fontWeightRegular = '400';
-export const fontWeightBold = '700';
 export const inputControlHeight = '24px';
-export const choiceGroupDimensions = '18px';
-export const inputControlPadding = '12px';
 export const inputControlHeightInner = '20px';
-export const textAlignCenter = 'center';
-export const transparent = 'transparent';
+export const inputControlPadding = '12px';
 export const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMaxSmall);
 export const MediumScreenSelector = getScreenSelector(ScreenWidthMinMedium, ScreenWidthMaxMedium);
+export const textAlignCenter = 'center';
+export const transparent = 'transparent';

--- a/packages/azure-themes/src/azure/styles/Checkbox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Checkbox.styles.ts
@@ -13,7 +13,7 @@ export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxSty
       {
         fontSize: theme.fonts.medium.fontSize,
         color: semanticColors.bodyText,
-        lineHeight: StyleConstants.inputHeight,
+        lineHeight: StyleConstants.choiceFieldHeight,
       },
       disabled && {
         color: semanticColors.disabledBodyText,
@@ -28,8 +28,8 @@ export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxSty
             backgroundColor: BaseColors.BLUE_0078D4,
           },
         },
-        width: StyleConstants.inputHeight,
-        height: StyleConstants.inputHeight,
+        width: StyleConstants.choiceFieldHeight,
+        height: StyleConstants.choiceFieldHeight,
       },
       indeterminate && {
         selectors: {

--- a/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
@@ -37,8 +37,8 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
           // The circle
           ':before': [
             {
-              width: StyleConstants.choiceGroupDimensions,
-              height: StyleConstants.choiceGroupDimensions,
+              width: StyleConstants.choiceFieldHeight,
+              height: StyleConstants.choiceFieldHeight,
               borderColor: semanticColors.bodyText,
             },
             checked && {

--- a/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
@@ -63,7 +63,7 @@ export const ComboBoxStyles = (theme: ITheme): Partial<IComboBoxStyles> => {
     },
     rootError: {
       borderColor: semanticColors.errorBackground,
-      borderWidth: StyleConstants.borderWidthError,
+      borderWidth: StyleConstants.borderWidth,
     },
     rootPressed: {
       borderColor: semanticColors.focusBorder,

--- a/packages/azure-themes/src/azure/styles/DropDown.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DropDown.styles.ts
@@ -118,7 +118,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
       },
       hasError && {
         borderColor: semanticColors.errorBackground,
-        borderWidth: StyleConstants.borderWidthError,
+        borderWidth: StyleConstants.borderWidth,
       },
       isOpen &&
         !hasError && {

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -37,7 +37,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
       },
       hasErrorMessage && [
         {
-          borderWidth: StyleConstants.borderWidthError,
+          borderWidth: StyleConstants.borderWidth,
         },
         focused && {
           borderColor: semanticColors.focusBorder,


### PR DESCRIPTION
## New Behavior
No visual changes. Alphabetized the Azure Theme constants and renamed choiceGroupHeight to choiceFieldHeight to be applicable to multiple selection controls (choicegroup, checkbox). 
<img width="670" alt="image" src="https://user-images.githubusercontent.com/30805892/207921240-3b899404-2855-4f52-87c5-871aac097a16.png">

## Related Issue(s)
Allows partner teams like Elixir to theme their controls when Azure Theme is applied. 


