### PR TITLE
removed disabled property from Label

### DIFF
--- a/packages/react-components/react-input/stories/Input/InputDisabled.stories.tsx
+++ b/packages/react-components/react-input/stories/Input/InputDisabled.stories.tsx
@@ -19,9 +19,7 @@ export const Disabled = () => {
 
   return (
     <div className={styles.root}>
-      <Label disabled htmlFor={inputId}>
-        Disabled input
-      </Label>
+      <Label htmlFor={inputId}>Disabled input</Label>
       <Input disabled id={inputId} defaultValue="disabled value" />
     </div>
   );

--- a/packages/react-components/react-radio/stories/RadioGroup/RadioGroupDisabled.stories.tsx
+++ b/packages/react-components/react-radio/stories/RadioGroup/RadioGroupDisabled.stories.tsx
@@ -13,9 +13,7 @@ export const Disabled = () => {
   const labelId = useId('label');
   return (
     <div className={styles.field}>
-      <Label id={labelId} disabled>
-        Favorite Fruit
-      </Label>
+      <Label id={labelId}>Favorite Fruit</Label>
       <RadioGroup defaultValue="apple" disabled aria-labelledby={labelId}>
         <Radio value="apple" label="Apple" />
         <Radio value="pear" label="Pear" />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
Disabled stories for Input and RadioGroup had Label also set as disabled

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Disabled stories for Input and RadioGroup had don't have Label set as disabled

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26507
