### PR TITLE
Jackieg/azuretheme cal

### DIFF
--- a/change/@fluentui-azure-themes-fde6e654-0910-4897-912e-842bf2024601.json
+++ b/change/@fluentui-azure-themes-fde6e654-0910-4897-912e-842bf2024601.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "azure theme calendar selection, contextmenu border, pivot focus border, dropdown item size updates",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -92,6 +92,7 @@ export namespace BaseColors {
   export const GRAY_AFAFAF = '#afafaf';
   export const GRAY_A19F9D = '#A19F9D';
   export const GRAY_C8C6C4 = '#C8C6C4';
+  export const GRAY_E5E5E5 = '#E5E5E5';
   export const GRAY_EDEBE9 = '#EDEBE9';
   export const GRAY_E1DFDD = '#E1DFDD';
   export const GRAY_F3F2F1 = '#F3F2F1';
@@ -132,7 +133,7 @@ export namespace CommonSemanticColors {
     upsell: BaseColors.PURPLE_8A2DA5,
   };
   export const dividers = {
-    lineSeparator: BaseColors.GRAY_6B849C_025,
+    lineSeparator: BaseColors.GRAY_E5E5E5,
     sectionDivider: BaseColors.GRAY_6B849C_035,
   };
   export const backgrounds = {

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -1,5 +1,5 @@
 import { createTheme, Theme } from '@fluentui/react';
-import { CommonSemanticColors, DarkSemanticColors } from './AzureColors';
+import { BaseColors, CommonSemanticColors, DarkSemanticColors } from './AzureColors';
 import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
@@ -100,7 +100,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   rowBorder: DarkSemanticColors.detailsRow.border,
   rowFocus: DarkSemanticColors.detailsRow.focus,
   tabHover: DarkSemanticColors.tabs.hover,
-  variantBorder: CommonSemanticColors.dividers.lineSeparator,
+  variantBorder: BaseColors.TRANSPARENT,
 
   // extended
   commandBarButtonAfterColor: DarkSemanticColors.commandBar.button.focus.borderColor,

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -13,7 +13,6 @@ export const buttonPadding = '0px 16px';
 export const calendarHeightInner = '22px';
 export const choiceFieldHeight = '18px';
 export const commandBarHeight = '36px';
-export const DayIsTodayDimension = '27px';
 export const dropDownItemHeight = '32px';
 export const fontFamily =
   // eslint-disable-next-line @fluentui/max-len

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -10,6 +10,7 @@ export const borderRadius = '3px';
 export const borderSolid = 'solid';
 export const borderWidth = '1px';
 export const buttonPadding = '0px 16px';
+export const calendarHeightInner = '22px';
 export const choiceFieldHeight = '18px';
 export const commandBarHeight = '36px';
 export const dropDownItemHeight = '32px';

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -6,13 +6,14 @@ import {
 } from '@fluentui/react/lib/Styling';
 
 export const borderNone = 'none';
-export const borderRadius = '3px';
+export const borderRadius = '2px';
 export const borderSolid = 'solid';
 export const borderWidth = '1px';
 export const buttonPadding = '0px 16px';
 export const calendarHeightInner = '22px';
 export const choiceFieldHeight = '18px';
 export const commandBarHeight = '36px';
+export const DayIsTodayDimension = '27px';
 export const dropDownItemHeight = '32px';
 export const fontFamily =
   // eslint-disable-next-line @fluentui/max-len

--- a/packages/azure-themes/src/azure/styles/Calendar.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Calendar.styles.ts
@@ -10,6 +10,7 @@ import {
   ICalendarPickerStyleProps,
 } from '@fluentui/react';
 import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import * as StyleConstants from '../Constants';
 
 // Effects general area of callout.
 export const CalendarStyles = (props: ICalendarStyleProps): Partial<ICalendarStyles> => {
@@ -90,7 +91,7 @@ export const CalendarDayGridStyles = (props: ICalendarDayGridStyleProps): Partia
     },
     dayButton: [
       {
-        borderRadius: 2,
+        borderRadius: StyleConstants.borderRadius,
         color: 'inherit !important',
         selectors: {
           '&:after': {

--- a/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
@@ -17,8 +17,9 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
     subComponentStyles: {
       callout: {
         root: {
-          backgroundColor: semanticColors.inputBackground,
-          borderColor: semanticColors.inputBorder,
+          backgroundColor: extendedSemanticColors.controlBackground,
+
+          borderColor: semanticColors.variantBorder,
           borderStyle: StyleConstants.borderSolid,
           borderWidth: StyleConstants.borderWidth,
           boxShadow: Depths.depth8,
@@ -34,15 +35,19 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
           root: [
             {
               fontSize: theme.fonts.medium.fontSize,
+              backgroundColor: extendedSemanticColors.controlBackground,
               selectors: {
                 '&:hover': {
-                  backgroundColor: semanticColors.buttonBackgroundHovered,
-                  color: semanticColors.buttonTextHovered,
+                  backgroundColor: semanticColors.listItemBackgroundHovered,
+                  color: semanticColors.bodyText,
                   selectors: {
                     '.ms-ContextualMenu-icon': {
                       color: extendedSemanticColors.iconButtonFillHovered,
                     },
                   },
+                },
+                '&:active': {
+                  color: semanticColors.buttonTextHovered,
                 },
                 '.ms-ContextualMenu-icon': {
                   color: extendedSemanticColors.iconButtonFill,
@@ -54,7 +59,7 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
             fontSize: theme.fonts.medium.fontSize,
           },
           divider: {
-            backgroundColor: semanticColors.inputBorder,
+            backgroundColor: semanticColors.variantBorder,
           },
           iconColor: {
             color: semanticColors.focusBorder,

--- a/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
@@ -18,7 +18,6 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
       callout: {
         root: {
           backgroundColor: extendedSemanticColors.controlBackground,
-
           borderColor: semanticColors.variantBorder,
           borderStyle: StyleConstants.borderSolid,
           borderWidth: StyleConstants.borderWidth,

--- a/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
@@ -1,5 +1,6 @@
 import { IDatePickerStyles, IDatePickerStyleProps } from '@fluentui/react/lib/DatePicker';
 import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
+import * as StyleConstants from '../Constants';
 
 export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
   const { disabled, theme } = props;
@@ -17,7 +18,7 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
         bottom: '0px',
         top: '0px',
         height: '19px',
-        padding: '2px 2px 0 0',
+        padding: '3px 5px 0 0',
       },
       disabled && {
         color: extendedSemanticColors.calendarTextDisabled,
@@ -28,7 +29,8 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
         fontSize: theme.fonts.medium.fontSize,
         selectors: {
           '.ms-TextField-field': {
-            lineHeight: 22,
+            lineHeight: StyleConstants.calendarHeightInner,
+            height: StyleConstants.calendarHeightInner,
           },
         },
       },
@@ -42,6 +44,19 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
           },
           '.ms-TextField-field': {
             lineHeight: 22,
+          },
+        },
+      },
+    ],
+    callout: [
+      {
+        selectors: {
+          '.ms-CalendarDay-daySelected::before': {
+            display: 'none !important',
+            border: 0,
+          },
+          '.ms-CalendarDay-dayIsToday': {
+            borderRadius: 3,
           },
         },
       },

--- a/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
@@ -55,12 +55,6 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
             display: 'none !important',
             border: 0,
           },
-          '.ms-CalendarDay-dayIsToday': {
-            color: semanticColors.primaryButtonText,
-            borderRadius: StyleConstants.borderRadius,
-            width: StyleConstants.DayIsTodayDimension,
-            height: StyleConstants.DayIsTodayDimension,
-          },
         },
       },
     ],

--- a/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
@@ -40,7 +40,7 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
         selectors: {
           '.ms-TextField-fieldGroup': {
             borderColor: semanticColors.datePickerDisabledBorder,
-            borderRadius: 2,
+            borderRadius: StyleConstants.borderRadius,
           },
           '.ms-TextField-field': {
             lineHeight: 22,
@@ -56,7 +56,10 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
             border: 0,
           },
           '.ms-CalendarDay-dayIsToday': {
-            borderRadius: 3,
+            color: semanticColors.primaryButtonText,
+            borderRadius: StyleConstants.borderRadius,
+            width: StyleConstants.DayIsTodayDimension,
+            height: StyleConstants.DayIsTodayDimension,
           },
         },
       },

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -29,8 +29,8 @@ export const CheckStyles = (props: ICheckStyleProps): Partial<ICheckStyles> => {
     ],
     check: [
       {
-        left: 2.5,
-        top: 1.5,
+        left: 1.8,
+        top: 0.5,
       },
       checked && {
         color: semanticColors.inputText,
@@ -110,7 +110,11 @@ export const DetailsRowStyles = (props: IDetailsRowStyleProps): Partial<IDetails
         borderColor: extendedSemanticColors.rowBorder,
         color: semanticColors.listText,
         fontSize: theme.fonts.medium.fontSize,
-        borderBottom: `1px solid ${extendedSemanticColors.listItemBackgroundSelected} !important`,
+        selectors: {
+          '&.ms-DetailsRow': {
+            borderBottom: `1px solid ${extendedSemanticColors.listItemBackgroundSelected}`,
+          },
+        },
       },
       !isSelected && [
         {

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -19,7 +19,7 @@ export const CheckStyles = (props: ICheckStyleProps): Partial<ICheckStyles> => {
         fontSize: 0,
         paddingTop: 1,
         paddingLeft: 1,
-        borderRadius: 2,
+        borderRadius: StyleConstants.borderRadius,
         color: semanticColors.listBackground,
         backgroundColor: semanticColors.listBackground,
         borderColor: semanticColors.ButtonBorderFocus,

--- a/packages/azure-themes/src/azure/styles/Pivot.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Pivot.styles.ts
@@ -99,6 +99,9 @@ export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
           ':active': {
             backgroundColor: semanticColors.bodyBackground,
           },
+          ':focus': {
+            border: 0,
+          },
         },
       },
       !rootIsLarge && {

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -33,6 +33,7 @@ import { TooltipBasicExample } from '../components/tooltip.stories';
 import { SliderBasicExample } from '../components/slider.stories';
 import { SpinButtonBasicExample } from '../components/SpinButton.stories';
 import { DatePickerBasicExample } from '../components/defaultDatePicker';
+import { ProgressIndicatorBasicExample } from '../components/ProgressIndicator.stories';
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -85,6 +86,11 @@ const Example = () => (
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>
       <Label>Slider</Label>
       <SliderBasicExample />
+    </Stack>
+
+    <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>
+      <Label>Progress Indicator</Label>
+      <ProgressIndicatorBasicExample />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -34,6 +34,7 @@ import { SliderBasicExample } from '../components/slider.stories';
 import { SpinButtonBasicExample } from '../components/SpinButton.stories';
 import { DatePickerBasicExample } from '../components/defaultDatePicker';
 import { ProgressIndicatorBasicExample } from '../components/ProgressIndicator.stories';
+import { CalendarInlineMultidayDayViewExample } from '../components/CalendarInlineMultidayDayView.stories';
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -97,6 +98,7 @@ const Example = () => (
       <Label className="section">DatePicker</Label>
       <DatePickerBasicExample />
       <DatePickerBoundedExample />
+      <CalendarInlineMultidayDayViewExample />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -32,6 +32,7 @@ import { MessageBarBasicExample } from '../components/messageBar.stories';
 import { TooltipBasicExample } from '../components/tooltip.stories';
 import { SliderBasicExample } from '../components/slider.stories';
 import { SpinButtonBasicExample } from '../components/SpinButton.stories';
+import { DatePickerBasicExample } from '../components/defaultDatePicker';
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -88,6 +89,7 @@ const Example = () => (
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>
       <Label className="section">DatePicker</Label>
+      <DatePickerBasicExample />
       <DatePickerBoundedExample />
     </Stack>
 

--- a/packages/react-examples/src/azure-themes/stories/components/CalendarInlineMultidayDayView.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/CalendarInlineMultidayDayView.stories.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Calendar, Dropdown, IDropdownOption, mergeStyleSets, defaultCalendarStrings } from '@fluentui/react';
+
+const styles = mergeStyleSets({
+  wrapper: { height: 360 },
+  dropdown: { width: 230 },
+});
+
+const dayOptions: IDropdownOption[] = [
+  { key: '1', text: '1' },
+  { key: '2', text: '2' },
+  { key: '3', text: '3' },
+  { key: '4', text: '4' },
+  { key: '5', text: '5' },
+  { key: '6', text: '6' },
+];
+
+export const CalendarInlineMultidayDayViewExample: React.FunctionComponent = () => {
+  const [selectedDateRange, setSelectedDateRange] = React.useState<Date[]>();
+  const [selectedDate, setSelectedDate] = React.useState<Date>();
+  const [daysToSelectInDayView, setDaysToSelectInDayView] = React.useState(4);
+
+  const onSelectDate = React.useCallback((date: Date, dateRangeArray: Date[]): void => {
+    setSelectedDate(date);
+    setSelectedDateRange(dateRangeArray);
+  }, []);
+
+  const onDaysToSelectInDayViewDropdownChange = React.useCallback(
+    (ev: React.FormEvent<HTMLElement>, option: IDropdownOption | undefined) => {
+      if (option) {
+        setDaysToSelectInDayView(Number(option.key));
+      }
+    },
+    [],
+  );
+
+  let dateRangeString = 'Not set';
+  if (selectedDateRange) {
+    const rangeStart = selectedDateRange[0];
+    const rangeEnd = selectedDateRange[selectedDateRange.length - 1];
+    dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <p>
+        This calendar uses <code>dateRangeType = Day</code> and <code>daysToSelectInView = 4</code>.
+      </p>
+      <div>Selected date: {selectedDate?.toLocaleString() || 'Not set'}</div>
+      <div>Selected range: {dateRangeString}</div>
+      <Calendar
+        highlightSelectedMonth
+        showGoToToday
+        onSelectDate={onSelectDate}
+        value={selectedDate}
+        calendarDayProps={{ daysToSelectInDayView }}
+        // Calendar uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultCalendarStrings}
+      />
+      <Dropdown
+        className={styles.dropdown}
+        selectedKey={String(daysToSelectInDayView)}
+        label="Choose days to select"
+        options={dayOptions}
+        onChange={onDaysToSelectInDayViewDropdownChange}
+      />
+    </div>
+  );
+};

--- a/packages/react-examples/src/azure-themes/stories/components/ProgressIndicator.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/ProgressIndicator.stories.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ProgressIndicator } from '@fluentui/react/lib/ProgressIndicator';
+
+const intervalDelay = 100;
+const intervalIncrement = 0.01;
+
+export const ProgressIndicatorBasicExample: React.FunctionComponent = () => {
+  const [percentComplete, setPercentComplete] = React.useState(0);
+
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      setPercentComplete((intervalIncrement + percentComplete) % 1);
+    }, intervalDelay);
+    return () => {
+      clearInterval(id);
+    };
+  });
+
+  return (
+    <ProgressIndicator label="Example title" description="Example description" percentComplete={percentComplete} />
+  );
+};

--- a/packages/react-examples/src/azure-themes/stories/components/defaultDatePicker.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/defaultDatePicker.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {
+  DatePicker,
+  DayOfWeek,
+  Dropdown,
+  IDropdownOption,
+  mergeStyles,
+  defaultDatePickerStrings,
+} from '@fluentui/react';
+
+const days: IDropdownOption[] = [
+  { text: 'Sunday', key: DayOfWeek.Sunday },
+  { text: 'Monday', key: DayOfWeek.Monday },
+  { text: 'Tuesday', key: DayOfWeek.Tuesday },
+  { text: 'Wednesday', key: DayOfWeek.Wednesday },
+  { text: 'Thursday', key: DayOfWeek.Thursday },
+  { text: 'Friday', key: DayOfWeek.Friday },
+  { text: 'Saturday', key: DayOfWeek.Saturday },
+];
+const rootClass = mergeStyles({ minWidth: 170, selectors: { '> *': { marginBottom: 15 } } });
+
+export const DatePickerBasicExample: React.FunctionComponent = () => {
+  const [firstDayOfWeek, setFirstDayOfWeek] = React.useState(DayOfWeek.Sunday);
+
+  return (
+    <div className={rootClass}>
+      <DatePicker
+        firstDayOfWeek={firstDayOfWeek}
+        placeholder="Select a date..."
+        ariaLabel="Select a date"
+        // DatePicker uses English strings by default. For localized apps, you must override this prop.
+        strings={defaultDatePickerStrings}
+      />
+    </div>
+  );
+};

--- a/packages/react-examples/src/azure-themes/stories/components/defaultDatePicker.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/defaultDatePicker.tsx
@@ -1,31 +1,14 @@
 import * as React from 'react';
-import {
-  DatePicker,
-  DayOfWeek,
-  Dropdown,
-  IDropdownOption,
-  mergeStyles,
-  defaultDatePickerStrings,
-} from '@fluentui/react';
+import { DatePicker, mergeStyles, defaultDatePickerStrings } from '@fluentui/react';
 
-const days: IDropdownOption[] = [
-  { text: 'Sunday', key: DayOfWeek.Sunday },
-  { text: 'Monday', key: DayOfWeek.Monday },
-  { text: 'Tuesday', key: DayOfWeek.Tuesday },
-  { text: 'Wednesday', key: DayOfWeek.Wednesday },
-  { text: 'Thursday', key: DayOfWeek.Thursday },
-  { text: 'Friday', key: DayOfWeek.Friday },
-  { text: 'Saturday', key: DayOfWeek.Saturday },
-];
 const rootClass = mergeStyles({ minWidth: 170, selectors: { '> *': { marginBottom: 15 } } });
 
 export const DatePickerBasicExample: React.FunctionComponent = () => {
-  const [firstDayOfWeek, setFirstDayOfWeek] = React.useState(DayOfWeek.Sunday);
+  // const [firstDayOfWeek, setFirstDayOfWeek] = React.useState(DayOfWeek.Sunday);
 
   return (
     <div className={rootClass}>
       <DatePicker
-        firstDayOfWeek={firstDayOfWeek}
         placeholder="Select a date..."
         ariaLabel="Select a date"
         // DatePicker uses English strings by default. For localized apps, you must override this prop.


### PR DESCRIPTION
This PR removes the ContextMenu harsh border, updates the DatePicker/Calendar "today is selected" blue and gray selections, reduced the dropdown items size to 32px, and removed the focus border from the pivot - all for Azure Theme only. 

## Previous Behavior

Context Menu harsh border
![image](https://user-images.githubusercontent.com/30805892/214354670-c8a1371a-7adb-4594-8340-ec54832c29b5.png)
![image](https://user-images.githubusercontent.com/30805892/214355843-bb31f9f6-7243-437b-835a-09d6912f052a.png)

Dropdown item height previously 36px
![image](https://user-images.githubusercontent.com/30805892/214374880-ea83a31a-8360-472d-9b4d-5328823b6180.png)

Pivots had a focus border, even when just pressed.
![image](https://user-images.githubusercontent.com/30805892/215375854-01b9f84e-e876-4669-a03a-a5b974807349.png)

## New Behavior
![image](https://user-images.githubusercontent.com/30805892/215373043-886c64fa-6535-4686-997b-72acda45d037.png)


![image](https://user-images.githubusercontent.com/30805892/214359153-935518d5-4797-40b7-aa90-dd83e82d910a.png)

with header item 
![image](https://user-images.githubusercontent.com/30805892/214359356-c2a3e87c-b7b9-43fd-924b-bd1a269f25bb.png)

Dropdown item height updated to 32px
![image](https://user-images.githubusercontent.com/30805892/214374518-ab2330a7-ed6f-49f8-9f4f-4400ad09ba7a.png)

Pivot button:focus border removed
![image](https://user-images.githubusercontent.com/30805892/215377343-f60aa6e8-9af9-4923-81d9-19f676871bff.png)
