### PR TITLE
chore (v0 vr-tests): Remove unneeded eslint rule disable comments

### DIFF
--- a/packages/fluentui/docs/.eslintrc.json
+++ b/packages/fluentui/docs/.eslintrc.json
@@ -3,7 +3,12 @@
   "overrides": [
     {
       // These files don't have actual dependencies
-      "files": ["src/vr-tests/**/*.stories.tsx", "src/vr-tests/**/*.stories.ts", "src/vr-tests/**/*.ts"],
+      "files": [
+        "src/vr-tests/**/*.stories.tsx",
+        "src/vr-tests/**/*.stories.ts",
+        "src/vr-tests/**/*.tsx",
+        "src/vr-tests/**/*.ts"
+      ],
       "rules": {
         "import/no-extraneous-dependencies": "off"
       }

--- a/packages/fluentui/docs/src/vr-tests/Accordion/Accordion.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Accordion/Accordion.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Accordion } from '@fluentui/react-northstar';
 import AccordionDefaultBsize from '../../examples/components/Accordion/Performance/AccordionDefault.bsize';

--- a/packages/fluentui/docs/src/vr-tests/Accordion/AccordionExampleCustomTitle.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Accordion/AccordionExampleCustomTitle.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Accordion, accordionTitleSlotClassNames } from '@fluentui/react-northstar';
 import AccordionExampleCustomTitle from '../../examples/components/Accordion/Visual/AccordionExampleCustomTitle.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Alert/Alert.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Alert/Alert.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Alert } from '@fluentui/react-northstar';
 import AlertDefaultBsize from '../../examples/components/Alert/Performance/AlertDefault.bsize';

--- a/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleDanger.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleDanger.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Alert } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities/getThemeStoryVariant';

--- a/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleDismissible.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleDismissible.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Alert } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleInfo.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleInfo.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Alert } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities/getThemeStoryVariant';

--- a/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleOof.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleOof.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Alert } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleUrgent.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Alert/AlertExampleUrgent.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Alert } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Alert/commonStoryWrightSteps.ts
+++ b/packages/fluentui/docs/src/vr-tests/Alert/commonStoryWrightSteps.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, Steps } from 'storywright';
 import { alertDismissActionClassName } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/Animation/Animation.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Animation/Animation.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Animation } from '@fluentui/react-northstar';
 import AnimationExample from '../../examples/components/Animation/Types/AnimationExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Attachment/Attachment.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Attachment/Attachment.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Attachment } from '@fluentui/react-northstar';
 import AttachmentDefaultBsize from '../../examples/components/Attachment/Performance/AttachmentDefault.bsize';

--- a/packages/fluentui/docs/src/vr-tests/Attachment/AttachmentActionExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Attachment/AttachmentActionExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Attachment } from '@fluentui/react-northstar';
 import { CloseIcon, MoreIcon } from '@fluentui/react-icons-northstar';

--- a/packages/fluentui/docs/src/vr-tests/Attachment/AttachmentActionableExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Attachment/AttachmentActionableExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Attachment } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Avatar/Avatar.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Avatar/Avatar.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Avatar } from '@fluentui/react-northstar';
 import AvatarDefaultBsize from '../../examples/components/Avatar/Performance/AvatarDefault.bsize';

--- a/packages/fluentui/docs/src/vr-tests/Box/Box.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Box/Box.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Box } from '@fluentui/react-northstar';
 import BoxDefaultBsize from '../../examples/components/Box/Performance/BoxDefault.bsize';

--- a/packages/fluentui/docs/src/vr-tests/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Breadcrumb } from '@fluentui/react-northstar';
 import BreadcrumbExampleIconDivider from '../../examples/components/Breadcrumb/Content/BreadcrumbExampleIconDivider';

--- a/packages/fluentui/docs/src/vr-tests/Button/Button.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/Button.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import ButtonDefaultBsize from '../../examples/components/Button/Performance/ButtonDefault.bsize';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleContentAndIcon.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleContentAndIcon.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleDisabled.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleDisabled.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleTextShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleTextShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleWithTooltip.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonExampleWithTooltip.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonGroupCircularExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonGroupCircularExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/ButtonGroupExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Button/ButtonGroupExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Button/commonStoryWrightSteps.ts
+++ b/packages/fluentui/docs/src/vr-tests/Button/commonStoryWrightSteps.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, Steps } from 'storywright';
 import { buttonClassName } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/Card/Card.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Card/Card.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Card } from '@fluentui/react-northstar';
 import CardExampleBody from '../../examples/components/Card/Slots/CardExampleBody';

