### PR TITLE
chore: remove unused Gulp task

### DIFF
--- a/packages/fluentui/CONTRIBUTING.md
+++ b/packages/fluentui/CONTRIBUTING.md
@@ -42,8 +42,6 @@ yarn test                  # run all packages' tests once
 yarn build                 # build all packages
 yarn build:fluentui:docs   # build docs
 
-gulp deploy:docs           # deploy gh-pages doc site
-
 yarn lint                  # lint all packages
 
 yarn prettier              # run prettier on changed files

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -167,15 +167,6 @@ task('component-info:debug', done => {
 task('build:docs', series('build:docs:assets', 'build:docs:webpack'));
 
 // ----------------------------------------
-// Deploy
-// ----------------------------------------
-
-task('deploy:docs', cb => {
-  const relativePath = path.relative(process.cwd(), paths.docsDist());
-  return sh(`gh-pages -d ${relativePath} -m "deploy docs [ci skip]"`);
-});
-
-// ----------------------------------------
 // Serve
 // ----------------------------------------
 


### PR DESCRIPTION
## New Behavior

See title. We don't use `gh-pages` for deployments in this repo.
