### PR TITLE
Coachmark reposition on page resize 

### DIFF
--- a/change/@fluentui-react-92e3b62a-42e0-401c-be50-be5ee1c7240e.json
+++ b/change/@fluentui-react-92e3b62a-42e0-401c-be50-be5ee1c7240e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Coachmark: re-render and re-calculate bounds when page resizes",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/react/src/components/Coachmark/Coachmark.base.tsx
@@ -467,6 +467,16 @@ export const CoachmarkBase: React.FunctionComponent<ICoachmarkProps> = React.for
 
   const finalHeight: number | undefined = isCollapsed ? COACHMARK_HEIGHT : entityInnerHostRect.height;
 
+  function useGetBounds(): IRectangle | undefined {
+    const async = useAsync();
+    const [bounds, setBounds] = React.useState<IRectangle | undefined>();
+    const updateAsyncPosition = (): void => {
+      async.requestAnimationFrame(() => setBounds(getBounds(props)));
+    };
+    React.useEffect(updateAsyncPosition);
+    return bounds;
+  }
+
   return (
     <PositioningContainer
       target={target}
@@ -474,7 +484,7 @@ export const CoachmarkBase: React.FunctionComponent<ICoachmarkProps> = React.for
       finalHeight={finalHeight}
       ref={forwardedRef}
       onPositioned={onPositioned}
-      bounds={getBounds(props)}
+      bounds={useGetBounds()}
       {...positioningContainerProps}
     >
       <div className={classNames.root}>

--- a/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -34,30 +34,26 @@ const DEFAULT_PROPS = {
   directionalHint: DirectionalHint.bottomAutoEdge,
 };
 
-function useCachedBounds(props: IPositioningContainerProps, targetWindow: Window | undefined) {
+function useBounds(props: IPositioningContainerProps, targetWindow: Window | undefined) {
   /** The bounds used when determining if and where the PositioningContainer should be placed. */
-  const positioningBounds = React.useRef<IRectangle>();
 
-  const getCachedBounds = (): IRectangle => {
-    if (!positioningBounds.current) {
-      let currentBounds = props.bounds;
+  const getBounds = (): IRectangle => {
+    let currentBounds = props.bounds;
 
-      if (!currentBounds) {
-        currentBounds = {
-          top: 0 + props.minPagePadding!,
-          left: 0 + props.minPagePadding!,
-          right: targetWindow!.innerWidth - props.minPagePadding!,
-          bottom: targetWindow!.innerHeight - props.minPagePadding!,
-          width: targetWindow!.innerWidth - props.minPagePadding! * 2,
-          height: targetWindow!.innerHeight - props.minPagePadding! * 2,
-        };
-      }
-      positioningBounds.current = currentBounds;
+    if (!currentBounds) {
+      currentBounds = {
+        top: 0 + props.minPagePadding!,
+        left: 0 + props.minPagePadding!,
+        right: targetWindow!.innerWidth - props.minPagePadding!,
+        bottom: targetWindow!.innerHeight - props.minPagePadding!,
+        width: targetWindow!.innerWidth - props.minPagePadding! * 2,
+        height: targetWindow!.innerHeight - props.minPagePadding! * 2,
+      };
     }
-    return positioningBounds.current;
+    return currentBounds;
   };
 
-  return getCachedBounds;
+  return getBounds;
 }
 
 function usePositionState(
@@ -312,7 +308,7 @@ export const PositioningContainer: React.FunctionComponent<IPositioningContainer
   const rootRef = useMergedRefs(forwardedRef, positionedHost);
 
   const [targetRef, targetWindow] = useTarget(props.target, positionedHost);
-  const getCachedBounds = useCachedBounds(props, targetWindow);
+  const getCachedBounds = useBounds(props, targetWindow);
   const [positions, updateAsyncPosition] = usePositionState(
     props,
     positionedHost,


### PR DESCRIPTION
fixes #25415

Resizing the page via page zoom will recalculate the position of the PositioningContainer, but it will not update the bounds passed into the container. This causes layout errors when zooming out.

This change will re-render the coachmark on page resize, passing in the correct bounds value, and ensuring the the new bounds value is used when calculating the new coachmark position.