--- a/packages/fluentui/docs/src/vr-tests/Card/CardExampleFocusable.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Card/CardExampleFocusable.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Card } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Card/CardExampleWithPreview.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Card/CardExampleWithPreview.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Card } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Carousel/Carousel.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Carousel/Carousel.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Carousel } from '@fluentui/react-northstar';
 import CarouselExample from '../../examples/components/Carousel/Types/CarouselExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Chat/Chat.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/Chat.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import ChatExampleHeader from '../../examples/components/Chat/Content/ChatExampleHeader.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Chat/ChatExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/ChatExample.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Chat/ChatExampleCompact.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/ChatExampleCompact.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Chat/ChatExampleDetails.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/ChatExampleDetails.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Chat/ChatExampleInScrollableShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/ChatExampleInScrollableShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import ChatExampleInScrollableShorthand from '../../examples/components/Chat/Usage/ChatExampleInScrollable.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Chat/ChatMessageExampleBadge.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/ChatMessageExampleBadge.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Chat/MessageReactionsWithPopup.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Chat/MessageReactionsWithPopup.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Chat } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Checkbox/Checkbox.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Checkbox } from '@fluentui/react-northstar';
 import CheckboxExampleRtl from '../../examples/components/Checkbox/Rtl/CheckboxExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Checkbox/CheckboxExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Checkbox/CheckboxExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Checkbox } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Checkbox/CheckboxExampleCheckedMixed.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Checkbox/CheckboxExampleCheckedMixed.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Checkbox } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Checkbox/CheckboxExampleToggle.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Checkbox/CheckboxExampleToggle.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Checkbox } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Checkbox/commonStoryWrightSteps.ts
+++ b/packages/fluentui/docs/src/vr-tests/Checkbox/commonStoryWrightSteps.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, Steps } from 'storywright';
 import { checkboxClassName } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/Datepicker.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/Datepicker.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker } from '@fluentui/react-northstar';
 import DatepickerHeaderExample from '../../examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerCellExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerCellExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, inputClassName } from '@fluentui/react-northstar';
 import { datepickerCalendarCellSelector } from './utils';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleClearable.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleClearable.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, inputClassName } from '@fluentui/react-northstar';
 import { datepickerCalendarCellSelector } from './utils';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleLocalizationStrings.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleLocalizationStrings.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleMinMaxDate.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleMinMaxDate.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName, datepickerCalendarHeaderActionClassName } from '@fluentui/react-northstar';
 import { datepickerCalendarCellSelector } from './utils';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleNoInput.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleNoInput.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName, inputClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleRequired.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleRequired.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName } from '@fluentui/react-northstar';
 import { datepickerCalendarCellSelector } from './utils';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleRestrictedDates.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleRestrictedDates.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleStandaloneCalendarButton.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleStandaloneCalendarButton.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleToday.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleToday.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName } from '@fluentui/react-northstar';
 import { datepickerCalendarCellSelector } from './utils';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleWeek.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerExampleWeek.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, buttonClassName, datepickerCalendarCellClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerFormatExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerFormatExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, inputClassName } from '@fluentui/react-northstar';
 import { datepickerCalendarCellSelector } from './utils';

--- a/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerHeaderCellExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Datepicker/DatepickerHeaderCellExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Datepicker, datepickerCalendarHeaderCellClassName, inputClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/Dialog.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/Dialog.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import DialogExample from '../../examples/components/Dialog/Types/DialogExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleBackdrop.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleBackdrop.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleContent.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleContent.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleFooter.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleFooter.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleFullWidth.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleFullWidth.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleHeaderAction.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleHeaderAction.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleScroll.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleScroll.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleZoomContent.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/DialogExampleZoomContent.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dialog } from '@fluentui/react-northstar';
 import StoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Dialog/commonStoryWrightSteps.ts
