### PR TITLE
feat(react-tree): uses ButtonContext to modify default button size

### DIFF
--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -8,6 +8,7 @@
 
 import type { AvatarContextValue } from '@fluentui/react-avatar';
 import type { AvatarSize } from '@fluentui/react-avatar';
+import type { ButtonContextValue } from '@fluentui/react-button';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import { ContextSelector } from '@fluentui/react-context-selector';
@@ -110,9 +111,11 @@ export type TreeItemSlots = {
 };
 
 // @public
-export type TreeItemState = ComponentState<TreeItemSlots> & TreeItemContextValue & {
+export type TreeItemState = ComponentState<TreeItemSlots> & {
     open: boolean;
     isLeaf: boolean;
+    buttonSize: 'small';
+    isActionsVisible: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-tree/package.json
+++ b/packages/react-components/react-tree/package.json
@@ -38,6 +38,7 @@
     "@fluentui/react-aria": "^9.3.6",
     "@fluentui/react-tabster": "^9.4.1",
     "@fluentui/react-portal": "^9.1.4",
+    "@fluentui/react-button": "^9.1.16",
     "@fluentui/keyboard-keys": "^9.0.1",
     "@fluentui/react-theme": "^9.1.5",
     "@fluentui/react-utilities": "^9.5.0",

--- a/packages/react-components/react-tree/package.json
+++ b/packages/react-components/react-tree/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-aria": "^9.3.6",
     "@fluentui/react-tabster": "^9.4.1",
     "@fluentui/react-portal": "^9.1.4",
-    "@fluentui/react-button": "^9.1.16",
+    "@fluentui/react-button": "^9.2.0",
     "@fluentui/keyboard-keys": "^9.0.1",
     "@fluentui/react-theme": "^9.1.5",
     "@fluentui/react-utilities": "^9.5.0",

--- a/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
@@ -1,6 +1,6 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { TreeItemContextValue } from '../../contexts';
 import type { ButtonContextValue } from '@fluentui/react-button';
+import type { TreeItemContextValue } from '../../contexts';
 
 export type TreeItemSlots = {
   root: Slot<'div'>;

--- a/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
@@ -1,5 +1,6 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { TreeItemContextValue } from '../../contexts/treeItemContext';
+import type { TreeItemContextValue } from '../../contexts';
+import type { ButtonContextValue } from '@fluentui/react-button';
 
 export type TreeItemSlots = {
   root: Slot<'div'>;
@@ -19,6 +20,7 @@ export type TreeItemSlots = {
 
 export type TreeItemContextValues = {
   treeItem: TreeItemContextValue;
+  button: ButtonContextValue;
 };
 
 /**
@@ -29,8 +31,12 @@ export type TreeItemProps = ComponentProps<Partial<TreeItemSlots>>;
 /**
  * State used in rendering TreeItem
  */
-export type TreeItemState = ComponentState<TreeItemSlots> &
-  TreeItemContextValue & {
-    open: boolean;
-    isLeaf: boolean;
-  };
+export type TreeItemState = ComponentState<TreeItemSlots> & {
+  open: boolean;
+  isLeaf: boolean;
+  /**
+   * By design, a button included on the actions slot should be small
+   */
+  buttonSize: 'small';
+  isActionsVisible: boolean;
+};

--- a/packages/react-components/react-tree/src/components/TreeItem/renderTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/renderTreeItem.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { getSlots } from '@fluentui/react-utilities';
 import type { TreeItemState, TreeItemSlots, TreeItemContextValues } from './TreeItem.types';
-import { TreeItemProvider } from '../../contexts/treeItemContext';
+import { TreeItemProvider } from '../../contexts';
+import { ButtonContextProvider } from '@fluentui/react-button';
 
 /**
  * Render the final JSX of TreeItem
@@ -15,7 +16,9 @@ export const renderTreeItem_unstable = (state: TreeItemState, contextValues: Tre
         <slots.content {...slotProps.content}>
           {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
           {slotProps.content.children}
-          {slots.actions && <slots.actions {...slotProps.actions} />}
+          <ButtonContextProvider value={contextValues.button}>
+            {slots.actions && <slots.actions {...slotProps.actions} />}
+          </ButtonContextProvider>
         </slots.content>
         {slots.subtree && <slots.subtree {...slotProps.subtree} />}
       </slots.root>

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -127,6 +127,7 @@ export const useTreeItem_unstable = (props: TreeItemProps, ref: React.Ref<HTMLDi
   return {
     isLeaf: !isBranch,
     open,
+    buttonSize: 'small',
     isActionsVisible: actions ? isActionsVisible : false,
     components: {
       content: 'span',

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import type { ButtonContextValue } from '@fluentui/react-button';
 import type { TreeItemContextValue } from '../../contexts';
 import type { TreeItemContextValues, TreeItemState } from './TreeItem.types';
-import type { ButtonContextValue } from '@fluentui/react-button';
 
 export function useTreeItemContextValues_unstable(state: TreeItemState): TreeItemContextValues {
   const { isActionsVisible, buttonSize } = state;

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
@@ -1,16 +1,13 @@
 import * as React from 'react';
-import { TreeItemContextValue } from '../../contexts';
+import type { TreeItemContextValue } from '../../contexts';
 import type { TreeItemContextValues, TreeItemState } from './TreeItem.types';
+import type { ButtonContextValue } from '@fluentui/react-button';
 
 export function useTreeItemContextValues_unstable(state: TreeItemState): TreeItemContextValues {
-  const { isActionsVisible } = state;
+  const { isActionsVisible, buttonSize } = state;
 
-  const treeItem: TreeItemContextValue = React.useMemo(
-    () => ({
-      isActionsVisible,
-    }),
-    [isActionsVisible],
-  );
+  const treeItem = React.useMemo<TreeItemContextValue>(() => ({ isActionsVisible }), [isActionsVisible]);
+  const button = React.useMemo<ButtonContextValue>(() => ({ size: buttonSize }), [buttonSize]);
 
-  return { treeItem };
+  return { treeItem, button };
 }

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
@@ -4,7 +4,7 @@ import type { TreeItemContextValue } from '../../contexts';
 import type { TreeItemContextValues, TreeItemState } from './TreeItem.types';
 
 export function useTreeItemContextValues_unstable(state: TreeItemState): TreeItemContextValues {
-  const { isActionsVisible, buttonSize } = state;
+  const { buttonSize, isActionsVisible } = state;
 
   const treeItem = React.useMemo<TreeItemContextValue>(() => ({ isActionsVisible }), [isActionsVisible]);
   const button = React.useMemo<ButtonContextValue>(() => ({ size: buttonSize }), [buttonSize]);


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Introduces `ButtonContext` around `actions` slot to ensure proper button default size value as `small` as it's required by design specs.

