### PR TITLE
feat: TableCellLayout component now supports truncate prop

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Table.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Table.stories.tsx
@@ -591,6 +591,47 @@ const SubtleSelection: React.FC<SharedVrTestArgs> = ({ noNativeElements }) => (
   </Table>
 );
 
+const Truncate: React.FC<SharedVrTestArgs & { truncate?: boolean }> = ({ noNativeElements, truncate }) => (
+  <Table noNativeElements={noNativeElements} style={{ width: '400px' }}>
+    <TableHeader>
+      <TableRow>
+        {columns.map(column => (
+          <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
+        ))}
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {items.map((item, i) => (
+        <TableRow key={item.file.label} className={`row-${i}`}>
+          <TableCell>
+            <TableCellLayout truncate={truncate} media={item.file.icon}>
+              {item.file.label}
+              <TableCellActions>
+                <Button icon={<EditRegular />} appearance="subtle" />
+                <Button icon={<MoreHorizontalRegular />} appearance="subtle" />
+              </TableCellActions>
+            </TableCellLayout>
+          </TableCell>
+          <TableCell>
+            <TableCellLayout
+              truncate={truncate}
+              media={<Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />}
+            >
+              {item.author.label}
+            </TableCellLayout>
+          </TableCell>
+          <TableCell>{item.lastUpdated.label}</TableCell>
+          <TableCell>
+            <TableCellLayout truncate={truncate} media={item.lastUpdate.icon}>
+              {item.lastUpdate.label}
+            </TableCellLayout>
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
 ([true, false] as const).forEach(noNativeElements => {
   const layoutName = noNativeElements ? 'flex' : 'table';
   storiesOf(`Table layout ${layoutName} - cell actions`, module)
@@ -712,4 +753,9 @@ const SubtleSelection: React.FC<SharedVrTestArgs> = ({ noNativeElements }) => (
       includeDarkMode: true,
       includeHighContrast: true,
     });
+
+  storiesOf(`Table layout ${layoutName} - truncate`, module)
+    .addStory('default (disabled)', () => <Truncate noNativeElements={noNativeElements} />)
+    .addStory('false', () => <Truncate noNativeElements={noNativeElements} truncate={false} />)
+    .addStory('true', () => <Truncate noNativeElements={noNativeElements} truncate={true} />);
 });

--- a/apps/vr-tests-react-components/src/stories/Table.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Table.stories.tsx
@@ -620,7 +620,9 @@ const Truncate: React.FC<SharedVrTestArgs & { truncate?: boolean }> = ({ noNativ
               {item.author.label}
             </TableCellLayout>
           </TableCell>
-          <TableCell>{item.lastUpdated.label}</TableCell>
+          <TableCell>
+            <TableCellLayout truncate={truncate}>{item.lastUpdated.label}</TableCellLayout>
+          </TableCell>
           <TableCell>
             <TableCellLayout truncate={truncate} media={item.lastUpdate.icon}>
               {item.lastUpdate.label}

--- a/change/@fluentui-react-table-837a2183-555e-4693-9a8e-e3f1e89bed61.json
+++ b/change/@fluentui-react-table-837a2183-555e-4693-9a8e-e3f1e89bed61.json
@@ -1,7 +1,7 @@
 {
-  "type": "prerelease",
-  "comment": "TableCellLayout component now supports ellipsis prop",
-  "packageName": "@fluentui/react-table",
+  "comment": "feat: TableCellLayout component now supports truncate prop",
+  "dependentChangeType": "patch",
   "email": "jirivyhnalek@microsoft.com",
-  "dependentChangeType": "patch"
+  "packageName": "@fluentui/react-table",
+  "type": "prerelease"
 }

--- a/change/@fluentui-react-table-837a2183-555e-4693-9a8e-e3f1e89bed61.json
+++ b/change/@fluentui-react-table-837a2183-555e-4693-9a8e-e3f1e89bed61.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "TableCellLayout component now supports ellipsis prop",
+  "packageName": "@fluentui/react-table",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -292,6 +292,7 @@ export const tableCellLayoutClassNames: SlotClassNames<TableCellLayoutSlots>;
 // @public
 export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>> & {
     appearance?: 'primary';
+    ellipsis?: boolean;
 };
 
 // @public (undocumented)
@@ -304,7 +305,7 @@ export type TableCellLayoutSlots = {
 };
 
 // @public
-export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> & Pick<TableCellLayoutProps, 'appearance'> & {
+export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> & Pick<TableCellLayoutProps, 'appearance' | 'ellipsis'> & {
     avatarSize: AvatarSize | undefined;
 } & Pick<TableContextValue, 'size'>;
 

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -292,7 +292,7 @@ export const tableCellLayoutClassNames: SlotClassNames<TableCellLayoutSlots>;
 // @public
 export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>> & {
     appearance?: 'primary';
-    ellipsis?: boolean;
+    truncate?: boolean;
 };
 
 // @public (undocumented)
@@ -305,7 +305,7 @@ export type TableCellLayoutSlots = {
 };
 
 // @public
-export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> & Pick<TableCellLayoutProps, 'appearance' | 'ellipsis'> & {
+export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> & Pick<TableCellLayoutProps, 'appearance' | 'truncate'> & {
     avatarSize: AvatarSize | undefined;
 } & Pick<TableContextValue, 'size'>;
 

--- a/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
@@ -41,10 +41,18 @@ export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>>
    * @default undefined
    */
   appearance?: 'primary';
+
+  /**
+   * Renders content with hidden overflow and ellipsis enabled
+   */
+  ellipsis?: boolean;
 };
 
 /**
  * State used in rendering TableCellLayout
  */
 export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> &
-  Pick<TableCellLayoutProps, 'appearance'> & { avatarSize: AvatarSize | undefined } & Pick<TableContextValue, 'size'>;
+  Pick<TableCellLayoutProps, 'appearance' | 'ellipsis'> & { avatarSize: AvatarSize | undefined } & Pick<
+    TableContextValue,
+    'size'
+  >;

--- a/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
@@ -43,16 +43,16 @@ export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>>
   appearance?: 'primary';
 
   /**
-   * Renders content with hidden overflow and ellipsis enabled
+   * Renders content with overflow: hidden and text-overflow: ellipsis
    */
-  ellipsis?: boolean;
+  truncate?: boolean;
 };
 
 /**
  * State used in rendering TableCellLayout
  */
 export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> &
-  Pick<TableCellLayoutProps, 'appearance' | 'ellipsis'> & { avatarSize: AvatarSize | undefined } & Pick<
+  Pick<TableCellLayoutProps, 'appearance' | 'truncate'> & { avatarSize: AvatarSize | undefined } & Pick<
     TableContextValue,
     'size'
   >;

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
@@ -34,7 +34,7 @@ export const useTableCellLayout_unstable = (
     },
     root: getNativeElementProps('div', { ref, ...props }),
     appearance: props.appearance,
-    ellipsis: props.ellipsis,
+    truncate: props.truncate,
     main: resolveShorthand(props.main, { required: true }),
     media: resolveShorthand(props.media),
     description: resolveShorthand(props.description),

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
@@ -34,6 +34,7 @@ export const useTableCellLayout_unstable = (
     },
     root: getNativeElementProps('div', { ref, ...props }),
     appearance: props.appearance,
+    ellipsis: props.ellipsis,
     main: resolveShorthand(props.main, { required: true }),
     media: resolveShorthand(props.media),
     description: resolveShorthand(props.description),

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
     ...shorthands.flex(1, 1, '0px'),
   },
 
-  rootEllipsis: {
+  rootTruncate: {
     overflowX: 'hidden',
   },
 
@@ -32,7 +32,7 @@ const useStyles = makeStyles({
     flexDirection: 'column',
   },
 
-  contentEllipsis: {
+  contentTruncate: {
     overflowX: 'hidden',
   },
 
@@ -57,7 +57,7 @@ const useStyles = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
   },
 
-  mainEllipsis: {
+  mainTruncate: {
     overflowX: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
@@ -74,12 +74,12 @@ const useStyles = makeStyles({
  */
 export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): TableCellLayoutState => {
   const styles = useStyles();
-  const { ellipsis } = state;
+  const { truncate } = state;
 
   state.root.className = mergeClasses(
     tableCellLayoutClassNames.root,
     styles.root,
-    ellipsis && styles.rootEllipsis,
+    truncate && styles.rootTruncate,
     state.root.className,
   );
   const primary = state.appearance === 'primary';
@@ -103,7 +103,7 @@ export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): 
   if (state.main) {
     state.main.className = mergeClasses(
       tableCellLayoutClassNames.main,
-      ellipsis && styles.mainEllipsis,
+      truncate && styles.mainTruncate,
       primary && styles.mainPrimary,
       state.main.className,
     );
@@ -121,7 +121,7 @@ export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): 
     state.content.className = mergeClasses(
       tableCellLayoutClassNames.content,
       styles.content,
-      ellipsis && styles.contentEllipsis,
+      truncate && styles.contentTruncate,
       state.content.className,
     );
   }

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayoutStyles.ts
@@ -22,9 +22,18 @@ const useStyles = makeStyles({
     ...shorthands.gap(tokens.spacingHorizontalS),
     ...shorthands.flex(1, 1, '0px'),
   },
+
+  rootEllipsis: {
+    overflowX: 'hidden',
+  },
+
   content: {
     display: 'flex',
     flexDirection: 'column',
+  },
+
+  contentEllipsis: {
+    overflowX: 'hidden',
   },
 
   media: {
@@ -48,6 +57,12 @@ const useStyles = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
   },
 
+  mainEllipsis: {
+    overflowX: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
+
   description: {
     color: tokens.colorNeutralForeground2,
     ...typographyStyles.caption1,
@@ -59,7 +74,14 @@ const useStyles = makeStyles({
  */
 export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): TableCellLayoutState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(tableCellLayoutClassNames.root, styles.root, state.root.className);
+  const { ellipsis } = state;
+
+  state.root.className = mergeClasses(
+    tableCellLayoutClassNames.root,
+    styles.root,
+    ellipsis && styles.rootEllipsis,
+    state.root.className,
+  );
   const primary = state.appearance === 'primary';
 
   if (state.media) {
@@ -81,6 +103,7 @@ export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): 
   if (state.main) {
     state.main.className = mergeClasses(
       tableCellLayoutClassNames.main,
+      ellipsis && styles.mainEllipsis,
       primary && styles.mainPrimary,
       state.main.className,
     );
@@ -95,7 +118,12 @@ export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): 
   }
 
   if (state.content) {
-    state.content.className = mergeClasses(tableCellLayoutClassNames.content, styles.content, state.content.className);
+    state.content.className = mergeClasses(
+      tableCellLayoutClassNames.content,
+      styles.content,
+      ellipsis && styles.contentEllipsis,
+      state.content.className,
+    );
   }
 
   return state;

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsControlled.stories.tsx
@@ -33,7 +33,7 @@ const columnsDef: TableColumnDefinition<Item>[] = [
     columnId: 'file',
     renderHeaderCell: () => <>File</>,
     renderCell: (item: Item) => (
-      <TableCellLayout ellipsis media={item.file.icon}>
+      <TableCellLayout truncate media={item.file.icon}>
         {item.file.label}
       </TableCellLayout>
     ),
@@ -46,7 +46,7 @@ const columnsDef: TableColumnDefinition<Item>[] = [
     renderHeaderCell: () => <>Author</>,
     renderCell: (item: Item) => (
       <TableCellLayout
-        ellipsis
+        truncate
         media={<Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />}
       >
         {item.author.label}
@@ -59,7 +59,7 @@ const columnsDef: TableColumnDefinition<Item>[] = [
   createTableColumn<Item>({
     columnId: 'lastUpdated',
     renderHeaderCell: () => <>Last updated</>,
-    renderCell: (item: Item) => <TableCellLayout ellipsis>{item.lastUpdated.label}</TableCellLayout>,
+    renderCell: (item: Item) => <TableCellLayout truncate>{item.lastUpdated.label}</TableCellLayout>,
     compare: (a, b) => {
       return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
     },
@@ -68,7 +68,7 @@ const columnsDef: TableColumnDefinition<Item>[] = [
     columnId: 'lastUpdate',
     renderHeaderCell: () => <>Last update</>,
     renderCell: (item: Item) => (
-      <TableCellLayout ellipsis media={item.lastUpdate.icon}>
+      <TableCellLayout truncate media={item.lastUpdate.icon}>
         {item.lastUpdate.label}
       </TableCellLayout>
     ),

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsControlled.stories.tsx
@@ -32,7 +32,11 @@ const columnsDef: TableColumnDefinition<Item>[] = [
   createTableColumn<Item>({
     columnId: 'file',
     renderHeaderCell: () => <>File</>,
-    renderCell: (item: Item) => <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>,
+    renderCell: (item: Item) => (
+      <TableCellLayout ellipsis media={item.file.icon}>
+        {item.file.label}
+      </TableCellLayout>
+    ),
     compare: (a, b) => {
       return a.file.label.localeCompare(b.file.label);
     },
@@ -42,6 +46,7 @@ const columnsDef: TableColumnDefinition<Item>[] = [
     renderHeaderCell: () => <>Author</>,
     renderCell: (item: Item) => (
       <TableCellLayout
+        ellipsis
         media={<Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />}
       >
         {item.author.label}
@@ -54,7 +59,7 @@ const columnsDef: TableColumnDefinition<Item>[] = [
   createTableColumn<Item>({
     columnId: 'lastUpdated',
     renderHeaderCell: () => <>Last updated</>,
-    renderCell: (item: Item) => item.lastUpdated.label,
+    renderCell: (item: Item) => <TableCellLayout ellipsis>{item.lastUpdated.label}</TableCellLayout>,
     compare: (a, b) => {
       return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
     },
@@ -62,7 +67,11 @@ const columnsDef: TableColumnDefinition<Item>[] = [
   createTableColumn<Item>({
     columnId: 'lastUpdate',
     renderHeaderCell: () => <>Last update</>,
-    renderCell: (item: Item) => <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>,
+    renderCell: (item: Item) => (
+      <TableCellLayout ellipsis media={item.lastUpdate.icon}>
+        {item.lastUpdate.label}
+      </TableCellLayout>
+    ),
     compare: (a, b) => {
       return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
     },

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsUncontrolled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsUncontrolled.stories.tsx
@@ -170,13 +170,13 @@ export const ResizableColumnsUncontrolled = () => {
           {rows.map(({ item }) => (
             <TableRow key={item.file.label}>
               <TableCell {...columnSizing_unstable.getTableCellProps('file')}>
-                <TableCellLayout ellipsis media={item.file.icon}>
+                <TableCellLayout truncate media={item.file.icon}>
                   {item.file.label}
                 </TableCellLayout>
               </TableCell>
               <TableCell {...columnSizing_unstable.getTableCellProps('author')}>
                 <TableCellLayout
-                  ellipsis
+                  truncate
                   media={
                     <Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />
                   }
@@ -185,10 +185,10 @@ export const ResizableColumnsUncontrolled = () => {
                 </TableCellLayout>
               </TableCell>
               <TableCell {...columnSizing_unstable.getTableCellProps('lastUpdated')}>
-                <TableCellLayout ellipsis>{item.lastUpdated.label}</TableCellLayout>
+                <TableCellLayout truncate>{item.lastUpdated.label}</TableCellLayout>
               </TableCell>
               <TableCell {...columnSizing_unstable.getTableCellProps('lastUpdate')}>
-                <TableCellLayout ellipsis media={item.lastUpdate.icon}>
+                <TableCellLayout truncate media={item.lastUpdate.icon}>
                   {item.lastUpdate.label}
                 </TableCellLayout>
               </TableCell>

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsUncontrolled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsUncontrolled.stories.tsx
@@ -116,14 +116,14 @@ export const ResizableColumnsUncontrolled = () => {
   const [columnSizingOptions] = useState<TableColumnSizingOptions>({
     file: {
       idealWidth: 300,
-      minWidth: 190,
+      minWidth: 150,
     },
     author: {
-      minWidth: 170,
+      minWidth: 110,
       defaultWidth: 250,
     },
     lastUpdate: {
-      minWidth: 220,
+      minWidth: 150,
     },
   });
 
@@ -170,10 +170,13 @@ export const ResizableColumnsUncontrolled = () => {
           {rows.map(({ item }) => (
             <TableRow key={item.file.label}>
               <TableCell {...columnSizing_unstable.getTableCellProps('file')}>
-                <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
+                <TableCellLayout ellipsis media={item.file.icon}>
+                  {item.file.label}
+                </TableCellLayout>
               </TableCell>
               <TableCell {...columnSizing_unstable.getTableCellProps('author')}>
                 <TableCellLayout
+                  ellipsis
                   media={
                     <Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />
                   }
@@ -182,10 +185,12 @@ export const ResizableColumnsUncontrolled = () => {
                 </TableCellLayout>
               </TableCell>
               <TableCell {...columnSizing_unstable.getTableCellProps('lastUpdated')}>
-                {item.lastUpdated.label}
+                <TableCellLayout ellipsis>{item.lastUpdated.label}</TableCellLayout>
               </TableCell>
               <TableCell {...columnSizing_unstable.getTableCellProps('lastUpdate')}>
-                <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
+                <TableCellLayout ellipsis media={item.lastUpdate.icon}>
+                  {item.lastUpdate.label}
+                </TableCellLayout>
               </TableCell>
             </TableRow>
           ))}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

User would have to implement this feature by adding custom styles

## New Behavior

The prop `ellipsis` on `TableCellLayout` enables the ellipsis

![image](https://user-images.githubusercontent.com/2070479/217227805-279998d8-a37a-47eb-8323-0124d81fc909.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26735
