### PR TITLE
chore: fix typo in Dialog docs

### DIFF
--- a/change/@fluentui-react-dialog-e4f307fd-e8fd-40ef-ad9a-1644b08ddca0.json
+++ b/change/@fluentui-react-dialog-e4f307fd-e8fd-40ef-ad9a-1644b08ddca0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix typo in Dialog docs",
+  "packageName": "@fluentui/react-dialog",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-dialog/stories/Dialog/DialogNonModal.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogNonModal.md
@@ -1,5 +1,5 @@
 A `non-modal` Dialog by default presents no `backdrop`, allowing elements outside of the Dialog to be interacted with (unless `DialogSurface` `noTrapFocus` property is provided).
 
-`DialogTitle` compound componet will present by default a `closeButton`.
+`DialogTitle` compound component will present by default a `closeButton`.
 
 To ensure that `Escape` key still works for dismissing the Dialog an event listener in the `document` is added. `onOpenChange` method from `Dialog` will return data as: `{ type: 'documentEscapeKeyDown'; open: boolean; event: KeyboardEvent };`


### PR DESCRIPTION
Fixes typo in "component"