### PR TITLE
chore(scripts): use `*` for @fluentui/scripts version within all package.json

### DIFF
--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -22,7 +22,7 @@
     "@fluentui/react-provider": "^9.1.11",
     "@fluentui/react-spinbutton": "^9.0.12",
     "@fluentui/react-theme": "^9.1.5",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@microsoft/load-themed-styles": "^1.10.26",
     "flamegrill": "0.2.0",
     "lodash": "^4.17.15",

--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -12,7 +12,8 @@
     "code-style": "just-scripts code-style"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "*"
+    "@fluentui/eslint-plugin": "*",
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/core": "^1.8.1",
@@ -22,7 +23,6 @@
     "@fluentui/react-provider": "^9.1.11",
     "@fluentui/react-spinbutton": "^9.0.12",
     "@fluentui/react-theme": "^9.1.5",
-    "@fluentui/scripts": "*",
     "@microsoft/load-themed-styles": "^1.10.26",
     "flamegrill": "0.2.0",
     "lodash": "^4.17.15",

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -12,12 +12,12 @@
     "code-style": "just-scripts code-style"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "*"
+    "@fluentui/eslint-plugin": "*",
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/example-data": "^8.4.4",
     "@fluentui/react": "^8.104.1",
-    "@fluentui/scripts": "*",
     "@microsoft/load-themed-styles": "^1.10.26",
     "flamegrill": "0.2.0",
     "lodash": "^4.17.15",

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@fluentui/example-data": "^8.4.4",
     "@fluentui/react": "^8.104.1",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@microsoft/load-themed-styles": "^1.10.26",
     "flamegrill": "0.2.0",
     "lodash": "^4.17.15",

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -13,6 +13,6 @@
   "license": "MIT",
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   }
 }

--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@fluentui/api-docs": "^8.2.4",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -24,7 +24,6 @@
     "@fluentui/react": "^8.104.1",
     "@fluentui/react-northstar": "^0.65.0",
     "@fluentui/react-icons-northstar": "^0.65.0",
-    "@fluentui/scripts": "*",
     "@fluentui/storybook": "^1.0.0",
     "@fluentui/react-components": "^9.7.4",
     "@fluentui/react-storybook-addon": "9.0.0-rc.1",

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -18,13 +18,13 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",
     "@fluentui/react-northstar": "^0.65.0",
     "@fluentui/react-icons-northstar": "^0.65.0",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/storybook": "^1.0.0",
     "@fluentui/react-components": "^9.7.4",
     "@fluentui/react-storybook-addon": "9.0.0-rc.1",

--- a/apps/public-docsite/package.json
+++ b/apps/public-docsite/package.json
@@ -26,7 +26,7 @@
     "@fluentui/common-styles": "^1.2.14",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-monaco-editor": "^1.7.39",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "write-file-webpack-plugin": "^4.1.0"
   },
   "dependencies": {

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.7.4",

--- a/apps/ssr-tests-v9/package.json
+++ b/apps/ssr-tests-v9/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   }
 }

--- a/apps/ssr-tests/package.json
+++ b/apps/ssr-tests/package.json
@@ -16,7 +16,7 @@
     "@fluentui/react": "^8.104.1",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@types/mocha": "^7.0.2",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/public-docsite-resources": "^8.1.41",
     "mocha": "^7.1.2"
   },

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "parallel-webpack": "^2.6.0"
   }
 }

--- a/apps/theming-designer/package.json
+++ b/apps/theming-designer/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -57,7 +57,6 @@
     "@fluentui/react-tooltip": "^9.1.5",
     "@fluentui/react-toolbar": "9.0.0-rc.2",
     "@fluentui/react-utilities": "^9.3.0",
