### PR TITLE
Azure Theme: reduced spin button height to match TextField / DropDowns at 24px height

### DIFF
--- a/change/@fluentui-azure-themes-f2eeb068-7c57-433f-9da0-60afb1302fc4.json
+++ b/change/@fluentui-azure-themes-f2eeb068-7c57-433f-9da0-60afb1302fc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Spin button height fix for Azure theme. Reduced to 24px to match textfield / dropdown",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/styles/SpinButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/SpinButton.styles.ts
@@ -1,5 +1,6 @@
 import { ISpinButtonStyleProps, ISpinButtonStyles } from '@fluentui/react/lib/SpinButton';
 import { IStyleFunction } from '@fluentui/react/lib/Utilities';
+import * as StyleConstants from '../Constants';
 
 export const SpinButtonStyles: IStyleFunction<ISpinButtonStyleProps, ISpinButtonStyles> = (
   props: ISpinButtonStyleProps,
@@ -7,6 +8,13 @@ export const SpinButtonStyles: IStyleFunction<ISpinButtonStyleProps, ISpinButton
   const { theme } = props;
 
   return {
+    root: {
+      selectors: {
+        '>div': {
+          height: StyleConstants.inputControlHeight,
+        },
+      },
+    },
     input: {
       backgroundColor: theme.semanticColors.inputBackground,
       color: theme.semanticColors.inputText,

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -145,7 +145,7 @@ const Example = () => (
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>
-      <Label>Split button example</Label>
+      <Label>Spin button example</Label>
       <SpinButtonBasicExample />
     </Stack>
 

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -31,6 +31,7 @@ import { TeachingBubbleBasicExample } from '../components/TeachingBubble.stories
 import { MessageBarBasicExample } from '../components/messageBar.stories';
 import { TooltipBasicExample } from '../components/tooltip.stories';
 import { SliderBasicExample } from '../components/slider.stories';
+import { SpinButtonBasicExample } from '../components/SpinButton.stories';
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -141,6 +142,11 @@ const Example = () => (
       <TextField disabled value="disabled text" />
       <TextField placeholder="Hello" />
       <TextField errorMessage="Error message!" />
+    </Stack>
+
+    <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>
+      <Label>Split button example</Label>
+      <SpinButtonBasicExample />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>

--- a/packages/react-examples/src/azure-themes/stories/components/SpinButton.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/SpinButton.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { SpinButton, ISpinButtonStyles, Position, IIconProps } from '@fluentui/react';
+import { Stack, IStackTokens } from '@fluentui/react/lib/Stack';
+
+const stackTokens: IStackTokens = { childrenGap: 20 };
+// By default the field grows to fit available width. Constrain the width instead.
+const styles: Partial<ISpinButtonStyles> = { spinButtonWrapper: { width: 75 } };
+const iconProps: IIconProps = { iconName: 'IncreaseIndentLegacy' };
+export const SpinButtonBasicExample: React.FunctionComponent = () => {
+  return (
+    <Stack tokens={stackTokens}>
+      <SpinButton
+        label="Basic SpinButton"
+        defaultValue="0"
+        min={0}
+        max={100}
+        step={1}
+        incrementButtonAriaLabel="Increase value by 1"
+        decrementButtonAriaLabel="Decrease value by 1"
+        styles={styles}
+      />
+      <SpinButton
+        label="With label above"
+        labelPosition={Position.top}
+        defaultValue="0"
+        min={0}
+        max={100}
+        step={1}
+        incrementButtonAriaLabel="Increase value by 1"
+        decrementButtonAriaLabel="Decrease value by 1"
+        styles={styles}
+      />
+      <SpinButton
+        label="With icon"
+        iconProps={iconProps}
+        defaultValue="0"
+        min={0}
+        max={100}
+        step={1}
+        incrementButtonAriaLabel="Increase value by 1"
+        decrementButtonAriaLabel="Decrease value by 1"
+        styles={styles}
+      />
+      <SpinButton
+        label="Decimal SpinButton"
+        defaultValue="0"
+        min={0}
+        max={10}
+        step={0.1}
+        incrementButtonAriaLabel="Increase value by 0.1"
+        decrementButtonAriaLabel="Decrease value by 0.1"
+        styles={styles}
+      />
+      <SpinButton
+        label="Disabled SpinButton"
+        disabled={true}
+        defaultValue="25"
+        min={0}
+        max={100}
+        step={1}
+        incrementButtonAriaLabel="Increase value by 1"
+        decrementButtonAriaLabel="Decrease value by 1"
+        styles={styles}
+      />
+    </Stack>
+  );
+};


### PR DESCRIPTION
## Previous Behavior
Spin button height was set to default Fluent height. Per Azure Theme, we need higher density controls at 24px.
<img width="201" alt="image" src="https://user-images.githubusercontent.com/30805892/211399854-9f253ef9-1dc7-4785-98cb-280d75fee202.png">

## New Behavior
Spin button now set to same height as dropdowns and textfields, 24px. 
<img width="317" alt="image" src="https://user-images.githubusercontent.com/30805892/211400079-7b265339-19f7-4528-a829-8b74c1c7d329.png">

Light theme: 
<img width="213" alt="image" src="https://user-images.githubusercontent.com/30805892/211398955-6926fa04-8429-4877-8ac1-f88730d82a53.png">

dark theme
<img width="216" alt="image" src="https://user-images.githubusercontent.com/30805892/211398894-83fcfabc-fb0d-4ba4-bc59-cbf0369f9ca1.png">

high contrast light
<img width="198" alt="image" src="https://user-images.githubusercontent.com/30805892/211398806-10cc6103-5628-41de-b3a7-310e5c30f0b1.png">

high contrast dark
<img width="222" alt="image" src="https://user-images.githubusercontent.com/30805892/211398841-7cd4ca78-2533-454a-ba06-71ddf87e918d.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
