### PR TITLE
Fixing wrong link hover value

### DIFF
--- a/change/@fluentui-react-charting-2b98d193-3938-4458-83e7-b27b31f6c8e9.json
+++ b/change/@fluentui-react-charting-2b98d193-3938-4458-83e7-b27b31f6c8e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing wrong value on link hover",
+  "packageName": "@fluentui/react-charting",
+  "email": "ankityadav@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
@@ -531,8 +531,7 @@ export class SankeyChartBase extends React.Component<ISankeyChartProps, ISankeyC
         isCalloutVisible: true,
         color: (singleLink.source as SNode).color,
         xCalloutValue: (singleLink.target as SNode).name,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        yCalloutValue: ((singleLink.source as SNode).actualValue! as any) as string,
+        yCalloutValue: singleLink.unnormalizedValue!.toString(),
         descriptionMessage: 'from ' + (singleLink.source as SNode).name,
       });
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x ] Code is up-to-date with the `master` branch
* [ x] Your changes are covered by tests (if possible)
* [ x] You've run `yarn change` locally


PR flow tips:
* [ x] Try to start with a Draft PR
* [ x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Node value was coming on link Hover
<!-- This is the behavior we have today -->

## New Behavior
Link hover will show link value
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

* Fixes #
