### PR TITLE
chore: Add bug bash to convergence checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/convergence_epic.md
+++ b/.github/ISSUE_TEMPLATE/convergence_epic.md
@@ -42,6 +42,7 @@ completed as part of creating a v9 component. More info can be found here: https
   - [ ] Accessibility behavior tests
   - [ ] Create an issue and run [manual accessibility tests](https://github.com/microsoft/fluentui/wiki/Manual-Accessibility-Review-Checklist): [link to issue]
 - [ ] [Validate with partners](https://github.com/microsoft/fluentui/wiki/Component-Implementation-Guide#validation)
+- [ ] [Run a bug bash with other FUI crews](https://github.com/microsoft/fluentui/wiki/Component-Implementation-Guide#bug-bash)
 - [ ] [Finalize documentation](https://github.com/microsoft/fluentui/wiki/Component-Implementation-Guide#finalize-documentation)
   - [ ] Review and add any missing storybook stories
   - [ ] Finalize migration guide


### PR DESCRIPTION
I have reviewed the convergence epic to verify it matches the currently intended process.

Added `bug bash` item to both the checklist and [wiki](https://github.com/microsoft/fluentui/wiki/Component-Implementation-Guide#bug-bash).

I also documented the [versioning workflow](https://github.com/microsoft/fluentui/wiki/Component-Implementation-Guide#versioning-overview):
1. component prototype might be released as `alpha`, without exporting from `react-components`.
2. after initial implementation, it is released as `beta`, re-exported from `react-components/unstable`.
3. after validation, it is released as final, re-exported from `react-components`.

This matches [Fluent UI React Component Lifecycle - DEV Community 👩‍💻👨‍💻](https://dev.to/paulgildea/fluent-ui-react-component-lifecycle-29n5).