### PR TITLE
ci: fix github pushes auth for release

### DIFF
--- a/azure-pipelines.release.web-components.yml
+++ b/azure-pipelines.release.web-components.yml
@@ -40,7 +40,8 @@ jobs:
       - script: |
           git config user.name "Fluent UI Build"
           git config user.email "fluentui-internal@service.microsoft.com"
-        displayName: Configure git user (used by beachball)
+          git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
+        displayName: Authenticate git for pushes
 
       - task: Bash@3
         inputs:

--- a/change/@fluentui-web-components-925986c6-b42e-4db6-a621-44ff55110a4f.json
+++ b/change/@fluentui-web-components-925986c6-b42e-4db6-a621-44ff55110a4f.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore: run manually bump to fix failed CI release",
-  "packageName": "@fluentui/web-components",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-cd25bca5-3470-4f00-b462-08403e27845d.json
+++ b/change/@fluentui-web-components-cd25bca5-3470-4f00-b462-08403e27845d.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: export theme",
-  "packageName": "@fluentui/web-components",
-  "email": "miroslav.stastny@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-web-components-f4ad3059-b14e-4647-bef9-7f9458e4f9ab.json
+++ b/change/@fluentui-web-components-f4ad3059-b14e-4647-bef9-7f9458e4f9ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(web-components): run manually bump to fix failed CI release",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/CHANGELOG.json
+++ b/packages/web-components/CHANGELOG.json
@@ -2,6 +2,29 @@
   "name": "@fluentui/web-components",
   "entries": [
     {
+      "date": "Wed, 25 Jan 2023 17:42:30 GMT",
+      "tag": "@fluentui/web-components_v3.0.0-alpha.2",
+      "version": "3.0.0-alpha.2",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "miroslav.stastny@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "68de783e80c71173a717c758680a63bf9c7e8c78",
+            "comment": "feat: export theme"
+          }
+        ],
+        "none": [
+          {
+            "author": "martinhochel@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "c5b3031ada2f788ef0a36185024f4c10c16143d6",
+            "comment": "chore: run manually bump to fix failed CI release"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 14:49:08 GMT",
       "tag": "@fluentui/web-components_v3.0.0-alpha.1",
       "version": "3.0.0-alpha.1",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/web-components
 
-This log was last generated on Wed, 25 Jan 2023 14:49:08 GMT and should not be manually modified.
+This log was last generated on Wed, 25 Jan 2023 17:42:30 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [3.0.0-alpha.2](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-alpha.2)
+
+Wed, 25 Jan 2023 17:42:30 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/web-components_v3.0.0-alpha.1..@fluentui/web-components_v3.0.0-alpha.2)
+
+### Changes
+
+- feat: export theme ([PR #26500](https://github.com/microsoft/fluentui/pull/26500) by miroslav.stastny@microsoft.com)
 
 ## [3.0.0-alpha.1](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-alpha.1)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui/web-components",
   "description": "A library of Fluent Web Components",
   "sideEffects": false,
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- auth for git pushes was not sufficient

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- pipeline should now have proper auth for pushes 
- manual bump to mirror effects that happened on ci with release but didn't came to origin

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Follows https://github.com/microsoft/fluentui/pull/26498
