### PR TITLE
fix(scripts-generators): run generate-version-files logic on node execution

### DIFF
--- a/scripts/generators/generate-version-files.spec.ts
+++ b/scripts/generators/generate-version-files.spec.ts
@@ -1,0 +1,197 @@
+import childProcess from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { stripIndents } from '@nrwl/devkit';
+import * as tmp from 'tmp';
+
+import { generateVersionFiles } from './generate-version-files';
+
+// ☝️ NOTE - don't comment or remove this mock while running tests
+jest.mock('child_process');
+
+tmp.setGracefulCleanup();
+
+describe(`generate-version-files`, () => {
+  function getFileContents(filePath: string) {
+    return fs.readFileSync(filePath, 'utf-8');
+  }
+  function setup() {
+    const { name: rootDir } = tmp.dirSync({ prefix: 'generate-version-files', unsafeCleanup: true });
+    const packagesRoot = path.join(rootDir, 'packages');
+
+    const packageNames = ['react-one', 'react-two'];
+
+    const packages = packageNames.map((packageName, idx) => {
+      const pkgRoot = `${packagesRoot}/${packageName}`;
+      const pkgVersionFilePath = `${packagesRoot}/${packageName}/src/version.ts`;
+      const pkgJsonPath = `${pkgRoot}/package.json`;
+      const pkgVersion = `1.${idx}.0`;
+      fs.mkdirSync(`${pkgRoot}/src`, { recursive: true });
+      fs.writeFileSync(
+        pkgJsonPath,
+        JSON.stringify({
+          name: `@proj/${packageName}`,
+          version: pkgVersion,
+          dependencies: {
+            '@fluentui/set-version': '1.0.0',
+          },
+        }),
+      );
+      fs.writeFileSync(
+        `${pkgVersionFilePath}`,
+        stripIndents`
+        import { setVersion } from '@proj/set-version';
+        setVersion('@proj/${packageName}', '0.0.0');
+        `,
+      );
+
+      return {
+        pkgRoot,
+        pkgJsonPath,
+        pkgVersion,
+        pkgVersionFilePath,
+      };
+    });
+
+    const spawnSyncMock = jest.spyOn(childProcess, 'spawnSync').mockImplementation((() => {
+      return { status: 0, stdout: 'ok' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(Date.prototype, 'getTime').mockImplementation(() => 1482363367071);
+
+    return { rootDir, packages, spawnSyncMock, logSpy };
+  }
+
+  it(`should bump -> update versions.ts -> revert bump`, () => {
+    const { rootDir, /* packages, */ logSpy, spawnSyncMock } = setup();
+    generateVersionFiles({
+      args: {},
+      bumpCmd: ['bin/node', 'node_modules/bin/beachball', 'bump'],
+      gitRoot: rootDir,
+    });
+    expect(logSpy.mock.calls.flat()).toEqual(
+      expect.arrayContaining([
+        'bumping',
+        'reverting',
+        `writing to ${rootDir}/packages/react-one/src/version.ts`,
+        `writing to ${rootDir}/packages/react-two/src/version.ts`,
+      ]),
+    );
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    expect(spawnSyncMock.mock.calls.flat()).toMatchInlineSnapshot(`
+      Array [
+        "bin/node",
+        Array [
+          "node_modules/bin/beachball",
+          "bump",
+        ],
+        Object {
+          "cwd": "${rootDir}",
+        },
+        "git",
+        Array [
+          "stash",
+          "push",
+          "-u",
+          "-m",
+          "tmp_bump_1482363367071",
+        ],
+        Object {
+          "cwd": "${rootDir}",
+        },
+        "git",
+        Array [
+          "stash",
+          "list",
+        ],
+        Object {
+          "cwd": "${rootDir}",
+        },
+      ]
+    `);
+  });
+
+  it(`should not do anything if package doesnt contain set-version as dependency or src/version.ts doesnt exist`, () => {
+    const { rootDir, packages, logSpy, spawnSyncMock } = setup();
+
+    packages.forEach(pkg => {
+      fs.unlinkSync(pkg.pkgVersionFilePath);
+      const pkgJson = JSON.parse(getFileContents(pkg.pkgJsonPath));
+      delete pkgJson.dependencies['@fluentui/set-version'];
+      fs.writeFileSync(pkg.pkgJsonPath, JSON.stringify(pkgJson));
+    });
+
+    generateVersionFiles({
+      args: { generateOnly: true },
+      bumpCmd: ['bin/node', 'node_modules/bin/beachball', 'bump'],
+      gitRoot: rootDir,
+    });
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+
+    expect(logSpy.mock.calls.flat()).toEqual([]);
+  });
+
+  it(`should "generate only" versions.ts`, () => {
+    const { rootDir, packages, logSpy, spawnSyncMock } = setup();
+    generateVersionFiles({
+      args: { generateOnly: true },
+      bumpCmd: ['bin/node', 'node_modules/bin/beachball', 'bump'],
+      gitRoot: rootDir,
+    });
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+
+    expect(logSpy.mock.calls.flat()).toEqual(
+      expect.arrayContaining([
+        `writing to ${rootDir}/packages/react-one/src/version.ts`,
+        `writing to ${rootDir}/packages/react-two/src/version.ts`,
+      ]),
+    );
+
+    expect(getFileContents(packages[0].pkgVersionFilePath)).toMatchInlineSnapshot(`
+      "// Do not modify this file; it is generated as part of publish.
+      // The checked in version is a placeholder only and will not be updated.
+      import { setVersion } from '@fluentui/set-version';
+      setVersion('@proj/react-one', '1.0.0');"
+    `);
+    expect(getFileContents(packages[1].pkgVersionFilePath)).toMatchInlineSnapshot(`
+      "// Do not modify this file; it is generated as part of publish.
+      // The checked in version is a placeholder only and will not be updated.
+      import { setVersion } from '@fluentui/set-version';
+      setVersion('@proj/react-two', '1.1.0');"
+    `);
+  });
+
+  it(`should not update versions.ts if its contents is identical`, () => {
+    const { rootDir, packages, logSpy, spawnSyncMock } = setup();
+
+    // modify version.ts
+    const firstPackage = packages[0];
+    const pkgVersionsFileContent = getFileContents(firstPackage.pkgVersionFilePath);
+    const pkgVersionsFileContentModified = pkgVersionsFileContent.replace(`'0.0.0'`, `'${firstPackage.pkgVersion}'`);
+    fs.writeFileSync(firstPackage.pkgVersionFilePath, pkgVersionsFileContentModified, 'utf-8');
+
+    generateVersionFiles({
+      args: { generateOnly: true, forceUpdate: true },
+      bumpCmd: ['bin/node', 'node_modules/bin/beachball', 'bump'],
+      gitRoot: rootDir,
+    });
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.flat()).toEqual(
+      expect.arrayContaining([`writing to ${rootDir}/packages/react-two/src/version.ts`]),
+    );
+    expect(getFileContents(packages[1].pkgVersionFilePath)).toMatchInlineSnapshot(`
+      "// Do not modify this file; it is generated as part of publish.
+      // The checked in version is a placeholder only and will not be updated.
+      import { setVersion } from '@fluentui/set-version';
+      setVersion('@proj/react-two', '1.1.0');"
+    `);
+  });
+});

--- a/scripts/generators/generate-version-files.ts
+++ b/scripts/generators/generate-version-files.ts
@@ -1,17 +1,31 @@
 import { spawnSync } from 'child_process';
 import * as path from 'path';
+
+import { findGitRoot } from '@fluentui/scripts-monorepo';
+import { stripIndents } from '@nrwl/devkit';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
-import { findGitRoot } from '@fluentui/scripts-monorepo';
 
-const generateOnly = process.argv.includes('-g');
-const beachballBin = require.resolve('beachball/bin/beachball.js');
-const bumpCmd = [process.execPath, beachballBin, 'bump'];
-const gitRoot = findGitRoot();
+const isExecutedFromCli = require.main === module;
 
-function run(args: string[]) {
+if (isExecutedFromCli) {
+  const argv = process.argv.slice(2);
+  const beachballBin = require.resolve('beachball/bin/beachball.js');
+  const bumpCmd = [process.execPath, beachballBin, 'bump'];
+  const gitRoot = findGitRoot();
+
+  main({ argv, bumpCmd, gitRoot });
+}
+
+function main(options: { argv: string[]; bumpCmd: string[]; gitRoot: string }) {
+  const { argv, gitRoot, bumpCmd } = options;
+  const args = { generateOnly: argv.includes('-g'), forceUpdate: argv.includes('-f') };
+  generateVersionFiles({ args, gitRoot, bumpCmd });
+}
+
+function run(args: string[], cwd: string) {
   const [cmd, ...restArgs] = args;
-  const runResult = spawnSync(cmd, restArgs, { cwd: gitRoot });
+  const runResult = spawnSync(cmd, restArgs, { cwd });
   if (runResult.status === 0) {
     return runResult.stdout.toString().trim();
   }
@@ -19,10 +33,10 @@ function run(args: string[]) {
   return null;
 }
 
-function revertLocalChanges() {
+function revertLocalChanges(cwd: string) {
   const stash = `tmp_bump_${new Date().getTime()}`;
-  run(['git', 'stash', 'push', '-u', '-m', stash]);
-  const results = run(['git', 'stash', 'list']);
+  run(['git', 'stash', 'push', '-u', '-m', stash], cwd);
+  const results = run(['git', 'stash', 'list'], cwd);
   if (results) {
     const lines = results.split(/\n/);
     const foundLine = lines.find(line => line.includes(stash));
@@ -30,7 +44,7 @@ function revertLocalChanges() {
     if (foundLine) {
       const matched = foundLine.match(/^[^:]+/);
       if (matched) {
-        run(['git', 'stash', 'drop', matched[0]]);
+        run(['git', 'stash', 'drop', matched[0]], cwd);
         return true;
       }
     }
@@ -49,14 +63,26 @@ function revertLocalChanges() {
  *
  * "generateOnly" mode takes existing versions and write them out to version files (do this when out of sync)
  */
-export function generateVersionFiles() {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  const gitRoot = findGitRoot();
+export function generateVersionFiles(options: {
+  args: {
+    /**
+     * "generateOnly" mode takes existing versions and write them out to version files (do this when out of sync)
+     */
+    generateOnly?: boolean;
+    /**
+     * TODO: ??? if version.ts placeholder is identical to package version don't update it
+     */
+    forceUpdate?: boolean;
+  };
+  gitRoot: string;
+  bumpCmd: string[];
+}) {
+  const { args, gitRoot, bumpCmd } = options;
 
-  if (!generateOnly) {
+  if (!args.generateOnly) {
     console.log('bumping');
     // Do a dry-run on all packages
-    run(bumpCmd);
+    run(bumpCmd, gitRoot);
   }
 
   // 2. gather version info
@@ -77,23 +103,26 @@ export function generateVersionFiles() {
 
     let shouldGenerate = true;
     const setCurrentVersion = `setVersion('${packageJson.name}', '${packageJson.version}');`;
-    if (fs.existsSync(versionFile) && process.argv.includes('-f')) {
+
+    if (fs.existsSync(versionFile) && args.forceUpdate) {
       const originVersionFileContent = fs.readFileSync(versionFile).toString();
       shouldGenerate = !originVersionFileContent.includes(setCurrentVersion);
     }
 
     if (shouldGenerate) {
-      updatedVersionContents[versionFile] = `// Do not modify this file; it is generated as part of publish.
-// The checked in version is a placeholder only and will not be updated.
-import { setVersion } from '@fluentui/set-version';
-${setCurrentVersion}`;
+      updatedVersionContents[versionFile] = stripIndents`
+      // Do not modify this file; it is generated as part of publish.
+      // The checked in version is a placeholder only and will not be updated.
+      import { setVersion } from '@fluentui/set-version';
+      ${setCurrentVersion}
+      `;
     }
   });
 
   // 3. revert bump changes
-  if (!generateOnly) {
+  if (!args.generateOnly) {
     console.log('reverting');
-    revertLocalChanges();
+    revertLocalChanges(gitRoot);
   }
 
   // 4. write version files


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`generate-version-files` was not calling any logic on execution during release pipeline

## New Behavior

`generate-version-files` properly executes logic during release

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes https://github.com/microsoft/fluentui/issues/26526
