### PR TITLE
Better documentation for SpinButton home/end behavior

### DIFF
--- a/change/@fluentui-react-spinbutton-650c02b2-0132-46f6-8f55-dfbd03eaaa65.json
+++ b/change/@fluentui-react-spinbutton-650c02b2-0132-46f6-8f55-dfbd03eaaa65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: improve SpinButton documentation for home/end hotkeys",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SpinButton } from './SpinButton';
 import { isConformant } from '../../testing/isConformant';
-import * as Keys from '@fluentui/keyboard-keys';
+import { ArrowUp, ArrowDown, End, Escape, Home, PageDown, PageUp } from '@fluentui/keyboard-keys';
 
 const getSpinButtonInput = (): HTMLInputElement => {
   return screen.getByRole('spinbutton') as HTMLInputElement;
@@ -206,6 +206,80 @@ describe('SpinButton', () => {
       userEvent.click(decrementButton);
       expect(onChange.mock.calls[1][1]).toEqual({ value: 0, displayValue: undefined });
     });
+
+    it('sets the value to min when "Home" is pressed when uncontrolled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton defaultValue={5} min={0} max={10} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      fireEvent.keyDown(spinButton, { key: Home });
+      expect(onChange.mock.calls[0][1]).toEqual({ value: 0, displayValue: undefined });
+      expect(spinButton.value).toEqual('0');
+    });
+
+    it('sets the value to min when "Home" is pressed when controlled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton value={5} min={0} max={10} onChange={onChange} />);
+
+      fireEvent.keyDown(getSpinButtonInput(), { key: Home });
+      expect(onChange.mock.calls[0][1]).toEqual({ value: 0, displayValue: undefined });
+    });
+
+    it('does not change the value when "Home" is pressed if no min value is set when uncontrolled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton defaultValue={5} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      fireEvent.keyDown(spinButton, { key: Home });
+      expect(onChange).toHaveBeenCalledTimes(0);
+      expect(spinButton.value).toEqual('5');
+    });
+
+    it('does not change the value when "Home" is pressed if no min value is set when controlled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton value={5} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      fireEvent.keyDown(spinButton, { key: Home });
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
+
+    it('sets the value to max when "End" is pressed when uncontrolled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton defaultValue={5} min={0} max={10} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      fireEvent.keyDown(spinButton, { key: End });
+      expect(onChange.mock.calls[0][1]).toEqual({ value: 10, displayValue: undefined });
+      expect(spinButton.value).toEqual('10');
+    });
+
+    it('sets the value to max when "End" is pressed when controlled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton value={5} min={0} max={10} onChange={onChange} />);
+
+      fireEvent.keyDown(getSpinButtonInput(), { key: End });
+      expect(onChange.mock.calls[0][1]).toEqual({ value: 10, displayValue: undefined });
+    });
+
+    it('does not change the value when "End" is pressed if no max value is set when uncontrolled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton defaultValue={5} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      fireEvent.keyDown(spinButton, { key: End });
+      expect(onChange).toHaveBeenCalledTimes(0);
+      expect(spinButton.value).toEqual('5');
+    });
+
+    it('does not change the value when "End" is pressed if no max value is set when controlled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton value={5} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      fireEvent.keyDown(spinButton, { key: End });
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('value updates', () => {
@@ -304,12 +378,12 @@ describe('SpinButton', () => {
       render(<SpinButton defaultValue={2} onChange={onChange} />);
 
       const spinButton = getSpinButtonInput();
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 3, displayValue: undefined });
       expect(spinButton.value).toEqual('3');
 
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowDown });
+      fireEvent.keyDown(spinButton, { key: ArrowDown });
 
       expect(onChange.mock.calls[1][1]).toEqual({ value: 2, displayValue: undefined });
       expect(spinButton.value).toEqual('2');
@@ -322,12 +396,12 @@ describe('SpinButton', () => {
       const { rerender } = render(<SpinButton value={2} onChange={onChange} />);
 
       const spinButton = getSpinButtonInput();
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 3, displayValue: undefined });
 
       rerender(<SpinButton value={3} onChange={onChange} />);
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowDown });
+      fireEvent.keyDown(spinButton, { key: ArrowDown });
 
       expect(onChange.mock.calls[1][1]).toEqual({ value: 2, displayValue: undefined });
 
@@ -339,12 +413,12 @@ describe('SpinButton', () => {
       render(<SpinButton defaultValue={2} stepPage={10} onChange={onChange} />);
 
       const spinButton = getSpinButtonInput();
-      fireEvent.keyDown(spinButton, { key: Keys.PageUp });
+      fireEvent.keyDown(spinButton, { key: PageUp });
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 12, displayValue: undefined });
       expect(spinButton.value).toEqual('12');
 
