### PR TITLE
fix: react-combobox perf improvements

### DIFF
--- a/change/@fluentui-react-combobox-9f8aba26-8e89-4812-a093-00ff3dd02053.json
+++ b/change/@fluentui-react-combobox-9f8aba26-8e89-4812-a093-00ff3dd02053.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: perf improvements with useEventCallback",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -55,11 +55,16 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   const triggerRef = React.useRef<HTMLInputElement>(null);
 
   // calculate listbox width style based on trigger width
-  const [popupWidth, setPopupWidth] = React.useState<string>();
+  const [popupDimensions, setPopupDimensions] = React.useState<{ width: string }>();
   React.useEffect(() => {
-    const width = open ? `${rootRef.current?.clientWidth}px` : undefined;
-    setPopupWidth(width);
-  }, [open]);
+    // only recalculate width when opening
+    if (open) {
+      const width = `${rootRef.current?.clientWidth}px`;
+      if (width !== popupDimensions?.width) {
+        setPopupDimensions({ width });
+      }
+    }
+  }, [open, popupDimensions]);
 
   // set active option and selection based on typing
   const getOptionFromInput = (inputValue: string): OptionValue | undefined => {
@@ -165,7 +170,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
           required: true,
           defaultProps: {
             children: props.children,
-            style: { width: popupWidth },
+            style: popupDimensions,
           },
         })
       : undefined;

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -68,10 +68,13 @@ export const useComboboxBaseState = (props: ComboboxBaseProps & { editable?: boo
     initialState: false,
   });
 
-  const setOpen = (event: ComboboxBaseOpenEvents, newState: boolean) => {
-    onOpenChange?.(event, { open: newState });
-    setOpenState(newState);
-  };
+  const setOpen = React.useCallback(
+    (event: ComboboxBaseOpenEvents, newState: boolean) => {
+      onOpenChange?.(event, { open: newState });
+      setOpenState(newState);
+    },
+    [onOpenChange, setOpenState],
+  );
 
   // update active option based on change in open state
   React.useEffect(() => {

--- a/packages/react-components/react-combobox/src/utils/useSelection.ts
+++ b/packages/react-components/react-combobox/src/utils/useSelection.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useControllableState } from '@fluentui/react-utilities';
 import { OptionValue } from './OptionCollection.types';
 import { SelectionEvents, SelectionProps, SelectionState } from './Selection.types';
@@ -11,30 +12,33 @@ export const useSelection = (props: SelectionProps): SelectionState => {
     initialState: [],
   });
 
-  const selectOption = (event: SelectionEvents, option: OptionValue) => {
-    // if the option is disabled, do nothing
-    if (option.disabled) {
-      return;
-    }
-
-    // for single-select, always return the selected option
-    let newSelection = [option.value];
-
-    // toggle selected state of the option for multiselect
-    if (multiselect) {
-      const selectedIndex = selectedOptions.findIndex(o => o === option.value);
-      if (selectedIndex > -1) {
-        // deselect option
-        newSelection = [...selectedOptions.slice(0, selectedIndex), ...selectedOptions.slice(selectedIndex + 1)];
-      } else {
-        // select option
-        newSelection = [...selectedOptions, option.value];
+  const selectOption = useCallback(
+    (event: SelectionEvents, option: OptionValue) => {
+      // if the option is disabled, do nothing
+      if (option.disabled) {
+        return;
       }
-    }
 
-    setSelectedOptions(newSelection);
-    onOptionSelect?.(event, { optionValue: option.value, optionText: option.text, selectedOptions: newSelection });
-  };
+      // for single-select, always return the selected option
+      let newSelection = [option.value];
+
+      // toggle selected state of the option for multiselect
+      if (multiselect) {
+        const selectedIndex = selectedOptions.findIndex(o => o === option.value);
+        if (selectedIndex > -1) {
+          // deselect option
+          newSelection = [...selectedOptions.slice(0, selectedIndex), ...selectedOptions.slice(selectedIndex + 1)];
+        } else {
+          // select option
+          newSelection = [...selectedOptions, option.value];
+        }
+      }
+
+      setSelectedOptions(newSelection);
+      onOptionSelect?.(event, { optionValue: option.value, optionText: option.text, selectedOptions: newSelection });
+    },
+    [onOptionSelect, multiselect, selectedOptions, setSelectedOptions],
+  );
 
   const clearSelection = (event: SelectionEvents) => {
     setSelectedOptions([]);


### PR DESCRIPTION
Addresses perf bullets from #26069

## Changes

- In `useCombobox`, `popupWidth` created a new object assigned to `listbox.style` every render. Now the object is created in the `useState` hook, and only updated when opened/closed.
- In `useTriggerListboxSlots`, listbox event handlers every render. Now it uses `useEventCallback`, and should only update on open/close.
- `selectOption` and `setOpen` were recreated every render, and since they are used in the combobox context, they caused options to re-render. Now they use `useCallback`.