### PR TITLE
chore: set @fluentui/react-storybook-addon dependency to a pinned version in various packages

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -27,7 +27,7 @@
     "@fluentui/scripts": "^1.0.0",
     "@fluentui/storybook": "^1.0.0",
     "@fluentui/react-components": "^9.7.4",
-    "@fluentui/react-storybook-addon": "^9.0.0-rc.1",
+    "@fluentui/react-storybook-addon": "9.0.0-rc.1",
     "@fluentui/react-theme": "^9.1.5",
     "@griffel/react": "^1.4.2",
     "react": "17.0.2",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -48,7 +48,7 @@
     "@fluentui/react-slider": "^9.0.14",
     "@fluentui/react-spinner": "^9.0.14",
     "@fluentui/react-spinbutton": "^9.0.12",
-    "@fluentui/react-storybook-addon": "^9.0.0-rc.1",
+    "@fluentui/react-storybook-addon": "9.0.0-rc.1",
     "@fluentui/react-switch": "^9.0.15",
     "@fluentui/react-tabs": "^9.1.4",
     "@fluentui/react-table": "9.0.0-alpha.15",

--- a/change/@fluentui-react-components-d72c0cfe-6075-444c-9af6-3fa0a3ae2501.json
+++ b/change/@fluentui-react-components-d72c0cfe-6075-444c-9af6-3fa0a3ae2501.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: set @fluentui/react-storybook-addon dev dependency to a pinned version.",
+  "packageName": "@fluentui/react-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/react-storybook-addon": "^9.0.0-rc.1",
+    "@fluentui/react-storybook-addon": "9.0.0-rc.1",
     "@fluentui/scripts": "^1.0.0",
     "react-hook-form": "^5.7.2"
   },


### PR DESCRIPTION
## Changes:
- sets `@fluentui/react-storybook-addon` dev dependency to a pinned version in v9, v9 docsite and v9 vr-tests packages. `@fluentui/react-storybook-addon` is still in `prerelease` and thus having it set as a caret can lead to non-deterministic resolutions.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #25490
