### PR TITLE
fix: New overflow items all always dispatch updates to subscriber

### DIFF
--- a/change/@fluentui-priority-overflow-06e37a2f-4190-4541-9eba-5d513a0200da.json
+++ b/change/@fluentui-priority-overflow-06e37a2f-4190-4541-9eba-5d513a0200da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: New overflow items all always dispatch updates to subscriber",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-7c228aac-d8dc-4651-96ce-3b3b4b504c0f.json
+++ b/change/@fluentui-react-overflow-7c228aac-d8dc-4651-96ce-3b3b4b504c0f.json
@@ -1,6 +1,0 @@
-{
-  "type": "patch",
-  "packageName": "@fluentui/react-overflow",
-  "email": "lingfangao@hotmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-overflow-7c228aac-d8dc-4651-96ce-3b3b4b504c0f.json
+++ b/change/@fluentui-react-overflow-7c228aac-d8dc-4651-96ce-3b3b4b504c0f.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-8b8469a8-30b4-4a4d-bc67-d168fd9e2362.json
+++ b/change/@fluentui-react-overflow-8b8469a8-30b4-4a4d-bc67-d168fd9e2362.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Export useOverflowContext as @internal for testing purposes",
+  "packageName": "@fluentui/react-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -121,11 +121,12 @@ export function createOverflowManager(): OverflowManager {
     options.onUpdateOverflow({ visibleItems, invisibleItems, groupVisibility });
   };
 
