### PR TITLE
fix: Update Field label padding to match spec

### DIFF
--- a/change/@fluentui-react-field-c0f37c59-769b-4ad0-abdd-a19f0986fdba.json
+++ b/change/@fluentui-react-field-c0f37c59-769b-4ad0-abdd-a19f0986fdba.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix: Update Label padding to match spec",
+  "comment": "fix: Update Field label padding to match spec",
   "packageName": "@fluentui/react-field",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-field-c0f37c59-769b-4ad0-abdd-a19f0986fdba.json
+++ b/change/@fluentui-react-field-c0f37c59-769b-4ad0-abdd-a19f0986fdba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Update Label padding to match spec",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
+++ b/packages/react-components/react-field/src/components/Field/useFieldStyles.ts
@@ -41,8 +41,21 @@ const useRootStyles = makeStyles({
 
 const useLabelStyles = makeStyles({
   base: {
-    marginTop: tokens.spacingVerticalXXS,
+    paddingTop: tokens.spacingVerticalXXS,
+    paddingBottom: tokens.spacingVerticalXXS,
+  },
+
+  large: {
+    paddingTop: '1px',
+    paddingBottom: '1px',
+  },
+
+  vertical: {
     marginBottom: tokens.spacingVerticalXXS,
+  },
+
+  verticalLarge: {
+    marginBottom: tokens.spacingVerticalXS,
   },
 
   horizontal: {
@@ -122,6 +135,9 @@ export const useFieldStyles_unstable = <T extends FieldControl>(state: FieldStat
       classNames.label,
       labelStyles.base,
       horizontal && labelStyles.horizontal,
+      !horizontal && labelStyles.vertical,
+      state.label.size === 'large' && labelStyles.large,
+      !horizontal && state.label.size === 'large' && labelStyles.verticalLarge,
       state.label.className,
     );
   }


### PR DESCRIPTION
## Previous Behavior

There is insufficient padding between the Field and its input component. See #26223 for more details.

## New Behavior

Update padding of Field's label to match the visual spec.

## Related Issue(s)

* Fixes #26223
