### PR TITLE
Update theme shim stories

### DIFF
--- a/change/@fluentui-react-migration-v8-v9-97512810-4b6e-4699-acaa-097f1384e460.json
+++ b/change/@fluentui-react-migration-v8-v9-97512810-4b6e-4699-acaa-097f1384e460.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated shim to use fluent2 theme component styles",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-migration-v8-v9/package.json
+++ b/packages/react-migration-v8-v9/package.json
@@ -31,8 +31,10 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "3.3.4",
+    "@fluentui/fluent2-theme": "^8.104.10",
     "@fluentui/react": "^8.104.6",
     "@fluentui/react-components": "^9.11.0",
+    "@fluentui/react-icons": "^2.0.175",
     "@fluentui/react-theme": "^9.1.5",
     "@fluentui/react-utilities": "^9.4.0",
     "@griffel/react": "^1.5.2",

--- a/packages/react-migration-v8-v9/src/components/Theme/v8ThemeShim.ts
+++ b/packages/react-migration-v8-v9/src/components/Theme/v8ThemeShim.ts
@@ -1,5 +1,6 @@
-import { createTheme, DefaultPalette } from '@fluentui/react';
 import type { IPalette, ISemanticColors, IFontStyles, IFontWeight, IEffects, Theme as ThemeV8 } from '@fluentui/react';
+import { createTheme, DefaultPalette } from '@fluentui/react';
+import { fluent2ComponentStyles } from '@fluentui/fluent2-theme';
 
 import { BrandVariants, Theme as ThemeV9 } from '@fluentui/react-components';
 
