### PR TITLE
chore(react-infobutton): Making InfoButton's content focusable and update example's text

### DIFF
--- a/change/@fluentui-react-infobutton-69f14ed0-88e3-4612-94cb-3734976c0c7e.json
+++ b/change/@fluentui-react-infobutton-69f14ed0-88e3-4612-94cb-3734976c0c7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Making the content focusable and updating example's text.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
@@ -58,6 +58,7 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
       required: true,
       defaultProps: {
         role: 'note',
+        tabIndex: -1,
       },
     }),
   };

--- a/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonWithLabel.stories.tsx
+++ b/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonWithLabel.stories.tsx
@@ -31,7 +31,7 @@ export const InfoButtonWithLabel = () => {
         <InfoButton
           id={infoButtonId}
           aria-labelledby={`${labelId} ${infoButtonId}`}
-          content="Your username should have at least 6 characters."
+          content="Usernames offer a unique way to identify you and keep your account secure."
         />
       </div>
       <Input id={inputId} placeholder="Username" />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

InfoButton's content was not focused when opened, this forced screen reader users to go through 2 more steps to get to content.

## New Behavior

InfoButton's content is now focused when opened (it doesn't trap focus) so screen reader users are able to go through the text right away.

InfoButton with label example was also updated to have a more useful text.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Related #26427 
