### PR TITLE
fix: Field sets role="alert" on its error message so it is announced by screen readers

### DIFF
--- a/change/@fluentui-react-field-ee01fe61-b500-4b36-a794-0fa4365aafe3.json
+++ b/change/@fluentui-react-field-ee01fe61-b500-4b36-a794-0fa4365aafe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Field sets role=\"alert\" on its error message so it is announced by screen readers",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/src/components/Field/Field.test.tsx
+++ b/packages/react-components/react-field/src/components/Field/Field.test.tsx
@@ -145,4 +145,12 @@ describe('Field', () => {
 
     expect(input.getAttribute('aria-describedby')).toBe('test-describedby');
   });
+
+  it('sets role="alert" on the validation when it is an error', () => {
+    const result = render(<MockField validationState="error" validationMessage="test error message" />);
+
+    const validationMessage = result.getByText('test error message');
+
+    expect(validationMessage.getAttribute('role')).toBe('alert');
+  });
 });

--- a/packages/react-components/react-field/src/components/Field/useField.tsx
+++ b/packages/react-components/react-field/src/components/Field/useField.tsx
@@ -82,6 +82,7 @@ export const useField_unstable = <T extends FieldControl>(
   const validationMessage = resolveShorthand(fieldProps.validationMessage, {
     defaultProps: {
       id: baseId + '__validationMessage',
+      role: validationState === 'error' ? 'alert' : undefined,
     },
   });
 


### PR DESCRIPTION
## Previous Behavior

Field error messages are not announced by screen readers when they appear.

## New Behavior

Add `role="alert"` to the field's validation message when it is an error, so that it is read by screen readers.

## Related Issue(s)


* Fixes #26032
