### PR TITLE
Fix: Allow root slot refs to merge with focus refs in Slider

### DIFF
--- a/change/@fluentui-react-slider-2f917409-4eb9-4200-a537-14c6a2e11be2.json
+++ b/change/@fluentui-react-slider-2f917409-4eb9-4200-a537-14c6a2e11be2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: allow refs passed in root slot to merge with focus refs",
+  "packageName": "@fluentui/react-slider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSlider.ts
@@ -34,9 +34,7 @@ export const useSlider_unstable = (props: SliderProps, ref: React.Ref<HTMLInputE
     },
     root: resolveShorthand(root, {
       required: true,
-      defaultProps: {
-        ...nativeProps.root,
-      },
+      defaultProps: nativeProps.root,
     }),
     input: resolveShorthand(input, {
       required: true,

--- a/packages/react-components/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSlider.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getPartitionedNativeProps, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, resolveShorthand, useId, useMergedRefs } from '@fluentui/react-utilities';
 import { useSliderState_unstable } from './useSliderState';
 import { SliderProps, SliderState } from './Slider.types';
 import { useFocusWithin } from '@fluentui/react-tabster';
@@ -35,7 +35,6 @@ export const useSlider_unstable = (props: SliderProps, ref: React.Ref<HTMLInputE
     root: resolveShorthand(root, {
       required: true,
       defaultProps: {
-        ref: useFocusWithin<HTMLDivElement>(),
         ...nativeProps.root,
       },
     }),
@@ -52,6 +51,8 @@ export const useSlider_unstable = (props: SliderProps, ref: React.Ref<HTMLInputE
     rail: resolveShorthand(rail, { required: true }),
     thumb: resolveShorthand(thumb, { required: true }),
   };
+
+  state.root.ref = useMergedRefs(state.root.ref, useFocusWithin<HTMLDivElement>());
 
   useSliderState_unstable(state, props);
 


### PR DESCRIPTION
without merging refs, the user provided ref will override the default ref

https://codesandbox.io/s/component-focus-when-ref-is-set-8o77uy?file=/example.tsx


This is a fix for Slider only, but we'll need to make this change on probably any component that uses useFocusWithin