### PR TITLE
Update fluent 2 theme to reconcile with v9

### DIFF
--- a/change/@fluentui-fluent2-theme-8de94a1d-8f86-46ae-9a71-92747400ae1f.json
+++ b/change/@fluentui-fluent2-theme-8de94a1d-8f86-46ae-9a71-92747400ae1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated theme colors to match Fluent2",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/fluent2SharedColors.ts
+++ b/packages/fluent2-theme/src/fluent2SharedColors.ts
@@ -1,0 +1,32 @@
+import { IPalette } from '@fluentui/react';
+
+/**
+ * Shared colors from the Fluent 2 global palettes mapped to the v8 shared colors.
+ * The mappings are based on closest color match available as semantic name.
+ */
+export const fluent2SharedColors: Partial<IPalette> = {
+  yellowDark: '#d39300', // sharedColors.marigold.shade10
+  yellow: '#fde300', // sharedColors.yellow.primary
+  yellowLight: '#fef7b2', // sharedColors.yellow.tint40
+  orange: '#f7630c', // sharedColors.orange.primary
+  orangeLight: '#f98845', // sharedColors.orange.tint20
+  orangeLighter: '#fdcfb4', // sharedColors.orange.tint40
+  redDark: '#750b1c', // sharedColors.darkRed.primary
+  red: '#d13438', // sharedColors.red.primary
+  magentaDark: '#6b0043', // sharedColors.magenta.shade30
+  magenta: '#bf0077', // sharedColors.magenta.primary
+  magentaLight: '#d957a8', // sharedColors.magenta.tint30
+  purpleDark: '#401b6c', // sharedColors.darkPurple.primary
+  purple: '#5c2e91', // sharedColors.purple.primary
+  purpleLight: '#c6b1de', // sharedColors.purple.tint40
+  blueDark: '#003966', // sharedColors.darkBlue.primary
+  blueMid: '#004e8c', // sharedColors.royalBlue.primary
+  blue: '#0078d4', // sharedColors.blue.primary
+  blueLight: '#3a96dd', // sharedColors.lightBlue.primary
+  tealDark: '#006666', // sharedColors.darkTeal.primary
+  teal: '#038387', // sharedColors.teal.primary
+  tealLight: '#00b7c3', // sharedColors.lightTeal.primary
+  greenDark: '#0b6a0b', // sharedColors.darkGreen.primary
+  green: '#107c10', // sharedColors.green.primary
+  greenLight: '#13a10e', // sharedColors.lightGreen.primary
+};

--- a/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
@@ -2,6 +2,7 @@ import type { IPalette, ISemanticColors, ITheme } from '@fluentui/react';
 import { createTheme } from '@fluentui/react';
 import { IExtendedEffects } from './types';
 import { fluent2ComponentStyles } from './fluent2ComponentStyles';
