### PR TITLE
chore: Add FieldContext and connect it to input components

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Field.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Field.stories.tsx
@@ -6,13 +6,14 @@ import { ComboboxField_unstable as ComboboxField } from '@fluentui/react-combobo
 import { SparkleFilled } from '@fluentui/react-icons';
 import type { InputFieldProps_unstable as InputFieldProps } from '@fluentui/react-input';
 import { InputField_unstable as InputField } from '@fluentui/react-input';
-import { ProgressField_unstable as ProgressField } from '@fluentui/react-progress';
+import { ProgressBar, ProgressField_unstable as ProgressField } from '@fluentui/react-progress';
 import { Radio, RadioGroupField_unstable as RadioGroupField } from '@fluentui/react-radio';
 import { SelectField_unstable as SelectField } from '@fluentui/react-select';
 import { SliderField_unstable as SliderField } from '@fluentui/react-slider';
 import { SpinButtonField_unstable as SpinButtonField } from '@fluentui/react-spinbutton';
 import { SwitchField_unstable as SwitchField } from '@fluentui/react-switch';
 import { TextareaField_unstable as TextareaField } from '@fluentui/react-textarea';
+import { Field } from '../../../../packages/react-components/react-field/src/Field';
 
 type FieldControlProps = Pick<
   InputFieldProps,
@@ -89,11 +90,9 @@ storiesOfFieldWithSize('InputField converged', InputField);
 // ProgressField
 //
 storiesOfField('ProgressField converged', props => (
-  <ProgressField
-    value={0.5}
-    {...props}
-    validationState={props.validationState === 'none' ? undefined : props.validationState}
-  />
+  <Field {...props}>
+    <ProgressBar value={0.75} />
+  </Field>
 ));
 
 //

--- a/change/@fluentui-react-combobox-929732d3-3ce3-403f-892f-91541458946e.json
+++ b/change/@fluentui-react-combobox-929732d3-3ce3-403f-892f-91541458946e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Connect to FieldContext to set size properly when inside a Field ",
+  "packageName": "@fluentui/react-combobox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-fe20b1be-ff71-4622-a210-5d35c306921e.json
+++ b/change/@fluentui-react-components-fe20b1be-ff71-4622-a210-5d35c306921e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Export useFieldContext from react-components/unstable",
+  "packageName": "@fluentui/react-components",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-947d8f5f-fd7d-4719-9f79-61b1a5b7d23b.json
+++ b/change/@fluentui-react-field-947d8f5f-fd7d-4719-9f79-61b1a5b7d23b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Add FieldContext to pass state to controls inside Field",
+  "packageName": "@fluentui/react-field",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-b2c83ccf-bacd-4e67-8304-eeec8a3f4228.json
+++ b/change/@fluentui-react-input-b2c83ccf-bacd-4e67-8304-eeec8a3f4228.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Connect to FieldContext to set size properly when inside a Field",
+  "packageName": "@fluentui/react-input",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-daf435c9-0b07-44c7-adae-67a2e38ace2a.json
+++ b/change/@fluentui-react-progress-daf435c9-0b07-44c7-adae-67a2e38ace2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Connect to FieldContext to set validationState properly when inside a Field",
+  "packageName": "@fluentui/react-progress",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-cf99e48b-46c5-459f-81f6-63c871014a2f.json
+++ b/change/@fluentui-react-select-cf99e48b-46c5-459f-81f6-63c871014a2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Connect to FieldContext to set size properly when inside a Field",
+  "packageName": "@fluentui/react-select",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-01d992ca-0707-4572-98d7-6739a21021ec.json
+++ b/change/@fluentui-react-slider-01d992ca-0707-4572-98d7-6739a21021ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Connect to FieldContext to set size properly when inside a Field",
+  "packageName": "@fluentui/react-slider",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-1eb833bd-4919-447c-bca9-b43102245997.json
+++ b/change/@fluentui-react-spinbutton-1eb833bd-4919-447c-bca9-b43102245997.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Connect to FieldContext to set size properly when inside a Field",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-7063e418-8d1b-477c-95d7-1e2bb10a695f.json
+++ b/change/@fluentui-react-textarea-7063e418-8d1b-477c-95d7-1e2bb10a695f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Connect to FieldContext to set size properly when inside a Field",
+  "packageName": "@fluentui/react-textarea",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import { useControllableState, useFirstMount } from '@fluentui/react-utilities';
 import { useOptionCollection } from '../utils/useOptionCollection';
 import { OptionValue } from '../utils/OptionCollection.types';
