### PR TITLE
fix: Toggle button high contrast mode focus outline

### DIFF
--- a/change/@fluentui-react-button-f9384ea2-7591-4d5c-88a4-44fc94e15575.json
+++ b/change/@fluentui-react-button-f9384ea2-7591-4d5c-88a4-44fc94e15575.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: high contrast mode focus styles are applied",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -62,14 +62,11 @@ const useRootCheckedStyles = makeStyles({
       },
 
       ':focus': {
-        ...shorthands.borderColor('Highlight'),
+        ...shorthands.border('1px', 'solid', 'HighlightText'),
+        outlineColor: 'Highlight',
       },
     },
   },
-  highContrastFocusStyles: createCustomFocusIndicatorStyle({
-    ...shorthands.border('1px', 'solid', 'HighlightText'),
-    outlineColor: 'Highlight',
-  }),
 
   // Appearance variations
   outline: {


### PR DESCRIPTION
Fixes #26062, depends on #26089 to work for all appearance variants

## Previous Behavior

The ToggleButton high contrast mode focus outline isn't showing up for two reasons:

1. The style was overridden by the second call of `createCustomFocusIndicatorStyle` for circular/small/large/etc. appearance variants, which is fixed in #26089
2. The former `highContrastFocusStyles` is never applied

## New Behavior

I moved the styles in `highContrastFocusStyles` to the `:focus` selector within the HCM media query
