### PR TITLE
fix: react-combobox activedescendant calculation updates

### DIFF
--- a/change/@fluentui-react-combobox-b23addfc-cfb1-42ee-801e-f921ac020168.json
+++ b/change/@fluentui-react-combobox-b23addfc-cfb1-42ee-801e-f921ac020168.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: combobox should recalculate the active option when the children change while open",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-b23addfc-cfb1-42ee-801e-f921ac020168.json
+++ b/change/@fluentui-react-combobox-b23addfc-cfb1-42ee-801e-f921ac020168.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix: combobox should recalculate the active option when the children change while open",
+  "comment": "fix: combobox should recalculate the activedescendant when the children change while open, and clear it when moving text cursor",
   "packageName": "@fluentui/react-combobox",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as keys from '@fluentui/keyboard-keys';
+import { ArrowLeft, ArrowRight } from '@fluentui/keyboard-keys';
 import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
 import {
   getPartitionedNativeProps,
@@ -157,7 +157,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     }
 
     // clear activedescendant when moving the text insertion cursor
-    if (ev.key === keys.ArrowLeft || ev.key === keys.ArrowRight) {
+    if (ev.key === ArrowLeft || ev.key === ArrowRight) {
       setHideActiveDescendant(true);
     } else {
       setHideActiveDescendant(false);

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as keys from '@fluentui/keyboard-keys';
 import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
 import {
   getPartitionedNativeProps,
@@ -55,6 +56,11 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
 
   const rootRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<HTMLInputElement>(null);
+
+  // NVDA and JAWS have bugs that suppress reading the input value text when aria-activedescendant is set
+  // To prevent this, we clear the HTML attribute (but save the state) when a user presses left/right arrows
+  // ref: https://github.com/microsoft/fluentui/issues/26359#issuecomment-1397759888
+  const [hideActiveDescendant, setHideActiveDescendant] = React.useState(false);
 
   // calculate listbox width style based on trigger width
   const [popupDimensions, setPopupDimensions] = React.useState<{ width: string }>();
@@ -149,6 +155,13 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     if (!open && getDropdownActionFromKey(ev) === 'Type') {
       baseState.setOpen(ev, true);
     }
+
+    // clear activedescendant when moving the text insertion cursor
+    if (ev.key === keys.ArrowLeft || ev.key === keys.ArrowRight) {
+      setHideActiveDescendant(true);
+    } else {
+      setHideActiveDescendant(false);
+    }
   };
 
   // resolve input and listbox slot props
@@ -183,6 +196,10 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
 
   [triggerSlot, listboxSlot] = useComboboxPopup(props, triggerSlot, listboxSlot);
   [triggerSlot, listboxSlot] = useTriggerListboxSlots(props, baseState, ref, triggerSlot, listboxSlot);
+
+  if (hideActiveDescendant) {
+    triggerSlot['aria-activedescendant'] = undefined;
+  }
 
   const state: ComboboxState = {
     components: {

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -8,9 +8,12 @@ import type { ComboboxBaseProps, ComboboxBaseOpenEvents, ComboboxBaseState } fro
 /**
  * State shared between Combobox and Dropdown components
  */
-export const useComboboxBaseState = (props: ComboboxBaseProps & { editable?: boolean }): ComboboxBaseState => {
+export const useComboboxBaseState = (
+  props: ComboboxBaseProps & { children?: React.ReactNode; editable?: boolean },
+): ComboboxBaseState => {
   const {
     appearance = 'outline',
+    children,
     editable = false,
     inlinePopup = false,
     multiselect,
@@ -76,7 +79,7 @@ export const useComboboxBaseState = (props: ComboboxBaseProps & { editable?: boo
     [onOpenChange, setOpenState],
   );
 
-  // update active option based on change in open state
+  // update active option based on change in open state or children
   React.useEffect(() => {
     if (open && !activeOption) {
       // if it is single-select and there is a selected option, start at the selected option
@@ -92,9 +95,9 @@ export const useComboboxBaseState = (props: ComboboxBaseProps & { editable?: boo
       // reset the active option when closing
       setActiveOption(undefined);
     }
-    // this should only be run in response to changes in the open state
+    // this should only be run in response to changes in the open state or children
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, children]);
 
   return {
     ...optionCollection,


### PR DESCRIPTION
There were two behavior issues with the `aria-activedescendant` calculation in combobox:

1. When the author mutated Option children while open, the active option was not recalculated

Now, when the children are changed while open and there is no current active option, combobox resets the active option.
Fixes #26316

2. A screen reader bug prevents the input value from being read while an `aria-activedescendant` association is present for JAWS & NVDA

While this should work out of the box, there's also a relatively easy fix we can do -- `aria-activedescendant` attribute (but not internal state) is cleared with left/right arrows, and it is restored with any other keyboard interaction. Home/end do not apply here, since they do listbox interactions. I left a comment by the relevant code, so if the screen reader bug is fixed, we can remove it.

Fixes #26359