### PR TITLE
fix: handle single digit text input in SpinButton

### DIFF
--- a/change/@fluentui-react-spinbutton-d1c4887c-0860-4d73-976c-52ab691a1772.json
+++ b/change/@fluentui-react-spinbutton-d1c4887c-0860-4d73-976c-52ab691a1772.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: properly handle single character text input for SpinButton",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/SpinButton.test.tsx
@@ -646,6 +646,29 @@ describe('SpinButton', () => {
       spinButton.blur();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('updates value when typing a single digit when uncontrolled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton defaultValue={10} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      spinButton.setSelectionRange(0, spinButton.value.length);
+      userEvent.type(spinButton, '2{enter}');
+      expect(spinButton.value).toEqual('2');
+
+      expect(onChange.mock.calls[0][1]).toEqual({ value: undefined, displayValue: '2' });
+    });
+
+    it('updates value when typing a single digit when controlled', () => {
+      const onChange = jest.fn();
+      render(<SpinButton value={10} onChange={onChange} />);
+
+      const spinButton = getSpinButtonInput();
+      spinButton.setSelectionRange(0, spinButton.value.length);
+      userEvent.type(spinButton, '2{enter}');
+
+      expect(onChange.mock.calls[0][1]).toEqual({ value: undefined, displayValue: '2' });
+    });
   });
 
   describe('text input with step', () => {

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -143,7 +143,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!internalState.current.previousTextValue) {
-      internalState.current.previousTextValue = textValue;
+      internalState.current.previousTextValue = textValue ?? String(currentValue);
     }
     const newValue = e.target.value;
     setTextValue(newValue);


### PR DESCRIPTION
## Previous Behavior

Single digit text input may not properly update internal state, resulting in changed values not being committed on blur or "enter" press. See linked bug for details.

## New Behavior

Internal state is correctly updated and values are committed as expected on blur, enter. Added tests for this case.

## Related Issue(s)

* Fixes #26741