@@ -11,6 +12,8 @@ import type { ComboboxBaseProps, ComboboxBaseOpenEvents, ComboboxBaseState } fro
 export const useComboboxBaseState = (
   props: ComboboxBaseProps & { children?: React.ReactNode; editable?: boolean },
 ): ComboboxBaseState => {
+  const fieldSize = useFieldContext(field => field?.size);
+
   const {
     appearance = 'outline',
     children,
@@ -18,7 +21,7 @@ export const useComboboxBaseState = (
     inlinePopup = false,
     multiselect,
     onOpenChange,
-    size = 'medium',
+    size = fieldSize ?? 'medium',
   } = props;
 
   const optionCollection = useOptionCollection();

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -96,6 +96,8 @@ import { DropdownSlots } from '@fluentui/react-combobox';
 import { DropdownState } from '@fluentui/react-combobox';
 import { Field } from '@fluentui/react-field';
 import { fieldClassNames } from '@fluentui/react-field';
+import { FieldContextValue } from '@fluentui/react-field';
+import { FieldContextValues } from '@fluentui/react-field';
 import { FieldProps } from '@fluentui/react-field';
 import { FieldSlots } from '@fluentui/react-field';
 import { FieldState } from '@fluentui/react-field';
@@ -281,6 +283,8 @@ import { useDataGridStyles_unstable } from '@fluentui/react-table';
 import { useDropdown_unstable } from '@fluentui/react-combobox';
 import { useDropdownStyles_unstable } from '@fluentui/react-combobox';
 import { useField_unstable } from '@fluentui/react-field';
+import { useFieldContext } from '@fluentui/react-field';
+import { useFieldContextValues_unstable } from '@fluentui/react-field';
 import { useFieldStyles_unstable } from '@fluentui/react-field';
 import { useInfoButton_unstable } from '@fluentui/react-infobutton';
 import { useInfoButtonStyles_unstable } from '@fluentui/react-infobutton';
@@ -512,6 +516,10 @@ export { DropdownState }
 export { Field }
 
 export { fieldClassNames }
+
+export { FieldContextValue }
+
+export { FieldContextValues }
 
 export { FieldProps }
 
@@ -882,6 +890,10 @@ export { useDropdown_unstable }
 export { useDropdownStyles_unstable }
 
 export { useField_unstable }
+
+export { useFieldContext }
+
+export { useFieldContextValues_unstable }
 
 export { useFieldStyles_unstable }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -338,10 +338,12 @@ export {
   Field,
   fieldClassNames,
   renderField_unstable,
-  useFieldStyles_unstable,
   useField_unstable,
+  useFieldContext,
+  useFieldContextValues_unstable,
+  useFieldStyles_unstable,
 } from '@fluentui/react-field';
-export type { FieldProps, FieldSlots, FieldState } from '@fluentui/react-field';
+export type { FieldContextValue, FieldContextValues, FieldProps, FieldSlots, FieldState } from '@fluentui/react-field';
 
 export {
   ProgressBar,

--- a/packages/react-components/react-field/etc/react-field.api.md
+++ b/packages/react-components/react-field/etc/react-field.api.md
@@ -8,6 +8,7 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { ContextSelector } from '@fluentui/react-context-selector';
 import { ForwardRefComponent } from '@fluentui/react-utilities';
 import { Label } from '@fluentui/react-label';
 import * as React_2 from 'react';
@@ -25,6 +26,14 @@ export const Field: ForwardRefComponent<FieldProps>;
 
 // @public (undocumented)
 export const fieldClassNames: SlotClassNames<FieldSlots>;
+
+// @public
+export type FieldContextValue = Pick<FieldState, 'orientation' | 'required' | 'size' | 'validationState'>;
+
+// @public (undocumented)
+export type FieldContextValues = {
+    field: FieldContextValue;
+};
 
 // @public
 export type FieldProps = Omit<ComponentProps<FieldSlots>, 'children'> & {
@@ -45,7 +54,7 @@ export type FieldSlots = {
 };
 
 // @public
-export type FieldState = ComponentState<Required<FieldSlots>> & Required<Pick<FieldProps, 'orientation' | 'validationState'>>;
+export type FieldState = ComponentState<Required<FieldSlots>> & Required<Pick<FieldProps, 'orientation' | 'required' | 'size' | 'validationState'>>;
 
 // @internal @deprecated (undocumented)
 export const getDeprecatedFieldClassNames: (controlRootClassName: string) => {
@@ -64,10 +73,16 @@ export function makeDeprecatedField<ControlProps>(Control: React_2.ComponentType
 }): ForwardRefComponent<DeprecatedFieldProps<ControlProps>>;
 
 // @public
-export const renderField_unstable: (state: FieldState) => JSX.Element;
+export const renderField_unstable: (state: FieldState, context: FieldContextValues) => JSX.Element;
 
 // @public
 export const useField_unstable: (props: FieldProps, ref: React_2.Ref<HTMLDivElement>) => FieldState;
+
+// @public
+export const useFieldContext: <T>(selector: ContextSelector<FieldContextValue | undefined, T>) => T;
+
+// @public
+export const useFieldContextValues_unstable: (state: FieldState) => FieldContextValues;
 
 // @public
 export const useFieldStyles_unstable: (state: FieldState) => void;

--- a/packages/react-components/react-field/src/components/Field/Field.test.tsx
+++ b/packages/react-components/react-field/src/components/Field/Field.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
-import { Field } from './index';
+import { Field, FieldContextValue } from './index';
+import { useFieldContext } from '../../contexts/FieldContext';
 
 describe('Field', () => {
   isConformant({
@@ -188,5 +189,55 @@ describe('Field', () => {
       'aria-invalid': true,
       'aria-required': true,
     });
+  });
+
+  // const ExpectFieldContext = (props: { expected: FieldContextValue | undefined }) => {
+  //   expect(useFieldContext(ctx => ctx)).toEqual(props.expected);
+  //   return null;
+  // };
+
+  const FieldContextReader = (props: { contextRef: React.MutableRefObject<FieldContextValue | undefined | null> }) => {
+    props.contextRef.current = useFieldContext(ctx => ctx);
+    return null;
+  };
+
+  it('passes default state via context', () => {
+    const contextRef = React.createRef<FieldContextValue | undefined>();
+
+    render(
+      <Field>
+        <FieldContextReader contextRef={contextRef} />
+      </Field>,
+    );
+
+    expect(contextRef.current).toEqual({
+      size: 'medium',
+      orientation: 'vertical',
+      required: false,
+      validationState: 'none',
+    });
+  });
+
+  it('passes provided state via context', () => {
+    const contextRef = React.createRef<FieldContextValue | undefined>();
+
+    render(
+      <Field size="small" orientation="horizontal" required validationState="warning">
+        <FieldContextReader contextRef={contextRef} />
+      </Field>,
+    );
+
+    expect(contextRef.current).toEqual({
+      size: 'small',
+      orientation: 'horizontal',
+      required: true,
+      validationState: 'warning',
+    });
+  });
+
+  it('context is undefined outside of a Field', () => {
+    const contextRef = React.createRef<FieldContextValue | undefined>();
+    render(<FieldContextReader contextRef={contextRef} />);
+    expect(contextRef.current).toBeUndefined();
   });
 });

--- a/packages/react-components/react-field/src/components/Field/Field.tsx
+++ b/packages/react-components/react-field/src/components/Field/Field.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react';
+
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { FieldProps } from './Field.types';
 import { renderField_unstable } from './renderField';
 import { useField_unstable } from './useField';
+import { useFieldContextValues_unstable } from './useFieldContextValues';
 import { useFieldStyles_unstable } from './useFieldStyles';
 
 export const Field: ForwardRefComponent<FieldProps> = React.forwardRef((props, ref) => {
   const state = useField_unstable(props, ref);
   useFieldStyles_unstable(state);
-  return renderField_unstable(state);
+  const contextValues = useFieldContextValues_unstable(state);
+  return renderField_unstable(state, contextValues);
 });
 
 Field.displayName = 'Field';

--- a/packages/react-components/react-field/src/components/Field/Field.types.ts
+++ b/packages/react-components/react-field/src/components/Field/Field.types.ts
@@ -100,4 +100,13 @@ export type FieldProps = Omit<ComponentProps<FieldSlots>, 'children'> & {
  * State used in rendering Field
  */
 export type FieldState = ComponentState<Required<FieldSlots>> &
-  Required<Pick<FieldProps, 'orientation' | 'validationState'>>;
+  Required<Pick<FieldProps, 'orientation' | 'required' | 'size' | 'validationState'>>;
+
+/**
+ * When a component is wrapped by a Field, it can access the Field's state through this context
+ */
+export type FieldContextValue = Pick<FieldState, 'orientation' | 'required' | 'size' | 'validationState'>;
+
+export type FieldContextValues = {
+  field: FieldContextValue;
+};

--- a/packages/react-components/react-field/src/components/Field/index.ts
+++ b/packages/react-components/react-field/src/components/Field/index.ts
@@ -2,4 +2,5 @@ export * from './Field.types';
 export * from './Field';
 export * from './renderField';
 export * from './useField';
+export * from './useFieldContextValues';
 export * from './useFieldStyles';

--- a/packages/react-components/react-field/src/components/Field/renderField.tsx
+++ b/packages/react-components/react-field/src/components/Field/renderField.tsx
@@ -1,24 +1,28 @@
 import * as React from 'react';
+
 import { getSlots } from '@fluentui/react-utilities';
-import type { FieldSlots, FieldState } from './Field.types';
+import { FieldContextProvider } from '../../contexts/FieldContext';
+import type { FieldContextValues, FieldSlots, FieldState } from './Field.types';
 
 /**
  * Render the final JSX of Field
  */
-export const renderField_unstable = (state: FieldState) => {
+export const renderField_unstable = (state: FieldState, context: FieldContextValues) => {
   const { slots, slotProps } = getSlots<FieldSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.label && <slots.label {...slotProps.label} />}
-      {slotProps.root.children}
-      {slots.validationMessage && (
-        <slots.validationMessage {...slotProps.validationMessage}>
-          {slots.validationMessageIcon && <slots.validationMessageIcon {...slotProps.validationMessageIcon} />}
-          {slotProps.validationMessage.children}
-        </slots.validationMessage>
-      )}
-      {slots.hint && <slots.hint {...slotProps.hint} />}
-    </slots.root>
+    <FieldContextProvider value={context.field}>
+      <slots.root {...slotProps.root}>
+        {slots.label && <slots.label {...slotProps.label} />}
+        {slotProps.root.children}
+        {slots.validationMessage && (
+          <slots.validationMessage {...slotProps.validationMessage}>
+            {slots.validationMessageIcon && <slots.validationMessageIcon {...slotProps.validationMessageIcon} />}
+            {slotProps.validationMessage.children}
+          </slots.validationMessage>
+        )}
+        {slots.hint && <slots.hint {...slotProps.hint} />}
+      </slots.root>
+    </FieldContextProvider>
   );
 };

--- a/packages/react-components/react-field/src/components/Field/useField.tsx
+++ b/packages/react-components/react-field/src/components/Field/useField.tsx
@@ -25,9 +25,9 @@ export const useField_unstable = (props: FieldProps, ref: React.Ref<HTMLDivEleme
   const {
     children,
     orientation = 'vertical',
-    required,
+    required = false,
     validationState = props.validationMessage ? 'error' : 'none',
-    size,
+    size = 'medium',
   } = props;
 
   const baseId = useId('field-');
@@ -101,6 +101,8 @@ export const useField_unstable = (props: FieldProps, ref: React.Ref<HTMLDivEleme
 
   return {
     orientation,
+    required,
+    size,
     validationState,
     components: {
       root: 'div',

--- a/packages/react-components/react-field/src/components/Field/useFieldContextValues.ts
+++ b/packages/react-components/react-field/src/components/Field/useFieldContextValues.ts
@@ -1,0 +1,17 @@
+import { FieldContextValues, FieldState } from '../Field';
+
+/**
+ * Get values for the Field context from the state
+ */
+export const useFieldContextValues_unstable = (state: FieldState): FieldContextValues => {
+  const { orientation, required, size, validationState } = state;
+
+  return {
+    field: {
+      orientation,
+      required,
+      size,
+      validationState,
+    },
+  };
+};

--- a/packages/react-components/react-field/src/contexts/FieldContext.ts
+++ b/packages/react-components/react-field/src/contexts/FieldContext.ts
@@ -1,0 +1,22 @@
+import type { ContextSelector } from '@fluentui/react-context-selector';
+import { createContext, useContextSelector } from '@fluentui/react-context-selector';
+import type { FieldContextValue } from '../Field';
+
+const FieldContext = createContext<FieldContextValue | undefined>(undefined);
+
+/**
+ * @internal
+ */
+export const FieldContextProvider = FieldContext.Provider;
+
+/**
+ * If this control is inside a Field, retreive a property from the Field context.
+ * Note the context passed to the selector will be `undefined` if not inside a Field.
+ *
+ * @example
+ * ```
+ * const fieldSize = useFieldContext(ctx => ctx?.size); // 'small' | 'medium' | 'large' | undefined
+ * ```
+ */
+export const useFieldContext = <T>(selector: ContextSelector<FieldContextValue | undefined, T>): T =>
+  useContextSelector(FieldContext, selector);

--- a/packages/react-components/react-field/src/contexts/index.ts
+++ b/packages/react-components/react-field/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './FieldContext';

--- a/packages/react-components/react-field/src/index.ts
+++ b/packages/react-components/react-field/src/index.ts
@@ -1,5 +1,14 @@
-export { Field, fieldClassNames, renderField_unstable, useFieldStyles_unstable, useField_unstable } from './Field';
-export type { FieldProps, FieldSlots, FieldState } from './Field';
+export {
+  Field,
+  fieldClassNames,
+  renderField_unstable,
+  useField_unstable,
+  useFieldContextValues_unstable,
+  useFieldStyles_unstable,
+} from './Field';
+export type { FieldContextValue, FieldContextValues, FieldProps, FieldSlots, FieldState } from './Field';
+
+export { useFieldContext } from './contexts/FieldContext';
 
 // eslint-disable-next-line deprecation/deprecation
 export { getDeprecatedFieldClassNames, makeDeprecatedField } from './util/makeDeprecatedField';

--- a/packages/react-components/react-field/stories/Field/FieldSize.stories.tsx
+++ b/packages/react-components/react-field/stories/Field/FieldSize.stories.tsx
@@ -16,13 +16,13 @@ export const Size = () => {
   return (
     <div className={styles.stack}>
       <Field label="Size small" size="small">
-        <Input size="small" />
+        <Input />
       </Field>
       <Field label="Size medium" size="medium">
-        <Input size="medium" />
+        <Input />
       </Field>
       <Field label="Size large" size="large">
-        <Input size="large" />
+        <Input />
       </Field>
     </div>
   );

--- a/packages/react-components/react-input/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/src/components/Input/useInput.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import {
   getPartitionedNativeProps,
   resolveShorthand,
@@ -19,8 +20,9 @@ import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-co
  */
 export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
   const overrides = useOverrides();
+  const fieldSize = useFieldContext(field => field?.size);
 
-  const { size = 'medium', appearance = overrides.inputDefaultAppearance ?? 'outline', onChange } = props;
+  const { size = fieldSize ?? 'medium', appearance = overrides.inputDefaultAppearance ?? 'outline', onChange } = props;
 
   if (
     process.env.NODE_ENV !== 'production' &&

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBar.tsx
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
 
@@ -12,8 +13,16 @@ import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
  * @param ref - reference to root HTMLElement of ProgressBar
  */
 export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<HTMLElement>): ProgressBarState => {
+  const fieldValidationState = useFieldContext(field => field?.validationState);
+
   // Props
-  const { max = 1.0, shape = 'rounded', thickness = 'medium', validationState, value } = props;
+  const {
+    max = 1.0,
+    shape = 'rounded',
+    thickness = 'medium',
+    validationState = fieldValidationState === 'none' ? undefined : fieldValidationState,
+    value,
+  } = props;
 
   const root = getNativeElementProps('div', {
     ref,

--- a/packages/react-components/react-select/src/components/Select/useSelect.tsx
+++ b/packages/react-components/react-select/src/components/Select/useSelect.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import { getPartitionedNativeProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import type { SelectProps, SelectState } from './Select.types';
@@ -15,6 +16,7 @@ import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-co
  */
 export const useSelect_unstable = (props: SelectProps, ref: React.Ref<HTMLSelectElement>): SelectState => {
   const overrides = useOverrides();
+  const fieldSize = useFieldContext(field => field?.size);
 
   const {
     defaultValue,
@@ -25,7 +27,7 @@ export const useSelect_unstable = (props: SelectProps, ref: React.Ref<HTMLSelect
     appearance = overrides.inputDefaultAppearance ?? 'outline',
 
     onChange,
-    size = 'medium',
+    size = fieldSize ?? 'medium',
   } = props;
 
   const nativeProps = getPartitionedNativeProps({

--- a/packages/react-components/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSlider.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import { getPartitionedNativeProps, resolveShorthand, useId, useMergedRefs } from '@fluentui/react-utilities';
 import { useSliderState_unstable } from './useSliderState';
 import { SliderProps, SliderState } from './Slider.types';
@@ -11,10 +12,12 @@ export const useSlider_unstable = (props: SliderProps, ref: React.Ref<HTMLInputE
     excludedPropNames: ['onChange', 'size'],
   });
 
+  const fieldSize = useFieldContext(field => field?.size);
+
   const {
     disabled,
     vertical,
-    size = 'medium',
+    size = fieldSize === 'small' ? 'small' : 'medium',
     // Slots
     root,
     input,

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import {
   getPartitionedNativeProps,
   mergeCallbacks,
@@ -53,6 +54,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   });
 
   const overrides = useOverrides();
+  const fieldSize = useFieldContext(field => field?.size);
 
   const {
     value,
@@ -64,7 +66,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     stepPage = 1,
     precision: precisionFromProps,
     onChange,
-    size = 'medium',
+    size = fieldSize === 'small' ? 'small' : 'medium',
     appearance = overrides.inputDefaultAppearance ?? 'outline',
     root,
     input,

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextarea.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextarea.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFieldContext } from '@fluentui/react-field';
 import {
   getPartitionedNativeProps,
   resolveShorthand,
@@ -19,9 +20,10 @@ import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-co
  */
 export const useTextarea_unstable = (props: TextareaProps, ref: React.Ref<HTMLTextAreaElement>): TextareaState => {
   const overrides = useOverrides();
+  const fieldSize = useFieldContext(field => field?.size);
 
   const {
-    size = 'medium',
+    size = fieldSize ?? 'medium',
     appearance = overrides.inputDefaultAppearance ?? 'outline',
     resize = 'none',
     onChange,


### PR DESCRIPTION
## Previous Behavior

Now that `Field` is a standalone component as of PR #26430, we don't have a direct way to pass the field's `size` or `validationState` to controls like `Input` and `ProgressBar`.

## New Behavior

Add `FieldContext` so that controls can apply styling customizations when they're in a Field, like `size` or `validationState`.

## Related Issue(s)

* Fixes #26538
