### PR TITLE
docs: use full source in "Show code"

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,6 +37,9 @@ export const parameters = {
       excludeDecorators: true,
       type: 'source',
     },
+    // "transformSource" allows to override code that will be used for "Show Code" tab.
+    // This config reuses sources generated for CodeSandbox export feature (storybook-addon-export-to-codesandbox).
+    transformSource: (snippet, story) => story.parameters.fullSource,
   },
   exportToCodeSandbox: {
     requiredDependencies: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,7 +37,6 @@ export const parameters = {
       excludeDecorators: true,
       type: 'source',
     },
-    // "transformSource" allows to override code that will be used for "Show Code" tab.
     // This config reuses sources generated for CodeSandbox export feature (storybook-addon-export-to-codesandbox).
     transformSource: (snippet, story) => story.parameters.fullSource,
   },

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "schema-utils": "3.1.1",
     "semver": "^6.2.0",
     "source-map-loader": "4.0.0",
-    "storybook-addon-export-to-codesandbox": "0.8.1",
+    "storybook-addon-export-to-codesandbox": "0.8.2",
     "storybook-addon-performance": "0.16.1",
     "storywright": "0.0.26-beta.1",
     "strip-ansi": "6.0.0",

--- a/typings/storybook__addons/index.d.ts
+++ b/typings/storybook__addons/index.d.ts
@@ -43,6 +43,10 @@ declare module '@storybook/addons' {
         type: 'source' | 'auto' | 'dynamic';
       };
 
+     /**
+     * Allows to override code that will be used for "Show Code" tab.
+     * @see https://github.com/storybookjs/storybook/blob/main/addons/docs/docs/recipes.md#customizing-source-snippets
+     */
       transformSource: (snippet: string, story: StoryContextForEnhancers) => string | undefined;
 
       container?: React.ComponentType<any>;

--- a/typings/storybook__addons/index.d.ts
+++ b/typings/storybook__addons/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/storybookjs/storybook/tree/main/lib/addons
 
 import { ViewMode } from '@storybook/addons';
+import { StoryContextForEnhancers } from '@storybook/csf';
 import * as React from 'react';
 
 declare module '@storybook/addons' {
@@ -41,6 +42,8 @@ declare module '@storybook/addons' {
         excludeDecorators: boolean;
         type: 'source' | 'auto' | 'dynamic';
       };
+
+      transformSource: (snippet: string, story: StoryContextForEnhancers) => string | undefined;
 
       container?: React.ComponentType<any>;
       page?: React.ComponentType<any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23532,10 +23532,10 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
-storybook-addon-export-to-codesandbox@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.8.1.tgz#82cde111a1fead05dbc2293fa6c49cd743c8fd09"
-  integrity sha512-/14+HxnwDgbIS2ghpXIOgST7REEVgaP/zPRrLMaBcgq80vMcqUGDjVirRbGFNE/UNI4QTaJR4VvMhPWwwBBq5w==
+storybook-addon-export-to-codesandbox@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.8.2.tgz#96d8506aa336620d6e68287f6259e52a50be3427"
+  integrity sha512-jLu8j03qeUzp82+mXnvjcvjgxz9BeEeql5TQTCgZdvZfkBt5vpd4EzvhOnw+y75AeBXCMU4XrXzb4vlNH9ln2A==
   dependencies:
     codesandbox-import-utils "^2.2.3"
     pkg-up "^3.1.0"


### PR DESCRIPTION
## Previous Behavior

![image](https://user-images.githubusercontent.com/14183168/215821375-2973b283-216f-420f-83f4-bf8bf5c95c8b.png)

## New Behavior

![image](https://user-images.githubusercontent.com/14183168/215821465-1d23540f-710b-4f11-abe0-58c83f0a3c42.png)

Note: snippets will not have proper formatting till https://github.com/microsoft/fluentui-storybook-addons/pull/30.

## Related Issue(s)

Fixes #20367
