### PR TITLE
docs: fix config for import rewrites for Storybook export

### DIFF
--- a/change/@fluentui-react-table-c5aef9c7-f255-40b3-923f-df603517898e.json
+++ b/change/@fluentui-react-table-c5aef9c7-f255-40b3-923f-df603517898e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "docs: update imports in DataGrid stories",
+  "packageName": "@fluentui/react-table",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/stories/DataGrid/CustomRowId.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/CustomRowId.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar, Checkbox } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,12 +16,13 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   TableRowData,
   createTableColumn,
   TableRowId,
   DataGridProps,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/DataGridDescription.md
+++ b/packages/react-components/react-table/stories/DataGrid/DataGridDescription.md
@@ -4,7 +4,7 @@
 >
 > ```jsx
 >
-> import { Table } from '@fluentui/react-components/unstable';
+> import { DataGrid } from '@fluentui/react-components/unstable';
 >
 > ```
 >

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,9 +16,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/MultipleSelect.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,9 +16,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/MultipleSelectControlled.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,11 +16,12 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
   TableRowId,
   DataGridProps,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/RowNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/RowNavigation.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,9 +16,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/SelectionAppearance.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SelectionAppearance.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,9 +16,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SingleSelect.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,9 +16,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SingleSelectControlled.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,11 +16,12 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
   TableRowId,
   DataGridProps,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/packages/react-components/react-table/stories/DataGrid/Sort.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Sort.stories.tsx
@@ -9,18 +9,18 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
   DataGrid,
+  DataGridProps,
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
-import { SortState } from '../../src/hooks/types';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;
@@ -149,7 +149,10 @@ const columns: TableColumnDefinition<Item>[] = [
 ];
 
 export const Sort = () => {
-  const defaultSortState = React.useMemo<SortState>(() => ({ sortColumn: 'file', sortDirection: 'ascending' }), []);
+  const defaultSortState = React.useMemo<Parameters<NonNullable<DataGridProps['onSortChange']>>[1]>(
+    () => ({ sortColumn: 'file', sortDirection: 'ascending' }),
+    [],
+  );
 
   return (
     <DataGrid items={items} columns={columns} sortable defaultSortState={defaultSortState}>

--- a/packages/react-components/react-table/stories/DataGrid/SortControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SortControlled.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,11 +16,11 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
   DataGridProps,
-} from '@fluentui/react-table';
-import { SortState } from '../../src/hooks/types';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;
@@ -150,7 +149,10 @@ const columns: TableColumnDefinition<Item>[] = [
 ];
 
 export const SortControlled = () => {
-  const [sortState, setSortState] = React.useState<SortState>({ sortColumn: 'file', sortDirection: 'ascending' });
+  const [sortState, setSortState] = React.useState<Parameters<NonNullable<DataGridProps['onSortChange']>>[1]>({
+    sortColumn: 'file',
+    sortDirection: 'ascending',
+  });
   const onSortChange: DataGridProps['onSortChange'] = (e, nextSortState) => {
     setSortState(nextSortState);
   };

--- a/packages/react-components/react-table/stories/DataGrid/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SubtleSelection.stories.tsx
@@ -9,7 +9,6 @@ import {
   VideoRegular,
 } from '@fluentui/react-icons';
 import { PresenceBadgeStatus, Avatar } from '@fluentui/react-components';
-import { TableCellLayout } from '@fluentui/react-components/unstable';
 import {
   DataGridBody,
   DataGridRow,
@@ -17,9 +16,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
+  TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-} from '@fluentui/react-table';
+} from '@fluentui/react-components/unstable';
 
 type FileCell = {
   label: string;

--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const semver = require('semver');
-const { stripIndents, offsetFromRoot } = require('@nrwl/devkit');
-const { workspaceRoot } = require('nx/src/utils/app-root');
 
 const { isConvergedPackage, getAllPackageInfo, getProjectMetadata } = require('@fluentui/scripts-monorepo');
+const { stripIndents, offsetFromRoot } = require('@nrwl/devkit');
+const { workspaceRoot } = require('nx/src/utils/app-root');
+const semver = require('semver');
 
 const loadWorkspaceAddonDefaultOptions = { workspaceRoot };
 /**
@@ -123,9 +123,9 @@ function getCodesandboxBabelOptions() {
 
   return Object.values(allPackageInfo).reduce((acc, cur) => {
     if (isConvergedPackage({ packagePathOrJson: cur.packageJson, projectType: 'library' })) {
-      const prereleaseTags = semver.prerelease(cur.packageJson.version);
-      const isNonRcPrerelease = prereleaseTags && !prereleaseTags[0].includes('rc');
-      acc[cur.packageJson.name] = isNonRcPrerelease
+      const isPrerelease = semver.prerelease(cur.packageJson.version) !== null;
+
+      acc[cur.packageJson.name] = isPrerelease
         ? { replace: '@fluentui/react-components/unstable' }
         : { replace: '@fluentui/react-components' };
     }


### PR DESCRIPTION
## Previous Behavior

```ts
import { PresenceBadgeStatus, Avatar, DataGridBody, DataGridRow, DataGrid, DataGridHeader, DataGridHeaderCell, DataGridCell, TableColumnDefinition, createTableColumn, SortState } from "@fluentui/react-components";
```

## New Behavior

This PR fixes the config that was outdated.

```ts
import { PresenceBadgeStatus, Avatar } from "@fluentui/react-components";
import { DataGridBody, DataGridRow, DataGrid, DataGridHeader, DataGridHeaderCell, DataGridCell, TableCellLayout, TableColumnDefinition, createTableColumn } from '@fluentui/react-components/unstable';
```

Also fixes imports in `DataGrid` stories.

## Related Issue(s)

Fixes #26433
