### PR TITLE
feat(react-portal): elementContains supports Node types

### DIFF
--- a/change/@fluentui-react-portal-5ad76945-0626-47e1-95d8-8cdc349fbd47.json
+++ b/change/@fluentui-react-portal-5ad76945-0626-47e1-95d8-8cdc349fbd47.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: elementContains supports Node types",
+  "packageName": "@fluentui/react-portal",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal/etc/react-portal.api.md
+++ b/packages/react-components/react-portal/etc/react-portal.api.md
@@ -7,7 +7,7 @@
 import * as React_2 from 'react';
 
 // @public
-export function elementContains(parent: HTMLElement | null, child: HTMLElement | null): boolean;
+export function elementContains(parent: Node | null, child: Node | null): boolean;
 
 // @public
 export const Portal: React_2.FC<PortalProps>;
@@ -27,7 +27,7 @@ export type PortalState = Pick<PortalProps, 'children'> & Required<Pick<PortalPr
 export const renderPortal_unstable: (state: PortalState) => React_2.ReactElement;
 
 // @public
-export function setVirtualParent(child: HTMLElement, parent?: HTMLElement): void;
+export function setVirtualParent(child: Node, parent?: Node): void;
 
 // @public
 export const usePortal_unstable: (props: PortalProps) => PortalState;

--- a/packages/react-components/react-portal/src/virtualParent/elementContains.ts
+++ b/packages/react-components/react-portal/src/virtualParent/elementContains.ts
@@ -5,7 +5,7 @@ import { getParent } from './getParent';
  *
  * @returns true if the child can find the parent in its virtual hierarchy
  */
-export function elementContains(parent: HTMLElement | null, child: HTMLElement | null): boolean {
+export function elementContains(parent: Node | null, child: Node | null): boolean {
   if (!parent || !child) {
     return false;
   }
@@ -14,7 +14,7 @@ export function elementContains(parent: HTMLElement | null, child: HTMLElement |
     return true;
   } else {
     while (child) {
-      const nextParent: HTMLElement | null = getParent(child);
+      const nextParent = getParent(child);
 
       if (nextParent === parent) {
         return true;

--- a/packages/react-components/react-portal/src/virtualParent/getParent.ts
+++ b/packages/react-components/react-portal/src/virtualParent/getParent.ts
@@ -4,6 +4,6 @@ import { getVirtualParent } from './getVirtualParent';
  * Gets the element which is the parent of a given element.
  * This method prefers the virtual parent over real DOM parent when present.
  */
-export function getParent(child: HTMLElement | null): HTMLElement | null {
-  return (child && getVirtualParent(child)) || (child?.parentNode as HTMLElement | null);
+export function getParent(child: Node | null): Node | null {
+  return ((child && getVirtualParent(child)) || child?.parentNode) ?? null;
 }

--- a/packages/react-components/react-portal/src/virtualParent/getVirtualParent.ts
+++ b/packages/react-components/react-portal/src/virtualParent/getVirtualParent.ts
@@ -2,10 +2,6 @@ import { isVirtualElement } from './isVirtualElement';
 /**
  * Gets the virtual parent given the child element, if it exists.
  */
-export function getVirtualParent(child: HTMLElement): HTMLElement | undefined {
-  let parent: HTMLElement | undefined;
-  if (isVirtualElement(child)) {
-    parent = child._virtual.parent;
-  }
-  return parent;
+export function getVirtualParent(child: Node): Node | undefined {
+  return isVirtualElement(child) ? child._virtual.parent : undefined;
 }

--- a/packages/react-components/react-portal/src/virtualParent/isVirtualElement.ts
+++ b/packages/react-components/react-portal/src/virtualParent/isVirtualElement.ts
@@ -3,6 +3,6 @@ import type { VirtualElement } from './types';
 /**
  * Determines whether or not an element has the virtual hierarchy extension.
  */
-export function isVirtualElement(element: HTMLElement | VirtualElement): element is VirtualElement {
+export function isVirtualElement(element: Node | VirtualElement): element is VirtualElement {
   return element && !!(<VirtualElement>element)._virtual;
 }

--- a/packages/react-components/react-portal/src/virtualParent/setVirtualParent.ts
+++ b/packages/react-components/react-portal/src/virtualParent/setVirtualParent.ts
@@ -6,12 +6,12 @@ import type { VirtualElement } from './types';
  * @param child - Theme element to set the virtual parent
  * @param parent - The virtual parent, use `undefined` to remove a virtual parent relationship
  */
-export function setVirtualParent(child: HTMLElement, parent?: HTMLElement): void {
+export function setVirtualParent(child: Node, parent?: Node): void {
   if (!child) {
     return;
   }
 
-  const virtualChild = <VirtualElement>child;
+  const virtualChild = child as VirtualElement;
 
   if (!virtualChild._virtual) {
     virtualChild._virtual = {};

--- a/packages/react-components/react-portal/src/virtualParent/types.ts
+++ b/packages/react-components/react-portal/src/virtualParent/types.ts
@@ -1,5 +1,5 @@
-export interface VirtualElement extends HTMLElement {
+export interface VirtualElement extends Node {
   _virtual: {
-    parent?: HTMLElement;
+    parent?: Node;
   };
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`elementContains` only supports `HTMLElement` type for verification of parent and children. The base type for `event.target` is `Node` which is a more generic type, and it'd be a common case scenario to have `elementContains` being used with `event.target`:

```ts
// the casting is required right now as elementContains doesn't support Node
elementContains(someParentRef.current, event.target as HTMLElement)
```

## New Behavior

Supports `Node` type for `elementContains` for both parent and children.


```ts
// no casting is required
elementContains(someParentRef.current, event.target)
```