### PR TITLE
fix(scripts-generators): make create-component work properly on windows and improve DX

### DIFF
--- a/change/@fluentui-eslint-plugin-9c309582-f6de-425d-bc96-c927db2786da.json
+++ b/change/@fluentui-eslint-plugin-9c309582-f6de-425d-bc96-c927db2786da.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(eslint-plugin): turn off fluentui/max-lenght rule for v9",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/base.js
+++ b/packages/eslint-plugin/src/configs/base.js
@@ -13,6 +13,7 @@ module.exports = {
      * @see https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin
      */
     ...getNamingConventionRule(),
+    '@fluentui/max-len': 'off',
   },
   overrides: [
     {

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -669,7 +669,7 @@ function updatePackageJson(tree: Tree, options: NormalizedSchemaWithTsConfigs) {
     return json;
 
     function normalizePackageEntryPointPaths(entryPath: string) {
-      return './' + path.normalize(entryPath);
+      return './' + path.posix.normalize(entryPath);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`yarn create-component`

execution introduces sets package in invalid state:
- lint errors
- doesn't set export map correctly when executing on windows

## New Behavior

`yarn create-component`
- empty `export {}` is being removed on 1st `create-component` execution
- `export * from` is expanded on every `create-component` run
- `migrate-converged-pkg` properly setups export maps when invoked on windows OS
- eslint-plugin `@fluentui/max-length` rule was turned off for v9 packages (it doesn't make much sense as we have prettier that will enforce line length automatically without any churn to the user (DX)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes https://github.com/microsoft/fluentui/pull/26529/commits/08c84ee99739e969e98e352d02a08fb0c8528c53