+import { fluent2SharedColors } from './fluent2SharedColors';
 
 const fluent2ForV8DarkEffects: IExtendedEffects = {
   elevation4: '0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
@@ -16,29 +17,37 @@ const fluent2ForV8DarkEffects: IExtendedEffects = {
 };
 
 const fluent2ForV8DarkPalette: Partial<IPalette> = {
-  accent: '#2886de',
-  themePrimary: '#2886de',
-  themeLighterAlt: '#0A2E4A',
-  themeLighter: '#0c3b5e',
-  themeLight: '#0e4775',
-  themeTertiary: '#0f548c',
-  themeSecondary: '#2886de',
-  themeDarkAlt: '#479ef5',
-  themeDark: '#479ef5',
+  // properties are ordered here as in IPalette.ts
+
   themeDarker: '#62abf5',
-  neutralLighterAlt: '#1a1a1a',
-  neutralLighter: '#242424',
-  neutralLight: '#292929',
-  neutralQuaternaryAlt: '#2e2e2e',
-  neutralQuaternary: '#3d3d3d',
-  neutralTertiaryAlt: '#424242',
-  neutralTertiary: '#707070',
-  neutralSecondary: '#d1d1d1',
-  neutralPrimaryAlt: '#d6d6d6',
-  neutralPrimary: '#f5f5f5',
-  neutralDark: '#fafafa',
+  themeDark: '#479ef5',
+  themeDarkAlt: '#479ef5',
+  themePrimary: '#2886de',
+  themeSecondary: '#2886de',
+  themeTertiary: '#0f548c',
+  themeLight: '#0e4775',
+  themeLighter: '#0c3b5e',
+  themeLighterAlt: '#0A2E4A',
+
   black: '#ffffff', // Note white and black are inverted in this theme
+  blackTranslucent40: 'rgba(255 ,255 ,255 ,0.4)',
+  neutralDark: '#fafafa',
+  neutralPrimary: '#f5f5f5',
+  neutralPrimaryAlt: '#d6d6d6',
+  neutralSecondary: '#d1d1d1',
+  neutralSecondaryAlt: '#8a8886',
+  neutralTertiary: '#707070',
+  neutralTertiaryAlt: '#424242',
+  neutralQuaternary: '#3d3d3d',
+  neutralQuaternaryAlt: '#2e2e2e',
+  neutralLight: '#292929',
+  neutralLighter: '#242424',
+  neutralLighterAlt: '#1a1a1a',
+  accent: '#2886de',
   white: '#141414',
+  whiteTranslucent40: 'rgba(0, 0, 0, 0.4)',
+
+  ...fluent2SharedColors,
 };
 
 const p = fluent2ForV8DarkPalette;

--- a/packages/fluent2-theme/src/fluent2WebLightTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebLightTheme.ts
@@ -3,6 +3,7 @@ import { createTheme } from '@fluentui/react';
 import { IExtendedEffects } from './types';
 
 import { fluent2ComponentStyles } from './fluent2ComponentStyles';
+import { fluent2SharedColors } from './fluent2SharedColors';
 
 const fluent2ForV8DLightEffects: IExtendedEffects = {
   elevation4: '0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
@@ -22,38 +23,38 @@ const grey26 = '#424242';
 const grey74 = '#BDBDBD';
 
 const fluent2LightPalette: Partial<IPalette> = {
-  accent: '#0f6cbd',
-  themePrimary: '#0f6cbd',
-  themeLighterAlt: '#ebf3fc',
-  themeLighter: '#cfe4fa',
-  themeLight: '#b4d6fa',
-  themeTertiary: '#77b7f7',
-  themeSecondary: '#2886de', // Required by Fabric palette, only used in ShimmerWave
-  themeDarkAlt: '#115ea3',
-  themeDark: '#0f548c',
-  themeDarker: '#0c3b5e',
-  neutralLighterAlt: '#fafafa',
-  neutralLighter: '#f5f5f5',
-  neutralLight: '#ebebeb',
-  neutralQuaternaryAlt: '#e0e0e0',
-  neutralQuaternary: '#d1d1d1',
-  neutralTertiaryAlt: '#c7c7c7',
-  neutralTertiary: '#9e9e9e',
-  neutralSecondary: '#5c5c5c',
-  neutralPrimaryAlt: '#383838',
-  neutralPrimary: '#242424',
-  neutralDark: '#141414',
-  black: '#000000',
-  white: '#FFFFFF',
+  // properties are ordered here as in IPalette.ts
 
-  yellowDark: '#835C00',
-  yellow: '#F2E384',
-  yellowLight: '#FBF6D9',
-  orange: '#A33D2A',
-  orangeLight: '#CC4A31',
-  orangeLighter: '#EDC2A7',
-  redDark: '#8E192E',
-  red: '#C4314B',
+  themeDarker: '#0c3b5e',
+  themeDark: '#0f548c',
+  themeDarkAlt: '#115ea3',
+  themePrimary: '#0f6cbd',
+  themeSecondary: '#2886de', // Required by Fabric palette, only used in ShimmerWave
+  themeTertiary: '#77b7f7',
+  themeLight: '#b4d6fa',
+  themeLighter: '#cfe4fa',
+  themeLighterAlt: '#ebf3fc',
+
+  black: '#000000',
+  blackTranslucent40: 'rgba(0, 0, 0, 0.4)',
+  neutralDark: '#141414',
+  neutralPrimary: '#242424',
+  neutralPrimaryAlt: '#383838',
+  neutralSecondary: '#5c5c5c',
+  neutralSecondaryAlt: '#8a8886',
+  neutralTertiary: '#9e9e9e',
+  neutralTertiaryAlt: '#c7c7c7',
+  neutralQuaternary: '#d1d1d1',
+  neutralQuaternaryAlt: '#e0e0e0',
+  neutralLight: '#ebebeb',
+  neutralLighter: '#f5f5f5',
+  neutralLighterAlt: '#fafafa',
+
+  accent: '#0f6cbd',
+  white: '#FFFFFF',
+  whiteTranslucent40: 'rgba(255 ,255 ,255 ,0.4)',
+
+  ...fluent2SharedColors,
 };
 
 const p = fluent2LightPalette;


### PR DESCRIPTION
## Changes

- Mapped the v9 global colors to the v8 shared colors creating a shared colors partial palette
- Updated both light and dark themes to pick up the new shared colors
- Added some missing palette colors in light and dark themes
- Fixed the alpha black/white color inversion in the dark theme
- Reorganized the light and dark palettes to be ordered like IPalette for readability/reconciliation