### PR TITLE
fix: Minimum visible overflow items should be respected

### DIFF
--- a/change/@fluentui-priority-overflow-a6c512bd-b2fc-4a49-8821-e3dcb2b2e162.json
+++ b/change/@fluentui-priority-overflow-a6c512bd-b2fc-4a49-8821-e3dcb2b2e162.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Minimum visible overflow items should be respected",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-1516fc28-9fa1-46ea-93e4-385e94dcb66c.json
+++ b/change/@fluentui-react-overflow-1516fc28-9fa1-46ea-93e4-385e94dcb66c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add tests for fix",
+  "packageName": "@fluentui/react-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -135,19 +135,25 @@ export function createOverflowManager(): OverflowManager {
       return sum + getOffsetSize(child);
     }, 0);
 
-    // Add items until available width is filled
+    // Add items until available width is filled - can result in overflow
     while (currentWidth < availableSize && invisibleItemQueue.size() > 0) {
       currentWidth += makeItemVisible();
     }
-    // Remove items until there's no more overlap
+
+    // Remove items until there's no more overflow
     while (currentWidth > availableSize && visibleItemQueue.size() > 0) {
-      if (visibleItemQueue.size() === options.minimumVisible) {
+      if (visibleItemQueue.size() <= options.minimumVisible) {
         break;
       }
       currentWidth -= makeItemInvisible();
     }
 
-    if (invisibleItemQueue.size() > 0 && currentWidth + overflowMenuOffset > availableSize) {
+    // make sure the overflow menu can fit
+    if (
+      visibleItemQueue.size() > options.minimumVisible &&
+      invisibleItemQueue.size() > 0 &&
+      currentWidth + overflowMenuOffset > availableSize
+    ) {
       makeItemInvisible();
     }
 

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -434,4 +434,22 @@ describe('Overflow', () => {
     setContainerSize(500);
     cy.get(`[${selectors.menu}]`).should('not.exist');
   });
+
+  it('should start overflowing once minimum visible items is reached', () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(
+      <Container minimumVisible={5}>
+        {mapHelper.map(i => (
+          <Item key={i} id={i.toString()}>
+            {i}
+          </Item>
+        ))}
+        <Menu />
+      </Container>,
+    );
+
+    setContainerSize(195);
+    cy.get(`[${selectors.menu}]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
+  });
 });


### PR DESCRIPTION
This fixes a regression from #25091, the updated mechanism to handle overflow menu was inadvertedly breaking the minumum visible options because it was still making items invisible without considering whether the minimum number of items was reached.
