### PR TITLE
refactor: render function children called in component render function

### DIFF
--- a/change/@fluentui-react-table-808432fb-a855-4007-b789-614057e34ad1.json
+++ b/change/@fluentui-react-table-808432fb-a855-4007-b789-614057e34ad1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: render function children called in component render function",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -69,7 +69,10 @@ export type DataGridBodyProps = Omit<TableBodyProps, 'children'> & {
 export type DataGridBodySlots = TableBodySlots;
 
 // @public
-export type DataGridBodyState = TableBodyState;
+export type DataGridBodyState = TableBodyState & {
+    rows: RowState<any>[];
+    renderRow: RowRenderFunction;
+};
 
 // @public
 export const DataGridCell: ForwardRefComponent<DataGridCellProps>;
@@ -156,7 +159,10 @@ export type DataGridRowSlots = TableRowSlots & {
 };
 
 // @public
-export type DataGridRowState = TableRowState & ComponentState<DataGridRowSlots>;
+export type DataGridRowState = TableRowState & ComponentState<DataGridRowSlots> & {
+    renderCell: CellRenderFunction;
+    columnDefs: ColumnDefinition<any>[];
+};
 
 // @public
 export const DataGridSelectionCell: ForwardRefComponent<DataGridSelectionCellProps>;

--- a/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.types.ts
@@ -22,4 +22,9 @@ export type DataGridBodyProps = Omit<TableBodyProps, 'children'> & {
 /**
  * State used in rendering DataGridBody
  */
-export type DataGridBodyState = TableBodyState;
+export type DataGridBodyState = TableBodyState & {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rows: RowState<any>[];
+
+  renderRow: RowRenderFunction;
+};

--- a/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
@@ -1,9 +1,22 @@
-import type { DataGridBodyState } from './DataGridBody.types';
-import { renderTableBody_unstable } from '../TableBody/renderTableBody';
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { DataGridBodyState, DataGridBodySlots } from './DataGridBody.types';
+import { RowIdContextProvider } from '../../contexts/rowIdContext';
 
 /**
  * Render the final JSX of DataGridBody
  */
 export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
-  return renderTableBody_unstable(state);
+  const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return (
+    <slots.root {...slotProps.root}>
+      {state.rows.map(row => (
+        <RowIdContextProvider key={row.rowId} value={row.rowId}>
+          {state.renderRow(row)}
+        </RowIdContextProvider>
+      ))}
+    </slots.root>
+  );
 };

--- a/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
@@ -9,7 +9,6 @@ import { RowIdContextProvider } from '../../contexts/rowIdContext';
 export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
   const { slots, slotProps } = getSlots<DataGridBodySlots>(state);
 
-  // TODO Add additional slots in the appropriate place
   return (
     <slots.root {...slotProps.root}>
       {state.rows.map(row => (

--- a/packages/react-components/react-table/src/components/DataGridBody/useDataGridBody.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/useDataGridBody.tsx
@@ -3,7 +3,6 @@ import type { DataGridBodyProps, DataGridBodyState } from './DataGridBody.types'
 import { useTableBody_unstable } from '../TableBody/useTableBody';
 import { useDataGridContext_unstable } from '../../contexts/dataGridContext';
 import { useTableContext } from '../../contexts/tableContext';
-import { RowIdContextProvider } from '../../contexts/rowIdContext';
 
 /**
  * Create the state required to render DataGridBody.
@@ -20,11 +19,10 @@ export const useDataGridBody_unstable = (props: DataGridBodyProps, ref: React.Re
   const sort = useDataGridContext_unstable(ctx => ctx.sort.sort);
   const rows = sortable ? sort(getRows()) : getRows();
 
-  const { children: renderRow } = props;
-  const children = rows.map(row => (
-    <RowIdContextProvider key={row.rowId} value={row.rowId}>
-      {renderRow(row)}
-    </RowIdContextProvider>
-  ));
-  return useTableBody_unstable({ ...props, children, as: 'div' }, ref);
+  const baseState = useTableBody_unstable({ ...props, children: null, as: 'div' }, ref);
+  return {
+    ...baseState,
+    rows,
+    renderRow: props.children,
+  };
 };

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
@@ -28,4 +28,9 @@ export type DataGridRowProps = Omit<TableRowProps, 'children'> &
 /**
  * State used in rendering DataGridRow
  */
-export type DataGridRowState = TableRowState & ComponentState<DataGridRowSlots>;
+export type DataGridRowState = TableRowState &
+  ComponentState<DataGridRowSlots> & {
+    renderCell: CellRenderFunction;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    columnDefs: ColumnDefinition<any>[];
+  };

--- a/packages/react-components/react-table/src/components/DataGridRow/renderDataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/renderDataGridRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
 import type { DataGridRowState, DataGridRowSlots } from './DataGridRow.types';
+import { ColumnIdContextProvider } from '../../contexts/columnIdContext';
 
 /**
  * Render the final JSX of DataGridRow
@@ -11,7 +12,11 @@ export const renderDataGridRow_unstable = (state: DataGridRowState) => {
   return (
     <slots.root {...slotProps.root}>
       {slots.selectionCell && <slots.selectionCell {...slotProps.selectionCell} />}
-      {slotProps.root.children}
+      {state.columnDefs.map(columnDef => (
+        <ColumnIdContextProvider value={columnDef.columnId} key={columnDef.columnId}>
+          {state.renderCell(columnDef)}
+        </ColumnIdContextProvider>
+      ))}
     </slots.root>
   );
 };

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.tsx
@@ -4,7 +4,6 @@ import { Space } from '@fluentui/keyboard-keys';
 import type { DataGridRowProps, DataGridRowState } from './DataGridRow.types';
 import { useTableRow_unstable } from '../TableRow/useTableRow';
 import { useDataGridContext_unstable } from '../../contexts/dataGridContext';
-import { ColumnIdContextProvider } from '../../contexts/columnIdContext';
 import { DataGridSelectionCell } from '../DataGridSelectionCell/DataGridSelectionCell';
 import { useRowIdContext } from '../../contexts/rowIdContext';
 import { useIsInTableHeader } from '../../contexts/tableHeaderContext';
@@ -34,15 +33,6 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
   });
   const toggleRow = useDataGridContext_unstable(ctx => ctx.selection.toggleRow);
 
-  const cellRenderFunction = props.children;
-  const cells = columnDefs.map(columnDef => {
-    return (
-      <ColumnIdContextProvider value={columnDef.columnId} key={columnDef.columnId}>
-        {cellRenderFunction(columnDef)}
-      </ColumnIdContextProvider>
-    );
-  });
-
   const onClick = useEventCallback((e: React.MouseEvent<HTMLTableRowElement>) => {
     if (selectable && !isHeader) {
       toggleRow(e, rowId);
@@ -68,7 +58,7 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
       ...props,
       onClick,
       onKeyDown,
-      children: cells,
+      children: null,
       as: 'div',
       tabIndex: tabbable && !isHeader ? 0 : undefined,
     },
@@ -82,5 +72,7 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
       selectionCell: DataGridSelectionCell,
     },
     selectionCell: resolveShorthand(props.selectionCell, { required: selectable }),
+    renderCell: props.children,
+    columnDefs,
   };
 };


### PR DESCRIPTION
Components like `DataGridBody` and `DataGridRow` only accept render functions as children. These render functions were always called during the `useComponent` hook. This was unnecessary, and makes recomposition harder because data is always processed even if the recomposed component should render children differently.

The change also makes more sense from a conceptual PoV, since render functions are called in render functions .