### PR TITLE
fix(react-utilities, react-provider): Remove colons from generated id and fix hook order error in React 18

### DIFF
--- a/change/@fluentui-react-provider-2dd88fac-fd7c-4313-98b8-3941d9399f42.json
+++ b/change/@fluentui-react-provider-2dd88fac-fd7c-4313-98b8-3941d9399f42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Do not add an escape character for colons in the styleTagId since useId now removes colons from the generated id in React 18.",
+  "packageName": "@fluentui/react-provider",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-db7dae74-67ca-40d9-9548-f9b0965366c2.json
+++ b/change/@fluentui-react-utilities-db7dae74-67ca-40d9-9548-f9b0965366c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Generate id first to avoid hook order mismatch in React 18 and remove colons from generated id in React 18.",
+  "packageName": "@fluentui/react-utilities",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -62,8 +62,7 @@ export const useFluentProviderThemeStyleTag = (options: Pick<FluentProviderState
       : '';
   }, [theme]);
 
-  // When using React 18, the id generated will contain : which is not valid unless we add an escape character
-  const rule = `.${styleTagId.replace(/:/g, '\\:')} { ${cssVarsAsString} }`;
+  const rule = `.${styleTagId} { ${cssVarsAsString} }`;
 
   useInsertionEffect(() => {
     styleTag.current = createStyleTag(targetDocument, { ...styleElementAttributes, id: styleTagId });

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -37,7 +37,9 @@ export function useId(prefix: string = 'fui-', providedId?: string): string {
   const _useId: () => string | undefined = (React as never)['use' + 'Id'];
 
   if (_useId) {
-    return providedId || `${idPrefix}${prefix}${_useId()}`;
+    const generatedId = _useId()?.replace(/:/g, '');
+
+    return providedId || `${idPrefix}${prefix}${generatedId}`;
   }
 
   // Hooks appear to be running conditionally, but they will always run in the same order since it's based on

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -34,12 +34,15 @@ export function useId(prefix: string = 'fui-', providedId?: string): string {
 
   // Checking if useId is available on React, if it is, we use it to generate the id. String concatenation is used to
   // prevent bundlers from complaining with older versions of React.
-  const _useId: () => string | undefined = (React as never)['use' + 'Id'];
+  const _useId = (React as never)['use' + 'Id'] as (() => string) | undefined;
 
   if (_useId) {
-    const generatedId = _useId()?.replace(/:/g, '');
+    const generatedId = _useId();
 
-    return providedId || `${idPrefix}${prefix}${generatedId}`;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const escapedId = React.useMemo(() => generatedId.replace(/:/g, ''), [generatedId]);
+
+    return providedId || `${idPrefix}${prefix}${escapedId}`;
   }
 
   // Hooks appear to be running conditionally, but they will always run in the same order since it's based on


### PR DESCRIPTION
fixes #26651

## Previous Behavior

When using React 18, our `useId` method calls React's `useId` conditionally.



## New Behavior

Our `useId` method now generates the id first and then returns the string generated conditionally to avoid using the hook conditionally.

Our `useId` method now also removes colons from React 18's generated id to avoid issues when querying in JS or CSS.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26653
