### PR TITLE
fix(ssr-tests-v9): don't open browser twice on CI to potentially mitigate TIMEOUT issues

### DIFF
--- a/apps/ssr-tests-v9/src/utils/getChromeVersion.ts
+++ b/apps/ssr-tests-v9/src/utils/getChromeVersion.ts
@@ -1,13 +1,39 @@
+import { isCI } from 'ci-info';
 import { launchBrowser } from './launchBrowser';
 
+/**
+ * https://github.com/puppeteer/puppeteer/blob/main/versions.js
+ */
+const CHROMIUM_VERSION = 'HeadlessChrome/110.0.5479.0';
+const staticVersion = normalizeChromiumVersion(CHROMIUM_VERSION);
+
 export async function getChromeVersion(): Promise<number> {
+  // this is a temporary solution to test if lanunching browser only once will mitigate TIMEOUT ISSUES ON CI
+  if (isCI) {
+    return staticVersion;
+  }
+
   const browser = await launchBrowser();
-
-  // includes browser name, example: HeadlessChrome/103.0.5058.0
-  const rawVersion = await browser.version();
-  const version = rawVersion.split('/')[1].split('.')[0];
-
+  const version = normalizeChromiumVersion(await browser.version());
   await browser.close();
 
-  return parseInt(version, 10);
+  if (version !== staticVersion) {
+    throw new Error(
+      `puppeteer uses different Chromium version!
+      puppeteer: ${version} , chromium_version constant: ${staticVersion}
+
+      Please update CHROMIUM_VERSION constant to match puppeteer installed version https://github.com/puppeteer/puppeteer/blob/main/versions.js.`,
+    );
+  }
+
+  return version;
+}
+
+/**
+ *
+ * @param value - includes browser name, example: HeadlessChrome/103.0.5058.0
+ * @returns
+ */
+function normalizeChromiumVersion(value: string) {
+  return Number(value.split('/')[1].split('.')[0]);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Most of CI failures we run into are triggered by ssr-test-v9 Timout error on browser open with puppeteer. This is temporary approach to monitor if opening it only once per pipeline for this app mitigates those intermittent errors on CI.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Follows https://github.com/microsoft/fluentui/pull/26375
