### PR TITLE
chore: remove obsolete configs and decouple type-check from bundling in v0 `perf` app

### DIFF
--- a/packages/fluentui/perf/gulp/shared.ts
+++ b/packages/fluentui/perf/gulp/shared.ts
@@ -1,0 +1,6 @@
+import * as path from 'path';
+
+export const packageRoot = path.join(__dirname, '..');
+
+export const packageDist = path.join(packageRoot, 'dist');
+export const packageSrc = path.join(packageRoot, 'src');

--- a/packages/fluentui/perf/gulp/webpack.config.ts
+++ b/packages/fluentui/perf/gulp/webpack.config.ts
@@ -7,7 +7,7 @@ import webpack from 'webpack';
 import { config } from '@fluentui/scripts-gulp';
 import { getDefaultEnvironmentVars } from '@fluentui/scripts-monorepo';
 
-const { paths } = config;
+import { packageDist, packageSrc, packageRoot } from './shared';
 
 export const webpackConfig: webpack.Configuration = {
   name: 'client',
@@ -15,11 +15,11 @@ export const webpackConfig: webpack.Configuration = {
   // eslint-disable-next-line no-extra-boolean-cast
   mode: Boolean(argv.debug) ? 'development' : 'production',
   entry: {
-    app: path.join(__dirname, '..', 'src/index'),
+    app: path.join(packageSrc, 'index'),
   },
   output: {
     filename: `[name].js`,
-    path: path.join(__dirname, '..', 'dist'),
+    path: packageDist,
     pathinfo: true,
     publicPath: config.compiler_public_path,
   },
@@ -44,14 +44,14 @@ export const webpackConfig: webpack.Configuration = {
     new webpack.DefinePlugin(getDefaultEnvironmentVars(!argv.debug)),
     new ForkTsCheckerWebpackPlugin({
       typescript: {
-        configFile: paths.e2e('tsconfig.json'),
+        configFile: path.join(packageRoot, 'tsconfig.json'),
       },
     }),
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: path.join(__dirname, '..', 'src/index.html'),
-          to: path.join(__dirname, '..', 'dist'),
+          from: path.join(packageRoot, 'src/index.html'),
+          to: packageDist,
         },
       ],
     }),
@@ -63,16 +63,11 @@ export const webpackConfig: webpack.Configuration = {
     extensions: ['.ts', '.tsx', '.js', '.json'],
     alias: {
       ...config.lernaAliases({ type: 'webpack' }),
-      src: paths.packageSrc('react-northstar'),
 
       // We are using React in production mode with tracing.
       // https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977
       'react-dom$': 'react-dom/profiling',
       'scheduler/tracing': 'scheduler/tracing-profiling',
-
-      // Can be removed once Prettier will be upgraded to v2
-      // https://github.com/prettier/prettier/issues/6903
-      '@microsoft/typescript-etw': false,
     },
   },
   performance: {

--- a/packages/fluentui/perf/gulp/webpack.config.ts
+++ b/packages/fluentui/perf/gulp/webpack.config.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import { argv } from 'yargs';
 import webpack from 'webpack';
 
@@ -42,11 +41,6 @@ export const webpackConfig: webpack.Configuration = {
   },
   plugins: [
     new webpack.DefinePlugin(getDefaultEnvironmentVars(!argv.debug)),
-    new ForkTsCheckerWebpackPlugin({
-      typescript: {
-        configFile: path.join(packageRoot, 'tsconfig.json'),
-      },
-    }),
     new CopyWebpackPlugin({
       patterns: [
         {

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -23,6 +23,7 @@
     "perf:test": "cross-env PERF=true gulp perf --times=100",
     "perf:test:debug": "cross-env PERF=true gulp perf:debug --debug",
     "lint": "eslint --ext .js,.ts,.tsx .",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "type-check": "tsc -p ."
   }
 }

--- a/packages/fluentui/perf/src/globals.ts
+++ b/packages/fluentui/perf/src/globals.ts
@@ -1,0 +1,9 @@
+import type { ProfilerMeasureCycle, ProfilerMeasure } from '../types';
+
+declare global {
+  interface Window {
+    runMeasures: (filter?: string) => Promise<ProfilerMeasureCycle>;
+  }
+}
+
+export type { ProfilerMeasureCycle, ProfilerMeasure };

--- a/packages/fluentui/perf/src/index.tsx
+++ b/packages/fluentui/perf/src/index.tsx
@@ -6,7 +6,7 @@ import * as minimatch from 'minimatch';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { ProfilerMeasure, ProfilerMeasureCycle } from '../types';
+import type { ProfilerMeasure, ProfilerMeasureCycle } from '../types';
 
 const mountNode = document.querySelector('#root');
 const performanceExamplesContext = require.context('@fluentui/docs/src/examples/', true, /.perf.tsx$/);

--- a/packages/fluentui/perf/src/index.tsx
+++ b/packages/fluentui/perf/src/index.tsx
@@ -6,7 +6,7 @@ import * as minimatch from 'minimatch';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import type { ProfilerMeasure, ProfilerMeasureCycle } from '../types';
+import type { ProfilerMeasure, ProfilerMeasureCycle } from './globals';
 
 const mountNode = document.querySelector('#root');
 const performanceExamplesContext = require.context('@fluentui/docs/src/examples/', true, /.perf.tsx$/);

--- a/packages/fluentui/perf/tsconfig.json
+++ b/packages/fluentui/perf/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.v0.json",
   "compilerOptions": {
+    "noEmit": true,
     "module": "esnext",
     "types": ["node", "webpack-env"]
   },

--- a/packages/fluentui/perf/types.ts
+++ b/packages/fluentui/perf/types.ts
@@ -1,9 +1,3 @@
-declare global {
-  interface Window {
-    runMeasures: (filter?: string) => Promise<ProfilerMeasureCycle>;
-  }
-}
-
 export type MeasuredValues = 'actualTime' | 'renderComponentTime' | 'componentCount';
 
 export type ProfilerMeasure = { [key in MeasuredValues]: number } & {

--- a/scripts/gulp/src/webpack/webpack.config.e2e.ts
+++ b/scripts/gulp/src/webpack/webpack.config.e2e.ts
@@ -1,8 +1,7 @@
+import { getDefaultEnvironmentVars } from '@fluentui/scripts-monorepo';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import webpack from 'webpack';
-
-import { getDefaultEnvironmentVars } from '@fluentui/scripts-monorepo';
 
 import config from '../config';
 
@@ -25,10 +24,7 @@ const webpackConfig: webpack.Configuration = {
     global: true,
   },
   module: {
-    noParse: [
-      /anchor-js/,
-      /prettier\/parser-typescript/, // prettier issue, should be solved after upgrade prettier to version 2 https://github.com/prettier/prettier/issues/6903
-    ],
+    noParse: [/anchor-js/],
     rules: [
       {
         test: /\.(js|ts|tsx)$/,

--- a/tsconfig.base.v0.json
+++ b/tsconfig.base.v0.json
@@ -15,6 +15,7 @@
     "strictNullChecks": false,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "typeRoots": ["node_modules/@types", "./typings"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

- obsolete configs removed from webpack
- introduced `type-check` alias to run tsc
- skipLibCheck for v0 enabled

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Follows https://github.com/microsoft/fluentui/pull/26410
