### PR TITLE
chore: fix Panel Confirm Dismiss example to properly restore focus after panel closes

### DIFF
--- a/packages/react-examples/src/react/Panel/Panel.ConfirmDismiss.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.ConfirmDismiss.Example.tsx
@@ -46,17 +46,19 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
       >
         <p>{explanation}</p>
       </Panel>
-      <Dialog
-        hidden={!isDialogVisible}
-        onDismiss={hideDialog}
-        dialogContentProps={dialogContentProps}
-        modalProps={dialogModalProps}
-      >
-        <DialogFooter>
-          <PrimaryButton onClick={hideDialogAndPanel} text="Yes" />
-          <DefaultButton onClick={hideDialog} text="No" />
-        </DialogFooter>
-      </Dialog>
+      {isDialogVisible && (
+        <Dialog
+          hidden={false}
+          onDismiss={hideDialog}
+          dialogContentProps={dialogContentProps}
+          modalProps={dialogModalProps}
+        >
+          <DialogFooter>
+            <PrimaryButton onClick={hideDialogAndPanel} text="Yes" />
+            <DefaultButton onClick={hideDialog} text="No" />
+          </DialogFooter>
+        </Dialog>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Previous behavior was that focus would be set to body as dialog closed after panel. New behavior is to add/remove dialog from the DOM to stop onDismiss from firing when we only want the dialog to disappear.