### PR TITLE
feat: FluentProvider applies style attributes defined by a renderer

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/AdvancedConfiguration.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/AdvancedConfiguration.stories.mdx
@@ -1,18 +1,20 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Concepts/Developer/Child Window Rendering" />
+<Meta title="Concepts/Developer/Advanced Configuration" />
 
-## Child Window Rendering
+## Advanced Configuration
+
+### Child Window Rendering
 
 When rendering on the main browser window, many components need access to `window` or `document` for applying styling, listening for events, or measuring things. However it is possible to render to child windows and elements hosted in `iframe` elements.
 
 In these cases, the target element is hosted in a different context, and thus have a different `window` reference. To aid in providing components with the correct instances of `window` or `document`, React context can be used to provide the tree of React components with the correct instance.
 
-### Configuring rendering
+#### Configuring rendering
 
 We need to configure a renderer for `makeStyles()` and pass a `targetDocument` to `RendererProvider` & `FluentProvider`:
 
-```js
+```jsx
 import { createDOMRenderer, FluentProvider, RendererProvider } from '@fluentui/react-components';
 import * as React from 'react';
 
@@ -29,3 +31,30 @@ function MyComponent(props) {
 ```
 
 You can check complete example at [CodeSandbox](https://codesandbox.io/s/fluentuireact-components-render-into-iframe-l62ke).
+
+### Content Security Policies
+
+To add `nonce` attribute need for [Content Security Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), please use `styleElementAttributes` to specify it:
+
+```jsx
+import { createDOMRenderer, FluentProvider, RendererProvider } from '@fluentui/react-components';
+import * as React from 'react';
+
+function MyComponent(props) {
+  const { children } = props;
+  const renderer = React.useMemo(
+    () => createDOMRenderer(document, { styleElementAttributes: { nonce: 'random' } }),
+    [],
+  );
+
+  return (
+    <RendererProvider renderer={renderer}>
+      <FluentProvider>{children}</FluentProvider>
+    </RendererProvider>
+  );
+}
+```
+
+## References
+
+- https://griffel.js.org/react/api/create-dom-renderer

--- a/change/@fluentui-react-provider-b0221870-0188-4949-b08b-69ebb21956d2.json
+++ b/change/@fluentui-react-provider-b0221870-0188-4949-b08b-69ebb21956d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: FluentProvider applies style attributes defined by a renderer from Griffel",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
@@ -1,8 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { createDOMRenderer, RendererProvider } from '@griffel/react';
+import type { Theme } from '@fluentui/react-theme';
 import { resetIdsForTests } from '@fluentui/react-utilities';
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
 
 import { useFluentProviderThemeStyleTag } from './useFluentProviderThemeStyleTag';
-import type { Theme } from '@fluentui/react-theme';
 
 jest.mock('@fluentui/react-theme');
 
@@ -69,5 +71,20 @@ describe('useFluentProviderThemeStyleTag', () => {
     const rule = sheet.cssRules[0] as CSSStyleRule;
     expect(rule.selectorText).toEqual(`.${result.current}`);
     expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--css-variable-update: xxx;}"`);
+  });
+
+  it('should update style tag on theme change', () => {
+    const renderer = createDOMRenderer(document, {
+      styleElementAttributes: { nonce: 'random' },
+    });
+
+    const { result } = renderHook(
+      () => useFluentProviderThemeStyleTag({ theme: defaultTheme, targetDocument: document }),
+      { wrapper: props => <RendererProvider renderer={renderer}>{props.children}</RendererProvider> },
+    );
+    const tag = document.getElementById(result.current) as HTMLStyleElement;
+
+    expect(tag.getAttribute('id')).toBe('fui-FluentProvider1');
+    expect(tag.getAttribute('nonce')).toBe('random');
   });
 });

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -1,5 +1,7 @@
 import { useId, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useRenderer_unstable } from '@griffel/react';
 import * as React from 'react';
+
 import type { FluentProviderState } from './FluentProvider.types';
 import { fluentProviderClassNames } from './useFluentProviderStyles';
 
@@ -8,12 +10,17 @@ const useInsertionEffect = (React as never)['useInsertion' + 'Effect']
   ? (React as never)['useInsertion' + 'Effect']
   : useIsomorphicLayoutEffect;
 
-const createStyleTag = (target: Document | undefined, id: string) => {
+const createStyleTag = (target: Document | undefined, elementAttributes: Record<string, string>) => {
   if (!target) {
     return undefined;
   }
+
   const tag = target.createElement('style');
-  tag.setAttribute('id', id);
+
+  Object.keys(elementAttributes).forEach(attrName => {
+    tag.setAttribute(attrName, elementAttributes[attrName]);
+  });
+
   target.head.appendChild(tag);
   return tag;
 };
@@ -39,9 +46,12 @@ const insertSheet = (tag: HTMLStyleElement, rule: string) => {
  */
 export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState, 'theme' | 'targetDocument'>) => {
   const { targetDocument, theme } = options;
+
+  const renderer = useRenderer_unstable();
   const styleTag = React.useRef<HTMLStyleElement>();
 
   const styleTagId = useId(fluentProviderClassNames.root);
+  const styleElementAttributes = renderer.styleElementAttributes;
 
   const cssVarsAsString = React.useMemo(() => {
     return theme
@@ -55,7 +65,7 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
   const rule = `.${styleTagId} { ${cssVarsAsString} }`;
 
   useInsertionEffect(() => {
-    styleTag.current = createStyleTag(targetDocument, styleTagId);
+    styleTag.current = createStyleTag(targetDocument, { ...styleElementAttributes, id: styleTagId });
 
     if (styleTag.current) {
       insertSheet(styleTag.current, rule);
@@ -64,7 +74,7 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
         styleTag.current?.remove();
       };
     }
-  }, [styleTagId, targetDocument, rule]);
+  }, [styleTagId, targetDocument, rule, styleElementAttributes]);
 
   return styleTagId;
 };


### PR DESCRIPTION
## New Behavior

`FluentProvider` now applies the same style attributes as Griffel does:

```tsx
const renderer = createDOMRenderer(document, {
  styleElementAttributes: {
    nonce: "random"
  }
});

ReactDOM.render(
  <RendererProvider renderer={renderer}>
    <FluentProvider />
  </RendererProvider>
);
```

With this change we will get following in DOM:

```html
<!-- Tags created by Griffel -->
<style nonce="random" data-make-styles-bucket="d"></style>
<!-- Tags created by FluentProvider -->
<style nonce="random" id="fui-FluentProvider1"></style>
```

## Docs changes

Documentation page was renamed to include also a guide on how to configure `nonce` for CSP.

## Related Issue(s)

- Fixes #25421
