### PR TITLE
feat(web-components): bump tslib to 2.1. to align with rest of monorepo packages

### DIFF
--- a/apps/ssr-tests/package.json
+++ b/apps/ssr-tests/package.json
@@ -15,9 +15,9 @@
   "devDependencies": {
     "@fluentui/react": "^8.104.6",
     "@microsoft/load-themed-styles": "^1.10.26",
-    "@types/mocha": "^7.0.2",
+    "@types/mocha": "7.0.2",
     "@fluentui/public-docsite-resources": "^8.1.41",
-    "mocha": "^7.1.2",
+    "mocha": "7.2.0",
     "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-webpack": "*"
   },

--- a/apps/stress-test/package.json
+++ b/apps/stress-test/package.json
@@ -14,7 +14,7 @@
     "@fluentui/react-components": "^9.11.0",
     "@fluentui/react-icons": "^2.0.175",
     "@fluentui/web-components": "^2.5.11",
-    "@microsoft/fast-element": "^1.10.4",
+    "@microsoft/fast-element": "^1.11.0",
     "afterframe": "1.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/change/@fluentui-web-components-84f7b31a-225a-4684-b0fa-195c17676891.json
+++ b/change/@fluentui-web-components-84f7b31a-225a-4684-b0fa-195c17676891.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: bump tslib to 2.1 to align with rest of monorepo packages",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
     "source": [
       "package.json",
       "apps/!(react-18-tests-v8|react-18-tests-v9)/package.json",
-      "packages/!(web-components)/package.json",
+      "packages/web-components/package.json",
       "packages/react-components/*/package.json",
       "packages/fluentui/*/package.json",
       "scripts/package.json"
@@ -440,12 +440,6 @@
           "webpack-bundle-analyzer",
           "yargs"
         ]
-      },
-      {
-        "packages": [
-          "@fluentui/web-components"
-        ],
-        "dependencies": []
       },
       {
         "packages": [

--- a/package.json
+++ b/package.json
@@ -445,12 +445,7 @@
         "packages": [
           "@fluentui/web-components"
         ],
-        "dependencies": [
-          "mocha",
-          "ts-loader",
-          "tslib",
-          "webpack"
-        ]
+        "dependencies": []
       },
       {
         "packages": [

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -76,6 +76,6 @@
     "@microsoft/fast-element": "^1.11.0",
     "@microsoft/fast-foundation": "^2.47.0",
     "@microsoft/fast-web-utilities": "^5.4.0",
-    "tslib": "^1.13.0"
+    "tslib": "^2.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,7 +3019,7 @@
   resolved "https://registry.yarnpkg.com/@microsoft/fast-colors/-/fast-colors-5.3.1.tgz#defc59874176e42316be7e6d24c31885ead8ca56"
   integrity sha512-72RZXVfCbwQzvo5sXXkuLXLT7rMeYaSf5r/6ewQiv/trBtqpWRm4DEH2EilHw/iWTBKOXs1qZNQndgUMa5n4LA==
 
-"@microsoft/fast-element@^1.10.4", "@microsoft/fast-element@^1.11.0":
+"@microsoft/fast-element@^1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.11.0.tgz#494f6c87057bcbb42406982d68a92887d6b5acb1"
   integrity sha512-VKJYMkS5zgzHHb66sY7AFpYv6IfFhXrjQcAyNgi2ivD65My1XOhtjfKez5ELcLFRJfgZNAxvI8kE69apXERTkw==
@@ -5680,7 +5680,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/mocha@7.0.2", "@types/mocha@^7.0.2":
+"@types/mocha@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
@@ -18765,7 +18765,7 @@ mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mocha@7.2.0, mocha@^7.1.2:
+mocha@7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.2.0.tgz#01cc227b00d875ab1eed03a75106689cfed5a604"
   integrity sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- web-components is using olg tslib v1. The reasoning behind was that some OSS folks on FAST were using [Typescript v3.9](https://github.com/microsoft/tslib/releases/tag/2.0.0). 
- web-components is ignored from syncpack dependency checks which allows us to introduce deps inconsistencies 

## New Behavior

- web-components now depend on tslib v2 to align with rest of monorepo and as previous restriction is no longer in place
- web-components is part of syncpack dep check

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Follows https://github.com/microsoft/fluentui/issues/21395
