### PR TITLE
updating fluent-tooltip wc styles to support custom tag names

### DIFF
--- a/change/@fluentui-web-components-009b1050-81d9-453d-9e6a-0cdebcba8a0f.json
+++ b/change/@fluentui-web-components-009b1050-81d9-453d-9e6a-0cdebcba8a0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix fluent-tooltip not showing anchor pointer when wc prefix is changed",
+  "packageName": "@fluentui/web-components",
+  "email": "abcy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/src/tooltip/tooltip.styles.ts
@@ -1,9 +1,9 @@
 import { css, ElementStyles } from '@microsoft/fast-element';
 import {
+  AnchoredRegion,
   ElementDefinitionContext,
   forcedColorsStylesheetBehavior,
-  FoundationElementDefinition,
-  AnchoredRegion
+  FoundationElementDefinition
 } from '@microsoft/fast-foundation';
 import { elevationShadowTooltip } from '../styles/index';
 import {

--- a/packages/web-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/src/tooltip/tooltip.styles.ts
@@ -3,6 +3,7 @@ import {
   ElementDefinitionContext,
   forcedColorsStylesheetBehavior,
   FoundationElementDefinition,
+  AnchoredRegion
 } from '@microsoft/fast-foundation';
 import { elevationShadowTooltip } from '../styles/index';
 import {

--- a/packages/web-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/src/tooltip/tooltip.styles.ts
@@ -42,7 +42,7 @@ export const tooltipStyles: (
       box-shadow: ${elevationShadowTooltip};
     }
 
-    fluent-anchored-region {
+    ${context.tagFor(AnchoredRegion)} {
       display: flex;
       justify-content: center;
       align-items: center;
@@ -50,15 +50,15 @@ export const tooltipStyles: (
       flex-direction: row;
     }
 
-    fluent-anchored-region.right,
-    fluent-anchored-region.left {
+    ${context.tagFor(AnchoredRegion)}.right,
+    ${context.tagFor(AnchoredRegion)}.left {
       flex-direction: column;
     }
 
-    fluent-anchored-region.top .tooltip::after,
-    fluent-anchored-region.bottom .tooltip::after,
-    fluent-anchored-region.left .tooltip::after,
-    fluent-anchored-region.right .tooltip::after {
+    ${context.tagFor(AnchoredRegion)}.top .tooltip::after,
+    ${context.tagFor(AnchoredRegion)}.bottom .tooltip::after,
+    ${context.tagFor(AnchoredRegion)}.left .tooltip::after,
+    ${context.tagFor(AnchoredRegion)}.right .tooltip::after {
       content: '';
       width: 12px;
       height: 12px;
@@ -68,55 +68,53 @@ export const tooltipStyles: (
       position: absolute;
     }
 
-    fluent-anchored-region.top .tooltip::after {
+    ${context.tagFor(AnchoredRegion)}.top .tooltip::after {
       transform: translateX(-50%) rotate(225deg);
       bottom: 5px;
       left: 50%;
     }
 
-    fluent-anchored-region.top .tooltip {
+    ${context.tagFor(AnchoredRegion)}.top .tooltip {
       margin-bottom: 12px;
     }
 
-    fluent-anchored-region.bottom .tooltip::after {
+    ${context.tagFor(AnchoredRegion)}.bottom .tooltip::after {
       transform: translateX(-50%) rotate(45deg);
       top: 5px;
       left: 50%;
     }
 
-    fluent-anchored-region.bottom .tooltip {
+    ${context.tagFor(AnchoredRegion)}.bottom .tooltip {
       margin-top: 12px;
     }
 
-    fluent-anchored-region.left .tooltip::after {
+    ${context.tagFor(AnchoredRegion)}.left .tooltip::after {
       transform: translateY(-50%) rotate(135deg);
       top: 50%;
       right: 5px;
     }
 
-    fluent-anchored-region.left .tooltip {
+    ${context.tagFor(AnchoredRegion)}.left .tooltip {
       margin-right: 12px;
     }
 
-    fluent-anchored-region.right .tooltip::after {
+    ${context.tagFor(AnchoredRegion)}.right .tooltip::after {
       transform: translateY(-50%) rotate(-45deg);
       top: 50%;
       left: 5px;
     }
 
-    fluent-anchored-region.right .tooltip {
+    ${context.tagFor(AnchoredRegion)}.right .tooltip {
       margin-left: 12px;
     }
-  `.withBehaviors(
-    forcedColorsStylesheetBehavior(
-      css`
+  `.withBehaviors(forcedColorsStylesheetBehavior(css `
         :host([disabled]) {
           opacity: 1;
         }
-        fluent-anchored-region.top .tooltip::after,
-        fluent-anchored-region.bottom .tooltip::after,
-        fluent-anchored-region.left .tooltip::after,
-        fluent-anchored-region.right .tooltip::after {
+        ${context.tagFor(AnchoredRegion)}.top .tooltip::after,
+        ${context.tagFor(AnchoredRegion)}.bottom .tooltip::after,
+        ${context.tagFor(AnchoredRegion)}.left .tooltip::after,
+        ${context.tagFor(AnchoredRegion)}.right .tooltip::after {
           content: '';
           width: unset;
           height: unset;

--- a/packages/web-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/src/tooltip/tooltip.styles.ts
@@ -108,7 +108,9 @@ export const tooltipStyles: (
     ${context.tagFor(AnchoredRegion)}.right .tooltip {
       margin-left: 12px;
     }
-  `.withBehaviors(forcedColorsStylesheetBehavior(css `
+  `.withBehaviors(
+    forcedColorsStylesheetBehavior(
+      css`
         :host([disabled]) {
           opacity: 1;
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Fluent tooltip not showing triangle tip when tag is renamed

## New Behavior

Fluent tooltip correctly shows triangle tip when tag is renamed


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26153
