### PR TITLE
Remove deprecated exports

### DIFF
--- a/change/@fluentui-react-components-1ec556c8-312b-4f16-8020-f39a7c56511e.json
+++ b/change/@fluentui-react-components-1ec556c8-312b-4f16-8020-f39a7c56511e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "(chore): remove deprecated exports from ProgressBar",
+  "packageName": "@fluentui/react-components",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-de9cb16b-be85-4f69-b976-0a868ed0d472.json
+++ b/change/@fluentui-react-progress-de9cb16b-be85-4f69-b976-0a868ed0d472.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "(chore): remove deprecated exports from ProgressBar",
+  "packageName": "@fluentui/react-progress",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -135,19 +135,14 @@ import { personaClassNames } from '@fluentui/react-persona';
 import { PersonaProps } from '@fluentui/react-persona';
 import { PersonaSlots } from '@fluentui/react-persona';
 import { PersonaState } from '@fluentui/react-persona';
-import { Progress } from '@fluentui/react-progress';
 import { ProgressBar } from '@fluentui/react-progress';
 import { progressBarClassNames } from '@fluentui/react-progress';
 import { ProgressBarProps } from '@fluentui/react-progress';
 import { ProgressBarSlots } from '@fluentui/react-progress';
 import { ProgressBarState } from '@fluentui/react-progress';
-import { progressClassNames } from '@fluentui/react-progress';
 import { ProgressField_unstable as ProgressField } from '@fluentui/react-progress';
 import { progressFieldClassNames } from '@fluentui/react-progress';
 import { ProgressFieldProps_unstable as ProgressFieldProps } from '@fluentui/react-progress';
-import { ProgressProps } from '@fluentui/react-progress';
-import { ProgressSlots } from '@fluentui/react-progress';
-import { ProgressState } from '@fluentui/react-progress';
 import { RadioGroupField_unstable as RadioGroupField } from '@fluentui/react-radio';
 import { radioGroupFieldClassNames } from '@fluentui/react-radio';
 import { RadioGroupFieldProps_unstable as RadioGroupFieldProps } from '@fluentui/react-radio';
@@ -171,7 +166,6 @@ import { renderListbox_unstable } from '@fluentui/react-combobox';
 import { renderOption_unstable } from '@fluentui/react-combobox';
 import { renderOptionGroup_unstable } from '@fluentui/react-combobox';
 import { renderPersona_unstable } from '@fluentui/react-persona';
-import { renderProgress_unstable } from '@fluentui/react-progress';
 import { renderProgressBar_unstable } from '@fluentui/react-progress';
 import { renderSelect_unstable } from '@fluentui/react-select';
 import { renderTable_unstable } from '@fluentui/react-table';
@@ -323,10 +317,8 @@ import { useOptionStyles_unstable } from '@fluentui/react-combobox';
 import { useOverflowMenu } from '@fluentui/react-overflow';
 import { usePersona_unstable } from '@fluentui/react-persona';
 import { usePersonaStyles_unstable } from '@fluentui/react-persona';
-import { useProgress_unstable } from '@fluentui/react-progress';
 import { useProgressBar_unstable } from '@fluentui/react-progress';
 import { useProgressBarStyles_unstable } from '@fluentui/react-progress';
-import { useProgressStyles_unstable } from '@fluentui/react-progress';
 import { useSelect_unstable } from '@fluentui/react-select';
 import { useSelectStyles_unstable } from '@fluentui/react-select';
 import { useTable_unstable } from '@fluentui/react-table';
@@ -618,8 +610,6 @@ export { PersonaSlots }
 
 export { PersonaState }
 
-export { Progress }
-
 export { ProgressBar }
 
 export { progressBarClassNames }
@@ -630,19 +620,11 @@ export { ProgressBarSlots }
 
 export { ProgressBarState }
 
-export { progressClassNames }
-
 export { ProgressField }
 
 export { progressFieldClassNames }
 
 export { ProgressFieldProps }
-
-export { ProgressProps }
-
-export { ProgressSlots }
-
-export { ProgressState }
 
 export { RadioGroupField }
 
@@ -689,8 +671,6 @@ export { renderOption_unstable }
 export { renderOptionGroup_unstable }
 
 export { renderPersona_unstable }
-
-export { renderProgress_unstable }
 
 export { renderProgressBar_unstable }
 
@@ -995,13 +975,9 @@ export { usePersona_unstable }
 
 export { usePersonaStyles_unstable }
 
-export { useProgress_unstable }
-
 export { useProgressBar_unstable }
 
 export { useProgressBarStyles_unstable }
