### PR TITLE
ci(github): set due_on when creating milestone to make milestone auto-assign work as expected

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -16,10 +16,12 @@ jobs:
       - name: Create milestone
         run: |
           month=$(date +"%B")
+          month_numeric=$(date +"%m")
           quarter=$(date +"%q")
           year=$(date +"%Y")
           title="${month} Project Cycle Q${quarter} ${year}"
-          echo "Using title '${title}'"
-          gh api --method POST repos/microsoft/fluentui/milestones -f title="${title}"
+          due_on=$(date -v1d -v${month_numeric}m -v-1d +"%Y-%m-%dT%H:%M:%S%z")
+          echo "Using title '${title}' and setting due date: '${due-on}'"
+          gh api --method POST repos/microsoft/fluentui/milestones -f title="${title} -f due_on="${due_on}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

auto assign milestone will keeps adding wrong milestone to every PR change because there is no due_date set when creating one.

for example, this PR has set October milestone -> <img width="358" alt="image" src="https://user-images.githubusercontent.com/1223799/210414244-e9d007cf-27c5-41b8-b797-85501757721c.png">


## New Behavior

during milestone creation due_date is set this automation will work as expected

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
