### PR TITLE
chore(react-infobutton): Add vr tests for InfoButton

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -31,6 +31,7 @@
     "@fluentui/react-field": "9.0.0-alpha.14",
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-image": "^9.0.17",
+    "@fluentui/react-infobutton": "9.0.0-beta.6",
     "@fluentui/react-input": "^9.2.11",
     "@fluentui/react-label": "^9.0.16",
     "@fluentui/react-link": "^9.0.17",

--- a/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
@@ -10,11 +10,11 @@ storiesOf('InfoButton', module)
     <StoryWright
       steps={new Steps()
         .snapshot('rest', { cropTo: '.testWrapper' })
-        .hover('.info-button')
-        .snapshot('hover', { cropTo: '.testWrapper' })
         // keys 'tab' is used instead of .focus, since .focus won't show the focus indicator.
         .keys('.info-button', 'Tab')
         .snapshot('focus', { cropTo: '.testWrapper' })
+        .hover('.info-button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
         .click('.info-button')
         .snapshot('active', { cropTo: '.testWrapper' })
         .end()}
@@ -25,7 +25,7 @@ storiesOf('InfoButton', module)
   .addStory(
     'default',
     () => (
-      <div style={{ padding: '10px' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-end', padding: '10px', minHeight: '80px' }}>
         <InfoButton className="info-button" content="This is the content of an InfoButton." />
       </div>
     ),
@@ -40,27 +40,20 @@ storiesOf('InfoButton', module)
   .addDecorator(story => (
     <StoryWright steps={new Steps().snapshot('rest', { cropTo: '.testWrapper' }).end()}>{story()}</StoryWright>
   ))
-  .addStory(
-    'size',
-    () => (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          paddingTop: '60px',
-          paddingLeft: '10px',
-          paddingBottom: '10px',
-          gap: '80px',
-          alignItems: 'start',
-        }}
-      >
-        <InfoButton size="small" content="This is the content of an InfoButton." popover={{ open: true }} />
-        <InfoButton size="medium" content="This is the content of an InfoButton." popover={{ open: true }} />
-        <InfoButton size="large" content="This is the content of an InfoButton." popover={{ open: true }} />
-      </div>
-    ),
-    {
-      includeHighContrast: true,
-      includeDarkMode: true,
-    },
-  );
+  .addStory('size', () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: '60px',
+        paddingLeft: '10px',
+        paddingBottom: '10px',
+        gap: '80px',
+        alignItems: 'start',
+      }}
+    >
+      <InfoButton size="small" content="This is the content of an InfoButton." popover={{ open: true }} />
+      <InfoButton size="medium" content="This is the content of an InfoButton." popover={{ open: true }} />
+      <InfoButton size="large" content="This is the content of an InfoButton." popover={{ open: true }} />
+    </div>
+  ));

--- a/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
@@ -10,11 +10,12 @@ storiesOf('InfoButton', module)
     <StoryWright
       steps={new Steps()
         .snapshot('rest', { cropTo: '.testWrapper' })
-        .hover('#info-button')
+        .hover('.info-button')
         .snapshot('hover', { cropTo: '.testWrapper' })
-        .focus('#info-button')
+        // keys 'tab' is used instead of .focus, since .focus won't show the focus indicator.
+        .keys('.info-button', 'Tab')
         .snapshot('focus', { cropTo: '.testWrapper' })
-        .mouseDown('#info-button')
+        .click('.info-button')
         .snapshot('active', { cropTo: '.testWrapper' })
         .end()}
     >
