### PR TITLE
fix (ContextualMenu): ContextualMenu list items now have correct hover state in HCM

### DIFF
--- a/change/@fluentui-react-c96185f0-24c9-47f5-b72b-1c11b3520979.json
+++ b/change/@fluentui-react-c96185f0-24c9-47f5-b72b-1c11b3520979.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ContextualMenu items now have correct hover styling in HCM.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -76,6 +76,9 @@ export const getMenuItemStyles = memoizeFunction(
           '.ms-ContextualMenu-submenuIcon': {
             color: palette.neutralPrimary,
           },
+          [HighContrastSelector]: {
+            ...getHighContrastNoAdjustStyle(),
+          },
         },
       },
       rootFocused: {

--- a/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -380,6 +380,10 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                             &:hover .ms-ContextualMenu-submenuIcon {
                               color: #323130;
                             }
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover {
+                              -ms-high-contrast-adjust: none;
+                              forced-color-adjust: none;
+                            }
                             &:active {
                               background-color: #edebe9;
                             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- When a `ContextualMenu` item is hovered in High Contrast Mode, there is no hover state style:

	- ![image](https://user-images.githubusercontent.com/8649804/213814328-a5b75772-7a4b-4925-a08f-c947dab66994.png)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- When a `ContextualMenu` item is hovered in High Contrast Mode, there is now a hover state style:

	- ![image](https://user-images.githubusercontent.com/8649804/213814427-060ac7c7-341e-4c4a-922c-f6623462a421.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes ##25330
