### PR TITLE
fix(TableCellActions): Background should match rown on hover and active

### DIFF
--- a/change/@fluentui-react-table-df5a4037-978d-47fd-806e-51e0efbe1ea3.json
+++ b/change/@fluentui-react-table-df5a4037-978d-47fd-806e-51e0efbe1ea3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(TableCellActions): Background should match rown on hover and active",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableCell/useTableCellStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCellStyles.ts
@@ -54,6 +54,7 @@ const useFlexLayoutStyles = makeStyles({
  */
 const useStyles = makeStyles({
   root: {
+    backgroundColor: 'inherit',
     position: 'relative',
     ...shorthands.padding('0px', tokens.spacingHorizontalS),
 

--- a/packages/react-components/react-table/src/components/TableCellActions/useTableCellActionsStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCellActions/useTableCellActionsStyles.ts
@@ -11,6 +11,7 @@ export const tableCellActionsClassNames: SlotClassNames<TableCellActionsSlots> =
  */
 const useStyles = makeStyles({
   root: {
+    backgroundColor: 'inherit',
     position: 'absolute',
     right: '0px',
     top: '50%',

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
@@ -57,10 +57,6 @@ const useStyles = makeStyles({
   noAppearanceFocusWithin: {
     ...createCustomFocusIndicatorStyle(
       {
-        [`& .${tableCellActionsClassNames.root}`]: {
-          backgroundColor: tokens.colorSubtleBackgroundHover,
-        },
-
         backgroundColor: tokens.colorSubtleBackgroundHover,
       },
       { selector: 'focus-within', enableOutline: true },
@@ -72,7 +68,6 @@ const useStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       color: tokens.colorNeutralForeground1Pressed,
       [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorSubtleBackgroundPressed,
         opacity: 1,
       },
       [`& .${tableSelectionCellClassNames.root}`]: {
@@ -83,7 +78,6 @@ const useStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundHover,
       color: tokens.colorNeutralForeground1Hover,
       [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorSubtleBackgroundHover,
         opacity: 1,
       },
       [`& .${tableSelectionCellClassNames.root}`]: {
@@ -110,15 +104,9 @@ const useStyles = makeStyles({
     ...shorthands.borderColor(tokens.colorNeutralStrokeOnBrand),
     ':hover': {
       backgroundColor: tokens.colorBrandBackground2,
-      [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorBrandBackground2,
-      },
     },
     ':active': {
       backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
-      [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
-      },
     },
 
     '@media(forced-colors: active)': {
@@ -144,15 +132,9 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground1Hover,
     ':hover': {
       backgroundColor: tokens.colorSubtleBackgroundSelected,
-      [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorSubtleBackgroundSelected,
-      },
     },
     ':active': {
       backgroundColor: tokens.colorSubtleBackgroundSelected,
-      [`& .${tableCellActionsClassNames.root}`]: {
-        backgroundColor: tokens.colorSubtleBackgroundSelected,
-      },
     },
 
     ...shorthands.borderColor(tokens.colorNeutralStrokeOnBrand),

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.ts
@@ -110,9 +110,15 @@ const useStyles = makeStyles({
     ...shorthands.borderColor(tokens.colorNeutralStrokeOnBrand),
     ':hover': {
       backgroundColor: tokens.colorBrandBackground2,
+      [`& .${tableCellActionsClassNames.root}`]: {
+        backgroundColor: tokens.colorBrandBackground2,
+      },
     },
     ':active': {
       backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
+      [`& .${tableCellActionsClassNames.root}`]: {
+        backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
+      },
     },
 
     '@media(forced-colors: active)': {
@@ -136,10 +142,19 @@ const useStyles = makeStyles({
     },
     backgroundColor: tokens.colorSubtleBackgroundSelected,
     color: tokens.colorNeutralForeground1Hover,
-
+    ':hover': {
+      backgroundColor: tokens.colorSubtleBackgroundSelected,
+      [`& .${tableCellActionsClassNames.root}`]: {
+        backgroundColor: tokens.colorSubtleBackgroundSelected,
+      },
+    },
     ':active': {
       backgroundColor: tokens.colorSubtleBackgroundSelected,
+      [`& .${tableCellActionsClassNames.root}`]: {
+        backgroundColor: tokens.colorSubtleBackgroundSelected,
+      },
     },
+
     ...shorthands.borderColor(tokens.colorNeutralStrokeOnBrand),
   },
 

--- a/packages/react-components/react-table/stories/Table/SelectionWithCellActions.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SelectionWithCellActions.stories.tsx
@@ -1,0 +1,223 @@
+import * as React from 'react';
+import {
+  FolderRegular,
+  EditRegular,
+  OpenRegular,
+  DocumentRegular,
+  PeopleRegular,
+  DocumentPdfRegular,
+  VideoRegular,
+  EditFilled,
+  MoreHorizontalFilled,
+  MoreHorizontalRegular,
+  bundleIcon,
+} from '@fluentui/react-icons';
+import { PresenceBadgeStatus, Avatar, Button } from '@fluentui/react-components';
+import {
+  TableBody,
+  TableCell,
+  TableRow,
+  Table,
+  TableHeader,
+  TableHeaderCell,
+  TableSelectionCell,
+  TableCellLayout,
+  useTableFeatures,
+  TableColumnDefinition,
+  useTableSelection,
+  createTableColumn,
+  TableCellActions,
+} from '@fluentui/react-components/unstable';
+
+const EditIcon = bundleIcon(EditFilled, EditRegular);
+const MoreHorizontalIcon = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
+
+type FileCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type LastUpdatedCell = {
+  label: string;
+  timestamp: number;
+};
+
+type LastUpdateCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type AuthorCell = {
+  label: string;
+  status: PresenceBadgeStatus;
+};
+
+type Item = {
+  file: FileCell;
+  author: AuthorCell;
+  lastUpdated: LastUpdatedCell;
+  lastUpdate: LastUpdateCell;
+};
+
+const items: Item[] = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 3 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 1 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
+
+const columns: TableColumnDefinition<Item>[] = [
+  createTableColumn<Item>({
+    columnId: 'file',
+  }),
+  createTableColumn<Item>({
+    columnId: 'author',
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdated',
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdate',
+  }),
+];
+
+export const SelectionWithCellActions = () => {
+  const {
+    getRows,
+    selection: { allRowsSelected, someRowsSelected, toggleAllRows, toggleRow, isRowSelected },
+  } = useTableFeatures(
+    {
+      columns,
+      items,
+    },
+    [
+      useTableSelection({
+        selectionMode: 'multiselect',
+        defaultSelectedItems: new Set([0, 1]),
+      }),
+    ],
+  );
+
+  const rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: (e: React.MouseEvent) => !e.defaultPrevented && toggleRow(e, row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ' && !e.defaultPrevented) {
+          e.preventDefault();
+          toggleRow(e, row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
+
+  const toggleAllKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ') {
+        toggleAllRows(e);
+        e.preventDefault();
+      }
+    },
+    [toggleAllRows],
+  );
+
+  const onClickCellActions = (e: React.MouseEvent<HTMLDivElement>) => e.preventDefault();
+  const onKeyDownCellActions = (e: React.KeyboardEvent<HTMLDivElement>) => e.key === ' ' && e.preventDefault();
+
+  return (
+    <Table aria-label="Table with multiselect">
+      <TableHeader>
+        <TableRow>
+          <TableSelectionCell
+            checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
+            onClick={toggleAllRows}
+            onKeyDown={toggleAllKeydown}
+            checkboxIndicator={{ 'aria-label': 'Select all rows ' }}
+          />
+          <TableHeaderCell>File</TableHeaderCell>
+          <TableHeaderCell>Author</TableHeaderCell>
+          <TableHeaderCell>Last updated</TableHeaderCell>
+          <TableHeaderCell>Last update</TableHeaderCell>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
+          <TableRow
+            key={item.file.label}
+            onClick={onClick}
+            onKeyDown={onKeyDown}
+            aria-selected={selected}
+            appearance={appearance}
+          >
+            <TableSelectionCell checked={selected} checkboxIndicator={{ 'aria-label': 'Select row' }} />
+            <TableCell>
+              <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
+              <TableCellActions onClick={onClickCellActions} onKeyDown={onKeyDownCellActions}>
+                <Button icon={<EditIcon />} appearance="subtle" />
+                <Button icon={<MoreHorizontalIcon />} appearance="subtle" />
+              </TableCellActions>
+            </TableCell>
+            <TableCell>
+              <TableCellLayout media={<Avatar aria-label={item.author.label} badge={{ status: item.author.status }} />}>
+                {item.author.label}
+              </TableCellLayout>
+            </TableCell>
+            <TableCell>{item.lastUpdated.label}</TableCell>
+            <TableCell>
+              <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+SelectionWithCellActions.parameters = {
+  docs: {
+    description: {
+      story: [
+        'When using cell actions with row selection, some event handling logic is necessary so that',
+        'invoking the cell actions does not invoke the row (therefore invoking selection).',
+        'How this is done will depend on each use case, so this event handling is not handled by any of',
+        'the library components. This examples handles such events by using `preventDefault` and `defaultPrevented`',
+        'properties.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-table/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/index.stories.tsx
@@ -25,6 +25,7 @@ export { SingleSelect } from './SingleSelect.stories';
 export { MultipleSelectControlled } from './MultipleSelectControlled.stories';
 export { SingleSelectControlled } from './SingleSelectControlled.stories';
 export { SubtleSelection } from './SubtleSelection.stories';
+export { SelectionWithCellActions } from './SelectionWithCellActions.stories';
 export { Virtualization } from './Virtualization.stories';
 export { DataGrid } from './DataGrid.stories';
 


### PR DESCRIPTION
## Previous Behavior

![image](https://user-images.githubusercontent.com/20744592/212764864-fa4dd514-ef7d-40e3-a7e6-c559f2745ded.png)

## New Behavior

![image](https://user-images.githubusercontent.com/20744592/212764907-0391bb03-f7c4-44ea-bc57-fbf673d91ba8.png)

Also adds a selection example with cell actions to handle event propagation

## Related Issue(s)

Fixes #26202
