### PR TITLE
feat: export TextareaOnChangeData type

### DIFF
--- a/change/@fluentui-react-components-79b19460-fc74-43b0-ab6b-93273a9373a5.json
+++ b/change/@fluentui-react-components-79b19460-fc74-43b0-ab6b-93273a9373a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export TextareaOnChangeData type",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-e883e997-b8a8-47fe-afd4-cef302188893.json
+++ b/change/@fluentui-react-textarea-e883e997-b8a8-47fe-afd4-cef302188893.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export TextareaOnChangeData type",
+  "packageName": "@fluentui/react-textarea",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -473,6 +473,7 @@ import { teamsLightTheme } from '@fluentui/react-theme';
 import { Text as Text_2 } from '@fluentui/react-text';
 import { Textarea } from '@fluentui/react-textarea';
 import { textareaClassNames } from '@fluentui/react-textarea';
+import { TextareaOnChangeData } from '@fluentui/react-textarea';
 import { TextareaProps } from '@fluentui/react-textarea';
 import { TextareaSlots } from '@fluentui/react-textarea';
 import { TextareaState } from '@fluentui/react-textarea';
@@ -1629,6 +1630,8 @@ export { Text_2 as Text }
 export { Textarea }
 
 export { textareaClassNames }
+
+export { TextareaOnChangeData }
 
 export { TextareaProps }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -620,7 +620,7 @@ export {
   useTextarea_unstable,
   useTextareaStyles_unstable,
 } from '@fluentui/react-textarea';
-export type { TextareaProps, TextareaSlots, TextareaState } from '@fluentui/react-textarea';
+export type { TextareaOnChangeData, TextareaProps, TextareaSlots, TextareaState } from '@fluentui/react-textarea';
 export {
   Tooltip,
   renderTooltip_unstable,

--- a/packages/react-components/react-textarea/etc/react-textarea.api.md
+++ b/packages/react-components/react-textarea/etc/react-textarea.api.md
@@ -35,6 +35,11 @@ export const textareaFieldClassNames: SlotClassNames<FieldSlots<FieldControl>>;
 export type TextareaFieldProps_unstable = FieldProps<typeof Textarea>;
 
 // @public
+export type TextareaOnChangeData = {
+    value: string;
+};
+
+// @public
 export type TextareaProps = Omit<ComponentProps<Partial<TextareaSlots>, 'textarea'>, 'defaultValue' | 'onChange' | 'size' | 'value'> & {
     appearance?: 'outline' | 'filled-darker' | 'filled-lighter' | 'filled-darker-shadow' | 'filled-lighter-shadow';
     defaultValue?: string;

--- a/packages/react-components/react-textarea/src/components/Textarea/Textarea.types.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/Textarea.types.ts
@@ -71,6 +71,6 @@ export type TextareaState = ComponentState<TextareaSlots> &
 /**
  * Data passed to the `onChange` callback when the textarea's value changes.
  */
-type TextareaOnChangeData = {
+export type TextareaOnChangeData = {
   value: string;
 };

--- a/packages/react-components/react-textarea/src/index.ts
+++ b/packages/react-components/react-textarea/src/index.ts
@@ -5,7 +5,7 @@ export {
   useTextareaStyles_unstable,
   useTextarea_unstable,
 } from './Textarea';
-export type { TextareaProps, TextareaSlots, TextareaState } from './Textarea';
+export type { TextareaOnChangeData, TextareaProps, TextareaSlots, TextareaState } from './Textarea';
 
 export { TextareaField as TextareaField_unstable, textareaFieldClassNames } from './TextareaField';
 export type { TextareaFieldProps as TextareaFieldProps_unstable } from './TextareaField';


### PR DESCRIPTION
## New Behavior

This PR exports `TextareaOnChangeData` like in other components:

https://github.com/microsoft/fluentui/blob/c075fab840bf34761b3b8dfc2e37de1ad2ac23fc/packages/react-components/react-components/src/index.ts#L291
https://github.com/microsoft/fluentui/blob/c075fab840bf34761b3b8dfc2e37de1ad2ac23fc/packages/react-components/react-components/src/index.ts#L307

## Related Issue(s)

Fixes #26405
