### PR TITLE
chore(scripts): remove deep imports from `scripts/webpack/*` and replace relative imports with package namespace imports

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 const exportToCodesandboxAddon = require('storybook-addon-export-to-codesandbox');
 
-const { loadWorkspaceAddon, getCodesandboxBabelOptions } = require('../scripts/storybook');
+const { loadWorkspaceAddon, getCodesandboxBabelOptions } = require('@fluentui/scripts/storybook');
 
 /**
  * @typedef {import('@storybook/core-common').StorybookConfig} StorybookBaseConfig

--- a/apps/perf-test-react-components/webpack.config.js
+++ b/apps/perf-test-react-components/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 // The issue here is making readable Flamegraphs that don't have complicated paths like:
 //  ~Fabric.../../packages/react/lib/components/DetailsList/DetailsRow.base.js.DetailsRowBase.render

--- a/apps/perf-test-react-components/webpack.config.js
+++ b/apps/perf-test-react-components/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 // The issue here is making readable Flamegraphs that don't have complicated paths like:
 //  ~Fabric.../../packages/react/lib/components/DetailsList/DetailsRow.base.js.DetailsRowBase.render

--- a/apps/perf-test/webpack.config.js
+++ b/apps/perf-test/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 // The issue here is making readable Flamegraphs that don't have complicated paths like:
 //  ~Fabric.../../packages/react/lib/components/DetailsList/DetailsRow.base.js.DetailsRowBase.render

--- a/apps/perf-test/webpack.config.js
+++ b/apps/perf-test/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 // The issue here is making readable Flamegraphs that don't have complicated paths like:
 //  ~Fabric.../../packages/react/lib/components/DetailsList/DetailsRow.base.js.DetailsRowBase.render

--- a/apps/pr-deploy-site/just.config.ts
+++ b/apps/pr-deploy-site/just.config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { series, task, copyInstructionsTask, copyInstructions, cleanTask } from '@fluentui/scripts/tasks';
-import { findGitRoot, getAllPackageInfo } from '@fluentui/scripts/monorepo/index';
+import { findGitRoot, getAllPackageInfo } from '@fluentui/scripts/monorepo';
 
 task('clean', cleanTask());
 

--- a/apps/public-docsite/webpack.config.js
+++ b/apps/public-docsite/webpack.config.js
@@ -2,8 +2,8 @@
 const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const { resources } = require('../../scripts/webpack');
-const { getResolveAlias } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
+const { getResolveAlias } = require('@fluentui/scripts/webpack');
 const { addMonacoWebpackConfig } = require('@fluentui/react-monaco-editor/scripts/addMonacoWebpackConfig');
 const { getLoadSiteConfig } = require('@fluentui/public-docsite-setup/scripts/getLoadSiteConfig');
 

--- a/apps/public-docsite/webpack.config.js
+++ b/apps/public-docsite/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 const { getResolveAlias } = require('../../scripts/webpack');
 const { addMonacoWebpackConfig } = require('@fluentui/react-monaco-editor/scripts/addMonacoWebpackConfig');
 const { getLoadSiteConfig } = require('@fluentui/public-docsite-setup/scripts/getLoadSiteConfig');

--- a/apps/public-docsite/webpack.serve.config.js
+++ b/apps/public-docsite/webpack.serve.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
-const { getResolveAlias, resources } = require('../../scripts/webpack');
+const { getResolveAlias, resources } = require('@fluentui/scripts/webpack');
 const { addMonacoWebpackConfig } = require('@fluentui/react-monaco-editor/scripts/addMonacoWebpackConfig');
 const { getLoadSiteConfig } = require('@fluentui/public-docsite-setup/scripts/getLoadSiteConfig');
 

--- a/apps/ssr-tests/webpack.config.js
+++ b/apps/ssr-tests/webpack.config.js
@@ -1,4 +1,4 @@
-const { getResolveAlias, resources } = require('../../scripts/webpack');
+const { getResolveAlias, resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createConfig('ssr-tests', false, {
   entry: './test/test.js',

--- a/apps/test-bundles/webpackUtils.js
+++ b/apps/test-bundles/webpackUtils.js
@@ -1,7 +1,7 @@
 // @ts-check
 const path = require('path');
 const fs = require('fs-extra');
-const resources = require('@fluentui/scripts/webpack/webpack-resources');
+const { resources } = require('@fluentui/scripts/webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const TerserPlugin = require('terser-webpack-plugin');
 
@@ -159,7 +159,7 @@ function buildEntries(packageName, entries = {}, includeStats = true) {
     const entryName = itemName.replace(/.js$/, '');
     const entryPath = path.resolve(path.join(packagePath, itemName));
     entries[`${packageName.replace('@', '').replace('/', '-')}-${entryName}`] = {
-      entryPath: entryPath,
+      entryPath,
       includeStats,
     };
   });

--- a/apps/theming-designer/webpack.config.js
+++ b/apps/theming-designer/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 const BUNDLE_NAME = 'theming-designer';
 const IS_PRODUCTION = process.argv.indexOf('--production') > -1;

--- a/apps/theming-designer/webpack.config.js
+++ b/apps/theming-designer/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 const BUNDLE_NAME = 'theming-designer';
 const IS_PRODUCTION = process.argv.indexOf('--production') > -1;

--- a/apps/theming-designer/webpack.serve.config.js
+++ b/apps/theming-designer/webpack.serve.config.js
@@ -1,4 +1,4 @@
-const { getResolveAlias, resources } = require('../../scripts/webpack');
+const { getResolveAlias, resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createServeConfig(
   {

--- a/change/@fluentui-azure-themes-b324575f-0b29-4640-b337-a6102b1e8bab.json
+++ b/change/@fluentui-azure-themes-b324575f-0b29-4640-b337-a6102b1e8bab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/azure-themes",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-example-data-5b8ead1d-d98e-4cf4-8acf-7e24068646bb.json
+++ b/change/@fluentui-example-data-5b8ead1d-d98e-4cf4-8acf-7e24068646bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/example-data",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-fluent2-theme-ee07e125-a5c7-4eec-83f9-9eca8bd8c5be.json
+++ b/change/@fluentui-fluent2-theme-ee07e125-a5c7-4eec-83f9-9eca8bd8c5be.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-38e60c3a-0725-4dd4-91f3-309df59d5498.json
+++ b/change/@fluentui-foundation-legacy-38e60c3a-0725-4dd4-91f3-309df59d5498.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-43d5fdaa-36e3-46c7-816e-ac0d752e5776.json
+++ b/change/@fluentui-merge-styles-43d5fdaa-36e3-46c7-816e-ac0d752e5776.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-46d19d55-3226-42c0-a9b8-21a34193a366.json
+++ b/change/@fluentui-react-46d19d55-3226-42c0-a9b8-21a34193a366.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-1891ec45-7f78-4d89-b648-b2bc2bf9e632.json
+++ b/change/@fluentui-react-cards-1891ec45-7f78-4d89-b648-b2bc2bf9e632.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-ed18e90d-7631-473a-bdff-2aab0988f3d5.json
+++ b/change/@fluentui-react-charting-ed18e90d-7631-473a-bdff-2aab0988f3d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-57413eab-efdf-4d82-bfc0-3f43937a885a.json
+++ b/change/@fluentui-react-date-time-57413eab-efdf-4d82-bfc0-3f43937a885a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-date-time",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-956cd273-def9-4cf1-991e-5feedc82ca4b.json
+++ b/change/@fluentui-react-docsite-components-956cd273-def9-4cf1-991e-5feedc82ca4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-b6a4d2f0-0777-4f07-a533-feef4214b2dd.json
+++ b/change/@fluentui-react-experiments-b6a4d2f0-0777-4f07-a533-feef4214b2dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-e7353a5e-10d3-4dd3-8396-ca40dc8b7b84.json
+++ b/change/@fluentui-react-focus-e7353a5e-10d3-4dd3-8396-ca40dc8b7b84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-9716a5e8-7828-4a2a-abe9-5f642f4429b3.json
+++ b/change/@fluentui-react-hooks-9716a5e8-7828-4a2a-abe9-5f642f4429b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-87598c09-0e1f-411c-83ed-1bff8d21f7ca.json
+++ b/change/@fluentui-react-icon-provider-87598c09-0e1f-411c-83ed-1bff8d21f7ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-c0f3dc02-0514-4c32-8130-879c06820d18.json
+++ b/change/@fluentui-react-icons-mdl2-c0f3dc02-0514-4c32-8130-879c06820d18.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-a68d23bf-fba2-48f2-8733-e931b0ffdad1.json
+++ b/change/@fluentui-react-monaco-editor-a68d23bf-fba2-48f2-8733-e931b0ffdad1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-8fcea373-4a3c-4906-b12b-7c2e3a4c6c73.json
+++ b/change/@fluentui-scheme-utilities-8fcea373-4a3c-4906-b12b-7c2e3a4c6c73.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-5f63d4cc-9003-4ddb-9f37-45e2d8e6869c.json
+++ b/change/@fluentui-theme-samples-5f63d4cc-9003-4ddb-9f37-45e2d8e6869c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(scripts): remove deep imports from scripts/webpack/",
+  "packageName": "@fluentui/theme-samples",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/azure-themes/webpack.config.js
+++ b/packages/azure-themes/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIAzureThemes',

--- a/packages/azure-themes/webpack.config.js
+++ b/packages/azure-themes/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIAzureThemes',

--- a/packages/example-data/webpack.config.js
+++ b/packages/example-data/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIExampleData',

--- a/packages/example-data/webpack.config.js
+++ b/packages/example-data/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIExampleData',

--- a/packages/fluent2-theme/webpack.config.js
+++ b/packages/fluent2-theme/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIFluent2Theme',

--- a/packages/fluent2-theme/webpack.config.js
+++ b/packages/fluent2-theme/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIFluent2Theme',

--- a/packages/foundation-legacy/webpack.config.js
+++ b/packages/foundation-legacy/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIFoundationLegacy',

--- a/packages/foundation-legacy/webpack.config.js
+++ b/packages/foundation-legacy/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIFoundationLegacy',

--- a/packages/merge-styles/webpack.config.js
+++ b/packages/merge-styles/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 const BUNDLE_NAME = 'merge-styles';
 

--- a/packages/merge-styles/webpack.config.js
+++ b/packages/merge-styles/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 const BUNDLE_NAME = 'merge-styles';
 

--- a/packages/react-cards/webpack.config.js
+++ b/packages/react-cards/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactCards',

--- a/packages/react-cards/webpack.config.js
+++ b/packages/react-cards/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactCards',

--- a/packages/react-charting/webpack.config.js
+++ b/packages/react-charting/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = [
   // Create a bundle for consumption in the browser

--- a/packages/react-charting/webpack.config.js
+++ b/packages/react-charting/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = [
   // Create a bundle for consumption in the browser

--- a/packages/react-charting/webpack.serve.config.js
+++ b/packages/react-charting/webpack.serve.config.js
@@ -1,3 +1,3 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createLegacyDemoAppConfig();

--- a/packages/react-charting/webpack.serve.config.js
+++ b/packages/react-charting/webpack.serve.config.js
@@ -1,3 +1,3 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createLegacyDemoAppConfig();

--- a/packages/react-date-time/webpack.config.js
+++ b/packages/react-date-time/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactDateTime',

--- a/packages/react-date-time/webpack.config.js
+++ b/packages/react-date-time/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactDateTime',

--- a/packages/react-docsite-components/webpack.serve.config.js
+++ b/packages/react-docsite-components/webpack.serve.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createServeConfig({
   entry: ['react-app-polyfill/ie11', './src/index.demo.tsx'],

--- a/packages/react-docsite-components/webpack.serve.config.js
+++ b/packages/react-docsite-components/webpack.serve.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createServeConfig({
   entry: ['react-app-polyfill/ie11', './src/index.demo.tsx'],

--- a/packages/react-experiments/webpack.config.js
+++ b/packages/react-experiments/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = [
   // Create a bundle for consumption in the browser

--- a/packages/react-experiments/webpack.config.js
+++ b/packages/react-experiments/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = [
   // Create a bundle for consumption in the browser

--- a/packages/react-experiments/webpack.serve.config.js
+++ b/packages/react-experiments/webpack.serve.config.js
@@ -1,3 +1,3 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createLegacyDemoAppConfig();

--- a/packages/react-experiments/webpack.serve.config.js
+++ b/packages/react-experiments/webpack.serve.config.js
@@ -1,3 +1,3 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createLegacyDemoAppConfig();

--- a/packages/react-focus/webpack.config.js
+++ b/packages/react-focus/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactFocus',

--- a/packages/react-focus/webpack.config.js
+++ b/packages/react-focus/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactFocus',

--- a/packages/react-hooks/webpack.config.js
+++ b/packages/react-hooks/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactHooks',

--- a/packages/react-hooks/webpack.config.js
+++ b/packages/react-hooks/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactHooks',

--- a/packages/react-icon-provider/webpack.config.js
+++ b/packages/react-icon-provider/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactIconProvider',

--- a/packages/react-icon-provider/webpack.config.js
+++ b/packages/react-icon-provider/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactIconProvider',

--- a/packages/react-icons-mdl2/webpack.config.js
+++ b/packages/react-icons-mdl2/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactIconsMDL2',

--- a/packages/react-icons-mdl2/webpack.config.js
+++ b/packages/react-icons-mdl2/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIReactIconsMDL2',

--- a/packages/react-monaco-editor/webpack.serve.config.js
+++ b/packages/react-monaco-editor/webpack.serve.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 const path = require('path');
-const { getResolveAlias, resources } = require('../../scripts/webpack');
+const { getResolveAlias, resources } = require('@fluentui/scripts/webpack');
 const { addMonacoWebpackConfig } = require('@fluentui/monaco-editor/scripts/addMonacoWebpackConfig');
 
 const BUNDLE_NAME = 'demo-app';

--- a/packages/react/webpack.codepen.config.js
+++ b/packages/react/webpack.codepen.config.js
@@ -1,4 +1,4 @@
-const { getResolveAlias, resources } = require('../../scripts/webpack');
+const { getResolveAlias, resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createServeConfig({
   entry: './src/index.bundle.ts',

--- a/packages/react/webpack.config.js
+++ b/packages/react/webpack.config.js
@@ -1,11 +1,11 @@
 // @ts-check
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 const BUNDLE_NAME = 'fluentui-react';
 
 /**
  * @param {object} param0
- * @param {string | import("webpack").Output} param0.output - If a string, name for the output varible.
+ * @param {string | import("webpack").Configuration['output']} param0.output - If a string, name for the output varible.
  * If an object, full custom `output` config.
  * @param {boolean} param0.onlyProduction
  */