+++ b/packages/fluentui/docs/src/vr-tests/Dialog/commonStoryWrightSteps.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Steps } from 'storywright';
 import { buttonClassName } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/Divider/Divider.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/Divider.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import DividerExampleContent from '../../examples/components/Divider/Types/DividerExampleContent';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleColor.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleColor.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleContent.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleContent.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleFittedShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleFittedShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleImportantShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleImportantShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleRtl.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleRtlAndLtr.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleRtlAndLtr.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleSize.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Divider/DividerExampleSize.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Divider } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/Dropdown.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown } from '@fluentui/react-northstar';
 import DropdownExampleFreeform from '../../examples/components/Dropdown/Types/DropdownExampleFreeform.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownClearableExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownClearableExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import DropdownClearableExample from '../../examples/components/Dropdown/Types/DropdownExampleClearable.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownCustomClearableExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownCustomClearableExample.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleDisabled.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleDisabled.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames, dropdownSearchInputSlotClassNames } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleHeaderMessage.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleHeaderMessage.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import DropdownExampleHeaderMessage from '../../examples/components/Dropdown/Slots/DropdownExampleHeaderMessage.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleLoading.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleLoading.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames, dropdownSearchInputSlotClassNames } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleMultiple.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleMultiple.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames, dropdownSelectedItemSlotClassNames } from '@fluentui/react-northstar';
 import DropdownExampleMultiple from '../../examples/components/Dropdown/Types/DropdownExampleMultiple.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExamplePosition.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExamplePosition.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import DropdownExamplePosition from '../../examples/components/Dropdown/Variations/DropdownExampleOffset.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import DropdownExampleRtl from '../../examples/components/Dropdown/Rtl/DropdownExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleSearchMultiple.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Dropdown/DropdownExampleSearchMultiple.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Dropdown, dropdownSearchInputSlotClassNames, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Embed/Embed.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Embed/Embed.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Embed } from '@fluentui/react-northstar';
 import EmbedExampleVideo from '../../examples/components/Embed/Slots/EmbedExampleVideo.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Flex/Flex.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Flex/Flex.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Flex } from '@fluentui/react-northstar';
 import FlexExampleMediaCard from '../../examples/components/Flex/Rtl/FlexExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Form/Form.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Form/Form.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Form } from '@fluentui/react-northstar';
 import FormExampleRtl from '../../examples/components/Form/Rtl/FormExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Grid/Grid.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Grid/Grid.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Grid } from '@fluentui/react-northstar';
 import GridExample from '../../examples/components/Grid/Rtl/GridExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Header/Header.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Header/Header.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Header } from '@fluentui/react-northstar';
 import HeaderExampleRtl from '../../examples/components/Header/Rtl/HeaderExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Image/Image.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Image/Image.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Image } from '@fluentui/react-northstar';
 import ImageExampleRtl from '../../examples/components/Image/Rtl/ImageExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Input/Input.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Input/Input.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Input } from '@fluentui/react-northstar';
 import InputExampleRtl from '../../examples/components/Input/Rtl/InputExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Input/InputExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Input/InputExample.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Input } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Input/InputExampleClearable.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Input/InputExampleClearable.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Input, inputClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Input/InputExampleLabelShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Input/InputExampleLabelShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Input } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/ItemLayout/ItemLayout.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/ItemLayout/ItemLayout.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { ItemLayout } from '@fluentui/react-northstar';
 import ItemLayoutExampleContent from '../../examples/components/ItemLayout/Content/ItemLayoutExampleContent.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Label/Label.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Label/Label.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Label } from '@fluentui/react-northstar';
 import LabelExampleShorthand from '../../examples/components/Label/Content/LabelExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Layout/Layout.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Layout/Layout.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Layout } from '@fluentui/react-northstar';
 import LayoutExample from '../../examples/components/Layout/Types/LayoutExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/List/List.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/List/List.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { List } from '@fluentui/react-northstar';
 import ListExample from '../../examples/components/List/Content/ListExampleContent.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/List/ListExampleNavigable.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/List/ListExampleNavigable.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { List, listItemClassName, listClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/List/ListExampleSelectable.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/List/ListExampleSelectable.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { List, listItemClassName, listClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Loader/Loader.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Loader/Loader.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Loader } from '@fluentui/react-northstar';
 import LoaderExampleRtl from '../../examples/components/Loader/Rtl/LoaderExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Menu/Menu.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/Menu.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import MenuPlayground from '../../examples/components/Menu/Playground';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleIconOnly.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleIconOnly.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExamplePointing.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExamplePointing.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExamplePositioningShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExamplePositioningShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import MenuExamplePositioningShorthand from '../../examples/components/Menu/Visual/MenuExamplePositioning.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExamplePositioningUpdateShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExamplePositioningUpdateShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import MenuExamplePositioningUpdateShorthand from '../../examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleToolbarShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleToolbarShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu, menuClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleUnderlined.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleUnderlined.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleVertical.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleVertical.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu, menuClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleVerticalPointing.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleVerticalPointing.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithIcons.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithIcons.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithSubMenu.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithSubMenu.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu } from '@fluentui/react-northstar';
 import getStoryWrightSteps from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithSubMenuHover.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithSubMenuHover.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu, menuClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithTooltip.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Menu/MenuExampleWithTooltip.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Menu, menuClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Menu/commonStoryWrightSteps.ts