-      fireEvent.keyDown(spinButton, { key: Keys.PageDown });
+      fireEvent.keyDown(spinButton, { key: PageDown });
 
       expect(onChange.mock.calls[1][1]).toEqual({ value: 2, displayValue: undefined });
       expect(spinButton.value).toEqual('2');
@@ -357,12 +431,12 @@ describe('SpinButton', () => {
       const { rerender } = render(<SpinButton value={2} stepPage={10} onChange={onChange} />);
 
       const spinButton = getSpinButtonInput();
-      fireEvent.keyDown(spinButton, { key: Keys.PageUp });
+      fireEvent.keyDown(spinButton, { key: PageUp });
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 12, displayValue: undefined });
 
       rerender(<SpinButton value={12} step={2} stepPage={10} onChange={onChange} />);
-      fireEvent.keyDown(spinButton, { key: Keys.PageDown });
+      fireEvent.keyDown(spinButton, { key: PageDown });
 
       expect(onChange.mock.calls[1][1]).toEqual({ value: 2, displayValue: undefined });
 
@@ -382,9 +456,9 @@ describe('SpinButton', () => {
       userEvent.click(decrementButton);
       // Already at min bound, no change
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowDown });
+      fireEvent.keyDown(spinButton, { key: ArrowDown });
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.keyDown(spinButton, { key: Keys.PageDown });
+      fireEvent.keyDown(spinButton, { key: PageDown });
       expect(onChange).not.toHaveBeenCalled();
 
       userEvent.click(incrementButton);
@@ -394,9 +468,9 @@ describe('SpinButton', () => {
       userEvent.click(incrementButton);
       // At max bound, no change
       expect(onChange).toHaveBeenCalledTimes(1);
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
       expect(onChange).toHaveBeenCalledTimes(1);
-      fireEvent.keyDown(spinButton, { key: Keys.PageUp });
+      fireEvent.keyDown(spinButton, { key: PageUp });
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
@@ -411,9 +485,9 @@ describe('SpinButton', () => {
       userEvent.click(decrementButton);
       // Already at min bound, no change
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowDown });
+      fireEvent.keyDown(spinButton, { key: ArrowDown });
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.keyDown(spinButton, { key: Keys.PageDown });
+      fireEvent.keyDown(spinButton, { key: PageDown });
       expect(onChange).not.toHaveBeenCalled();
 
       rerender(<SpinButton value={1} min={0} max={1} onChange={onChange} />);
@@ -421,9 +495,9 @@ describe('SpinButton', () => {
       userEvent.click(incrementButton);
       // Already at maz bound, no change
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.keyDown(spinButton, { key: Keys.PageUp });
+      fireEvent.keyDown(spinButton, { key: PageUp });
       expect(onChange).not.toHaveBeenCalled();
     });
 
@@ -638,7 +712,7 @@ describe('SpinButton', () => {
 
       expect(spinButton.value).toEqual('123');
 
-      fireEvent.keyDown(spinButton, { key: Keys.Escape });
+      fireEvent.keyDown(spinButton, { key: Escape });
 
       expect(spinButton.value).toEqual('1');
       expect(onChange).not.toHaveBeenCalled();
@@ -657,12 +731,12 @@ describe('SpinButton', () => {
       userEvent.type(spinButton, '23');
       expect(spinButton.value).toEqual('123');
 
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
       expect(spinButton.value).toEqual('124');
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 124, displayValue: undefined });
 
-      fireEvent.keyDown(spinButton, { key: Keys.PageUp });
+      fireEvent.keyDown(spinButton, { key: PageUp });
       expect(spinButton.value).toEqual('126');
 
       expect(onChange.mock.calls[1][1]).toEqual({ value: 126, displayValue: undefined });
@@ -676,13 +750,13 @@ describe('SpinButton', () => {
       userEvent.type(spinButton, '23');
       expect(spinButton.value).toEqual('123');
 
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowDown });
+      fireEvent.keyDown(spinButton, { key: ArrowDown });
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 122, displayValue: undefined });
 
       rerender(<SpinButton value={122} stepPage={2} onChange={onChange} />);
 
-      fireEvent.keyDown(spinButton, { key: Keys.PageDown });
+      fireEvent.keyDown(spinButton, { key: PageDown });
 
       expect(onChange.mock.calls[1][1]).toEqual({ value: 120, displayValue: undefined });
     });
