### PR TITLE
fix: v8 Dropdown option focus should not be cut off in HCM

### DIFF
--- a/change/@fluentui-react-94027d49-963c-4769-b134-8dc2632fe98c.json
+++ b/change/@fluentui-react-94027d49-963c-4769-b134-8dc2632fe98c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Dropdown option focus in high contrast mode should not be cut off by the popup",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -173,6 +173,9 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
           top: 0,
           bottom: 0,
           right: 0,
+          [HighContrastSelector]: {
+            inset: '2px',
+          },
         },
         [HighContrastSelector]: {
           border: 'none',
@@ -382,8 +385,8 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     dropdownItemsWrapper: { selectors: { '&:focus': { outline: 0 } } },
     dropdownItems: [globalClassnames.dropdownItems, { display: 'block' }],
     dropdownItem: [...dropdownItemStyle, itemSelectors()],
-    dropdownItemSelected: dropdownItemSelected,
-    dropdownItemDisabled: dropdownItemDisabled,
+    dropdownItemSelected,
+    dropdownItemDisabled,
     dropdownItemSelectedAndDisabled: [dropdownItemSelected, dropdownItemDisabled, { backgroundColor: 'transparent' }],
     dropdownItemHidden: [...dropdownItemStyle, { display: 'none' }],
     dropdownDivider: [globalClassnames.dropdownDivider, { height: 1, backgroundColor: semanticColors.bodyDivider }],

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -459,6 +459,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             right: 0px;
                             top: 0px;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                            inset: 2px;
+                          }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){& {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
@@ -701,6 +704,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           left: 0px;
                           right: 0px;
                           top: 0px;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                          inset: 2px;
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           border: none;
@@ -1608,6 +1614,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             bottom: -2px;
+                            inset: 2px;
                             left: -2px;
                             outline-color: ButtonText;
                             right: -2px;
@@ -1774,6 +1781,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                           bottom: -2px;
+                          inset: 2px;
                           left: -2px;
                           outline-color: ButtonText;
                           right: -2px;


### PR DESCRIPTION
## Previous Behavior

In High Contrast mode, the Button focus styles for outline offset caused it to be cut off by the edge of the Dropdown popup. The outline offset also caused the scrollbar to appear when the last option was focused. This is especially noticeable for the top/bottom options (and worse if there are only a few options in the Dropdown):
![Dropdown with the last option highlighted, only the top side of the outline is visible](https://user-images.githubusercontent.com/3819570/215919808-d250271d-136f-4c86-a3a1-368151073d26.png)

## New Behavior

Sets the outline to be inset, so it always is visible:
![Dropdown with the last option highlighted in high contrast, showing a full outline visible inside the popup](https://user-images.githubusercontent.com/3819570/215919696-ccf0e8c1-6779-4a9b-9f37-d01b36ffbb75.png)

* Fixes [15747](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15747)
