### PR TITLE
fix: Update `useId` to work correctly in React 18 and React 18 strictmode

### DIFF
--- a/change/@fluentui-react-provider-8fc63cd5-dc28-483f-8ea9-04cd91d6d69c.json
+++ b/change/@fluentui-react-provider-8fc63cd5-dc28-483f-8ea9-04cd91d6d69c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Update FluentProvider's class name to use backslash when a colon is present.",
+  "packageName": "@fluentui/react-provider",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-e64decea-bd78-44df-85fb-6e83069ecd84.json
+++ b/change/@fluentui-react-utilities-e64decea-bd78-44df-85fb-6e83069ecd84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Leverage React.useId when available for our useId hook.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -62,6 +62,7 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
       : '';
   }, [theme]);
 
+  // When using React 18, the id generated will contain : which is not valid unless we add an escape character
   const rule = `.${styleTagId.replace(/:/g, '\\:')} { ${cssVarsAsString} }`;
 
   useInsertionEffect(() => {

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -62,7 +62,7 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
       : '';
   }, [theme]);
 
-  const rule = `.${styleTagId} { ${cssVarsAsString} }`;
+  const rule = `.${styleTagId.replace(/:/g, '\\:')} { ${cssVarsAsString} }`;
 
   useInsertionEffect(() => {
     styleTag.current = createStyleTag(targetDocument, { ...styleElementAttributes, id: styleTagId });

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -26,7 +26,7 @@ export function useId(prefix: string = 'fui-', providedId?: string): string {
   // Hooks appear to be running conditionally, but they will always run in the same order since it's based on
   // the version of React being used. This is safe to ignore.
   return _useId
-    ? providedId ?? `${prefix}${_useId()}`
+    ? providedId || `${prefix}${_useId()}`
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       React.useMemo(() => {
         if (providedId) {

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -21,18 +21,20 @@ export function useId(prefix: string = 'fui-', providedId?: string): string {
 
   // Checking if useId is available on React, if it is, we use it to generate the id. String concatenation is used to
   // prevent bundlers from complaining with older versions of React.
-  const _useId: () => string = (React as never)['use' + 'Id'];
+  const _useId: () => string | undefined = (React as never)['use' + 'Id'];
+
+  if (_useId) {
+    return providedId || `${prefix}${_useId()}`;
+  }
 
   // Hooks appear to be running conditionally, but they will always run in the same order since it's based on
   // the version of React being used. This is safe to ignore.
-  return _useId
-    ? providedId || `${prefix}${_useId()}`
-    : // eslint-disable-next-line react-hooks/rules-of-hooks
-      React.useMemo(() => {
-        if (providedId) {
-          return providedId;
-        }
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return React.useMemo(() => {
+    if (providedId) {
+      return providedId;
+    }
 
-        return `${prefix}${++contextValue.current}`;
-      }, [prefix, providedId, contextValue]);
+    return `${prefix}${++contextValue.current}`;
+  }, [prefix, providedId, contextValue]);
 }

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -26,8 +26,7 @@ export function useId(prefix: string = 'fui-', providedId?: string): string {
   // Hooks appear to be running conditionally, but they will always run in the same order since it's based on
   // the version of React being used. This is safe to ignore.
   return _useId
-    ? // We need to replace : with -- because we used it as a class name.
-      `${prefix}${_useId().replace(/:/g, '--')}`
+    ? providedId ?? `${prefix}${_useId()}`
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       React.useMemo(() => {
         if (providedId) {

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -19,11 +19,21 @@ export function resetIdsForTests(): void {
 export function useId(prefix: string = 'fui-', providedId?: string): string {
   const contextValue = useSSRContext();
 
-  return React.useMemo(() => {
-    if (providedId) {
-      return providedId;
-    }
+  // Checking if useId is available on React, if it is, we use it to generate the ID. String concatenation is used to
+  // prevent bundlers to complain with older versions of React
+  const _useId: () => string = (React as never)['use' + 'Id'];
 
-    return `${prefix}${++contextValue.current}`;
-  }, [prefix, providedId, contextValue]);
+  // Hooks appear to be running conditionally, but they will always run in the same order since it's based on
+  // the version of React being used. This is safe to ignore.
+  return _useId
+    ? // We need to replace : with -- because we used it as a class name.
+      `${prefix}${_useId().replace(/:/g, '--')}`
+    : // eslint-disable-next-line react-hooks/rules-of-hooks
+      React.useMemo(() => {
+        if (providedId) {
+          return providedId;
+        }
+
+        return `${prefix}${++contextValue.current}`;
+      }, [prefix, providedId, contextValue]);
 }

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -19,8 +19,8 @@ export function resetIdsForTests(): void {
 export function useId(prefix: string = 'fui-', providedId?: string): string {
   const contextValue = useSSRContext();
 
-  // Checking if useId is available on React, if it is, we use it to generate the ID. String concatenation is used to
-  // prevent bundlers to complain with older versions of React
+  // Checking if useId is available on React, if it is, we use it to generate the id. String concatenation is used to
+  // prevent bundlers from complaining with older versions of React.
   const _useId: () => string = (React as never)['use' + 'Id'];
 
   // Hooks appear to be running conditionally, but they will always run in the same order since it's based on


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

We generate our own ids and use a context to keep track of server vs client id generation.

## New Behavior

We still have the previous behavior, but we now check if `React.useId` is available (React 18+) and use it when available. This will help fix issues with React 18+ when using SSR and/or strictmode. This is due to `React.useId` being aware of strictmode and SSR.

> **Note**: React's `useId` hook uses `:` for its generated id, this is a problem for us since we use ids as class names when loading up our theme css vars. To fix this issue, we have to add a backslash to the className when inserting it into the style tag turning `:` to `\:`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #23620
