### PR TITLE
fix(react-persona): Reduce spacing between first and second line

### DIFF
--- a/change/@fluentui-react-persona-d5166e84-0f0c-4a5c-836f-4230ede932a3.json
+++ b/change/@fluentui-react-persona-d5166e84-0f0c-4a5c-836f-4230ede932a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reduce spacing between first and second line.",
+  "packageName": "@fluentui/react-persona",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
+++ b/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
@@ -58,6 +58,10 @@ const useStyles = makeStyles({
     gridRowStart: 'unset',
     gridColumnStart: 'middle',
   },
+
+  secondLineSpacing: {
+    marginTop: '-2px',
+  },
 });
 
 const useAvatarSpacingStyles = makeStyles({
@@ -147,6 +151,7 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
     state.secondaryText.className = mergeClasses(
       personaClassNames.secondaryText,
       optionalTextClassName,
+      styles.secondLineSpacing,
       state.secondaryText.className,
     );
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://user-images.githubusercontent.com/5953191/214963246-b589e3a6-d8e5-4f5e-aab5-50dabc4ef026.png)
![image](https://user-images.githubusercontent.com/5953191/214963301-22379f34-0051-44ff-a58b-8d9c2d66373e.png)


## New Behavior

![image](https://user-images.githubusercontent.com/5953191/214963363-469d80e6-5c0d-45a0-9185-dd6aa30621d9.png)
![image](https://user-images.githubusercontent.com/5953191/214963422-dd74b463-70b1-488f-9861-447a84e1c354.png)

This request was made so that when using two lines only, the spacing between these lines is more cohesive with the Avatar.

