### PR TITLE
Users/jes/menu layering bug

### DIFF
--- a/change/@fluentui-web-components-178171d1-0703-48ef-85dc-74bfd1bef5e2.json
+++ b/change/@fluentui-web-components-178171d1-0703-48ef-85dc-74bfd1bef5e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: layering zindex issue with sub menus",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -43,6 +43,7 @@ export const menuItemStyles: (context: ElementDefinitionContext, definition: Men
       cursor: pointer;
       border-radius: calc(${controlCornerRadius} * 1px);
       border: calc(${strokeWidth} * 1px) solid transparent;
+      position: relative;
     }
 
     :host(.indent-0) {
@@ -95,6 +96,7 @@ export const menuItemStyles: (context: ElementDefinitionContext, definition: Men
     :host(.expanded) {
       background: ${neutralFillStealthActive};
       color: ${neutralForegroundRest};
+      z-index: 2;
     }
 
     :host([disabled]) {

--- a/packages/web-components/src/menu/menu.stories.ts
+++ b/packages/web-components/src/menu/menu.stories.ts
@@ -12,7 +12,14 @@ const MenuTemplate = () => `
       Menu item 2
       <fluent-menu>
         <fluent-menu-item>Nested Menu item 2.1</fluent-menu-item>
-        <fluent-menu-item>Nested Menu item 2.2</fluent-menu-item>
+        <fluent-menu-item>
+          Nested Menu item 2.2
+          <fluent-menu>
+            <fluent-menu-item>Nested Menu item 2.2.1</fluent-menu-item>
+            <fluent-menu-item>Nested Menu item 2.2.2</fluent-menu-item>
+            <fluent-menu-item>Nested Menu item 2.2.3</fluent-menu-item>
+          </fluent-menu>
+        </fluent-menu-item>
         <fluent-menu-item>Nested Menu item 2.3</fluent-menu-item>
       </fluent-menu>
     </fluent-menu-item>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Sub menus would layer behind menu items.

Fix sets z-index for expanded menu items.

After Fix:
<img width="664" alt="Screenshot 2023-01-09 at 10 46 03 AM" src="https://user-images.githubusercontent.com/37851214/211385365-a582042f-ebaf-4778-8f4d-731f1d961ddd.png">

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #23771 
