### PR TITLE
docs: Styling Component (v9) now introduces shorthands

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Source } from '@storybook/addon-docs';
 
 ## Styling components
 
-To style Fluent UI React v9 components `makeStyles` is used. `makeStyles` comes from [`Griffel`](https://griffel.js.org) a homegrown CSS-in-JS implementation which generates atomic CSS classes.
+To style Fluent UI React v9 components `makeStyles` is used. `makeStyles` comes from [Griffel](https://griffel.js.org) a homegrown CSS-in-JS implementation which generates atomic CSS classes.
 
 Get started by simply importing:
 
@@ -136,9 +136,13 @@ function Component(props) {
 
 [Griffel devtools chrome extension](https://chrome.google.com/webstore/detail/griffel-devtools/bejhagjehnpgagkaaeehdpdadmffbigb) can be used to debug style overrides. It shows all griffel styles applied on the currently selected DOM element, including the styles that are overridden in `mergeClasses`.
 
+### Limitations
+
+The Griffel's approach to styling comes with certain [limitations](https://griffel.js.org/react/guides/limitations). One of them is the lack of support for [CSS shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties). To work around this, Griffel [provides a `shorthands`](https://griffel.js.org/react/api/shorthands) function, whose use is demonstrated in the next example.
+
 ## Overriding FUI component styles
 
-To override an appearance of a FUI component, you use the exactly same approach - You call makeStyles/useStyles in your code and pass the resulting classes through `props`.
+To override an appearance of a FUI component, you use the exactly same approach - You call `makeStyles`/`useStyles` in your code and pass the resulting classes through `props`.
 
 ```jsx
 import { makeStyles, tokens, shorthands } from '@fluentui/react-components';

--- a/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/StylingComponents.stories.mdx
@@ -138,7 +138,7 @@ function Component(props) {
 
 ### Limitations
 
-The Griffel's approach to styling comes with certain [limitations](https://griffel.js.org/react/guides/limitations). One of them is the lack of support for [CSS shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties). To work around this, Griffel [provides a `shorthands`](https://griffel.js.org/react/api/shorthands) function, whose use is demonstrated in the next example.
+Griffel's approach to styling comes with certain [limitations](https://griffel.js.org/react/guides/limitations). One of which is the lack of support for [CSS shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties). To work around this, Griffel [provides a collection of shorthand functions](https://griffel.js.org/react/api/shorthands) to write css shorthand. Their usage is demonstrated in the next example.
 
 ## Overriding FUI component styles
 


### PR DESCRIPTION
## New Behavior

- Removed ticks around Griffel in the introduction to make obvious it's a link
- Added a section about limitations which introduces the `shorthands` function and links to the Griffel docs
- Added missing ticks aroung `makeStyles` and `useStyles`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #26179
