### PR TITLE
chore: Bump storybook-addon-export-to-codesandbox to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
     "schema-utils": "3.1.1",
     "semver": "^6.2.0",
     "source-map-loader": "4.0.0",
-    "storybook-addon-export-to-codesandbox": "0.7.1",
+    "storybook-addon-export-to-codesandbox": "0.8.1",
     "storybook-addon-performance": "0.16.1",
     "storywright": "0.0.26-beta.1",
     "strip-ansi": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21018,7 +21018,7 @@ prettyjson@^1.2.1:
     colors "1.4.0"
     minimist "^1.2.0"
 
-prismjs@~1.16.0, prismjs@^1.16.0, prismjs@^1.8.4:
+prismjs@^1.16.0, prismjs@^1.8.4, prismjs@~1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.16.0.tgz#406eb2c8aacb0f5f0f1167930cb83835d10a4308"
   integrity sha512-OA4MKxjFZHSvZcisLGe14THYsug/nF6O1f0pAJc0KN0wTyAcLqmsbE+lTGKSpyh+9pEW57+k6pg2AfYR+coyHA==
@@ -23604,10 +23604,10 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
-storybook-addon-export-to-codesandbox@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.7.1.tgz#bdfeddc1bde2cc6178a31298305db5c276bb4127"
-  integrity sha512-ARroFvBylOcyc+XkG0xJmrFo4CokXpKqJVSwLP3ZUSYakqRvqSZaGEefoR5zDFvqZjG7XLX7D6g9cfnId3uUEg==
+storybook-addon-export-to-codesandbox@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.8.1.tgz#82cde111a1fead05dbc2293fa6c49cd743c8fd09"
+  integrity sha512-/14+HxnwDgbIS2ghpXIOgST7REEVgaP/zPRrLMaBcgq80vMcqUGDjVirRbGFNE/UNI4QTaJR4VvMhPWwwBBq5w==
   dependencies:
     codesandbox-import-utils "^2.2.3"
     pkg-up "^3.1.0"


### PR DESCRIPTION
## New Behavior

This PR bumps the dependency. The new version fixes some of the CodeSandbox examples which were broken before.

https://github.com/microsoft/fluentui-storybook-addons/pull/26

## Related Issue(s)
Fixes #26181
https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/2856270
