### PR TITLE
Menu: added unstable_disableAutoFocus

### DIFF
--- a/change/@fluentui-react-menu-32068a02-9198-4d93-b404-808eb10a740b.json
+++ b/change/@fluentui-react-menu-32068a02-9198-4d93-b404-808eb10a740b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "added unstable_disableAutoFocus to Menu to control first focusable element behavior on open",
+  "packageName": "@fluentui/react-menu",
+  "email": "kakrookaran@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -297,6 +297,7 @@ export type MenuProps = ComponentProps<MenuSlots> & Pick<MenuListProps, 'checked
     persistOnItemClick?: boolean;
     positioning?: PositioningShorthand;
     closeOnScroll?: boolean;
+    unstable_disableAutoFocus?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.types.ts
@@ -86,6 +86,14 @@ export type MenuProps = ComponentProps<MenuSlots> &
      * @default false
      */
     closeOnScroll?: boolean;
+    /**
+     * By default Menu focuses it's first focusable element on open.
+     * Specify `disableAutoFocus` to prevent this behavior.
+     *
+     * @default false
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    unstable_disableAutoFocus?: boolean;
   };
 
 export type MenuState = ComponentState<MenuSlots> &

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -35,6 +35,8 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     persistOnItemClick = false,
     openOnHover = isSubmenu,
     defaultCheckedValues,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    unstable_disableAutoFocus = false,
   } = props;
   const triggerId = useId('menu');
   const [contextTarget, setContextTarget] = usePositioningMouseTarget();
@@ -83,6 +85,8 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     defaultOpen: props.defaultOpen,
     onOpenChange: props.onOpenChange,
     openOnContext,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    unstable_disableAutoFocus,
   });
 
   const [checkedValues, onCheckedValueChange] = useMenuSelectableState({
@@ -151,7 +155,7 @@ const useMenuOpenState = (
     | 'closeOnScroll'
     | 'hoverDelay'
   > &
-    Pick<MenuProps, 'open' | 'defaultOpen' | 'onOpenChange'>,
+    Pick<MenuProps, 'open' | 'defaultOpen' | 'onOpenChange' | 'unstable_disableAutoFocus'>,
 ) => {
   const { targetDocument } = useFluent();
   const parentSetOpen = useMenuContext_unstable(context => context.setOpen);
@@ -258,6 +262,9 @@ const useMenuOpenState = (
   }, [findFirstFocusable, state.menuPopoverRef]);
 
   React.useEffect(() => {
+    if (state.unstable_disableAutoFocus) {
+      return;
+    }
     if (open) {
       focusFirst();
     } else {
@@ -273,7 +280,7 @@ const useMenuOpenState = (
     }
 
     shouldHandleCloseRef.current = false;
-  }, [state.triggerRef, state.isSubmenu, open, focusFirst]);
+  }, [state.triggerRef, state.isSubmenu, open, focusFirst, state.unstable_disableAutoFocus]);
 
   return [open, setOpen] as const;
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
By default `Menu` focuses its first focusable element on open. 
If we added a tooltip on the first `MenuItem` of a `Menu` it would open as soon as the `Menu` is opened.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Added `unstable_disableAutoFocus` which prevents the behavior of `Menu` from focusing its first focusable element on open. 
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


* Fixes #26575
