### PR TITLE
chore: Re-exporting missing exports from @fluentui/react-combobox

### DIFF
--- a/change/@fluentui-react-components-628325e5-01eb-451b-81b1-938803d37d3d.json
+++ b/change/@fluentui-react-components-628325e5-01eb-451b-81b1-938803d37d3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Re-exporting missing exports from @fluentui/react-combobox.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -38,6 +38,7 @@ import { ColumnDefinition } from '@fluentui/react-table';
 import { ColumnId } from '@fluentui/react-table';
 import { Combobox } from '@fluentui/react-combobox';
 import { comboboxClassNames } from '@fluentui/react-combobox';
+import { ComboboxContextValue } from '@fluentui/react-combobox';
 import { ComboboxContextValues } from '@fluentui/react-combobox';
 import { ComboboxField_unstable as ComboboxField } from '@fluentui/react-combobox';
 import { comboboxFieldClassNames } from '@fluentui/react-combobox';
@@ -45,6 +46,7 @@ import { ComboboxFieldProps_unstable as ComboboxFieldProps } from '@fluentui/rea
 import { ComboboxOpenChangeData } from '@fluentui/react-combobox';
 import { ComboboxOpenEvents } from '@fluentui/react-combobox';
 import { ComboboxProps } from '@fluentui/react-combobox';
+import { ComboboxProvider } from '@fluentui/react-combobox';
 import { ComboboxSlots } from '@fluentui/react-combobox';
 import { ComboboxState } from '@fluentui/react-combobox';
 import { createColumn } from '@fluentui/react-table';
@@ -112,8 +114,10 @@ import { inputFieldClassNames } from '@fluentui/react-input';
 import { InputFieldProps_unstable as InputFieldProps } from '@fluentui/react-input';
 import { Listbox } from '@fluentui/react-combobox';
 import { listboxClassNames } from '@fluentui/react-combobox';
+import { ListboxContextValue } from '@fluentui/react-combobox';
 import { ListboxContextValues } from '@fluentui/react-combobox';
 import { ListboxProps } from '@fluentui/react-combobox';
+import { ListboxProvider } from '@fluentui/react-combobox';
 import { ListboxSlots } from '@fluentui/react-combobox';
 import { ListboxState } from '@fluentui/react-combobox';
 import { Option as Option_2 } from '@fluentui/react-combobox';
@@ -287,6 +291,7 @@ import { useCardPreview_unstable } from '@fluentui/react-card';
 import { useCardPreviewStyles_unstable } from '@fluentui/react-card';
 import { useCardStyles_unstable } from '@fluentui/react-card';
 import { useCombobox_unstable } from '@fluentui/react-combobox';
+import { useComboboxContextValues } from '@fluentui/react-combobox';
 import { useComboboxStyles_unstable } from '@fluentui/react-combobox';
 import { useDataGrid_unstable } from '@fluentui/react-table';
 import { useDataGridBody_unstable } from '@fluentui/react-table';
@@ -311,6 +316,7 @@ import { useInfoButtonStyles_unstable } from '@fluentui/react-infobutton';
 import { useIsOverflowGroupVisible } from '@fluentui/react-overflow';
 import { useIsOverflowItemVisible } from '@fluentui/react-overflow';
 import { useListbox_unstable } from '@fluentui/react-combobox';
+import { useListboxContextValues } from '@fluentui/react-combobox';
 import { useListboxStyles_unstable } from '@fluentui/react-combobox';
 import { useOption_unstable } from '@fluentui/react-combobox';
 import { useOptionGroup_unstable } from '@fluentui/react-combobox';
@@ -425,6 +431,8 @@ export { Combobox }
 
 export { comboboxClassNames }
 
+export { ComboboxContextValue }
+
 export { ComboboxContextValues }
 
 export { ComboboxField }
@@ -438,6 +446,8 @@ export { ComboboxOpenChangeData }
 export { ComboboxOpenEvents }
 
 export { ComboboxProps }
+
+export { ComboboxProvider }
 
 export { ComboboxSlots }
 
@@ -573,9 +583,13 @@ export { Listbox }
 
 export { listboxClassNames }
 
+export { ListboxContextValue }
+
 export { ListboxContextValues }
 
 export { ListboxProps }
+
+export { ListboxProvider }
 
 export { ListboxSlots }
 
@@ -924,6 +938,8 @@ export { useCardStyles_unstable }
 
 export { useCombobox_unstable }
 
+export { useComboboxContextValues }
+
 export { useComboboxStyles_unstable }
 
 export { useDataGrid_unstable }
@@ -971,6 +987,8 @@ export { useIsOverflowGroupVisible }
 export { useIsOverflowItemVisible }
 
 export { useListbox_unstable }
+
+export { useListboxContextValues }
 
 export { useListboxStyles_unstable }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -72,9 +72,14 @@ export {
   optionGroupClassNames,
   useOptionGroupStyles_unstable,
   useOptionGroup_unstable,
+  ComboboxProvider,
+  useComboboxContextValues,
+  ListboxProvider,
+  useListboxContextValues,
 } from '@fluentui/react-combobox';
 export type {
   ComboboxProps,
+  ComboboxContextValue,
   ComboboxContextValues,
   ComboboxOpenChangeData,
   ComboboxOpenEvents,
@@ -86,6 +91,7 @@ export type {
   DropdownOpenEvents,
   DropdownSlots,
   DropdownState,
+  ListboxContextValue,
   ListboxContextValues,
   ListboxProps,
   ListboxSlots,


### PR DESCRIPTION
## Previous Behavior

There were a couple of exports in `@fluentui/react-combobox` that were not being re-exported by `@fluentui/react-components/unstable`:
- `ComboboxProvider`
- `useComboboxContextValues`
- `ListboxProvider`
- `useListboxContextValues`

## New Behavior

The previously stated exports are now re-exported by `@fluentui/react-components/unstable`.
