### PR TITLE
chore(release): v9 packages can be determined by tags in workspace.json

### DIFF
--- a/scripts/monorepo/isConvergedPackage.js
+++ b/scripts/monorepo/isConvergedPackage.js
@@ -33,7 +33,9 @@ function isConvergedPackage(options = {}) {
     return false;
   }
 
-  return semver.major(packageJson.version) >= 9 || isNightlyVersion(packageJson.version);
+  const hasVNextTag = !!metadata.tags?.includes('vNext');
+
+  return semver.major(packageJson.version) >= 9 || isNightlyVersion(packageJson.version) || hasVNextTag;
 }
 
 /**

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -201,8 +201,9 @@ export function isPackageVersionPrerelease(versionString: string) {
 }
 
 export function isPackageConverged(tree: Tree, project: ProjectConfiguration) {
+  const hasVNextTag = project.tags?.includes('vNext');
   const packageJson = readJson<PackageJson>(tree, joinPathFragments(project.root, 'package.json'));
-  return isPackageVersionConverged(packageJson.version);
+  return isPackageVersionConverged(packageJson.version) || hasVNextTag;
 }
 
 export function isV8Package(tree: Tree, project: ProjectConfiguration) {

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -201,7 +201,7 @@ export function isPackageVersionPrerelease(versionString: string) {
 }
 
 export function isPackageConverged(tree: Tree, project: ProjectConfiguration) {
-  const hasVNextTag = project.tags?.includes('vNext');
+  const hasVNextTag = !!project.tags?.includes('vNext');
   const packageJson = readJson<PackageJson>(tree, joinPathFragments(project.root, 'package.json'));
   return isPackageVersionConverged(packageJson.version) || hasVNextTag;
 }


### PR DESCRIPTION
Since we now have 'v9' packages that don't necessarily have the major version v9 after #26039, we need to update the release and version bumping tools to release these kinds of packages.

After this PR `@fluentui/tokens` will be published along with other v9 packages