### PR TITLE
feat: add combo and dropdown vr tests

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Combobox.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Combobox.stories.tsx
@@ -123,47 +123,57 @@ storiesOf('Combobox Converged', module)
     </StoryWright>
   ))
   .addStory('Open', () => (
-    <Combobox open>
-      <Option>Red</Option>
-      <Option>Green</Option>
-      <Option>Blue</Option>
-    </Combobox>
-  ))
-  .addStory('Open with inlinePopup', () => (
-    <Combobox open inlinePopup>
-      <Option>Red</Option>
-      <Option>Green</Option>
-      <Option>Blue</Option>
-    </Combobox>
-  ))
-  .addStory('Option with long content', () => (
-    <Combobox open>
-      <Option>
-        Blue indigo periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt blue indigo
-        periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt
-      </Option>
-      <Option>Red</Option>
-      <Option>Green</Option>
-    </Combobox>
-  ))
-  .addStory('Disabled option', () => (
-    <Combobox open>
-      <Option disabled>Red</Option>
-      <Option>Green</Option>
-      <Option>Blue</Option>
-    </Combobox>
-  ))
-  .addStory('Open with grouped options', () => (
-    <Combobox open>
-      <OptionGroup label="Colors">
+    <div style={{ paddingBottom: '120px' }}>
+      <Combobox open>
         <Option>Red</Option>
         <Option>Green</Option>
         <Option>Blue</Option>
-      </OptionGroup>
-      <OptionGroup label="Shapes">
-        <Option>Circle</Option>
-        <Option>Square</Option>
-        <Option>Oval</Option>
-      </OptionGroup>
-    </Combobox>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Open with inlinePopup', () => (
+    <div style={{ paddingBottom: '120px' }}>
+      <Combobox open inlinePopup>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Option with long content', () => (
+    <div style={{ paddingBottom: '240px' }}>
+      <Combobox open>
+        <Option>
+          Blue indigo periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt blue indigo
+          periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt
+        </Option>
+        <Option>Red</Option>
+        <Option>Green</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Disabled option', () => (
+    <div style={{ paddingBottom: '120px' }}>
+      <Combobox open>
+        <Option disabled>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Open with grouped options', () => (
+    <div style={{ paddingBottom: '300px' }}>
+      <Combobox open>
+        <OptionGroup label="Colors">
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </OptionGroup>
+        <OptionGroup label="Shapes">
+          <Option>Circle</Option>
+          <Option>Square</Option>
+          <Option>Oval</Option>
+        </OptionGroup>
+      </Combobox>
+    </div>
   ));

