### PR TITLE
chore(react-badge): updates border-radius to use proper token value

### DIFF
--- a/change/@fluentui-react-badge-89865f4b-4f22-47b4-ae63-6e60301303e0.json
+++ b/change/@fluentui-react-badge-89865f4b-4f22-47b4-ae63-6e60301303e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Updates border-radius to use proper token",
+  "packageName": "@fluentui/react-badge",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -28,7 +28,7 @@ const useStyles = makeStyles({
     '& span': {
       display: 'flex',
     },
-    ...shorthands.borderRadius('50%'),
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
     backgroundColor: tokens.colorNeutralBackground1,
   },
   statusBusy: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`border-radius` was defined with a percentage value of `50%`

## New Behavior

Updates `border-radius` to properly use `borderRadiusCircular` token instead.

## Related Issue(s)


* Fixes #26450
