### PR TITLE
chore(react-datepicker): Create Calendar components and DatePicker component

### DIFF
--- a/packages/react-components/react-datepicker/.storybook/main.js
+++ b/packages/react-components/react-datepicker/.storybook/main.js
@@ -1,0 +1,14 @@
+const rootMain = require('../../../../.storybook/main');
+
+module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+  ...rootMain,
+  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: [...rootMain.addons],
+  webpackFinal: (config, options) => {
+    const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+    // add your own webpack tweaks if needed
+
+    return localConfig;
+  },
+});

--- a/packages/react-components/react-datepicker/.storybook/preview.js
+++ b/packages/react-components/react-datepicker/.storybook/preview.js
@@ -1,0 +1,7 @@
+import * as rootPreview from '../../../../.storybook/preview';
+
+/** @type {typeof rootPreview.decorators} */
+export const decorators = [...rootPreview.decorators];
+
+/** @type {typeof rootPreview.parameters} */
+export const parameters = { ...rootPreview.parameters };

--- a/packages/react-components/react-datepicker/.storybook/tsconfig.json
+++ b/packages/react-components/react-datepicker/.storybook/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "",
+    "allowJs": true,
+    "checkJs": true,
+    "types": ["static-assets", "environment", "storybook__addons"]
+  },
+  "include": ["../stories/**/*.stories.ts", "../stories/**/*.stories.tsx", "*.js"]
+}

