### PR TITLE
fix(react-infobutton): Change role of PopoverSurface to note and fix API to not require cast

### DIFF
--- a/change/@fluentui-react-infobutton-a65e9aed-2d7e-47dc-800d-4ef527235880.json
+++ b/change/@fluentui-react-infobutton-a65e9aed-2d7e-47dc-800d-4ef527235880.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Update PopoverSurface's role to note and remove need to cast props passed to popover slot.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/etc/react-infobutton.api.md
+++ b/packages/react-components/react-infobutton/etc/react-infobutton.api.md
@@ -22,8 +22,9 @@ export const InfoButton: ForwardRefComponent<InfoButtonProps>;
 export const infoButtonClassNames: SlotClassNames<InfoButtonSlots>;
 
 // @public
-export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
+export type InfoButtonProps = Omit<ComponentProps<Partial<Omit<InfoButtonSlots, 'popover'>>>, 'disabled'> & {
     size?: 'small' | 'medium' | 'large';
+    popover?: Partial<PopoverProps>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-infobutton/etc/react-infobutton.api.md
+++ b/packages/react-components/react-infobutton/etc/react-infobutton.api.md
@@ -22,15 +22,14 @@ export const InfoButton: ForwardRefComponent<InfoButtonProps>;
 export const infoButtonClassNames: SlotClassNames<InfoButtonSlots>;
 
 // @public
-export type InfoButtonProps = Omit<ComponentProps<Partial<Omit<InfoButtonSlots, 'popover'>>>, 'disabled'> & {
+export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
     size?: 'small' | 'medium' | 'large';
-    popover?: Partial<PopoverProps>;
 };
 
 // @public (undocumented)
 export type InfoButtonSlots = {
     root: NonNullable<Slot<'button'>>;
-    popover: NonNullable<Slot<PopoverProps>>;
+    popover: NonNullable<Slot<Partial<PopoverProps>>>;
     content: NonNullable<Slot<typeof PopoverSurface>>;
 };
 

--- a/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.test.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.test.tsx
@@ -4,20 +4,20 @@ import { infoButtonClassNames } from './useInfoButtonStyles';
 import type { RenderResult } from '@testing-library/react';
 
 // testing-library's queryByRole function doesn't look inside portals
-function queryByRoleDialog(result: RenderResult) {
-  const dialogs = result.baseElement.querySelectorAll('[role="dialog"]');
-  if (!dialogs?.length) {
+function queryByRoleNote(result: RenderResult) {
+  const notes = result.baseElement.querySelectorAll('[role="note"]');
+  if (!notes?.length) {
     return null;
   } else {
-    expect(dialogs.length).toBe(1);
-    return dialogs.item(0) as HTMLElement;
+    expect(notes.length).toBe(1);
+    return notes.item(0) as HTMLElement;
   }
 }
 
 const getPopoverSurfaceElement = (result: RenderResult) => {
   // button needs to be clicked otherwise content won't be rendered.
   result.getByRole('button').click();
-  const dialog = queryByRoleDialog(result);
+  const dialog = queryByRoleNote(result);
   expect(dialog).not.toBeNull();
   return dialog!;
 };

--- a/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.types.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.types.ts
@@ -7,7 +7,7 @@ export type InfoButtonSlots = {
   /**
    * The Popover element that wraps the content and root. Use this slot to pass props to the Popover.
    */
-  popover: NonNullable<Slot<PopoverProps>>;
+  popover: NonNullable<Slot<Partial<PopoverProps>>>;
 
   /**
    * The content to be displayed in the PopoverSurface when the button is pressed.
@@ -18,18 +18,13 @@ export type InfoButtonSlots = {
 /**
  * InfoButton Props
  */
-export type InfoButtonProps = Omit<ComponentProps<Partial<Omit<InfoButtonSlots, 'popover'>>>, 'disabled'> & {
+export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
   /**
    * Size of the InfoButton.
    *
    * @default medium
    */
   size?: 'small' | 'medium' | 'large';
-
-  /**
-   * The Popover element that wraps the content and root. Use this slot to pass props to the Popover.
-   */
-  popover?: Partial<PopoverProps>;
 };
 
 /**

--- a/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.types.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.types.ts
@@ -18,13 +18,18 @@ export type InfoButtonSlots = {
 /**
  * InfoButton Props
  */
-export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
+export type InfoButtonProps = Omit<ComponentProps<Partial<Omit<InfoButtonSlots, 'popover'>>>, 'disabled'> & {
   /**
    * Size of the InfoButton.
    *
    * @default medium
    */
   size?: 'small' | 'medium' | 'large';
+
+  /**
+   * The Popover element that wraps the content and root. Use this slot to pass props to the Popover.
+   */
+  popover?: Partial<PopoverProps>;
 };
 
 /**

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
@@ -35,7 +35,7 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
 
     components: {
       root: 'button',
-      popover: Popover,
+      popover: Popover as React.FC<Partial<PopoverProps>>,
       content: PopoverSurface,
     },
 
@@ -45,10 +45,9 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
       ...props,
       ref,
     }),
-    popover: resolveShorthand(props.popover as PopoverProps, {
+    popover: resolveShorthand(props.popover, {
       required: true,
       defaultProps: {
-        children: <></>,
         positioning: 'above-start',
         size: popoverSizeMap[size],
         withArrow: true,

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
@@ -4,6 +4,7 @@ import { getNativeElementProps, mergeCallbacks, resolveShorthand } from '@fluent
 import { Popover, PopoverSurface } from '@fluentui/react-popover';
 import { useControllableState } from '@fluentui/react-utilities';
 import type { InfoButtonProps, InfoButtonState } from './InfoButton.types';
+import type { PopoverProps } from '@fluentui/react-popover';
 
 const infoButtonIconMap = {
   small: <DefaultInfoButtonIcon12 />,
@@ -44,7 +45,7 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
       ...props,
       ref,
     }),
-    popover: resolveShorthand(props.popover, {
+    popover: resolveShorthand(props.popover as PopoverProps, {
       required: true,
       defaultProps: {
         children: <></>,
@@ -56,7 +57,7 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
     content: resolveShorthand(props.content, {
       required: true,
       defaultProps: {
-        role: 'dialog',
+        role: 'note',
       },
     }),
   };


### PR DESCRIPTION
This PR does the following:
* Update `PopoverSurface`'s role to `note`.
* Make `Popover`'s type the regular `Popover`'s props since `ComponentProps` resolves to an undesired type for its API. This was causing a need to cast the props when the user wanted to override any of its props as such:
 ```
<InfoButton content="content" popover={{ appearance: "inverted"} as PopoverProps } />
```


