### PR TITLE
BREAKING(TableCellLayout): `wrapper` slot renamed to `content`

### DIFF
--- a/change/@fluentui-react-table-b7b4e350-1297-4672-9a9d-88072c4990fa.json
+++ b/change/@fluentui-react-table-b7b4e350-1297-4672-9a9d-88072c4990fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "BREAKING(TableCellLayout): `wrapper` slot renamed to `content`",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -329,7 +329,7 @@ export type TableCellLayoutSlots = {
     media: Slot<'span'>;
     main: Slot<'span'>;
     description: Slot<'span'>;
-    wrapper: Slot<'div'>;
+    content: Slot<'div'>;
 };
 
 // @public

--- a/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
@@ -29,7 +29,7 @@ export type TableCellLayoutSlots = {
   /**
    * A layout wrapper for the main and description slots
    */
-  wrapper: Slot<'div'>;
+  content: Slot<'div'>;
 };
 
 /**

--- a/packages/react-components/react-table/src/components/TableCellLayout/__snapshots__/TableCellLayout.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/TableCellLayout/__snapshots__/TableCellLayout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TableCellLayout renders a default state 1`] = `
     class="fui-TableCellLayout"
   >
     <div
-      class="fui-TableCellLayout__wrapper"
+      class="fui-TableCellLayout__content"
     >
       <span
         class="fui-TableCellLayout__main"

--- a/packages/react-components/react-table/src/components/TableCellLayout/renderTableCellLayout.tsx
+++ b/packages/react-components/react-table/src/components/TableCellLayout/renderTableCellLayout.tsx
@@ -19,11 +19,11 @@ export const renderTableCellLayout_unstable = (
           <slots.media {...slotProps.media} />
         </AvatarContextProvider>
       )}
-      {slots.wrapper && (
-        <slots.wrapper {...slotProps.wrapper}>
+      {slots.content && (
+        <slots.content {...slotProps.content}>
           {slots.main && <slots.main {...slotProps.main}>{slotProps.root.children}</slots.main>}
           {slots.description && <slots.description {...slotProps.description} />}
-        </slots.wrapper>
+        </slots.content>
       )}
     </slots.root>
   );

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
@@ -29,7 +29,7 @@ export const useTableCellLayout_unstable = (
       root: 'div',
       main: 'span',
       description: 'span',
-      wrapper: 'div',
+      content: 'div',
       media: 'span',
     },
     root: getNativeElementProps('div', { ref, ...props }),
@@ -37,7 +37,7 @@ export const useTableCellLayout_unstable = (
     main: resolveShorthand(props.main, { required: true }),
     media: resolveShorthand(props.media),
     description: resolveShorthand(props.description),
-    wrapper: resolveShorthand(props.wrapper, { required: !!props.description || !!props.children }),
+    content: resolveShorthand(props.content, { required: !!props.description || !!props.children }),
     avatarSize: tableAvatarSizeMap[size],
     size,
   };

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
@@ -9,7 +9,7 @@ export const tableCellLayoutClassNames: SlotClassNames<TableCellLayoutSlots> = {
   media: 'fui-TableCellLayout__media',
   main: 'fui-TableCellLayout__main',
   description: 'fui-TableCellLayout__description',
-  wrapper: 'fui-TableCellLayout__wrapper',
+  content: 'fui-TableCellLayout__content',
 };
 
 /**
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
     ...shorthands.gap(tokens.spacingHorizontalS),
     ...shorthands.flex(1, 1, '0px'),
   },
-  wrapper: {
+  content: {
     display: 'flex',
     flexDirection: 'column',
   },
@@ -94,8 +94,8 @@ export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): 
     );
   }
 
-  if (state.wrapper) {
-    state.wrapper.className = mergeClasses(tableCellLayoutClassNames.wrapper, styles.wrapper, state.wrapper.className);
+  if (state.content) {
+    state.content.className = mergeClasses(tableCellLayoutClassNames.content, styles.content, state.content.className);
   }
 
   return state;


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

### Before
```tsx
<TableCellLayout wrapper={{ className: 'wrapperSlot' }}>
  <Component />
</TableCellLayout>
```

### After

```tsx
<TableCellLayout content={{ className: 'contentSlot' }}>
  <Component />
</TableCellLayout>
```

Fixes #26203