-
-export { useProgressStyles_unstable }
 
 export { useSelect_unstable }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -363,38 +363,10 @@ export {
 export type { PersonaProps, PersonaState, PersonaSlots } from '@fluentui/react-persona';
 
 export {
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  Progress,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  progressClassNames,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  renderProgress_unstable,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  useProgressStyles_unstable,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  useProgress_unstable,
   ProgressBar,
   progressBarClassNames,
   renderProgressBar_unstable,
   useProgressBarStyles_unstable,
   useProgressBar_unstable,
 } from '@fluentui/react-progress';
-export type {
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  ProgressProps,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  ProgressState,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  ProgressSlots,
-  ProgressBarProps,
-  ProgressBarState,
-  ProgressBarSlots,
-} from '@fluentui/react-progress';
+export type { ProgressBarProps, ProgressBarState, ProgressBarSlots } from '@fluentui/react-progress';

--- a/packages/react-components/react-progress/README.md
+++ b/packages/react-components/react-progress/README.md
@@ -8,29 +8,29 @@ These are not production-ready components and **should never be used in product*
 
 ## Usage
 
-To import `Progress`:
+To import `ProgressBar`:
 
 ```js
-import { Progress } from '@fluentui/react-progress';
+import { ProgressBar } from '@fluentui/react-progress';
 ```
 
 Once the Progress component graduates to a production release, the component will be available at:
 
 ```js
-import { Progress } from '@fluentui/react-components';
+import { ProgressBar } from '@fluentui/react-components';
 ```
 
 ### Examples
 
 ```jsx
-const ProgressExample = () => {
-  return <Progress thickness="large" value={0.5} />;
+const ProgressBarExample = () => {
+  return <ProgressBar thickness="large" value={0.5} />;
 };
 ```
 
 #### Using ProgressField
 
-The `ProgressField` component is a wrapper around the `Progress` component that allows the user to add a `label`, `hint`, `validationMessage`, and `validationState` to the `Progress` component. You can pass these props, as well as the regular `Progress` props to a `ProgressField` component.
+The `ProgressField` component is a wrapper around the `ProgressBar` component that allows the user to add a `label`, `hint`, `validationMessage`, and `validationState` to the `ProgressBar` component. You can pass these props, as well as the regular `ProgressBar` props to a `ProgressField` component.
 
 To import `ProgressField`:
 
@@ -42,7 +42,7 @@ import { ProgressField } from '@fluentui/react-field';
 const ProgressFieldExample = () => {
   return (
     <ProgressField
-      label="Determinate Progress"
+      label="Determinate ProgressBar"
       hint="This is a determinate Progress with description"
       value={0.5}
       validationState="warning"

--- a/packages/react-components/react-progress/etc/react-progress.api.md
+++ b/packages/react-components/react-progress/etc/react-progress.api.md
@@ -6,7 +6,7 @@
 
 /// <reference types="react" />
 
-import { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import { FieldControl } from '@fluentui/react-field';
 import type { FieldProps } from '@fluentui/react-field';
@@ -15,15 +15,6 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
-
-// @public @deprecated (undocumented)
-export const Progress: React_2.ForwardRefExoticComponent<Omit<ComponentProps<ProgressBarSlots, "root">, "size"> & {
-    shape?: "rounded" | "rectangular" | undefined;
-    value?: number | undefined;
-    max?: number | undefined;
-    thickness?: "medium" | "large" | undefined;
-    validationState?: "error" | "success" | "warning" | undefined;
-} & React_2.RefAttributes<HTMLDivElement>>;
 
 // @public
 export const ProgressBar: ForwardRefComponent<ProgressBarProps>;
@@ -49,9 +40,6 @@ export type ProgressBarSlots = {
 // @public
 export type ProgressBarState = ComponentState<ProgressBarSlots> & Required<Pick<ProgressBarProps, 'max' | 'shape' | 'thickness'>> & Pick<ProgressBarProps, 'value' | 'validationState'>;
 
-// @public @deprecated (undocumented)
-export const progressClassNames: SlotClassNames<ProgressBarSlots>;
-
 // @public (undocumented)
 export const ProgressField_unstable: ForwardRefComponent<ProgressFieldProps_unstable>;
 
@@ -61,32 +49,14 @@ export const progressFieldClassNames: SlotClassNames<FieldSlots<FieldControl>>;
 // @public (undocumented)
 export type ProgressFieldProps_unstable = FieldProps<typeof ProgressBar>;
 
-// @public @deprecated (undocumented)
-export type ProgressProps = ProgressBarProps;
-
-// @public @deprecated (undocumented)
-export type ProgressSlots = ProgressBarSlots;
-
-// @public @deprecated (undocumented)
-export type ProgressState = ProgressBarState;
-
-// @public @deprecated (undocumented)
-export const renderProgress_unstable: (state: ProgressBarState) => JSX.Element;
-
 // @public
 export const renderProgressBar_unstable: (state: ProgressBarState) => JSX.Element;
-
-// @public @deprecated (undocumented)
-export const useProgress_unstable: (props: ProgressBarProps, ref: React_2.Ref<HTMLElement>) => ProgressBarState;
 
 // @public
 export const useProgressBar_unstable: (props: ProgressBarProps, ref: React_2.Ref<HTMLElement>) => ProgressBarState;
 
 // @public
 export const useProgressBarStyles_unstable: (state: ProgressBarState) => ProgressBarState;
-
-// @public @deprecated (undocumented)
-export const useProgressStyles_unstable: (state: ProgressBarState) => ProgressBarState;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-progress/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/react-components/react-progress/src/components/ProgressBar/ProgressBar.tsx
@@ -15,8 +15,4 @@ export const ProgressBar: ForwardRefComponent<ProgressBarProps> = React.forwardR
   return renderProgressBar_unstable(state);
 });
 
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to ProgressBar */
-export const Progress = ProgressBar;
-
 ProgressBar.displayName = 'ProgressBar';

--- a/packages/react-components/react-progress/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/ProgressBar.types.ts
@@ -11,10 +11,6 @@ export type ProgressBarSlots = {
   bar?: NonNullable<Slot<'div'>>;
 };
 
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to ProgressBarSlots */
-export type ProgressSlots = ProgressBarSlots;
-
 /**
  * ProgressBar Props
  */
@@ -49,17 +45,9 @@ export type ProgressBarProps = Omit<ComponentProps<ProgressBarSlots>, 'size'> & 
   validationState?: 'success' | 'warning' | 'error';
 };
 
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to ProgressBarProps */
-export type ProgressProps = ProgressBarProps;
-
 /**
  * State used in rendering ProgressBar
  */
 export type ProgressBarState = ComponentState<ProgressBarSlots> &
   Required<Pick<ProgressBarProps, 'max' | 'shape' | 'thickness'>> &
   Pick<ProgressBarProps, 'value' | 'validationState'>;
-
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to ProgressBarState */
-export type ProgressState = ProgressBarState;

--- a/packages/react-components/react-progress/src/components/ProgressBar/renderProgressBar.tsx
+++ b/packages/react-components/react-progress/src/components/ProgressBar/renderProgressBar.tsx
@@ -9,7 +9,3 @@ export const renderProgressBar_unstable = (state: ProgressBarState) => {
   const { slots, slotProps } = getSlots<ProgressBarSlots>(state);
   return <slots.root {...slotProps.root}>{slots.bar && <slots.bar {...slotProps.bar} />}</slots.root>;
 };
-
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to renderProgressBar_unstable */
-export const renderProgress_unstable = renderProgressBar_unstable;

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBar.tsx
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBar.tsx
@@ -44,7 +44,3 @@ export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<
 
   return state;
 };
-
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to useProgressBar_unstable */
-export const useProgress_unstable = useProgressBar_unstable;

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
@@ -9,10 +9,6 @@ export const progressBarClassNames: SlotClassNames<ProgressBarSlots> = {
   bar: 'fui-ProgressBar__bar',
 };
 
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to progressBarClassNames */
-export const progressClassNames = progressBarClassNames;
-
 // If the percentComplete is near 0, don't animate it.
 // This prevents animations on reset to 0 scenarios.
 const ZERO_THRESHOLD = 0.01;
@@ -162,7 +158,3 @@ export const useProgressBarStyles_unstable = (state: ProgressBarState): Progress
 
   return state;
 };
