### PR TITLE
fix: add aria-owns to react-combobox non-inline popups

### DIFF
--- a/change/@fluentui-react-combobox-9ad3f5bc-8c19-4f73-a4b3-1cd41e43e7b2.json
+++ b/change/@fluentui-react-combobox-9ad3f5bc-8c19-4f73-a4b3-1cd41e43e7b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: add aria-owns to combobox and dropdown\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -145,7 +145,7 @@ describe('Combobox', () => {
       </Combobox>,
     );
     const listboxId = getByRole('listbox').id;
-    expect(container.querySelector('.root')?.getAttribute('aria-owns')).toEqual(listboxId);\
+    expect(container.querySelector('.root')?.getAttribute('aria-owns')).toEqual(listboxId);
   });
 
   /* open/close tests */

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -136,6 +136,18 @@ describe('Combobox', () => {
     expect(chevronButton?.getAttribute('aria-labelledby')).toEqual('testId');
   });
 
+  it('adds aria-owns pointing to the popup', () => {
+    const { getByRole, container } = render(
+      <Combobox open className="root">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+    const listboxId = getByRole('listbox').id;
+    expect(container.querySelector('.root')?.getAttribute('aria-owns')).toEqual(listboxId);\
+  });
+
   /* open/close tests */
   it('opens the popup on click', () => {
     const { getByRole } = render(

--- a/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Combobox renders an open listbox 1`] = `
     class="fui-Combobox"
   >
     <input
-      aria-activedescendant="fluent-option11"
+      aria-activedescendant="fluent-option21"
       aria-expanded="true"
       class="fui-Combobox__input"
       role="combobox"
@@ -73,14 +73,14 @@ exports[`Combobox renders an open listbox 1`] = `
     </span>
     <div
       class="fui-Listbox fui-Combobox__listbox"
-      id="fluent-listbox10"
+      id="fluent-listbox20"
       role="listbox"
       style="position: fixed; left: 0px; top: 0px; margin: 0px; width: 0px;"
     >
       <div
         aria-selected="false"
         class="fui-Option"
-        id="fluent-option11"
+        id="fluent-option21"
         role="option"
       >
         <span
@@ -107,7 +107,7 @@ exports[`Combobox renders an open listbox 1`] = `
       <div
         aria-selected="false"
         class="fui-Option"
-        id="fluent-option12"
+        id="fluent-option22"
         role="option"
       >
         <span
@@ -134,7 +134,7 @@ exports[`Combobox renders an open listbox 1`] = `
       <div
         aria-selected="false"
         class="fui-Option"
-        id="fluent-option13"
+        id="fluent-option23"
         role="option"
       >
         <span

--- a/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`Combobox renders an open listbox 1`] = `
     </span>
     <div
       class="fui-Listbox fui-Combobox__listbox"
+      id="fluent-listbox10"
       role="listbox"
       style="position: fixed; left: 0px; top: 0px; margin: 0px; width: 0px;"
     >

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -44,7 +44,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     setValue,
     value,
   } = baseState;
-  const { disabled, freeform, multiselect } = props;
+  const { disabled, freeform, inlinePopup, multiselect } = props;
   const comboId = useId('combobox-');
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
@@ -194,6 +194,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     root: resolveShorthand(props.root, {
       required: true,
       defaultProps: {
+        'aria-owns': !inlinePopup ? listboxSlot?.id : undefined,
         ...rootNativeProps,
       },
     }),

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -68,6 +68,19 @@ describe('Dropdown', () => {
     expect(container.querySelector('[role=listbox]')).not.toBeNull();
   });
 
+  it('adds aria-owns pointing to the popup', () => {
+    const { getByRole, container } = render(
+      <Dropdown open className="root">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    const listboxId = getByRole('listbox').id;
+    expect(container.querySelector('.root')?.getAttribute('aria-owns')).toEqual(listboxId);
+  });
+
   /* open/close tests */
   it('opens the popup on click', () => {
     const { getByRole } = render(

--- a/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Dropdown renders an open listbox 1`] = `
     class="fui-Dropdown"
   >
     <button
-      aria-activedescendant="fluent-option1"
+      aria-activedescendant="fluent-option11"
       aria-expanded="true"
       class="fui-Dropdown__button"
       role="combobox"
@@ -67,13 +67,14 @@ exports[`Dropdown renders an open listbox 1`] = `
     </button>
     <div
       class="fui-Listbox fui-Dropdown__listbox"
+      id="fluent-listbox10"
       role="listbox"
       style="position: fixed; left: 0px; top: 0px; margin: 0px; width: 0px;"
     >
       <div
         aria-selected="false"
         class="fui-Option"
-        id="fluent-option1"
+        id="fluent-option11"
         role="option"
       >
         <span
@@ -100,7 +101,7 @@ exports[`Dropdown renders an open listbox 1`] = `
       <div
         aria-selected="false"
         class="fui-Option"
-        id="fluent-option2"
+        id="fluent-option12"
         role="option"
       >
         <span
@@ -127,7 +128,7 @@ exports[`Dropdown renders an open listbox 1`] = `
       <div
         aria-selected="false"
         class="fui-Option"
-        id="fluent-option3"
+        id="fluent-option13"
         role="option"
       >
         <span

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -146,6 +146,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
     root: resolveShorthand(props.root, {
       required: true,
       defaultProps: {
+        'aria-owns': !props.inlinePopup ? listboxSlot?.id : undefined,
         children: props.children,
         ...rootNativeProps,
       },

--- a/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mergeCallbacks, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
+import { mergeCallbacks, useId, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import type { ExtractSlotProps, Slot } from '@fluentui/react-utilities';
 import { getDropdownActionFromKey, getIndexFromAction } from '../utils/dropdownKeyActions';
 import { Listbox } from '../components/Listbox/Listbox';
@@ -54,7 +54,9 @@ export function useTriggerListboxSlots(
   const triggerRef: typeof ref = React.useRef(null);
 
   // resolve listbox shorthand props
+  const listboxId = useId('fluent-listbox', listboxSlot?.id);
   const listbox: typeof listboxSlot = listboxSlot && {
+    id: listboxId,
     multiselect,
     tabIndex: undefined,
     ...listboxSlot,


### PR DESCRIPTION
## Previous Behavior

No `aria-owns`, so when the listbox popup is appended at the end of the DOM, it was not really reachable with virtual cursor/scan mode/swipe navigation

## New Behavior

`aria-owns` is added to the root node pointing at the listbox when the listbox is not inline (it's not needed with an inline popup, since then the listbox DOM is already adjacent to the trigger).

This works for every browser but Safari.

## Related Issue(s)

Part of work in #26069