### PR TITLE
chore: Update suggestion type docs to mention not adding interactive elements to the footer

### DIFF
--- a/change/@fluentui-react-ad8a4cf9-019c-49a0-9d87-323f6f5f0969.json
+++ b/change/@fluentui-react-ad8a4cf9-019c-49a0-9d87-323f6f5f0969.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Suggestions: change resultsFooter docs to mention not adding interactive elements",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -190,11 +190,13 @@ export interface ISuggestionsProps<T> extends IReactProps<any> {
 
   /**
    * A renderer that adds an element at the end of the suggestions list it has more items than resultsMaximumNumber.
+   * This should not include interactive elements as the footer is not focusable
    */
   resultsFooterFull?: (props: ISuggestionsProps<T>) => JSX.Element;
 
   /**
    * A renderer that adds an element at the end of the suggestions list it has fewer items than resultsMaximumNumber.
+   * This should not include interactive elements as the footer is not focusable
    */
   resultsFooter?: (props: ISuggestionsProps<T>) => JSX.Element;
 

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -190,13 +190,13 @@ export interface ISuggestionsProps<T> extends IReactProps<any> {
 
   /**
    * A renderer that adds an element at the end of the suggestions list it has more items than resultsMaximumNumber.
-   * This should not include interactive elements as the footer is not focusable
+   * This should not include interactive elements as the footer is not focusable.
    */
   resultsFooterFull?: (props: ISuggestionsProps<T>) => JSX.Element;
 
   /**
    * A renderer that adds an element at the end of the suggestions list it has fewer items than resultsMaximumNumber.
-   * This should not include interactive elements as the footer is not focusable
+   * This should not include interactive elements as the footer is not focusable.
    */
   resultsFooter?: (props: ISuggestionsProps<T>) => JSX.Element;
 


### PR DESCRIPTION
As mentioned in #24028, the footer of a suggestion listbox is not focusable. Changing this would be too disruptive to the existing pattern, so we're changing the docs to recommend not adding interactive elements to the footer (rather use it for text like error messages etc). If the user needs an interactive element, it should go inside the listbox.