-    "@fluentui/scripts": "*",
     "@griffel/react": "^1.4.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "storywright": "0.0.26-beta.1"
   },
   "dependencies": {
@@ -57,7 +57,7 @@
     "@fluentui/react-tooltip": "^9.1.5",
     "@fluentui/react-toolbar": "9.0.0-rc.2",
     "@fluentui/react-utilities": "^9.3.0",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@griffel/react": "^1.4.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
+    "@fluentui/scripts": "*",
     "storywright": "0.0.26-beta.1"
   },
   "dependencies": {
@@ -25,7 +26,6 @@
     "@fluentui/react-experiments": "^8.14.34",
     "@fluentui/react-hooks": "^8.6.14",
     "@fluentui/react-icons-mdl2": "^1.3.28",
-    "@fluentui/scripts": "*",
     "@fluentui/storybook": "^1.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -25,7 +25,7 @@
     "@fluentui/react-experiments": "^8.14.34",
     "@fluentui/react-hooks": "^8.6.14",
     "@fluentui/react-icons-mdl2": "^1.3.28",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/storybook": "^1.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/change/@fluentui-api-docs-4cdc4ce7-a7d2-48c1-a4f4-3f9aea29b1ac.json
+++ b/change/@fluentui-api-docs-4cdc4ce7-a7d2-48c1-a4f4-3f9aea29b1ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/api-docs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-azure-themes-b374ab53-45cb-4bd7-bee2-552678e2caad.json
+++ b/change/@fluentui-azure-themes-b374ab53-45cb-4bd7-bee2-552678e2caad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/azure-themes",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-babel-preset-global-context-0ced776d-6f6f-4b16-ad9f-b536d8b76667.json
+++ b/change/@fluentui-babel-preset-global-context-0ced776d-6f6f-4b16-ad9f-b536d8b76667.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-66177b6f-d489-4f70-b5a7-8e2434511c53.json
+++ b/change/@fluentui-codemods-66177b6f-d489-4f70-b5a7-8e2434511c53.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/codemods",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-common-styles-a42c406f-a8fa-43c2-ae3a-9dcdb31e23d0.json
+++ b/change/@fluentui-common-styles-a42c406f-a8fa-43c2-ae3a-9dcdb31e23d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/common-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-cra-template-ebc58f2d-db70-4c9a-8ccf-05359fab084e.json
+++ b/change/@fluentui-cra-template-ebc58f2d-db70-4c9a-8ccf-05359fab084e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/cra-template",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-date-time-utilities-f47e94a8-bbbf-48c3-8242-084f4dae762c.json
+++ b/change/@fluentui-date-time-utilities-f47e94a8-bbbf-48c3-8242-084f4dae762c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-dom-utilities-704e73a8-0049-48d2-bdb1-39a114bf8987.json
+++ b/change/@fluentui-dom-utilities-704e73a8-0049-48d2-bdb1-39a114bf8987.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-example-data-45dfa67d-51e9-4e08-8222-ee45787debed.json
+++ b/change/@fluentui-example-data-45dfa67d-51e9-4e08-8222-ee45787debed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/example-data",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-fluent2-theme-05068c5c-dad6-4ae5-9e31-20839119ca4d.json
+++ b/change/@fluentui-fluent2-theme-05068c5c-dad6-4ae5-9e31-20839119ca4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-aa2c152a-9bc4-4f6a-a101-3d9c6caeace3.json
+++ b/change/@fluentui-font-icons-mdl2-aa2c152a-9bc4-4f6a-a101-3d9c6caeace3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-585356b9-e483-4edf-ad70-12d203ac11af.json
+++ b/change/@fluentui-foundation-legacy-585356b9-e483-4edf-ad70-12d203ac11af.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-global-context-a62ce833-d5a9-493f-97ac-2c74b7240355.json
+++ b/change/@fluentui-global-context-a62ce833-d5a9-493f-97ac-2c74b7240355.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-24a1c7ef-05fd-47ce-a847-87037270b4e2.json
+++ b/change/@fluentui-jest-serializer-merge-styles-24a1c7ef-05fd-47ce-a847-87037270b4e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-f41aa382-96b1-4bca-ac9b-bdd0f933b8f5.json
+++ b/change/@fluentui-keyboard-key-f41aa382-96b1-4bca-ac9b-bdd0f933b8f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-keys-67d10af0-66d2-4297-a5f0-8fdef9e238ff.json
+++ b/change/@fluentui-keyboard-keys-67d10af0-66d2-4297-a5f0-8fdef9e238ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-9658c5de-00d9-4429-9561-36a9f8bcba8a.json
+++ b/change/@fluentui-merge-styles-9658c5de-00d9-4429-9561-36a9f8bcba8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-monaco-editor-70d5a8b8-b0e9-4712-a264-f3001e8b6d1e.json
+++ b/change/@fluentui-monaco-editor-70d5a8b8-b0e9-4712-a264-f3001e8b6d1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-priority-overflow-7d9b0dc9-3b1b-4cd9-bd49-40c10a67cfae.json
+++ b/change/@fluentui-priority-overflow-7d9b0dc9-3b1b-4cd9-bd49-40c10a67cfae.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-public-docsite-setup-d2b01539-8471-42bd-83aa-50a24953353d.json
+++ b/change/@fluentui-public-docsite-setup-d2b01539-8471-42bd-83aa-50a24953353d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-c6d79535-306b-4cfc-ba53-6cac0eabd713.json
+++ b/change/@fluentui-react-accordion-c6d79535-306b-4cfc-ba53-6cac0eabd713.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-alert-cd52b50d-9a51-4bb2-916b-9f2a65bf9c99.json
+++ b/change/@fluentui-react-alert-cd52b50d-9a51-4bb2-916b-9f2a65bf9c99.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-alert",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-0533cb84-6539-4ed8-aa85-a10f42105a36.json
+++ b/change/@fluentui-react-aria-0533cb84-6539-4ed8-aa85-a10f42105a36.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-9eb246f3-30fa-46b2-bdb7-f2f14eac8108.json
+++ b/change/@fluentui-react-avatar-9eb246f3-30fa-46b2-bdb7-f2f14eac8108.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-a19c8ff6-8efb-4a35-bdc9-2b85fba4876c.json
+++ b/change/@fluentui-react-badge-a19c8ff6-8efb-4a35-bdc9-2b85fba4876c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-0feae155-9d08-4b86-b30d-a94e858cbbe2.json
+++ b/change/@fluentui-react-button-0feae155-9d08-4b86-b30d-a94e858cbbe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-39aac0f0-bd30-4e84-8c46-d6a496d14c50.json
+++ b/change/@fluentui-react-card-39aac0f0-bd30-4e84-8c46-d6a496d14c50.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-9ef8b57a-3f0f-41fc-83df-d75f370da39b.json
+++ b/change/@fluentui-react-cards-9ef8b57a-3f0f-41fc-83df-d75f370da39b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-82ff1965-1738-4b1b-96df-9237a9bcb511.json
+++ b/change/@fluentui-react-charting-82ff1965-1738-4b1b-96df-9237a9bcb511.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-471b3610-a00e-4f1e-80b7-b3ee47ca3619.json
+++ b/change/@fluentui-react-checkbox-471b3610-a00e-4f1e-80b7-b3ee47ca3619.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-combobox-2715fc8b-4d88-426c-ab55-f6df583a6799.json
+++ b/change/@fluentui-react-combobox-2715fc8b-4d88-426c-ab55-f6df583a6799.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-4d039c5e-9124-4577-93c4-b5f2daefde75.json
+++ b/change/@fluentui-react-components-4d039c5e-9124-4577-93c4-b5f2daefde75.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-06eafd6d-95b9-402b-866a-444c260dd67d.json
+++ b/change/@fluentui-react-conformance-06eafd6d-95b9-402b-866a-444c260dd67d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-griffel-1982ac5f-7dd9-48eb-b6fa-7e314f06cc6e.json
+++ b/change/@fluentui-react-conformance-griffel-1982ac5f-7dd9-48eb-b6fa-7e314f06cc6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-8eaad48a-9470-405b-a3c2-bc8b9caaf77d.json
+++ b/change/@fluentui-react-context-selector-8eaad48a-9470-405b-a3c2-bc8b9caaf77d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-d31cdc24-8332-494c-b127-7720af6fc426.json
+++ b/change/@fluentui-react-d31cdc24-8332-494c-b127-7720af6fc426.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-790f661e-9dae-4d7c-815e-3ea2d4bdb349.json
+++ b/change/@fluentui-react-date-time-790f661e-9dae-4d7c-815e-3ea2d4bdb349.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-date-time",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-dialog-4cabeed7-9bdb-4d7b-9a4b-67c924df7189.json
+++ b/change/@fluentui-react-dialog-4cabeed7-9bdb-4d7b-9a4b-67c924df7189.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-54eb7f5b-080d-4e79-94d0-1823afcd2490.json
+++ b/change/@fluentui-react-divider-54eb7f5b-080d-4e79-94d0-1823afcd2490.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-3777ca1e-e533-4313-9834-42b33925b110.json
+++ b/change/@fluentui-react-docsite-components-3777ca1e-e533-4313-9834-42b33925b110.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-e61adf5c-43d4-4a2e-8d6b-f7fc515c3005.json
+++ b/change/@fluentui-react-experiments-e61adf5c-43d4-4a2e-8d6b-f7fc515c3005.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-field-0977dcdb-a90b-400f-ad52-345697c7948d.json
+++ b/change/@fluentui-react-field-0977dcdb-a90b-400f-ad52-345697c7948d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-e15d669a-8559-42b7-844e-832cb483075a.json
+++ b/change/@fluentui-react-file-type-icons-e15d669a-8559-42b7-844e-832cb483075a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-fb2ac3b5-7215-471e-83c6-1359ea6cd3f1.json
+++ b/change/@fluentui-react-focus-fb2ac3b5-7215-471e-83c6-1359ea6cd3f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-df2d5de4-fae4-4a3e-9ad9-764525823210.json
+++ b/change/@fluentui-react-hooks-df2d5de4-fae4-4a3e-9ad9-764525823210.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-bc090b35-7aff-4aaa-b682-dc821a60763f.json
+++ b/change/@fluentui-react-icon-provider-bc090b35-7aff-4aaa-b682-dc821a60763f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-6cebdbf7-1001-4e32-9f27-982a15114a2f.json
+++ b/change/@fluentui-react-icons-mdl2-6cebdbf7-1001-4e32-9f27-982a15114a2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-a9fc82c6-ca09-4994-9df5-04a38b18f4ca.json
+++ b/change/@fluentui-react-icons-mdl2-branded-a9fc82c6-ca09-4994-9df5-04a38b18f4ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-a0746c71-6940-470f-abc9-35b0c700b36f.json
+++ b/change/@fluentui-react-image-a0746c71-6940-470f-abc9-35b0c700b36f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infobutton-c82a4fb5-01cd-4b26-a6b8-26aed40371da.json
+++ b/change/@fluentui-react-infobutton-c82a4fb5-01cd-4b26-a6b8-26aed40371da.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-110035c2-905f-4ea3-8e08-6bc7665b5f1b.json
+++ b/change/@fluentui-react-input-110035c2-905f-4ea3-8e08-6bc7665b5f1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-1d442c9c-ae1e-4fb3-8a6f-afcd61430012.json
+++ b/change/@fluentui-react-label-1d442c9c-ae1e-4fb3-8a6f-afcd61430012.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-ab30bcab-a49a-46f8-8556-e14868dfb085.json
+++ b/change/@fluentui-react-link-ab30bcab-a49a-46f8-8556-e14868dfb085.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-27083c3a-3928-4f97-895a-432bd93502bc.json
+++ b/change/@fluentui-react-menu-27083c3a-3928-4f97-895a-432bd93502bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v8-v9-e8bfd374-1171-443b-8506-0e04413e4713.json
+++ b/change/@fluentui-react-migration-v8-v9-e8bfd374-1171-443b-8506-0e04413e4713.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-ca4e5742-8bc0-46f0-802a-26efff9b098a.json
+++ b/change/@fluentui-react-monaco-editor-ca4e5742-8bc0-46f0-802a-26efff9b098a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-baba9dbd-74ec-4fb4-b178-599ea59d9d7c.json
+++ b/change/@fluentui-react-overflow-baba9dbd-74ec-4fb4-b178-599ea59d9d7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-persona-e5a90671-7e73-4b76-a446-f27796665629.json
+++ b/change/@fluentui-react-persona-e5a90671-7e73-4b76-a446-f27796665629.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-173ce13c-a11d-418e-b762-c339ca1232cf.json
+++ b/change/@fluentui-react-popover-173ce13c-a11d-418e-b762-c339ca1232cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-98c6f928-a80e-42b8-b0ca-8c6f5a98b1ef.json
+++ b/change/@fluentui-react-portal-98c6f928-a80e-42b8-b0ca-8c6f5a98b1ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-5b8020f1-a293-4c59-95c4-d34e8868893b.json
+++ b/change/@fluentui-react-portal-compat-5b8020f1-a293-4c59-95c4-d34e8868893b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-context-b624c758-46e6-491c-ae90-b546e4e62878.json
+++ b/change/@fluentui-react-portal-compat-context-b624c758-46e6-491c-ae90-b546e4e62878.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-e9d3e233-6e68-4998-b792-85e59a04ff04.json
+++ b/change/@fluentui-react-positioning-e9d3e233-6e68-4998-b792-85e59a04ff04.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-progress-894acc93-fcce-4538-a464-000280d5f875.json
+++ b/change/@fluentui-react-progress-894acc93-fcce-4538-a464-000280d5f875.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-eb803473-cb67-40e3-ab16-f65cee0b092c.json
+++ b/change/@fluentui-react-provider-eb803473-cb67-40e3-ab16-f65cee0b092c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-e5d45dbd-e71b-47fc-bf72-f32bb8b76ec9.json
+++ b/change/@fluentui-react-shared-contexts-e5d45dbd-e71b-47fc-bf72-f32bb8b76ec9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-978ed420-e254-48d1-84e5-e6934d76e125.json
+++ b/change/@fluentui-react-slider-978ed420-e254-48d1-84e5-e6934d76e125.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinbutton-c780f5cc-1ae6-401a-b194-57499d946c84.json
+++ b/change/@fluentui-react-spinbutton-c780f5cc-1ae6-401a-b194-57499d946c84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinner-ae73b0ef-bb42-4cb6-af45-4eb8e079f7b0.json
+++ b/change/@fluentui-react-spinner-ae73b0ef-bb42-4cb6-af45-4eb8e079f7b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-af529dc3-329c-4c91-a869-3a2fc489c154.json
+++ b/change/@fluentui-react-switch-af529dc3-329c-4c91-a869-3a2fc489c154.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-table-84cb199c-6825-4552-994c-0946c29d787c.json
+++ b/change/@fluentui-react-table-84cb199c-6825-4552-994c-0946c29d787c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-0a7c56f2-fca7-47af-8cf0-2e7ccd96d12c.json
+++ b/change/@fluentui-react-tabs-0a7c56f2-fca7-47af-8cf0-2e7ccd96d12c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-cb4d5da3-bd3d-49bb-832b-5a11b08698de.json
+++ b/change/@fluentui-react-tabster-cb4d5da3-bd3d-49bb-832b-5a11b08698de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-1bfd2a4b-c540-43d2-9dfb-64e8523356f4.json
+++ b/change/@fluentui-react-text-1bfd2a4b-c540-43d2-9dfb-64e8523356f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-textarea-066f7ba3-e717-411d-b8c8-663389d48261.json
+++ b/change/@fluentui-react-textarea-066f7ba3-e717-411d-b8c8-663389d48261.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-8335153a-4b62-43bf-ac92-4f3768725fed.json
+++ b/change/@fluentui-react-theme-8335153a-4b62-43bf-ac92-4f3768725fed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-sass-95413577-af21-4dab-8680-3681fa8e96da.json
+++ b/change/@fluentui-react-theme-sass-95413577-af21-4dab-8680-3681fa8e96da.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toolbar-c00abe52-b174-4123-abaa-e37594c93276.json
+++ b/change/@fluentui-react-toolbar-c00abe52-b174-4123-abaa-e37594c93276.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-87b65bef-7fb2-4c8c-b149-0e8d8bbb6f5f.json
+++ b/change/@fluentui-react-tooltip-87b65bef-7fb2-4c8c-b149-0e8d8bbb6f5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-2e6f4f41-14df-4e36-af6e-9eec2f7a04c7.json
+++ b/change/@fluentui-react-utilities-2e6f4f41-14df-4e36-af6e-9eec2f7a04c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-92f54b2e-d2f3-4d5d-ba1e-3a5c4d7db8b1.json
+++ b/change/@fluentui-react-window-provider-92f54b2e-d2f3-4d5d-ba1e-3a5c4d7db8b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-b1aa39d8-92bf-4087-b037-88cc6dff4869.json
+++ b/change/@fluentui-scheme-utilities-b1aa39d8-92bf-4087-b037-88cc6dff4869.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-set-version-1026f2b9-efd7-44de-9c77-c4f59a8671cb.json
+++ b/change/@fluentui-set-version-1026f2b9-efd7-44de-9c77-c4f59a8671cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/set-version",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-0773f279-53eb-4425-8ef1-b1b7ec7328a9.json
+++ b/change/@fluentui-style-utilities-0773f279-53eb-4425-8ef1-b1b7ec7328a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/style-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-bf369c98-1dd3-44e4-9568-192773215172.json
+++ b/change/@fluentui-test-utilities-bf369c98-1dd3-44e4-9568-192773215172.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/test-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-5cceea03-7c34-40d3-a7a7-5923fec594f0.json
+++ b/change/@fluentui-theme-5cceea03-7c34-40d3-a7a7-5923fec594f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-d4564e66-ce39-4037-913b-fa3020291e39.json
+++ b/change/@fluentui-theme-samples-d4564e66-ce39-4037-913b-fa3020291e39.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/theme-samples",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-tokens-97fe6e57-dea8-4e9e-8d53-8b96b1e075cc.json
+++ b/change/@fluentui-tokens-97fe6e57-dea8-4e9e-8d53-8b96b1e075cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/tokens",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-5d9f655e-11e1-481c-835c-19e48c4febf6.json
+++ b/change/@fluentui-utilities-5d9f655e-11e1-481c-835c-19e48c4febf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-f1d3960b-2e5b-4ec7-932f-5f1882059698.json
+++ b/change/@fluentui-webpack-utilities-f1d3960b-2e5b-4ec7-932f-5f1882059698.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): use for @fluentui/scripts version within all package.json",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -439,7 +439,6 @@
         "dependencies": [
           "@fluentui/a11y-testing",
           "@fluentui/dom-utilities",
-          "@fluentui/eslint-plugin",
           "@fluentui/react",
           "@fluentui/react-conformance",
           "stylis"
@@ -450,7 +449,6 @@
           "@fluentui/react-northstar-emotion-renderer"
         ],
         "dependencies": [
-          "@fluentui/eslint-plugin",
           "stylis"
         ]
       },

