### PR TITLE
fix: react-combobox story fixes and docs wording updates

### DIFF
--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxComplexOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxComplexOptions.stories.tsx
@@ -70,9 +70,10 @@ ComplexOptions.parameters = {
   docs: {
     description: {
       story:
-        'Options can have structured JSX children. ' +
-        "When this is the case, the Option's `text` prop should be a the plain text version of the option, " +
-        'and is used as the Combobox value when the option is selected.',
+        'Options are defined as JSX children, and can include nested elements or other components. ' +
+        "When this is the case, the Option's `text` prop should be the plain text version of the option, " +
+        'and is used as the Combobox value when the option is selected. ' +
+        'Options should never contain interactive elements, such as buttons or links.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxCustomOptions.stories.tsx
@@ -60,7 +60,11 @@ export const CustomOptions = (props: Partial<ComboboxProps>) => {
 CustomOptions.parameters = {
   docs: {
     description: {
-      story: 'Options and OptionGroups can be extended and customized.',
+      story:
+        'Options and OptionGroups can be extended and customized.' +
+        'Here `OptionGroup` is wrapped in `CustomOptionGroup`,' +
+        'which adds a custom label style and takes an `options` array prop which is mapped to child Option elements.' +
+        '`Option` is also wrapped in `CustomOption`, which adds a custom check icon.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxCustomOptions.stories.tsx
@@ -9,11 +9,12 @@ const CustomOption = (props: OptionProps) => {
 };
 
 const CustomOptionGroup = (props: Partial<OptionGroupProps> & { options: string[] }) => {
-  const labelSlot = typeof props.label === 'object' ? props.label : { children: props.label };
+  const { label, options, ...optionGroupProps } = props;
+  const labelSlot = typeof label === 'object' ? label : { children: label };
 
   return (
-    <OptionGroup label={{ style: { fontStyle: 'italic' }, ...labelSlot }}>
-      {props.options.map(option => (
+    <OptionGroup label={{ style: { fontStyle: 'italic' }, ...labelSlot }} {...optionGroupProps}>
+      {options.map(option => (
         <CustomOption key={option} disabled={option === 'Ferret'}>
           {option}
         </CustomOption>

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownComplexOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownComplexOptions.stories.tsx
@@ -70,9 +70,10 @@ ComplexOptions.parameters = {
   docs: {
     description: {
       story:
-        'Options can have structured JSX children. ' +
-        "When this is the case, the Option's `text` prop should be a plain text version of the option, " +
-        "and is used as the Dropdown button's content when the option is selected.",
+        'Options are defined as JSX children, and can include nested elements or other components. ' +
+        "When this is the case, the Option's `text` prop should be the plain text version of the option, " +
+        "and is used as the Dropdown button's value when the option is selected. " +
+        'Options should never contain interactive elements, such as buttons or links.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownCustomOptions.stories.tsx
@@ -51,7 +51,7 @@ const CustomOptionGroup = (props: Partial<OptionGroupProps> & { options: (keyof 
   const labelSlot = typeof props.label === 'object' ? props.label : { children: props.label };
 
   return (
-    <OptionGroup label={{ style: { fontStyle: 'italic' }, ...labelSlot }}>
+    <OptionGroup {...props} label={{ style: { fontStyle: 'italic' }, ...labelSlot }}>
       {props.options.map(option => (
         <CustomOption key={option} animal={option} />
       ))}
@@ -98,8 +98,11 @@ CustomOptions.parameters = {
   docs: {
     description: {
       story:
-        'Options and OptionGroups can be extended and customized. ' +
-        'The `value` prop is used here, since the children of `<Option>` include JSX.',
+        'Options and OptionGroups can be extended and customized.' +
+        'Here `OptionGroup` is wrapped in `CustomOptionGroup`,' +
+        'which adds a custom label style and takes an `options` array prop which is mapped to child Option elements.' +
+        '`Option` is also wrapped in `CustomOption`, which adds a custom check icon and animal icon.' +
+        'The `text` prop is added to `<Option>`, since the children of `<Option>` are not a simple string.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownCustomOptions.stories.tsx
@@ -48,11 +48,12 @@ const CustomOption = (props: CustomOptionProps) => {
 };
 
 const CustomOptionGroup = (props: Partial<OptionGroupProps> & { options: (keyof typeof animalIcons)[] }) => {
-  const labelSlot = typeof props.label === 'object' ? props.label : { children: props.label };
+  const { label, options, ...optionGroupProps } = props;
+  const labelSlot = typeof label === 'object' ? label : { children: label };
 
   return (
-    <OptionGroup {...props} label={{ style: { fontStyle: 'italic' }, ...labelSlot }}>
-      {props.options.map(option => (
+    <OptionGroup label={{ style: { fontStyle: 'italic' }, ...labelSlot }} {...optionGroupProps}>
+      {options.map(option => (
         <CustomOption key={option} animal={option} />
       ))}
     </OptionGroup>

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownDefault.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownDefault.stories.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
 
 export const Default = (props: Partial<DropdownProps>) => {
   const dropdownId = useId('dropdown-default');
-  const options = ['Cat', 'Caterpiller', 'Corgi', 'Chupacabra', 'Dog', 'Ferret', 'Fish', 'Fox', 'Hamster', 'Snake'];
+  const options = ['Cat', 'Caterpillar', 'Corgi', 'Chupacabra', 'Dog', 'Ferret', 'Fish', 'Fox', 'Hamster', 'Snake'];
   const styles = useStyles();
   return (
     <div className={styles.root}>


### PR DESCRIPTION
Examples-only PR. This takes care of a bunch of the examples/story items in #26069

-  Updates "JSX children" wording for complex options stories
- More detailed description for the custom options stories
- Spread the OptionGroup props in the custom options story
- Caterpillar was misspelled in the default dropdown story