### PR TITLE
chore(web-components): run manually bump to fix failed CI release

### DIFF
--- a/change/@fluentui-web-components-06188225-69da-4cf6-918c-932a9ceab1b3.json
+++ b/change/@fluentui-web-components-06188225-69da-4cf6-918c-932a9ceab1b3.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "add text as a new component",
-  "packageName": "@fluentui/web-components",
-  "email": "chhol@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-web-components-06a3ebaf-3485-4ea9-a024-ff17305e1f88.json
+++ b/change/@fluentui-web-components-06a3ebaf-3485-4ea9-a024-ff17305e1f88.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore: bump web-components to 3.0.0-alpha.0",
-  "packageName": "@fluentui/web-components",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-0b247950-52cb-4f3a-a1c3-9455ef090098.json
+++ b/change/@fluentui-web-components-0b247950-52cb-4f3a-a1c3-9455ef090098.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore(web-components): resolve invalid webpack test regex on windows",
-  "packageName": "@fluentui/web-components",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-19128575-ce2e-40b1-8a3b-8334eb585f40.json
+++ b/change/@fluentui-web-components-19128575-ce2e-40b1-8a3b-8334eb585f40.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "update clean file to .cjs and ensure rimraf is in dependency tree",
-  "packageName": "@fluentui/web-components",
-  "email": "chhol@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-25e8f64c-845e-401f-a7f8-c9472a5720df.json
+++ b/change/@fluentui-web-components-25e8f64c-845e-401f-a7f8-c9472a5720df.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "add badge and counter badge as new components",
-  "packageName": "@fluentui/web-components",
-  "email": "chhol@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-web-components-7d0424dc-fe77-4d05-b911-295ca60d04fd.json
+++ b/change/@fluentui-web-components-7d0424dc-fe77-4d05-b911-295ca60d04fd.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add initial theme",
-  "packageName": "@fluentui/web-components",
-  "email": "miroslav.stastny@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-web-components-925986c6-b42e-4db6-a621-44ff55110a4f.json
+++ b/change/@fluentui-web-components-925986c6-b42e-4db6-a621-44ff55110a4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: run manually bump to fix failed CI release",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-974b7e3c-cb82-4399-8daf-f58a9a1b23ed.json
+++ b/change/@fluentui-web-components-974b7e3c-cb82-4399-8daf-f58a9a1b23ed.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore: setup typescript 4.7 for web-components package",
-  "packageName": "@fluentui/web-components",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-a9829849-1747-4588-aadf-da70207d0cf0.json
+++ b/change/@fluentui-web-components-a9829849-1747-4588-aadf-da70207d0cf0.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Reset web-components for v3 development",
-  "packageName": "@fluentui/web-components",
-  "email": "miroslav.stastny@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-d423d05a-1b1e-422f-ab9a-afc288197681.json
+++ b/change/@fluentui-web-components-d423d05a-1b1e-422f-ab9a-afc288197681.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "add progressbar as new component",
-  "packageName": "@fluentui/web-components",
-  "email": "ryan@ryanmerrill.net",
-  "dependentChangeType": "patch"
-}

--- a/packages/web-components/CHANGELOG.json
+++ b/packages/web-components/CHANGELOG.json
@@ -2,6 +2,71 @@
   "name": "@fluentui/web-components",
   "entries": [
     {
+      "date": "Wed, 25 Jan 2023 14:49:08 GMT",
+      "tag": "@fluentui/web-components_v3.0.0-alpha.1",
+      "version": "3.0.0-alpha.1",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "ryan@ryanmerrill.net",
+            "package": "@fluentui/web-components",
+            "commit": "1322f3f962e8a850fe104cc2ba9b12b2bc2f2842",
+            "comment": "add progressbar as new component"
+          },
+          {
+            "author": "miroslav.stastny@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "6de62a46eafd74b968ec913901729b3f7284dc7a",
+            "comment": "Add initial theme"
+          },
+          {
+            "author": "chhol@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "eead74fee07339f998615fe34d8f847d0f63af6e",
+            "comment": "add badge and counter badge as new components"
+          },
+          {
+            "author": "chhol@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "5e3ba35835c0a5487b574ea58a51cccd67b5fa8c",
+            "comment": "add text as a new component"
+          }
+        ],
+        "none": [
+          {
+            "author": "martinhochel@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "7c94cbd46051ea57bba4e8885c86e89967bb412c",
+            "comment": "chore: setup typescript 4.7 for web-components package"
+          },
+          {
+            "author": "miroslav.stastny@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "cd42ab4f8aa11c7ac134538193dc8dc4a01ca0f3",
+            "comment": "Reset web-components for v3 development"
+          },
+          {
+            "author": "martinhochel@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "7f15428e8fb2c3cfbfe8e555978bfa66f74f8fd8",
+            "comment": "chore: bump web-components to 3.0.0-alpha.0"
+          },
+          {
+            "author": "martinhochel@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "9b29aada3dba8f929530ddc1b4b64e869d5fffd4",
+            "comment": "chore(web-components): resolve invalid webpack test regex on windows"
+          },
+          {
+            "author": "chhol@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "be3d30fcbe222be34b02a554e948d14bb2d730df",
+            "comment": "update clean file to .cjs and ensure rimraf is in dependency tree"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 26 Oct 2022 07:52:54 GMT",
       "tag": "@fluentui/web-components_v2.5.8",
       "version": "2.5.8",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log - @fluentui/web-components
 
-This log was last generated on Wed, 26 Oct 2022 07:52:54 GMT and should not be manually modified.
+This log was last generated on Wed, 25 Jan 2023 14:49:08 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [3.0.0-alpha.1](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-alpha.1)
+
+Wed, 25 Jan 2023 14:49:08 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/web-components_v2.5.8..@fluentui/web-components_v3.0.0-alpha.1)
+
+### Changes
+
+- add progressbar as new component ([PR #26329](https://github.com/microsoft/fluentui/pull/26329) by ryan@ryanmerrill.net)
+- Add initial theme ([PR #25660](https://github.com/microsoft/fluentui/pull/25660) by miroslav.stastny@microsoft.com)
+- add badge and counter badge as new components ([PR #26357](https://github.com/microsoft/fluentui/pull/26357) by chhol@microsoft.com)
+- add text as a new component ([PR #26090](https://github.com/microsoft/fluentui/pull/26090) by chhol@microsoft.com)
 
 ## [2.5.8](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v2.5.8)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui/web-components",
   "description": "A library of Fluent Web Components",
   "sideEffects": false,
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Automated nightly releases have been blocked since Dec 26th, which created lot of on hold pipelines.

Enabling those this week caused probably npm release parallel race conditions leading into not release pipeline failing 
<img width="850" alt="image" src="https://user-images.githubusercontent.com/1223799/214596811-a8298ba0-1fbc-46f2-ae87-a278a4b9d6bf.png">
 

## New Behavior

I manually ran bump on local machine via command 

`yarn beachball bump -b origin/web-components-v3 --access public --no-fetch --no-publish --no-push --no-git-tags --verbose --config ./scripts/beachball/release-web-components.config.js`

This PR are changes created by bump. This should hopefully resolve any upcoming releases 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


