### PR TITLE
Adds Fluent 2 styles for v8 SpinButton

### DIFF
--- a/change/@fluentui-fluent2-theme-943b3afc-4b98-42b7-ac96-c53550f16473.json
+++ b/change/@fluentui-fluent2-theme-943b3afc-4b98-42b7-ac96-c53550f16473.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding styles for SpinButton",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Button.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Button.styles.ts
@@ -1,4 +1,4 @@
-import { IButtonProps, IButtonStyles, IStyleFunctionOrObject, ITheme } from '@fluentui/react';
+import { IButtonProps, IButtonStyles, IStyle, IStyleFunctionOrObject, ITheme } from '@fluentui/react';
 import { concatStyleSets } from '@fluentui/react';
 
 type FocusStyleType = {
@@ -125,10 +125,31 @@ export function getIconButtonStyles(props: IButtonProps): IStyleFunctionOrObject
 }
 
 export function getDefaultButtonStyles(props: IButtonProps): IStyleFunctionOrObject<IButtonProps, IButtonStyles> {
-  const { theme, primary } = props;
+  const { theme, primary, split } = props;
 
   return concatStyleSets(
     getBaseButtonStyles(theme!),
     primary ? getPrimaryButtonStyles(theme!) : getStandardButtonStyles(theme!),
+    split && getSplitButtonStyles(theme!),
   );
+}
+
+const fluent2SplitButtonDividerStyles: IStyle = {
+  position: 'relative',
+  top: 'unset',
+  bottom: 'unset',
+};
+
+export function getSplitButtonStyles(theme: ITheme): Partial<IButtonStyles> {
+  const styles: Partial<IButtonStyles> = {
+    splitButtonMenuButton: {
+      borderRadius: 'unset',
+      borderTopRightRadius: theme?.effects.roundedCorner4,
+      borderBottomRightRadius: theme?.effects.roundedCorner4,
+    },
+    splitButtonDivider: fluent2SplitButtonDividerStyles,
+    splitButtonDividerDisabled: fluent2SplitButtonDividerStyles,
+  };
+
+  return styles;
 }


### PR DESCRIPTION
Adds Fluent 2 styles for v8 SpinButton to match v9 implementation
- Rounds right top and right bottom menu button corners.
- Extends vertical divider to top and bottom of button.

Fixes #26269 

![image](https://user-images.githubusercontent.com/17346018/211449925-0608dc48-992d-402c-a846-0dabb73652e3.png)

![image](https://user-images.githubusercontent.com/17346018/211449965-542b8396-2849-4f94-ad58-009ba3ef9cd9.png)