+++ b/packages/fluentui/docs/src/vr-tests/Menu/commonStoryWrightSteps.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, Steps } from 'storywright';
 import { menuClassName } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/MenuButton/MenuButton.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/MenuButton/MenuButton.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { MenuButton } from '@fluentui/react-northstar';
 import MenuButtonOpenExample from '../../examples/components/MenuButton/State/MenuButtonExampleOpen.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/MenuButton/MenuButtonExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/MenuButton/MenuButtonExampleRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { MenuButton, buttonClassName } from '@fluentui/react-northstar';
 import MenuButtonExampleRtl from '../../examples/components/MenuButton/Rtl/MenuButtonExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Pill/Pill.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Pill/Pill.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Pill } from '@fluentui/react-northstar';
 import PillExampleDisabled from '../../examples/components/Pill/State/PillExampleDisabled';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopperExamplePositioning.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopperExamplePositioning.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup } from '@fluentui/react-northstar';
 import PopperExamplePositioning from '../../examples/components/Popup/Visual/PopperExamplePositioning';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopperExampleVisibilityModifiers.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopperExampleVisibilityModifiers.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup } from '@fluentui/react-northstar';
 import PopperExampleVisibilityModifiers from '../../examples/components/Popup/Visual/PopperExampleVisibilityModifiers';

--- a/packages/fluentui/docs/src/vr-tests/Popup/Popup.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/Popup.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup } from '@fluentui/react-northstar';
 import PopupControlledExample from '../../examples/components/Popup/Types/PopupControlledExample';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopupControlledExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopupControlledExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup, buttonClassName, dropdownSlotClassNames } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopupCustomTargetExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopupCustomTargetExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup, buttonClassName } from '@fluentui/react-northstar';
 import PopupCustomTargetExample from '../../examples/components/Popup/Types/PopupCustomTargetExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopupExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopupExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup, buttonClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopupExampleOffset.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopupExampleOffset.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup, buttonClassName } from '@fluentui/react-northstar';
 import PopupExampleOffset from '../../examples/components/Popup/Variations/PopupExampleOffset.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopupExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopupExampleRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup, buttonClassName } from '@fluentui/react-northstar';
 import PopupExampleRtl from '../../examples/components/Popup/Rtl/PopupExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Popup/PopupScrollExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Popup/PopupScrollExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Popup, buttonClassName } from '@fluentui/react-northstar';
 import PopupScrollExample from '../../examples/components/Popup/Visual/PopupScrollExample';

--- a/packages/fluentui/docs/src/vr-tests/Portal/Portal.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Portal/Portal.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Portal } from '@fluentui/react-northstar';
 import PortalExampleOpen from '../../examples/components/Portal/State/PortalExampleOpen';

