### PR TITLE
chore: export GroupedListV2 types

### DIFF
--- a/change/@fluentui-react-03381c14-7db9-4502-8ad9-3eea9bea4bb2.json
+++ b/change/@fluentui-react-03381c14-7db9-4502-8ad9-3eea9bea4bb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: export GroupedListV2 types",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -2012,8 +2012,6 @@ export class GroupedListSection extends React_2.Component<IGroupedListSectionPro
     render(): JSX.Element;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IGroupedListV2Props" needs to be exported by the entry point index.d.ts
-//
 // @public
 export const GroupedListV2_unstable: React_2.FunctionComponent<IGroupedListV2Props>;
 
@@ -6126,6 +6124,32 @@ export interface IGroupedListStyles {
     groupIsDropping: IStyle;
     // (undocumented)
     root: IStyle;
+}
+
+// @public (undocumented)
+export interface IGroupedListV2Props extends IGroupedListProps {
+    groupExpandedVersion?: {};
+    listRef?: React_2.Ref<List>;
+    onRenderCell: (nestingDepth?: number, item?: any, index?: number, group?: IGroup) => React_2.ReactNode;
+    version?: {};
+}
+
+// @public (undocumented)
+export interface IGroupedListV2State {
+    // (undocumented)
+    compact?: IGroupedListV2Props['compact'];
+    // (undocumented)
+    groupExpandedVersion: {};
+    // (undocumented)
+    groups?: IGroup[];
+    // (undocumented)
+    items?: IGroupedListV2Props['items'];
+    // (undocumented)
+    listProps?: IGroupedListV2Props['listProps'];
+    // (undocumented)
+    selectionMode?: IGroupedListV2Props['selectionMode'];
+    // (undocumented)
+    version: {};
 }
 
 // @public (undocumented)

--- a/packages/react/src/components/GroupedList/GroupedListV2.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.tsx
@@ -25,3 +25,4 @@ const GroupedListV2: React.FunctionComponent<IGroupedListV2Props> = styled<
 GroupedListV2.displayName = 'GroupedListV2_unstable';
 
 export { GroupedListV2 as GroupedListV2_unstable };
+export type { IGroupedListV2Props } from './GroupedListV2.types';

--- a/packages/react/src/components/GroupedList/index.ts
+++ b/packages/react/src/components/GroupedList/index.ts
@@ -11,4 +11,6 @@ export type { IGroupHeaderStyleProps, IGroupHeaderStyles, IGroupHeaderCheckboxPr
 export type { IGroupFooterStyleProps, IGroupFooterStyles } from './GroupFooter.types';
 export type { IGroupShowAllStyleProps, IGroupShowAllStyles } from './GroupShowAll.types';
 
-export { GroupedListV2_unstable } from './GroupedListV2';
+export * from './GroupedListV2';
+export * from './GroupedListV2.base';
+export * from './GroupedListV2.types';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -550,6 +550,8 @@ export type {
   IGroupedListSectionProps,
   IGroupedListSectionState,
   IGroupedListState,
+  IGroupedListV2Props,
+  IGroupedListV2State,
 } from './GroupedList';
 export {
   ExpandingCard,


### PR DESCRIPTION
## Previous Behavior

Some types for `GroupedListV2` are not exported.

## New Behavior

`GroupedListV2` props and state types are exported.

