### PR TITLE
Fix react errors on ThemeProvider when as React.Fragment is set to remove the div root

### DIFF
--- a/change/@fluentui-react-3958e349-5c28-4835-b5ea-22a5886dc33f.json
+++ b/change/@fluentui-react-3958e349-5c28-4835-b5ea-22a5886dc33f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix the react errors when we set the ThemeProvider as a React.Fragment to remove the root div, issue: 16633",
+  "packageName": "@fluentui/react",
+  "email": "farcemolina@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/ThemeProvider/renderThemeProvider.tsx
+++ b/packages/react/src/utilities/ThemeProvider/renderThemeProvider.tsx
@@ -6,7 +6,12 @@ import type { ThemeProviderState } from './ThemeProvider.types';
 export const renderThemeProvider = (state: ThemeProviderState) => {
   const { customizerContext, ref, theme } = state;
   const Root = state.as || 'div';
-  const rootProps = typeof state.as === 'string' ? getNativeElementProps(state.as, state) : omit(state, ['as']);
+  const rootProps =
+    typeof state.as === 'string'
+      ? getNativeElementProps(state.as, state)
+      : state.as === React.Fragment
+      ? { children: state.children }
+      : omit(state, ['as']);
 
   return (
     <ThemeContext.Provider value={theme}>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
ThemeProvider adds a div in the root that may break the styles of the app, so we can use as={React.Fragment} to avoid this, like this:
![image](https://user-images.githubusercontent.com/106703105/210585598-18faf1b2-ccda-4676-9909-8858d05599e8.png)

but this will throw a react error:

![image](https://user-images.githubusercontent.com/106703105/210586061-8b03c34c-1d58-49c6-b2a5-ac212def1400.png)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
The goal of this change is to avoid passing the theme prop to the React.Fragment by just returning the state.children in case the 
as={React.Fragment} is being set in the ThemeProvider
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/microsoft/fluentui/issues/16633

* Fixes #
