### PR TITLE
fix: Small mistake in docs for Avatar name prop

### DIFF
--- a/change/@fluentui-react-avatar-b5550fce-57c1-4cc6-8a4c-a8b22d9e4dd6.json
+++ b/change/@fluentui-react-avatar-b5550fce-57c1-4cc6-8a4c-a8b22d9e4dd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: Small mistake in docs for Avatar icon prop",
+  "packageName": "@fluentui/react-avatar",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -120,7 +120,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
   /**
    * The name of the person or entity represented by this Avatar. This should always be provided if it is available.
    *
-   * The name will be used to determine the initials displayed when there is no icon, as well as provided to
+   * The name is used to determine the initials displayed when there is no image. It is also provided to
    * accessibility tools.
    */
   name?: string;


### PR DESCRIPTION
## Previous Behavior

Avatar's docs say the `name` is used to determine the initials displayed when there is no **icon**, which is incorrect: the initials are displayed when there is no **image**.

## New Behavior

Fix doc comment for Avatar's `name` prop.

## Related Issue(s)

* Fixes #26601
