### PR TITLE
fix: Dropdown/Combobox checkboxes have double swipe stops for some screen readers 

### DIFF
--- a/change/@fluentui-react-89173b86-4f03-440a-93e8-23c4c3569f3b.json
+++ b/change/@fluentui-react-89173b86-4f03-440a-93e8-23c4c3569f3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Combobox/Dropdown multiselect checkbox+label pattern with role=option results in duplicate text",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1489,7 +1489,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
   private _renderOption = (item: IComboBoxOption): JSX.Element => {
     const { onRenderOption = this._onRenderOptionContent } = this.props;
-    const id = this._id;
+    const id = item.id ?? this._id + '-list' + item.index;
     const isSelected: boolean = this._isOptionSelected(item.index);
     const isChecked: boolean = this._isOptionChecked(item.index);
     const isIndeterminate: boolean = this._isOptionIndeterminate(item.index);
@@ -1497,12 +1497,16 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
     const title = item.title;
 
-    const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
+    const onRenderCheckboxLabel = () => (
+      <div id={id + '-label'} aria-hidden="true">
+        onRenderOption(item, this._onRenderOptionContent)
+      </div>
+    );
 
     const getOptionComponent = () => {
       return !this.props.multiSelect ? (
         <CommandButton
-          id={item.id ?? id + '-list' + item.index}
+          id={id}
           key={item.key}
           data-index={item.index}
           styles={optionStyles}
@@ -1529,8 +1533,9 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         </CommandButton>
       ) : (
         <Checkbox
-          id={item.id ?? id + '-list' + item.index}
+          id={id}
           ariaLabel={item.ariaLabel}
+          ariaLabelledBy={item.ariaLabel ? undefined : id + '-label'}
           key={item.key}
           styles={optionStyles}
           className={'ms-ComboBox-option'}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1487,7 +1487,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     );
   }
 
-  private _renderCheckboxLabel(item: IComboBoxOption): JSX.Element {
+  private _renderCheckboxLabel(item: IComboBoxOption): JSX.Element | null {
     const { onRenderOption = this._onRenderMultiselectOptionContent } = this.props;
     return onRenderOption(item, this._onRenderMultiselectOptionContent);
   }

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1499,7 +1499,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     const onRenderCheckboxLabel = () => (
       <div id={id + '-label'} aria-hidden="true">
-        onRenderOption(item, this._onRenderOptionContent)
+        {onRenderOption(item, this._onRenderOptionContent)}
       </div>
     );
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1487,6 +1487,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     );
   }
 
