### PR TITLE
Fix svg-img-alt accessibility issue in vertical stacked bar chart

### DIFF
--- a/change/@fluentui-react-charting-66596414-f3fe-4f18-a947-2f131b34c32c.json
+++ b/change/@fluentui-react-charting-66596414-f3fe-4f18-a947-2f131b34c32c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix svg-img-alt accessibility issue in vertical stacked bar chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -741,6 +741,7 @@ export class VerticalStackedBarChartBase extends React.Component<
           onFocus: this._onRectFocus.bind(this, point, singleChartData.xAxisPoint, color, ref),
           onBlur: this._handleMouseOut,
           onClick: this._onClick.bind(this, point),
+          role: 'img',
         };
 
         let barHeight = heightValueScale * point.data;
@@ -787,7 +788,6 @@ export class VerticalStackedBarChartBase extends React.Component<
             fill={color}
             ref={e => (ref.refElement = e)}
             {...rectFocusProps}
-            role="img"
             transform={`translate(${xScaleBandwidthTranslate}, 0)`}
           />
         );

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -1249,7 +1249,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#0078d4"
             height={196.15384615384616}
             key="0"
-            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
@@ -1265,7 +1264,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#00188f"
             height={24.51923076923077}
             key="1"
-            role="img"
             transform="translate(0, 0)"
             width={32}
             x={40}
@@ -1295,7 +1293,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#0078d4"
             height={147.1153846153846}
             key="1"
-            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}
@@ -1311,7 +1308,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             fill="#00188f"
             height={98.07692307692308}
             key="2"
-            role="img"
             transform="translate(0, 0)"
             width={32}
             x={-52}


### PR DESCRIPTION
## Previous Behavior

Bar segments in VerticalStackedBarChart have an img role without an accessible text

## New Behavior

Bar segments in VerticalStackedBarChart don't have an img role when the whole stack (bar) can be focused