### PR TITLE
feat(react-tabster): add unstable hook `useArrowNavigationGroupWithDefaultFocus_unstable`

### DIFF
--- a/change/@fluentui-react-tabster-7db5c554-9526-4833-a25a-438c3d004fd5.json
+++ b/change/@fluentui-react-tabster-7db5c554-9526-4833-a25a-438c3d004fd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add unstable hook `useArrowNavigationGroupWithDefaultFocus_unstable` that supports arrow navigation group with default focusable item in the group",
+  "packageName": "@fluentui/react-tabster",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -48,7 +48,7 @@ export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions)
 
 // @public (undocumented)
 export interface UseArrowNavigationGroupOptions {
-    axis?: 'vertical' | 'horizontal' | 'grid';
+    axis?: 'vertical' | 'horizontal' | 'grid' | 'both';
     circular?: boolean;
     ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
     memorizeCurrent?: boolean;

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -48,12 +48,18 @@ export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions)
 
 // @public (undocumented)
 export interface UseArrowNavigationGroupOptions {
-    axis?: 'vertical' | 'horizontal' | 'grid' | 'both';
+    axis?: 'vertical' | 'horizontal' | 'grid';
     circular?: boolean;
     ignoreDefaultKeydown?: Types.FocusableProps['ignoreKeydown'];
     memorizeCurrent?: boolean;
     tabbable?: boolean;
 }
+
+// @public
+export const useArrowNavigationGroupWithDefaultFocus_unstable: (options?: UseArrowNavigationGroupOptions) => {
+    defaultFocusableAttributes: Types.TabsterDOMAttribute;
+    arrowNavigationGroupAttributes: Types.TabsterDOMAttribute;
+};
 
 // @public
 export const useFocusableGroup: (options?: UseFocusableGroupOptions | undefined) => Types.TabsterDOMAttribute;

--- a/packages/react-components/react-tabster/src/hooks/index.ts
+++ b/packages/react-components/react-tabster/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useFocusWithin';
 export * from './useKeyboardNavAttribute';
 export * from './useModalAttributes';
 export * from './useTabsterAttributes';
+export * from './useArrowNavigationGroupWithDefaultFocus';

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -7,7 +7,7 @@ export interface UseArrowNavigationGroupOptions {
    * Focus will navigate vertically, horizontally or in both directions (grid), defaults to horizontally
    * @defaultValue vertical
    */
-  axis?: 'vertical' | 'horizontal' | 'grid' | 'both';
+  axis?: 'vertical' | 'horizontal' | 'grid';
   /**
    * Focus will cycle to the first/last elements of the group without stopping
    */
@@ -43,8 +43,8 @@ export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions 
     mover: {
       cyclic: !!circular,
       direction: axisToMoverDirection(axis ?? 'vertical'),
-      memorizeCurrent: memorizeCurrent,
-      tabbable: tabbable,
+      memorizeCurrent,
+      tabbable,
     },
     ...(ignoreDefaultKeydown && {
       focusable: {
@@ -54,14 +54,12 @@ export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions 
   });
 };
 
-function axisToMoverDirection(axis: UseArrowNavigationGroupOptions['axis']): Types.MoverDirection {
+export function axisToMoverDirection(axis: UseArrowNavigationGroupOptions['axis']): Types.MoverDirection {
   switch (axis) {
     case 'horizontal':
       return Types.MoverDirections.Horizontal;
     case 'grid':
       return Types.MoverDirections.Grid;
-    case 'both':
-      return Types.MoverDirections.Both;
 
     case 'vertical':
     default:

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -7,7 +7,7 @@ export interface UseArrowNavigationGroupOptions {
    * Focus will navigate vertically, horizontally or in both directions (grid), defaults to horizontally
    * @defaultValue vertical
    */
-  axis?: 'vertical' | 'horizontal' | 'grid';
+  axis?: 'vertical' | 'horizontal' | 'grid' | 'both';
   /**
    * Focus will cycle to the first/last elements of the group without stopping
    */
@@ -60,6 +60,8 @@ export function axisToMoverDirection(axis: UseArrowNavigationGroupOptions['axis'
       return Types.MoverDirections.Horizontal;
     case 'grid':
       return Types.MoverDirections.Grid;
+    case 'both':
+      return Types.MoverDirections.Both;
 
     case 'vertical':
     default:

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroupWithDefaultFocus.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroupWithDefaultFocus.ts
@@ -1,0 +1,45 @@
+import { Types as TabsterTypes, getMover } from 'tabster';
+import { useTabsterAttributes } from './useTabsterAttributes';
+import { useTabster } from './useTabster';
+import { axisToMoverDirection, UseArrowNavigationGroupOptions } from './useArrowNavigationGroup';
+
+/**
+ * A hook that returns the necessary tabster attributes to support arrow key navigation with default focusable item.
+ * Default focusable element will be the first element to receive focus when user enters the arrow navigation group.
+ *
+ * @param options - Options to configure keyboard navigation
+ */
+export const useArrowNavigationGroupWithDefaultFocus_unstable = (
+  options: UseArrowNavigationGroupOptions = {},
+): {
+  defaultFocusableAttributes: TabsterTypes.TabsterDOMAttribute;
+  arrowNavigationGroupAttributes: TabsterTypes.TabsterDOMAttribute;
+} => {
+  const { circular, axis, memorizeCurrent, tabbable, ignoreDefaultKeydown } = options;
+  const tabster = useTabster();
+
+  if (tabster) {
+    getMover(tabster);
+  }
+
+  const defaultFocusableAttributes = useTabsterAttributes({
+    focusable: { isDefault: true },
+  });
+
+  const arrowNavigationGroupAttributes = useTabsterAttributes({
+    mover: {
+      cyclic: !!circular,
+      direction: axisToMoverDirection(axis ?? 'vertical'),
+      memorizeCurrent,
+      tabbable,
+      hasDefault: true,
+    },
+    ...(ignoreDefaultKeydown && {
+      focusable: {
+        ignoreKeydown: ignoreDefaultKeydown,
+      },
+    }),
+  });
+
+  return { defaultFocusableAttributes, arrowNavigationGroupAttributes };
+};

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -7,6 +7,7 @@ export {
   useKeyboardNavAttribute,
   useModalAttributes,
   useTabsterAttributes,
+  useArrowNavigationGroupWithDefaultFocus_unstable,
 } from './hooks/index';
 export type {
   UseArrowNavigationGroupOptions,


### PR DESCRIPTION
Add unstable hook `useArrowNavigationGroupWithDefaultFocus_unstable` that supports arrow navigation group with default focusable item in the group.

usage:
```tsx
const {
  defaultFocusableAttributes,
  arrowNavigationGroupAttributes,
} = useArrowNavigationGroupWithDefaultFocus_unstable();

return (
  <TabList {...arrowNavigationGroupAttributes}>
    <Tab value="tab1">First Tab</Tab>
    // tab2 will be focused by default when user enters the TabList
    <Tab value="tab2" {...defaultFocusableAttributes}>
      Second Tab
    </Tab>
    <Tab value="tab3">Third Tab</Tab>
  </TabList>
);
```