### PR TITLE
remove mwf styles

### DIFF
--- a/apps/public-docsite/src/root.tsx
+++ b/apps/public-docsite/src/root.tsx
@@ -9,6 +9,13 @@ import { androidLogo, appleLogo, webLogo, macLogo, windowsLogo, crossPlatformLog
 
 // TODO: handle redirects
 
+// Remove MWF stylesheet as it is unused by the site and causes conflicts with our styles
+for (const tag of Array.from(document.getElementsByTagName('link'))) {
+  if (tag.href.includes('mwf-main')) {
+    tag.remove();
+  }
+}
+
 initializeFileTypeIcons(cdnUrl + '/assets/item-types/');
 
 setRTL(false);

--- a/change/@fluentui-public-docsite-setup-f65ab594-9c63-4e06-b925-0110463f3c03.json
+++ b/change/@fluentui-public-docsite-setup-f65ab594-9c63-4e06-b925-0110463f3c03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove mwf styles causing conflicts with react components",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/public-docsite-setup/index.html
+++ b/packages/public-docsite-setup/index.html
@@ -8,6 +8,12 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" user-scalable="no" />
+    <!-- replicate the MWF styles being added to the live header -->
+    <link
+      href="https://mwf-service.akamaized.net/mwf/css/bundle/1.58.2/west-european/default/mwf-main.min.css"
+      rel="stylesheet"
+      type="text/css"
+    />
     <title>Fluent UI</title>
     <link
       href="https://devofficecdn.azureedge.net/themes/DevOffice/Content/favicon.ico"


### PR DESCRIPTION
MWF styles have always caused clashes with our control styles, and after finding a clash that was nearly impossible to fix, we decided to try removing it completely from the site, as it appears to not be used by any of the site chrome.