### PR TITLE
fix(storybook): turn off mangling on production builds to provide same output as with Terser

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -49,6 +49,7 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
             loose: true,
           },
         },
+        swcMinifyOptions: { mangle: false },
       }),
     },
     '@storybook/addon-essentials',

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "schema-utils": "3.1.1",
     "semver": "^6.2.0",
     "source-map-loader": "4.0.0",
-    "storybook-addon-export-to-codesandbox": "0.8.2",
+    "storybook-addon-export-to-codesandbox": "0.8.3",
     "storybook-addon-performance": "0.16.1",
     "storybook-addon-swc": "1.1.9",
     "storywright": "0.0.26-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10325,15 +10325,10 @@ d3-interpolate@1, "d3-interpolate@1.2.0 - 3", d3-interpolate@^1.1.4:
   dependencies:
     d3-color "1"
 
-d3-path@1:
+d3-path@1, "d3-path@1 - 2":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
   integrity sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==
-
-"d3-path@2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
-  integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
 
 d3-sankey@^0.12.3:
   version "0.12.3"
@@ -10386,7 +10381,7 @@ d3-shape@2.1.0:
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.1.0.tgz#3b6a82ccafbc45de55b57fcf956c584ded3b666f"
   integrity sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==
   dependencies:
-    d3-path "2"
+    d3-path "1 - 2"
 
 d3-shape@^1.1.0, d3-shape@^1.2.0:
   version "1.3.7"
@@ -23533,10 +23528,10 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
-storybook-addon-export-to-codesandbox@0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.8.2.tgz#96d8506aa336620d6e68287f6259e52a50be3427"
-  integrity sha512-jLu8j03qeUzp82+mXnvjcvjgxz9BeEeql5TQTCgZdvZfkBt5vpd4EzvhOnw+y75AeBXCMU4XrXzb4vlNH9ln2A==
+storybook-addon-export-to-codesandbox@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/storybook-addon-export-to-codesandbox/-/storybook-addon-export-to-codesandbox-0.8.3.tgz#ef92a594e2109c80f9ac074e5f3bfbf96c463ceb"
+  integrity sha512-6KLD1mfZwDTO23JvnxpCUYHJSgvSLVbXS4KTAal9tBMoU59/+5ESd239ddX6PMB+/mzgh5v7+FTtVHqAslkubQ==
   dependencies:
     codesandbox-import-utils "^2.2.3"
     pkg-up "^3.1.0"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- storybook production builds mangle JS code
- swc generates different story names in the output 

## New Behavior

- bumped storybook-addon-export-to-codesandbox which properly transforms production build export tokens
- mangle is turned off for storybook production build by default (via terser plugin 
<img width="227" alt="image" src="https://user-images.githubusercontent.com/1223799/217038047-ba86c119-3821-46f9-80a2-35d39b234270.png">
). Swc minifier was mangling by default which was introducing property mangling that will cause VR test act on stories without explicit `storyName` randomly. Thus mangling is explicitly turned off within our configs as well.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26751

## Related PRs

https://github.com/microsoft/fluentui-storybook-addons/pull/32

