### PR TITLE
fix: force update memory leak in positioning manager

### DIFF
--- a/change/@fluentui-react-positioning-79cab7f0-3879-4f3b-a855-253d7bd87fec.json
+++ b/change/@fluentui-react-positioning-79cab7f0-3879-4f3b-a855-253d7bd87fec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: force update memory leak in positioning manager",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -52,7 +52,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
   // Without this scroll jumps can occur when the element is rendered initially and receives focus
   Object.assign(container.style, { position: 'fixed', left: 0, top: 0, margin: 0 });
 
-  const forceUpdate = () => {
+  let forceUpdate = () => {
     if (isFirstUpdate) {
       scrollParents.add(getScrollParent(container));
       if (target instanceof HTMLElement) {
@@ -97,6 +97,10 @@ export function createPositionManager(options: PositionManagerOptions): Position
   const updatePosition = debounce(() => forceUpdate());
 
   const dispose = () => {
+    // debounced update can still occur afterwards
+    // so destroy the reference to forceUpdate
+    forceUpdate = () => null;
+
     if (targetWindow) {
       targetWindow.removeEventListener('scroll', updatePosition);
       targetWindow.removeEventListener('resize', updatePosition);


### PR DESCRIPTION
Even though the position manager can be disposed, the debounced `forceUpdate` can still happen. This will add scroll listeners to the document without cleaning them up (the manager has already been disposed).

This PR updates the disposal of the position manager to destroy the reference to the original `forceUpdate` so that it never executes.