### PR TITLE
chore(scripts-puppeteer): try closing open about:blank to free up memory

### DIFF
--- a/apps/ssr-tests-v9/src/utils/visitPage.ts
+++ b/apps/ssr-tests-v9/src/utils/visitPage.ts
@@ -1,5 +1,5 @@
 import type { Browser } from 'puppeteer';
-import { visitUrl } from '@fluentui/scripts-puppeteer';
+import { closeUrl, visitUrl } from '@fluentui/scripts-puppeteer';
 import { PROVIDER_ID } from './constants';
 
 class RenderError extends Error {
@@ -37,7 +37,8 @@ export async function visitPage(browser: Browser, url: string) {
   await visitUrl(page, url);
 
   await page.waitForSelector(`#${PROVIDER_ID}`);
-  await page.close();
+
+  await closeUrl(browser, page);
 
   if (error) {
     throw error;

--- a/scripts/projects-test/src/performBrowserTest.ts
+++ b/scripts/projects-test/src/performBrowserTest.ts
@@ -1,7 +1,7 @@
 import { Server } from 'http';
 import { AddressInfo } from 'net';
 
-import { launch, visitUrl } from '@fluentui/scripts-puppeteer';
+import { closeUrl, launch, visitUrl } from '@fluentui/scripts-puppeteer';
 import express, { Express } from 'express';
 
 /**
@@ -99,8 +99,7 @@ export async function performBrowserTest(publicDirectory: string) {
   });
 
   await visitUrl(page, url);
-
-  await page.close();
+  await closeUrl(browser, page);
   await browser.close();
   await closeServer(server);
 

--- a/scripts/puppeteer/src/index.ts
+++ b/scripts/puppeteer/src/index.ts
@@ -1,1 +1,1 @@
-export { launch, visitUrl } from './utils';
+export { launch, visitUrl, closeUrl } from './utils';

--- a/scripts/puppeteer/src/utils.ts
+++ b/scripts/puppeteer/src/utils.ts
@@ -30,6 +30,32 @@ export async function launch(options: LaunchOptions = {}) {
   return browser;
 }
 
+/**
+ *
+ * Try out https://github.com/puppeteer/puppeteer/issues/1490
+ */
+export async function closeUrl(browser: puppeteer.Browser, page: puppeteer.Page) {
+  await page.close();
+
+  const pages = await browser.pages();
+  console.log(
+    'puppeteer: existing open pages',
+    pages.map(_page => _page.url()),
+  );
+
+  for (const browserPage of pages) {
+    if (browserPage.isClosed()) {
+      continue;
+    }
+
+    const url = browserPage.url();
+    if (url === 'about:blank') {
+      console.log('puppeteer: closing about:blank page');
+      await browserPage.close();
+    }
+  }
+}
+
 export async function visitUrl(page: puppeteer.Page, url: string) {
   const TEN_SECONDS = 10 * 1000;
   const maxAttempts = 5;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Behavior

Puppeteer page open timeout errors still continue. Added helper to try another thing that might help to improve the situation.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Follows https://github.com/microsoft/fluentui/pull/26375