--- a/packages/fluentui/docs/src/vr-tests/Provider/Provider.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Provider/Provider.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Provider } from '@fluentui/react-northstar';
 import ProviderExampleAnimation from '../../examples/components/Provider/Types/ProviderDisableAnimationsExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Provider/ProviderExampleFocusBorderShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Provider/ProviderExampleFocusBorderShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Provider, buttonClassName } from '@fluentui/react-northstar';
 import ProviderExampleFocusBorderShorthand from '../../examples/components/Provider/Types/ProviderExampleFocusBorder.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/RadioGroup/RadioGroup.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider, RadioGroup } from '@fluentui/react-northstar';
 import RadioGroupItemExample from '../../examples/components/RadioGroup/Item/RadioGroupItemExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/RadioGroup/RadioGroupVerticalExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/RadioGroup/RadioGroupVerticalExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Divider, RadioGroup } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Reaction/Reaction.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Reaction/Reaction.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Reaction } from '@fluentui/react-northstar';
 import ReactionGroupExampleRtl from '../../examples/components/Reaction/Rtl/ReactionExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Segment/Segment.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Segment/Segment.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Segment } from '@fluentui/react-northstar';
 import SegmentExampleRtl from '../../examples/components/Segment/Rtl/SegmentExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Skeleton/Skeleton.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Skeleton/Skeleton.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Skeleton } from '@fluentui/react-northstar';
 import SkeletonExampleCard from '../../examples/components/Skeleton/Usage/SkeletonExampleCard';

--- a/packages/fluentui/docs/src/vr-tests/Slider/Slider.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Slider/Slider.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Slider } from '@fluentui/react-northstar';
 import SliderExampleDisabledShorthand from '../../examples/components/Slider/States/SliderExampleDisabled.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Slider/SliderExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Slider/SliderExampleRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Slider } from '@fluentui/react-northstar';
 import { focusSliderSteps, rightArrowSteps, upArrowSteps } from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Slider/SliderExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Slider/SliderExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Slider } from '@fluentui/react-northstar';
 import { focusSliderSteps, rightArrowSteps, upArrowSteps } from './commonStoryWrightSteps';

--- a/packages/fluentui/docs/src/vr-tests/Slider/commonStoryWrightSteps.ts
+++ b/packages/fluentui/docs/src/vr-tests/Slider/commonStoryWrightSteps.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, Steps } from 'storywright';
 import { sliderSlotClassNames } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButton.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButton.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SplitButton } from '@fluentui/react-northstar';
 import SplitButtonIconAndContentExampleShorthand from '../../examples/components/SplitButton/Slots/SplitButtonIconAndContentExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButtonExamplePrimaryShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButtonExamplePrimaryShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SplitButton, splitButtonToggleClassName } from '@fluentui/react-northstar';
 import SplitButtonExamplePrimaryShorthand from '../../examples/components/SplitButton/Types/SplitButtonExamplePrimary.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButtonExampleSmallContainer.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButtonExampleSmallContainer.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SplitButton } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButtonPositioningExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SplitButton/SplitButtonPositioningExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SplitButton, splitButtonToggleClassName } from '@fluentui/react-northstar';
 import SplitButtonPositioningExampleShorthand from '../../examples/components/SplitButton/Usage/SplitButtonPositioningExampleShorthand.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Status/Status.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Status/Status.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Status } from '@fluentui/react-northstar';
 import StatusExampleShorthand from '../../examples/components/Status/Types/StatusExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Status/StatusTypeExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Status/StatusTypeExampleShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Status } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIcon.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIcon.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import SvgPlayground from '../../examples/components/SvgIcon/Playground';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExample.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleCircular.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleCircular.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleColor.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleColor.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleDisabled.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleDisabled.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleSize.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleSize.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleSpace.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconExampleSpace.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconSetExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgIconSetExampleShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgconExampleBordered.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/SvgIcon/SvgconExampleBordered.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { SvgIcon } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Table/StaticTable.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Table/StaticTable.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Table } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Table/Table.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Table/Table.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Table } from '@fluentui/react-northstar';
 import TableExampleStaticShorthand from '../../examples/components/Table/Usage/TableExampleStatic.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Text/Text.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Text/Text.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Text } from '@fluentui/react-northstar';
 import TextExampleRtl from '../../examples/components/Text/Rtl/TextExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/TextArea/TextArea.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/TextArea/TextArea.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { TextArea } from '@fluentui/react-northstar';
 import TextAreaDisabledExample from '../../examples/components/TextArea/States/TextAreaDisabledExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/TextArea/TextAreaExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/TextArea/TextAreaExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { TextArea, textAreaClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/TextArea/TextAreaExampleInverted.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/TextArea/TextAreaExampleInverted.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { TextArea } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/Toolbar.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/Toolbar.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import ToolbarExampleCustomContentShorthand from '../../examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleActionPopupInMenu.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleActionPopupInMenu.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar, toolbarItemWrapperClassName, toolbarMenuItemClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleEditorShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleEditorShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleMenuShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleMenuShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import ToolbarExampleMenuShorthand from '../../examples/components/Toolbar/Visual/ToolbarExampleCompose.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleMenuWithSubmenuShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleMenuWithSubmenuShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar, toolbarItemWrapperClassName, toolbarMenuItemClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleOverflow.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleOverflow.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import ToolbarExampleOverflow from '../../examples/components/Toolbar/Visual/ToolbarExampleChatMessage';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleOverflowPositioningShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleOverflowPositioningShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import ToolbarExampleOverflowPositioningShorthand from '../../examples/components/Toolbar/Visual/ToolbarExampleOverflowPositioning.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleOverflowPositioningShorthandRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleOverflowPositioningShorthandRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import ToolbarExampleOverflowPositioningShorthandRtl from '../../examples/components/Toolbar/Visual/ToolbarExampleOverflowPositioning.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExamplePopupInMenu.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExamplePopupInMenu.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar, toolbarItemClassName, toolbarMenuItemClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExamplePopupShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExamplePopupShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar, toolbarItemClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleRadioGroupShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleRadioGroupShorthand.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar, toolbarClassName, toolbarItemClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleVariables.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Toolbar/ToolbarExampleVariables.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Toolbar } from '@fluentui/react-northstar';
 import ToolbarExampleVariables from '../../examples/components/Toolbar/Visual/ToolbarExampleVariables.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Tooltip/Tooltip.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tooltip } from '@fluentui/react-northstar';
 import TooltipOpenExample from '../../examples/components/Tooltip/States/TooltipOpenControlledExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tooltip, buttonClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExampleDialogContentShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExampleDialogContentShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tooltip, buttonClassName, dialogSlotClassNames } from '@fluentui/react-northstar';
 import TooltipExampleDialogContentShorthand from '../../examples/components/Tooltip/Usage/TooltipExampleDialogContent.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExamplePointing.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExamplePointing.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tooltip, buttonClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExampleRtl.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExampleRtl.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tooltip, buttonClassName } from '@fluentui/react-northstar';
 import TooltipExampleRtl from '../../examples/components/Tooltip/Rtl/TooltipExample.rtl';

