### PR TITLE
fix: v8 HoverCard example adjusts to viewport, add a11y info to docs

### DIFF
--- a/packages/react-examples/src/react/HoverCard/HoverCard.Target.Example.tsx
+++ b/packages/react-examples/src/react/HoverCard/HoverCard.Target.Example.tsx
@@ -73,6 +73,7 @@ const KeyCellWithHoverCard: React.FunctionComponent<{ item: IExampleItem }> = ({
     onRenderExpandedCard,
     renderData: item,
     directionalHint: DirectionalHint.rightTopEdge,
+    directionalHintFixed: false,
     gapSpace: 16,
     calloutProps: {
       isBeakVisible: true,

--- a/packages/react-examples/src/react/HoverCard/docs/HoverCardBestPractices.md
+++ b/packages/react-examples/src/react/HoverCard/docs/HoverCardBestPractices.md
@@ -1,4 +1,10 @@
 ### Layout
 
+- Hover cards, particularly expanding hover cards, are not well suited to small display sizes. It is best to only display the hover card on larger viewports.
 - Hover cards contain both compact and expanded states, with the compact state appearing after 500 milliseconds and the expanded state appearing as the user continues to hover after 1500 milliseconds.
 - The hover card positions itself automatically, depending upon where the target is on the viewport. Position the target so the card doesn’t obstruct inline commanding on the item.
+- When setting an explicit `directionalHint`, the hover card will not automatically adjust position based on screen availability unless `directionalHintFixed: false` is explicitly set.
+
+### Accessibility
+
+Hover cards are not accessible to anyone not using a mouse with hover capability. It is strongly suggested that any information or functionality available in the hover card is also easily accessible through another means. An example is using a hover card to preview page content on a link, where the content can also be accessed by following the link.


### PR DESCRIPTION
Examples & docs only, no changes to the components

## Previous Behavior

HoverCard defaults `directionalHintFixed` to `true`, which means if `directionalHint` is set, it will not adjust based on available space in the viewport. This only affects one example, the expanding HoverCard + target.

## New Behavior

This PR explicitly sets `directionalHintFixed: false` in that example. I'm guessing there was a specific reason to pin cards to a position by default, so it seemed safer to avoid changing the default behavior, particularly in a specalized-use-case control.

I also added more documentation around both `directionalHintFixed`, and the ways in which HoverCard should not be considered an accessible mode of accessing content when used in isolation.

## Related Issue(s)

Fixes [15357](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15357)
