### PR TITLE
feat(react-tabster): add `unstable_hasDefault` option on `useArrowNavigationGroup`

### DIFF
--- a/change/@fluentui-react-tabster-8a739d1e-a76c-4604-90e3-5ddb2d3da5fa.json
+++ b/change/@fluentui-react-tabster-8a739d1e-a76c-4604-90e3-5ddb2d3da5fa.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: add `hasDefault` option in `useArrowNavigationGroup` that specifies the arrow navigation group has default focusable item",
+  "comment": "feat: add `unstable_hasDefault` option in `useArrowNavigationGroup` that specifies the arrow navigation group has default focusable item",
   "packageName": "@fluentui/react-tabster",
   "email": "yuanboxue@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-tabster-8a739d1e-a76c-4604-90e3-5ddb2d3da5fa.json
+++ b/change/@fluentui-react-tabster-8a739d1e-a76c-4604-90e3-5ddb2d3da5fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add `hasDefault` option in `useArrowNavigationGroup` that specifies the arrow navigation group has default focusable item",
+  "packageName": "@fluentui/react-tabster",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`TabList renders tabs when disabled 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   >
     <button
@@ -64,7 +64,7 @@ exports[`TabList renders tabs with default selected tab 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   >
     <button
@@ -127,7 +127,7 @@ exports[`TabList renders with no tabs 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   />
 </div>
@@ -137,7 +137,7 @@ exports[`TabList renders with tabs 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
     role="tablist"
   >
     <button

--- a/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
+++ b/packages/react-components/react-tabs/src/components/TabList/__snapshots__/TabList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`TabList renders tabs when disabled 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
     role="tablist"
   >
     <button
@@ -64,7 +64,7 @@ exports[`TabList renders tabs with default selected tab 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
     role="tablist"
   >
     <button
@@ -127,7 +127,7 @@ exports[`TabList renders with no tabs 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
     role="tablist"
   />
 </div>
@@ -137,7 +137,7 @@ exports[`TabList renders with tabs 1`] = `
 <div>
   <div
     class="fui-TabList"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":2,\\"memorizeCurrent\\":true,\\"hasDefault\\":false}}"
     role="tablist"
   >
     <button

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -50,6 +50,7 @@ export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions)
 export interface UseArrowNavigationGroupOptions {
     axis?: 'vertical' | 'horizontal' | 'grid' | 'both';
     circular?: boolean;
+    hasDefault?: boolean;
     ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
     memorizeCurrent?: boolean;
     tabbable?: boolean;

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -50,10 +50,10 @@ export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions)
 export interface UseArrowNavigationGroupOptions {
     axis?: 'vertical' | 'horizontal' | 'grid' | 'both';
     circular?: boolean;
-    hasDefault?: boolean;
     ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
     memorizeCurrent?: boolean;
     tabbable?: boolean;
+    unstable_hasDefault?: boolean;
 }
 
 // @public

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -26,7 +26,9 @@ export interface UseArrowNavigationGroupOptions {
    */
   ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
   /**
-   * The default focusable item in the group will be an element with Focusable.isDefault property
+   * The default focusable item in the group will be an element with Focusable.isDefault property.
+   * Note that there is no way in @fluentui/react-tabster to set default focusable element,
+   * and this option is currently for internal testing purposes only.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   unstable_hasDefault?: boolean;
@@ -58,7 +60,7 @@ export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions 
       direction: axisToMoverDirection(axis ?? 'vertical'),
       memorizeCurrent,
       tabbable,
-      hasDefault: !!unstable_hasDefault,
+      hasDefault: unstable_hasDefault,
     },
     ...(ignoreDefaultKeydown && {
       focusable: {

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -25,6 +25,10 @@ export interface UseArrowNavigationGroupOptions {
    * Tabster should ignore default handling of keydown events
    */
   ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
+  /**
+   * The default focusable item in the group will be an element with Focusable.isDefault property
+   */
+  hasDefault?: boolean;
 }
 
 /**
@@ -32,7 +36,7 @@ export interface UseArrowNavigationGroupOptions {
  * @param options - Options to configure keyboard navigation
  */
 export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions = {}): Types.TabsterDOMAttribute => {
-  const { circular, axis, memorizeCurrent, tabbable, ignoreDefaultKeydown } = options;
+  const { circular, axis, memorizeCurrent, tabbable, ignoreDefaultKeydown, hasDefault } = options;
   const tabster = useTabster();
 
   if (tabster) {
@@ -43,8 +47,9 @@ export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions 
     mover: {
       cyclic: !!circular,
       direction: axisToMoverDirection(axis ?? 'vertical'),
-      memorizeCurrent: memorizeCurrent,
-      tabbable: tabbable,
+      memorizeCurrent,
+      tabbable,
+      hasDefault: !!hasDefault,
     },
     ...(ignoreDefaultKeydown && {
       focusable: {

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -28,7 +28,8 @@ export interface UseArrowNavigationGroupOptions {
   /**
    * The default focusable item in the group will be an element with Focusable.isDefault property
    */
-  hasDefault?: boolean;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  unstable_hasDefault?: boolean;
 }
 
 /**
@@ -36,7 +37,15 @@ export interface UseArrowNavigationGroupOptions {
  * @param options - Options to configure keyboard navigation
  */
 export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions = {}): Types.TabsterDOMAttribute => {
-  const { circular, axis, memorizeCurrent, tabbable, ignoreDefaultKeydown, hasDefault } = options;
+  const {
+    circular,
+    axis,
+    memorizeCurrent,
+    tabbable,
+    ignoreDefaultKeydown,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    unstable_hasDefault,
+  } = options;
   const tabster = useTabster();
 
   if (tabster) {
@@ -49,7 +58,7 @@ export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions 
       direction: axisToMoverDirection(axis ?? 'vertical'),
       memorizeCurrent,
       tabbable,
-      hasDefault: !!hasDefault,
+      hasDefault: !!unstable_hasDefault,
     },
     ...(ignoreDefaultKeydown && {
       focusable: {

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -27,7 +27,7 @@ export interface UseArrowNavigationGroupOptions {
   ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
   /**
    * The default focusable item in the group will be an element with Focusable.isDefault property.
-   * Note that there is no way in @fluentui/react-tabster to set default focusable element,
+   * Note that there is no way in \@fluentui/react-tabster to set default focusable element,
    * and this option is currently for internal testing purposes only.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
 
 
Add `unstable_hasDefault` option on `useArrowNavigationGroup` that allows user to specifies the mover group has default focusable item.
The user can assign default focusable item by:
```tsx
const defaultFocusableAttributes = useTabsterAttributes({
  focusable: { isDefault: true },
});

<Button {...defaultFocusableAttributes} />
```

Related tabster PR: https://github.com/microsoft/tabster/pull/224
 