@@ -695,7 +769,7 @@ describe('SpinButton', () => {
       userEvent.type(spinButton, '{backspace}kittens');
       expect(spinButton.value).toEqual('kittens');
 
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
       expect(spinButton.value).toEqual('2');
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 2, displayValue: undefined });
@@ -709,7 +783,7 @@ describe('SpinButton', () => {
       userEvent.type(spinButton, '{backspace}kittens');
       expect(spinButton.value).toEqual('kittens');
 
-      fireEvent.keyDown(spinButton, { key: Keys.ArrowUp });
+      fireEvent.keyDown(spinButton, { key: ArrowUp });
 
       expect(onChange.mock.calls[0][1]).toEqual({ value: 2, displayValue: undefined });
     });

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -6,7 +6,7 @@ import {
   useControllableState,
   useTimeout,
 } from '@fluentui/react-utilities';
-import * as Keys from '@fluentui/keyboard-keys';
+import { ArrowUp, ArrowDown, End, Enter, Escape, Home, PageDown, PageUp } from '@fluentui/keyboard-keys';
 import {
   SpinButtonProps,
   SpinButtonState,
@@ -174,30 +174,30 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     let nextKeyboardSpinState: SpinButtonSpinState = 'rest';
 
-    if (e.key === Keys.ArrowUp) {
+    if (e.key === ArrowUp) {
       stepValue(e, 'up', textValue);
       nextKeyboardSpinState = 'up';
-    } else if (e.key === Keys.ArrowDown) {
+    } else if (e.key === ArrowDown) {
       stepValue(e, 'down', textValue);
       nextKeyboardSpinState = 'down';
-    } else if (e.key === Keys.PageUp) {
+    } else if (e.key === PageUp) {
       e.preventDefault();
       stepValue(e, 'upPage', textValue);
       nextKeyboardSpinState = 'up';
-    } else if (e.key === Keys.PageDown) {
+    } else if (e.key === PageDown) {
       e.preventDefault();
       stepValue(e, 'downPage', textValue);
       nextKeyboardSpinState = 'down';
-    } else if (!e.shiftKey && e.key === Keys.Home && min !== undefined) {
+    } else if (!e.shiftKey && e.key === Home && min !== undefined) {
       commit(e, min);
       nextKeyboardSpinState = 'down';
-    } else if (!e.shiftKey && e.key === Keys.End && max !== undefined) {
+    } else if (!e.shiftKey && e.key === End && max !== undefined) {
       commit(e, max);
       nextKeyboardSpinState = 'up';
-    } else if (e.key === Keys.Enter) {
+    } else if (e.key === Enter) {
       commit(e, currentValue, textValue);
       internalState.current.previousTextValue = undefined;
-    } else if (e.key === Keys.Escape) {
+    } else if (e.key === Escape) {
       if (internalState.current.previousTextValue) {
         setTextValue(undefined);
         internalState.current.previousTextValue = undefined;

--- a/packages/react-components/react-spinbutton/stories/SpinButton/SpinButtonBounds.stories.tsx
+++ b/packages/react-components/react-spinbutton/stories/SpinButton/SpinButtonBounds.stories.tsx
@@ -32,7 +32,8 @@ Bounds.parameters = {
       story: `SpinButton can be bounded with the \`min\` and \`max\` props.
       Using the spin buttons or hotkeys will clamp values in the range of [min, max].
       Users may type a value outside the range into the text input and it will not be clamped
-      by the control.`,
+      by the control. Pressing the "home" key will set the value to \`min\` and pressing the "end"
+      key will set the value to \`max\` when the props are set.`,
     },
   },
 };

--- a/packages/react-components/react-spinbutton/stories/SpinButton/SpinButtonDefault.stories.tsx
+++ b/packages/react-components/react-spinbutton/stories/SpinButton/SpinButtonDefault.stories.tsx
@@ -20,7 +20,7 @@ export const Default = () => {
   return (
     <div className={layoutStyles.base}>
       <Label htmlFor={id}>Default SpinButton</Label>
-      <SpinButton defaultValue={10} id={id} />
+      <SpinButton defaultValue={10} min={0} max={20} id={id} />
     </div>
   );
 };


### PR DESCRIPTION
## Previous Behavior

`SpinButton` supported home and end hotkeys but lacked tests for this behavior and didn't clearly document it in user-facing documentation.

## New Behavior

- Adds test cases for home/end hotkeys
- Updates "bounds" story with information about home/end
- Updates "default" story to include min/max props so home/end behavior is observable
- Changes the "keys" import for better tree-shaking

## Related Issue(s)

* Fixes #26539
