### PR TITLE
fix: Remove ReallyClean from CI pipelines

### DIFF
--- a/.devops/templates/cleanup.yml
+++ b/.devops/templates/cleanup.yml
@@ -12,7 +12,7 @@ steps:
   # In theory the "workspace: clean: all" setting should handle this, but it doesn't always seem to work.
   # ReallyClean is a custom task from our internal UI Fabric azure-devops-tasks repo which attempts to
   # delete the given directory with multiple retries.
-  - task: ReallyClean@0
-    inputs:
-      directory: $(Agent.BuildDirectory)
-    condition: always()
+  # - task: ReallyClean@0
+  #   inputs:
+  #     directory: $(Agent.BuildDirectory)
+  #   condition: always()


### PR DESCRIPTION
Since component governance is forced, we should disable this step since it will remove all files from the working directory and fail component governance

