### PR TITLE
fix: Styles should be inserted on portal at render time

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -38,6 +38,7 @@
     "@fluentui/react-menu": "^9.6.2",
     "@fluentui/react-persona": "^9.1.2",
     "@fluentui/react-popover": "^9.4.1",
+    "@fluentui/react-portal": "^9.1.1",
     "@fluentui/react-positioning": "^9.3.8",
     "@fluentui/react-progress": "9.0.0-alpha.12",
     "@fluentui/react-provider": "^9.2.2",

--- a/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Portal } from '@fluentui/react-portal';
+import { Button } from '@fluentui/react-button';
+import { tokens } from '@fluentui/react-theme';
+import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { makeStyles, shorthands } from '@griffel/react';
+import { ComponentMeta } from '@storybook/react';
+import { Steps } from 'storywright';
+import { withStoryWrightSteps } from '../utilities/withStoryWrightSteps';
+
+export const steps = new Steps()
+  .mouseDown('button')
+  .snapshot('should have green border', { cropTo: '.testWrapper' })
+  .end();
+
+export default {
+  title: 'Portal',
+  Component: Portal,
+  decorators: [story => withStoryWrightSteps({ story, steps })],
+} as ComponentMeta<typeof Portal>;
+
+const useStyles = makeStyles({
+  canary: {
+    ...shorthands.borderColor(tokens.colorPaletteGreenBackground2),
+    ...shorthands.borderWidth('5px'),
+  },
+});
+
+export const ApplyClassNames = () => {
+  const styles = useStyles();
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <button>foo</button>
+      </PopoverTrigger>
+      <PopoverSurface>
+        <Button className={styles.canary}>should have green border</Button>
+      </PopoverSurface>
+    </Popover>
+  );
+};

--- a/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
@@ -4,15 +4,14 @@ import { tokens } from '@fluentui/react-theme';
 import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
 import { makeStyles, shorthands } from '@griffel/react';
 import { ComponentMeta } from '@storybook/react';
-import { Steps } from 'storywright';
-import { withStoryWrightSteps } from '../utilities/withStoryWrightSteps';
+import { Steps, StoryWright } from 'storywright';
 