--- a/packages/a11y-testing/package.json
+++ b/packages/a11y-testing/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@microsoft/api-extractor-model": "7.13.3",

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0",

--- a/packages/common-styles/package.json
+++ b/packages/common-styles/package.json
@@ -18,7 +18,7 @@
     "office-ui-fabric-core": "^11.0.0"
   },
   "devDependencies": {
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/style-utilities": "^8.8.4"
   }
 }

--- a/packages/cra-template/package.json
+++ b/packages/cra-template/package.json
@@ -19,6 +19,6 @@
   ],
   "devDependencies": {
     "@fluentui/react": "^8.104.1",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   }
 }

--- a/packages/date-time-utilities/package.json
+++ b/packages/date-time-utilities/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/dom-utilities/package.json
+++ b/packages/dom-utilities/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/example-data/package.json
+++ b/packages/example-data/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/fluent2-theme/package.json
+++ b/packages/fluent2-theme/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/fluentui/circulars-test/package.json
+++ b/packages/fluentui/circulars-test/package.json
@@ -7,7 +7,7 @@
     "@fluentui/react-northstar": "^0.65.0"
   },
   "devDependencies": {
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/code-sandbox/package.json
+++ b/packages/fluentui/code-sandbox/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-northstar": "^0.65.0",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "files": [
     "dist"

--- a/packages/fluentui/docs-components/package.json
+++ b/packages/fluentui/docs-components/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "files": [
     "dist"

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/classnames": "^2.2.9",
     "@types/color": "^3.0.0",
     "@types/faker": "^4.1.3",

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/projects-test/package.json
+++ b/packages/fluentui/projects-test/package.json
@@ -7,7 +7,7 @@
     "@fluentui/react-northstar": "^0.65.0"
   },
   "devDependencies": {
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/classnames": "^2.2.9",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/react-frame-component": "^4.1.1",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/simulant": "^0.2.0",
     "lerna-alias": "^3.0.3-0",
     "simulant": "^0.2.2"

--- a/packages/fluentui/react-component-nesting-registry/package.json
+++ b/packages/fluentui/react-component-nesting-registry/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/fluentui/react-icons-northstar/package.json
+++ b/packages/fluentui/react-icons-northstar/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/classnames": "^2.2.9",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-northstar-emotion-renderer/package.json
+++ b/packages/fluentui/react-northstar-emotion-renderer/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/stylis": "4.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-northstar-fela-renderer/package.json
+++ b/packages/fluentui/react-northstar-fela-renderer/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0",
     "react-fela": "^10.6.1"
   },

--- a/packages/fluentui/react-northstar-prototypes/package.json
+++ b/packages/fluentui/react-northstar-prototypes/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/classnames": "^2.2.9",
     "@types/faker": "^4.1.3",
     "@types/react-custom-scrollbars": "^4.0.5",

--- a/packages/fluentui/react-northstar-styles-renderer/package.json
+++ b/packages/fluentui/react-northstar-styles-renderer/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -32,7 +32,7 @@
     "@fluentui/a11y-testing": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/classnames": "^2.2.9",
     "@types/faker": "^4.1.3",
     "@types/simulant": "^0.2.0",

--- a/packages/fluentui/react-proptypes/package.json
+++ b/packages/fluentui/react-proptypes/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/fluentui/react-telemetry/package.json
+++ b/packages/fluentui/react-telemetry/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/react-table": "^7.0.19",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/state/package.json
+++ b/packages/fluentui/state/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "lerna-alias": "^3.0.3-0"
   },
   "files": [

--- a/packages/font-icons-mdl2/package.json
+++ b/packages/font-icons-mdl2/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/foundation-legacy/package.json
+++ b/packages/foundation-legacy/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21",
     "react-hooks-testing-library": "^0.5.0"
   },

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/merge-styles": "^8.5.4"

