### PR TITLE
fix syntactically, replaced backtick with single quote, because types…

### DIFF
--- a/packages/react-components/react-components/stories/Concepts/Icons/IconTable.stories.mdx
+++ b/packages/react-components/react-components/stories/Concepts/Icons/IconTable.stories.mdx
@@ -10,7 +10,7 @@ This page contains a list of available icons under `@fluentui/react-icons` packa
 For example:
 
 ```tsx
-import { DismissSquareRegular } from `@fluentui/react-icons`;
+import { DismissSquareRegular } from '@fluentui/react-icons';
 
 function App() {
   return <DismissSquareRegular />;


### PR DESCRIPTION
## Behavior Change

TypeScript intellisense was not working with backtick **`** So, replaced it with single-quote **'**