### PR TITLE
Upgrade the version of @fluentui/dom-utilities 

### DIFF
--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.4",
     "@fluentui/accessibility": "^0.65.0",
-    "@fluentui/dom-utilities": "^1.1.1",
+    "@fluentui/dom-utilities": "^2.2.3",
     "@fluentui/react-bindings": "^0.65.0",
     "@fluentui/react-component-event-listener": "^0.65.0",
     "@fluentui/react-component-nesting-registry": "^0.65.0",


### PR DESCRIPTION
Upgrade the version of @fluentui/dom-utilities from ^1.1.1 to ^2.2.3
We are using @fluentui/react-northstar in our repo . It pulls @fluentui/dom-utilities@^1.1.1 and we want upgraded version of @fluentui/dom-utilities i.e >2.2.3. We are getting **_Multiple versions of @fluentui/dom-utilities found_** error while doing the bundle for our package.,
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
