### PR TITLE
chore: Re-exporting makeResetStyles in @fluentui/react-components

### DIFF
--- a/change/@fluentui-react-components-a51180d1-0c56-4535-940f-5a4bb8cfeadd.json
+++ b/change/@fluentui-react-components-a51180d1-0c56-4535-940f-5a4bb8cfeadd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Re-exporting makeResetStyles.",
+  "packageName": "@fluentui/react-components",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -201,6 +201,7 @@ import { linkClassNames } from '@fluentui/react-link';
 import { LinkProps } from '@fluentui/react-link';
 import { LinkSlots } from '@fluentui/react-link';
 import { LinkState } from '@fluentui/react-link';
+import { makeResetStyles } from '@griffel/react';
 import { makeStaticStyles } from '@griffel/react';
 import { makeStyles } from '@griffel/react';
 import { Menu } from '@fluentui/react-menu';
@@ -1034,6 +1035,8 @@ export { LinkProps }
 export { LinkSlots }
 
 export { LinkState }
+
+export { makeResetStyles }
 
 export { makeStaticStyles }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -5,6 +5,7 @@ export {
   __resetStyles,
   __styles,
   createDOMRenderer,
+  makeResetStyles,
   makeStaticStyles,
   makeStyles,
   mergeClasses,


### PR DESCRIPTION
## PR Description

This PR re-exports `makeResetStyles` in `@fluentui/react-components` to allow for its consumption without having to import it from `@griffel/react` directly.