### PR TITLE
fix: Tabster creation should be strict mode safe

### DIFF
--- a/change/@fluentui-react-tabster-9dea04a5-ff31-4297-a355-51cbf939f1ec.json
+++ b/change/@fluentui-react-tabster-9dea04a5-ff31-4297-a355-51cbf939f1ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Tabster creation should be strict mode safe",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -1,6 +1,7 @@
 import { Types, getMover } from 'tabster';
 import { useTabsterAttributes } from './useTabsterAttributes';
 import { useTabster } from './useTabster';
+import * as React from 'react';
 
 export interface UseArrowNavigationGroupOptions {
   /**
@@ -33,18 +34,21 @@ export interface UseArrowNavigationGroupOptions {
  */
 export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions = {}): Types.TabsterDOMAttribute => {
   const { circular, axis, memorizeCurrent, tabbable, ignoreDefaultKeydown } = options;
-  const tabster = useTabster();
+  const getTabster = useTabster();
 
-  if (tabster) {
-    getMover(tabster);
-  }
+  React.useEffect(() => {
+    const tabster = getTabster();
+    if (tabster) {
+      getMover(tabster);
+    }
+  }, [getTabster]);
 
   return useTabsterAttributes({
     mover: {
       cyclic: !!circular,
       direction: axisToMoverDirection(axis ?? 'vertical'),
-      memorizeCurrent: memorizeCurrent,
-      tabbable: tabbable,
+      memorizeCurrent,
+      tabbable,
     },
     ...(ignoreDefaultKeydown && {
       focusable: {

--- a/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
@@ -6,34 +6,35 @@ import { useTabster } from './useTabster';
  * Returns a set of helper functions that will traverse focusable elements in the context of a root DOM element
  */
 export const useFocusFinders = () => {
-  const tabster = useTabster();
+  const getTabster = useTabster();
 
   // Narrow props for now and let need dictate additional props in the future
   const findAllFocusable = React.useCallback(
     (container: HTMLElement, acceptCondition?: (el: HTMLElement) => boolean) =>
-      tabster?.focusable.findAll({ container, acceptCondition }) || [],
-    [tabster],
+      getTabster()?.focusable.findAll({ container, acceptCondition }) || [],
+    [getTabster],
   );
 
   const findFirstFocusable = React.useCallback(
-    (container: HTMLElement) => tabster?.focusable.findFirst({ container }),
-    [tabster],
+    (container: HTMLElement) => getTabster()?.focusable.findFirst({ container }),
+    [getTabster],
   );
 
-  const findLastFocusable = React.useCallback((container: HTMLElement) => tabster?.focusable.findLast({ container }), [
-    tabster,
-  ]);
+  const findLastFocusable = React.useCallback(
+    (container: HTMLElement) => getTabster()?.focusable.findLast({ container }),
+    [getTabster],
+  );
 
   const findNextFocusable = React.useCallback(
     (currentElement: HTMLElement, options: Pick<TabsterTypes.FindNextProps, 'container'> = {}) =>
-      tabster?.focusable.findNext({ currentElement, ...options }),
-    [tabster],
+      getTabster()?.focusable.findNext({ currentElement, ...options }),
+    [getTabster],
   );
 
   const findPrevFocusable = React.useCallback(
     (currentElement: HTMLElement, options: Pick<TabsterTypes.FindNextProps, 'container'> = {}) =>
-      tabster?.focusable.findPrev({ currentElement, ...options }),
-    [tabster],
+      getTabster()?.focusable.findPrev({ currentElement, ...options }),
+    [getTabster],
   );
 
   return {

--- a/packages/react-components/react-tabster/src/hooks/useFocusableGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusableGroup.ts
@@ -1,6 +1,7 @@
 import { Types, getGroupper } from 'tabster';
 import { useTabsterAttributes } from './useTabsterAttributes';
 import { useTabster } from './useTabster';
+import * as React from 'react';
 
 export interface UseFocusableGroupOptions {
   /**
@@ -14,11 +15,14 @@ export interface UseFocusableGroupOptions {
  * @param options - Options to configure keyboard navigation
  */
 export const useFocusableGroup = (options?: UseFocusableGroupOptions): Types.TabsterDOMAttribute => {
-  const tabster = useTabster();
+  const getTabster = useTabster();
 
-  if (tabster) {
-    getGroupper(tabster);
-  }
+  React.useEffect(() => {
+    const tabster = getTabster();
+    if (tabster) {
+      getGroupper(tabster);
+    }
+  }, [getTabster]);
 
   return useTabsterAttributes({
     groupper: {

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -2,6 +2,7 @@ import { useId } from '@fluentui/react-utilities';
 import { useTabsterAttributes } from './useTabsterAttributes';
 import { getDeloser, getModalizer, Types as TabsterTypes } from 'tabster';
 import { useTabster } from './useTabster';
+import * as React from 'react';
 
 export interface UseModalAttributesOptions {
   /**
@@ -37,12 +38,7 @@ export const useModalAttributes = (
   options: UseModalAttributesOptions = {},
 ): { modalAttributes: TabsterTypes.TabsterDOMAttribute; triggerAttributes: TabsterTypes.TabsterDOMAttribute } => {
   const { trapFocus, alwaysFocusable, legacyTrapFocus } = options;
-  const tabster = useTabster();
-  // Initializes the modalizer and deloser APIs
-  if (tabster) {
-    getModalizer(tabster);
-    getDeloser(tabster);
-  }
+  const getTabster = useTabster();
 
   const id = useId('modal-');
   const modalAttributes = useTabsterAttributes({
@@ -58,6 +54,15 @@ export const useModalAttributes = (
   const triggerAttributes = useTabsterAttributes({
     deloser: {},
   });
+
+  React.useEffect(() => {
+    const tabster = getTabster();
+    // Initializes the modalizer and deloser APIs
+    if (tabster) {
+      getModalizer(tabster);
+      getDeloser(tabster);
+    }
+  }, [getTabster]);
 
   return { modalAttributes, triggerAttributes };
 };

--- a/packages/react-components/react-tabster/src/hooks/useTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabsterAttributes.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { getTabsterAttribute, Types as TabsterTypes } from 'tabster';
 import { useTabster } from './useTabster';
 
@@ -6,9 +7,13 @@ import { useTabster } from './useTabster';
  * Hook that returns tabster attributes while ensuring tabster exists
  */
 export const useTabsterAttributes = (props: TabsterTypes.TabsterAttributeProps): TabsterTypes.TabsterDOMAttribute => {
-  // A tabster instance is not necessary to generate tabster attributes
-  // but calling the hook will ensure that a tabster instance exists internally and avoids consumers doing the same
-  useTabster();
+  const getTabster = useTabster();
+
+  React.useEffect(() => {
+    // A tabster instance is not necessary to generate tabster attributes
+    // but calling the hook will ensure that a tabster instance exists internally and avoids consumers doing the same
+    getTabster();
+  }, [getTabster]);
 
   return getTabsterAttribute(props);
 };


### PR DESCRIPTION
Although currently it seems that tabster doesn't seem to have obvious breaks in strict mode
https://codesandbox.io/s/pensive-mestorf-70fus1?file=/src/App.js the instance creation still happens in `useMemo` which is run twice in React 18 strict mode.

Updates the usage pattern to be consistent with one of the suggested patterns in https://github.com/reactwg/react-18/discussions/18 which is a factory getter that should only be invoked in event callbacks or effects.

Fixes #24085