### PR TITLE
feat(react-tabster): add id to useModalAttributes options

### DIFF
--- a/change/@fluentui-react-tabster-5065c018-0a25-4a76-9359-7f114ddf23e8.json
+++ b/change/@fluentui-react-tabster-5065c018-0a25-4a76-9359-7f114ddf23e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add modalizer id to `useModalAttributes` option",
+  "packageName": "@fluentui/react-tabster",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -90,6 +90,7 @@ export const useModalAttributes: (options?: UseModalAttributesOptions) => {
 // @public (undocumented)
 export interface UseModalAttributesOptions {
     alwaysFocusable?: boolean;
+    id?: string;
     legacyTrapFocus?: boolean;
     trapFocus?: boolean;
 }

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -24,6 +24,11 @@ export interface UseModalAttributesOptions {
    * Always reachabled in Tab order
    */
   alwaysFocusable?: boolean;
+
+  /**
+   * Id to use for the modalizer. An id will be generated if not provided.
+   */
+  id?: string;
 }
 
 /**
@@ -44,7 +49,7 @@ export const useModalAttributes = (
     getDeloser(tabster);
   }
 
-  const id = useId('modal-');
+  const id = useId('modal-', options.id);
   const modalAttributes = useTabsterAttributes({
     deloser: {},
     modalizer: {


### PR DESCRIPTION
Add `id` to `useModalAttributes` to allow consumer to specify modalizer id.

This will come in handy with the tabster feature that allows multiple DOM element being in the same modalizer by sharing the same id.