--- a/packages/keyboard-key/package.json
+++ b/packages/keyboard-key/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "monaco-editor": "0.33.0"
   },
   "dependencies": {

--- a/packages/public-docsite-setup/package.json
+++ b/packages/public-docsite-setup/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {}
 }

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -30,7 +30,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react": "^8.104.1",
     "@types/react-addons-test-utils": "0.14.18",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21"
   },
   "dependencies": {

--- a/packages/react-components/babel-preset-global-context/package.json
+++ b/packages/react-components/babel-preset-global-context/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@babel/core": "^7.10.4",

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.3",

--- a/packages/react-components/keyboard-keys/package.json
+++ b/packages/react-components/keyboard-keys/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/react-components/priority-overflow/package.json
+++ b/packages/react-components/priority-overflow/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.3.3",

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-avatar": "^9.2.10",

--- a/packages/react-components/react-aria/package.json
+++ b/packages/react-components/react-aria/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-avatar-context/package.json
+++ b/packages/react-components/react-avatar-context/package.json
@@ -26,7 +26,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -30,7 +30,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "es6-weak-map": "^2.0.2"
   },
   "dependencies": {

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.175",

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -29,7 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-card/package.json
+++ b/packages/react-components/react-card/package.json
@@ -32,7 +32,7 @@
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-button": "^9.1.12",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "9.0.0-alpha.12",

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-storybook-addon": "9.0.0-rc.1",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "react-hook-form": "^5.7.2"
   },
   "dependencies": {

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/react-conformance": "*"
   },
   "peerDependencies": {

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-utilities": "^9.3.0",

--- a/packages/react-components/react-data-grid-react-window/package.json
+++ b/packages/react-components/react-data-grid-react-window/package.json
@@ -26,7 +26,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-dialog/package.json
+++ b/packages/react-components/react-dialog/package.json
@@ -30,7 +30,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-divider/package.json
+++ b/packages/react-components/react-divider/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-field/package.json
+++ b/packages/react-components/react-field/package.json
@@ -27,7 +27,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.3",

--- a/packages/react-components/react-image/package.json
+++ b/packages/react-components/react-image/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-infobutton/package.json
+++ b/packages/react-components/react-infobutton/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.175",

--- a/packages/react-components/react-input/package.json
+++ b/packages/react-components/react-input/package.json
@@ -29,7 +29,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
     "@fluentui/react-text": "^9.1.10",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "9.0.0-alpha.12",

--- a/packages/react-components/react-label/package.json
+++ b/packages/react-components/react-label/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-link/package.json
+++ b/packages/react-components/react-link/package.json
@@ -29,7 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -30,7 +30,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.3.3",

--- a/packages/react-components/react-overflow/package.json
+++ b/packages/react-components/react-overflow/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/priority-overflow": "^9.0.0-rc.1",

--- a/packages/react-components/react-persona/package.json
+++ b/packages/react-components/react-persona/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-avatar": "^9.2.10",

--- a/packages/react-components/react-popover/package.json
+++ b/packages/react-components/react-popover/package.json
@@ -30,7 +30,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-components": "^9.7.4",
     "@fluentui/react-shared-contexts": "^9.1.4",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-portal-compat-context": "^9.0.4",

--- a/packages/react-components/react-portal/package.json
+++ b/packages/react-components/react-portal/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.1.4",

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.0.0",

--- a/packages/react-components/react-progress/package.json
+++ b/packages/react-components/react-progress/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "9.0.0-alpha.12",

--- a/packages/react-components/react-provider/package.json
+++ b/packages/react-components/react-provider/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/core": "^1.8.1",

--- a/packages/react-components/react-shared-contexts/package.json
+++ b/packages/react-components/react-shared-contexts/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-skeleton/package.json
+++ b/packages/react-components/react-skeleton/package.json
@@ -26,7 +26,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-slider/package.json
+++ b/packages/react-components/react-slider/package.json
@@ -29,7 +29,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
     "@fluentui/react-label": "^9.0.14",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -29,7 +29,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
     "@fluentui/react-label": "^9.0.14",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-spinner/package.json
+++ b/packages/react-components/react-spinner/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "9.0.0-alpha.12",

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -27,7 +27,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-tabs/package.json
+++ b/packages/react-components/react-tabs/package.json
@@ -27,7 +27,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.3",

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-tags/package.json
+++ b/packages/react-components/react-tags/package.json
@@ -26,7 +26,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-components/react-text/package.json
+++ b/packages/react-components/react-text/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@griffel/react": "^1.4.2",

--- a/packages/react-components/react-textarea/package.json
+++ b/packages/react-components/react-textarea/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "9.0.0-alpha.12",

--- a/packages/react-components/react-theme-sass/package.json
+++ b/packages/react-components/react-theme-sass/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/react-theme": "^9.1.5"
   },
   "beachball": {

--- a/packages/react-components/react-theme/package.json
+++ b/packages/react-components/react-theme/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0",

--- a/packages/react-components/react-toolbar/package.json
+++ b/packages/react-components/react-toolbar/package.json
@@ -29,7 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-button": "^9.1.12",

--- a/packages/react-components/react-tooltip/package.json
+++ b/packages/react-components/react-tooltip/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/react-tree/package.json
+++ b/packages/react-components/react-tree/package.json
@@ -28,7 +28,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.3",

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.1",

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.5",

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "lodash": "^4.17.15",

--- a/packages/react-date-time/package.json
+++ b/packages/react-date-time/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/react-docsite-components/package.json
+++ b/packages/react-docsite-components/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@fluentui/common-styles": "^1.2.14",
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@types/color-check": "0.0.0",
     "@types/react-custom-scrollbars": "^4.0.5"
   },

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/storybook": "^1.0.0",
     "@types/d3-format": "^1.3.1",
     "@types/d3-fetch": "^3.0.1"