@@ -330,6 +331,7 @@ export const createV8Theme = (
   return {
     ...baseTheme,
     palette: mapPalette(brandColors, isDarkTheme),
+    components: fluent2ComponentStyles,
     semanticColors: mapSemanticColors(baseTheme.semanticColors, themeV9),
     fonts: mapFonts(baseTheme.fonts, themeV9),
     effects: mapEffects(baseTheme.effects, themeV9),

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/ThemePreviewV8.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/ThemePreviewV8.tsx
@@ -1,0 +1,309 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as React from 'react';
+import { Checkbox } from '@fluentui/react/lib/Checkbox';
+import { ChoiceGroup } from '@fluentui/react/lib/ChoiceGroup';
+import { CommandBar } from '@fluentui/react/lib/CommandBar';
+import { DefaultButton, PrimaryButton, IconButton } from '@fluentui/react/lib/Button';
+import { Dropdown } from '@fluentui/react/lib/Dropdown';
+import { Icon } from '@fluentui/react/lib/Icon';
+import { Link } from '@fluentui/react/lib/Link';
+import { mergeStyles } from '@fluentui/react';
+import { Persona, PersonaPresence } from '@fluentui/react/lib/Persona';
+import { Pivot, PivotItem } from '@fluentui/react/lib/Pivot';
+import { Slider } from '@fluentui/react/lib/Slider';
+import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
+import { Text } from '@fluentui/react/lib/Text';
+import { TextField } from '@fluentui/react/lib/TextField';
+import { Toggle } from '@fluentui/react/lib/Toggle';
+
+export interface ISamplesProps {
+  backgroundColor: string;
+  textColor: string;
+}
+
+export interface ISamplesState {
+  learnMoreLinkDisabled: boolean;
+  selectOneDropdownDisabled: boolean;
+  textFieldDisabled: boolean;
+  checkboxOneDisabled: boolean;
+  checkboxTwoDisabled: boolean;
+  checkboxThreeDisabled: boolean;
+  choicegroupDisabled: boolean;
+  sliderDisabled: boolean;
+  likeIconButtonDisabled: boolean;
+  bookmarkIconButtonDisabled: boolean;
+  sunnyIconButtonDisabled: boolean;
+  primaryButtonDisabled: boolean;
+  defaultButtonDisabled: boolean;
+}
+
+const iconButtonStyles = mergeStyles({
+  color: '#0078D4',
+});
+
+const commandBarItems = [
+  {
+    key: 'newItem',
+    name: 'New',
+    cacheKey: 'myCacheKey', // changing this key will invalidate this item's cache
+    iconProps: {
+      iconName: 'Add',
+    },
+    ariaLabel: 'New',
+    subMenuProps: {
+      items: [
+        {
+          key: 'emailMessage',
+          name: 'Email message',
+          iconProps: {
+            iconName: 'Mail',
+          },
+          ['data-automation-id']: 'newEmailButton',
+        },
+        {
+          key: 'calendarEvent',
+          name: 'Calendar event',
+          iconProps: {
+            iconName: 'Calendar',
+          },
+        },
+      ],
+    },
+  },
+  {
+    key: 'upload',
+    name: 'Upload',
+    iconProps: {
+      iconName: 'Upload',
+    },
+    onClick: () => console.log('Upload'),
+    ['data-automation-id']: 'uploadButton',
+  },
+  {
+    key: 'share',
+    name: 'Share',
+    iconProps: {
+      iconName: 'Share',
+    },
+    onClick: () => console.log('Share'),
+  },
+  {
+    key: 'download',
+    name: 'Download',
+    iconProps: {
+      iconName: 'Download',
+    },
+    onClick: () => console.log('Download'),
+  },
+  {
+    key: 'more',
+    name: 'More',
+    iconProps: {
+      iconName: 'More',
+    },
+    onClick: () => console.log('More'),
+  },
+];
+
+const commandBarFarItems = [
+  {
+    key: 'search',
+    ariaLabel: 'Search',
+    iconProps: {
+      iconName: 'Search',
+    },
+    onClick: () => console.log('Search'),
+  },
+  {
+    key: 'filter',
+    name: 'Filter',
+    ariaLabel: 'Filter',
+    iconProps: {
+      iconName: 'Filter',
+    },
+    iconOnly: true,
+    onClick: () => console.log('Filter'),
+  },
+  {
+    key: 'list',
+    name: 'List',
+    ariaLabel: 'List',
+    iconProps: {
+      iconName: 'List',
+    },
+    iconOnly: true,
+    onClick: () => console.log('List'),
+  },
+];
+
+const layoutStyles = {
+  root: mergeStyles({
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr 1fr',
+    gridTemplateRows: 'auto',
+    gridColumnGap: '32px',
+    gridRowGap: '32px',
+    padding: '16px',
+  }),
+  commandBar: mergeStyles({
+    gridColumnStart: '1',
+    gridColumnEnd: '4',
+  }),
+};
+
+const stackXXXLGap: IStackTokens = { childrenGap: 32 };
+const stackXLGap: IStackTokens = { childrenGap: 20 };
+const stackLGap: IStackTokens = { childrenGap: 16 };
+const stackMNudgeGap: IStackTokens = { childrenGap: 10 };
+
+const checkboxStackTokens: IStackTokens = {
+  childrenGap: 13,
+};
+
+export class ThemePreviewV8 extends React.Component<ISamplesProps, ISamplesState> {
+  constructor(props: ISamplesProps) {
+    super(props);
+    this.state = {
+      learnMoreLinkDisabled: false,
+      selectOneDropdownDisabled: false,
+      textFieldDisabled: false,
+      checkboxOneDisabled: false,
+      checkboxTwoDisabled: false,
+      checkboxThreeDisabled: false,
+      choicegroupDisabled: false,
+      sliderDisabled: false,
+      likeIconButtonDisabled: false,
+      bookmarkIconButtonDisabled: false,
+      sunnyIconButtonDisabled: false,
+      primaryButtonDisabled: false,
+      defaultButtonDisabled: false,
+    };
+    this._onToggleChange = this._onToggleChange.bind(this);
+  }
+  public render() {
+    return (
+      <div style={{ backgroundColor: this.props.backgroundColor, color: this.props.textColor }}>
+        <div className={layoutStyles.root}>
+          <div className={layoutStyles.commandBar}>
+            <CommandBar farItems={commandBarFarItems} items={commandBarItems} />
+          </div>
+          <div>
+            <Stack tokens={stackXXXLGap}>
+              <Stack tokens={stackXLGap}>
+                <Text variant="small" styles={{ root: { color: this.props.textColor } }}>
+                  STORIES
+                </Text>
+                <Text variant="xxLarge" styles={{ root: { color: this.props.textColor, lineHeight: '1em' } }}>
+                  Make an impression
+                </Text>
+                <Text variant="medium" styles={{ root: { color: this.props.textColor } }}>
+                  Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate
+                  information to people inside or outisde your team. Share your ideas, results, and more in this
+                  visually compelling format.
+                </Text>
+                <Link disabled={this.state.learnMoreLinkDisabled}>
+                  Learn more <Icon iconName="ChevronRight" />
+                </Link>
+              </Stack>
+              <Persona
+                text="Cameron Evans"
+                secondaryText="Senior Researcher at Contoso"
+                presence={PersonaPresence.online}
+              />
+            </Stack>
+          </div>
+          <div>
+            <Stack tokens={stackXXXLGap}>
+              <Dropdown
+                selectedKey="content"
+                label="Select one"
+                options={[
+                  { key: 'content', text: 'Content' },
+                  { key: 'morecontent', text: 'More content' },
+                ]}
+                disabled={this.state.selectOneDropdownDisabled}
+              />
+              <TextField disabled={this.state.textFieldDisabled} label="Enter text here" placeholder="Placeholder" />
+              <Stack horizontal tokens={stackXLGap}>
+                <Stack tokens={checkboxStackTokens} grow={1}>
+                  <div />
+                  <Checkbox disabled={this.state.checkboxOneDisabled} label="Option 1" />
+                  <Checkbox disabled={this.state.checkboxTwoDisabled} label="Option 2" defaultChecked />
+                  <Checkbox disabled={this.state.checkboxThreeDisabled} label="Option 3" defaultChecked />
+                </Stack>
+                <Stack tokens={stackMNudgeGap} grow={1}>
+                  <ChoiceGroup
+                    defaultSelectedKey="A"
+                    options={[
+                      { key: 'A', text: 'Option 1' },
+                      { key: 'B', text: 'Option 2' },
+                      { key: 'C', text: 'Option 3' },
+                    ]}
+                    disabled={this.state.choicegroupDisabled}
+                  />
+                </Stack>
+              </Stack>
+            </Stack>
+          </div>
+          <div>
+            <Stack tokens={stackXXXLGap}>
+              <Slider disabled={this.state.sliderDisabled} max={11} />
+              <Toggle
+                onText="On"
+                offText="Off"
+                inlineLabel
+                label="Toggle for disabled states"
+                onChange={this._onToggleChange}
+              />
+              <Pivot>
+                <PivotItem headerText="Home" />
+                <PivotItem headerText="Pages" />
+                <PivotItem headerText="Documents" />
+                <PivotItem headerText="Activity" />
+              </Pivot>
+              <Stack horizontal tokens={stackLGap}>
+                <IconButton
+                  disabled={this.state.likeIconButtonDisabled}
+                  iconProps={{ iconName: 'Like' }}
+                  className={iconButtonStyles}
+                />
+                <IconButton
+                  disabled={this.state.bookmarkIconButtonDisabled}
+                  iconProps={{ iconName: 'SingleBookmark' }}
+                  className={iconButtonStyles}
+                />
+                <IconButton
+                  disabled={this.state.sunnyIconButtonDisabled}
+                  iconProps={{ iconName: 'Sunny' }}
+                  className={iconButtonStyles}
+                />
+              </Stack>
+              <Stack horizontal tokens={stackMNudgeGap}>
+                <PrimaryButton disabled={this.state.primaryButtonDisabled} text="Primary button" />
+                <DefaultButton disabled={this.state.defaultButtonDisabled} text="Default button" />
+              </Stack>
+            </Stack>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  private _onToggleChange() {
+    this.setState({
+      learnMoreLinkDisabled: !this.state.learnMoreLinkDisabled,
+      selectOneDropdownDisabled: !this.state.selectOneDropdownDisabled,
+      textFieldDisabled: !this.state.textFieldDisabled,
+      checkboxOneDisabled: !this.state.checkboxOneDisabled,
+      checkboxTwoDisabled: !this.state.checkboxTwoDisabled,
+      checkboxThreeDisabled: !this.state.checkboxThreeDisabled,
+      sliderDisabled: !this.state.sliderDisabled,
+      likeIconButtonDisabled: !this.state.likeIconButtonDisabled,
+      bookmarkIconButtonDisabled: !this.state.bookmarkIconButtonDisabled,
+      sunnyIconButtonDisabled: !this.state.sunnyIconButtonDisabled,
+      primaryButtonDisabled: !this.state.primaryButtonDisabled,
+      defaultButtonDisabled: !this.state.defaultButtonDisabled,
+    });
+  }
+}

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/ThemePreviewV9.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/ThemePreviewV9.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import {
+  tokens,
+  Body1,
+  Title3,
+  TabList,
+  Tab,
+  Input,
+  Button,
+  Caption1,
+  Slider,
+  Badge,
+  Switch,
+  Radio,
+  RadioGroup,
+  Checkbox,
+  Avatar,
+  useId,
+  Caption2,
+} from '@fluentui/react-components';
+import { Dropdown, Option } from '@fluentui/react-components/unstable';
+import {
+  SearchRegular,
+  bundleIcon,
+  ChevronRightRegular,
+  MeetNowRegular,
+  MeetNowFilled,
+  CalendarLtrFilled,
+  CalendarLtrRegular,
+} from '@fluentui/react-icons';
+
+export interface ContentProps {
+  className?: string;
+}
+
+const useStyles = makeStyles({
+  root: {
+    ...shorthands.padding('16px'),
+  },
+  threeCol: {
+    display: 'grid',
+    alignItems: 'start',
+    justifyContent: 'center',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gridTemplateRows: 'auto',
+    gridColumnGap: tokens.spacingHorizontalXXXL,
+  },
+  col1: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexDirection: 'column',
+    ...shorthands.gap(tokens.spacingVerticalL),
+  },
+  col2: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    ...shorthands.gap(tokens.spacingVerticalL),
+  },
+  col3: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridTemplateRows: 'repeat(4, auto)',
+    gridRowGap: tokens.spacingVerticalS,
+    gridColumnGap: tokens.spacingHorizontalS,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  twoCol: {
+    gridColumnStart: 1,
+    gridColumnEnd: 3,
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icons: {
+    display: 'grid',
+    gridTemplateColumns: 'auto auto',
+    gridTemplateRows: 'auto auto',
+    gridRowGap: tokens.spacingVerticalS,
+    gridColumnGap: tokens.spacingHorizontalS,
+    justifyContent: 'center',
+  },
+  avatar: {
+    display: 'flex',
+    ...shorthands.gap(tokens.spacingVerticalL),
+  },
+  avatarText: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'left',
+  },
+});
+
+const Column1 = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.col1}>
+      <Title3 block>Make an impression</Title3>
+      <Body1 block>
+        Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate information to
+        people inside or outside your team. Share your ideas, results, and more in this visually compelling format.
+      </Body1>
+      <div className={styles.avatar}>
+        <Avatar
+          color="brand"
+          initials="CE"
+          badge={{
+            status: 'available',
+            'aria-label': 'available',
+          }}
+        />
+        <div className={styles.avatarText}>
+          Cameron Evans
+          <Caption2>Senior Researcher at Contoso</Caption2>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Column2 = () => {
+  const styles = useStyles();
+  const dropdownId = useId('dropdown-default');
+  return (
+    <div className={styles.col2}>
+      <TabList defaultSelectedValue="tab1">
+        <Tab value="tab1">Home</Tab>
+        <Tab value="tab2">Pages</Tab>
+        <Tab value="tab3">Documents</Tab>
+      </TabList>
+      <Input
+        placeholder="Find"
+        contentAfter={<Button aria-label="Find" appearance="transparent" icon={<SearchRegular />} size="small" />}
+      />
+      <Dropdown aria-labelledby={dropdownId} placeholder="Select" inlinePopup>
+        <Option value="Action 1">Action 1</Option>
+        <Option value="Action 2">Action 2 </Option>
+        <Option value="Action 3">Action 3</Option>
+      </Dropdown>
+    </div>
+  );
+};
+
+const DemoIcons = () => {
+  const styles = useStyles();
+  const MeetNowIcon = bundleIcon(MeetNowFilled, MeetNowRegular);
+  const CalendarLtrIcon = bundleIcon(CalendarLtrFilled, CalendarLtrRegular);
+  return (
+    <div className={styles.icons}>
+      <Badge size="medium" appearance="filled" icon={<CalendarLtrIcon />} />
+      <Badge size="medium" appearance="ghost" icon={<CalendarLtrIcon />} />
+      <Badge size="medium" appearance="outline" icon={<MeetNowIcon />} />
+      <Badge size="medium" appearance="tint" icon={<MeetNowIcon />} />
+    </div>
+  );
+};
+
+const Column3 = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.col3}>
+      <Button appearance="primary">Sign Up</Button>
+      <Button appearance="transparent" icon={<ChevronRightRegular />} iconPosition="after">
+        Learn More
+      </Button>
+      <Slider className={styles.twoCol} defaultValue={50} />
+      <DemoIcons />
+      <div className={styles.controls}>
+        <Switch defaultChecked={true} label="On" />
+        <Switch label="Off" />
+      </div>
+      <div className={styles.controls}>
+        <Checkbox defaultChecked={true} label="Option 1" />
+        <Checkbox label="Option 2" />
+      </div>
+      <div className={styles.controls}>
+        <RadioGroup>
+          <Radio defaultChecked={true} label="Option 1" />
+          <Radio label="Option 2" />
+        </RadioGroup>
+      </div>
+    </div>
+  );
+};
+
+export const ThemePreviewV9: React.FC<ContentProps> = props => {
+  const styles = useStyles();
+  return (
+    <div className={styles.root}>
+      <Caption1>Examples</Caption1>
+      <div className={mergeClasses(styles.threeCol, props.className)}>
+        <Column1 />
+        <Column2 />
+        <Column3 />
+      </div>
+    </div>
+  );
+};

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/createV8Theme/Description.md
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/createV8Theme/Description.md
@@ -1,3 +1,4 @@
 The createV8Theme shim method allows you to create a v8 Theme from a BrandVariants (a.k.a brand ramp) and a v9 Theme.
 
