### PR TITLE
fix(createPositionManager): computePosition should not apply styles after destruction

### DIFF
--- a/change/@fluentui-react-positioning-4bd82184-0e7b-46e8-a681-c87900b25568.json
+++ b/change/@fluentui-react-positioning-4bd82184-0e7b-46e8-a681-c87900b25568.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(createPositinoManager): computePosition should not apply styles after destruction",
+  "comment": "fix(createPositionManager): computePosition should not apply styles after destruction",
   "packageName": "@fluentui/react-positioning",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-positioning-4bd82184-0e7b-46e8-a681-c87900b25568.json
+++ b/change/@fluentui-react-positioning-4bd82184-0e7b-46e8-a681-c87900b25568.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(createPositinoManager): computePosition should not apply styles after destruction",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -37,7 +37,7 @@ interface PositionManagerOptions {
  */
 export function createPositionManager(options: PositionManagerOptions): PositionManager {
   const { container, target, arrow, strategy, middleware, placement } = options;
-  let destroyed = false;
+  const isDestroyed = false;
   if (!target || !container) {
     return {
       updatePosition: () => undefined,
@@ -56,7 +56,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
   const forceUpdate = () => {
     // debounced update can still occur afterwards
     // early return to avoid memory leaks
-    if (destroyed) {
+    if (isDestroyed) {
       return;
     }
 
@@ -78,7 +78,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
       .then(({ x, y, middlewareData, placement: computedPlacement }) => {
         // Promise can still resolve after destruction
         // early return to avoid applying outdated position
-        if (destroyed) {
+        if (isDestroyed) {
           return;
         }
 

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -37,6 +37,7 @@ interface PositionManagerOptions {
  */
 export function createPositionManager(options: PositionManagerOptions): PositionManager {
   const { container, target, arrow, strategy, middleware, placement } = options;
+  let destroyed = false;
   if (!target || !container) {
     return {
       updatePosition: () => undefined,
@@ -52,7 +53,13 @@ export function createPositionManager(options: PositionManagerOptions): Position
   // Without this scroll jumps can occur when the element is rendered initially and receives focus
   Object.assign(container.style, { position: 'fixed', left: 0, top: 0, margin: 0 });
 
-  let forceUpdate = () => {
+  const forceUpdate = () => {
+    // debounced update can still occur afterwards
+    // early return to avoid memory leaks
+    if (destroyed) {
+      return;
+    }
+
     if (isFirstUpdate) {
       scrollParents.add(getScrollParent(container));
       if (target instanceof HTMLElement) {
@@ -69,6 +76,12 @@ export function createPositionManager(options: PositionManagerOptions): Position
     Object.assign(container.style, { position: strategy });
     computePosition(target, container, { placement, middleware, strategy })
       .then(({ x, y, middlewareData, placement: computedPlacement }) => {
+        // Promise can still resolve after destruction
+        // early return to avoid applying outdated position
+        if (destroyed) {
+          return;
+        }
+
         writeArrowUpdates({ arrow, middlewareData });
         writeContainerUpdates({
           container,
@@ -97,9 +110,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
   const updatePosition = debounce(() => forceUpdate());
 
   const dispose = () => {
-    // debounced update can still occur afterwards
-    // so destroy the reference to forceUpdate
-    forceUpdate = () => null;
+    destroyed = true;
 
     if (targetWindow) {
       targetWindow.removeEventListener('scroll', updatePosition);

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -110,7 +110,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
   const updatePosition = debounce(() => forceUpdate());
 
   const dispose = () => {
-    destroyed = true;
+    isDestroyed = true;
 
     if (targetWindow) {
       targetWindow.removeEventListener('scroll', updatePosition);

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -37,7 +37,7 @@ interface PositionManagerOptions {
  */
 export function createPositionManager(options: PositionManagerOptions): PositionManager {
   const { container, target, arrow, strategy, middleware, placement } = options;
-  const isDestroyed = false;
+  let isDestroyed = false;
   if (!target || !container) {
     return {
       updatePosition: () => undefined,


### PR DESCRIPTION
Since `computePosition` is an async function, it can still resolve after the instance is destroyed.

Updates the destruction mechanism to have a [flag similar to poppver v2](https://github.com/floating-ui/floating-ui/blob/2893e9a8d2ebd895eb4311a8873afac62f75123e/src/createPopper.js#L171). This flag is used both on `forceUpdate` (to avoid memory leaks) and `computePosition` (to avoid applying outdated position).