--- a/packages/react-experiments/package.json
+++ b/packages/react-experiments/package.json
@@ -32,7 +32,7 @@
     "@types/deep-assign": "^0.1.1",
     "@types/prop-types": "15.7.1",
     "@types/react-addons-test-utils": "0.14.18",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21",
     "react-hooks-testing-library": "^0.5.0"
   },

--- a/packages/react-file-type-icons/package.json
+++ b/packages/react-file-type-icons/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -29,7 +29,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/test-utilities": "^8.2.4",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21"
   },
   "dependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/test-utilities": "^8.2.4"
   },
   "dependencies": {

--- a/packages/react-icon-provider/package.json
+++ b/packages/react-icon-provider/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/react-icons-mdl2-branded/package.json
+++ b/packages/react-icons-mdl2-branded/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.10.26",

--- a/packages/react-migration-v8-v9/package.json
+++ b/packages/react-migration-v8-v9/package.json
@@ -25,7 +25,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "9.0.0-beta.18",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@ctrl/tinycolor": "3.3.4",

--- a/packages/react-monaco-editor/package.json
+++ b/packages/react-monaco-editor/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@types/react-syntax-highlighter": "^10.2.1",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/test-utilities": "^8.2.4",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/set-version": "^8.2.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
     "@fluentui/example-data": "^8.4.4",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21",
     "@fluentui/react-conformance": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/test-utilities": "^8.2.4",
     "@fluentui/webpack-utilities": "^8.1.9",
     "office-ui-fabric-core": "^11.0.0"

--- a/packages/scheme-utilities/package.json
+++ b/packages/scheme-utilities/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/theme": "^2.6.20",

--- a/packages/set-version/package.json
+++ b/packages/set-version/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/style-utilities/package.json
+++ b/packages/style-utilities/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.10.26",

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <19.0.0",

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/react": "^8.104.1",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "@fluentui/merge-styles": "^8.5.4",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0",
+    "@fluentui/scripts": "*",
     "@fluentui/jest-serializer-merge-styles": "^8.0.21",
     "@fluentui/test-utilities": "^8.2.4"
   },

--- a/packages/webpack-utilities/package.json
+++ b/packages/webpack-utilities/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts": "^1.0.0"
+    "@fluentui/scripts": "*"
   },
   "dependencies": {
     "loader-utils": "^2.0.0",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- packages that depend on workspace only `@fluentui/scripts` use particular version
- some apps declare `@fluentui/scripts` as `dependencies` which is incorrext

## New Behavior

- all packages use `*` for `@fluentui/scripts` version  (pattern for inner workspace dev dependency)
- apps declare `scripts` only as `devDependency`
- `versionGroups` field has been simplified (unnecessary config was removed )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes partially https://github.com/microsoft/fluentui/issues/24349
