### PR TITLE
chore(react-tree): stops using aria-owns to organize tree

### DIFF
--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -33,9 +33,8 @@ export const Tree: ForwardRefComponent<TreeProps>;
 export const treeClassNames: SlotClassNames<TreeSlots>;
 
 // @public (undocumented)
-export type TreeContextValue = {
+export type TreeContextValue = Required<Pick<TreeProps, 'openItems'>> & {
     level: number;
-    openSubtrees: string[];
     appearance: 'subtle' | 'subtle-alpha' | 'transparent';
     size: 'small' | 'medium';
     focusFirstSubtreeItem(target: HTMLElement): void;
@@ -75,9 +74,10 @@ export type TreeItemProps = ComponentProps<Partial<TreeItemSlots>>;
 // @public (undocumented)
 export type TreeItemSlots = {
     root: Slot<'div'>;
+    content: NonNullable<Slot<'span'>>;
+    subtree?: Slot<'span'>;
     expandIcon?: Slot<'span'>;
     actions?: Slot<'span'>;
-    groupper: NonNullable<Slot<'span'>>;
 };
 
 // @public
@@ -90,8 +90,8 @@ export type TreeItemState = ComponentState<TreeItemSlots> & TreeItemContextValue
 export type TreeProps = ComponentProps<TreeSlots> & {
     appearance?: 'subtle' | 'subtle-alpha' | 'transparent';
     size?: 'small' | 'medium';
-    openSubtrees?: string | string[];
-    defaultOpenSubtrees?: string | string[];
+    openItems?: string | string[];
+    defaultOpenItems?: string | string[];
     onOpenChange?(event: TreeOpenChangeEvent, data: TreeOpenChangeData): void;
 };
 
@@ -104,9 +104,7 @@ export type TreeSlots = {
 };
 
 // @public
-export type TreeState = ComponentState<TreeSlots> & TreeContextValue & {
-    open: boolean;
-};
+export type TreeState = ComponentState<TreeSlots> & TreeContextValue;
 
 // @public
 export const useTree_unstable: (props: TreeProps, ref: React_2.Ref<HTMLElement>) => TreeState;

--- a/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
@@ -6,7 +6,7 @@ export type TreeSlots = {
   root: Slot<'div'>;
 };
 
-export type TreeOpenChangeData = { open: boolean; id: string } & (
+export type TreeOpenChangeData = { open: boolean } & (
   | {
       event: React.MouseEvent<HTMLElement>;
       type: 'expandIconClick';
@@ -44,22 +44,23 @@ export type TreeProps = ComponentProps<TreeSlots> & {
    * @default 'subtle'
    */
   appearance?: 'subtle' | 'subtle-alpha' | 'transparent';
-
   /**
    * Size of the tree item.
    * @default 'medium'
    */
   size?: 'small' | 'medium';
   /**
-   * Controls the state of the open subtrees.
+   * This refers to a list of ids of opened tree items.
+   * Controls the state of the open tree items.
    * These property is ignored for subtrees.
    */
-  openSubtrees?: string | string[];
+  openItems?: string | string[];
   /**
-   * Default value for the uncontrolled state of open subtrees.
+   * This refers to a list of ids of opened tree items.
+   * Default value for the uncontrolled state of open tree items.
    * These property is ignored for subtrees.
    */
-  defaultOpenSubtrees?: string | string[];
+  defaultOpenItems?: string | string[];
   /**
    * Callback fired when the component changes value from open state.
    * These property is ignored for subtrees.
@@ -75,7 +76,4 @@ export type TreeProps = ComponentProps<TreeSlots> & {
 /**
  * State used in rendering Tree
  */
-export type TreeState = ComponentState<TreeSlots> &
-  TreeContextValue & {
-    open: boolean;
-  };
+export type TreeState = ComponentState<TreeSlots> & TreeContextValue;

--- a/packages/react-components/react-tree/src/components/Tree/renderTree.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/renderTree.tsx
@@ -4,12 +4,11 @@ import type { TreeState, TreeSlots, TreeContextValues } from './Tree.types';
 import { TreeProvider } from '../../contexts';
 
 export const renderTree_unstable = (state: TreeState, contextValues: TreeContextValues) => {
-  const { open } = state;
   const { slots, slotProps } = getSlots<TreeSlots>(state);
 
   return (
     <TreeProvider value={contextValues.tree}>
-      {open && <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>}
+      <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>
     </TreeProvider>
   );
 };

--- a/packages/react-components/react-tree/src/components/Tree/useTreeContextValues.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTreeContextValues.ts
@@ -2,15 +2,7 @@ import { TreeContextValue } from '../../contexts';
 import type { TreeContextValues, TreeState } from './Tree.types';
 
 export function useTreeContextValues_unstable(state: TreeState): TreeContextValues {
-  const {
-    openSubtrees,
-    level,
-    appearance,
-    size,
-    requestOpenChange,
-    focusFirstSubtreeItem,
-    focusSubtreeOwnerItem,
-  } = state;
+  const { openItems, level, appearance, size, requestOpenChange, focusFirstSubtreeItem, focusSubtreeOwnerItem } = state;
   /**
    * This context is created with "@fluentui/react-context-selector",
    * there is no sense to memoize it
@@ -19,7 +11,7 @@ export function useTreeContextValues_unstable(state: TreeState): TreeContextValu
     appearance,
     size,
     level,
-    openSubtrees,
+    openItems,
     requestOpenChange,
     focusFirstSubtreeItem,
     focusSubtreeOwnerItem,

--- a/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
@@ -3,6 +3,8 @@ import { TreeItemContextValue } from '../../contexts/treeItemContext';
 
 export type TreeItemSlots = {
   root: Slot<'div'>;
+  content: NonNullable<Slot<'span'>>;
+  subtree?: Slot<'span'>;
   /**
    * Expand icon slot,
    * by default renders a chevron icon to indicate opening and closing
@@ -13,7 +15,6 @@ export type TreeItemSlots = {
    * when the item is hovered/focused
    */
   actions?: Slot<'span'>;
-  groupper: NonNullable<Slot<'span'>>;
 };
 
 export type TreeItemContextValues = {

--- a/packages/react-components/react-tree/src/components/TreeItem/__snapshots__/TreeItem.test.tsx.snap
+++ b/packages/react-components/react-tree/src/components/TreeItem/__snapshots__/TreeItem.test.tsx.snap
@@ -2,20 +2,20 @@
 
 exports[`TreeItem renders a default state 1`] = `
 <div>
-  <span
-    class="fui-TreeItem__groupper"
-    data-tabster="{\\"groupper\\":{}}"
-    role="presentation"
+  <div
+    aria-level="0"
+    class="fui-TreeItem"
+    id="fui-TreeItem-7"
+    role="treeitem"
+    style="--fluent-TreeItem--level: -1;"
+    tabindex="0"
   >
-    <div
-      aria-level="0"
-      class="fui-TreeItem"
-      role="treeitem"
-      style="--fluent-TreeItem--level: -1;"
-      tabindex="0"
+    <span
+      class="fui-TreeItem__content"
+      data-tabster="{\\"groupper\\":{}}"
     >
       Default TreeItem
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;

--- a/packages/react-components/react-tree/src/components/TreeItem/renderTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/renderTreeItem.tsx
@@ -11,13 +11,14 @@ export const renderTreeItem_unstable = (state: TreeItemState, contextValues: Tre
 
   return (
     <TreeItemProvider value={contextValues.treeItem}>
-      <slots.groupper {...slotProps.groupper}>
-        <slots.root {...slotProps.root}>
+      <slots.root {...slotProps.root}>
+        <slots.content {...slotProps.content}>
           {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-          {slotProps.root.children}
+          {slotProps.content.children}
           {slots.actions && <slots.actions {...slotProps.actions} />}
-        </slots.root>
-      </slots.groupper>
+        </slots.content>
+        {slots.subtree && <slots.subtree {...slotProps.subtree} />}
+      </slots.root>
     </TreeItemProvider>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, isResolvedShorthand, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, isResolvedShorthand, resolveShorthand, useId } from '@fluentui/react-utilities';
 import { ChevronRight12Regular } from '@fluentui/react-icons';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { useEventCallback } from '@fluentui/react-utilities';
@@ -21,27 +21,31 @@ import { useTreeContext_unstable } from '../../contexts/index';
  * @param ref - reference to root HTMLElement of TreeItem
  */
 export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDivElement>): TreeItemState => {
-  const { 'aria-owns': ariaOwns, as = 'div', onClick, onKeyDown, ...rest } = props;
+  const { content, subtree, expandIcon, actions, as = 'div', onClick, onKeyDown, ...rest } = props;
   const level = useTreeContext_unstable(ctx => ctx.level);
   const requestOpenChange = useTreeContext_unstable(ctx => ctx.requestOpenChange);
   const focusFirstSubtreeItem = useTreeContext_unstable(ctx => ctx.focusFirstSubtreeItem);
   const focusSubtreeOwnerItem = useTreeContext_unstable(ctx => ctx.focusSubtreeOwnerItem);
 
-  const isBranch = typeof ariaOwns === 'string';
-  const { expandIcon, actions, groupper } = props;
-  const open = useTreeContext_unstable(ctx => isBranch && ctx.openSubtrees.includes(ariaOwns!));
+  const [children, subtreeChildren] = React.Children.toArray(props.children);
+
+  const isBranch = subtreeChildren !== undefined;
+  const id = useId('fui-TreeItem-', props.id);
+
+  const open = useTreeContext_unstable(ctx => isBranch && ctx.openItems.includes(id));
   const { dir, targetDocument } = useFluent_unstable();
   const expandIconRotation = open ? 90 : dir !== 'rtl' ? 0 : 180;
   const groupperProps = useFocusableGroup();
 
   const actionsRef = React.useRef<HTMLElement>(null);
+  const subtreeRef = React.useRef<HTMLElement>(null);
 
   const handleArrowRight = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (open && isBranch) {
       focusFirstSubtreeItem(event.currentTarget);
     }
     if (isBranch && !open) {
-      requestOpenChange({ event, open: true, type: 'arrowRight', id: ariaOwns! });
+      requestOpenChange({ event, open: true, type: 'arrowRight' });
     }
   };
   const handleArrowLeft = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -49,7 +53,7 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
       focusSubtreeOwnerItem(event.currentTarget);
     }
     if (isBranch && open) {
-      requestOpenChange({ event, open: false, type: 'arrowLeft', id: ariaOwns! });
+      requestOpenChange({ event, open: false, type: 'arrowLeft' });
     }
   };
   const handleEnter = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -58,7 +62,7 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
       return;
     }
     if (isBranch) {
-      requestOpenChange({ event, open: !open, type: 'enter', id: ariaOwns! });
+      requestOpenChange({ event, open: !open, type: 'enter' });
     }
   };
 
@@ -69,8 +73,9 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
       return;
     }
     if (isBranch) {
-      requestOpenChange({ event, open: !open, type: 'click', id: ariaOwns! });
+      requestOpenChange({ event, open: !open, type: 'click' });
     }
+    event.stopPropagation();
   });
 
   const handleKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -92,11 +97,17 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
   });
 
   const [isActionsVisible, setActionsVisible] = React.useState(false);
-  const showActions = useEventCallback(() => {
-    setActionsVisible(true);
+  const showActions = useEventCallback((event: React.SyntheticEvent) => {
+    const isInternalEvent = subtreeRef.current?.contains(event.target as Node) ?? false;
+    if (!isInternalEvent) {
+      setActionsVisible(true);
+    }
   });
-  const hideActions = useEventCallback(() => {
-    setActionsVisible(false);
+  const hideActions = useEventCallback((event: React.SyntheticEvent) => {
+    const isInternalEvent = subtreeRef.current?.contains(event.target as Node) ?? false;
+    if (!isInternalEvent) {
+      setActionsVisible(false);
+    }
   });
 
   // Listens to focusout event on the document to ensure treeitem actions visibility on portal scenarios
@@ -118,16 +129,32 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
     open,
     isActionsVisible: actions ? isActionsVisible : false,
     components: {
+      content: 'span',
       root: 'div',
       expandIcon: 'span',
       actions: 'span',
-      groupper: 'span',
+      subtree: 'span',
     },
+    subtree: resolveShorthand(subtree, {
+      required: Boolean(subtreeChildren && open),
+      defaultProps: {
+        children: subtreeChildren,
+        ref: useMergedRefs(subtreeRef, isResolvedShorthand(subtree) ? subtree.ref : undefined),
+      },
+    }),
+    content: resolveShorthand(content, {
+      required: true,
+      defaultProps: {
+        children,
+        ...groupperProps,
+      },
+    }),
     root: getNativeElementProps(as, {
       ...rest,
+      id,
       ref,
       tabIndex: 0,
-      'aria-owns': ariaOwns,
+      children: null,
       'aria-level': level,
       // FIXME: tabster fails to navigate when aria-expanded is true
       // 'aria-expanded': isBranch ? isOpen : undefined,
@@ -138,13 +165,6 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
       onFocus: actions ? showActions : undefined,
       onMouseOut: actions ? hideActions : undefined,
       onBlur: actions ? hideActions : undefined,
-    }),
-    groupper: resolveShorthand(groupper, {
-      required: true,
-      defaultProps: {
-        role: 'presentation',
-        ...groupperProps,
-      },
     }),
     expandIcon: resolveShorthand(expandIcon, {
       required: isBranch,

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemStyles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemStyles.ts
@@ -9,15 +9,16 @@ import { levelToken } from '../../utils/tokens';
 
 export const treeItemClassNames: SlotClassNames<TreeItemSlots> = {
   root: 'fui-TreeItem',
+  content: 'fui-TreeItem__content',
+  subtree: 'fui-TreeItem__subtree',
   expandIcon: 'fui-TreeItem__expandIcon',
   actions: 'fui-TreeItem__actions',
-  groupper: 'fui-TreeItem__groupper',
 };
 
 /**
- * Styles for the root slot
+ * Styles for the content slot
  */
-const useRootStyles = makeStyles({
+const useContentStyles = makeStyles({
   base: {
     position: 'relative',
     alignItems: 'center',
@@ -119,7 +120,7 @@ export const expandIconInlineStyles = {
  * Apply styling to the TreeItem slots based on the state
  */
 export const useTreeItemStyles_unstable = (state: TreeItemState): TreeItemState => {
-  const rootStyles = useRootStyles();
+  const contentStyles = useContentStyles();
   const expandIconStyles = useExpandIconStyles();
   const actionsStyles = useActionsStyles();
 
@@ -127,18 +128,18 @@ export const useTreeItemStyles_unstable = (state: TreeItemState): TreeItemState 
   const size = useTreeContext_unstable(ctx => ctx.size);
   const appearance = useTreeContext_unstable(ctx => ctx.appearance);
 
-  const { actions, expandIcon, isActionsVisible: showActions } = state;
+  const { actions, subtree, expandIcon, isActionsVisible: showActions } = state;
 
-  state.root.className = mergeClasses(
-    treeItemClassNames.root,
-    rootStyles.base,
-    rootStyles[appearance],
-    rootStyles.focusIndicator,
-    state.isLeaf && rootStyles.leaf,
-    state.root.className,
+  state.root.className = mergeClasses(treeItemClassNames.root, state.root.className);
+
+  state.content.className = mergeClasses(
+    treeItemClassNames.content,
+    contentStyles.base,
+    contentStyles[appearance],
+    contentStyles.focusIndicator,
+    state.isLeaf && contentStyles.leaf,
+    state.content.className,
   );
-
-  state.groupper.className = mergeClasses(treeItemClassNames.groupper, state.groupper.className);
 
   state.root.style = {
     ...state.root.style,
@@ -160,6 +161,9 @@ export const useTreeItemStyles_unstable = (state: TreeItemState): TreeItemState 
       showActions && actionsStyles.open,
       actions.className,
     );
+  }
+  if (subtree) {
+    subtree.className = mergeClasses(treeItemClassNames.subtree, subtree.className);
   }
 
   return state;

--- a/packages/react-components/react-tree/src/contexts/treeContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeContext.ts
@@ -1,9 +1,8 @@
 import { Context, ContextSelector, createContext, useContextSelector } from '@fluentui/react-context-selector';
-import { TreeOpenChangeData } from '../Tree';
+import { TreeOpenChangeData, TreeProps } from '../Tree';
 
-export type TreeContextValue = {
+export type TreeContextValue = Required<Pick<TreeProps, 'openItems'>> & {
   level: number;
-  openSubtrees: string[];
   appearance: 'subtle' | 'subtle-alpha' | 'transparent';
   size: 'small' | 'medium';
   focusFirstSubtreeItem(target: HTMLElement): void;
@@ -16,7 +15,7 @@ export type TreeContextValue = {
 
 const defaultContextValue: TreeContextValue = {
   level: 0,
-  openSubtrees: [],
+  openItems: [],
   focusFirstSubtreeItem() {
     /* noop */
   },

--- a/packages/react-components/react-tree/stories/Tree/TreeActions.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeActions.stories.tsx
@@ -27,33 +27,33 @@ const RenderActions = () => {
 
 export const Actions = () => (
   <Tree aria-label="Tree">
-    <TreeItem aria-owns="default-subtree-1" actions={<RenderActions />}>
+    <TreeItem actions={<RenderActions />}>
       level 1, item 1
-    </TreeItem>
-    <Tree id="default-subtree-1">
-      <TreeItem actions={<RenderActions />}>level 2, item 1</TreeItem>
-      <TreeItem actions={<RenderActions />}>level 2, item 2</TreeItem>
-      <TreeItem actions={<RenderActions />}>level 2, item 3</TreeItem>
-    </Tree>
-    <TreeItem aria-owns="default-subtree-2" actions={<RenderActions />}>
-      level 1, item 2
-    </TreeItem>
-    <Tree id="default-subtree-2">
-      <TreeItem aria-owns="default-subtree-2-1" actions={<RenderActions />}>
-        level 2, item 1
-      </TreeItem>
-      <Tree id="default-subtree-2-1">
-        <TreeItem actions={<RenderActions />}>level 3, item 1</TreeItem>
-      </Tree>
-
-      <TreeItem aria-owns="default-subtree-3" actions={<RenderActions />}>
-        level 1, item 1
-      </TreeItem>
-      <Tree id="default-subtree-3">
+      <Tree>
         <TreeItem actions={<RenderActions />}>level 2, item 1</TreeItem>
         <TreeItem actions={<RenderActions />}>level 2, item 2</TreeItem>
         <TreeItem actions={<RenderActions />}>level 2, item 3</TreeItem>
       </Tree>
-    </Tree>
+    </TreeItem>
+    <TreeItem actions={<RenderActions />}>
+      level 1, item 2
+      <Tree>
+        <TreeItem actions={<RenderActions />}>
+          level 2, item 1
+          <Tree>
+            <TreeItem actions={<RenderActions />}>level 3, item 1</TreeItem>
+          </Tree>
+        </TreeItem>
+
+        <TreeItem actions={<RenderActions />}>
+          level 1, item 1
+          <Tree>
+            <TreeItem actions={<RenderActions />}>level 2, item 1</TreeItem>
+            <TreeItem actions={<RenderActions />}>level 2, item 2</TreeItem>
+            <TreeItem actions={<RenderActions />}>level 2, item 3</TreeItem>
+          </Tree>
+        </TreeItem>
+      </Tree>
+    </TreeItem>
   </Tree>
 );

--- a/packages/react-components/react-tree/stories/Tree/TreeBadges.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeBadges.stories.tsx
@@ -19,47 +19,47 @@ const Actions = () => (
 
 export const Badges = () => (
   <Tree aria-label="Tree">
-    <TreeItem aria-owns="default-subtree-1" actions={<Actions />}>
-      <TreeItemLayout aside={<RenderBadges />}>level 1, item 1 with actions</TreeItemLayout>
-    </TreeItem>
-    <Tree id="default-subtree-1">
-      <TreeItem>
-        <TreeItemLayout aside={<RenderBadges />}>level 2, item 1</TreeItemLayout>
-      </TreeItem>
-      <TreeItem>
-        <TreeItemLayout aside={<RenderBadges />}>level 2, item 2</TreeItemLayout>
-      </TreeItem>
-      <TreeItem>
-        <TreeItemLayout aside={<RenderBadges />}>level 2, item 3</TreeItemLayout>
-      </TreeItem>
-    </Tree>
-    <TreeItem aria-owns="default-subtree-2">
-      <TreeItemLayout aside={<RenderBadges />}>level 1, item 2</TreeItemLayout>
-    </TreeItem>
-    <Tree id="default-subtree-2">
-      <TreeItem aria-owns="default-subtree-2-1">
-        <TreeItemLayout aside={<RenderBadges />}>level 2, item 1</TreeItemLayout>
-      </TreeItem>
-      <Tree id="default-subtree-2-1">
-        <TreeItem>
-          <TreeItemLayout aside={<RenderBadges />}>level 3, item 1</TreeItemLayout>
-        </TreeItem>
-      </Tree>
-
-      <TreeItem aria-owns="default-subtree-3">
-        <TreeItemLayout aside={<RenderBadges />}>level 1, item 1</TreeItemLayout>
-      </TreeItem>
-      <Tree id="default-subtree-3">
-        <TreeItem>
+    <TreeItem actions={<Actions />}>
+      <TreeItemLayout aside={<RenderBadges />}>level 1, item 1</TreeItemLayout>
+      <Tree>
+        <TreeItem actions={<Actions />}>
           <TreeItemLayout aside={<RenderBadges />}>level 2, item 1</TreeItemLayout>
         </TreeItem>
-        <TreeItem>
+        <TreeItem actions={<Actions />}>
           <TreeItemLayout aside={<RenderBadges />}>level 2, item 2</TreeItemLayout>
         </TreeItem>
-        <TreeItem>
+        <TreeItem actions={<Actions />}>
           <TreeItemLayout aside={<RenderBadges />}>level 2, item 3</TreeItemLayout>
         </TreeItem>
       </Tree>
-    </Tree>
+    </TreeItem>
+    <TreeItem actions={<Actions />}>
+      <TreeItemLayout aside={<RenderBadges />}>level 1, item 2</TreeItemLayout>
+      <Tree>
+        <TreeItem actions={<Actions />}>
+          <TreeItemLayout aside={<RenderBadges />}>level 2, item 1</TreeItemLayout>
+          <Tree>
+            <TreeItem actions={<Actions />}>
+              <TreeItemLayout aside={<RenderBadges />}>level 3, item 1</TreeItemLayout>
+            </TreeItem>
+          </Tree>
+        </TreeItem>
+
+        <TreeItem actions={<Actions />}>
+          <TreeItemLayout aside={<RenderBadges />}>level 2, item 2</TreeItemLayout>
+          <Tree>
+            <TreeItem actions={<Actions />}>
+              <TreeItemLayout aside={<RenderBadges />}>level 3, item 1</TreeItemLayout>
+            </TreeItem>
+            <TreeItem actions={<Actions />}>
+              <TreeItemLayout aside={<RenderBadges />}>level 3, item 2</TreeItemLayout>
+            </TreeItem>
+            <TreeItem actions={<Actions />}>
+              <TreeItemLayout aside={<RenderBadges />}>level 3, item 3</TreeItemLayout>
+            </TreeItem>
+          </Tree>
+        </TreeItem>
+      </Tree>
+    </TreeItem>
   </Tree>
 );

--- a/packages/react-components/react-tree/stories/Tree/TreeControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeControllingOpenAndClose.stories.tsx
@@ -3,25 +3,33 @@ import { Tree, TreeItem } from '@fluentui/react-tree';
 import { TreeOpenChangeData, TreeOpenChangeEvent } from '../../src/Tree';
 
 export const ControllingOpenAndClose = () => {
-  const [openSubtrees, setOpenSubtrees] = React.useState<string[]>([]);
+  const [openItems, setOpenItems] = React.useState<string[]>([]);
   const handleOpenChange = (event: TreeOpenChangeEvent, data: TreeOpenChangeData) => {
-    setOpenSubtrees(curr => (data.open ? [...curr, data.id] : curr.filter(id => id !== data.id)));
+    setOpenItems(curr =>
+      data.open ? [...curr, event.currentTarget.id] : curr.filter(id => id !== event.currentTarget.id),
+    );
   };
   return (
-    <Tree openSubtrees={openSubtrees} onOpenChange={handleOpenChange} aria-label="Tree">
-      <TreeItem aria-owns="controlling-open-close-subtree-1">level 1, item 1</TreeItem>
-      <Tree id="controlling-open-close-subtree-1">
-        <TreeItem>level 2, item 1</TreeItem>
-        <TreeItem>level 2, item 2</TreeItem>
-        <TreeItem>level 2, item 3</TreeItem>
-      </Tree>
-      <TreeItem aria-owns="controlling-open-close-subtree-2">level 1, item 2</TreeItem>
-      <Tree id="controlling-open-close-subtree-2">
-        <TreeItem aria-owns="controlling-open-close-subtree-2.1">level 2, item 1</TreeItem>
-        <Tree id="controlling-open-close-subtree-2.1">
-          <TreeItem>level 3, item 1</TreeItem>
+    <Tree aria-label="Tree" openItems={openItems} onOpenChange={handleOpenChange}>
+      <TreeItem id="tree-item-1">
+        level 1, item 1
+        <Tree>
+          <TreeItem>level 2, item 1</TreeItem>
+          <TreeItem>level 2, item 2</TreeItem>
+          <TreeItem>level 2, item 3</TreeItem>
         </Tree>
-      </Tree>
+      </TreeItem>
+      <TreeItem id="tree-item-2">
+        level 1, item 2
+        <Tree>
+          <TreeItem id="tree-item-3">
+            level 2, item 1
+            <Tree>
+              <TreeItem>level 3, item 1</TreeItem>
+            </Tree>
+          </TreeItem>
+        </Tree>
+      </TreeItem>
     </Tree>
   );
 };

--- a/packages/react-components/react-tree/stories/Tree/TreeDefault.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeDefault.stories.tsx
@@ -4,19 +4,25 @@ import { Tree, TreeItem } from '@fluentui/react-tree';
 export const Default = () => {
   return (
     <Tree aria-label="Tree">
-      <TreeItem aria-owns="default-subtree-1">level 1, item 1</TreeItem>
-      <Tree id="default-subtree-1">
-        <TreeItem>level 2, item 1</TreeItem>
-        <TreeItem>level 2, item 2</TreeItem>
-        <TreeItem>level 2, item 3</TreeItem>
-      </Tree>
-      <TreeItem aria-owns="default-subtree-2">level 1, item 2</TreeItem>
-      <Tree id="default-subtree-2">
-        <TreeItem aria-owns="default-subtree-2-1">level 2, item 1</TreeItem>
-        <Tree id="default-subtree-2-1">
-          <TreeItem>level 3, item 1</TreeItem>
+      <TreeItem>
+        level 1, item 1
+        <Tree>
+          <TreeItem>level 2, item 1</TreeItem>
+          <TreeItem>level 2, item 2</TreeItem>
+          <TreeItem>level 2, item 3</TreeItem>
         </Tree>
-      </Tree>
+      </TreeItem>
+      <TreeItem>
+        level 1, item 2
+        <Tree>
+          <TreeItem>
+            level 2, item 1
+            <Tree>
+              <TreeItem>level 3, item 1</TreeItem>
+            </Tree>
+          </TreeItem>
+        </Tree>
+      </TreeItem>
     </Tree>
   );
 };

--- a/packages/react-components/react-tree/stories/Tree/TreeDefaultOpenTrees.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeDefaultOpenTrees.stories.tsx
@@ -5,7 +5,7 @@ export const DefaultOpenTrees = () => {
   const defaultOpenTrees = ['default-subtree-1', 'default-subtree-2', 'default-subtree-2-1'];
 
   return (
-    <Tree defaultOpenSubtrees={defaultOpenTrees} aria-label="Tree">
+    <Tree aria-label="Tree" defaultOpenItems={defaultOpenTrees}>
       <TreeItem aria-owns="default-subtree-1">level 1, item 1</TreeItem>
       <Tree id="default-subtree-1">
         <TreeItem>level 2, item 1</TreeItem>

--- a/packages/react-components/react-tree/stories/Tree/TreeExpandIcon.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeExpandIcon.stories.tsx
@@ -3,44 +3,43 @@ import { Tree, TreeItem } from '@fluentui/react-tree';
 import { Add12Regular, Subtract12Regular } from '@fluentui/react-icons';
 import { TreeOpenChangeData, TreeOpenChangeEvent } from '../../src/Tree';
 
-const RenderExpandIcon = ({ openSubtrees, id }: { openSubtrees: string[]; id: string }) =>
-  openSubtrees.includes(id) ? <Add12Regular /> : <Subtract12Regular />;
-
 export const ExpandIcon = () => {
-  const [openSubtrees, setOpenSubtrees] = React.useState<string[]>([]);
-  const handleOpenChange = (_e: TreeOpenChangeEvent, data: TreeOpenChangeData) => {
-    setOpenSubtrees(curr => (data.open ? [...curr, data.id] : curr.filter(id => id !== data.id)));
+  const [openItems, setOpenItems] = React.useState<string[]>([]);
+  const handleOpenChange = (event: TreeOpenChangeEvent, data: TreeOpenChangeData) => {
+    setOpenItems(curr =>
+      data.open ? [...curr, event.currentTarget.id] : curr.filter(id => id !== event.currentTarget.id),
+    );
   };
   return (
-    <Tree aria-label="Tree" onOpenChange={handleOpenChange}>
+    <Tree aria-label="Tree" openItems={openItems} onOpenChange={handleOpenChange}>
       <TreeItem
-        aria-owns="default-subtree-1"
-        expandIcon={<RenderExpandIcon openSubtrees={openSubtrees} id="default-subtree-1" />}
+        id="tree-item-1"
+        expandIcon={openItems.includes('tree-item-1') ? <Add12Regular /> : <Subtract12Regular />}
       >
         level 1, item 1
+        <Tree>
+          <TreeItem>level 2, item 1</TreeItem>
+          <TreeItem>level 2, item 2</TreeItem>
+          <TreeItem>level 2, item 3</TreeItem>
+        </Tree>
       </TreeItem>
-      <Tree id="default-subtree-1">
-        <TreeItem>level 2, item 1</TreeItem>
-        <TreeItem>level 2, item 2</TreeItem>
-        <TreeItem>level 2, item 3</TreeItem>
-      </Tree>
       <TreeItem
-        aria-owns="default-subtree-2"
-        expandIcon={<RenderExpandIcon openSubtrees={openSubtrees} id="default-subtree-2" />}
+        id="tree-item-2"
+        expandIcon={openItems.includes('tree-item-2') ? <Add12Regular /> : <Subtract12Regular />}
       >
         level 1, item 2
-      </TreeItem>
-      <Tree id="default-subtree-2">
-        <TreeItem
-          aria-owns="default-subtree-2-1"
-          expandIcon={<RenderExpandIcon openSubtrees={openSubtrees} id="default-subtree-2-1" />}
-        >
-          level 2, item 1
-        </TreeItem>
-        <Tree id="default-subtree-2-1">
-          <TreeItem>level 3, item 1</TreeItem>
+        <Tree>
+          <TreeItem
+            id="tree-item-3"
+            expandIcon={openItems.includes('tree-item-3') ? <Add12Regular /> : <Subtract12Regular />}
+          >
+            level 2, item 1
+            <Tree>
+              <TreeItem>level 3, item 1</TreeItem>
+            </Tree>
+          </TreeItem>
         </Tree>
-      </Tree>
+      </TreeItem>
     </Tree>
   );
 };

--- a/packages/react-components/react-tree/stories/Tree/TreeIconAfter.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeIconAfter.stories.tsx
@@ -5,23 +5,25 @@ import { LockClosed20Regular } from '@fluentui/react-icons';
 export const IconAfter = () => {
   return (
     <Tree aria-label="Tree">
-      <TreeItem aria-owns="default-subtree-1">
+      <TreeItem>
         <TreeItemLayout iconAfter={<LockClosed20Regular />}>level 1, item 1</TreeItemLayout>
-      </TreeItem>
-      <Tree id="default-subtree-1">
-        <TreeItem>level 2, item 1</TreeItem>
-        <TreeItem>level 2, item 2</TreeItem>
-        <TreeItem>level 2, item 3</TreeItem>
-      </Tree>
-      <TreeItem aria-owns="default-subtree-2">
-        <TreeItemLayout iconAfter={<LockClosed20Regular />}>level 1, item 2</TreeItemLayout>
-      </TreeItem>
-      <Tree id="default-subtree-2">
-        <TreeItem aria-owns="default-subtree-2-1">level 2, item 1</TreeItem>
-        <Tree id="default-subtree-2-1">
-          <TreeItem>level 3, item 1</TreeItem>
+        <Tree>
+          <TreeItem>level 2, item 1</TreeItem>
+          <TreeItem>level 2, item 2</TreeItem>
+          <TreeItem>level 2, item 3</TreeItem>
         </Tree>
-      </Tree>
+      </TreeItem>
+      <TreeItem>
+        <TreeItemLayout iconAfter={<LockClosed20Regular />}>level 1, item 2</TreeItemLayout>
+        <Tree>
+          <TreeItem>
+            level 2, item 1
+            <Tree>
+              <TreeItem>level 3, item 1</TreeItem>
+            </Tree>
+          </TreeItem>
+        </Tree>
+      </TreeItem>
     </Tree>
   );
 };

--- a/packages/react-components/react-tree/stories/Tree/TreeIconBefore.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeIconBefore.stories.tsx
@@ -5,23 +5,25 @@ import { CheckboxChecked20Filled, CheckboxUnchecked20Filled } from '@fluentui/re
 export const IconBefore = () => {
   return (
     <Tree aria-label="Tree">
-      <TreeItem aria-owns="default-subtree-1">
+      <TreeItem>
         <TreeItemLayout iconBefore={<CheckboxUnchecked20Filled />}>level 1, item 1</TreeItemLayout>
-      </TreeItem>
-      <Tree id="default-subtree-1">
-        <TreeItem>level 2, item 1</TreeItem>
-        <TreeItem>level 2, item 2</TreeItem>
-        <TreeItem>level 2, item 3</TreeItem>
-      </Tree>
-      <TreeItem aria-owns="default-subtree-2">
-        <TreeItemLayout iconBefore={<CheckboxChecked20Filled />}>level 1, item 2</TreeItemLayout>
-      </TreeItem>
-      <Tree id="default-subtree-2">
-        <TreeItem aria-owns="default-subtree-2-1">level 2, item 1</TreeItem>
-        <Tree id="default-subtree-2-1">
-          <TreeItem>level 3, item 1</TreeItem>
+        <Tree>
+          <TreeItem>level 2, item 1</TreeItem>
+          <TreeItem>level 2, item 2</TreeItem>
+          <TreeItem>level 2, item 3</TreeItem>
         </Tree>
-      </Tree>
+      </TreeItem>
+      <TreeItem>
+        <TreeItemLayout iconBefore={<CheckboxChecked20Filled />}>level 1, item 2</TreeItemLayout>
+        <Tree>
+          <TreeItem>
+            level 2, item 1
+            <Tree>
+              <TreeItem>level 3, item 1</TreeItem>
+            </Tree>
+          </TreeItem>
+        </Tree>
+      </TreeItem>
     </Tree>
   );
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previous implementation would require the usage of `aria-owns` to properly set and organize items on a tree, something similar to the example provided on https://www.w3.org/WAI/ARIA/apg/example-index/treeview/treeview-navigation.html

## New Behavior

After some investigation and pairing with @smhigley the conclusion is that depending on `aria-owns` is not ideal as it is not a supported solution by all screen readers. The ideal would be to nest each subtree inside of the tree item it belongs to. as in  this example https://www.w3.org/WAI/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.html 

This PR updates the `Tree` and `TreeItem` component to properly follow this structural modification.