--- a/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExampleTarget.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tooltip/TooltipExampleTarget.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tooltip, buttonClassName } from '@fluentui/react-northstar';
 import TooltipExampleTarget from '../../examples/components/Tooltip/Usage/TooltipExampleTarget.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Tree/Tree.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tree/Tree.stories.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tree } from '@fluentui/react-northstar';
 import TreeExclusiveExample from '../../examples/components/Tree/Types/TreeExclusiveExample.shorthand';

--- a/packages/fluentui/docs/src/vr-tests/Tree/TreeExampleShorthand.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tree/TreeExampleShorthand.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tree, treeTitleClassName, treeItemClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Tree/TreeMultiselectExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tree/TreeMultiselectExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Keys, StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tree, treeItemClassName, treeTitleClassName, treeTitleSlotClassNames } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Tree/TreeTitleCustomizationExample.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Tree/TreeTitleCustomizationExample.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StoryWright, Steps } from 'storywright';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Tree, treeItemClassName, treeTitleClassName } from '@fluentui/react-northstar';
 import { getThemeStoryVariant } from '../utilities';

--- a/packages/fluentui/docs/src/vr-tests/Video/Video.stories.tsx
+++ b/packages/fluentui/docs/src/vr-tests/Video/Video.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentMeta } from '@storybook/react';
 import { Flex, Text, Video } from '@fluentui/react-northstar';
 

--- a/packages/fluentui/docs/src/vr-tests/utilities/getThemeStoryVariant.tsx
+++ b/packages/fluentui/docs/src/vr-tests/utilities/getThemeStoryVariant.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ComponentStory } from '@storybook/react';
 import { Provider, teamsDarkV2Theme, teamsHighContrastTheme, teamsV2Theme } from '@fluentui/react-northstar';
 


### PR DESCRIPTION
## Changes:
- removes unneeded `eslint-disable-next-line import/no-extraneous-dependencies` line comments.
- updates eslint config rule override to also include `"src/vr-tests/**/*.tsx"`.
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26054
* Part of #25078
