### PR TITLE
fix: react-combobox add listbox max-height and shift shadow style location

### DIFF
--- a/change/@fluentui-react-combobox-180e14ee-bb08-41bc-ae39-3046c6fa0c5e.json
+++ b/change/@fluentui-react-combobox-180e14ee-bb08-41bc-ae39-3046c6fa0c5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: add popup maxHeight, and move shadow styles to combobox/dropdown\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-180e14ee-bb08-41bc-ae39-3046c6fa0c5e.json
+++ b/change/@fluentui-react-combobox-180e14ee-bb08-41bc-ae39-3046c6fa0c5e.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix: add popup maxHeight, and move shadow styles to combobox/dropdown\"",
+  "comment": "fix: add popup maxHeight, and move shadow styles to combobox/dropdown",
   "packageName": "@fluentui/react-combobox",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.ts
@@ -80,7 +80,11 @@ const useStyles = makeStyles({
     },
   },
 
-  listbox: {},
+  listbox: {
+    boxShadow: `${tokens.shadow16}`,
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    maxHeight: '80vh',
+  },
 
   listboxCollapsed: {
     display: 'none',

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.ts
@@ -68,7 +68,11 @@ const useStyles = makeStyles({
     },
   },
 
-  listbox: {},
+  listbox: {
+    boxShadow: `${tokens.shadow16}`,
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    maxHeight: '80vh',
+  },
 
   listboxCollapsed: {
     display: 'none',

--- a/packages/react-components/react-combobox/src/components/Listbox/useListboxStyles.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListboxStyles.ts
@@ -12,10 +12,8 @@ export const listboxClassNames: SlotClassNames<ListboxSlots> = {
  */
 const useStyles = makeStyles({
   root: {
-    boxShadow: `${tokens.shadow16}`,
-    boxSizing: 'border-box',
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
     backgroundColor: tokens.colorNeutralBackground1,
+    boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
     minWidth: '160px',


### PR DESCRIPTION
## Changes

- The listbox popup did not have a max-height, so grew with its contents past the screen height. Now it's set to `80vh`
- box-shadow and border-radius were defined in `useListboxStyles`. Those have been moved to `useComboboxStyles` and `useDropdownStyles` so Listbox can be more easily re-used in different contexts (and because the shadow and border-radius are more tied to the popup, not the listbox)

Max-height is part of #26069
Shadow styles are part of #25866