### PR TITLE
fix: use unknown instead of any

### DIFF
--- a/change/@fluentui-react-table-7101d4bd-9432-48ee-b768-fe717976aae5.json
+++ b/change/@fluentui-react-table-7101d4bd-9432-48ee-b768-fe717976aae5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use \"unknown\" instead of \"any\"",
+  "packageName": "@fluentui/react-table",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -20,7 +20,7 @@ import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public (undocumented)
-export type CellRenderFunction = (column: ColumnDefinition<any>) => React_2.ReactNode;
+export type CellRenderFunction = (column: ColumnDefinition<unknown>) => React_2.ReactNode;
 
 // @public (undocumented)
 export interface ColumnDefinition<TItem> {
@@ -161,7 +161,7 @@ export type DataGridRowSlots = TableRowSlots & {
 // @public
 export type DataGridRowState = TableRowState & ComponentState<DataGridRowSlots> & {
     renderCell: CellRenderFunction;
-    columnDefs: ColumnDefinition<any>[];
+    columnDefs: ColumnDefinition<unknown>[];
 };
 
 // @public

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
@@ -18,10 +18,9 @@ export type DataGridContextValues = TableContextValues & {
   dataGrid: DataGridContextValue;
 };
 
-// Use any here since we can't know the user types
+// Use unknown here since we can't know the user types
 // The user is responsible for narrowing the type downstream
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type DataGridContextValue = HeadlessTableState<any> & {
+export type DataGridContextValue = HeadlessTableState<unknown> & {
   /**
    * How focus navigation will work in the datagrid
    * @default cell

--- a/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridBody/DataGridBody.types.ts
@@ -4,10 +4,9 @@ import type { TableBodySlots, TableBodyProps, TableBodyState } from '../TableBod
 
 export type DataGridBodySlots = TableBodySlots;
 
-// Use any here since we can't know the user types
+// Use unknown here since we can't know the user types
 // The user is responsible for narrowing the type downstream
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RowRenderFunction<TItem = any> = (row: RowState<TItem>) => React.ReactNode;
+export type RowRenderFunction<TItem = unknown> = (row: RowState<TItem>) => React.ReactNode;
 
 /**
  * DataGridBody Props
@@ -23,8 +22,7 @@ export type DataGridBodyProps = Omit<TableBodyProps, 'children'> & {
  * State used in rendering DataGridBody
  */
 export type DataGridBodyState = TableBodyState & {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rows: RowState<any>[];
+  rows: RowState<unknown>[];
 
   renderRow: RowRenderFunction;
 };

--- a/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridRow/DataGridRow.types.ts
@@ -12,10 +12,9 @@ export type DataGridRowSlots = TableRowSlots & {
   selectionCell?: Slot<typeof TableSelectionCell>;
 };
 
-// Use any here since we can't know the user types
+// Use unknown here since we can't know the user types
 // The user is responsible for narrowing the type downstream
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type CellRenderFunction = (column: ColumnDefinition<any>) => React.ReactNode;
+export type CellRenderFunction = (column: ColumnDefinition<unknown>) => React.ReactNode;
 
 /**
  * DataGridRow Props
@@ -31,6 +30,5 @@ export type DataGridRowProps = Omit<TableRowProps, 'children'> &
 export type DataGridRowState = TableRowState &
   ComponentState<DataGridRowSlots> & {
     renderCell: CellRenderFunction;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    columnDefs: ColumnDefinition<any>[];
+    columnDefs: ColumnDefinition<unknown>[];
   };


### PR DESCRIPTION
`unkdown` requires type cast to be used, `any` allows anything.
