### PR TITLE
chore (CI v6): disable scheduled releases, future releases will need to be triggered manually 

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -66,9 +66,10 @@ steps:
       npm run publish:beachball -- -b origin/6.0 -t lts-6 -n $(npmToken) --access public -y
     displayName: 'Publish Change Requests and Bump Versions'
 
-  - script: |
-      node scripts/updateReleaseNotes.js --token=$(githubPAT) --apply --debug
-    displayName: 'Update github release notes'
+  # TODO: updateReleaseNotes script results in too many calls to the github API causing a timeout, needs to be refactored
+  # - script: |
+  #     node scripts/updateReleaseNotes.js --token=$(githubPAT) --apply --debug
+  #   displayName: 'Update github release notes'
 
   - script: |
       oufrVersion=$(node -p -e "require('./packages/office-ui-fabric-react/package.json').version") &&

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -11,15 +11,6 @@ variables:
 pool:
   vmImage: 'Ubuntu 20.04'
 
-schedules:
-  # minute 0, hour 12 in UTC (5am in UTC+7), any day of month, any month, days 1-5 of week (M-F)
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?tabs=yaml&view=azure-devops#supported-cron-syntax
-  - cron: '0 12 * * 1-5'
-    displayName: 'Daily release (M-F at 5am)' # will be 4am when DST ends unless trigger is updated
-    branches:
-      include:
-        - 6.0
-
 steps:
   - task: NodeTool@0
     inputs:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- Automatic releases are scheduled for the v6 branch.
- Release pipeline for v6 errors out due to too many calls to the github API (example [error](https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=279592&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=c3091b1e-314e-512e-11db-151fdba14cd6))

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- No more automatic releases, any future v6 releases will need to be triggered manually.
- Release pipeline no longer fails

