### PR TITLE
fix(ProgressBar): rename rectangular shape to square

### DIFF
--- a/change/@fluentui-react-progress-d61e18f8-f765-4611-92ed-4d9630561ce2.json
+++ b/change/@fluentui-react-progress-d61e18f8-f765-4611-92ed-4d9630561ce2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rename rectangular shape to square",
+  "packageName": "@fluentui/react-progress",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-progress/etc/react-progress.api.md
+++ b/packages/react-components/react-progress/etc/react-progress.api.md
@@ -24,7 +24,7 @@ export const progressBarClassNames: SlotClassNames<ProgressBarSlots>;
 
 // @public
 export type ProgressBarProps = Omit<ComponentProps<ProgressBarSlots>, 'size'> & {
-    shape?: 'rounded' | 'rectangular';
+    shape?: 'rounded' | 'square';
     value?: number;
     max?: number;
     thickness?: 'medium' | 'large';

--- a/packages/react-components/react-progress/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/ProgressBar.types.ts
@@ -19,7 +19,7 @@ export type ProgressBarProps = Omit<ComponentProps<ProgressBarSlots>, 'size'> & 
    * The shape of the bar and track.
    * @default 'rounded'
    */
-  shape?: 'rounded' | 'rectangular';
+  shape?: 'rounded' | 'square';
   /**
    * A decimal number between `0` and `1` (or between `0` and `max` if given),
    * which specifies how much of the task has been completed.

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
@@ -52,7 +52,7 @@ const useRootStyles = makeStyles({
   rounded: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
   },
-  rectangular: {
+  square: {
     ...shorthands.borderRadius(tokens.borderRadiusNone),
   },
   medium: {

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarDescription.md
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarDescription.md
@@ -6,7 +6,7 @@ A Progress provides a visual representation of content being loaded or processed
 >
 > ```jsx
 >
-> import { Progress } from '@fluentui/react-components/unstable';
+> import { ProgressBar } from '@fluentui/react-components/unstable';
 >
 > ```
 >

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarShape.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarShape.stories.tsx
@@ -15,7 +15,7 @@ export const Shape = () => {
     <div>
       <ProgressBar className={styles.container} shape="rounded" thickness="large" value={0.5} />
 
-      <ProgressBar className={styles.container} shape="rectangular" thickness="large" value={0.5} />
+      <ProgressBar className={styles.container} shape="square" thickness="large" value={0.5} />
     </div>
   );
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

```jsx
<ProgressBar shape="rectangular" />
```

The `rectangular` shape is inconsistent with all other components which use `'rounded' | 'circular' | 'square'`

## New Behavior

```jsx
<ProgressBar shape="square" />
```

The `shape` prop now accepts `'rounded' | 'square'`

