### PR TITLE
fix: v9 Combobox option focus on open updates

### DIFF
--- a/change/@fluentui-react-combobox-b1fa3ab7-ea40-4131-ba9a-4e1f7b78d110.json
+++ b/change/@fluentui-react-combobox-b1fa3ab7-ea40-4131-ba9a-4e1f7b78d110.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Combobox always starts at the first option if multiselect, and correctly sets focus visible\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -216,6 +216,9 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
       // open and set focus
       state.setOpen(event, !state.open);
       triggerRef.current?.focus();
+
+      // set focus visible=false, since this can only be done with the mouse/pointer
+      setFocusVisible(false);
     }),
   );
 

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -76,10 +76,10 @@ export const useComboboxBaseState = (props: ComboboxBaseProps & { editable?: boo
   // update active option based on change in open state
   React.useEffect(() => {
     if (open && !activeOption) {
-      // if there is a selection, start at the most recently selected item
-      if (selectedOptions.length > 0) {
-        const lastSelectedOption = getOptionsMatchingText(v => v === selectedOptions[selectedOptions.length - 1]).pop();
-        lastSelectedOption && setActiveOption(lastSelectedOption);
+      // if it is single-select and there is a selected option, start at the selected option
+      if (!multiselect && selectedOptions.length > 0) {
+        const selectedOption = getOptionsMatchingText(v => v === selectedOptions[0]).pop();
+        selectedOption && setActiveOption(selectedOption);
       }
       // default to starting at the first option
       else {


### PR DESCRIPTION
## Previous Behavior

- Multiselect Combobox & Dropdown began option focus at last selected option when opened (similar to single-select combobox)
- When opened from the combobox chevron, the option keyboard focus outline still showed up

## New Behavior

- Multiselect combo & dropdown always begin from the first option when opened (unlike single-select) -- discussed with design
- Focus visibility is reset when using the mouse to open a combobox from the chevron icon

## Related Issue(s)

Addresses poitns 1 & 2 in #26069

* Fixes #
