### PR TITLE
Storybook: make codeblocks default to source to more accurately show source code

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -35,6 +35,7 @@ export const parameters = {
   docs: {
     source: {
       excludeDecorators: true,
+      type: 'source',
     },
   },
   exportToCodeSandbox: {

--- a/typings/storybook__addons/index.d.ts
+++ b/typings/storybook__addons/index.d.ts
@@ -39,6 +39,7 @@ declare module '@storybook/addons' {
          * enable/disable rendering decorators in Docs mode
          */
         excludeDecorators: boolean;
+        type: 'source' | 'auto' | 'dynamic';
       };
 
       container?: React.ComponentType<any>;


### PR DESCRIPTION
Previously codeblocks were processed and showed an approximation of the JSX initially rendered

![image](https://user-images.githubusercontent.com/1434956/208178111-1bb3334f-02e8-4249-afd6-ef2ad1f32ee8.png)

This ends up removing conditionally rendered JSX, as well as hooks and other configuration

![image](https://user-images.githubusercontent.com/1434956/208178213-ac4d1f21-4c28-4c4a-b533-daf1cbf1b980.png)

This update makes storybook use the source code verbatum so that it could be copied and pasted.

With this change, the default behavior will make the codeblocks look like this:

![image](https://user-images.githubusercontent.com/1434956/208178531-f6d3b680-a77c-471f-a146-5bcdd525dd07.png)

This adjustment will change ALL storybooks that reference this default config, but can be overriden if this behavior doesn't fit their package or individual story