+  private _renderCheckboxLabel(item: IComboBoxOption): JSX.Element {
+    const { onRenderOption = this._onRenderMultiselectOptionContent } = this.props;
+    return onRenderOption(item, this._onRenderMultiselectOptionContent);
+  }
+
   private _renderOption = (item: IComboBoxOption): JSX.Element => {
     const { onRenderOption = this._onRenderOptionContent } = this.props;
     const id = item.id ?? this._id + '-list' + item.index;
@@ -1496,12 +1501,6 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
     const title = item.title;
-
-    const onRenderCheckboxLabel = () => (
-      <div id={id + '-label'} aria-hidden="true">
-        {onRenderOption(item, this._onRenderOptionContent)}
-      </div>
-    );
 
     const getOptionComponent = () => {
       return !this.props.multiSelect ? (
@@ -1546,7 +1545,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           title={title}
           disabled={item.disabled}
           // eslint-disable-next-line react/jsx-no-bind
-          onRenderLabel={onRenderCheckboxLabel}
+          onRenderLabel={this._renderCheckboxLabel.bind(this, { ...item, id: id + '-label' })}
           inputProps={{
             // aria-selected should only be applied to checked items, not hovered items
             'aria-selected': isChecked ? 'true' : 'false',
@@ -1753,6 +1752,19 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   private _onRenderOptionContent = (item: IComboBoxOption): JSX.Element => {
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
     return <span className={optionClassNames.optionText}>{item.text}</span>;
+  };
+
+  /*
+   * Render content of a multiselect item label.
+   * Text within the label is aria-hidden, to prevent duplicate input/label exposure
+   */
+  private _onRenderMultiselectOptionContent = (item: IComboBoxOption): JSX.Element => {
+    const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
+    return (
+      <span id={item.id} aria-hidden="true" className={optionClassNames.optionText}>
+        {item.text}
+      </span>
+    );
   };
 
   /**

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -1742,27 +1742,24 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                             
                           </i>
                         </div>
-                        <div
+                        <span
                           aria-hidden="true"
+                          class=
+                              ms-ComboBox-optionText
+                              {
+                                display: inline-block;
+                                max-width: 100%;
+                                min-width: 0px;
+                                overflow-wrap: break-word;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                white-space: nowrap;
+                                word-wrap: break-word;
+                              }
                           id="ComboBox0-list1-label"
                         >
-                          <span
-                            class=
-                                ms-ComboBox-optionText
-                                {
-                                  display: inline-block;
-                                  max-width: 100%;
-                                  min-width: 0px;
-                                  overflow-wrap: break-word;
-                                  overflow: hidden;
-                                  text-overflow: ellipsis;
-                                  white-space: nowrap;
-                                  word-wrap: break-word;
-                                }
-                          >
-                            Option 1
-                          </span>
-                        </div>
+                          Option 1
+                        </span>
                       </label>
                     </div>
                     <div
@@ -1965,27 +1962,24 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                           
                         </i>
                       </div>
-                      <div
+                      <span
                         aria-hidden="true"
+                        class=
+                            ms-ComboBox-optionText
+                            {
+                              display: inline-block;
+                              max-width: 100%;
+                              min-width: 0px;
+                              overflow-wrap: break-word;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              word-wrap: break-word;
+                            }
                         id="ComboBox0-list3-label"
                       >
-                        <span
-                          class=
-                              ms-ComboBox-optionText
-                              {
-                                display: inline-block;
-                                max-width: 100%;
-                                min-width: 0px;
-                                overflow-wrap: break-word;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                                white-space: nowrap;
-                                word-wrap: break-word;
-                              }
-                        >
-                          Option 2
-                        </span>
-                      </div>
+                        Option 2
+                      </span>
                     </label>
                   </div>
                 </div>

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -1641,6 +1641,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                           }
                     >
                       <input
+                        aria-labelledby="ComboBox0-list1-label"
                         aria-selected="false"
                         class=
 
@@ -1741,22 +1742,27 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                             
                           </i>
                         </div>
-                        <span
-                          class=
-                              ms-ComboBox-optionText
-                              {
-                                display: inline-block;
-                                max-width: 100%;
-                                min-width: 0px;
-                                overflow-wrap: break-word;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                                white-space: nowrap;
-                                word-wrap: break-word;
-                              }
+                        <div
+                          aria-hidden="true"
+                          id="ComboBox0-list1-label"
                         >
-                          Option 1
-                        </span>
+                          <span
+                            class=
+                                ms-ComboBox-optionText
+                                {
+                                  display: inline-block;
+                                  max-width: 100%;
+                                  min-width: 0px;
+                                  overflow-wrap: break-word;
+                                  overflow: hidden;
+                                  text-overflow: ellipsis;
+                                  white-space: nowrap;
+                                  word-wrap: break-word;
+                                }
+                          >
+                            Option 1
+                          </span>
+                        </div>
                       </label>
                     </div>
                     <div
@@ -1854,6 +1860,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                         }
                   >
                     <input
+                      aria-labelledby="ComboBox0-list3-label"
                       aria-selected="true"
                       checked=""
                       class=
@@ -1958,22 +1965,27 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                           
                         </i>
                       </div>
-                      <span
-                        class=
-                            ms-ComboBox-optionText
-                            {
-                              display: inline-block;
-                              max-width: 100%;
-                              min-width: 0px;
-                              overflow-wrap: break-word;
-                              overflow: hidden;
-                              text-overflow: ellipsis;
-                              white-space: nowrap;
-                              word-wrap: break-word;
-                            }
+                      <div
+                        aria-hidden="true"
+                        id="ComboBox0-list3-label"
                       >
-                        Option 2
-                      </span>
+                        <span
+                          class=
+                              ms-ComboBox-optionText
+                              {
+                                display: inline-block;
+                                max-width: 100%;
+                                min-width: 0px;
+                                overflow-wrap: break-word;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                white-space: nowrap;
+                                word-wrap: break-word;
+                              }
+                        >
+                          Option 2
+                        </span>
+                      </div>
                     </label>
                   </div>
                 </div>

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -798,7 +798,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     // define the id and label id (for multiselect checkboxes)
     const id = this._listId + item.index;
-    const labelId = id + '-label';
+    const labelId = item.id ?? id + '-label';
 
     const multiSelectItemStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.multiSelectItem as IStyleFunctionOrObject<

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -346,7 +346,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       isRenderingPlaceholder: !selectedOptions.length,
       panelClassName: panelProps ? panelProps.className : undefined,
       calloutClassName: calloutProps ? calloutProps.className : undefined,
-      calloutRenderEdge: calloutRenderEdge,
+      calloutRenderEdge,
     });
 
     const hasErrorMessage: boolean = !!errorMessage && errorMessage.length > 0;
@@ -847,13 +847,14 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         label={item.text}
         title={title}
         // eslint-disable-next-line react/jsx-no-bind
-        onRenderLabel={this._onRenderItemLabel.bind(this, item)}
+        onRenderLabel={this._onRenderItemLabel.bind(this, item, this._listId + item.index + '-label')}
         className={css(itemClassName, 'is-multi-select')}
         checked={isItemSelected}
         styles={multiSelectItemStyles}
         ariaPositionInSet={!item.hidden ? this._sizePosCache.positionInSet(item.index) : undefined}
         ariaSetSize={!item.hidden ? this._sizePosCache.optionSetSize : undefined}
         ariaLabel={item.ariaLabel}
+        ariaLabelledBy={item.ariaLabel ? undefined : this._listId + item.index + '-label'}
       />
     );
   };
@@ -864,9 +865,13 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   };
 
   /** Render custom label for drop down item */
-  private _onRenderItemLabel = (item: IDropdownOption): JSX.Element | null => {
+  private _onRenderItemLabel = (item: IDropdownOption, id: string): JSX.Element | null => {
     const { onRenderOption = this._onRenderOption } = this.props;
-    return onRenderOption(item, this._onRenderOption);
+    return (
+      <div id={id} aria-hidden="true">
+        {onRenderOption(item, this._onRenderOption)}
+      </div>
+    );
   };
 
   private _onPositioned = (positions?: ICalloutPositionedInfo): void => {

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -851,7 +851,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         label={item.text}
         title={title}
         // eslint-disable-next-line react/jsx-no-bind
-        onRenderLabel={this._onRenderItemLabel.bind(this, item, labelId)}
+        onRenderLabel={this._onRenderItemLabel.bind(this, { ...item, id: labelId })}
         className={css(itemClassName, 'is-multi-select')}
         checked={isItemSelected}
         styles={multiSelectItemStyles}
@@ -868,14 +868,22 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     return <span className={this._classNames.dropdownOptionText}>{item.text}</span>;
   };
 
-  /** Render custom label for drop down item */
-  private _onRenderItemLabel = (item: IDropdownOption, id: string): JSX.Element | null => {
-    const { onRenderOption = this._onRenderOption } = this.props;
+  /*
+   * Render content of a multiselect item label.
+   * Text within the label is aria-hidden, to prevent duplicate input/label exposure
+   */
+  private _onRenderMultiselectOption = (item: IDropdownOption): JSX.Element => {
     return (
-      <div id={id} aria-hidden="true">
-        {onRenderOption(item, this._onRenderOption)}
-      </div>
+      <span id={item.id} aria-hidden="true" className={this._classNames.dropdownOptionText}>
+        {item.text}
+      </span>
     );
+  };
+
+  /** Render custom label for multiselect checkbox items */
+  private _onRenderItemLabel = (item: IDropdownOption, id: string): JSX.Element | null => {
+    const { onRenderOption = this._onRenderMultiselectOption } = this.props;
+    return onRenderOption(item, this._onRenderMultiselectOption);
   };
 
   private _onPositioned = (positions?: ICalloutPositionedInfo): void => {

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -796,6 +796,10 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     const { title } = item;
 
+    // define the id and label id (for multiselect checkboxes)
+    const id = this._listId + item.index;
+    const labelId = id + '-label';
+
     const multiSelectItemStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.multiSelectItem as IStyleFunctionOrObject<
           ICheckboxStyleProps,
@@ -805,7 +809,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     return !this.props.multiSelect ? (
       <CommandButton
-        id={this._listId + item.index}
+        id={id}
         key={item.key}
         data-index={item.index}
         data-is-focusable={!item.disabled}
@@ -829,7 +833,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       </CommandButton>
     ) : (
       <Checkbox
-        id={this._listId + item.index}
+        id={id}
         key={item.key}
         disabled={item.disabled}
         onChange={this._onItemClick(item)}
@@ -847,14 +851,14 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         label={item.text}
         title={title}
         // eslint-disable-next-line react/jsx-no-bind
-        onRenderLabel={this._onRenderItemLabel.bind(this, item, this._listId + item.index + '-label')}
+        onRenderLabel={this._onRenderItemLabel.bind(this, item, labelId)}
         className={css(itemClassName, 'is-multi-select')}
         checked={isItemSelected}
         styles={multiSelectItemStyles}
         ariaPositionInSet={!item.hidden ? this._sizePosCache.positionInSet(item.index) : undefined}
         ariaSetSize={!item.hidden ? this._sizePosCache.optionSetSize : undefined}
         ariaLabel={item.ariaLabel}
-        ariaLabelledBy={item.ariaLabel ? undefined : this._listId + item.index + '-label'}
+        ariaLabelledBy={item.ariaLabel ? undefined : labelId}
       />
     );
   };

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -798,7 +798,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     // define the id and label id (for multiselect checkboxes)
     const id = this._listId + item.index;
-    const labelId = item.id ?? id + '-label';
+    const labelId = item.id ?? (id + '-label');
 
     const multiSelectItemStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.multiSelectItem as IStyleFunctionOrObject<
@@ -881,7 +881,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
   };
 
   /** Render custom label for multiselect checkbox items */
-  private _onRenderItemLabel = (item: IDropdownOption, id: string): JSX.Element | null => {
+  private _onRenderItemLabel = (item: IDropdownOption): JSX.Element | null => {
     const { onRenderOption = this._onRenderMultiselectOption } = this.props;
     return onRenderOption(item, this._onRenderMultiselectOption);
   };

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -468,6 +468,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           }
                     >
                       <input
+                        aria-labelledby="Dropdown0-list1-label"
                         aria-posinset="1"
                         aria-selected="true"
                         aria-setsize="2"
@@ -581,25 +582,30 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             
                           </i>
                         </div>
-                        <span
-                          class=
-                              ms-Dropdown-optionText
-                              {
-                                margin-bottom: 1px;
-                                margin-left: 1px;
-                                margin-right: 1px;
-                                margin-top: 1px;
-                                max-width: 100%;
-                                min-width: 0px;
-                                overflow-wrap: break-word;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                                white-space: nowrap;
-                                word-wrap: break-word;
-                              }
+                        <div
+                          aria-hidden="true"
+                          id="Dropdown0-list1-label"
                         >
-                          1
-                        </span>
+                          <span
+                            class=
+                                ms-Dropdown-optionText
+                                {
+                                  margin-bottom: 1px;
+                                  margin-left: 1px;
+                                  margin-right: 1px;
+                                  margin-top: 1px;
+                                  max-width: 100%;
+                                  min-width: 0px;
+                                  overflow-wrap: break-word;
+                                  overflow: hidden;
+                                  text-overflow: ellipsis;
+                                  white-space: nowrap;
+                                  word-wrap: break-word;
+                                }
+                          >
+                            1
+                          </span>
+                        </div>
                       </label>
                     </div>
                     <div
@@ -714,6 +720,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                     title="test"
                   >
                     <input
+                      aria-labelledby="Dropdown0-list3-label"
                       aria-posinset="2"
                       aria-selected="false"
                       aria-setsize="2"
@@ -824,25 +831,30 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           
                         </i>
                       </div>
-                      <span
-                        class=
-                            ms-Dropdown-optionText
-                            {
-                              margin-bottom: 1px;
-                              margin-left: 1px;
-                              margin-right: 1px;
-                              margin-top: 1px;
-                              max-width: 100%;
-                              min-width: 0px;
-                              overflow-wrap: break-word;
-                              overflow: hidden;
-                              text-overflow: ellipsis;
-                              white-space: nowrap;
-                              word-wrap: break-word;
-                            }
+                      <div
+                        aria-hidden="true"
+                        id="Dropdown0-list3-label"
                       >
-                        2
-                      </span>
+                        <span
+                          class=
+                              ms-Dropdown-optionText
+                              {
+                                margin-bottom: 1px;
+                                margin-left: 1px;
+                                margin-right: 1px;
+                                margin-top: 1px;
+                                max-width: 100%;
+                                min-width: 0px;
+                                overflow-wrap: break-word;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                white-space: nowrap;
+                                word-wrap: break-word;
+                              }
+                        >
+                          2
+                        </span>
+                      </div>
                     </label>
                   </div>
                 </div>

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -582,30 +582,27 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             
                           </i>
                         </div>
-                        <div
+                        <span
                           aria-hidden="true"
+                          class=
+                              ms-Dropdown-optionText
+                              {
+                                margin-bottom: 1px;
+                                margin-left: 1px;
+                                margin-right: 1px;
+                                margin-top: 1px;
+                                max-width: 100%;
+                                min-width: 0px;
+                                overflow-wrap: break-word;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                white-space: nowrap;
+                                word-wrap: break-word;
+                              }
                           id="Dropdown0-list1-label"
                         >
-                          <span
-                            class=
-                                ms-Dropdown-optionText
-                                {
-                                  margin-bottom: 1px;
-                                  margin-left: 1px;
-                                  margin-right: 1px;
-                                  margin-top: 1px;
-                                  max-width: 100%;
-                                  min-width: 0px;
-                                  overflow-wrap: break-word;
-                                  overflow: hidden;
-                                  text-overflow: ellipsis;
-                                  white-space: nowrap;
-                                  word-wrap: break-word;
-                                }
-                          >
-                            1
-                          </span>
-                        </div>
+                          1
+                        </span>
                       </label>
                     </div>
                     <div
@@ -831,30 +828,27 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           
                         </i>
                       </div>
-                      <div
+                      <span
                         aria-hidden="true"
+                        class=
+                            ms-Dropdown-optionText
+                            {
+                              margin-bottom: 1px;
+                              margin-left: 1px;
+                              margin-right: 1px;
+                              margin-top: 1px;
+                              max-width: 100%;
+                              min-width: 0px;
+                              overflow-wrap: break-word;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              word-wrap: break-word;
+                            }
                         id="Dropdown0-list3-label"
                       >
-                        <span
-                          class=
-                              ms-Dropdown-optionText
-                              {
-                                margin-bottom: 1px;
-                                margin-left: 1px;
-                                margin-right: 1px;
-                                margin-top: 1px;
-                                max-width: 100%;
-                                min-width: 0px;
-                                overflow-wrap: break-word;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                                white-space: nowrap;
-                                word-wrap: break-word;
-                              }
-                        >
-                          2
-                        </span>
-                      </div>
+                        2
+                      </span>
                     </label>
                   </div>
                 </div>


### PR DESCRIPTION
## Previous Behavior

We have `<Checkbox>` components for the multiselect options in Dropdown & ComboBox, which use the `<input type="checkbox">` element + `<label>`, but they override the role of the input element to be `role=option`.

VoiceOver automatically combines a label + checkbox input to be a single swipe stop, but adding `role="option"` interferes with that, so it reaches the checkbox and label text separately. Normally this wouldn't be a huge issue, but since this is used within a listbox, it is expected that everything reached within the listbox will be an option, and also the announcement of options is not much different from static text. The end result is that it is easy to assume the label itself is an option, and that the ComboBox/Dropdown isn't working because the label text doesn't respond to interaction.

## New Behavior

I've hidden the label text from the accessibility tree. To do that, I needed to:
- Add an `aria-labelledby` association, since the native label + for does not continue to provide an accname if the label is hidden
- Add `aria-hidden` to a wrapper around the text provided in the `onRenderLabel` function within both components.

## Related Issue(s)

Fixes [15484](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15484)