-
-// TODO #25997: Remove deprecated export before ProgressBar is released as stable
-/** @deprecated renamed to useProgressBarStyles_unstable */
-export const useProgressStyles_unstable = useProgressBarStyles_unstable;

--- a/packages/react-components/react-progress/src/index.ts
+++ b/packages/react-components/react-progress/src/index.ts
@@ -1,39 +1,11 @@
 export {
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  Progress,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  progressClassNames,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  renderProgress_unstable,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  useProgress_unstable,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  useProgressStyles_unstable,
   ProgressBar,
   progressBarClassNames,
   renderProgressBar_unstable,
   useProgressBar_unstable,
   useProgressBarStyles_unstable,
 } from './ProgressBar';
-export type {
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  ProgressProps,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  ProgressSlots,
-  // TODO #25997: Remove deprecated export before ProgressBar is released as stable
-  // eslint-disable-next-line deprecation/deprecation
-  ProgressState,
-  ProgressBarProps,
-  ProgressBarSlots,
-  ProgressBarState,
-} from './ProgressBar';
+export type { ProgressBarProps, ProgressBarSlots, ProgressBarState } from './ProgressBar';
 
 export { ProgressField as ProgressField_unstable, progressFieldClassNames } from './ProgressField';
 export type { ProgressFieldProps as ProgressFieldProps_unstable } from './ProgressField';


### PR DESCRIPTION
This PR is to remove deprecated `ProgressBar` exports from the renaming from `Progress` to `ProgressBar`. Fixes #25997 