### PR TITLE
Update web-components code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,7 @@ packages/fluentui/react-northstar/src/components/Chat @microsoft/fluentui-norths
 packages/fluentui/react-northstar/src/themes/teams/components/Chat @microsoft/fluentui-northstar @Hirse
 
 #### Web Components
-packages/web-components @chrisdholt @EisenbergEffect @nicholasrice
+packages/web-components @microsoft/fui-wc
 
 #### Apps
 apps/public-docsite @microsoft/fluentui-v8-website


### PR DESCRIPTION
Update web-components code owners.

Individual contributors replaced by `microsoft/fui-wc` group.
@miroslavstastny and @chrisdholt are currently maintainers of the group.