### PR TITLE
chore(react-perf-test-react-components): Adding perf test for InfoButton 

### DIFF
--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -20,6 +20,7 @@
     "@griffel/core": "^1.9.0",
     "@fluentui/react-avatar": "^9.2.12",
     "@fluentui/react-button": "^9.1.14",
+    "@fluentui/react-infobutton": "9.0.0-beta.6",
     "@fluentui/react-persona": "^9.1.1",
     "@fluentui/react-provider": "^9.2.1",
     "@fluentui/react-spinbutton": "^9.0.14",

--- a/apps/perf-test-react-components/src/scenarios/InfoButton.tsx
+++ b/apps/perf-test-react-components/src/scenarios/InfoButton.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { InfoButton } from '@fluentui/react-infobutton';
+import { FluentProvider } from '@fluentui/react-provider';
+import { webLightTheme } from '@fluentui/react-theme';
+
+const Scenario = () => <InfoButton content={"This is an InfoButton's content."} />;
+
+Scenario.decorator = (props: { children: React.ReactNode }) => {
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>;
+};
+
+export default Scenario;


### PR DESCRIPTION
This PR adds the perf test scenario for `react-infobutton`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26271
