### PR TITLE
chore(react-builder): migrate to axe-core v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "ignore-not-found-export-webpack-plugin": "1.0.2",
     "imports-loader": "1.2.0",
     "jest": "26.6.3",
-    "jest-axe": "5.0.1",
+    "jest-axe": "6.0.1",
     "jest-cli": "26.6.3",
     "jest-environment-jsdom": "26.6.2",
     "jest-environment-node-single-context": "26.2.0",
@@ -374,7 +374,8 @@
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/experimental-utils": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
-    "@types/jest-axe/axe-core": "4.2.1",
+    "@types/jest-axe/axe-core": "4.4.3",
+    "jest-axe/axe-core": "4.4.3",
     "eslint": "7.25.0",
     "@mdx-js/loader/loader-utils": "~2.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -374,9 +374,9 @@
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/experimental-utils": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
+    "@types/jest-axe/axe-core": "4.2.1",
     "eslint": "7.25.0",
-    "@mdx-js/loader/loader-utils": "~2.0.4",
-    "@types/jest-axe/axe-core": "4.2.1"
+    "@mdx-js/loader/loader-utils": "~2.0.4"
   },
   "syncpack": {
     "prod": true,

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@types/gulp-sourcemaps": "0.0.35",
     "@types/gulp-util": "3.0.36",
     "@types/jest": "26.0.24",
-    "@types/jest-axe": "3.5.3",
+    "@types/jest-axe": "3.5.5",
     "@types/jju": "1.4.1",
     "@types/json-schema": "^7.0.8",
     "@types/lerna-alias": "3.0.0",
@@ -374,9 +374,9 @@
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/experimental-utils": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
-    "@types/jest-axe/axe-core": "4.2.1",
     "eslint": "7.25.0",
-    "@mdx-js/loader/loader-utils": "~2.0.4"
+    "@mdx-js/loader/loader-utils": "~2.0.4",
+    "@types/jest-axe/axe-core": "4.2.1"
   },
   "syncpack": {
     "prod": true,

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -12,7 +12,7 @@
     "@fluentui/react-component-ref": "^0.66.0",
     "@fluentui/react-icons-northstar": "^0.66.0",
     "@fluentui/react-northstar": "^0.66.0",
-    "axe-core": "3.5.0",
+    "axe-core": "4.2.1",
     "immer": "^9.0.12",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -12,7 +12,7 @@
     "@fluentui/react-component-ref": "^0.66.0",
     "@fluentui/react-icons-northstar": "^0.66.0",
     "@fluentui/react-northstar": "^0.66.0",
-    "axe-core": "4.2.1",
+    "axe-core": "4.4.3",
     "immer": "^9.0.12",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",

--- a/scripts/jest/src/jest.preset.v0.js
+++ b/scripts/jest/src/jest.preset.v0.js
@@ -12,6 +12,7 @@ const createConfig = (/** @type {import('@jest/types').Config.InitialOptions} */
   transform: {
     '^.+\\.tsx?$': 'babel-jest',
   },
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   verbose: false,
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
   ...customConfig,

--- a/scripts/jest/src/jest.preset.v0.spec.ts
+++ b/scripts/jest/src/jest.preset.v0.spec.ts
@@ -12,6 +12,7 @@ describe(`v0 preset`, () => {
         coverageReporters: ['json', 'lcov'],
         moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
         moduleNameMapper: expect.any(Object),
+        modulePathIgnorePatterns: expect.any(Array),
         setupFilesAfterEnv: [`${workspaceRoot}/scripts/jest/src/v0/setupTests.js`],
         testRegex: '/test/.*-test\\.tsx?$',
         transform: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7529,10 +7529,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.2.1, axe-core@^3.5.5, axe-core@^4.0.2, axe-core@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
-  integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
+axe-core@4.4.1, axe-core@4.4.3, axe-core@^3.5.5, axe-core@^4.0.2, axe-core@^4.2.0:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
+  integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
 
 axios@^0.21.1:
   version "0.21.4"
@@ -15850,12 +15850,12 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
-jest-axe@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/jest-axe/-/jest-axe-5.0.1.tgz#26c43643b2e5f2bd4900c1ab36f8283635957a6e"
-  integrity sha512-MMOWA6gT4pcZGbTLS8ZEqABH08Lnj5bInfLPpn9ADWX2wFF++odbbh8csmSfkwKjHaioVPzlCtIypAtxFDx/rw==
+jest-axe@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jest-axe/-/jest-axe-6.0.1.tgz#54a8b7dc09afd6190b21f38b51b8bddc2d923834"
+  integrity sha512-+KcRAdZeKXBbtHTmMkokRq5/hXHaVFpX+WS2o3uvhkmF3szdr4+TYAz+QuOTeM0B1d4YPoNmQWhGzSzxHJNZrA==
   dependencies:
-    axe-core "4.2.1"
+    axe-core "4.4.1"
     chalk "4.1.0"
     jest-matcher-utils "27.0.2"
     lodash.merge "4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5560,10 +5560,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest-axe@3.5.3":
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/@types/jest-axe/-/jest-axe-3.5.3.tgz#5af918553388aa0a448af75603b44093985778c6"
-  integrity sha512-ad9qI9f+00N8IlOuGh6dnZ6o0BDdV9VhGfTUr1zCejsPvOfZd6eohffe4JYxUoUuRYEftyMcaJ6Ux4+MsOpGHg==
+"@types/jest-axe@3.5.5":
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/@types/jest-axe/-/jest-axe-3.5.5.tgz#21fd8152dc3963bf6e1f72f34a7ce4e827838b7b"
+  integrity sha512-b8WDIdoeKtr/JDJ2+QjFXMuS8UhfdMA6+15Z5KjjIie3jQrSXD9KZWMSQxc0nPtx7L9rIFKdiDpQk+m7s4a/8w==
   dependencies:
     "@types/jest" "*"
     axe-core "^3.5.5"
@@ -7528,11 +7528,6 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-
-axe-core@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.0.tgz#161b17fc6ce07a5470ff179e0703957c422b2220"
-  integrity sha512-wJqOIreoFiGjvZ1UZvGLAUs8H3QQ3cS833+6ctFcCdr/xFd5oB66mmwGWnwQlBXFFaefRt+KR+m2dY9em2RxVg==
 
 axe-core@4.2.1, axe-core@^3.5.5, axe-core@^4.0.2, axe-core@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- axe-core 3 and 4 are used within monorepo. 
- running tests on v0 if build snapshots are present produces double mock warnings 
<img width="506" alt="image" src="https://user-images.githubusercontent.com/1223799/214036670-948e3dc3-05d2-4960-a5e1-820d11a765aa.png">


## New Behavior

- we use only axe-core 4 within monorepo (4.4.x in particular as that contains webpack 5 bug fix https://github.com/dequelabs/axe-core/blob/develop/CHANGELOG.md#bug-fixes-9)
- duplicate mocks violations warnings has been fixed in v0 tests

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes https://github.com/microsoft/fluentui/issues/20799
* Follows https://github.com/microsoft/fluentui/issues/21395