-Create your v9 theme using `createLightTheme` or `createDarkTheme,` passing the BrandVariants you also pass to createV8Theme. The shim populates the v8 palette from the BrandVariants and the semanticColors from the v9 Theme. Because v9 Theme does not expose the BrandVariants used to create it, it must be passed in separately.
+The `fluent2ComponentStyles` are applied from the `@fluentui/fluent2-theme`.
+This updates the component styles to better match the exact styling of v9.

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/createV8Theme/index.stories.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/createV8Theme/index.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Theme as ThemeV8 } from '@fluentui/react';
+import { createTheme, Theme as ThemeV8, ThemeProvider, initializeIcons } from '@fluentui/react';
 import {
   Button,
   makeStyles,
@@ -12,11 +12,16 @@ import {
   Theme as ThemeV9,
   createLightTheme,
   createDarkTheme,
-  Checkbox,
+  tokens,
+  FluentProvider,
 } from '@fluentui/react-components';
 import { brandWeb, createV8Theme } from '../../../components/Theme/index';
 import descriptionMd from './Description.md';
 import { Meta } from '@storybook/react';
+import { ThemePreviewV8 } from '../ThemePreviewV8';
+import { ThemePreviewV9 } from '../ThemePreviewV9';
+
+initializeIcons();
 
 const useStyles = makeStyles({
   root: {
@@ -26,6 +31,9 @@ const useStyles = makeStyles({
     gridRowGap: '10px',
     justifyItems: 'start',
     ...shorthands.padding('5px'),
+  },
+  instructions: {
+    color: tokens.colorNeutralForeground2,
   },
   editor: {
     width: '400px',
@@ -38,6 +46,9 @@ const useStyles = makeStyles({
     [`& > *`]: {
       ...shorthands.margin('5px'),
     },
+  },
+  error: {
+    color: 'red',
   },
   result: {
     display: 'grid',
@@ -54,37 +65,24 @@ const useStyles = makeStyles({
   },
 });
 
-export const Default = () => {
+export const Playground = () => {
   const styles = useStyles();
 
   const defaultBrandVariantText = JSON.stringify(brandWeb, null, 4);
-  const defaultV9ThemeText = JSON.stringify(webLightTheme, null, 4);
-
-  const [isDarkTheme, setIsDarkTheme] = React.useState(false);
   const [brandVariantText, setBrandVariantText] = React.useState(defaultBrandVariantText);
+  const defaultV9Theme = webLightTheme;
+  const defaultV9ThemeText = JSON.stringify(defaultV9Theme, null, 4);
+  const [v9Theme, setV9Theme] = React.useState<ThemeV9>(defaultV9Theme);
   const [v9ThemeText, setV9ThemeText] = React.useState(defaultV9ThemeText);
-  const [v8Theme, setV8Theme] = React.useState<ThemeV8>();
+  const [createV9ThemeError, setCreateV9ThemeError] = React.useState('');
+  const [previewV9ThemeError, setPreviewV9ThemeError] = React.useState('');
 
-  const v8Effects = React.useMemo(() => ((v8Theme ? v8Theme.effects : {}) as unknown) as Record<string, string>, [
-    v8Theme,
-  ]);
-
-  const v8Fonts = React.useMemo(() => ((v8Theme ? v8Theme.fonts : {}) as unknown) as Record<string, string>, [v8Theme]);
-
-  const v8Spacing = React.useMemo(() => ((v8Theme ? v8Theme.spacing : {}) as unknown) as Record<string, string>, [
-    v8Theme,
-  ]);
-
-  const v8Palette = React.useMemo(() => ((v8Theme ? v8Theme.palette : {}) as unknown) as Record<string, string>, [
-    v8Theme,
-  ]);
-
-  const v8SemanticColors = React.useMemo(
-    () => ((v8Theme ? v8Theme.semanticColors : {}) as unknown) as Record<string, string>,
-    [v8Theme],
-  );
-
-  const [message, setMessage] = React.useState('');
+  const defaultV8Theme = createTheme();
+  const defaultV8ThemeText = JSON.stringify(defaultV8Theme, null, 4);
+  const [isDarkTheme, setIsDarkTheme] = React.useState(false);
+  const [v8Theme, setV8Theme] = React.useState<ThemeV8>(defaultV8Theme);
+  const [v8ThemeText, setV8ThemeText] = React.useState(defaultV8ThemeText);
+  const [createV8ThemeError, setCreateV8ThemeError] = React.useState('');
 
   const onBrandVariantTextChange: TextareaProps['onChange'] = (_, data) => {
     setBrandVariantText(data.value);
@@ -98,50 +96,99 @@ export const Default = () => {
     setBrandVariantText(defaultBrandVariantText);
   };
 
-  const onResetTheme = () => {
+  const onResetV9Theme = () => {
+    setV9Theme(defaultV9Theme);
     setV9ThemeText(defaultV9ThemeText);
+    setCreateV9ThemeError('');
+    setPreviewV9ThemeError('');
   };
 
-  const onSetLightBrandTheme = React.useCallback(() => {
-    const brandVariants = JSON.parse(brandVariantText) as BrandVariants;
-    const v9Theme = createLightTheme(brandVariants);
-    setV9ThemeText(JSON.stringify(v9Theme, null, 4));
-    setIsDarkTheme(false);
-  }, [brandVariantText]);
-
-  const onSetDarkBrandTheme = React.useCallback(() => {
-    const brandVariants = JSON.parse(brandVariantText) as BrandVariants;
-    const v9Theme = createDarkTheme(brandVariants);
-    setV9ThemeText(JSON.stringify(v9Theme, null, 4));
-    setIsDarkTheme(true);
-  }, [brandVariantText]);
-
-  const onCreateTheme = React.useCallback(() => {
+  const onCreateLightV9Theme = React.useCallback(() => {
     try {
+      setCreateV9ThemeError('');
       const brandVariants = JSON.parse(brandVariantText) as BrandVariants;
-      const v9Theme = JSON.parse(v9ThemeText) as ThemeV9;
-      const newV8Theme = createV8Theme(brandVariants, v9Theme, isDarkTheme);
-      setV8Theme(newV8Theme);
+      const newV9Theme = createLightTheme(brandVariants);
+      setV9Theme(newV9Theme);
+      setV9ThemeText(JSON.stringify(newV9Theme, null, 4));
+      setIsDarkTheme(false);
     } catch (e) {
-      setMessage((e as Error).message);
+      setCreateV9ThemeError((e as Error).message);
+    }
+  }, [brandVariantText]);
+
+  const onCreateDarkv9Theme = React.useCallback(() => {
+    try {
+      setCreateV9ThemeError('');
+      const brandVariants = JSON.parse(brandVariantText) as BrandVariants;
+      const newV9Theme = createDarkTheme(brandVariants);
+      setV9Theme(newV9Theme);
+      setV9ThemeText(JSON.stringify(newV9Theme, null, 4));
+      setIsDarkTheme(true);
+    } catch (e) {
+      setCreateV9ThemeError((e as Error).message);
+    }
+  }, [brandVariantText]);
+
+  const onPreviewV9Theme = React.useCallback(() => {
+    try {
+      setPreviewV9ThemeError('');
+      const newV9Theme = JSON.parse(v9ThemeText) as ThemeV9;
+      setV9Theme(newV9Theme);
+    } catch (e) {
+      setPreviewV9ThemeError((e as Error).message);
+    }
+  }, [v9ThemeText]);
+
+  const onCreateV8Theme = React.useCallback(() => {
+    try {
+      setCreateV8ThemeError('');
+      const newV9Theme = JSON.parse(v9ThemeText) as ThemeV9;
+      setV9Theme(newV9Theme);
+      const brandVariants = JSON.parse(brandVariantText) as BrandVariants;
+      const newV8Theme = createV8Theme(brandVariants, newV9Theme, isDarkTheme);
+      setV8Theme(newV8Theme);
+      setV8ThemeText(JSON.stringify(newV8Theme, null, 4));
+    } catch (e) {
+      setCreateV8ThemeError((e as Error).message);
     }
   }, [brandVariantText, isDarkTheme, v9ThemeText]);
 
+  const onResetV8Theme = () => {
+    setV8Theme(defaultV8Theme);
+    setV8ThemeText(defaultV8ThemeText);
+    setCreateV8ThemeError('');
+  };
+
   return (
     <div className={styles.root}>
-      <h2>Brand</h2>
+      <h2>1. Define Brand Variants</h2>
+      <div className={styles.instructions}>
+        <p>Adjust the brand variants (aka brand ramp). You can reset to the default brand colors.</p>
+        <p>
+          If you want to generate entirely different brand variants or v9 theme, use the&nbsp;
+          <a href="https://aka.ms/themedesigner-v9">v9 Theme Designer</a>.
+        </p>
+      </div>
+      <div className={styles.actions}>
+        <Button onClick={onResetBrand}>Reset</Button>
+      </div>
       <Textarea
         resize="both"
         textarea={{ className: styles.editor }}
         value={brandVariantText}
         onChange={onBrandVariantTextChange}
       />
-      <div className={styles.actions}>
-        <Button onClick={onResetBrand}>Reset</Button>
-        <Button onClick={onSetLightBrandTheme}>Set Light v9 Theme from Brand</Button>
-        <Button onClick={onSetDarkBrandTheme}>Set Dark v9 Theme from Brand</Button>
+      <h2>2. Create a v9 Theme</h2>
+      <div className={styles.instructions}>
+        Create a light or dark v9 theme from the brand variants. You can adjust the theme and click preview anytime.
+        them.
       </div>
-      <h2>v9 Theme</h2>
+      <div className={styles.actions}>
+        <Button onClick={onResetV9Theme}>Reset</Button>
+        <Button onClick={onCreateLightV9Theme}>Create Light Theme</Button>
+        <Button onClick={onCreateDarkv9Theme}>Create Dark Theme</Button>
+      </div>
+      <div className={styles.error}>{createV9ThemeError}</div>
       <Textarea
         resize="both"
         textarea={{ className: styles.editor }}
@@ -149,77 +196,30 @@ export const Default = () => {
         onChange={onV9ThemeTextChange}
       />
       <div className={styles.actions}>
-        <Button onClick={onResetTheme}>Reset</Button>
-        <Button onClick={onCreateTheme}>Create</Button>
-        <Checkbox
-          label="Dark Theme"
-          checked={isDarkTheme}
-          onChange={(_, data) => setIsDarkTheme(data.checked === true)}
-        />
+        <Button onClick={onPreviewV9Theme}>Preview</Button>
       </div>
-      <h2>v8 Theme</h2>
-      <div>{message}</div>
-      <h3>effects</h3>
-      <div className={styles.result}>
-        {Object.keys(v8Effects)
-          .sort()
-          .map(key => (
-            <>
-              <div>{key}</div>
-              <div>{v8Effects[key]}</div>
-            </>
-          ))}
+      <div className={styles.error}>{previewV9ThemeError}</div>
+      <FluentProvider theme={v9Theme}>
+        <ThemePreviewV9 />
+      </FluentProvider>
+      <h2>3. Create a v8 Theme</h2>
+      <div className={styles.instructions}>
+        Create a v8 theme from the v9 theme. You can copy the result to use it in your application.
       </div>
-      <h3>fonts</h3>
-      <div className={styles.result}>
-        {Object.keys(v8Fonts)
-          .sort()
-          .map(key => (
-            <>
-              <div>{key}</div>
-              <div>{JSON.stringify(v8Fonts[key])}</div>
-            </>
-          ))}
+      <div className={styles.actions}>
+        <Button onClick={onResetV8Theme}>Reset</Button>
+        <Button onClick={onCreateV8Theme}>Create</Button>
       </div>
-      <h3>palette</h3>
-      <div className={styles.result}>
-        {Object.keys(v8Palette)
-          .sort()
-          .map(key => (
-            <>
-              <div>{key}</div>
-              <div>
-                {v8Palette[key]}&nbsp;
-                <span className={styles.colorBlock} style={{ backgroundColor: v8Palette[key] }} />
-              </div>
-            </>
-          ))}
+      <div className={styles.error}>{createV8ThemeError}</div>
+      <div>
+        <ThemeProvider theme={v8Theme}>
+          <ThemePreviewV8
+            backgroundColor={v8Theme?.semanticColors.bodyBackground || 'white'}
+            textColor={v8Theme?.semanticColors.bodyText || 'black'}
+          />
+        </ThemeProvider>
       </div>
-      <h3>semanticColors</h3>
-      <div className={styles.result}>
-        {Object.keys(v8SemanticColors)
-          .sort()
-          .map(key => (
-            <>
-              <div>{key}</div>
-              <div>
-                {v8SemanticColors[key]}&nbsp;
-                <span className={styles.colorBlock} style={{ backgroundColor: v8SemanticColors[key] }} />
-              </div>
-            </>
-          ))}
-      </div>
-      <h3>spacing</h3>
-      <div className={styles.result}>
-        {Object.keys(v8Spacing)
-          .sort()
-          .map(key => (
-            <>
-              <div>{key}</div>
-              <div>{v8Spacing[key]}</div>
-            </>
-          ))}
-      </div>
+      <Textarea resize="both" readOnly textarea={{ className: styles.editor }} value={v8ThemeText} />
     </div>
   );
 };

--- a/packages/react-migration-v8-v9/src/stories/ThemeShim/createV9Theme/index.stories.tsx
+++ b/packages/react-migration-v8-v9/src/stories/ThemeShim/createV9Theme/index.stories.tsx
@@ -1,11 +1,23 @@
 import * as React from 'react';
 
-import { createTheme } from '@fluentui/react';
-import { Button, makeStyles, Textarea, TextareaProps, shorthands } from '@fluentui/react-components';
+import { createTheme, ThemeProvider, Theme as ThemeV8, DefaultPalette } from '@fluentui/react';
+import {
+  Button,
+  makeStyles,
+  Textarea,
+  TextareaProps,
+  shorthands,
+  tokens,
+  Theme as ThemeV9,
+  webLightTheme,
+  FluentProvider,
+} from '@fluentui/react-components';
 import { createV9Theme } from '../../../components/Theme/index';
 
 import descriptionMd from './Description.md';
 import { Meta } from '@storybook/react';
+import { ThemePreviewV8 } from '../ThemePreviewV8';
+import { ThemePreviewV9 } from '../ThemePreviewV9';
 
 const useStyles = makeStyles({
   root: {
@@ -16,6 +28,9 @@ const useStyles = makeStyles({
     justifyItems: 'start',
     ...shorthands.padding('5px'),
   },
+  instructions: {
+    color: tokens.colorNeutralForeground2,
+  },
   editor: {
     width: '400px',
     height: '300px',
@@ -25,6 +40,9 @@ const useStyles = makeStyles({
     gridTemplateColumns: 'auto auto',
     gridColumnGap: '10px',
     justifyItems: 'start',
+  },
+  error: {
+    color: 'red',
   },
   result: {
     display: 'grid',
@@ -41,65 +59,149 @@ const useStyles = makeStyles({
   },
 });
 
-export const Default = () => {
+export const Playground = () => {
   const styles = useStyles();
+
+  const defaultPaletteText = JSON.stringify(DefaultPalette, null, 4);
+  const [paletteText, setPaletteText] = React.useState(defaultPaletteText);
 
   const defaultV8Theme = createTheme();
   const defaultV8ThemeText = JSON.stringify(defaultV8Theme, null, 4);
-
   const [v8ThemeText, setV8ThemeText] = React.useState(defaultV8ThemeText);
-  const [v9Theme, setV9Theme] = React.useState({} as Record<string, string>);
+  const [v8Theme, setV8Theme] = React.useState<ThemeV8>(defaultV8Theme);
+  const [createV8ThemeError, setCreateV8ThemeError] = React.useState('');
+  const [previewV8ThemeError, setPreviewV8ThemeError] = React.useState('');
 
-  const [message, setMessage] = React.useState('');
+  const defaultV9Theme = webLightTheme;
+  const defaultV9ThemeText = JSON.stringify(defaultV9Theme, null, 4);
+  const [v9Theme, setV9Theme] = React.useState<ThemeV9>(defaultV9Theme);
+  const [v9ThemeText, setV9ThemeText] = React.useState(defaultV9ThemeText);
+  const [createV9ThemeError, setCreateV9ThemeError] = React.useState('');
+
+  const onPaletteTextChange: TextareaProps['onChange'] = (_, data) => {
+    setPaletteText(data.value);
+  };
 
   const onV8ThemeTextChange: TextareaProps['onChange'] = (_, data) => {
     setV8ThemeText(data.value);
   };
 
-  const onResetTheme = () => {
-    setV8ThemeText(defaultV8ThemeText);
+  const onResetPalette = () => {
+    setPaletteText(defaultPaletteText);
   };
 
-  const onCreateTheme = React.useCallback(() => {
+  const onResetV8Theme = () => {
+    setV8Theme(defaultV8Theme);
+    setV8ThemeText(defaultV8ThemeText);
+    setCreateV8ThemeError('');
+    setPreviewV8ThemeError('');
+  };
+
+  const onCreateV8Theme = React.useCallback(() => {
     try {
-      const v8Theme = JSON.parse(v8ThemeText);
-      const newV9Theme = createV9Theme(v8Theme);
-      setV9Theme((newV9Theme as unknown) as Record<string, string>);
+      setCreateV8ThemeError('');
+      const palette = JSON.parse(paletteText);
+      const newPalette = { ...DefaultPalette, ...palette };
+      const newV8Theme = createTheme({ palette: newPalette });
+      setV8Theme(newV8Theme);
+      setV8ThemeText(JSON.stringify(newV8Theme, null, 4));
     } catch (e) {
-      setMessage((e as Error).message);
+      setCreateV8ThemeError((e as Error).message);
+    }
+  }, [paletteText]);
+
+  const onPreviewV8Theme = React.useCallback(() => {
+    try {
+      setPreviewV8ThemeError('');
+      const newV8Theme = JSON.parse(v8ThemeText);
+      setV8Theme(newV8Theme);
+    } catch (e) {
+      setPreviewV8ThemeError((e as Error).message);
+    }
+  }, [v8ThemeText]);
+
+  const onResetV9Theme = () => {
+    setV9Theme(defaultV9Theme);
+    setV9ThemeText(defaultV9ThemeText);
+    setCreateV9ThemeError('');
+  };
+
+  const onCreateV9Theme = React.useCallback(() => {
+    try {
+      setCreateV9ThemeError('');
+      const newV8Theme = JSON.parse(v8ThemeText);
+      setV8Theme(newV8Theme);
+      const newV9Theme = createV9Theme(newV8Theme);
+      setV9Theme(newV9Theme);
+      setV9ThemeText(JSON.stringify(newV9Theme, null, 4));
+    } catch (e) {
+      setCreateV9ThemeError((e as Error).message);
     }
   }, [v8ThemeText]);
 
   return (
     <div className={styles.root}>
-      <h2>v8 Theme</h2>
+      <h2>1. Define a v8 Palette</h2>
+      <div className={styles.instructions}>
+        <p>Adjust the palette. You can reset to the default colors.</p>
+        <p>
+          If you want to generate an entirely different v8 palette, use the&nbsp;
+          <a href="https://aka.ms/themedesigner">v8 Theme Designer</a>.
+        </p>
+      </div>
+      <div className={styles.actions}>
+        <Button onClick={onResetPalette}>Reset</Button>
+      </div>
+      <Textarea
+        resize="both"
+        textarea={{ className: styles.editor }}
+        value={paletteText}
+        onChange={onPaletteTextChange}
+      />
+      <h2>2. Create a v8 Theme</h2>
+      <div className={styles.instructions}>
+        <p>Create a v8 theme from the palette.</p>
+        <p>You can adjust the theme and click preview to see the result.</p>
+      </div>
+      <div className={styles.actions}>
+        <Button onClick={onResetV8Theme}>Reset</Button>
+        <Button onClick={onCreateV8Theme}>Create</Button>
+      </div>
+      <div className={styles.error}>{createV8ThemeError}</div>
       <Textarea
         resize="both"
         textarea={{ className: styles.editor }}
         value={v8ThemeText}
         onChange={onV8ThemeTextChange}
       />
+      <h3>v8 Theme</h3>
       <div className={styles.actions}>
-        <Button onClick={onCreateTheme}>Create</Button>
-        <Button onClick={onResetTheme}>Reset</Button>
+        <Button onClick={onPreviewV8Theme}>Preview</Button>
       </div>
-      <div>{message}</div>
-      <h2>v9 Theme</h2>
-      <div className={styles.result}>
-        {Object.keys(v9Theme)
-          .sort()
-          .map(key => (
-            <>
-              <div>{key}</div>
-              <div>
-                {v9Theme[key]}&nbsp;
-                {key.startsWith('color') && (
-                  <span className={styles.colorBlock} style={{ backgroundColor: v9Theme[key] }} />
-                )}
-              </div>
-            </>
-          ))}
+      <div className={styles.error}>{previewV8ThemeError}</div>
+      <div>
+        <ThemeProvider theme={v8Theme}>
+          <ThemePreviewV8
+            backgroundColor={v8Theme?.semanticColors.bodyBackground || 'white'}
+            textColor={v8Theme?.semanticColors.bodyText || 'black'}
+          />
+        </ThemeProvider>
       </div>
+      <h2>2. Create a v9 Theme</h2>
+      <p className={styles.instructions}>
+        Create a v9 theme from the v8 theme. You can copy the result to use it in your application.
+      </p>
+      <div className={styles.actions}>
+        <Button onClick={onResetV9Theme}>Reset</Button>
+        <Button onClick={onCreateV9Theme}>Create</Button>
+      </div>
+      <div className={styles.error}>{createV9ThemeError}</div>
+
+      <FluentProvider theme={v9Theme}>
+        <ThemePreviewV9 />
+      </FluentProvider>
+      <h3>v9 Theme</h3>
+      <Textarea resize="both" textarea={{ className: styles.editor }} value={v9ThemeText} readOnly />
     </div>
   );
 };


### PR DESCRIPTION
## Changes
- Updated the createV8Theme shim method to apply the component styles from the fluent2-theme.  This makes it resemble v9 closely.
- Imported and tuned the previews of v8 and v9 themes from the theme designers.  Incorporated into shim stories.
- Updated the theme shim stories to have a clearer sequence of steps, allow editing of palette and brand variants, and display any errors.

## Screenshots

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/28762486/213789137-89127fdf-027f-455c-8598-6f4d0a978c8c.png">
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/28762486/213789362-b36325c8-ceba-45d3-8293-46b958ad6950.png">
