### PR TITLE
fix: Export all relevant Toolbar components and utilities

### DIFF
--- a/change/@fluentui-react-components-339acd12-98eb-4ed1-8be5-0b64cfc08152.json
+++ b/change/@fluentui-react-components-339acd12-98eb-4ed1-8be5-0b64cfc08152.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Export all relevant Toolbar components and utilities",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-89443f18-b94b-4c3b-9171-9dc4e4826524.json
+++ b/change/@fluentui-react-toolbar-89443f18-b94b-4c3b-9171-9dc4e4826524.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Export all relevant Toolbar components and utilities",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -178,6 +178,7 @@ import { renderTableHeaderCell_unstable } from '@fluentui/react-table';
 import { renderTableRow_unstable } from '@fluentui/react-table';
 import { renderTableSelectionCell_unstable } from '@fluentui/react-table';
 import { renderToolbar_unstable } from '@fluentui/react-toolbar';
+import { renderToolbarGroup_unstable } from '@fluentui/react-toolbar';
 import { RowId } from '@fluentui/react-table';
 import { RowState } from '@fluentui/react-table';
 import { Select } from '@fluentui/react-select';
@@ -268,7 +269,14 @@ import { ToolbarContextValues } from '@fluentui/react-toolbar';
 import { ToolbarDivider } from '@fluentui/react-toolbar';
 import { ToolbarDividerProps } from '@fluentui/react-toolbar';
 import { ToolbarDividerState } from '@fluentui/react-toolbar';
+import { ToolbarGroup } from '@fluentui/react-toolbar';
+import { toolbarGroupClassNames } from '@fluentui/react-toolbar';
+import { ToolbarGroupProps } from '@fluentui/react-toolbar';
+import { ToolbarGroupState } from '@fluentui/react-toolbar';
 import { ToolbarProps } from '@fluentui/react-toolbar';
+import { ToolbarRadioButton } from '@fluentui/react-toolbar';
+import { ToolbarRadioButtonProps } from '@fluentui/react-toolbar';
+import { ToolbarRadioButtonState } from '@fluentui/react-toolbar';
 import { ToolbarSlots } from '@fluentui/react-toolbar';
 import { ToolbarState } from '@fluentui/react-toolbar';
 import { ToolbarToggleButton } from '@fluentui/react-toolbar';
@@ -345,8 +353,17 @@ import { useTableSelectionCellStyles_unstable } from '@fluentui/react-table';
 import { useTableSort } from '@fluentui/react-table';
 import { useTableStyles_unstable } from '@fluentui/react-table';
 import { useToolbar_unstable } from '@fluentui/react-toolbar';
+import { useToolbarButton_unstable } from '@fluentui/react-toolbar';
+import { useToolbarButtonStyles_unstable } from '@fluentui/react-toolbar';
+import { useToolbarDivider_unstable } from '@fluentui/react-toolbar';
 import { useToolbarDividerStyles_unstable } from '@fluentui/react-toolbar';
+import { useToolbarGroup_unstable } from '@fluentui/react-toolbar';
+import { useToolbarGroupStyles_unstable } from '@fluentui/react-toolbar';
+import { useToolbarRadioButton_unstable } from '@fluentui/react-toolbar';
+import { useToolbarRadioButtonStyles_unstable } from '@fluentui/react-toolbar';
 import { useToolbarStyles_unstable } from '@fluentui/react-toolbar';
+import { useToolbarToggleButton_unstable } from '@fluentui/react-toolbar';
+import { useToolbarToggleButtonStyles_unstable } from '@fluentui/react-toolbar';
 
 export { Alert }
 
@@ -696,6 +713,8 @@ export { renderTableSelectionCell_unstable }
 
 export { renderToolbar_unstable }
 
+export { renderToolbarGroup_unstable }
+
 export { RowId }
 
 export { RowState }
@@ -877,7 +896,21 @@ export { ToolbarDividerProps }
 
 export { ToolbarDividerState }
 
+export { ToolbarGroup }
+
+export { toolbarGroupClassNames }
+
+export { ToolbarGroupProps }
+
+export { ToolbarGroupState }
+
 export { ToolbarProps }
