### PR TITLE
fix(scripts): make lint errors reporting propagate to STDOUT during pre-commit (lint-staged exec)

### DIFF
--- a/change/@fluentui-eslint-plugin-700c8d6f-1dc3-46ac-a416-d4aded1a6256.json
+++ b/change/@fluentui-eslint-plugin-700c8d6f-1dc3-46ac-a416-d4aded1a6256.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add cypress.config to config files glob to fix linting",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -22,6 +22,7 @@ const docsFiles = ['**/*Page.tsx', '**/{docs,demo}/**', '**/*.doc.{ts,tsx}'];
 
 const configFiles = [
   './just.config.ts',
+  './cypress.config.ts',
   './gulpfile.ts',
   './*.js',
   './.*.js',

--- a/scripts/lint-staged/eslint-for-package.js
+++ b/scripts/lint-staged/eslint-for-package.js
@@ -1,9 +1,10 @@
 // @ts-check
 
-const micromatch = require('micromatch');
-const fs = require('fs-extra');
 const path = require('path');
 const { ESLint } = require('eslint');
+const fs = require('fs-extra');
+const micromatch = require('micromatch');
+
 const { eslintConstants } = require('../monorepo');
 
 /**
@@ -57,18 +58,19 @@ async function run() {
 
   // Lint files then fix all auto-fixable issues
   const results = await eslint.lintFiles(filteredFiles);
+
   await ESLint.outputFixes(results);
 
   // Format results
   const formatter = await eslint.loadFormatter();
   const resultText = formatter.format(results);
   if (resultText) {
-    console.error(resultText);
-    process.exit(1);
+    throw new Error(resultText);
   }
 }
 
 run().catch(err => {
-  console.log(err);
-  process.exit(1);
+  // logging is handled by ./eslint.js. If you wanna directly call this script and see errors uncomment following line ↓
+  // console.error(err);
+  throw new Error(err);
 });

--- a/scripts/lint-staged/eslint.js
+++ b/scripts/lint-staged/eslint.js
@@ -1,10 +1,11 @@
 // @ts-check
 
+// eslint-disable-next-line @typescript-eslint/naming-convention, camelcase
+const child_process = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { promisify } = require('util');
-const child_process = require('child_process');
 const { rollup: lernaAliases } = require('lerna-alias');
 const { default: PQueue } = require('p-queue');
 const exec = promisify(child_process.exec);
@@ -66,11 +67,14 @@ async function runEslintOnFilesGroupedPerPackage() {
 
   await queue.addAll(
     Object.entries(filesGroupedByPackage).map(([packagePath, files]) => async () => {
+      const cmd = `node ${eslintForPackageScript} ${files.join(' ')}`;
+
       // This script handles running eslint on ONLY the appropriate files for each package.
       // See its comments for more details.
-      return exec(`node ${eslintForPackageScript} ${files.join(' ')}`, { cwd: packagePath }).catch(() => {
+      return exec(cmd, { cwd: packagePath }).catch((/** @type {{ stdout: string, stderr: string }} */ err) => {
         // The subprocess should already have handled logging. Just mark that there was an error.
         hasError = true;
+        throw new Error(err.stderr);
       });
     }),
   );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

- if linting fails on pre-commit any eslint error stdout is consumed by subprocess and nothing is printed to user besides `FAILURE`
- if you touched/created `cypress.config.ts` within your package/pr pre-commit linting will fail on `import/no-extraneous-dependencies` rule violation.

## New Behavior

- linting failures during pre-commit are propagated to STDOUT thus reported by eslint 
- if you touched/created `cypress.config.ts` within your package/pr pre-commit linting will pass (cypress.config.ts is now part of devdependecy globs for import rule configuration)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