--- a/apps/vr-tests-react-components/src/stories/Combobox.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Combobox.stories.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import { Steps, StoryWright } from 'storywright';
+import { storiesOf } from '@storybook/react';
+import { Combobox, Option, OptionGroup } from '@fluentui/react-combobox';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
+
+storiesOf('Combobox Converged', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('input')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .focus('input')
+        .wait(250) // let focus border animation finish
+        .snapshot('focused', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </StoryWright>
+  ))
+  .addStory('Appearance: outline (default)', () => (
+    <Combobox>
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Appearance: underline', () => (
+    <Combobox appearance="underline">
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Appearance: filled-darker', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Combobox appearance="filled-darker">
+        <Option>text</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Appearance: filled-lighter', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Combobox appearance="filled-lighter">
+        <Option>text</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Disabled', () => (
+    <Combobox disabled>
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Disabled with value', () => (
+    <Combobox disabled selectedOptions={['text']}>
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Invalid: outline', () => (
+    <Combobox aria-invalid>
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Invalid: underline', () => (
+    <Combobox aria-invalid appearance="underline">
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Invalid: filled-darker', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Combobox aria-invalid appearance="filled-darker">
+        <Option>text</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('Invalid: filled-lighter', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Combobox aria-invalid appearance="filled-lighter">
+        <Option>text</Option>
+      </Combobox>
+    </div>
+  ))
+  .addStory('With placeholder', () => (
+    <Combobox placeholder="Color">
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('With value', () => (
+    <Combobox value="Text text">
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('With multiselect value', () => (
+    <Combobox multiselect selectedOptions={['Green', 'Red']}>
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Combobox>
+  ))
+  .addStory('Size: small', () => (
+    <Combobox size="small">
+      <Option>text</Option>
+    </Combobox>
+  ))
+  .addStory('Size: large', () => (
+    <Combobox size="large">
+      <Option>text</Option>
+    </Combobox>
+  ));
+
+// Option interaction stories
+storiesOf('Combobox Converged', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('[role=option]')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .keys('input', 'ArrowDown')
+        .snapshot('active option', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </StoryWright>
+  ))
+  .addStory('Open', () => (
+    <Combobox open>
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Combobox>
+  ))
+  .addStory('Open with inlinePopup', () => (
+    <Combobox open inlinePopup>
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Combobox>
+  ))
+  .addStory('Option with long content', () => (
+    <Combobox open>
+      <Option>
+        Blue indigo periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt blue indigo
+        periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt
+      </Option>
+      <Option>Red</Option>
+      <Option>Green</Option>
+    </Combobox>
+  ))
+  .addStory('Disabled option', () => (
+    <Combobox open>
+      <Option disabled>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Combobox>
+  ))
+  .addStory('Open with grouped options', () => (
+    <Combobox open>
+      <OptionGroup label="Colors">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </OptionGroup>
+      <OptionGroup label="Shapes">
+        <Option>Circle</Option>
+        <Option>Square</Option>
+        <Option>Oval</Option>
+      </OptionGroup>
+    </Combobox>
+  ));

--- a/apps/vr-tests-react-components/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import { Steps, StoryWright } from 'storywright';
+import { storiesOf } from '@storybook/react';
+import { Dropdown, Option, OptionGroup } from '@fluentui/react-combobox';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
+
+storiesOf('Dropdown Converged', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('input')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .focus('input')
+        .wait(250) // let focus border animation finish
+        .snapshot('focused', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </StoryWright>
+  ))
+  .addStory('Appearance: outline (default)', () => (
+    <Dropdown>
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Appearance: underline', () => (
+    <Dropdown appearance="underline">
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Appearance: filled-darker', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Dropdown appearance="filled-darker">
+        <Option>text</Option>
+      </Dropdown>
+    </div>
+  ))
+  .addStory('Appearance: filled-lighter', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Dropdown appearance="filled-lighter">
+        <Option>text</Option>
+      </Dropdown>
+    </div>
+  ))
+  .addStory('Disabled', () => (
+    <Dropdown disabled>
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Disabled with value', () => (
+    <Dropdown disabled selectedOptions={['text']}>
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Invalid: outline', () => (
+    <Dropdown aria-invalid>
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Invalid: underline', () => (
+    <Dropdown aria-invalid appearance="underline">
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Invalid: filled-darker', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Dropdown aria-invalid appearance="filled-darker">
+        <Option>text</Option>
+      </Dropdown>
+    </div>
+  ))
+  .addStory('Invalid: filled-lighter', () => (
+    <div style={{ background: '#00335c', padding: '10px' }}>
+      <Dropdown aria-invalid appearance="filled-lighter">
+        <Option>text</Option>
+      </Dropdown>
+    </div>
+  ))
+  .addStory('With placeholder', () => (
+    <Dropdown placeholder="Select a Color">
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Dropdown>
+  ))
+  .addStory('With value', () => (
+    <Dropdown value="Text text">
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('With multiselect value', () => (
+    <Dropdown multiselect selectedOptions={['Green', 'Red']}>
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Dropdown>
+  ))
+  .addStory('Size: small', () => (
+    <Dropdown size="small">
+      <Option>text</Option>
+    </Dropdown>
+  ))
+  .addStory('Size: large', () => (
+    <Dropdown size="large">
+      <Option>text</Option>
+    </Dropdown>
+  ));
+
+// Option interaction stories
+storiesOf('Dropdown Converged', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('[role=option]')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .keys('input', 'ArrowDown')
+        .snapshot('active option', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </StoryWright>
+  ))
+  .addStory('Open', () => (
+    <Dropdown open>
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Dropdown>
+  ))
+  .addStory('Open with inlinePopup', () => (
+    <Dropdown open inlinePopup>
+      <Option>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Dropdown>
+  ))
+  .addStory('Option with long content', () => (
+    <Dropdown open>
+      <Option>
+        Blue indigo periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt blue indigo
+        periwinkle azure sapphire ultramarine teal cerulean navy turquoise cyan cobalt
+      </Option>
+      <Option>Red</Option>
+      <Option>Green</Option>
+    </Dropdown>
+  ))
+  .addStory('Disabled option', () => (
+    <Dropdown open>
+      <Option disabled>Red</Option>
+      <Option>Green</Option>
+      <Option>Blue</Option>
+    </Dropdown>
+  ))
+  .addStory('Open with grouped options', () => (
+    <Dropdown open>
+      <OptionGroup label="Colors">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </OptionGroup>
+      <OptionGroup label="Shapes">
+        <Option>Circle</Option>
+        <Option>Square</Option>
+        <Option>Oval</Option>
+      </OptionGroup>
+    </Dropdown>
+  ));


### PR DESCRIPTION
Adds both Combobox and Dropdown VR tests (both include essentially the same tests, since the typability of combobox does not affect what would be included in snapshot tests)