### PR TITLE
Cherry picked from #26152 : AzureTheme DetailsList checkbox fix 

### DIFF
--- a/change/@uifabric-azure-themes-e6839196-bf0a-421f-bcb4-e859ad624f8b.json
+++ b/change/@uifabric-azure-themes-e6839196-bf0a-421f-bcb4-e859ad624f8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cherry picked from 26152- fixing azure theme detailslist checkbox styling",
+  "packageName": "@uifabric/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -50,11 +50,6 @@ export const DetailsListStyles = (props: IDetailsListStyleProps): Partial<IDetai
   return {
     root: {
       borderTop: StyleConstants.borderNone,
-      selectors: {
-        '.ms-DetailsRow-check': {
-          opacity: 1,
-        },
-      },
     },
     headerWrapper: {
       selectors: {
@@ -116,11 +111,6 @@ export const DetailsRowStyles = (props: IDetailsRowStyleProps): Partial<IDetails
         color: semanticColors.listText,
         fontSize: theme.fonts.medium.fontSize,
         borderBottom: `1px solid ${extendedSemanticColors.listItemBackgroundSelected} !important`,
-        selectors: {
-          '.ms-DetailsRow-check': {
-            opacity: 1,
-          },
-        },
       },
       !isSelected && [
         {


### PR DESCRIPTION
Cherry picked from #26152 

## Previous Behavior
Azure Theme was showing a border on all checkboxes within a DetailsList / grid, regardless of state. Per Ibiza designs, checkbox border should only appear on selected, hovered, active states and _not_ in rest/unselected state.
<img width="252" alt="image" src="https://user-images.githubusercontent.com/30805892/210487557-b70bfd83-8adf-43b6-95aa-7a272e3dbf75.png">


## New Behavior

<img width="260" alt="image" src="https://user-images.githubusercontent.com/30805892/210487830-43205203-bd16-43d9-88cb-fe351f46435c.png">

dark
<img width="219" alt="image" src="https://user-images.githubusercontent.com/30805892/210656543-1da61067-b083-4798-a69e-217f88f38e09.png">

high contrast light
<img width="223" alt="image" src="https://user-images.githubusercontent.com/30805892/210656580-bec4cc02-ce45-4fd8-b80e-41861812946e.png">

high contrast dark
<img width="221" alt="image" src="https://user-images.githubusercontent.com/30805892/210656612-078916d9-9b74-42f5-92ce-b8c3be8dfddd.png">



Note: this change is only appearing in 8.0 as products have snapped to this branch 