### PR TITLE
feat: re-export useFocusWithin() hook

### DIFF
--- a/change/@fluentui-react-components-31797d7f-3bfb-4991-ab82-d4635515063a.json
+++ b/change/@fluentui-react-components-31797d7f-3bfb-4991-ab82-d4635515063a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: re-export useFocusWithin() hook",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -589,6 +589,7 @@ import { useFluentProviderStyles_unstable } from '@fluentui/react-provider';
 import { useFocusableGroup } from '@fluentui/react-tabster';
 import { UseFocusableGroupOptions } from '@fluentui/react-tabster';
 import { useFocusFinders } from '@fluentui/react-tabster';
+import { useFocusWithin } from '@fluentui/react-tabster';
 import { useId } from '@fluentui/react-utilities';
 import { useImage_unstable } from '@fluentui/react-image';
 import { useImageStyles_unstable } from '@fluentui/react-image';
@@ -1864,6 +1865,8 @@ export { useFocusableGroup }
 export { UseFocusableGroupOptions }
 
 export { useFocusFinders }
+
+export { useFocusWithin }
 
 export { useId }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -34,6 +34,7 @@ export {
   useArrowNavigationGroup,
   useFocusableGroup,
   useFocusFinders,
+  useFocusWithin,
   useKeyboardNavAttribute,
   useModalAttributes,
 } from '@fluentui/react-tabster';


### PR DESCRIPTION
## New Behavior

`useFocusWithin()` hook is exported.

## Related Issue(s)

Fixes #25668.
