### PR TITLE
feat: more Combobox examples

### DIFF
--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFiltering.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFiltering.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { makeStyles, shorthands, useId } from '@fluentui/react-components';
+import { Combobox, ComboboxProps, Option } from '@fluentui/react-combobox';
+
+const useStyles = makeStyles({
+  root: {
+    // Stack the label above the field with a gap
+    display: 'grid',
+    gridTemplateRows: 'repeat(1fr)',
+    justifyItems: 'start',
+    ...shorthands.gap('2px'),
+    maxWidth: '400px',
+  },
+});
+
+export const Filtering = (props: Partial<ComboboxProps>) => {
+  const comboId = useId('combo-default');
+  const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const [matchingOptions, setmatchingOptions] = React.useState([...options]);
+  const styles = useStyles();
+
+  const onChange: ComboboxProps['onChange'] = event => {
+    const value = event.target.value.trim();
+    const matches = options.filter(option => option.toLowerCase().indexOf(value.toLowerCase()) === 0);
+    setmatchingOptions(matches);
+  };
+
+  return (
+    <div className={styles.root}>
+      <label id={comboId}>Best pet</label>
+      <Combobox aria-labelledby={comboId} placeholder="Select an animal" onChange={onChange} {...props}>
+        {matchingOptions.map(option => (
+          <Option key={option} disabled={option === 'Ferret'}>
+            {option}
+          </Option>
+        ))}
+      </Combobox>
+    </div>
+  );
+};
+
+Filtering.parameters = {
+  docs: {
+    description: {
+      story: 'Filtering based on the user-typed string can be achieved by modifying the child Options directly.',
+    },
+  },
+};

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFiltering.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFiltering.stories.tsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles({
 export const Filtering = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-default');
   const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
-  const [matchingOptions, setmatchingOptions] = React.useState([...options]);
+  const [matchingOptions, setMatchingOptions] = React.useState([...options]);
   const styles = useStyles();
 
   const onChange: ComboboxProps['onChange'] = event => {
     const value = event.target.value.trim();
     const matches = options.filter(option => option.toLowerCase().indexOf(value.toLowerCase()) === 0);
-    setmatchingOptions(matches);
+    setMatchingOptions(matches);
   };
 
   return (

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
@@ -49,7 +49,7 @@ export const Freeform = (props: Partial<ComboboxProps>) => {
         onOptionSelect={onOptionSelect}
         {...props}
       >
-        {/* We recommend displaying the custom freeform string, if it doesn't match an animal */}
+        {/* We recommend displaying a custom freeform string, if the user input doesn't match an animal */}
         {customSearch ? (
           <Option key="freeform" text={customSearch}>
             "{customSearch}"

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
@@ -15,7 +15,25 @@ const useStyles = makeStyles({
 
 export const Freeform = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-default');
-  const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const options = [
+    'Cat',
+    'Caterpillar',
+    'Catfish',
+    'Cheetah',
+    'Chicken',
+    'Cockatiel',
+    'Cow',
+    'Dog',
+    'Dolphin',
+    'Ferret',
+    'Firefly',
+    'Fish',
+    'Fox',
+    'Fox Terrier',
+    'Frog',
+    'Hamster',
+    'Snake',
+  ];
   const [matchingOptions, setMatchingOptions] = React.useState([...options]);
   const [customSearch, setCustomSearch] = React.useState<string | undefined>();
   const styles = useStyles();

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
@@ -16,11 +16,45 @@ const useStyles = makeStyles({
 export const Freeform = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-default');
   const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const [customSearch, setCustomSearch] = React.useState<string | undefined>();
   const styles = useStyles();
+
+  const onChange: ComboboxProps['onChange'] = event => {
+    const value = event.target.value.trim();
+    const matches = options.filter(option => option.toLowerCase().indexOf(value.toLowerCase()) === 0);
+    if (value.length && matches.length < 1) {
+      setCustomSearch(value);
+    } else {
+      setCustomSearch(undefined);
+    }
+  };
+
+  const onOptionSelect: ComboboxProps['onOptionSelect'] = (event, data) => {
+    const matchingOption = data.optionText && options.includes(data.optionText);
+    if (matchingOption) {
+      setCustomSearch(undefined);
+    } else {
+      setCustomSearch(data.optionText);
+    }
+  };
+
   return (
     <div className={styles.root}>
       <label id={comboId}>Best pet</label>
-      <Combobox aria-labelledby={comboId} freeform placeholder="Select an animal" {...props}>
+      <Combobox
+        aria-labelledby={comboId}
+        freeform
+        placeholder="Select an animal"
+        onChange={onChange}
+        onOptionSelect={onOptionSelect}
+        {...props}
+      >
+        {/* We recommend displaying the custom freeform string, if it doesn't match an animal */}
+        {customSearch ? (
+          <Option key="freeform" text={customSearch}>
+            "{customSearch}"
+          </Option>
+        ) : null}
         {options.map(option => (
           <Option key={option} disabled={option === 'Ferret'}>
             {option}

--- a/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/ComboboxFreeform.stories.tsx
@@ -16,12 +16,14 @@ const useStyles = makeStyles({
 export const Freeform = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-default');
   const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const [matchingOptions, setMatchingOptions] = React.useState([...options]);
   const [customSearch, setCustomSearch] = React.useState<string | undefined>();
   const styles = useStyles();
 
   const onChange: ComboboxProps['onChange'] = event => {
     const value = event.target.value.trim();
     const matches = options.filter(option => option.toLowerCase().indexOf(value.toLowerCase()) === 0);
+    setMatchingOptions(matches);
     if (value.length && matches.length < 1) {
       setCustomSearch(value);
     } else {
@@ -55,10 +57,8 @@ export const Freeform = (props: Partial<ComboboxProps>) => {
             "{customSearch}"
           </Option>
         ) : null}
-        {options.map(option => (
-          <Option key={option} disabled={option === 'Ferret'}>
-            {option}
-          </Option>
+        {matchingOptions.map(option => (
+          <Option key={option}>{option}</Option>
         ))}
       </Combobox>
     </div>
@@ -70,7 +70,7 @@ Freeform.parameters = {
     description: {
       story:
         'Combobox supports the `freeform` prop, which allows freeform text input. ' +
-        'The input value will be reset on blur to reflect the selected options.',
+        'Implementing filtering together with `freeform` is generally recommended.',
     },
   },
 };

--- a/packages/react-components/react-combobox/src/stories/Combobox/index.stories.tsx
+++ b/packages/react-components/react-combobox/src/stories/Combobox/index.stories.tsx
@@ -7,6 +7,7 @@ import bestPracticesMd from './ComboboxBestPractices.md';
 export { Default } from './ComboboxDefault.stories';
 export { ComplexOptions } from './ComboboxComplexOptions.stories';
 export { CustomOptions } from './ComboboxCustomOptions.stories';
+export { Filtering } from './ComboboxFiltering.stories';
 export { Freeform } from './ComboboxFreeform.stories';
 export { Multiselect } from './ComboboxMultiselect.stories';
 export { Grouped } from './ComboboxGrouped.stories';


### PR DESCRIPTION
Adds/updates two combobox examples:

- The freeform example is updated to implement filtering options and show the freeform user-typed string as an option when no other options match.
- Added a basic Combobox filtering example, showing simple filtering by matching from the start of the string