### PR TITLE
fix: Coordinates should be rounded to device pixels to prevent blurriness

### DIFF
--- a/change/@fluentui-react-positioning-12d2fd1b-daef-4dc8-9886-61a7685ab3dd.json
+++ b/change/@fluentui-react-positioning-12d2fd1b-daef-4dc8-9886-61a7685ab3dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Coordinates should be rounded to device pixels to prevent blurriness",
+  "packageName": "@fluentui/react-positioning",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
+++ b/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
@@ -42,7 +42,9 @@ export function writeContainerUpdates(options: {
     container.setAttribute(DATA_POSITIONING_HIDDEN, '');
   }
 
-  // Round to the nearest device pixel. This prevents blurriness when the browser view is zoomed in.
+  // Round so that the coordinates land on device pixels.
+  // This prevents blurriness in cases where the browser doesn't apply pixel snapping, such as when other effects like
+  // `backdrop-filter: blur()` are applied to the container, and the browser is zoomed in.
   // See https://github.com/microsoft/fluentui/issues/26764 for more info.
   const devicePixelRatio = container.ownerDocument.defaultView?.devicePixelRatio || 1;
   const x = Math.round(coordinates.x * devicePixelRatio) / devicePixelRatio;

--- a/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
+++ b/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
@@ -42,8 +42,10 @@ export function writeContainerUpdates(options: {
     container.setAttribute(DATA_POSITIONING_HIDDEN, '');
   }
 
-  const x = Math.round(coordinates.x);
-  const y = Math.round(coordinates.y);
+  // Round to the nearest device pixel. This prevents blurriness when the browser view is zoomed in.
+  const devicePixelRatio = container.ownerDocument.defaultView?.devicePixelRatio || 1;
+  const x = Math.round(coordinates.x * devicePixelRatio) / devicePixelRatio;
+  const y = Math.round(coordinates.y * devicePixelRatio) / devicePixelRatio;
 
   Object.assign(container.style, {
     transform: lowPPI ? `translate(${x}px, ${y}px)` : `translate3d(${x}px, ${y}px, 0)`,

--- a/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
+++ b/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
@@ -43,6 +43,7 @@ export function writeContainerUpdates(options: {
   }
 
   // Round to the nearest device pixel. This prevents blurriness when the browser view is zoomed in.
+  // See https://github.com/microsoft/fluentui/issues/26764 for more info.
   const devicePixelRatio = container.ownerDocument.defaultView?.devicePixelRatio || 1;
   const x = Math.round(coordinates.x * devicePixelRatio) / devicePixelRatio;
   const y = Math.round(coordinates.y * devicePixelRatio) / devicePixelRatio;


### PR DESCRIPTION
## Previous Behavior

The react-positioning library uses a translate transform to position menus. Normally, the browser applies pixel snapping to the transform when the browser view is zoomed in. However, if the surface also has other effects applied, such as `backdrop-filter: blur()` as is the case in #26764, the browser seems to disable pixel snapping. This results in the popover being blurry even though the translate transform was using whole-pixel values.

<img alt="screenshot showing the bug" src="https://user-images.githubusercontent.com/48106640/218186383-f6a44dae-e5ec-4d46-b00e-1b1eab1fd4df.png">

## New Behavior

Round the translate transform so that it lands on device pixels even if the browser doesn't apply pixel snapping.

<img alt="screenshot showing the fix" src="https://user-images.githubusercontent.com/48106640/218186475-2b8c8af4-c104-4e5d-8268-97566ec410c3.png">


## Demo

Demo of the bug for testing the fix:
* Repro (no fix): https://fluentuipr.z22.web.core.windows.net/pull/26793/public-docsite-v9/storybook/index.html?path=/docs/components-popover--default#with-arrow
* With fix in this PR: https://fluentuipr.z22.web.core.windows.net/pull/26792/public-docsite-v9/storybook/index.html?path=/docs/components-popover--default#with-arrow

## Related Issue(s)

* Fixes #26764
* Related to #26038
