### PR TITLE
chore(react-infobutton): Add aria-label to InfoButton's button and add a11y guidance for using InfoButton with a label

### DIFF
--- a/change/@fluentui-react-infobutton-47bbda2e-ad83-4eda-90da-e2181d486f10.json
+++ b/change/@fluentui-react-infobutton-47bbda2e-ad83-4eda-90da-e2181d486f10.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Add aria-label to InfoButton's button and add a11y guidance for using InfoButton with a label.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
@@ -42,6 +42,7 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
     root: getNativeElementProps('button', {
       children: infoButtonIconMap[size],
       type: 'button',
+      'aria-label': 'information',
       ...props,
       ref,
     }),

--- a/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonBestPractices.md
+++ b/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonBestPractices.md
@@ -3,6 +3,10 @@
 Best Practices
 </summary>
 
+### Do's
+
+- Set `aria-labelledby` to the id of the label that the InfoButton provides more information about and the button's id. See the `InfoButton with Label` example below for more information.
+
 ### Don't
 
 - Because the Popover isn't always visible, don't include information that people must know in order to complete the field.

--- a/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonWithLabel.stories.tsx
+++ b/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonWithLabel.stories.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { InfoButton } from '@fluentui/react-infobutton';
+import { Label, Input, makeStyles, shorthands, useId } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  base: {
+    alignItems: 'start',
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.padding('20px'),
+    ...shorthands.gap('10px'),
+  },
+  labelSpacing: {
+    display: 'flex',
+    ...shorthands.gap('4px'),
+  },
+});
+
+export const InfoButtonWithLabel = () => {
+  const styles = useStyles();
+  const infoButtonId = useId();
+  const inputId = useId();
+  const labelId = useId();
+
+  return (
+    <div className={styles.base}>
+      <div className={styles.labelSpacing}>
+        <Label id={labelId} htmlFor={inputId}>
+          Enter your username
+        </Label>
+        <InfoButton
+          id={infoButtonId}
+          aria-labelledby={`${labelId} ${infoButtonId}`}
+          content="Your username should have at least 6 characters."
+        />
+      </div>
+      <Input id={inputId} placeholder="Username" />
+    </div>
+  );
+};
+
+InfoButtonWithLabel.parameters = {
+  docs: {
+    description: {
+      story:
+        "An InfoButton's `aria-labelledby` should include the label's id to correctly" +
+        ' associate the label with the InfoButton.',
+    },
+  },
+};

--- a/packages/react-components/react-infobutton/stories/Infobutton/index.stories.tsx
+++ b/packages/react-components/react-infobutton/stories/Infobutton/index.stories.tsx
@@ -5,6 +5,7 @@ import bestPracticesMd from './InfoButtonBestPractices.md';
 
 export { Default } from './InfoButtonDefault.stories';
 export { Size } from './InfoButtonSize.stories';
+export { InfoButtonWithLabel } from './InfoButtonWithLabel.stories';
 
 export default {
   title: 'Preview Components/InfoButton',


### PR DESCRIPTION
This PR adds the `information` aria-label to InfoButton's button and adds a11y guidance on how to use InfoButton with Label.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Related #26427
