### PR TITLE
fix(react-persona): Make before and after textPositions align correctly when the Avatar's size is larger than the text lines together

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Persona.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Persona.stories.tsx
@@ -86,16 +86,26 @@ storiesOf('Persona Converged', module)
   .addStory('textAlignment', () => (
     <div className="testWrapper" style={{ display: 'flex', gap: '50px', padding: '10px', maxWidth: '750px' }}>
       {textAlignments.map(textAlignment => (
-        <Persona
-          textAlignment={textAlignment}
-          presenceOnly
-          presence={{ status: 'available' }}
-          name="Kevin Sturgis"
-          secondaryText="Software Engineer"
-          tertiaryText="Available"
-          quaternaryText="Microsoft"
-          key={textAlignment}
-        />
+        <>
+          <Persona
+            textAlignment={textAlignment}
+            presenceOnly
+            presence={{ status: 'available' }}
+            name="Kevin Sturgis"
+            secondaryText="Software Engineer"
+            tertiaryText="Available"
+            quaternaryText="Microsoft"
+            key={'presence-' + textAlignment}
+          />
+          {/* This test is to verify that when the Avatar takes more space than the text lines, the text lines are centered */}
+          <Persona
+            textAlignment={textAlignment}
+            size="huge"
+            name="Kevin Sturgis"
+            secondaryText="Software Engineer"
+            key={'avatar-' + textAlignment}
+          />
+        </>
       ))}
     </div>
   ))

--- a/change/@fluentui-react-persona-dcb203db-48bb-4b12-8e0b-9e2793c577c7.json
+++ b/change/@fluentui-react-persona-dcb203db-48bb-4b12-8e0b-9e2793c577c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make before and after textPositions align correctly when the Avatar size is larger than the text lines together.",
+  "packageName": "@fluentui/react-persona",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
+++ b/packages/react-components/react-persona/src/components/Persona/usePersonaStyles.ts
@@ -24,6 +24,12 @@ const useStyles = makeStyles({
     gridAutoRows: 'max-content',
   },
 
+  beforeAfterCenter: {
+    // This template is needed to make sure the Avatar is centered when it takes up more space than the text lines
+    gridTemplateRows:
+      '1fr [primary] max-content [secondary] max-content [tertiary] max-content [quaternary] max-content 1fr',
+  },
+
   after: {
     gridAutoFlow: 'column',
     justifyItems: 'start',
@@ -37,8 +43,13 @@ const useStyles = makeStyles({
   below: {
     justifyItems: 'center',
   },
-  coin: {
+
+  media: {
     gridRowStart: 'span 5',
+  },
+
+  mediaBeforeAfterCenter: {
+    gridRowStart: 'span 6',
   },
 
   start: {
@@ -62,6 +73,11 @@ const useStyles = makeStyles({
   secondLineSpacing: {
     marginTop: '-2px',
   },
+
+  primary: { gridRowStart: 'primary' },
+  secondary: { gridRowStart: 'secondary' },
+  tertiary: { gridRowStart: 'tertiary' },
+  quaternary: { gridRowStart: 'quaternary' },
 });
 
 const useAvatarSpacingStyles = makeStyles({
@@ -107,18 +123,26 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
   const { presenceOnly, size, textAlignment, textPosition } = state;
 
   const alignToPrimary = presenceOnly && textAlignment === 'start' && size !== 'extra-large' && size !== 'huge';
+  const alignBeforeAfterCenter = textPosition !== 'below' && textAlignment === 'center';
   const { primaryTextClassName, optionalTextClassName } = useTextClassNames(state, alignToPrimary);
 
   const styles = useStyles();
   const avatarSpacingStyles = useAvatarSpacingStyles();
   const presenceSpacingStyles = { ...avatarSpacingStyles, ...usePresenceSpacingStyles() };
 
-  state.root.className = mergeClasses(personaClassNames.root, styles.base, styles[textPosition], state.root.className);
+  state.root.className = mergeClasses(
+    personaClassNames.root,
+    styles.base,
+    alignBeforeAfterCenter && styles.beforeAfterCenter,
+    styles[textPosition],
+    state.root.className,
+  );
 
   if (state.avatar) {
     state.avatar.className = mergeClasses(
       personaClassNames.avatar,
-      styles.coin,
+      textPosition !== 'below' && styles.media,
+      alignBeforeAfterCenter && styles.mediaBeforeAfterCenter,
       styles[textAlignment],
       avatarSpacingStyles[size],
       avatarSpacingStyles[textPosition],
@@ -129,7 +153,8 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
   if (state.presence) {
     state.presence.className = mergeClasses(
       personaClassNames.presence,
-      styles.coin,
+      textPosition !== 'below' && styles.media,
+      alignBeforeAfterCenter && styles.mediaBeforeAfterCenter,
       styles[textAlignment],
       presenceSpacingStyles[size],
       presenceSpacingStyles[textPosition],
@@ -142,6 +167,7 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
   if (state.primaryText) {
     state.primaryText.className = mergeClasses(
       personaClassNames.primaryText,
+      alignBeforeAfterCenter && styles.primary,
       primaryTextClassName,
       state.primaryText.className,
     );
@@ -150,6 +176,7 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
   if (state.secondaryText) {
     state.secondaryText.className = mergeClasses(
       personaClassNames.secondaryText,
+      alignBeforeAfterCenter && styles.secondary,
       optionalTextClassName,
       styles.secondLineSpacing,
       state.secondaryText.className,
@@ -159,6 +186,7 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
   if (state.tertiaryText) {
     state.tertiaryText.className = mergeClasses(
       personaClassNames.tertiaryText,
+      alignBeforeAfterCenter && styles.tertiary,
       optionalTextClassName,
       state.tertiaryText.className,
     );
@@ -167,6 +195,7 @@ export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => 
   if (state.quaternaryText) {
     state.quaternaryText.className = mergeClasses(
       personaClassNames.quaternaryText,
+      alignBeforeAfterCenter && styles.quaternary,
       optionalTextClassName,
       state.quaternaryText.className,
     );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Currently Persona centers the Avatar/Presence, but when the height of the Avatar is larger the text doesn't center correctly. To avoid this, two empty cells are added above and below the text lines that will take `1fr` the difference of the Avatar's height and the text lines height together. 
![image](https://user-images.githubusercontent.com/5953191/215536049-6c3763bd-5721-4948-b13d-0ec9be6f7c6e.png)
![image](https://user-images.githubusercontent.com/5953191/215537715-0bc4236d-684f-4e08-93b5-b0bd9c440995.png)


## New Behavior

![image](https://user-images.githubusercontent.com/5953191/215537542-0829c419-748b-46e3-be0c-51601193e2a1.png)
![image](https://user-images.githubusercontent.com/5953191/215538187-c0e01c92-b13d-47e6-82ed-d7b9d4441012.png)



