### PR TITLE
chore: properly use tokens for border radius

### DIFF
--- a/change/@fluentui-react-dialog-8b1f7572-249e-4619-8dcd-8688476b1763.json
+++ b/change/@fluentui-react-dialog-8b1f7572-249e-4619-8dcd-8688476b1763.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: properly use tokens for border radius",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.ts
@@ -4,7 +4,6 @@ import { tokens } from '@fluentui/react-theme';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import {
   MEDIA_QUERY_BREAKPOINT_SELECTOR,
-  SURFACE_BORDER_RADIUS,
   SURFACE_BORDER_WIDTH,
   SURFACE_PADDING,
   useDialogContext_unstable,
@@ -44,7 +43,7 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorNeutralBackground1,
     color: tokens.colorNeutralForeground1,
     ...shorthands.border(SURFACE_BORDER_WIDTH, 'solid', tokens.colorTransparentStroke),
-    ...shorthands.borderRadius(SURFACE_BORDER_RADIUS),
+    ...shorthands.borderRadius(tokens.borderRadiusXLarge),
     [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
       maxWidth: '100vw',
     },

--- a/packages/react-components/react-dialog/src/contexts/constants.ts
+++ b/packages/react-components/react-dialog/src/contexts/constants.ts
@@ -1,7 +1,6 @@
 export const MEDIA_QUERY_BREAKPOINT_SELECTOR = '@media screen and (max-width: 480px)';
 export const SURFACE_PADDING = '24px';
 export const DIALOG_GAP = '8px';
-export const SURFACE_BORDER_RADIUS = '8px';
 export const SURFACE_BORDER_WIDTH = '1px';
 
 export const ACTIONS_START_GRID_AREA = 'actions-start';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Dialog used a hard coded value of `8px` for border radius.

## New Behavior

Properly uses a token instead of a hard coded value.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26450
