### PR TITLE
fix: v8 SplitButton should not reset focus to trigger after opening menu

### DIFF
--- a/change/@fluentui-react-80a116b3-6d10-4c8e-9b19-923cb424f73c.json
+++ b/change/@fluentui-react-80a116b3-6d10-4c8e-9b19-923cb424f73c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: splitbutton should not refocus trigger after touch event",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -910,7 +910,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
       // Touch and pointer events don't focus the button naturally,
       // so adding an imperative focus call to guarantee this behavior.
-      this.focus();
+      // Only focus the button if a splitbutton menu is not open
+      if (this.state.menuHidden) {
+        this.focus();
+      }
     }, TouchIdleDelay);
   }
 


### PR DESCRIPTION
## Previous Behavior

We had a timeout that set focus on the button after a touch tap. I'm not sure we actually need that, but one side effect was that for the SplitButton variant, it was re-setting focus to the trigger after the menu was opened with touch and focus set to the first item.

## New Behavior

Focus is not called on the trigger after the timeout if the menu is open.

## Related Issue(s)

* Fixes [15545](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15545)
