### PR TITLE
feat(Popover): new prop unstable_disableAutoFocus to prevent auto focus on Popover open

### DIFF
--- a/change/@fluentui-react-popover-e6c0c11d-26c7-48a2-ae7e-ef5aa0fa8829.json
+++ b/change/@fluentui-react-popover-e6c0c11d-26c7-48a2-ae7e-ef5aa0fa8829.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add new prop unstable_disableAutoFocus on Popover",
+  "packageName": "@fluentui/react-popover",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -59,6 +59,7 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
     size?: PopoverSize;
     trapFocus?: UseModalAttributesOptions['trapFocus'];
     legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+    unstable_disableAutoFocus?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -117,6 +117,15 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
    * @default false
    */
   legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+
+  /**
+   * By default Popover focuses the first focusable element in PopoverSurface on open.
+   * Specify `disableAutoFocus` to prevent this behavior.
+   *
+   * @default false
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  unstable_disableAutoFocus?: boolean;
 };
 
 /**

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -120,7 +120,11 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   const { findFirstFocusable } = useFocusFinders();
 
   React.useEffect(() => {
-    if (open && positioningRefs.contentRef.current && !props.unstable_disableAutoFocus) {
+    if (props.unstable_disableAutoFocus) {
+      return;
+    }
+
+    if (open && positioningRefs.contentRef.current) {
       const containerTabIndex = positioningRefs.contentRef.current.getAttribute('tabIndex') ?? undefined;
       const firstFocusable = isNaN(containerTabIndex)
         ? findFirstFocusable(positioningRefs.contentRef.current)

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -120,14 +120,14 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   const { findFirstFocusable } = useFocusFinders();
 
   React.useEffect(() => {
-    if (open && positioningRefs.contentRef.current) {
+    if (open && positioningRefs.contentRef.current && !props.unstable_disableAutoFocus) {
       const containerTabIndex = positioningRefs.contentRef.current.getAttribute('tabIndex') ?? undefined;
       const firstFocusable = isNaN(containerTabIndex)
         ? findFirstFocusable(positioningRefs.contentRef.current)
         : positioningRefs.contentRef.current;
       firstFocusable?.focus();
     }
-  }, [findFirstFocusable, open, positioningRefs.contentRef]);
+  }, [findFirstFocusable, open, positioningRefs.contentRef, props.unstable_disableAutoFocus]);
 
   return {
     ...initialState,


### PR DESCRIPTION
When Popover opens, it automatically focuses on first focusable item in PopoverSurface.
There's no way to disable this from user side. After discussion we decide to introduce unstable prop `unstable_disableAutoFocus`
