### PR TITLE
ci: bump actions/checkout to v3 to fix node12 deprecation

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -38,7 +38,7 @@ jobs:
   dependency-mismatches:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
@@ -62,7 +62,7 @@ jobs:
   change-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

We use actions that run on node 12 which triggers warnings

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/1223799/211589431-4aeb0753-6404-444d-8421-50ac0692bb46.png">


## New Behavior

no warnings

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


