### PR TITLE
fix: Stopping className being unset in inner Stacks

### DIFF
--- a/change/@fluentui-react-d13203b4-5c4b-4735-a07b-79f0d4a82161.json
+++ b/change/@fluentui-react-d13203b4-5c4b-4735-a07b-79f0d4a82161.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Stopping className being unset in inner Stacks.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Stack/Stack.test.tsx
+++ b/packages/react/src/components/Stack/Stack.test.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { mergeStyles } from '@fluentui/merge-styles';
 import { Fabric } from '../../Fabric';
 import { isConformant } from '../../common/isConformant';
 import { Stack } from './Stack';
+import type { IStackProps } from './Stack.types';
 
 const sampleClass = mergeStyles({
   background: 'red',
@@ -333,5 +335,19 @@ describe('Stack', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('respects the className passed in an inner Stack', () => {
+    const customClassName = 'custom';
+    const CustomStack = (props: IStackProps) => <Stack className={customClassName} {...props} />;
+
+    const { getByText } = render(
+      <Stack>
+        <CustomStack>Inner Stack</CustomStack>
+      </Stack>,
+    );
+
+    const innerStack = getByText('Inner Stack');
+    expect(innerStack.classList.contains(customClassName)).toBe(true);
   });
 });

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -62,13 +62,20 @@ function _processStackChildren(
       defaultItemProps = { shrink: !disableShrink };
     }
 
-    return React.cloneElement(childAsReactElement, {
+    const clonedElementProps = {
       ...defaultItemProps,
       ...childAsReactElement.props,
       className: enableScopedSelectors
         ? css(StackGlobalClassNames.child, childAsReactElement.props.className)
         : childAsReactElement.props.className,
-    });
+    };
+
+    // Delete the className if it is undefined so it does not unset other classNames passed in.
+    if (clonedElementProps.className === undefined) {
+      delete clonedElementProps.className;
+    }
+
+    return React.cloneElement(childAsReactElement, clonedElementProps);
   });
 
   return childrenArray;

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -61,13 +61,13 @@ function _processStackChildren(
     if (_isStackItem(child)) {
       defaultItemProps = { shrink: !disableShrink };
     }
+    const childClassName = childAsReactElement.props.className;
 
     const clonedElementProps = {
       ...defaultItemProps,
       ...childAsReactElement.props,
-      className: enableScopedSelectors
-        ? css(StackGlobalClassNames.child, childAsReactElement.props.className)
-        : childAsReactElement.props.className,
+      ...(childClassName && { className: childClassName }),
+      ...(enableScopedSelectors && { className: css(StackGlobalClassNames.child, childClassName) }),
     };
 
     // Delete the className if it is undefined so it does not unset other classNames passed in.

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -63,19 +63,12 @@ function _processStackChildren(
     }
     const childClassName = childAsReactElement.props.className;
 
-    const clonedElementProps = {
+    return React.cloneElement(childAsReactElement, {
       ...defaultItemProps,
       ...childAsReactElement.props,
       ...(childClassName && { className: childClassName }),
       ...(enableScopedSelectors && { className: css(StackGlobalClassNames.child, childClassName) }),
-    };
-
-    // Delete the className if it is undefined so it does not unset other classNames passed in.
-    if (clonedElementProps.className === undefined) {
-      delete clonedElementProps.className;
-    }
-
-    return React.cloneElement(childAsReactElement, clonedElementProps);
+    });
   });
 
   return childrenArray;


### PR DESCRIPTION
## Previous Behavior

Inner `Stacks`, when passed via an HOC wrapper

```ts
const CustomStack = (props) => <Stack className="custom" {...props} />;
```

were having their `className` set to `undefined` given how we were cloning children within `Stacks`.

## New Behavior

We now account for nested `Stacks` when cloning children by only conditionally cloning the `className` if it has been set, instead of setting it to `undefined` if it hasn't, which was causing custom classNames to be unset.

We have also added a test, so this doesn't regress in the future.