+
+export { ToolbarRadioButton }
+
+export { ToolbarRadioButtonProps }
+
+export { ToolbarRadioButtonState }
 
 export { ToolbarSlots }
 
@@ -1031,9 +1064,27 @@ export { useTableStyles_unstable }
 
 export { useToolbar_unstable }
 
+export { useToolbarButton_unstable }
+
+export { useToolbarButtonStyles_unstable }
+
+export { useToolbarDivider_unstable }
+
 export { useToolbarDividerStyles_unstable }
 
+export { useToolbarGroup_unstable }
+
+export { useToolbarGroupStyles_unstable }
+
+export { useToolbarRadioButton_unstable }
+
+export { useToolbarRadioButtonStyles_unstable }
+
 export { useToolbarStyles_unstable }
+
+export { useToolbarToggleButton_unstable }
+
+export { useToolbarToggleButtonStyles_unstable }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -109,8 +109,21 @@ export type { SelectProps, SelectSlots, SelectState } from '@fluentui/react-sele
 export {
   Toolbar,
   ToolbarButton,
+  useToolbarButtonStyles_unstable,
+  useToolbarButton_unstable,
+  ToolbarRadioButton,
+  useToolbarRadioButton_unstable,
+  useToolbarRadioButtonStyles_unstable,
   ToolbarDivider,
+  useToolbarDivider_unstable,
+  ToolbarGroup,
+  useToolbarGroupStyles_unstable,
+  useToolbarGroup_unstable,
+  renderToolbarGroup_unstable,
+  toolbarGroupClassNames,
   ToolbarToggleButton,
+  useToolbarToggleButtonStyles_unstable,
+  useToolbarToggleButton_unstable,
   renderToolbar_unstable,
   toolbarClassNames,
   useToolbar_unstable,
@@ -130,6 +143,10 @@ export type {
   ToolbarState,
   ToolbarToggleButtonProps,
   ToolbarToggleButtonState,
+  ToolbarGroupProps,
+  ToolbarGroupState,
+  ToolbarRadioButtonProps,
+  ToolbarRadioButtonState,
 } from '@fluentui/react-toolbar';
 
 export {

--- a/packages/react-components/react-toolbar/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/etc/react-toolbar.api.md
@@ -24,6 +24,9 @@ import { ToggleButtonState } from '@fluentui/react-button';
 export const renderToolbar_unstable: (state: ToolbarState, contextValues: ToolbarContextValues) => JSX.Element;
 
 // @public
+export const renderToolbarGroup_unstable: (state: ToolbarGroupState) => JSX.Element;
+
+// @public
 export const Toolbar: ForwardRefComponent<ToolbarProps>;
 
 // @public
@@ -66,6 +69,9 @@ export type ToolbarDividerState = ComponentState<Partial<DividerSlots>> & Divide
 
 // @public
 export const ToolbarGroup: ForwardRefComponent<ToolbarGroupProps>;
+
+// @public (undocumented)
+export const toolbarGroupClassNames: SlotClassNames<ToolbarGroupSlots>;
 
 // @public
 export type ToolbarGroupProps = ComponentProps<ToolbarGroupSlots>;
@@ -123,10 +129,37 @@ export type ToolbarToggleButtonState = ComponentState<Partial<ButtonSlots>> & To
 export const useToolbar_unstable: (props: ToolbarProps, ref: React_2.Ref<HTMLElement>) => ToolbarState;
 
 // @public
+export const useToolbarButton_unstable: (props: ToolbarButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToolbarButtonState;
+
+// @public
+export const useToolbarButtonStyles_unstable: (state: ToolbarButtonState) => void;
+
+// @public
+export const useToolbarDivider_unstable: (props: ToolbarDividerProps, ref: React_2.Ref<HTMLElement>) => ToolbarDividerState;
+
+// @public
 export const useToolbarDividerStyles_unstable: (state: ToolbarDividerState) => ToolbarDividerState;
 
 // @public
+export const useToolbarGroup_unstable: (props: ToolbarGroupProps, ref: React_2.Ref<HTMLDivElement>) => ToolbarGroupState;
+
+// @public
+export const useToolbarGroupStyles_unstable: (state: ToolbarGroupState) => ToolbarGroupState;
+
+// @public
+export const useToolbarRadioButton_unstable: (props: ToolbarRadioButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToolbarRadioButtonState;
+
+// @public
+export const useToolbarRadioButtonStyles_unstable: (state: ToolbarRadioButtonState) => void;
+
+// @public
 export const useToolbarStyles_unstable: (state: ToolbarState) => ToolbarState;
+
+// @public
+export const useToolbarToggleButton_unstable: (props: ToolbarToggleButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToolbarToggleButtonState;
+
+// @public
+export const useToolbarToggleButtonStyles_unstable: (state: ToolbarToggleButtonState) => void;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-toolbar/src/components/ToolbarButton/index.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarButton/index.ts
@@ -1,2 +1,4 @@
 export * from './ToolbarButton';
 export * from './ToolbarButton.types';
+export * from './useToolbarButton';
+export * from './useToolbarButtonStyles';

--- a/packages/react-components/react-toolbar/src/components/ToolbarGroup/index.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarGroup/index.ts
@@ -1,2 +1,5 @@
 export * from './ToolbarGroup';
 export * from './ToolbarGroup.types';
+export * from './useToolbarGroup';
+export * from './useToolbarGroupStyles';
+export * from './renderToolbarGroup';

--- a/packages/react-components/react-toolbar/src/components/ToolbarRadioButton/index.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarRadioButton/index.ts
@@ -1,2 +1,4 @@
 export * from './ToolbarRadioButton';
 export * from './ToolbarRadioButton.types';
+export * from './useToolbarRadioButton';
+export * from './useToolbarRadioButtonStyles';

--- a/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/index.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarToggleButton/index.ts
@@ -1,2 +1,4 @@
 export * from './ToolbarToggleButton';
 export * from './ToolbarToggleButton.types';
+export * from './useToolbarToggleButton';
+export * from './useToolbarToggleButtonStyles';

--- a/packages/react-components/react-toolbar/src/index.ts
+++ b/packages/react-components/react-toolbar/src/index.ts
@@ -7,12 +7,31 @@ export {
 } from './Toolbar';
 export type { ToolbarContextValue, ToolbarContextValues, ToolbarProps, ToolbarSlots, ToolbarState } from './Toolbar';
 export { ToolbarButton } from './ToolbarButton';
-export type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton';
-export { ToolbarDivider, useToolbarDividerStyles_unstable } from './ToolbarDivider';
+export type {
+  ToolbarButtonProps,
+  ToolbarButtonState,
+  useToolbarButtonStyles_unstable,
+  useToolbarButton_unstable,
+} from './ToolbarButton';
+export { ToolbarDivider, useToolbarDividerStyles_unstable, useToolbarDivider_unstable } from './ToolbarDivider';
 export type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider';
-export { ToolbarToggleButton } from './ToolbarToggleButton';
+export {
+  ToolbarToggleButton,
+  useToolbarToggleButtonStyles_unstable,
+  useToolbarToggleButton_unstable,
+} from './ToolbarToggleButton';
 export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton';
-export { ToolbarRadioButton } from './ToolbarRadioButton';
+export {
+  ToolbarRadioButton,
+  useToolbarRadioButtonStyles_unstable,
+  useToolbarRadioButton_unstable,
+} from './ToolbarRadioButton';
 export type { ToolbarRadioButtonProps, ToolbarRadioButtonState } from './ToolbarRadioButton';
-export { ToolbarGroup } from './ToolbarGroup';
+export {
+  ToolbarGroup,
+  useToolbarGroupStyles_unstable,
+  useToolbarGroup_unstable,
+  renderToolbarGroup_unstable,
+  toolbarGroupClassNames,
+} from './ToolbarGroup';
 export type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup';

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarControlledToggleButton.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarControlledToggleButton.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextBold24Regular, TextItalic24Regular, TextUnderline24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarToggleButton, ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarToggleButton, ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const ControlledToggleButton = () => {
   const [checkedValues, setCheckedValues] = React.useState<Record<string, string[]>>({

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarDefault.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarDefault.stories.tsx
@@ -6,8 +6,8 @@ import {
   MoreHorizontal24Filled,
 } from '@fluentui/react-icons';
 import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItem } from '@fluentui/react-components';
-import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Default = (props: Partial<ToolbarProps>) => (
   <Toolbar {...props}>

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarFarGroup.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarFarGroup.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { makeStyles } from '@fluentui/react-components';
 import { FontIncreaseRegular, FontDecreaseRegular, TextFontRegular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarButton, ToolbarDivider, ToolbarGroup } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton, ToolbarDivider, ToolbarGroup } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   toolbar: {

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarLarge.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarLarge.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FontIncrease24Regular, FontDecrease24Regular, TextFont24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Large = (props: Partial<ToolbarProps>) => (
   <Toolbar

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarMedium.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarMedium.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FontIncrease24Regular, FontDecrease24Regular, TextFont24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Medium = (props: Partial<ToolbarProps>) => (
   <Toolbar

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarOverflow.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarOverflow.stories.tsx
@@ -5,8 +5,8 @@ import {
   FontIncrease24Regular,
   MoreHorizontal20Filled,
 } from '@fluentui/react-icons';
-import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-toolbar';
-import type { ToolbarProps, ToolbarButtonProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-components/unstable';
+import type { ToolbarProps, ToolbarButtonProps } from '@fluentui/react-components/unstable';
 import {
   Overflow,
   OverflowItem,

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarRadio.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarRadio.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { AlignCenterHorizontal24Regular, AlignLeft24Regular, AlignRight24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarRadioButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarRadioButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Radio = (props: Partial<ToolbarProps>) => (
   <Toolbar

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarRadioControlled.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarRadioControlled.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { AlignCenterHorizontal24Regular, AlignLeft24Regular, AlignRight24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarRadioButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarRadioButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const ControlledRadio = (props: Partial<ToolbarProps>) => {
   const [checkedValues, setCheckedValues] = React.useState<Record<string, string[]>>({

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarSmall.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarSmall.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FontIncrease24Regular, FontDecrease24Regular, TextFont24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Small = (props: Partial<ToolbarProps>) => (
   <Toolbar

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarSubtle.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarSubtle.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TextBold24Regular, TextItalic24Regular, TextUnderline24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarToggleButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarToggleButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Subtle = (props: Partial<ToolbarProps>) => (
   <Toolbar {...props}>

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarVertical.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarVertical.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TextBold24Regular, TextItalic24Regular, TextUnderline24Regular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarToggleButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarToggleButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const Vertical = (props: Partial<ToolbarProps>) => (
   <Toolbar vertical {...props}>

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarVerticalButton.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarVerticalButton.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FontIncreaseRegular, FontDecreaseRegular, TextFontRegular } from '@fluentui/react-icons';
-import { Toolbar, ToolbarButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 
 export const VerticalButton = (props: Partial<ToolbarProps>) => (
   <Toolbar {...props}>

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarWithPopover.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarWithPopover.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarButton, ToolbarDivider } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 import { Popover, PopoverSurface, PopoverTrigger, Button } from '@fluentui/react-components';
 import { MathFormatLinear24Regular, Image24Regular, Table24Filled } from '@fluentui/react-icons';
 

--- a/packages/react-components/react-toolbar/stories/Toolbar/ToolbarWithTooltip.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/ToolbarWithTooltip.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Toolbar, ToolbarToggleButton, ToolbarDivider, ToolbarButton } from '@fluentui/react-toolbar';
-import type { ToolbarProps } from '@fluentui/react-toolbar';
+import { Toolbar, ToolbarToggleButton, ToolbarDivider, ToolbarButton } from '@fluentui/react-components/unstable';
+import type { ToolbarProps } from '@fluentui/react-components/unstable';
 import { Tooltip } from '@fluentui/react-components';
 import {
   TextUnderline24Regular,

--- a/packages/react-components/react-toolbar/stories/Toolbar/index.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/Toolbar/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Toolbar } from '@fluentui/react-toolbar';
+import { Toolbar } from '@fluentui/react-components/unstable';
 
 import descriptionMd from './ToolbarDescription.md';
 import bestPracticesMd from './ToolbarBestPractices.md';


### PR DESCRIPTION
Exports all relevant Toolbar components and utilities

Currently toolbar docs components/types are imported from `@fluentui/react-toolbar`, this means that the sandbox example will export from `@fluentui/react-components` which will fail because the import should be from `@fluentui/react-components/unstable`
