### PR TITLE
feat(react-button): creates ButtonContext

### DIFF
--- a/change/@fluentui-react-button-f3600003-d5e8-4448-b335-4a0ff4c76dfd.json
+++ b/change/@fluentui-react-button-f3600003-d5e8-4448-b335-4a0ff4c76dfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: creates ButtonContext",
+  "packageName": "@fluentui/react-button",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/etc/react-button.api.md
+++ b/packages/react-components/react-button/etc/react-button.api.md
@@ -20,10 +20,10 @@ export const Button: ForwardRefComponent<ButtonProps>;
 // @public (undocumented)
 export const buttonClassNames: SlotClassNames<ButtonSlots>;
 
-// @internal (undocumented)
+// @internal
 export const ButtonContextProvider: React_2.Provider<ButtonContextValue | undefined>;
 
-// @internal (undocumented)
+// @internal
 export interface ButtonContextValue {
     // (undocumented)
     size?: ButtonSize;
@@ -136,7 +136,7 @@ export type ToggleButtonState = ButtonState & Required<Pick<ToggleButtonProps, '
 // @public
 export const useButton_unstable: (props: ButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ButtonState;
 
-// @internal (undocumented)
+// @internal
 export const useButtonContext: () => ButtonContextValue;
 
 // @public (undocumented)

--- a/packages/react-components/react-button/etc/react-button.api.md
+++ b/packages/react-components/react-button/etc/react-button.api.md
@@ -20,6 +20,15 @@ export const Button: ForwardRefComponent<ButtonProps>;
 // @public (undocumented)
 export const buttonClassNames: SlotClassNames<ButtonSlots>;
 
+// @internal (undocumented)
+export const ButtonContextProvider: React_2.Provider<ButtonContextValue | undefined>;
+
+// @internal (undocumented)
+export interface ButtonContextValue {
+    // (undocumented)
+    size?: ButtonSize;
+}
+
 // @public (undocumented)
 export type ButtonProps = ComponentProps<ButtonSlots> & {
     appearance?: 'secondary' | 'primary' | 'outline' | 'subtle' | 'transparent';
@@ -27,7 +36,7 @@ export type ButtonProps = ComponentProps<ButtonSlots> & {
     disabled?: boolean;
     iconPosition?: 'before' | 'after';
     shape?: 'rounded' | 'circular' | 'square';
-    size?: 'small' | 'medium' | 'large';
+    size?: ButtonSize;
 };
 
 // @public (undocumented)
@@ -126,6 +135,9 @@ export type ToggleButtonState = ButtonState & Required<Pick<ToggleButtonProps, '
 
 // @public
 export const useButton_unstable: (props: ButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ButtonState;
+
+// @internal (undocumented)
+export const useButtonContext: () => ButtonContextValue;
 
 // @public (undocumented)
 export const useButtonStyles_unstable: (state: ButtonState) => ButtonState;

--- a/packages/react-components/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-components/react-button/src/components/Button/Button.types.ts
@@ -13,6 +13,11 @@ export type ButtonSlots = {
   icon?: Slot<'span'>;
 };
 
+/**
+ * A button supports different sizes.
+ */
+export type ButtonSize = 'small' | 'medium' | 'large';
+
 export type ButtonProps = ComponentProps<ButtonSlots> & {
   /**
    * A button can have its content and borders styled for greater emphasis or to be subtle.
@@ -61,7 +66,7 @@ export type ButtonProps = ComponentProps<ButtonSlots> & {
    *
    * @default 'medium'
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: ButtonSize;
 };
 
 export type ButtonState = ComponentState<ButtonSlots> &

--- a/packages/react-components/react-button/src/components/Button/useButton.ts
+++ b/packages/react-components/react-button/src/components/Button/useButton.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ARIAButtonSlotProps, useARIAButtonShorthand } from '@fluentui/react-aria';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import type { ButtonProps, ButtonState } from './Button.types';
+import { useButtonContext } from '../../contexts/ButtonContext';
 
 /**
  * Given user props, defines default props for the Button, calls useButtonState, and returns processed state.
@@ -12,6 +13,7 @@ export const useButton_unstable = (
   props: ButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ButtonState => {
+  const { size: contextSize } = useButtonContext();
   const {
     appearance = 'secondary',
     as = 'button',
@@ -20,7 +22,7 @@ export const useButton_unstable = (
     icon,
     iconPosition = 'before',
     shape = 'rounded',
-    size = 'medium',
+    size = contextSize ?? 'medium',
   } = props;
   const iconShorthand = resolveShorthand(icon);
 

--- a/packages/react-components/react-button/src/components/Button/useButton.ts
+++ b/packages/react-components/react-button/src/components/Button/useButton.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { ARIAButtonSlotProps, useARIAButtonShorthand } from '@fluentui/react-aria';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
-import type { ButtonProps, ButtonState } from './Button.types';
 import { useButtonContext } from '../../contexts/ButtonContext';
+import type { ButtonProps, ButtonState } from './Button.types';
 
 /**
  * Given user props, defines default props for the Button, calls useButtonState, and returns processed state.

--- a/packages/react-components/react-button/src/contexts/ButtonContext.ts
+++ b/packages/react-components/react-button/src/contexts/ButtonContext.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { ButtonSize } from '../components/Button/Button.types';
+
+const buttonContext = React.createContext<ButtonContextValue | undefined>(undefined);
+
+/**
+ * @internal
+ */
+export interface ButtonContextValue {
+  size?: ButtonSize;
+}
+
+const buttonContextDefaultValue: ButtonContextValue = {};
+
+/**
+ * @internal
+ */
+export const ButtonContextProvider = buttonContext.Provider;
+
+/**
+ * @internal
+ */
+export const useButtonContext = () => React.useContext(buttonContext) ?? buttonContextDefaultValue;

--- a/packages/react-components/react-button/src/contexts/ButtonContext.ts
+++ b/packages/react-components/react-button/src/contexts/ButtonContext.ts
@@ -5,6 +5,7 @@ const buttonContext = React.createContext<ButtonContextValue | undefined>(undefi
 
 /**
  * @internal
+ * Internal context value used to update default values between internal components
  */
 export interface ButtonContextValue {
   size?: ButtonSize;
@@ -14,10 +15,12 @@ const buttonContextDefaultValue: ButtonContextValue = {};
 
 /**
  * @internal
+ * Internal context provider used to update default values between internal components
  */
 export const ButtonContextProvider = buttonContext.Provider;
 
 /**
  * @internal
+ * Internal context hook used to update default values between internal components
  */
 export const useButtonContext = () => React.useContext(buttonContext) ?? buttonContextDefaultValue;

--- a/packages/react-components/react-button/src/contexts/index.ts
+++ b/packages/react-components/react-button/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './ButtonContext';

--- a/packages/react-components/react-button/src/index.ts
+++ b/packages/react-components/react-button/src/index.ts
@@ -40,3 +40,6 @@ export {
 export type { ToggleButtonProps, ToggleButtonState } from './ToggleButton';
 
 export { useToggleState } from './utils/index';
+
+export { ButtonContextProvider, useButtonContext } from './contexts/index';
+export type { ButtonContextValue } from './contexts/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Inspired on `AvatarContext` implementation https://github.com/microsoft/fluentui/pull/24790. Some components such as `TableCell` require to modify `Avatar` default size. This PR creates `ButtonContext` to allow other components to modify the default size of a button (this will be required for `TreeItem`, since a `TreeItem` action will be a button that by default will be `small` sized).

