### PR TITLE
fix: Coordinates should be rounded to integers

### DIFF
--- a/change/@fluentui-react-positioning-0221531c-b4a7-45c3-9194-a022fc9bb865.json
+++ b/change/@fluentui-react-positioning-0221531c-b4a7-45c3-9194-a022fc9bb865.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Coordinates should be rounded to integers",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
+++ b/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
@@ -22,14 +22,7 @@ export function writeContainerUpdates(options: {
   strategy: Strategy;
   coordinates: Coords;
 }) {
-  const {
-    container,
-    placement,
-    middlewareData,
-    strategy,
-    lowPPI,
-    coordinates: { x, y },
-  } = options;
+  const { container, placement, middlewareData, strategy, lowPPI, coordinates } = options;
   if (!container) {
     return;
   }
@@ -48,6 +41,9 @@ export function writeContainerUpdates(options: {
   if (middlewareData.hide?.referenceHidden) {
     container.setAttribute(DATA_POSITIONING_HIDDEN, '');
   }
+
+  const x = Math.round(coordinates.x);
+  const y = Math.round(coordinates.y);
 
   Object.assign(container.style, {
     transform: lowPPI ? `translate(${x}px, ${y}px)` : `translate3d(${x}px, ${y}px, 0)`,


### PR DESCRIPTION
## Previous Behavior

Coordiates could have decimal values, this could cause bluriness

## New Behavior

Coordinates are always rounded to whole integer values using the same rounding method [that popper v2 uses](https://github.com/floating-ui/floating-ui/blob/2893e9a8d2ebd895eb4311a8873afac62f75123e/src/utils/math.js#L4)

Fixes #25288
