### PR TITLE
fix: react-field does not wrap SVG in inline parent

### DIFF
--- a/change/@fluentui-react-field-b2bd417e-f8c8-4fba-ab72-7f3c6e0cdfe2.json
+++ b/change/@fluentui-react-field-b2bd417e-f8c8-4fba-ab72-7f3c6e0cdfe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Field styles do not wrap SVG status icon in inline parent to avoid layout bugs",
+  "packageName": "@fluentui/react-field",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/src/components/Field/renderField.tsx
+++ b/packages/react-components/react-field/src/components/Field/renderField.tsx
@@ -13,14 +13,10 @@ export const renderField_unstable = <T extends FieldControl>(state: FieldState<T
       {slots.label && <slots.label {...slotProps.label} />}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       {slots.control && <slots.control {...(slotProps.control as any)} />}
-      {slots.validationMessage && (
-        <>
-          {slots.validationMessageIcon && <slots.validationMessageIcon {...slotProps.validationMessageIcon} />}
-          <slots.validationMessage {...slotProps.validationMessage}>
-            {slotProps.validationMessage.children}
-          </slots.validationMessage>
-        </>
+      {slots.validationMessage && slots.validationMessageIcon && (
+        <slots.validationMessageIcon {...slotProps.validationMessageIcon} />
       )}
+      {slots.validationMessage && <slots.validationMessage {...slotProps.validationMessage} />}
       {slots.hint && <slots.hint {...slotProps.hint} />}
     </slots.root>
   );

--- a/packages/react-components/react-field/src/components/Field/renderField.tsx
+++ b/packages/react-components/react-field/src/components/Field/renderField.tsx
@@ -14,10 +14,12 @@ export const renderField_unstable = <T extends FieldControl>(state: FieldState<T
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       {slots.control && <slots.control {...(slotProps.control as any)} />}
       {slots.validationMessage && (
-        <slots.validationMessage {...slotProps.validationMessage}>
+        <>
           {slots.validationMessageIcon && <slots.validationMessageIcon {...slotProps.validationMessageIcon} />}
-          {slotProps.validationMessage.children}
-        </slots.validationMessage>
+          <slots.validationMessage {...slotProps.validationMessage}>
+            {slotProps.validationMessage.children}
+          </slots.validationMessage>
+        </>
       )}
       {slots.hint && <slots.hint {...slotProps.hint} />}
     </slots.root>

--- a/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
+++ b/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
@@ -19,16 +19,23 @@ const useRootStyles = makeStyles({
   base: {
     display: 'grid',
     gridAutoFlow: 'row',
+    gridTemplateColumns: 'auto 1fr',
     justifyItems: 'start',
   },
 
   horizontal: {
     gridTemplateRows: 'auto auto auto auto',
-    gridTemplateColumns: '1fr 2fr',
+    gridTemplateColumns: '1fr auto 2fr',
+  },
+
+  fullWidth: {
+    gridColumnStart: '1',
+    gridColumnEnd: '-1',
   },
 
   secondColumn: {
     gridColumnStart: '2',
+    gridColumnEnd: '-1',
   },
 });
 
@@ -59,18 +66,18 @@ const useSecondaryTextStyles = makeStyles({
   },
 });
 
-const useValidationMessageStyles = makeStyles({
+const useValidationMessageIconStyles = makeStyles({
   base: {
-    display: 'flex',
-  },
-
-  icon: {
     display: 'block',
+    alignSelf: 'start',
     fontSize: '12px',
     lineHeight: '12px',
-    verticalAlign: 'middle',
     marginRight: tokens.spacingHorizontalXS,
-    marginTop: tokens.spacingVerticalXXS,
+    marginTop: tokens.spacingVerticalXS,
+  },
+
+  horizontal: {
+    gridColumnStart: 2,
   },
 
   error: {
@@ -103,6 +110,7 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
   if (state.control) {
     state.control.className = mergeClasses(
       classNames.control,
+      !horizontal && rootStyles.fullWidth,
       horizontal && rootStyles.secondColumn,
       state.control.className,
     );
@@ -113,17 +121,19 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
     state.label.className = mergeClasses(
       classNames.label,
       labelStyles.base,
+      !horizontal && rootStyles.fullWidth,
       horizontal && labelStyles.horizontal,
       state.label.className,
     );
   }
 
-  const validationMessageStyles = useValidationMessageStyles();
+  const validationMessageIconStyles = useValidationMessageIconStyles();
   if (state.validationMessageIcon) {
     state.validationMessageIcon.className = mergeClasses(
       classNames.validationMessageIcon,
-      validationMessageStyles.icon,
-      !!validationState && validationMessageStyles[validationState],
+      validationMessageIconStyles.base,
+      horizontal && validationMessageIconStyles.horizontal,
+      !!validationState && validationMessageIconStyles[validationState],
       state.validationMessageIcon.className,
     );
   }
@@ -132,9 +142,7 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
   if (state.validationMessage) {
     state.validationMessage.className = mergeClasses(
       classNames.validationMessage,
-      validationMessageStyles.base,
       secondaryTextStyles.base,
-      horizontal && rootStyles.secondColumn,
       validationState === 'error' && secondaryTextStyles.error,
       state.validationMessage.className,
     );
@@ -144,6 +152,7 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
     state.hint.className = mergeClasses(
       classNames.hint,
       secondaryTextStyles.base,
+      rootStyles.fullWidth,
       horizontal && rootStyles.secondColumn,
       state.hint.className,
     );

--- a/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
+++ b/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
@@ -59,12 +59,18 @@ const useSecondaryTextStyles = makeStyles({
   },
 });
 
-const useValidationMessageIconStyles = makeStyles({
+const useValidationMessageStyles = makeStyles({
   base: {
+    display: 'flex',
+  },
+
+  icon: {
+    display: 'block',
     fontSize: '12px',
     lineHeight: '12px',
     verticalAlign: 'middle',
     marginRight: tokens.spacingHorizontalXS,
+    marginTop: tokens.spacingVerticalXXS,
   },
 
   error: {
@@ -112,12 +118,12 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
     );
   }
 
-  const validationMessageIconStyles = useValidationMessageIconStyles();
+  const validationMessageStyles = useValidationMessageStyles();
   if (state.validationMessageIcon) {
     state.validationMessageIcon.className = mergeClasses(
       classNames.validationMessageIcon,
-      validationMessageIconStyles.base,
-      !!validationState && validationMessageIconStyles[validationState],
+      validationMessageStyles.icon,
+      !!validationState && validationMessageStyles[validationState],
       state.validationMessageIcon.className,
     );
   }
@@ -126,6 +132,7 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
   if (state.validationMessage) {
     state.validationMessage.className = mergeClasses(
       classNames.validationMessage,
+      validationMessageStyles.base,
       secondaryTextStyles.base,
       horizontal && rootStyles.secondColumn,
       validationState === 'error' && secondaryTextStyles.error,

--- a/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
+++ b/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
@@ -20,22 +20,50 @@ const useRootStyles = makeStyles({
     display: 'grid',
     gridAutoFlow: 'row',
     gridTemplateColumns: 'auto 1fr',
+    gridTemplateAreas: `
+      "label label"
+      "control control"
+      "validationIcon validationMessage"
+      "hint hint"
+    `,
     justifyItems: 'start',
   },
 
   horizontal: {
-    gridTemplateRows: 'auto auto auto auto',
-    gridTemplateColumns: '1fr auto 2fr',
+    gridTemplateColumns: '33% auto 1fr',
+    gridTemplateAreas: `
+      "label control control"
+      "label validationIcon validationMessage"
+      "label hint hint"
+      "label . ."
+    `,
   },
 
-  fullWidth: {
-    gridColumnStart: '1',
-    gridColumnEnd: '-1',
+  label: {
+    gridColumnStart: 'label',
+    gridColumnEnd: 'label',
+    gridRowStart: 'label',
+    gridRowEnd: 'label',
   },
 
-  secondColumn: {
-    gridColumnStart: '2',
-    gridColumnEnd: '-1',
+  control: {
+    gridColumnStart: 'control',
+    gridColumnEnd: 'control',
+  },
+
+  validationIcon: {
+    gridColumnStart: 'validationIcon',
+    gridColumnEnd: 'validationIcon',
+  },
+
+  validationMessage: {
+    gridColumnStart: 'validationMessage',
+    gridColumnEnd: 'validationMessage',
+  },
+
+  hint: {
+    gridColumnStart: 'hint',
+    gridColumnEnd: 'hint',
   },
 });
 
@@ -46,8 +74,6 @@ const useLabelStyles = makeStyles({
   },
 
   horizontal: {
-    gridRowStart: '1',
-    gridRowEnd: '-1',
     marginRight: tokens.spacingHorizontalM,
     alignSelf: 'start',
     justifySelf: 'stretch',
@@ -74,10 +100,6 @@ const useValidationMessageIconStyles = makeStyles({
     lineHeight: '12px',
     marginRight: tokens.spacingHorizontalXS,
     marginTop: tokens.spacingVerticalXS,
-  },
-
-  horizontal: {
-    gridColumnStart: 2,
   },
 
   error: {
@@ -108,31 +130,20 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
   );
 
   if (state.control) {
-    state.control.className = mergeClasses(
-      classNames.control,
-      !horizontal && rootStyles.fullWidth,
-      horizontal && rootStyles.secondColumn,
-      state.control.className,
-    );
+    state.control.className = mergeClasses(classNames.control, rootStyles.control, state.control.className);
   }
 
   const labelStyles = useLabelStyles();
   if (state.label) {
-    state.label.className = mergeClasses(
-      classNames.label,
-      labelStyles.base,
-      !horizontal && rootStyles.fullWidth,
-      horizontal && labelStyles.horizontal,
-      state.label.className,
-    );
+    state.label.className = mergeClasses(classNames.label, rootStyles.label, labelStyles.base, state.label.className);
   }
 
   const validationMessageIconStyles = useValidationMessageIconStyles();
   if (state.validationMessageIcon) {
     state.validationMessageIcon.className = mergeClasses(
       classNames.validationMessageIcon,
+      rootStyles.validationIcon,
       validationMessageIconStyles.base,
-      horizontal && validationMessageIconStyles.horizontal,
       !!validationState && validationMessageIconStyles[validationState],
       state.validationMessageIcon.className,
     );
@@ -142,6 +153,7 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
   if (state.validationMessage) {
     state.validationMessage.className = mergeClasses(
       classNames.validationMessage,
+      rootStyles.validationMessage,
       secondaryTextStyles.base,
       validationState === 'error' && secondaryTextStyles.error,
       state.validationMessage.className,
@@ -152,8 +164,7 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
     state.hint.className = mergeClasses(
       classNames.hint,
       secondaryTextStyles.base,
-      rootStyles.fullWidth,
-      horizontal && rootStyles.secondColumn,
+      rootStyles.hint,
       state.hint.className,
     );
   }


### PR DESCRIPTION
Fixes #26061

## Previous Behavior

Because an SVG was wrapped in a parent with `display: inline`, it caused odd layout issues, despite the SVG also being styled `display: inline`. Specifically, when used within a dialog, it would trigger a vertical scrollbar in the dialog (example in the issue).

We also previously styled status text to wrap like this:
![screenshot of success status message text wrapping below a check mark icon](https://user-images.githubusercontent.com/3819570/210433656-9b1215cc-b635-4747-adb8-a19445df0699.png)

## New Behavior

The scrollbar issue no longer happens, and now text wraps like this (checked with design, and this was the desired behavior):
![sreenshot of input field with icon in its own column, and text wrapping in a block adjacent to the icon column](https://user-images.githubusercontent.com/3819570/209726605-fbed05c0-327d-4b99-b9f4-8aa53bc48490.png)

![screenshot of a horizontal field with the same layout but the label appearing to the left of the input and all messages](https://user-images.githubusercontent.com/3819570/211405684-ec0bcc52-1956-4316-825f-8a6a38ff9365.png)

