### PR TITLE
fix: v8 ComboBox button is no longer aria-hidden by default

### DIFF
--- a/change/@fluentui-react-b2a0ebef-487f-495f-b9b6-e90e361cb18b.json
+++ b/change/@fluentui-react-b2a0ebef-487f-495f-b9b6-e90e361cb18b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ComboBox button is not aria-hidden by default",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1585,7 +1585,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
         value="1"
       />
       <button
-        aria-hidden={true}
         className=
             ms-Button
             ms-Button--icon

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -570,7 +570,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       required,
       errorMessage,
       buttonIconProps,
-      isButtonAriaHidden = true,
+      isButtonAriaHidden,
       title,
       placeholder: placeholderProp,
       tabIndex,

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -246,10 +246,9 @@ export interface IComboBoxProps
   dropdownMaxWidth?: number;
 
   /**
-   * Whether to hide the ComboBox's caret (expand) button element from screen readers. This is true
-   * (hidden) by default because all functionality is handled by the input element, and the arrow
-   * button is only meant to be decorative.
-   * @defaultvalue true
+   * Whether to hide the ComboBox's caret (expand) button element from screen readers. This is false
+   * (exposed to AT) by default because Android Talkback cannot otherwise expand the combobox.
+   * @defaultvalue false
    */
   isButtonAriaHidden?: boolean;
 

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -202,7 +202,6 @@ exports[`ComboBox Renders correctly 1`] = `
         value="testValue"
       />
       <button
-        aria-hidden="true"
         class=
             ms-Button
             ms-Button--icon
@@ -533,7 +532,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
         value="Option 2"
       />
       <button
-        aria-hidden="true"
         class=
             ms-Button
             ms-Button--icon
@@ -1302,7 +1300,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
         value=""
       />
       <button
-        aria-hidden="true"
         class=
             ms-Button
             ms-Button--icon
@@ -2193,7 +2190,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         value=""
       />
       <button
-        aria-hidden="true"
         class=
             ms-Button
             ms-Button--icon


### PR DESCRIPTION
## Previous Behavior

Previously, the chevron button had `aria-hidden=true` by default, since the input handles all keyboard interaction. Including the button in the accessibility tree effectively creates two form fields per combobox.

The issue is that Android Talkback does not allow the user to trigger a click or touch event in the input, making it impossible to expand the ComboBox with Talkback running. While this is a bug on their side, it is still a severe enough issue to make it worth changing our desktop screen reader behavior so that Talkback users are able to use the control.

## New Behavior

The chevron button does not have `aria-hidden` by default. This can still be changed by authors using the already-existing `isButtonAriaHidden` prop.

Note -- this does not affect the tab order or the DOM.

* Fixes [15717](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15717)
