### PR TITLE
filetype updates for loop, clipchamp [v7]

### DIFF
--- a/change/@uifabric-file-type-icons-b593d41a-81cf-4f36-8446-6dd7997cffb5.json
+++ b/change/@uifabric-file-type-icons-b593d41a-81cf-4f36-8446-6dd7997cffb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update CDN information for filetype icons, new icons for loop and clipchamp.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/file-type-icons/README.md
+++ b/packages/file-type-icons/README.md
@@ -12,14 +12,14 @@ If you are using Fluent UI React components, you can make all file type icons av
 ```tsx
 import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
 
-// Register icons and pull the fonts from the default SharePoint cdn.
+// Register icons and pull the fonts from the default Microsoft Fluent CDN:
 initializeFileTypeIcons();
 
-// ...or, register icons and pull the fonts from your own cdn:
+// Or register icons and pull the fonts from a different CDN or folder path:
 initializeFileTypeIcons('https://my.cdn.com/path/to/icons/');
 ```
 
-**NOTE:** Do not use the `item-types-fluent` icon set that was previously uploaded to the Fabric CDN; it is deprecated.
+**NOTE:** Proceed carefully if you override the default CDN location, whose contents may not match the registered file type icons and supported extensions. Do not use the `item-types-fluent` icon set that was previously uploaded to the Fluent CDN; it's deprecated.
 
 ## Usage in code
 

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -256,6 +256,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   classifier: {
     extensions: ['classifier'],
   },
+  clipchamp: {
+    extensions: ['clipchamp'],
+  },
   csv: {
     extensions: ['csv'],
   },

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-export const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20221015.001/assets/item-types/';
+export const DEFAULT_BASE_URL = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230106.001/assets/item-types/';
 export const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
## Changes

* filetype icons package was using old CDN URL, updated to new 1 CDN and latest version.
* clarified readme for filetype icons package
* added registration for clipchamp filetype icon
* [x] Cherry-pick of #26276