### PR TITLE
fix: remove Event type in selectionManager

### DIFF
--- a/change/@fluentui-react-table-2f6ac7ff-0a0f-4fcf-8515-64378641f5c3.json
+++ b/change/@fluentui-react-table-2f6ac7ff-0a0f-4fcf-8515-64378641f5c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove Event type in selectionManager",
+  "packageName": "@fluentui/react-table",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/selectionManager.ts
+++ b/packages/react-components/react-table/src/hooks/selectionManager.ts
@@ -1,19 +1,15 @@
 import * as React from 'react';
 import { SelectionMode } from './types';
 
-type OnSelectionChangeCallback = (e: React.SyntheticEvent | Event, selectedItems: Set<SelectionItemId>) => void;
+type OnSelectionChangeCallback = (e: React.SyntheticEvent, selectedItems: Set<SelectionItemId>) => void;
 
 export interface SelectionManager {
-  toggleItem(e: React.SyntheticEvent | Event, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
-  selectItem(e: React.SyntheticEvent | Event, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
-  deselectItem(e: React.SyntheticEvent | Event, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
-  clearItems(e: React.SyntheticEvent | Event): void;
+  toggleItem(e: React.SyntheticEvent, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  selectItem(e: React.SyntheticEvent, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  deselectItem(e: React.SyntheticEvent, id: SelectionItemId, selectedItems: Set<SelectionItemId>): void;
+  clearItems(e: React.SyntheticEvent): void;
   isSelected(id: SelectionItemId, selectedItems: Set<SelectionItemId>): boolean;
-  toggleAllItems(
-    e: React.SyntheticEvent | Event,
-    itemIds: SelectionItemId[],
-    selectedItems: Set<SelectionItemId>,
-  ): void;
+  toggleAllItems(e: React.SyntheticEvent, itemIds: SelectionItemId[], selectedItems: Set<SelectionItemId>): void;
 }
 
 export type SelectionItemId = string | number;


### PR DESCRIPTION
`Event` is redundant there as only React's event could be there.