### PR TITLE
fix: react-toolbar exports

### DIFF
--- a/change/@fluentui-react-toolbar-93622f01-7cbf-4851-b29d-d944254e3166.json
+++ b/change/@fluentui-react-toolbar-93622f01-7cbf-4851-b29d-d944254e3166.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export toolbar hooks as functions, not Typescript types",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/src/index.ts
+++ b/packages/react-components/react-toolbar/src/index.ts
@@ -6,13 +6,8 @@ export {
   useToolbar_unstable,
 } from './Toolbar';
 export type { ToolbarContextValue, ToolbarContextValues, ToolbarProps, ToolbarSlots, ToolbarState } from './Toolbar';
-export { ToolbarButton } from './ToolbarButton';
-export type {
-  ToolbarButtonProps,
-  ToolbarButtonState,
-  useToolbarButtonStyles_unstable,
-  useToolbarButton_unstable,
-} from './ToolbarButton';
+export { ToolbarButton, useToolbarButtonStyles_unstable, useToolbarButton_unstable } from './ToolbarButton';
+export type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton';
 export { ToolbarDivider, useToolbarDividerStyles_unstable, useToolbarDivider_unstable } from './ToolbarDivider';
 export type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider';
 export {


### PR DESCRIPTION
## Previous Behavior

useToolbarButtonStyles_unstable and useToolbarButton_unstable are exported as Typescript types but they are functions, not types.

## New Behavior

useToolbarButtonStyles_unstable and useToolbarButton_unstable are exported as functions.