-const steps = new Steps().mouseDown('button').snapshot('should have green border', { cropTo: '.testWrapper' }).end();
+const steps = new Steps().click('#popoverTrigger').snapshot('should have green border').end();
 
 export default {
   title: 'Portal',
   Component: Portal,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  decorators: [story => <StoryWright steps={steps}>{story()}</StoryWright>],
 } as ComponentMeta<typeof Portal>;
 
 const useStyles = makeStyles({
@@ -25,19 +24,12 @@ const useStyles = makeStyles({
   },
 });
 
-/**
- * CSS variable insertion can happen after the DOM is mounted.
- * This can accidentally trigger transitions on mount. The below example
- * adds a transition to the border. If the css variable insertion happens
- * after DOM is mounted, then the applied border colour should not be
- * visible in the screenshot since the transtion duration is 1000 seconds.
- */
-export const ApplyClassNames = () => {
+const Example = () => {
   const styles = useStyles();
   return (
     <Popover>
       <PopoverTrigger>
-        <button>foo</button>
+        <button id="popoverTrigger">foo</button>
       </PopoverTrigger>
       <PopoverSurface>
         <button className={styles.canary}>should have green border</button>
@@ -45,3 +37,12 @@ export const ApplyClassNames = () => {
     </Popover>
   );
 };
+
+/**
+ * CSS variable insertion can happen after the DOM is mounted.
+ * This can accidentally trigger transitions on mount. The below example
+ * adds a transition to the border. If the css variable insertion happens
+ * after DOM is mounted, then the applied border colour should not be
+ * visible in the screenshot since the transtion duration is 1000 seconds.
+ */
+export const ApplyClassNames = () => <Example />;

--- a/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Portal } from '@fluentui/react-portal';
-import { Button } from '@fluentui/react-button';
 import { tokens } from '@fluentui/react-theme';
 import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
 import { makeStyles, shorthands } from '@griffel/react';
@@ -23,9 +22,19 @@ const useStyles = makeStyles({
   canary: {
     ...shorthands.borderColor(tokens.colorPaletteGreenBackground2),
     ...shorthands.borderWidth('5px'),
+    transitionDuration: '1000s',
+    transitionProperty: 'border',
+    transitionTimingFunction: tokens.curveEasyEase,
   },
 });
 
+/**
+ * CSS variable insertion can happen after the DOM is mounted.
+ * This can accidentally trigger transitions on mount. The below example
+ * adds a transition to the border. If the css variable insertion happens
+ * after DOM is mounted, then the applied border colour should not be
+ * visible in the screenshot since the transtion duration is 1000 seconds.
+ */
 export const ApplyClassNames = () => {
   const styles = useStyles();
   return (
@@ -34,7 +43,7 @@ export const ApplyClassNames = () => {
         <button>foo</button>
       </PopoverTrigger>
       <PopoverSurface>
-        <Button className={styles.canary}>should have green border</Button>
+        <button className={styles.canary}>should have green border</button>
       </PopoverSurface>
     </Popover>
   );

--- a/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Portal.stories.tsx
@@ -7,10 +7,7 @@ import { ComponentMeta } from '@storybook/react';
 import { Steps } from 'storywright';
 import { withStoryWrightSteps } from '../utilities/withStoryWrightSteps';
 
-export const steps = new Steps()
-  .mouseDown('button')
-  .snapshot('should have green border', { cropTo: '.testWrapper' })
-  .end();
+const steps = new Steps().mouseDown('button').snapshot('should have green border', { cropTo: '.testWrapper' }).end();
 
 export default {
   title: 'Portal',

--- a/change/@fluentui-react-portal-64ab0884-f002-4c94-aef1-124662da7cb1.json
+++ b/change/@fluentui-react-portal-64ab0884-f002-4c94-aef1-124662da7cb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Insert css variables class at render time",
+  "packageName": "@fluentui/react-portal",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -6,12 +6,6 @@ import {
 import { makeStyles, mergeClasses } from '@griffel/react';
 import { useFocusVisible } from '@fluentui/react-tabster';
 import { useDisposable } from 'use-disposable';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
-
-// String concatenation is used to prevent bundlers to complain with older versions of React
-const useInsertionEffect = (React as never)['useInsertion' + 'Effect']
-  ? (React as never)['useInsertion' + 'Effect']
-  : useIsomorphicLayoutEffect;
 
 export type UsePortalMountNodeOptions = {
   /**

--- a/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -48,11 +48,11 @@ export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElem
     return [newElement, () => newElement.remove()];
   }, [targetDocument]);
 
-  // This useEffect call is intentional
+  // This useMemo call is intentional
   // We don't want to re-create the portal element when its attributes change.
   // This also should not be done in an effect because, changing the value of css variables
   // after initial mount can trigger interesting CSS side effects like transitions.
-  useInsertionEffect(() => {
+  React.useMemo(() => {
     if (!element) {
       return;
     }

--- a/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -7,6 +7,8 @@ import { makeStyles, mergeClasses } from '@griffel/react';
 import { useFocusVisible } from '@fluentui/react-tabster';
 import { useDisposable } from 'use-disposable';
 
+const useInsertionEffect = (React as never)['useInsertion' + 'Effect'] as typeof React.useLayoutEffect;
+
 export type UsePortalMountNodeOptions = {
   /**
    * Since hooks cannot be called conditionally use this flag to disable creating the node
@@ -46,7 +48,7 @@ export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElem
 
   if (reactMajorVersion >= 18) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    ((React as never)['useInsertion' + 'Effect'] as typeof React.useLayoutEffect)(() => {
+    useInsertionEffect(() => {
       if (!element) {
         return;
       }

--- a/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -21,6 +21,8 @@ const useStyles = makeStyles({
   },
 });
 
+const reactMajorVersion = Number(React.version.split('.')[0]);
+
 /**
  * Creates a new element on a document.body to mount portals
  */
@@ -42,7 +44,7 @@ export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElem
     return [newElement, () => newElement.remove()];
   }, [targetDocument]);
 
-  if (React.version.startsWith('18')) {
+  if (reactMajorVersion >= 18) {
     // @ts-expect-error useInsertionEffect does not exist on React 17 types
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useInsertionEffect(() => {

--- a/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortalMountNode.ts
@@ -45,9 +45,8 @@ export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElem
   }, [targetDocument]);
 
   if (reactMajorVersion >= 18) {
-    // @ts-expect-error useInsertionEffect does not exist on React 17 types
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useInsertionEffect(() => {
+    ((React as never)['useInsertion' + 'Effect'] as typeof React.useLayoutEffect)(() => {
       if (!element) {
         return;
       }


### PR DESCRIPTION
Fixes #25432 again

`useInsertionEffect` will run before DOM has been mounted. However, the fallback `useIsomorphicLayoutEffect` will still trigger the problem in React 17 and below.

Adds 2 different code paths for React 18 and below. React 18 will use `useInsertionEffect` which is strict mode safe. React 17 will still use `useMemo`.

This will result in extra code in the bundle but, means we are using correct API in future versions of React