### PR TITLE
chore: set @mdx-js/loader loader-utils to 2.0.4 to mitigate critical vulnerability reported by CGC

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,8 @@
     "@typescript-eslint/experimental-utils": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
     "@types/jest-axe/axe-core": "4.2.1",
-    "eslint": "7.25.0"
+    "eslint": "7.25.0",
+    "@mdx-js/loader/loader-utils": "~2.0.4"
   },
   "syncpack": {
     "prod": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17745,16 +17745,7 @@ loader-utils@1.4.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
-
-loader-utils@2.0.4, loader-utils@^2.0.0:
+loader-utils@2.0.0, loader-utils@2.0.4, loader-utils@^2.0.0, loader-utils@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

we have loader-utils@2.0.0 in our deps because mdx-js/loader declares it as dependency via exact version. we raised issue on their repo to release patch for v1 which was closed as wont do.

## New Behavior

Because mdx-js/loader doesn't enable using proper packages deduping by following semantic versioning principles, which would also enable anyone to resolve deps (patch,minor) on their own, we need to use yarn.resolution to force the behaviours. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes https://github.com/microsoft/fluentui/issues/26095