@@ -24,8 +25,8 @@ storiesOf('InfoButton', module)
   .addStory(
     'default',
     () => (
-      <div style={{ paddingTop: '60px' }}>
-        <InfoButton id="info-button" content="This is the content of an InfoButton." />
+      <div style={{ padding: '10px' }}>
+        <InfoButton className="info-button" content="This is the content of an InfoButton." />
       </div>
     ),
     {
@@ -42,7 +43,17 @@ storiesOf('InfoButton', module)
   .addStory(
     'size',
     () => (
-      <div style={{ display: 'flex', flexDirection: 'column', paddingTop: '60px', gap: '80px', alignItems: 'start' }}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          paddingTop: '60px',
+          paddingLeft: '10px',
+          paddingBottom: '10px',
+          gap: '80px',
+          alignItems: 'start',
+        }}
+      >
         <InfoButton size="small" content="This is the content of an InfoButton." popover={{ open: true }} />
         <InfoButton size="medium" content="This is the content of an InfoButton." popover={{ open: true }} />
         <InfoButton size="large" content="This is the content of an InfoButton." popover={{ open: true }} />

--- a/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Steps, StoryWright } from 'storywright';
+import { InfoButton } from '@fluentui/react-infobutton';
+import { storiesOf } from '@storybook/react';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
+
+storiesOf('InfoButton', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright
+      steps={new Steps()
+        .snapshot('rest', { cropTo: '.testWrapper' })
+        .hover('#info-button')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .focus('#info-button')
+        .snapshot('focus', { cropTo: '.testWrapper' })
+        .mouseDown('#info-button')
+        .snapshot('active', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </StoryWright>
+  ))
+  .addStory(
+    'default',
+    () => (
+      <div style={{ paddingTop: '60px' }}>
+        <InfoButton id="info-button" content="This is the content of an InfoButton." />
+      </div>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  );
+
+storiesOf('InfoButton', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright steps={new Steps().snapshot('rest', { cropTo: '.testWrapper' }).end()}>{story()}</StoryWright>
+  ))
+  .addStory(
+    'size',
+    () => (
+      <div style={{ display: 'flex', flexDirection: 'column', paddingTop: '60px', gap: '80px', alignItems: 'start' }}>
+        <InfoButton size="small" content="This is the content of an InfoButton." popover={{ open: true }} />
+        <InfoButton size="medium" content="This is the content of an InfoButton." popover={{ open: true }} />
+        <InfoButton size="large" content="This is the content of an InfoButton." popover={{ open: true }} />
+      </div>
+    ),
+    {
+      includeHighContrast: true,
+      includeDarkMode: true,
+    },
+  );

--- a/change/@fluentui-react-infobutton-37b75f9d-f4c1-4c94-b80c-7f1dc80591d6.json
+++ b/change/@fluentui-react-infobutton-37b75f9d-f4c1-4c94-b80c-7f1dc80591d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Update border for Teams HCM to be transparent.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.test.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.test.tsx
@@ -27,13 +27,13 @@ describe('InfoButton', () => {
     Component: InfoButton,
     displayName: 'InfoButton',
     requiredProps: {
-      content: 'Popover content',
+      content: "This is an InfoButton's Content.",
     },
     testOptions: {
       'has-static-classnames': [
         {
           props: {
-            content: 'Popover content',
+            content: "This is an InfoButton's Content.",
           },
           expectedClassNames: {
             root: infoButtonClassNames.root,

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.ts
@@ -1,4 +1,4 @@
-import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
@@ -23,12 +23,12 @@ const useButtonStyles = makeStyles({
     justifyContent: 'center',
     textDecorationLine: 'none',
     verticalAlign: 'middle',
+    position: 'relative',
 
     backgroundColor: tokens.colorTransparentBackground,
     color: tokens.colorNeutralForeground2,
 
-    ...shorthands.overflow('hidden'),
-    ...shorthands.border(tokens.strokeWidthThin, 'solid', 'transparent'),
+    ...shorthands.borderStyle('none'),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     ...shorthands.margin(0),
     ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalXS),
@@ -70,37 +70,23 @@ const useButtonStyles = makeStyles({
 
     '@media (forced-colors: active)': {
       backgroundColor: 'Highlight',
-      ...shorthands.borderColor('Canvas'),
       color: 'Canvas',
     },
   },
 
   highContrast: {
     '@media (forced-colors: active)': {
-      ...shorthands.borderColor('Canvas'),
       color: 'CanvasText',
 
-      ':hover, :hover:active': {
+      ':hover,:hover:active': {
         forcedColorAdjust: 'none',
         backgroundColor: 'Highlight',
-        ...shorthands.borderColor('Canvas'),
         color: 'Canvas',
       },
     },
   },
 
-  focusIndicator: createCustomFocusIndicatorStyle({
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
-    outlineColor: tokens.colorTransparentStroke,
-    outlineWidth: tokens.strokeWidthThick,
-    outlineStyle: 'solid',
-    boxShadow: `
-      ${tokens.shadow4},
-      0 0 0 2px ${tokens.colorStrokeFocus2}
-    `,
-    zIndex: 1,
-  }),
+  focusIndicator: createFocusOutlineStyle(),
 
   large: {
     ...shorthands.padding(tokens.spacingVerticalXXS, tokens.spacingVerticalXXS),

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.ts
@@ -28,7 +28,7 @@ const useButtonStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
 
     ...shorthands.overflow('hidden'),
-    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', 'transparent'),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     ...shorthands.margin(0),
     ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalXS),


### PR DESCRIPTION
## Previous behavior

* InfoButton didn't have vr-tests.
* InfoButton had a border when using Teams HCM due to `tokens.colorTransparentStroke`.

![image](https://user-images.githubusercontent.com/5953191/212175665-77a1fe40-e07e-41f4-8e38-a0aeeb6ee3f6.png)

## New behavior

* InfoButton now has vr-tests.
* InfoButton no longer has a border in Teams HCM.

![image](https://user-images.githubusercontent.com/5953191/212175502-cd05eeff-cb86-4af5-84bc-365019b03e74.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26270
