### PR TITLE
fix(Link): Handle "tabIndex" from user's input

### DIFF
--- a/change/@fluentui-react-link-7ca1987a-7983-4dc5-a459-671fe626c214.json
+++ b/change/@fluentui-react-link-7ca1987a-7983-4dc5-a459-671fe626c214.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle \"tabIndex\" from user's input",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/src/components/Link/Link.test.tsx
+++ b/packages/react-components/react-link/src/components/Link/Link.test.tsx
@@ -65,6 +65,17 @@ describe('Link', () => {
       anchor.focus();
       expect(document.activeElement).toEqual(anchor);
     });
+
+    it('allows overriding "tabIndex"', () => {
+      const result = render(
+        <Link href="https://www.bing.com" tabIndex={-1}>
+          This is a link
+        </Link>,
+      );
+      const link = result.getByRole('link');
+
+      expect(link.getAttribute('tabIndex')).toBe('-1');
+    });
   });
 
   describe('when rendered as a button', () => {
@@ -101,6 +112,13 @@ describe('Link', () => {
       expect(document.activeElement).not.toEqual(button);
       button.focus();
       expect(document.activeElement).toEqual(button);
+    });
+
+    it('allows overriding "tabIndex"', () => {
+      const result = render(<Link tabIndex={-1}>This is a link</Link>);
+      const button = result.getByRole('button');
+
+      expect(button.getAttribute('tabIndex')).toBe('-1');
     });
   });
 });

--- a/packages/react-components/react-link/src/components/Link/useLinkState.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkState.ts
@@ -8,7 +8,7 @@ import type { LinkState } from './Link.types';
  */
 export const useLinkState_unstable = (state: LinkState): LinkState => {
   const { disabled, disabledFocusable } = state;
-  const { onClick, onKeyDown, role, type, tabIndex } = state.root;
+  const { onClick, onKeyDown, role, tabIndex, type} = state.root;
 
   // Add href and tabIndex=0 for anchor elements.
   if (state.root.as === 'a') {

--- a/packages/react-components/react-link/src/components/Link/useLinkState.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkState.ts
@@ -8,12 +8,12 @@ import type { LinkState } from './Link.types';
  */
 export const useLinkState_unstable = (state: LinkState): LinkState => {
   const { disabled, disabledFocusable } = state;
-  const { onClick, onKeyDown, role, type } = state.root;
+  const { onClick, onKeyDown, role, type, tabIndex } = state.root;
 
   // Add href and tabIndex=0 for anchor elements.
   if (state.root.as === 'a') {
     state.root.href = disabled ? undefined : state.root.href;
-    state.root.tabIndex = disabled && !disabledFocusable ? undefined : 0;
+    state.root.tabIndex = tabIndex ?? (disabled && !disabledFocusable ? undefined : 0);
 
     // Add role="link" for disabled and disabledFocusable links.
     if (disabled || disabledFocusable) {


### PR DESCRIPTION
## Previous Behavior

```tsx
<Link tabIndex={-1} href="https://www.bing.com" />
```

⬇️⬇️⬇️

```html
<a href="https://www.bing.com" tabindex="0"></a>
```

💣 

## New Behavior

```tsx
<Link tabIndex={-1} href="https://www.bing.com" />
```

⬇️⬇️⬇️

```html
<a href="https://www.bing.com" tabindex="-1"></a>
```

User's input should always win over our defaults ✅ 

## Related Issue(s)

Fixes #26313
