### PR TITLE
perf: Don't render Checkbox icon when unchecked

### DIFF
--- a/change/@fluentui-react-checkbox-cba19a44-ae9e-485b-9089-6c7d0d4d8ce6.json
+++ b/change/@fluentui-react-checkbox-cba19a44-ae9e-485b-9089-6c7d0d4d8ce6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "perf: Don't render Checkbox icon when unchecked",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -13,7 +13,11 @@ exports[`Checkbox renders a custom indicator 1`] = `
     <div
       aria-hidden="true"
       class="fui-Checkbox__indicator"
-    />
+    >
+      <span
+        id="indicator"
+      />
+    </div>
     <label
       class="fui-Label fui-Checkbox__label"
       for="checkbox-1"

--- a/packages/react-components/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -13,11 +13,7 @@ exports[`Checkbox renders a custom indicator 1`] = `
     <div
       aria-hidden="true"
       class="fui-Checkbox__indicator"
-    >
-      <span
-        id="indicator"
-      />
-    </div>
+    />
     <label
       class="fui-Label fui-Checkbox__label"
       for="checkbox-1"
@@ -41,22 +37,7 @@ exports[`Checkbox renders a default state 1`] = `
     <div
       aria-hidden="true"
       class="fui-Checkbox__indicator"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        fill="currentColor"
-        height="12"
-        viewBox="0 0 12 12"
-        width="12"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
-          fill="currentColor"
-        />
-      </svg>
-    </div>
+    />
   </span>
 </div>
 `;
@@ -153,22 +134,7 @@ exports[`Checkbox renders with a label 1`] = `
     <div
       aria-hidden="true"
       class="fui-Checkbox__indicator"
-    >
-      <svg
-        aria-hidden="true"
-        class=""
-        fill="currentColor"
-        height="12"
-        viewBox="0 0 12 12"
-        width="12"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
-          fill="currentColor"
-        />
-      </svg>
-    </div>
+    />
     <label
       class="fui-Label fui-Checkbox__label"
       for="checkbox-1"

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -53,7 +53,7 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
     } else {
       checkmarkIcon = size === 'large' ? <Square16Filled /> : <Square12Filled />;
     }
-  } else {
+  } else if (checked) {
     checkmarkIcon = size === 'large' ? <Checkmark16Filled /> : <Checkmark12Filled />;
   }
 
@@ -102,13 +102,6 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
       },
     }),
   };
-
-  // Don't render the indicator's children (checkmark) when unchecked.
-  // Note that this is explicitly overriding any user-provided children, to maintain backwards compatibility
-  // with an earlier implementation that always hid the indicator icon via css when unchecked.
-  if (!checked && state.indicator) {
-    state.indicator.children = undefined;
-  }
 
   state.input.onChange = useEventCallback(ev => {
     const val = ev.currentTarget.indeterminate ? 'mixed' : ev.currentTarget.checked;

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -103,6 +103,13 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
     }),
   };
 
+  // Don't render the indicator's children (checkmark) when unchecked.
+  // Note that this is explicitly overriding any user-provided children, to maintain backwards compatibility
+  // with an earlier implementation that always hid the indicator icon via css when unchecked.
+  if (!checked && state.indicator) {
+    state.indicator.children = undefined;
+  }
+
   state.input.onChange = useEventCallback(ev => {
     const val = ev.currentTarget.indeterminate ? 'mixed' : ev.currentTarget.checked;
     onChange?.(ev, { checked: val });

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -33,11 +33,6 @@ const useInputBaseClassName = makeResetStyles({
   // This is done so that clicking on that "empty space" still toggles the checkbox.
   width: `calc(${indicatorSizeMedium} + 2 * ${tokens.spacingHorizontalS})`,
 
-  // When unchecked, hide the the checkmark icon (child of the indicator slot)
-  [`:not(:checked):not(:indeterminate) ~ .${checkboxClassNames.indicator} > *`]: {
-    opacity: 0,
-  },
-
   // Colors for the unchecked state
   ':enabled:not(:checked):not(:indeterminate)': {
     [`& ~ .${checkboxClassNames.label}`]: {

--- a/packages/react-components/react-table/src/components/TableSelectionCell/__snapshots__/TableSelectionCell.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/TableSelectionCell/__snapshots__/TableSelectionCell.test.tsx.snap
@@ -16,22 +16,7 @@ exports[`TableSelectionCell renders a default state 1`] = `
       <div
         aria-hidden="true"
         class="fui-Checkbox__indicator"
-      >
-        <svg
-          aria-hidden="true"
-          class=""
-          fill="currentColor"
-          height="12"
-          viewBox="0 0 12 12"
-          width="12"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.76 3.2c.3.29.32.76.04 1.06l-4.25 4.5a.75.75 0 01-1.08.02L2.22 6.53a.75.75 0 011.06-1.06l1.7 1.7L8.7 3.24a.75.75 0 011.06-.04z"
-            fill="currentColor"
-          />
-        </svg>
-      </div>
+      />
     </span>
   </td>
 </tr>


### PR DESCRIPTION
## Previous Behavior

Checkbox always renders its checkmark icon, even when unchecked. It uses a universal selector in css (`> *`) to target the checkmark and set its opacity to 0 when unchecked.

## New Behavior

Don't render the checkmark at all when unchecked, and remove the universal selector rule in CSS.

