### PR TITLE
chore: update v8 ComboBox & Dropdown docs to explicitly prohibit nested interactive content

### DIFF
--- a/change/@fluentui-react-32aa49c5-bacb-44c3-998b-5fe09a293db0.json
+++ b/change/@fluentui-react-32aa49c5-bacb-44c3-998b-5fe09a293db0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update ComboBox & Dropdown docs to explicitly prohibit nested interactive content",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
+++ b/packages/react-examples/src/react/ComboBox/docs/ComboBoxBestPractices.md
@@ -6,6 +6,7 @@
 
 - Use single words or shortened statements as options.
 - Don't use punctuation at the end of options.
+- ComboBox does not support any interactive content aside from the options themselves.
 
 ### Accessibility
 

--- a/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
+++ b/packages/react-examples/src/react/Dropdown/docs/DropdownBestPractices.md
@@ -11,6 +11,7 @@
 - If there isn't a default option, use "Select an option" as placeholder text.
 - If "None" is an option, include it.
 - Write the choices using parallel construction. For example, start with the same part of speech or verb tense.
+- Dropdown does not support any interactive content aside from the options themselves.
 
 ### Accessibility
 

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -220,12 +220,12 @@ export interface IComboBoxProps
   scrollSelectedToTop?: boolean;
 
   /**
-   * Add additional content above the option list in the callout.
+   * Add additional content above the option list in the callout. Content should not include interactive items.
    */
   onRenderUpperContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-   * Add additional content below the option list in the callout.
+   * Add additional content below the option list in the callout. Content should not include interactive items.
    */
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
 


### PR DESCRIPTION
Docs update related to a misunderstanding around `onRenderUpperContent` & `onRenderLowerContent`. I've added docs wording both to those two props, and to the best practices section of v8's Combobox and Dropdown to make it clearer that miscellaneous interactive content is not supported.