### PR TITLE
DetailsList: Add method getColumns

### DIFF
--- a/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
+++ b/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "DetailsList: Add method getColumns",
+  "comment": "DetailsList: Add method getColumnOverrides",
   "packageName": "@fluentui/react",
   "email": "erabelle@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
+++ b/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "DetailsList: Add method getCurrentColumnWidths",
+  "packageName": "@fluentui/react",
+  "email": "erabelle@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
+++ b/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "DetailsList: Add method getCurrentColumnWidths",
+  "comment": "DetailsList: Add method getColumns",
   "packageName": "@fluentui/react",
   "email": "erabelle@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
+++ b/change/@fluentui-react-d2665118-720b-4d50-8785-ea6f982c3811.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "DetailsList: Add method getColumnOverrides",
+  "comment": "DetailsList: Add method getColumns",
   "packageName": "@fluentui/react",
   "email": "erabelle@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1316,10 +1316,7 @@ export class DetailsListBase extends React_2.Component<IDetailsListProps, IDetai
     focusIndex(index: number, forceIntoFirstElement?: boolean, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     forceUpdate(): void;
-    // (undocumented)
-    getColumnOverrides(): {
-        [key: string]: IColumn;
-    };
+    getColumns(): IColumn[];
     // (undocumented)
     static getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
     // (undocumented)
@@ -4680,9 +4677,6 @@ export interface IDetailsItemProps {
 export interface IDetailsList extends IList {
     focusIndex: (index: number, forceIntoFirstElement?: boolean, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode) => void;
     forceUpdate: () => void;
-    getColumnOverrides(): {
-        [key: string]: IColumn;
-    };
     getStartItemIndexInView: () => number;
     updateColumn: (column: IColumn, options: {
         width?: number;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1316,7 +1316,10 @@ export class DetailsListBase extends React_2.Component<IDetailsListProps, IDetai
     focusIndex(index: number, forceIntoFirstElement?: boolean, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     forceUpdate(): void;
-    getColumns(): IColumn[];
+    // (undocumented)
+    getColumnOverrides(): {
+        [key: string]: IColumn;
+    };
     // (undocumented)
     static getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
     // (undocumented)
@@ -4677,6 +4680,9 @@ export interface IDetailsItemProps {
 export interface IDetailsList extends IList {
     focusIndex: (index: number, forceIntoFirstElement?: boolean, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode) => void;
     forceUpdate: () => void;
+    getColumnOverrides(): {
+        [key: string]: IColumn;
+    };
     getStartItemIndexInView: () => number;
     updateColumn: (column: IColumn, options: {
         width?: number;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1317,6 +1317,10 @@ export class DetailsListBase extends React_2.Component<IDetailsListProps, IDetai
     // (undocumented)
     forceUpdate(): void;
     // (undocumented)
+    getCurrentColumnWidths(): {
+        [columnKey: string]: number | undefined;
+    };
+    // (undocumented)
     static getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
     // (undocumented)
     getStartItemIndexInView(): number;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -1316,10 +1316,7 @@ export class DetailsListBase extends React_2.Component<IDetailsListProps, IDetai
     focusIndex(index: number, forceIntoFirstElement?: boolean, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     forceUpdate(): void;
-    // (undocumented)
-    getCurrentColumnWidths(): {
-        [columnKey: string]: number | undefined;
-    };
+    getColumns(): IColumn[];
     // (undocumented)
     static getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
     // (undocumented)

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -867,7 +867,6 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     return 0;
   }
 
-  /** Returns current state of adjusted columns */
   public getColumns(): IColumn[] {
     return this.state.adjustedColumns;
   }

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -867,13 +867,9 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     return 0;
   }
 
-  public getCurrentColumnWidths(): { [columnKey: string]: number | undefined } {
-    const columnWidths: { [columnKey: string]: number | undefined } = {};
-
-    for (const key in this._columnOverrides) {
-      columnWidths[key] = this._columnOverrides[key].currentWidth;
-    }
-    return columnWidths;
+  /** Returns current state of adjusted columns */
+  public getColumns(): IColumn[] {
+    return this.state.adjustedColumns;
   }
 
   public updateColumn(column: IColumn, options: { width?: number; newColumnIndex?: number }) {

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -867,6 +867,15 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     return 0;
   }
 
+  public getCurrentColumnWidths(): { [columnKey: string]: number | undefined } {
+    const columnWidths: { [columnKey: string]: number | undefined } = {};
+
+    for (const key in this._columnOverrides) {
+      columnWidths[key] = this._columnOverrides[key].currentWidth;
+    }
+    return columnWidths;
+  }
+
   public updateColumn(column: IColumn, options: { width?: number; newColumnIndex?: number }) {
     const NO_COLUMNS: IColumn[] = [];
 

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -867,8 +867,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     return 0;
   }
 
-  public getColumnOverrides(): { [key: string]: IColumn } {
-    return this._columnOverrides;
+  public getColumns(): IColumn[] {
+    return this.state.adjustedColumns;
   }
 
   public updateColumn(column: IColumn, options: { width?: number; newColumnIndex?: number }) {

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -867,8 +867,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     return 0;
   }
 
-  public getColumns(): IColumn[] {
-    return this.state.adjustedColumns;
+  public getColumnOverrides(): { [key: string]: IColumn } {
+    return this._columnOverrides;
   }
 
   public updateColumn(column: IColumn, options: { width?: number; newColumnIndex?: number }) {

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -58,9 +58,9 @@ export interface IDetailsList extends IList {
   getStartItemIndexInView: () => number;
 
   /**
-   * Returns the current state of column overrides
+   * Returns the current state of adjusted columns
    */
-  getColumnOverrides(): { [key: string]: IColumn };
+  getColumns(): IColumn[];
 
   /**
    * Use to programatically resize and/or reorder columns in the DetailsList.

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -58,6 +58,11 @@ export interface IDetailsList extends IList {
   getStartItemIndexInView: () => number;
 
   /**
+   * Returns the current state of adjusted columns
+   */
+  getColumns(): IColumn[];
+
+  /**
    * Use to programatically resize and/or reorder columns in the DetailsList.
    * @param column - column to resize/reorder.
    * @param options - includes width which is desired width in pixels the column should be resized

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -58,9 +58,9 @@ export interface IDetailsList extends IList {
   getStartItemIndexInView: () => number;
 
   /**
-   * Returns the current state of adjusted columns
+   * Returns the current state of column overrides
    */
-  getColumns(): IColumn[];
+  getColumnOverrides(): { [key: string]: IColumn };
 
   /**
    * Use to programatically resize and/or reorder columns in the DetailsList.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Column widths are only tracked internally in `DetailsList`. We are trying to implement the method `updateColumn()` to resize columns via keyboard. Our design adds to/subtracts from the current column width, which we are unable to access from the `DetailsList` `componentRef`.

## New Behavior

Add method `DetailsList.getColumns()` to make the current state of columns retrievable through the `DetailsList` `componentRef`.
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
