### PR TITLE
fix: Focus visibility when directly calling setFocusVisibility

### DIFF
--- a/change/@fluentui-react-d89e5599-f5a5-4701-8093-88c930b1a96a.json
+++ b/change/@fluentui-react-d89e5599-f5a5-4701-8093-88c930b1a96a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: set focus visibility className on correct element when calling setFocusVisibility directly",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -198,6 +198,7 @@ import { IEventRecordList } from '@fluentui/utilities';
 import { IEventRecordsByName } from '@fluentui/utilities';
 import { IFitContentToBoundsOptions } from '@fluentui/utilities';
 import { IFocusRectsContext } from '@fluentui/utilities';
+import { IFocusRectsContext as IFocusRectsContext_2 } from '@fluentui/utilities/lib/useFocusRects';
 import { IFocusZone } from '@fluentui/react-focus';
 import { IFocusZoneProps } from '@fluentui/react-focus';
 import { IFontFace } from '@fluentui/style-utilities';
@@ -506,6 +507,10 @@ export class BaseButton extends React_2.Component<IBaseButtonProps, IBaseButtonS
     componentDidUpdate(prevProps: IBaseButtonProps, prevState: IBaseButtonState): void;
     // (undocumented)
     componentWillUnmount(): void;
+    // (undocumented)
+    context: React_2.ContextType<typeof FocusRectsContext>;
+    // (undocumented)
+    static contextType: React_2.Context<IFocusRectsContext_2 | undefined>;
     // (undocumented)
     static defaultProps: Partial<IBaseButtonProps>;
     // (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -198,7 +198,6 @@ import { IEventRecordList } from '@fluentui/utilities';
 import { IEventRecordsByName } from '@fluentui/utilities';
 import { IFitContentToBoundsOptions } from '@fluentui/utilities';
 import { IFocusRectsContext } from '@fluentui/utilities';
-import { IFocusRectsContext as IFocusRectsContext_2 } from '@fluentui/utilities/lib/useFocusRects';
 import { IFocusZone } from '@fluentui/react-focus';
 import { IFocusZoneProps } from '@fluentui/react-focus';
 import { IFontFace } from '@fluentui/style-utilities';
@@ -508,9 +507,9 @@ export class BaseButton extends React_2.Component<IBaseButtonProps, IBaseButtonS
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    context: React_2.ContextType<typeof FocusRectsContext>;
+    context: IFocusRectsContext;
     // (undocumented)
-    static contextType: React_2.Context<IFocusRectsContext_2 | undefined>;
+    static contextType: React_2.Context<IFocusRectsContext | undefined>;
     // (undocumented)
     static defaultProps: Partial<IBaseButtonProps>;
     // (undocumented)

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -27,7 +27,7 @@ import { ContextualMenu } from '../../ContextualMenu';
 import { getBaseButtonClassNames } from './BaseButton.classNames';
 import { getSplitButtonClassNames as getBaseSplitButtonClassNames } from './SplitButton/SplitButton.classNames';
 import { KeytipData } from '../../KeytipData';
-import type { IRenderFunction } from '../../Utilities';
+import type { IFocusRectsContext, IRenderFunction } from '../../Utilities';
 import type { IContextualMenuProps } from '../../ContextualMenu';
 import type { IButtonProps, IButton } from './Button.types';
 import type { IButtonClassNames } from './BaseButton.classNames';
@@ -69,7 +69,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
   // needed to access registeredProviders when manually setting focus visibility
   public static contextType = FocusRectsContext;
-  public context: React.ContextType<typeof FocusRectsContext>;
+  public context: IFocusRectsContext;
 
   private _async: Async;
   private _events: EventGroup;

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -18,6 +18,7 @@ import {
   Async,
   EventGroup,
   FocusRects,
+  FocusRectsContext,
   KeyCodes,
 } from '../../Utilities';
 import { Icon, FontIcon, ImageIcon } from '../../Icon';
@@ -65,6 +66,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     styles: {},
     split: false,
   };
+
+  // needed to access registeredProviders when manually setting focus visibility
+  public static contextType = FocusRectsContext;
+  public context: React.ContextType<typeof FocusRectsContext>;
 
   private _async: Async;
   private _events: EventGroup;
@@ -290,10 +295,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
   public focus(): void {
     if (this._isSplitButton && this._splitButtonContainer.current) {
-      setFocusVisibility(true);
+      setFocusVisibility(true, undefined, this.context?.registeredProviders);
       this._splitButtonContainer.current.focus();
     } else if (this._buttonElement.current) {
-      setFocusVisibility(true);
+      setFocusVisibility(true, undefined, this.context?.registeredProviders);
       this._buttonElement.current.focus();
     }
   }
@@ -841,7 +846,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       // We manually set the focus visibility to true if opening via Enter or Space to account for the scenario where
       // a user clicks on the button, closes the menu and then opens it via keyboard. In this scenario our default logic
       // for setting focus visibility is not triggered since there is no keyboard navigation present beforehand.
-      setFocusVisibility(true, ev.target as Element);
+      setFocusVisibility(true, ev.target as Element, this.context?.registeredProviders);
     }
 
     if (!(ev.altKey || ev.metaKey) && (isUp || isDown)) {


### PR DESCRIPTION
## Previous Behavior

Two components, Button and ChoiceGroup, directly call the `setFocusVisibility` function. This defaults to setting the className on the parent `<body>` tag unless an explicit `registeredProviders` array is passed in.

This is an issue if the provider ref in the `FocusRectsContext` is anything other than the `<body>`, as is the case on our docs site. What happens is the manual call of `setFocusVisibility` sets the focus-visible className on `<body>`, while subsequent updates through `useFocusRects` set it correctly on the element provided in the context. This means there is always a focus-visible className on `<body>` that never updates, which causes focus to always be visible.

## New Behavior

Both components that directly call `setFocusVisibility` now pass in the `registeredProvider` from the `FocusRectsContext` by directly consuming the context within the component.

There isn't really a way to query the context from `setFocusVisibility`, since it is neither a hook nor a component. Since only two components use it directly, a more involved solution seems like overkill.

## Related Issue(s)

Fixes #26030

That issue is about Button, but the same focus visibility issue can be seen in ChoiceGroup in cases where `.focus()` is called on the component. The example used in this issue (#20173) is a good example of where the focus visibility bug can be seen if the example code is recreated in our latest Fluent version.
