### PR TITLE
fix: remove invalid and unnecessary DetailsRow check

### DIFF
--- a/change/@fluentui-react-efaa52aa-9b7f-4aab-8f44-65aa3b1d9807.json
+++ b/change/@fluentui-react-efaa52aa-9b7f-4aab-8f44-65aa3b1d9807.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: remove invalid extra checkbox at end of DetailsRow",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4959,8 +4959,8 @@ export interface IDetailsRowStyles {
     check: IStyle;
     // (undocumented)
     checkCell: IStyle;
-    // (undocumented)
-    checkCover: IStyle;
+    // @deprecated (undocumented)
+    checkCover?: IStyle;
     // (undocumented)
     fields: IStyle;
     // (undocumented)

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -384,13 +384,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
             />
           </span>
         )}
-
-        <span
-          role="checkbox"
-          className={this._classNames.checkCover}
-          aria-checked={isSelected}
-          data-selection-toggle={true}
-        />
       </FocusZone>
     );
   }

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -55,7 +55,6 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
     isSelected,
     canSelect,
     droppingClassName,
-    anySelected,
     isCheckVisible,
     checkboxCellClassName,
     compact,
@@ -389,14 +388,6 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
         flexShrink: 0,
       },
     ],
-    checkCover: {
-      position: 'absolute',
-      top: -1,
-      left: 0,
-      bottom: 0,
-      right: 0,
-      display: anySelected ? 'block' : 'none',
-    },
     fields: [
       classNames.fields,
       {

--- a/packages/react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.types.ts
@@ -324,6 +324,9 @@ export interface IDetailsRowStyles {
   isMultiline: IStyle;
   fields: IStyle;
   cellMeasurer: IStyle;
-  checkCover: IStyle;
+  /**
+   * @deprecated Node removed, do not use
+   */
+  checkCover?: IStyle;
   check: IStyle;
 }

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -8316,21 +8316,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     0
                                   </div>
                                 </div>
-                                <span
-                                  aria-checked={false}
-                                  className=
-
-                                      {
-                                        bottom: 0px;
-                                        display: none;
-                                        left: 0px;
-                                        position: absolute;
-                                        right: 0px;
-                                        top: -1px;
-                                      }
-                                  data-selection-toggle={true}
-                                  role="checkbox"
-                                />
                               </div>
                             </div>
                             <div
@@ -8618,21 +8603,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     1
                                   </div>
                                 </div>
-                                <span
-                                  aria-checked={false}
-                                  className=
-
-                                      {
-                                        bottom: 0px;
-                                        display: none;
-                                        left: 0px;
-                                        position: absolute;
-                                        right: 0px;
-                                        top: -1px;
-                                      }
-                                  data-selection-toggle={true}
-                                  role="checkbox"
-                                />
                               </div>
                             </div>
                           </div>
@@ -9178,21 +9148,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     2
                                   </div>
                                 </div>
-                                <span
-                                  aria-checked={false}
-                                  className=
-
-                                      {
-                                        bottom: 0px;
-                                        display: none;
-                                        left: 0px;
-                                        position: absolute;
-                                        right: 0px;
-                                        top: -1px;
-                                      }
-                                  data-selection-toggle={true}
-                                  role="checkbox"
-                                />
                               </div>
                             </div>
                             <div
@@ -9480,21 +9435,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     3
                                   </div>
                                 </div>
-                                <span
-                                  aria-checked={false}
-                                  className=
-
-                                      {
-                                        bottom: 0px;
-                                        display: none;
-                                        left: 0px;
-                                        position: absolute;
-                                        right: 0px;
-                                        top: -1px;
-                                      }
-                                  data-selection-toggle={true}
-                                  role="checkbox"
-                                />
                               </div>
                             </div>
                             <div
@@ -9782,21 +9722,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                     4
                                   </div>
                                 </div>
-                                <span
-                                  aria-checked={false}
-                                  className=
-
-                                      {
-                                        bottom: 0px;
-                                        display: none;
-                                        left: 0px;
-                                        position: absolute;
-                                        right: 0px;
-                                        top: -1px;
-                                      }
-                                  data-selection-toggle={true}
-                                  role="checkbox"
-                                />
                               </div>
                             </div>
                           </div>

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
@@ -7766,21 +7766,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                           0
                         </div>
                       </div>
-                      <span
-                        aria-checked={false}
-                        className=
-
-                            {
-                              bottom: 0px;
-                              display: none;
-                              left: 0px;
-                              position: absolute;
-                              right: 0px;
-                              top: -1px;
-                            }
-                        data-selection-toggle={true}
-                        role="checkbox"
-                      />
                     </div>
                   </div>
                   <div
@@ -8068,21 +8053,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                           1
                         </div>
                       </div>
-                      <span
-                        aria-checked={false}
-                        className=
-
-                            {
-                              bottom: 0px;
-                              display: none;
-                              left: 0px;
-                              position: absolute;
-                              right: 0px;
-                              top: -1px;
-                            }
-                        data-selection-toggle={true}
-                        role="checkbox"
-                      />
                     </div>
                   </div>
                   <div
@@ -8595,21 +8565,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                           2
                         </div>
                       </div>
-                      <span
-                        aria-checked={false}
-                        className=
-
-                            {
-                              bottom: 0px;
-                              display: none;
-                              left: 0px;
-                              position: absolute;
-                              right: 0px;
-                              top: -1px;
-                            }
-                        data-selection-toggle={true}
-                        role="checkbox"
-                      />
                     </div>
                   </div>
                   <div
@@ -8897,21 +8852,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                           3
                         </div>
                       </div>
-                      <span
-                        aria-checked={false}
-                        className=
-
-                            {
-                              bottom: 0px;
-                              display: none;
-                              left: 0px;
-                              position: absolute;
-                              right: 0px;
-                              top: -1px;
-                            }
-                        data-selection-toggle={true}
-                        role="checkbox"
-                      />
                     </div>
                   </div>
                   <div
@@ -9199,21 +9139,6 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                           4
                         </div>
                       </div>
-                      <span
-                        aria-checked={false}
-                        className=
-
-                            {
-                              bottom: 0px;
-                              display: none;
-                              left: 0px;
-                              position: absolute;
-                              right: 0px;
-                              top: -1px;
-                            }
-                        data-selection-toggle={true}
-                        role="checkbox"
-                      />
                     </div>
                   </div>
                 </div>

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -2169,21 +2169,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       
     </div>
   </div>
-  <span
-    aria-checked={false}
-    className=
-
-        {
-          bottom: 0px;
-          display: none;
-          left: 0px;
-          position: absolute;
-          right: 0px;
-          top: -1px;
-        }
-    data-selection-toggle={true}
-    role="checkbox"
-  />
 </div>
 `;
 


### PR DESCRIPTION
## Previous Behavior

There's a random 0-width static `<span role="checkbox">` at the end of every DetailsRow. It doesn't seem to do anything, and the check inside the first cell of the row already handles selection.

Because the random end-of-row checkbox is a direct child of the row, it causes an automated a11y failure (and if a screen reader user did actually navigate to it, it'd be super weird. It also doesn't have a label?).

## New Behavior

No check.

## Related Issue(s)
Fixes #26330
