### PR TITLE
fix: react-button high contrast mode primary variant

### DIFF
--- a/change/@fluentui-react-button-6070b42d-35c8-4c8a-b515-e0893216885b.json
+++ b/change/@fluentui-react-button-6070b42d-35c8-4c8a-b515-e0893216885b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add forced-colors primary button variant",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -161,6 +161,25 @@ const useRootStyles = makeStyles({
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForegroundOnBrand,
     },
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight',
+      ...shorthands.borderColor('HighlightText'),
+      color: 'HighlightText',
+      forcedColorAdjust: 'none',
+
+      ':hover': {
+        backgroundColor: 'HighlightText',
+        ...shorthands.borderColor('Highlight'),
+        color: 'Highlight',
+      },
+
+      ':hover:active': {
+        backgroundColor: 'HighlightText',
+        ...shorthands.borderColor('Highlight'),
+        color: 'Highlight',
+      },
+    },
   },
   secondary: {
     /* The secondary styles are exactly the same as the base styles. */
@@ -296,6 +315,7 @@ const useRootDisabledStyles = makeStyles({
   // High contrast styles
   highContrast: {
     '@media (forced-colors: active)': {
+      backgroundColor: 'ButtonFace',
       ...shorthands.borderColor('GrayText'),
       color: 'GrayText',
 
@@ -304,11 +324,13 @@ const useRootDisabledStyles = makeStyles({
       },
 
       ':hover': {
+        backgroundColor: 'ButtonFace',
         ...shorthands.borderColor('GrayText'),
         color: 'GrayText',
       },
 
       ':hover:active': {
+        backgroundColor: 'ButtonFace',
         ...shorthands.borderColor('GrayText'),
         color: 'GrayText',
       },

--- a/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.ts
@@ -70,6 +70,12 @@ const useRootStyles = makeStyles({
         color: tokens.colorNeutralForegroundOnBrand,
       },
     },
+
+    '@media (forced-colors: active)': {
+      [`& .${compoundButtonClassNames.secondaryContent}`]: {
+        color: 'HighlightText',
+      },
+    },
   },
   secondary: {
     /* The secondary styles are exactly the same as the base styles. */

--- a/packages/react-components/react-button/src/components/SplitButton/useSplitButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/SplitButton/useSplitButtonStyles.ts
@@ -64,6 +64,24 @@ const useRootStyles = makeStyles({
         borderRightColor: tokens.colorNeutralForegroundOnBrand,
       },
     },
+
+    '@media (forced-colors: active)': {
+      [`& .${splitButtonClassNames.primaryActionButton}`]: {
+        borderRightColor: 'HighlightText',
+      },
+
+      ':hover': {
+        [`& .${splitButtonClassNames.primaryActionButton}`]: {
+          borderRightColor: 'Highlight',
+        },
+      },
+
+      ':hover:active': {
+        [`& .${splitButtonClassNames.primaryActionButton}`]: {
+          borderRightColor: 'Highlight',
+        },
+      },
+    },
   },
   secondary: {
     /* The secondary styles are exactly the same as the base styles. */

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -217,15 +217,44 @@ const useIconCheckedStyles = makeStyles({
   },
 });
 
+const usePrimaryHighContrastStyles = makeStyles({
+  // Do not use primary variant high contrast styles for toggle buttons
+  // otherwise there isn't enough difference between on/off states
+  base: {
+    '@media (forced-colors: active)': {
+      backgroundColor: 'ButtonFace',
+      ...shorthands.borderColor('ButtonBorder'),
+      color: 'ButtonText',
+      forcedColorAdjust: 'auto',
+    },
+  },
+
+  disabled: {
+    '@media (forced-colors: active)': {
+      ...shorthands.borderColor('GrayText'),
+      color: 'GrayText',
+
+      ':focus': {
+        ...shorthands.borderColor('GrayText'),
+      },
+    },
+  },
+});
+
 export const useToggleButtonStyles_unstable = (state: ToggleButtonState): ToggleButtonState => {
   const rootCheckedStyles = useRootCheckedStyles();
   const rootDisabledStyles = useRootDisabledStyles();
   const iconCheckedStyles = useIconCheckedStyles();
+  const primaryHighContrastStyles = usePrimaryHighContrastStyles();
 
   const { appearance, checked, disabled, disabledFocusable } = state;
 
   state.root.className = mergeClasses(
     toggleButtonClassNames.root,
+
+    // Primary high contrast styles
+    appearance === 'primary' && primaryHighContrastStyles.base,
+    appearance === 'primary' && (disabled || disabledFocusable) && primaryHighContrastStyles.disabled,
 
     // Checked styles
     checked && rootCheckedStyles.base,


### PR DESCRIPTION
## Previous Behavior

In HCM, we rendered all style variants with the same colors, including the primary button.

![screenshot of all button variants in a dark forced colors theme, showing them all with a dark button face and light text](https://user-images.githubusercontent.com/3819570/216491092-db057737-2fa5-474a-8a70-ae0406b1cba3.png)

## New Behavior

The primary button now has its own high contrast mode variant, using Highlight and HighlightText. The one exception is ToggleButton, where the primary variant stays the same as all other variants, so that the on/off states have enough of a distinction.

![screenshot of the same button variants in high contrast, but the primary button is dark text on a light background](https://user-images.githubusercontent.com/3819570/216491428-a57a9c25-da7b-4cf8-8ad1-a4e28e3032bf.png)

The PR includes tweaks for the new primary style for CompoundButton and SplitButton.

## Related Issue(s)

Fixes #26063
