### PR TITLE
docs: make unsized icons searchable

### DIFF
--- a/change/@fluentui-react-components-07ca147c-df50-4259-9ea4-4939cedbc454.json
+++ b/change/@fluentui-react-components-07ca147c-df50-4259-9ea4-4939cedbc454.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make unsized icons searchable",
+  "packageName": "@fluentui/react-components",
+  "email": "martin.troback@axis.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/src/Concepts/Icons/ReactIconGrid.tsx
+++ b/packages/react-components/react-components/src/Concepts/Icons/ReactIconGrid.tsx
@@ -80,12 +80,20 @@ const ReactIconGrid = () => {
 
   const filteredIcons = React.useMemo(
     () =>
-      reactIcons.filter(icon =>
-        size === 'Unsized'
-          ? icon.displayName! && !/\d/.test(icon.displayName.toLowerCase())
-          : icon.displayName?.toLowerCase().indexOf(search.toLowerCase()) !== -1 &&
-            icon.displayName?.indexOf(String(size)) !== -1,
-      ),
+      reactIcons.filter(icon => {
+        if (size === 'Unsized') {
+          return (
+            icon.displayName! &&
+            !/\d/.test(icon.displayName.toLowerCase()) &&
+            icon.displayName?.toLowerCase().indexOf(search.toLowerCase()) !== -1
+          );
+        }
+
+        return (
+          icon.displayName?.toLowerCase().indexOf(search.toLowerCase()) !== -1 &&
+          icon.displayName?.indexOf(String(size)) !== -1
+        );
+      }),
     [search, size],
   );
 


### PR DESCRIPTION
Adds the ability to use the search engine on
the docs page even for the "Unsized" icons.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![search_before](https://user-images.githubusercontent.com/7765599/214021301-bdd333fc-6555-42d7-b433-badc2b09fa29.gif)

<!-- This is the behavior we have today -->

## New Behavior

![search_after](https://user-images.githubusercontent.com/7765599/214021297-11c18879-c4b0-49b9-955b-3b8010b7d3f4.gif)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
