### PR TITLE
Add noflip to animation styling

### DIFF
--- a/change/@fluentui-react-progress-14cf1ca6-4a0c-479b-b6e6-b29236c45a35.json
+++ b/change/@fluentui-react-progress-14cf1ca6-4a0c-479b-b6e6-b29236c45a35.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "(fix): Add @noflip to animation styles to prevent extra from css being generated",
+  "packageName": "@fluentui/react-progress",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-14cf1ca6-4a0c-479b-b6e6-b29236c45a35.json
+++ b/change/@fluentui-react-progress-14cf1ca6-4a0c-479b-b6e6-b29236c45a35.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "(fix): Add @noflip to animation styles to prevent extra from css being generated",
+  "comment": "fix: Add @noflip to animation styles to prevent extra from css being generated",
   "packageName": "@fluentui/react-progress",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
@@ -20,18 +20,18 @@ const barThicknessValues = {
 
 const indeterminateProgressBar = {
   '0%': {
-    left: '0%',
+    left: '0% /* @noflip */',
   },
   '100%': {
-    left: '100%',
+    left: '100% /* @noflip */',
   },
 };
 const indeterminateProgressBarRTL = {
   '100%': {
-    right: '-100%',
+    right: '-100% /* @noflip */',
   },
   '0%': {
-    right: '100%',
+    right: '100% /* @noflip */',
   },
 };
 


### PR DESCRIPTION
This PR adds `@noflip` to `ProgressBar` animation styles to prevent styles from automatic flipping which will create less CSS/classes i.e. improves bundle size. Fixes #26028 