### PR TITLE
chore(scripts): remove deep imports from /scripts/tasks/*

### DIFF
--- a/change/@fluentui-monaco-editor-4fb3039b-1e7a-4e18-a0b3-1d0e9c200bfe.json
+++ b/change/@fluentui-monaco-editor-4fb3039b-1e7a-4e18-a0b3-1d0e9c200bfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from /scripts/tasks/*",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-87fa619c-f87b-479a-8b34-82479c930a16.json
+++ b/change/@fluentui-react-monaco-editor-87fa619c-f87b-479a-8b34-82479c930a16.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from /scripts/tasks/*",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/monaco-editor/just.config.ts
+++ b/packages/monaco-editor/just.config.ts
@@ -1,7 +1,5 @@
 import { preset, task, series, parallel, copyInstructions, copyInstructionsTask, cleanTask } from '@fluentui/scripts';
-import { ts } from '@fluentui/scripts/tasks/ts';
-import { postprocessTask, defaultLibPaths } from '@fluentui/scripts/tasks/postprocess';
-import { eslint } from '@fluentui/scripts/tasks/eslint';
+import { ts, postprocess, eslint } from '@fluentui/scripts/tasks';
 import * as path from 'path';
 import { transformCssTask } from './tasks/transformCssTask';
 
@@ -21,7 +19,7 @@ task(
 task('transform-css', transformCssTask);
 task('ts:esm', ts.esm);
 task('ts:commonjs', ts.commonjs);
-task('ts:postprocess', postprocessTask([...defaultLibPaths, 'esm/**/*.d.ts']));
+task('ts:postprocess', postprocess.postprocessTask([...postprocess.defaultLibPaths, 'esm/**/*.d.ts']));
 task('ts', series(parallel('ts:esm', 'ts:commonjs'), 'ts:postprocess'));
 task('eslint', eslint);
 

--- a/packages/react-monaco-editor/scripts/copyTypes.ts
+++ b/packages/react-monaco-editor/scripts/copyTypes.ts
@@ -1,5 +1,5 @@
 import { copyTask } from '@fluentui/scripts';
-import { expandSourcePath } from '@fluentui/scripts/tasks/copy';
+import { expandSourcePath } from '@fluentui/scripts/tasks';
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/scripts/tasks/index.ts
+++ b/scripts/tasks/index.ts
@@ -7,7 +7,7 @@ import { isConvergedPackage } from '../monorepo';
 
 import { babel } from './babel';
 import { clean } from './clean';
-import { copy, copyCompiled } from './copy';
+import { copy, copyCompiled, expandSourcePath } from './copy';
 import { jest as jestTask, jestWatch } from './jest';
 import { sass } from './sass';
 import { ts } from './ts';
@@ -16,7 +16,7 @@ import { webpack, webpackDevServer } from './webpack';
 import { apiExtractor } from './api-extractor';
 import { lintImports } from './lint-imports';
 import { prettier } from './prettier';
-import { postprocessTask } from './postprocess';
+import * as postprocess from './postprocess';
 import { postprocessAmdTask } from './postprocess-amd';
 import { startStorybookTask, buildStorybookTask } from './storybook';
 import { getJustArgv } from './argv';
@@ -51,7 +51,7 @@ export function preset() {
   task('jest', jestTask);
   task('jest-watch', jestWatch);
   task('sass', sass());
-  task('ts:postprocess', postprocessTask());
+  task('ts:postprocess', postprocess.postprocessTask());
   task('postprocess:amd', postprocessAmdTask);
   task('ts:commonjs', ts.commonjs);
   task('ts:esm', ts.esm);
@@ -127,3 +127,5 @@ if (process.cwd() === __dirname) {
   // load the preset if this is being run within the scripts package
   preset();
 }
+
+export { postprocess, eslint, ts, expandSourcePath };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

packages use deep imports to `scripts/tasks`

## New Behavior

packages dont use deep imports from `scripts/tasks`

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes partially https://github.com/microsoft/fluentui/issues/24349