-  const processOverflowItems = (availableSize: number) => {
+  const processOverflowItems = (): boolean => {
     if (!container) {
-      return;
+      return false;
     }
 
+    const availableSize = getOffsetSize(container) - options.padding;
     const overflowMenuOffset = overflowMenu ? getOffsetSize(overflowMenu) : 0;
 
     // Snapshot of the visible/invisible state to compare for updates
@@ -161,19 +162,18 @@ export function createOverflowManager(): OverflowManager {
     }
 
     // only update when the state of visible/invisible items has changed
-    if (visibleItemQueue.peek() !== visibleTop || invisibleItemQueue.peek() !== invisibleTop || forceDispatch) {
-      forceDispatch = false;
-      dispatchOverflowUpdate();
+    if (visibleItemQueue.peek() !== visibleTop || invisibleItemQueue.peek() !== invisibleTop) {
+      return true;
     }
+
+    return false;
   };
 
   const forceUpdate: OverflowManager['forceUpdate'] = () => {
-    if (!container) {
-      return;
+    if (processOverflowItems() || forceDispatch) {
+      forceDispatch = false;
+      dispatchOverflowUpdate();
     }
-
-    const availableSize = getOffsetSize(container) - options.padding;
-    processOverflowItems(availableSize);
   };
 
   const update: OverflowManager['update'] = debounce(forceUpdate);

--- a/packages/react-components/react-overflow/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/etc/react-overflow.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ContextSelector } from '@fluentui/react-context-selector';
 import type { ObserveOptions } from '@fluentui/priority-overflow';
 import type { OnUpdateOverflow } from '@fluentui/priority-overflow';
 import { OverflowGroupState } from '@fluentui/priority-overflow';
@@ -53,6 +54,9 @@ export const useOverflowContainer: <TElement extends HTMLElement>(update: OnUpda
 export interface UseOverflowContainerReturn<TElement extends HTMLElement> extends Pick<OverflowContextValue, 'registerItem' | 'updateOverflow' | 'registerOverflowMenu'> {
     containerRef: React_2.RefObject<TElement>;
 }
+
+// @internal (undocumented)
+export const useOverflowContext: <SelectedValue>(selector: ContextSelector<OverflowContextValue, SelectedValue>) => SelectedValue;
 
 // @public (undocumented)
 export const useOverflowCount: () => number;

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -468,6 +468,10 @@ describe('Overflow', () => {
     cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
   });
 
+  // Container will fit 4 items with width 100 and the overflow menu
+  // Once the priority of the foo item is updated it should have more
+  // priority than Item 5 (width 100 item), so the foo item should be visible
+  // once this foo item is visible, make sure that the subscriber is in sync.
   it('should dispatch update when updating priority of an item', () => {
     const Example = () => {
       const [priority, setPriority] = React.useState<number | undefined>();
@@ -475,32 +479,29 @@ describe('Overflow', () => {
       return (
         <>
           <Container>
-            <Item id="today" width={87.59}>
-              Today
+            <Item id="1" width={100}>
+              Item 1
             </Item>
-            <Item id="agenda" width={99.19}>
-              Agenda
+            <Item id="2" width={100}>
+              Item 2
             </Item>
-            <Item id="day" width={74.47}>
-              Day
+            <Item id="3" width={100}>
+              Item 3
             </Item>
-            <Item id="threeDay" width={114.13}>
-              Three Day
+            <Item id="4" width={100}>
+              Item 4
             </Item>
-            <Item id="workWeek" width={123.3}>
-              Work Week
+            <Item id="5" width={100}>
+              Item 5
             </Item>
-            <Item id="week" width={85.39} priority={priority}>
-              Week
+            <Item id="foo" width={50} priority={priority}>
+              Foo
             </Item>
-            <Item id="month" width={92.69}>
-              Month
+            <Item id="7" width={50}>
+              Item
             </Item>
-            <Item id="search" width={92.17}>
-              Search
-            </Item>
-            <Item id="chat" width={139.56}>
-              Conversations
+            <Item id="8" width={50}>
+              Item
             </Item>
             <Menu width={32} />
           </Container>
@@ -510,7 +511,7 @@ describe('Overflow', () => {
     };
     mount(<Example />);
 
-    setContainerSize(520);
-    cy.contains('Update priority').click().get('#week-visibility').should('have.text', 'visible');
+    setContainerSize(500);
+    cy.contains('Update priority').click().get('#foo-visibility').should('have.text', 'visible');
   });
 });

--- a/packages/react-components/react-overflow/src/index.ts
+++ b/packages/react-components/react-overflow/src/index.ts
@@ -9,5 +9,7 @@ export { useOverflowCount } from './useOverflowCount';
 export { useOverflowItem } from './useOverflowItem';
 export { useOverflowMenu } from './useOverflowMenu';
 
+export { useOverflowContext } from './overflowContext';
+
 export type { OverflowItemProps } from './components/OverflowItem/OverflowItem.types';
 export { OverflowItem } from './components/OverflowItem/OverflowItem';

--- a/packages/react-components/react-overflow/src/overflowContext.ts
+++ b/packages/react-components/react-overflow/src/overflowContext.ts
@@ -1,6 +1,9 @@
 import type { OverflowGroupState, OverflowItemEntry } from '@fluentui/priority-overflow';
 import { ContextSelector, createContext, useContextSelector, Context } from '@fluentui/react-context-selector';
 
+/**
+ * @internal
+ */
 export interface OverflowContextValue {
   itemVisibility: Record<string, boolean>;
   groupVisibility: Record<string, OverflowGroupState>;
@@ -23,5 +26,8 @@ const overflowContextDefaultValue: OverflowContextValue = {
   registerOverflowMenu: () => () => null,
 };
 
+/**
+ * @internal
+ */
 export const useOverflowContext = <SelectedValue>(selector: ContextSelector<OverflowContextValue, SelectedValue>) =>
   useContextSelector(OverflowContext, (ctx = overflowContextDefaultValue) => selector(ctx));


### PR DESCRIPTION
The dispatch process is done by analyzing the tops of the visibile and invisible queues. The update triggered after adding a new element might not be dispatched to the subscriber because the queue tops don't change. This can result in a desync between the visibility and the subscriber state.

Adds a `forceDispatch` flag which is used when new items are added while observing so that the next batched update will flush to subscribers even if queue tops don't change.

Fixes #23555