### PR TITLE
fix(react-northstar)(ChatMessage): action menu positioning in RTL

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- `ChatMessage` action menu is moved horizontally at the start in RTL. @silviuaavram ([#26378](https://github.com/microsoft/fluentui/pull/26378))
+
 <!--------------------------------[ v0.66.0 ]------------------------------- -->
 ## [v0.66.0](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.66.0) (2023-01-06)
 [Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-northstar_v0.65.0..@fluentui/react-northstar_v0.66.0)

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatMessage.tsx
@@ -336,6 +336,7 @@ export const ChatMessage = (React.forwardRef<HTMLDivElement, ChatMessageProps>((
   const popperRef = React.useRef<PopperRefHandle>();
   const { targetRef: actionsMenuTargetRef, containerRef: actionsMenuRef } = usePopper({
     align: 'end',
+    rtl: context.rtl,
     position: 'above',
     positionFixed: overflow,
 

--- a/packages/fluentui/react-northstar/test/specs/components/Chat/ChatMessage-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Chat/ChatMessage-test.tsx
@@ -1,9 +1,23 @@
+import * as React from 'react';
+
 import { handlesAccessibility, implementsShorthandProp, isConformant } from 'test/specs/commonTests';
 
 import { ChatMessage } from 'src/components/Chat/ChatMessage';
 import { Text } from 'src/components/Text/Text';
+import { usePopper } from 'src/utils/positioner';
+import { LikeIcon } from '@fluentui/react-icons-northstar';
 import { ChatMessageDetails } from 'src/components/Chat/ChatMessageDetails';
 import { ChatMessageContent } from 'src/components/Chat/ChatMessageContent';
+import { mountWithProvider, EmptyThemeProvider } from 'test/utils';
+
+jest.mock('src/utils/positioner', () => {
+  const actualPositioner = jest.requireActual('src/utils/positioner');
+
+  return {
+    ...actualPositioner,
+    usePopper: jest.fn().mockReturnValue(actualPositioner.usePopper),
+  };
+});
 
 const chatMessageImplementsShorthandProp = implementsShorthandProp(ChatMessage);
 
@@ -23,5 +37,48 @@ describe('ChatMessage', () => {
 
   describe('accessibility', () => {
     handlesAccessibility(ChatMessage);
+  });
+
+  describe('rtl', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    function render(wrappingComponent?: React.ComponentType) {
+      const actionMenu = {
+        iconOnly: true,
+        items: [
+          {
+            key: 'like',
+            icon: <LikeIcon />,
+            title: 'Like',
+          },
+        ],
+      };
+
+      mountWithProvider(
+        <ChatMessage
+          actionMenu={actionMenu}
+          key="message-1"
+          content="Hello"
+          author="Robert Tolbert"
+          timestamp="10:15 PM"
+          mine
+        />,
+        { wrappingComponent },
+      );
+    }
+    it('should pass rtl parameter as true to usePopper in RTL', () => {
+      const RTLProvider = props => <EmptyThemeProvider {...props} rtl={true} />;
+      render(RTLProvider);
+
+      expect(usePopper).toHaveBeenCalledTimes(1);
+      expect(usePopper).toHaveBeenCalledWith(expect.objectContaining({ rtl: true }));
+    });
+
+    it('should pass rtl parameter as undefined to usePopper in LTR', () => {
+      render();
+
+      expect(usePopper).toHaveBeenCalledTimes(1);
+      expect(usePopper).toHaveBeenCalledWith(expect.objectContaining({ rtl: undefined }));
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The ChatMessage action menu position in RTL languages was the same as in LTR, starting horizontally at the end of the message element.

<img width="305" alt="Screenshot 2023-01-17 at 17 23 37" src="https://user-images.githubusercontent.com/11275392/212939096-490f2de8-001f-4c8e-95f1-09c43ec1d51f.png">

<!-- This is the behavior we have today -->

## New Behavior

In RTL, it should be placed at the start of the message element.

<img width="288" alt="Screenshot 2023-01-17 at 17 25 11" src="https://user-images.githubusercontent.com/11275392/212939151-d3b82f46-31ce-4429-9362-cf338489eb84.png">

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
