### PR TITLE
fix: Using correct icon and color for away + out-of-office PresenceBadge

### DIFF
--- a/change/@fluentui-react-badge-1d02e00e-35d1-4d9a-8f0e-9a522c35bd8d.json
+++ b/change/@fluentui-react-badge-1d02e00e-35d1-4d9a-8f0e-9a522c35bd8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Using correct icon and color for away + out-of-office PresenceBadge.",
+  "packageName": "@fluentui/react-badge",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -20,7 +20,7 @@ const iconMap = (status: PresenceBadgeState['status'], outOfOffice: boolean, siz
     case 'available':
       return outOfOffice ? presenceAvailableRegular[size] : presenceAvailableFilled[size];
     case 'away':
-      return outOfOffice ? presenceOfflineRegular[size] : presenceAwayFilled[size];
+      return outOfOffice ? presenceOofRegular[size] : presenceAwayFilled[size];
     case 'blocked':
       return presenceBlockedRegular[size];
     case 'busy':

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -56,7 +56,7 @@ const useStyles = makeStyles({
     color: tokens.colorPaletteRedBackground3,
   },
   outOfOfficeAway: {
-    color: tokens.colorPaletteMarigoldBackground3,
+    color: tokens.colorPaletteBerryForeground3,
   },
 
   // Icons are not resizeable, and these sizes are currently missing

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -55,9 +55,6 @@ const useStyles = makeStyles({
   outOfOfficeBusy: {
     color: tokens.colorPaletteRedBackground3,
   },
-  outOfOfficeAway: {
-    color: tokens.colorPaletteBerryForeground3,
-  },
 
   // Icons are not resizeable, and these sizes are currently missing
   // use `!important` to size the currently available icons to the missing ones
@@ -105,7 +102,7 @@ export const usePresenceBadgeStyles_unstable = (state: PresenceBadgeState): Pres
     state.outOfOffice && styles.outOfOffice,
     state.outOfOffice && state.status === 'available' && styles.outOfOfficeAvailable,
     state.outOfOffice && isBusy && styles.outOfOfficeBusy,
-    state.outOfOffice && state.status === 'away' && styles.outOfOfficeAway,
+    state.outOfOffice && state.status === 'away' && styles.statusOutOfOffice,
     state.outOfOffice && state.status === 'offline' && styles.statusOffline,
     state.outOfOffice && state.status === 'out-of-office' && styles.statusOutOfOffice,
     state.size === 'tiny' && styles.tiny,


### PR DESCRIPTION
## Previous Behavior

The `PresenceBadge` with `status="away"` and `outOfOffice={true}` is showing the wrong icon + color. According to the design specification it should have the same icon + color as the `status="outOfOffice"` `PresenceBadge`.

![image](https://user-images.githubusercontent.com/7798177/216730985-d391fcb6-b314-4c58-b386-ee799d7bcc1d.png)

## New Behavior

The `PresenceBadge` with `status="away"` and `outOfOffice={true}` is now showing the correct icon + color.

![image](https://user-images.githubusercontent.com/7798177/216731060-cba6cc97-4fce-4450-b46b-0ee74b31d2f0.png)

## Related Issue(s)

* Fixes part of #26036