--- a/packages/react/webpack.config.js
+++ b/packages/react/webpack.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 const BUNDLE_NAME = 'fluentui-react';
 

--- a/packages/scheme-utilities/webpack.config.js
+++ b/packages/scheme-utilities/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 const BUNDLE_NAME = 'scheme-utilities';
 

--- a/packages/scheme-utilities/webpack.config.js
+++ b/packages/scheme-utilities/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 const BUNDLE_NAME = 'scheme-utilities';
 

--- a/packages/theme-samples/webpack.config.js
+++ b/packages/theme-samples/webpack.config.js
@@ -1,4 +1,4 @@
-const { resources } = require('../../scripts/webpack');
+const { resources } = require('@fluentui/scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIThemeSamples',

--- a/packages/theme-samples/webpack.config.js
+++ b/packages/theme-samples/webpack.config.js
@@ -1,4 +1,4 @@
-const resources = require('../../scripts/webpack/webpack-resources');
+const { resources } = require('../../scripts/webpack');
 
 module.exports = resources.createBundleConfig({
   output: 'FluentUIThemeSamples',

--- a/scripts/webpack/index.d.ts
+++ b/scripts/webpack/index.d.ts
@@ -1,0 +1,3 @@
+export { default as resources } from './webpack-resources';
+export { getResolveAlias } from './getResolveAlias';
+export { createStorybookWebpackConfig } from './storybook-webpack.config';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

```diff
-require('../../scripts/webpack/webpack-resources')
+require('@fluentui/scripts/webpack')
```

```diff
-require('../../scripts/storybook')
+require('@fluentui/scripts/storybook')
```

### Remarks:

Some configs files/calls will keep using relative paths until we come with better solution (encapsulation to nx executors for example)

_Why? :_
-  we use beachball check or triage-bot on CI without need of installing all node_modules ( which also registers workspaces ).  If we forced importing from `@fluentui/scripts/*` we would need to run `yarn` on this check ( which would slow down the checks by the time of yarn install which is quite a big number ATM )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes partially https://github.com/microsoft/fluentui/issues/24349
