### PR TITLE
fix(public-docsite-v9): add migration packages as dependency to properly build when releasing

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -22,7 +22,8 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/fluent2-theme": "^8.104.15",
+    "@fluentui/react-migration-v8-v9": "^9.1.1",
+    "@fluentui/react-migration-v0-v9": "9.0.0-alpha.0",
     "@fluentui/react": "^8.105.1",
     "@fluentui/react-northstar": "^0.66.0",
     "@fluentui/react-icons-northstar": "^0.66.0",


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

docsite release fails because migration packages are not build (lage wont run those because they are not specified as dependencies

## New Behavior

docsite have properly defined dependencies so release will succeed

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Follows https://github.com/microsoft/fluentui/pull/26571
