### PR TITLE
fix: Stretch Field components to full width

### DIFF
--- a/change/@fluentui-react-field-5e8c8b4f-2cf4-48b1-bbff-5c5191886ff5.json
+++ b/change/@fluentui-react-field-5e8c8b4f-2cf4-48b1-bbff-5c5191886ff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Stretch Field components to full width",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
+++ b/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
@@ -21,7 +21,6 @@ const iconSize = '12px';
 const useRootStyles = makeStyles({
   base: {
     display: 'grid',
-    justifyItems: 'start',
   },
 
   // In horizontal layout, the field is a grid with the label taking up the entire first column.
@@ -49,8 +48,6 @@ const useLabelStyles = makeStyles({
     marginRight: tokens.spacingHorizontalM,
     gridRowStart: '1',
     gridRowEnd: '-1',
-    alignSelf: 'start',
-    justifySelf: 'stretch',
   },
 });
 


### PR DESCRIPTION
## Previous Behavior

Components inside a Field are their natural width; not the full width of the Field's div.
<img width="235" alt="image" src="https://user-images.githubusercontent.com/48106640/211090906-d6e07777-91d9-4fb6-82b0-d921491751bd.png">

## New Behavior

The component within a field stretches to fill the whole width of the field. The field itself can be resized to the desired width of the component, label, hint, etc.
<img width="237" alt="image" src="https://user-images.githubusercontent.com/48106640/211091070-5e0429c8-c048-4d38-8eb8-5a8b516fccfe.png">

## Related Issue(s)

* Fixes #26224
