### PR TITLE
docs: fix storybook code tag not having any highlight/monospace font

### DIFF
--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -295,7 +295,7 @@
 #docs-root .docblock-argstable-body > tr > td:nth-child(2) > div:nth-child(2) span,
 #docs-root .docblock-argstable-body > tr > td:nth-child(2) > div:nth-child(1) > div > span,
 #docs-root .css-16d4d7t {
-  font-family: Menlo, monospace;
+  font-family: 'Cascadia Code', Menlo, 'Courier New', Courier, monospace;
   font-style: normal;
   font-weight: normal;
   font-size: 14px;
@@ -332,7 +332,6 @@
   display: inline-block;
   background-color: rgba(17, 16, 15, 0.1);
   border-radius: 2px;
-  font-family: 'Cascadia Code', 'Fira Code', 'Courier New', Courier, monospace;
 }
 
 .os-content-glue {

--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -62,6 +62,11 @@
   padding: 48px 0 0 0;
 }
 
+#docs-root .sbdocs-h2 code {
+  border-radius: 4px;
+  font-size: 20px;
+}
+
 #docs-root .sbdocs-h3 {
   font-family: 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue',
     sans-serif;
@@ -70,6 +75,11 @@
   margin: 25px 0 0 0 !important;
   letter-spacing: -0.01em;
   color: #000000;
+}
+
+#docs-root .sbdocs-h3 code {
+  border-radius: 3px;
+  font-size: 16px;
 }
 
 /* Only apply to H3s inside of stories which have a parent with an ID */
@@ -318,7 +328,11 @@
 }
 
 #docs-root code {
-  margin: 1px 0 1px 0;
+  padding: 0.1em 0.2em;
+  display: inline-block;
+  background-color: rgba(17, 16, 15, 0.1);
+  border-radius: 2px;
+  font-family: 'Cascadia Code', 'Fira Code', 'Courier New', Courier, monospace;
 }
 
 .os-content-glue {


### PR DESCRIPTION
Improve how <code> tags look like in public docsite v9. Before, there was no differentiation between plain text and code tags, which made it hard to head props and values.

## Previous Behavior
![SCR-20230105-taz](https://user-images.githubusercontent.com/1357885/210871755-d4faf3a9-71ca-4303-9645-231abaa9605a.png)

## New Behavior
![SCR-20230105-tbd](https://user-images.githubusercontent.com/1357885/210871750-ccede07e-df52-45f2-8a1e-9c6b66f5e7bb.png)