### PR TITLE
fix: Pickers' live region announcement text is removed from the DOM 

### DIFF
--- a/change/@fluentui-react-acde88e8-7f76-4606-bf70-55d23dda62f7.json
+++ b/change/@fluentui-react-acde88e8-7f76-4606-bf70-55d23dda62f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove Pickers live announcement text after timeout",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -838,6 +838,12 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
       const newItems: T[] = items.slice(0, index).concat(items.slice(index + 1));
       this.setState({ selectionRemoved: item });
       this._updateSelectedItems(newItems);
+
+      // reset selection removed text after a timeout so it isn't reached by screen reader virtual cursor.
+      // the exact timing isn't important, the live region will fully read even if the text is removed.
+      this._async.setTimeout(() => {
+        this.setState({ selectionRemoved: undefined });
+      }, 1000);
     }
   };
 


### PR DESCRIPTION
## Previous Behavior

We fire an invisible live region when selected tags are removed, but since we don't clear the text, it's discoverable with a screen reader's virtual cursor.

## New Behavior

We can remove the live region text on a timeout so it will still fire the event and be read by screen readers, but the text will not remain in the DOM/accessibility tree in between the label and form field.

* Fixes [15715](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15715)
