### PR TITLE
fix: react-combobox examples a11y updates

### DIFF
--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxComplexOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxComplexOptions.stories.tsx
@@ -23,7 +23,7 @@ export const ComplexOptions = (props: Partial<ComboboxProps>) => {
       <Combobox aria-labelledby={comboId} {...props}>
         <Option text="Katri Athokas">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Katri Athokas"
             presence={{
               status: 'available',
@@ -33,7 +33,7 @@ export const ComplexOptions = (props: Partial<ComboboxProps>) => {
         </Option>
         <Option text="Elvia Atkins">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Elvia Atkins"
             presence={{
               status: 'busy',
@@ -43,7 +43,7 @@ export const ComplexOptions = (props: Partial<ComboboxProps>) => {
         </Option>
         <Option text="Cameron Evans">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Cameron Evans"
             presence={{
               status: 'away',
@@ -53,7 +53,7 @@ export const ComplexOptions = (props: Partial<ComboboxProps>) => {
         </Option>
         <Option text="Wanda Howard">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Wanda Howard"
             presence={{
               status: 'out-of-office',

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxFiltering.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxFiltering.stories.tsx
@@ -15,7 +15,25 @@ const useStyles = makeStyles({
 
 export const Filtering = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combo-default');
-  const options = ['Cat', 'Dog', 'Ferret', 'Fish', 'Hamster', 'Snake'];
+  const options = [
+    'Cat',
+    'Caterpillar',
+    'Catfish',
+    'Cheetah',
+    'Chicken',
+    'Cockatiel',
+    'Cow',
+    'Dog',
+    'Dolphin',
+    'Ferret',
+    'Firefly',
+    'Fish',
+    'Fox',
+    'Fox Terrier',
+    'Frog',
+    'Hamster',
+    'Snake',
+  ];
   const [matchingOptions, setMatchingOptions] = React.useState([...options]);
   const styles = useStyles();
 
@@ -34,6 +52,11 @@ export const Filtering = (props: Partial<ComboboxProps>) => {
             {option}
           </Option>
         ))}
+        {matchingOptions.length === 0 ? (
+          <Option key="no-results" text="">
+            No results found
+          </Option>
+        ) : null}
       </Combobox>
     </div>
   );
@@ -42,7 +65,9 @@ export const Filtering = (props: Partial<ComboboxProps>) => {
 Filtering.parameters = {
   docs: {
     description: {
-      story: 'Filtering based on the user-typed string can be achieved by modifying the child Options directly.',
+      story:
+        'Filtering based on the user-typed string can be achieved by modifying the child Options directly.' +
+        'We recommend implementing filtering when creating a freeform Combobox.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxFreeform.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxFreeform.stories.tsx
@@ -88,7 +88,7 @@ Freeform.parameters = {
       story:
         'Combobox supports the `freeform` prop, which allows freeform text input. ' +
         'Implementing filtering together with `freeform` is generally recommended.' +
-        "We also recommend displaying a custom freeform string if the user input doesn't match an animal",
+        "We also recommend displaying a custom freeform string if the user input doesn't match an existing option.",
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxFreeform.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxFreeform.stories.tsx
@@ -60,7 +60,7 @@ export const Freeform = (props: Partial<ComboboxProps>) => {
 
   return (
     <div className={styles.root}>
-      <label id={comboId}>Best pet</label>
+      <label id={comboId}>Find pets</label>
       <Combobox
         aria-labelledby={comboId}
         freeform
@@ -69,10 +69,9 @@ export const Freeform = (props: Partial<ComboboxProps>) => {
         onOptionSelect={onOptionSelect}
         {...props}
       >
-        {/* We recommend displaying a custom freeform string, if the user input doesn't match an animal */}
         {customSearch ? (
           <Option key="freeform" text={customSearch}>
-            "{customSearch}"
+            Search for "{customSearch}"
           </Option>
         ) : null}
         {matchingOptions.map(option => (
@@ -88,7 +87,8 @@ Freeform.parameters = {
     description: {
       story:
         'Combobox supports the `freeform` prop, which allows freeform text input. ' +
-        'Implementing filtering together with `freeform` is generally recommended.',
+        'Implementing filtering together with `freeform` is generally recommended.' +
+        "We also recommend displaying a custom freeform string if the user input doesn't match an animal",
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxMultiselectWithValueString.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxMultiselectWithValueString.stories.tsx
@@ -69,7 +69,11 @@ export const MultiselectWithValueString = (props: Partial<ComboboxProps>) => {
 MultiselectWithValueString.parameters = {
   docs: {
     description: {
-      story: 'Multiselect Combobox supports using a controlled value to display selected options when not in focus.',
+      story:
+        'Multiselect Combobox supports using a controlled value to' +
+        'display selected options when not in focus, similar to v8 behavior.' +
+        'We recommend using tags rather than the value string when possible,' +
+        'since they have better UX and accessibility.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownComplexOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownComplexOptions.stories.tsx
@@ -23,7 +23,7 @@ export const ComplexOptions = (props: Partial<DropdownProps>) => {
       <Dropdown aria-labelledby={dropdownId} {...props}>
         <Option text="Katri Athokas">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Katri Athokas"
             presence={{
               status: 'available',
@@ -33,7 +33,7 @@ export const ComplexOptions = (props: Partial<DropdownProps>) => {
         </Option>
         <Option text="Elvia Atkins">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Elvia Atkins"
             presence={{
               status: 'busy',
@@ -43,7 +43,7 @@ export const ComplexOptions = (props: Partial<DropdownProps>) => {
         </Option>
         <Option text="Cameron Evans">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Cameron Evans"
             presence={{
               status: 'away',
@@ -53,7 +53,7 @@ export const ComplexOptions = (props: Partial<DropdownProps>) => {
         </Option>
         <Option text="Wanda Howard">
           <Persona
-            avatar={{ color: 'colorful' }}
+            avatar={{ color: 'colorful', 'aria-hidden': true }}
             name="Wanda Howard"
             presence={{
               status: 'out-of-office',


### PR DESCRIPTION
This PR only touches stories, and makes a few accessibility fixes:

- Fixes #26315 by adding a "no results found" fallback item in the filtering example
- Fixes #26317 by updating the freeform custom string option in the freeform example
- Fixes #26320 by adding better warning language for the multiselect w/ value text example
- Fixes #26314 by setting the Persona avatar to `aria-hidden`