--- a/packages/react-components/react-datepicker/etc/react-datepicker.api.md
+++ b/packages/react-components/react-datepicker/etc/react-datepicker.api.md
@@ -4,6 +4,195 @@
 
 ```ts
 
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import * as React_2 from 'react';
+import type { Slot } from '@fluentui/react-utilities';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+// @public
+export const Calendar: ForwardRefComponent<CalendarProps>;
+
+// @public (undocumented)
+export const calendarClassNames: SlotClassNames<CalendarSlots>;
+
+// @public
+export const CalendarDay: ForwardRefComponent<CalendarDayProps>;
+
+// @public (undocumented)
+export const calendarDayClassNames: SlotClassNames<CalendarDaySlots>;
+
+// @public
+export type CalendarDayProps = ComponentProps<CalendarDaySlots> & {};
+
+// @public (undocumented)
+export type CalendarDaySlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type CalendarDayState = ComponentState<CalendarDaySlots>;
+
+// @public
+export const CalendarGrid: ForwardRefComponent<CalendarGridProps>;
+
+// @public (undocumented)
+export const calendarGridClassNames: SlotClassNames<CalendarGridSlots>;
+
+// @public
+export type CalendarGridProps = ComponentProps<CalendarGridSlots> & {};
+
+// @public (undocumented)
+export type CalendarGridSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type CalendarGridState = ComponentState<CalendarGridSlots>;
+
+// @public
+export const CalendarMonth: ForwardRefComponent<CalendarMonthProps>;
+
+// @public (undocumented)
+export const calendarMonthClassNames: SlotClassNames<CalendarMonthSlots>;
+
+// @public
+export type CalendarMonthProps = ComponentProps<CalendarMonthSlots> & {};
+
+// @public (undocumented)
+export type CalendarMonthSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type CalendarMonthState = ComponentState<CalendarMonthSlots>;
+
+// @public
+export const CalendarPicker: ForwardRefComponent<CalendarPickerProps>;
+
+// @public (undocumented)
+export const calendarPickerClassNames: SlotClassNames<CalendarPickerSlots>;
+
+// @public
+export type CalendarPickerProps = ComponentProps<CalendarPickerSlots> & {};
+
+// @public (undocumented)
+export type CalendarPickerSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type CalendarPickerState = ComponentState<CalendarPickerSlots>;
+
+// @public
+export type CalendarProps = ComponentProps<CalendarSlots> & {};
+
+// @public (undocumented)
+export type CalendarSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type CalendarState = ComponentState<CalendarSlots>;
+
+// @public
+export const CalendarYear: ForwardRefComponent<CalendarYearProps>;
+
+// @public (undocumented)
+export const calendarYearClassNames: SlotClassNames<CalendarYearSlots>;
+
+// @public
+export type CalendarYearProps = ComponentProps<CalendarYearSlots> & {};
+
+// @public (undocumented)
+export type CalendarYearSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type CalendarYearState = ComponentState<CalendarYearSlots>;
+
+// @public
+export const DatePicker: ForwardRefComponent<DatePickerProps>;
+
+// @public (undocumented)
+export const datePickerClassNames: SlotClassNames<DatePickerSlots>;
+
+// @public
+export type DatePickerProps = ComponentProps<DatePickerSlots> & {};
+
+// @public (undocumented)
+export type DatePickerSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type DatePickerState = ComponentState<DatePickerSlots>;
+
+// @public
+export const renderCalendar_unstable: (state: CalendarState) => JSX.Element;
+
+// @public
+export const renderCalendarDay_unstable: (state: CalendarDayState) => JSX.Element;
+
+// @public
+export const renderCalendarGrid_unstable: (state: CalendarGridState) => JSX.Element;
+
+// @public
+export const renderCalendarMonth_unstable: (state: CalendarMonthState) => JSX.Element;
+
+// @public
+export const renderCalendarPicker_unstable: (state: CalendarPickerState) => JSX.Element;
+
+// @public
+export const renderCalendarYear_unstable: (state: CalendarYearState) => JSX.Element;
+
+// @public
+export const renderDatePicker_unstable: (state: DatePickerState) => JSX.Element;
+
+// @public
+export const useCalendar_unstable: (props: CalendarProps, ref: React_2.Ref<HTMLElement>) => CalendarState;
+
+// @public
+export const useCalendarDay_unstable: (props: CalendarDayProps, ref: React_2.Ref<HTMLElement>) => CalendarDayState;
+
+// @public
+export const useCalendarDayStyles_unstable: (state: CalendarDayState) => CalendarDayState;
+
+// @public
+export const useCalendarGrid_unstable: (props: CalendarGridProps, ref: React_2.Ref<HTMLElement>) => CalendarGridState;
+
+// @public
+export const useCalendarGridStyles_unstable: (state: CalendarGridState) => CalendarGridState;
+
+// @public
+export const useCalendarMonth_unstable: (props: CalendarMonthProps, ref: React_2.Ref<HTMLElement>) => CalendarMonthState;
+
+// @public
+export const useCalendarMonthStyles_unstable: (state: CalendarMonthState) => CalendarMonthState;
+
+// @public
+export const useCalendarPicker_unstable: (props: CalendarPickerProps, ref: React_2.Ref<HTMLElement>) => CalendarPickerState;
+
+// @public
+export const useCalendarPickerStyles_unstable: (state: CalendarPickerState) => CalendarPickerState;
+
+// @public
+export const useCalendarStyles_unstable: (state: CalendarState) => CalendarState;
+
+// @public
+export const useCalendarYear_unstable: (props: CalendarYearProps, ref: React_2.Ref<HTMLElement>) => CalendarYearState;
+
+// @public
+export const useCalendarYearStyles_unstable: (state: CalendarYearState) => CalendarYearState;
+
+// @public
+export const useDatePicker_unstable: (props: DatePickerProps, ref: React_2.Ref<HTMLElement>) => DatePickerState;
+
+// @public
+export const useDatePickerStyles_unstable: (state: DatePickerState) => DatePickerState;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-datepicker/package.json
+++ b/packages/react-components/react-datepicker/package.json
@@ -20,7 +20,9 @@
     "lint": "just-scripts lint",
     "test": "jest --passWithNoTests",
     "type-check": "tsc -b tsconfig.json",
-    "generate-api": "tsc -p ./tsconfig.lib.json --emitDeclarationOnly && just-scripts api-extractor"
+    "generate-api": "tsc -p ./tsconfig.lib.json --emitDeclarationOnly && just-scripts api-extractor",
+    "storybook": "start-storybook",
+    "start": "yarn storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/react-components/react-datepicker/src/Calendar.ts
+++ b/packages/react-components/react-datepicker/src/Calendar.ts
@@ -1,0 +1,1 @@
+export * from './components/Calendar/index';

--- a/packages/react-components/react-datepicker/src/CalendarDay.ts
+++ b/packages/react-components/react-datepicker/src/CalendarDay.ts
@@ -1,0 +1,1 @@
+export * from './components/CalendarDay/index';

--- a/packages/react-components/react-datepicker/src/CalendarGrid.ts
+++ b/packages/react-components/react-datepicker/src/CalendarGrid.ts
@@ -1,0 +1,1 @@
+export * from './components/CalendarGrid/index';

--- a/packages/react-components/react-datepicker/src/CalendarMonth.ts
+++ b/packages/react-components/react-datepicker/src/CalendarMonth.ts
@@ -1,0 +1,1 @@
+export * from './components/CalendarMonth/index';

--- a/packages/react-components/react-datepicker/src/CalendarPicker.ts
+++ b/packages/react-components/react-datepicker/src/CalendarPicker.ts
@@ -1,0 +1,1 @@
+export * from './components/CalendarPicker/index';

--- a/packages/react-components/react-datepicker/src/CalendarYear.ts
+++ b/packages/react-components/react-datepicker/src/CalendarYear.ts
@@ -1,0 +1,1 @@
+export * from './components/CalendarYear/index';

--- a/packages/react-components/react-datepicker/src/DatePicker.ts
+++ b/packages/react-components/react-datepicker/src/DatePicker.ts
@@ -1,0 +1,1 @@
+export * from './components/DatePicker/index';

--- a/packages/react-components/react-datepicker/src/components/Calendar/Calendar.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/Calendar/Calendar.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Calendar } from './Calendar';
+import { isConformant } from '../../testing/isConformant';
+
+describe('Calendar', () => {
+  isConformant({
+    Component: Calendar,
+    displayName: 'Calendar',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<Calendar>Default Calendar</Calendar>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-datepicker/src/components/Calendar/Calendar.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useCalendar_unstable } from './useCalendar';
+import { renderCalendar_unstable } from './renderCalendar';
+import { useCalendarStyles_unstable } from './useCalendarStyles';
+import type { CalendarProps } from './Calendar.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * Calendar component - TODO: add more docs
+ */
+export const Calendar: ForwardRefComponent<CalendarProps> = React.forwardRef((props, ref) => {
+  const state = useCalendar_unstable(props, ref);
+
+  useCalendarStyles_unstable(state);
+  return renderCalendar_unstable(state);
+});
+
+Calendar.displayName = 'Calendar';

--- a/packages/react-components/react-datepicker/src/components/Calendar/Calendar.types.ts
+++ b/packages/react-components/react-datepicker/src/components/Calendar/Calendar.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type CalendarSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * Calendar Props
+ */
+export type CalendarProps = ComponentProps<CalendarSlots> & {};
+
+/**
+ * State used in rendering Calendar
+ */
+export type CalendarState = ComponentState<CalendarSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarProps.
+// & Required<Pick<CalendarProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/Calendar/Calendar.types.ts
+++ b/packages/react-components/react-datepicker/src/components/Calendar/Calendar.types.ts
@@ -13,5 +13,4 @@ export type CalendarProps = ComponentProps<CalendarSlots> & {};
  * State used in rendering Calendar
  */
 export type CalendarState = ComponentState<CalendarSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarProps.
 // & Required<Pick<CalendarProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Calendar renders a default state 1`] = `
+<div>
+  <div
+    class="fui-Calendar"
+  >
+    Default Calendar
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/Calendar/index.ts
+++ b/packages/react-components/react-datepicker/src/components/Calendar/index.ts
@@ -1,0 +1,5 @@
+export * from './Calendar';
+export * from './Calendar.types';
+export * from './renderCalendar';
+export * from './useCalendar';
+export * from './useCalendarStyles';

--- a/packages/react-components/react-datepicker/src/components/Calendar/renderCalendar.tsx
+++ b/packages/react-components/react-datepicker/src/components/Calendar/renderCalendar.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { CalendarState, CalendarSlots } from './Calendar.types';
+
+/**
+ * Render the final JSX of Calendar
+ */
+export const renderCalendar_unstable = (state: CalendarState) => {
+  const { slots, slotProps } = getSlots<CalendarSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/Calendar/useCalendar.ts
+++ b/packages/react-components/react-datepicker/src/components/Calendar/useCalendar.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { CalendarProps, CalendarState } from './Calendar.types';
+
+/**
+ * Create the state required to render Calendar.
+ *
+ * The returned state can be modified with hooks such as useCalendarStyles_unstable,
+ * before being passed to renderCalendar_unstable.
+ *
+ * @param props - props from this instance of Calendar
+ * @param ref - reference to root HTMLElement of Calendar
+ */
+export const useCalendar_unstable = (props: CalendarProps, ref: React.Ref<HTMLElement>): CalendarState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/Calendar/useCalendarStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/Calendar/useCalendarStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { CalendarSlots, CalendarState } from './Calendar.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const calendarClassNames: SlotClassNames<CalendarSlots> = {
+  root: 'fui-Calendar',
+  // TODO: add class names for all slots on CalendarSlots.
+  // Should be of the form `<slotName>: 'fui-Calendar__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the Calendar slots based on the state
+ */
+export const useCalendarStyles_unstable = (state: CalendarState): CalendarState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(calendarClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { CalendarDay } from './CalendarDay';
+import { isConformant } from '../../testing/isConformant';
+
+describe('CalendarDay', () => {
+  isConformant({
+    Component: CalendarDay,
+    displayName: 'CalendarDay',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<CalendarDay>Default CalendarDay</CalendarDay>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useCalendarDay_unstable } from './useCalendarDay';
+import { renderCalendarDay_unstable } from './renderCalendarDay';
+import { useCalendarDayStyles_unstable } from './useCalendarDayStyles';
+import type { CalendarDayProps } from './CalendarDay.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * CalendarDay component - TODO: add more docs
+ */
+export const CalendarDay: ForwardRefComponent<CalendarDayProps> = React.forwardRef((props, ref) => {
+  const state = useCalendarDay_unstable(props, ref);
+
+  useCalendarDayStyles_unstable(state);
+  return renderCalendarDay_unstable(state);
+});
+
+CalendarDay.displayName = 'CalendarDay';

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type CalendarDaySlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * CalendarDay Props
+ */
+export type CalendarDayProps = ComponentProps<CalendarDaySlots> & {};
+
+/**
+ * State used in rendering CalendarDay
+ */
+export type CalendarDayState = ComponentState<CalendarDaySlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarDayProps.
+// & Required<Pick<CalendarDayProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/CalendarDay.types.ts
@@ -13,5 +13,4 @@ export type CalendarDayProps = ComponentProps<CalendarDaySlots> & {};
  * State used in rendering CalendarDay
  */
 export type CalendarDayState = ComponentState<CalendarDaySlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarDayProps.
 // & Required<Pick<CalendarDayProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/__snapshots__/CalendarDay.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/__snapshots__/CalendarDay.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarDay renders a default state 1`] = `
+<div>
+  <div
+    class="fui-CalendarDay"
+  >
+    Default CalendarDay
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/index.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/index.ts
@@ -1,0 +1,5 @@
+export * from './CalendarDay';
+export * from './CalendarDay.types';
+export * from './renderCalendarDay';
+export * from './useCalendarDay';
+export * from './useCalendarDayStyles';

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/renderCalendarDay.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/renderCalendarDay.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { CalendarDayState, CalendarDaySlots } from './CalendarDay.types';
+
+/**
+ * Render the final JSX of CalendarDay
+ */
+export const renderCalendarDay_unstable = (state: CalendarDayState) => {
+  const { slots, slotProps } = getSlots<CalendarDaySlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/useCalendarDay.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/useCalendarDay.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { CalendarDayProps, CalendarDayState } from './CalendarDay.types';
+
+/**
+ * Create the state required to render CalendarDay.
+ *
+ * The returned state can be modified with hooks such as useCalendarDayStyles_unstable,
+ * before being passed to renderCalendarDay_unstable.
+ *
+ * @param props - props from this instance of CalendarDay
+ * @param ref - reference to root HTMLElement of CalendarDay
+ */
+export const useCalendarDay_unstable = (props: CalendarDayProps, ref: React.Ref<HTMLElement>): CalendarDayState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarDay/useCalendarDayStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarDay/useCalendarDayStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { CalendarDaySlots, CalendarDayState } from './CalendarDay.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const calendarDayClassNames: SlotClassNames<CalendarDaySlots> = {
+  root: 'fui-CalendarDay',
+  // TODO: add class names for all slots on CalendarDaySlots.
+  // Should be of the form `<slotName>: 'fui-CalendarDay__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the CalendarDay slots based on the state
+ */
+export const useCalendarDayStyles_unstable = (state: CalendarDayState): CalendarDayState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(calendarDayClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { CalendarGrid } from './CalendarGrid';
+import { isConformant } from '../../testing/isConformant';
+
+describe('CalendarGrid', () => {
+  isConformant({
+    Component: CalendarGrid,
+    displayName: 'CalendarGrid',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<CalendarGrid>Default CalendarGrid</CalendarGrid>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useCalendarGrid_unstable } from './useCalendarGrid';
+import { renderCalendarGrid_unstable } from './renderCalendarGrid';
+import { useCalendarGridStyles_unstable } from './useCalendarGridStyles';
+import type { CalendarGridProps } from './CalendarGrid.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * CalendarGrid component - TODO: add more docs
+ */
+export const CalendarGrid: ForwardRefComponent<CalendarGridProps> = React.forwardRef((props, ref) => {
+  const state = useCalendarGrid_unstable(props, ref);
+
+  useCalendarGridStyles_unstable(state);
+  return renderCalendarGrid_unstable(state);
+});
+
+CalendarGrid.displayName = 'CalendarGrid';

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.types.ts
@@ -13,5 +13,4 @@ export type CalendarGridProps = ComponentProps<CalendarGridSlots> & {};
  * State used in rendering CalendarGrid
  */
 export type CalendarGridState = ComponentState<CalendarGridSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarGridProps.
 // & Required<Pick<CalendarGridProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/CalendarGrid.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type CalendarGridSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * CalendarGrid Props
+ */
+export type CalendarGridProps = ComponentProps<CalendarGridSlots> & {};
+
+/**
+ * State used in rendering CalendarGrid
+ */
+export type CalendarGridState = ComponentState<CalendarGridSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarGridProps.
+// & Required<Pick<CalendarGridProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/__snapshots__/CalendarGrid.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/__snapshots__/CalendarGrid.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarGrid renders a default state 1`] = `
+<div>
+  <div
+    class="fui-CalendarGrid"
+  >
+    Default CalendarGrid
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/index.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/index.ts
@@ -1,0 +1,5 @@
+export * from './CalendarGrid';
+export * from './CalendarGrid.types';
+export * from './renderCalendarGrid';
+export * from './useCalendarGrid';
+export * from './useCalendarGridStyles';

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/renderCalendarGrid.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/renderCalendarGrid.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { CalendarGridState, CalendarGridSlots } from './CalendarGrid.types';
+
+/**
+ * Render the final JSX of CalendarGrid
+ */
+export const renderCalendarGrid_unstable = (state: CalendarGridState) => {
+  const { slots, slotProps } = getSlots<CalendarGridSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/useCalendarGrid.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/useCalendarGrid.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { CalendarGridProps, CalendarGridState } from './CalendarGrid.types';
+
+/**
+ * Create the state required to render CalendarGrid.
+ *
+ * The returned state can be modified with hooks such as useCalendarGridStyles_unstable,
+ * before being passed to renderCalendarGrid_unstable.
+ *
+ * @param props - props from this instance of CalendarGrid
+ * @param ref - reference to root HTMLElement of CalendarGrid
+ */
+export const useCalendarGrid_unstable = (props: CalendarGridProps, ref: React.Ref<HTMLElement>): CalendarGridState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarGrid/useCalendarGridStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarGrid/useCalendarGridStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { CalendarGridSlots, CalendarGridState } from './CalendarGrid.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const calendarGridClassNames: SlotClassNames<CalendarGridSlots> = {
+  root: 'fui-CalendarGrid',
+  // TODO: add class names for all slots on CalendarGridSlots.
+  // Should be of the form `<slotName>: 'fui-CalendarGrid__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the CalendarGrid slots based on the state
+ */
+export const useCalendarGridStyles_unstable = (state: CalendarGridState): CalendarGridState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(calendarGridClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { CalendarMonth } from './CalendarMonth';
+import { isConformant } from '../../testing/isConformant';
+
+describe('CalendarMonth', () => {
+  isConformant({
+    Component: CalendarMonth,
+    displayName: 'CalendarMonth',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<CalendarMonth>Default CalendarMonth</CalendarMonth>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useCalendarMonth_unstable } from './useCalendarMonth';
+import { renderCalendarMonth_unstable } from './renderCalendarMonth';
+import { useCalendarMonthStyles_unstable } from './useCalendarMonthStyles';
+import type { CalendarMonthProps } from './CalendarMonth.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * CalendarMonth component - TODO: add more docs
+ */
+export const CalendarMonth: ForwardRefComponent<CalendarMonthProps> = React.forwardRef((props, ref) => {
+  const state = useCalendarMonth_unstable(props, ref);
+
+  useCalendarMonthStyles_unstable(state);
+  return renderCalendarMonth_unstable(state);
+});
+
+CalendarMonth.displayName = 'CalendarMonth';

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type CalendarMonthSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * CalendarMonth Props
+ */
+export type CalendarMonthProps = ComponentProps<CalendarMonthSlots> & {};
+
+/**
+ * State used in rendering CalendarMonth
+ */
+export type CalendarMonthState = ComponentState<CalendarMonthSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarMonthProps.
+// & Required<Pick<CalendarMonthProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/CalendarMonth.types.ts
@@ -13,5 +13,4 @@ export type CalendarMonthProps = ComponentProps<CalendarMonthSlots> & {};
  * State used in rendering CalendarMonth
  */
 export type CalendarMonthState = ComponentState<CalendarMonthSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarMonthProps.
 // & Required<Pick<CalendarMonthProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/__snapshots__/CalendarMonth.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/__snapshots__/CalendarMonth.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarMonth renders a default state 1`] = `
+<div>
+  <div
+    class="fui-CalendarMonth"
+  >
+    Default CalendarMonth
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/index.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/index.ts
@@ -1,0 +1,5 @@
+export * from './CalendarMonth';
+export * from './CalendarMonth.types';
+export * from './renderCalendarMonth';
+export * from './useCalendarMonth';
+export * from './useCalendarMonthStyles';

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/renderCalendarMonth.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/renderCalendarMonth.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { CalendarMonthState, CalendarMonthSlots } from './CalendarMonth.types';
+
+/**
+ * Render the final JSX of CalendarMonth
+ */
+export const renderCalendarMonth_unstable = (state: CalendarMonthState) => {
+  const { slots, slotProps } = getSlots<CalendarMonthSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/useCalendarMonth.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/useCalendarMonth.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { CalendarMonthProps, CalendarMonthState } from './CalendarMonth.types';
+
+/**
+ * Create the state required to render CalendarMonth.
+ *
+ * The returned state can be modified with hooks such as useCalendarMonthStyles_unstable,
+ * before being passed to renderCalendarMonth_unstable.
+ *
+ * @param props - props from this instance of CalendarMonth
+ * @param ref - reference to root HTMLElement of CalendarMonth
+ */
+export const useCalendarMonth_unstable = (
+  props: CalendarMonthProps,
+  ref: React.Ref<HTMLElement>,
+): CalendarMonthState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarMonth/useCalendarMonthStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarMonth/useCalendarMonthStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { CalendarMonthSlots, CalendarMonthState } from './CalendarMonth.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const calendarMonthClassNames: SlotClassNames<CalendarMonthSlots> = {
+  root: 'fui-CalendarMonth',
+  // TODO: add class names for all slots on CalendarMonthSlots.
+  // Should be of the form `<slotName>: 'fui-CalendarMonth__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the CalendarMonth slots based on the state
+ */
+export const useCalendarMonthStyles_unstable = (state: CalendarMonthState): CalendarMonthState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(calendarMonthClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { CalendarPicker } from './CalendarPicker';
+import { isConformant } from '../../testing/isConformant';
+
+describe('CalendarPicker', () => {
+  isConformant({
+    Component: CalendarPicker,
+    displayName: 'CalendarPicker',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<CalendarPicker>Default CalendarPicker</CalendarPicker>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useCalendarPicker_unstable } from './useCalendarPicker';
+import { renderCalendarPicker_unstable } from './renderCalendarPicker';
+import { useCalendarPickerStyles_unstable } from './useCalendarPickerStyles';
+import type { CalendarPickerProps } from './CalendarPicker.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * CalendarPicker component - TODO: add more docs
+ */
+export const CalendarPicker: ForwardRefComponent<CalendarPickerProps> = React.forwardRef((props, ref) => {
+  const state = useCalendarPicker_unstable(props, ref);
+
+  useCalendarPickerStyles_unstable(state);
+  return renderCalendarPicker_unstable(state);
+});
+
+CalendarPicker.displayName = 'CalendarPicker';

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type CalendarPickerSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * CalendarPicker Props
+ */
+export type CalendarPickerProps = ComponentProps<CalendarPickerSlots> & {};
+
+/**
+ * State used in rendering CalendarPicker
+ */
+export type CalendarPickerState = ComponentState<CalendarPickerSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarPickerProps.
+// & Required<Pick<CalendarPickerProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/CalendarPicker.types.ts
@@ -13,5 +13,4 @@ export type CalendarPickerProps = ComponentProps<CalendarPickerSlots> & {};
  * State used in rendering CalendarPicker
  */
 export type CalendarPickerState = ComponentState<CalendarPickerSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarPickerProps.
 // & Required<Pick<CalendarPickerProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/__snapshots__/CalendarPicker.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/__snapshots__/CalendarPicker.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarPicker renders a default state 1`] = `
+<div>
+  <div
+    class="fui-CalendarPicker"
+  >
+    Default CalendarPicker
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/index.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/index.ts
@@ -1,0 +1,5 @@
+export * from './CalendarPicker';
+export * from './CalendarPicker.types';
+export * from './renderCalendarPicker';
+export * from './useCalendarPicker';
+export * from './useCalendarPickerStyles';

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/renderCalendarPicker.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/renderCalendarPicker.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { CalendarPickerState, CalendarPickerSlots } from './CalendarPicker.types';
+
+/**
+ * Render the final JSX of CalendarPicker
+ */
+export const renderCalendarPicker_unstable = (state: CalendarPickerState) => {
+  const { slots, slotProps } = getSlots<CalendarPickerSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/useCalendarPicker.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/useCalendarPicker.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { CalendarPickerProps, CalendarPickerState } from './CalendarPicker.types';
+
+/**
+ * Create the state required to render CalendarPicker.
+ *
+ * The returned state can be modified with hooks such as useCalendarPickerStyles_unstable,
+ * before being passed to renderCalendarPicker_unstable.
+ *
+ * @param props - props from this instance of CalendarPicker
+ * @param ref - reference to root HTMLElement of CalendarPicker
+ */
+export const useCalendarPicker_unstable = (
+  props: CalendarPickerProps,
+  ref: React.Ref<HTMLElement>,
+): CalendarPickerState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarPicker/useCalendarPickerStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarPicker/useCalendarPickerStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { CalendarPickerSlots, CalendarPickerState } from './CalendarPicker.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const calendarPickerClassNames: SlotClassNames<CalendarPickerSlots> = {
+  root: 'fui-CalendarPicker',
+  // TODO: add class names for all slots on CalendarPickerSlots.
+  // Should be of the form `<slotName>: 'fui-CalendarPicker__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the CalendarPicker slots based on the state
+ */
+export const useCalendarPickerStyles_unstable = (state: CalendarPickerState): CalendarPickerState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(calendarPickerClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { CalendarYear } from './CalendarYear';
+import { isConformant } from '../../testing/isConformant';
+
+describe('CalendarYear', () => {
+  isConformant({
+    Component: CalendarYear,
+    displayName: 'CalendarYear',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<CalendarYear>Default CalendarYear</CalendarYear>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useCalendarYear_unstable } from './useCalendarYear';
+import { renderCalendarYear_unstable } from './renderCalendarYear';
+import { useCalendarYearStyles_unstable } from './useCalendarYearStyles';
+import type { CalendarYearProps } from './CalendarYear.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * CalendarYear component - TODO: add more docs
+ */
+export const CalendarYear: ForwardRefComponent<CalendarYearProps> = React.forwardRef((props, ref) => {
+  const state = useCalendarYear_unstable(props, ref);
+
+  useCalendarYearStyles_unstable(state);
+  return renderCalendarYear_unstable(state);
+});
+
+CalendarYear.displayName = 'CalendarYear';

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.types.ts
@@ -13,5 +13,4 @@ export type CalendarYearProps = ComponentProps<CalendarYearSlots> & {};
  * State used in rendering CalendarYear
  */
 export type CalendarYearState = ComponentState<CalendarYearSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarYearProps.
 // & Required<Pick<CalendarYearProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.types.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/CalendarYear.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type CalendarYearSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * CalendarYear Props
+ */
+export type CalendarYearProps = ComponentProps<CalendarYearSlots> & {};
+
+/**
+ * State used in rendering CalendarYear
+ */
+export type CalendarYearState = ComponentState<CalendarYearSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from CalendarYearProps.
+// & Required<Pick<CalendarYearProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/__snapshots__/CalendarYear.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/__snapshots__/CalendarYear.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarYear renders a default state 1`] = `
+<div>
+  <div
+    class="fui-CalendarYear"
+  >
+    Default CalendarYear
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/index.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/index.ts
@@ -1,0 +1,5 @@
+export * from './CalendarYear';
+export * from './CalendarYear.types';
+export * from './renderCalendarYear';
+export * from './useCalendarYear';
+export * from './useCalendarYearStyles';

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/renderCalendarYear.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/renderCalendarYear.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { CalendarYearState, CalendarYearSlots } from './CalendarYear.types';
+
+/**
+ * Render the final JSX of CalendarYear
+ */
+export const renderCalendarYear_unstable = (state: CalendarYearState) => {
+  const { slots, slotProps } = getSlots<CalendarYearSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/useCalendarYear.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/useCalendarYear.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { CalendarYearProps, CalendarYearState } from './CalendarYear.types';
+
+/**
+ * Create the state required to render CalendarYear.
+ *
+ * The returned state can be modified with hooks such as useCalendarYearStyles_unstable,
+ * before being passed to renderCalendarYear_unstable.
+ *
+ * @param props - props from this instance of CalendarYear
+ * @param ref - reference to root HTMLElement of CalendarYear
+ */
+export const useCalendarYear_unstable = (props: CalendarYearProps, ref: React.Ref<HTMLElement>): CalendarYearState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/CalendarYear/useCalendarYearStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/CalendarYear/useCalendarYearStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { CalendarYearSlots, CalendarYearState } from './CalendarYear.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const calendarYearClassNames: SlotClassNames<CalendarYearSlots> = {
+  root: 'fui-CalendarYear',
+  // TODO: add class names for all slots on CalendarYearSlots.
+  // Should be of the form `<slotName>: 'fui-CalendarYear__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the CalendarYear slots based on the state
+ */
+export const useCalendarYearStyles_unstable = (state: CalendarYearState): CalendarYearState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(calendarYearClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DatePicker } from './DatePicker';
+import { isConformant } from '../../testing/isConformant';
+
+describe('DatePicker', () => {
+  isConformant({
+    Component: DatePicker,
+    displayName: 'DatePicker',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<DatePicker>Default DatePicker</DatePicker>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useDatePicker_unstable } from './useDatePicker';
+import { renderDatePicker_unstable } from './renderDatePicker';
+import { useDatePickerStyles_unstable } from './useDatePickerStyles';
+import type { DatePickerProps } from './DatePicker.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * DatePicker component - TODO: add more docs
+ */
+export const DatePicker: ForwardRefComponent<DatePickerProps> = React.forwardRef((props, ref) => {
+  const state = useDatePicker_unstable(props, ref);
+
+  useDatePickerStyles_unstable(state);
+  return renderDatePicker_unstable(state);
+});
+
+DatePicker.displayName = 'DatePicker';

--- a/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type DatePickerSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * DatePicker Props
+ */
+export type DatePickerProps = ComponentProps<DatePickerSlots> & {};
+
+/**
+ * State used in rendering DatePicker
+ */
+export type DatePickerState = ComponentState<DatePickerSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from DatePickerProps.
+// & Required<Pick<DatePickerProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/DatePicker.types.ts
@@ -13,5 +13,4 @@ export type DatePickerProps = ComponentProps<DatePickerSlots> & {};
  * State used in rendering DatePicker
  */
 export type DatePickerState = ComponentState<DatePickerSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from DatePickerProps.
 // & Required<Pick<DatePickerProps, 'propName'>>

--- a/packages/react-components/react-datepicker/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatePicker renders a default state 1`] = `
+<div>
+  <div
+    class="fui-DatePicker"
+  >
+    Default DatePicker
+  </div>
+</div>
+`;

--- a/packages/react-components/react-datepicker/src/components/DatePicker/index.ts
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/index.ts
@@ -1,0 +1,5 @@
+export * from './DatePicker';
+export * from './DatePicker.types';
+export * from './renderDatePicker';
+export * from './useDatePicker';
+export * from './useDatePickerStyles';

--- a/packages/react-components/react-datepicker/src/components/DatePicker/renderDatePicker.tsx
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/renderDatePicker.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { getSlots } from '@fluentui/react-utilities';
+import type { DatePickerState, DatePickerSlots } from './DatePicker.types';
+
+/**
+ * Render the final JSX of DatePicker
+ */
+export const renderDatePicker_unstable = (state: DatePickerState) => {
+  const { slots, slotProps } = getSlots<DatePickerSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <slots.root {...slotProps.root} />;
+};

--- a/packages/react-components/react-datepicker/src/components/DatePicker/useDatePicker.ts
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/useDatePicker.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@fluentui/react-utilities';
+import type { DatePickerProps, DatePickerState } from './DatePicker.types';
+
+/**
+ * Create the state required to render DatePicker.
+ *
+ * The returned state can be modified with hooks such as useDatePickerStyles_unstable,
+ * before being passed to renderDatePicker_unstable.
+ *
+ * @param props - props from this instance of DatePicker
+ * @param ref - reference to root HTMLElement of DatePicker
+ */
+export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HTMLElement>): DatePickerState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-datepicker/src/components/DatePicker/useDatePickerStyles.ts
+++ b/packages/react-components/react-datepicker/src/components/DatePicker/useDatePickerStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { DatePickerSlots, DatePickerState } from './DatePicker.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const datePickerClassNames: SlotClassNames<DatePickerSlots> = {
+  root: 'fui-DatePicker',
+  // TODO: add class names for all slots on DatePickerSlots.
+  // Should be of the form `<slotName>: 'fui-DatePicker__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the DatePicker slots based on the state
+ */
+export const useDatePickerStyles_unstable = (state: DatePickerState): DatePickerState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(datePickerClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-datepicker/src/index.ts
+++ b/packages/react-components/react-datepicker/src/index.ts
@@ -1,2 +1,16 @@
 // TODO: replace with real exports
 export {};
+export { DatePicker, datePickerClassNames, renderDatePicker_unstable, useDatePickerStyles_unstable, useDatePicker_unstable } from './DatePicker';
+export type { DatePickerProps, DatePickerSlots, DatePickerState } from './DatePicker';
+export { Calendar, calendarClassNames, renderCalendar_unstable, useCalendarStyles_unstable, useCalendar_unstable } from './Calendar';
+export type { CalendarProps, CalendarSlots, CalendarState } from './Calendar';
+export { CalendarDay, calendarDayClassNames, renderCalendarDay_unstable, useCalendarDayStyles_unstable, useCalendarDay_unstable } from './CalendarDay';
+export type { CalendarDayProps, CalendarDaySlots, CalendarDayState } from './CalendarDay';
+export { CalendarGrid, calendarGridClassNames, renderCalendarGrid_unstable, useCalendarGridStyles_unstable, useCalendarGrid_unstable } from './CalendarGrid';
+export type { CalendarGridProps, CalendarGridSlots, CalendarGridState } from './CalendarGrid';
+export { CalendarMonth, calendarMonthClassNames, renderCalendarMonth_unstable, useCalendarMonthStyles_unstable, useCalendarMonth_unstable } from './CalendarMonth';
+export type { CalendarMonthProps, CalendarMonthSlots, CalendarMonthState } from './CalendarMonth';
+export { CalendarPicker, calendarPickerClassNames, renderCalendarPicker_unstable, useCalendarPickerStyles_unstable, useCalendarPicker_unstable } from './CalendarPicker';
+export type { CalendarPickerProps, CalendarPickerSlots, CalendarPickerState } from './CalendarPicker';
+export { CalendarYear, calendarYearClassNames, renderCalendarYear_unstable, useCalendarYearStyles_unstable, useCalendarYear_unstable } from './CalendarYear';
+export type { CalendarYearProps, CalendarYearSlots, CalendarYearState } from './CalendarYear';

--- a/packages/react-components/react-datepicker/src/testing/isConformant.ts
+++ b/packages/react-components/react-datepicker/src/testing/isConformant.ts
@@ -1,0 +1,14 @@
+import { isConformant as baseIsConformant } from '@fluentui/react-conformance';
+import type { IsConformantOptions, TestObject } from '@fluentui/react-conformance';
+import griffelTests from '@fluentui/react-conformance-griffel';
+
+export function isConformant<TProps = {}>(
+  testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
+) {
+  const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+    componentPath: require.main?.filename.replace('.test', ''),
+    extraTests: griffelTests as TestObject<TProps>,
+  };
+
+  baseIsConformant(defaultOptions, testInfo);
+}

--- a/packages/react-components/react-datepicker/stories/Calendar/CalendarBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/Calendar/CalendarBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/Calendar/CalendarDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/Calendar/CalendarDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { Calendar, CalendarProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<CalendarProps>) => <Calendar {...props} />;

--- a/packages/react-components/react-datepicker/stories/Calendar/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/Calendar/index.stories.tsx
@@ -1,0 +1,18 @@
+import { Calendar } from '@fluentui/react-datepicker';
+
+import descriptionMd from './CalendarDescription.md';
+import bestPracticesMd from './CalendarBestPractices.md';
+
+export { Default } from './CalendarDefault.stories';
+
+export default {
+  title: 'Preview Components/Calendar',
+  component: Calendar,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/stories/CalendarDay/CalendarDayBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/CalendarDay/CalendarDayBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/CalendarDay/CalendarDayDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarDay/CalendarDayDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { CalendarDay, CalendarDayProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<CalendarDayProps>) => <CalendarDay {...props} />;

--- a/packages/react-components/react-datepicker/stories/CalendarDay/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarDay/index.stories.tsx
@@ -1,0 +1,18 @@
+import { CalendarDay } from '@fluentui/react-datepicker';
+
+import descriptionMd from './CalendarDayDescription.md';
+import bestPracticesMd from './CalendarDayBestPractices.md';
+
+export { Default } from './CalendarDayDefault.stories';
+
+export default {
+  title: 'Preview Components/CalendarDay',
+  component: CalendarDay,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/stories/CalendarGrid/CalendarGridBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/CalendarGrid/CalendarGridBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/CalendarGrid/CalendarGridDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarGrid/CalendarGridDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { CalendarGrid, CalendarGridProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<CalendarGridProps>) => <CalendarGrid {...props} />;

--- a/packages/react-components/react-datepicker/stories/CalendarGrid/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarGrid/index.stories.tsx
@@ -1,0 +1,18 @@
+import { CalendarGrid } from '@fluentui/react-datepicker';
+
+import descriptionMd from './CalendarGridDescription.md';
+import bestPracticesMd from './CalendarGridBestPractices.md';
+
+export { Default } from './CalendarGridDefault.stories';
+
+export default {
+  title: 'Preview Components/CalendarGrid',
+  component: CalendarGrid,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/stories/CalendarMonth/CalendarMonthBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/CalendarMonth/CalendarMonthBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/CalendarMonth/CalendarMonthDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarMonth/CalendarMonthDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { CalendarMonth, CalendarMonthProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<CalendarMonthProps>) => <CalendarMonth {...props} />;

--- a/packages/react-components/react-datepicker/stories/CalendarMonth/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarMonth/index.stories.tsx
@@ -1,0 +1,18 @@
+import { CalendarMonth } from '@fluentui/react-datepicker';
+
+import descriptionMd from './CalendarMonthDescription.md';
+import bestPracticesMd from './CalendarMonthBestPractices.md';
+
+export { Default } from './CalendarMonthDefault.stories';
+
+export default {
+  title: 'Preview Components/CalendarMonth',
+  component: CalendarMonth,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/stories/CalendarPicker/CalendarPickerBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/CalendarPicker/CalendarPickerBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/CalendarPicker/CalendarPickerDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarPicker/CalendarPickerDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { CalendarPicker, CalendarPickerProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<CalendarPickerProps>) => <CalendarPicker {...props} />;

--- a/packages/react-components/react-datepicker/stories/CalendarPicker/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarPicker/index.stories.tsx
@@ -1,0 +1,18 @@
+import { CalendarPicker } from '@fluentui/react-datepicker';
+
+import descriptionMd from './CalendarPickerDescription.md';
+import bestPracticesMd from './CalendarPickerBestPractices.md';
+
+export { Default } from './CalendarPickerDefault.stories';
+
+export default {
+  title: 'Preview Components/CalendarPicker',
+  component: CalendarPicker,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/stories/CalendarYear/CalendarYearBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/CalendarYear/CalendarYearBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/CalendarYear/CalendarYearDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarYear/CalendarYearDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { CalendarYear, CalendarYearProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<CalendarYearProps>) => <CalendarYear {...props} />;

--- a/packages/react-components/react-datepicker/stories/CalendarYear/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/CalendarYear/index.stories.tsx
@@ -1,0 +1,18 @@
+import { CalendarYear } from '@fluentui/react-datepicker';
+
+import descriptionMd from './CalendarYearDescription.md';
+import bestPracticesMd from './CalendarYearBestPractices.md';
+
+export { Default } from './CalendarYearDefault.stories';
+
+export default {
+  title: 'Preview Components/CalendarYear',
+  component: CalendarYear,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/stories/DatePicker/DatePickerBestPractices.md
+++ b/packages/react-components/react-datepicker/stories/DatePicker/DatePickerBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-datepicker/stories/DatePicker/DatePickerDefault.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/DatePicker/DatePickerDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { DatePicker, DatePickerProps } from '@fluentui/react-datepicker';
+
+export const Default = (props: Partial<DatePickerProps>) => <DatePicker {...props} />;

--- a/packages/react-components/react-datepicker/stories/DatePicker/index.stories.tsx
+++ b/packages/react-components/react-datepicker/stories/DatePicker/index.stories.tsx
@@ -1,0 +1,18 @@
+import { DatePicker } from '@fluentui/react-datepicker';
+
+import descriptionMd from './DatePickerDescription.md';
+import bestPracticesMd from './DatePickerBestPractices.md';
+
+export { Default } from './DatePickerDefault.stories';
+
+export default {
+  title: 'Preview Components/DatePicker',
+  component: DatePicker,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-datepicker/tsconfig.json
+++ b/packages/react-components/react-datepicker/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
     }
   ]
 }

--- a/packages/react-components/react-datepicker/tsconfig.lib.json
+++ b/packages/react-components/react-datepicker/tsconfig.lib.json
@@ -9,6 +9,14 @@
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": [
+    "./src/testing/**",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-datepicker/tsconfig.spec.json
+++ b/packages/react-components/react-datepicker/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }


### PR DESCRIPTION
This PR Creates the Calendar components and DatePicker component. This is the outcome of just running `yarn create-component`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26226, #26225
