### PR TITLE
fix: react components version in migration shim package

### DIFF
--- a/packages/react-components/react-migration-v0-v9/package.json
+++ b/packages/react-components/react-migration-v0-v9/package.json
@@ -34,7 +34,7 @@
     "@fluentui/react-utilities": "^9.4.0",
     "@griffel/react": "^1.5.2",
     "tslib": "^2.1.0",
-    "@fluentui/react-components": "^9.10.0",
+    "@fluentui/react-components": "^9.11.0",
     "@fluentui/react-northstar": "^0.66.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Overview

Fix `@fluentui/react-components` version in the `react-migration-v0-v9` package. 