### PR TITLE
Fix missing icons on overflowset v6

### DIFF
--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
@@ -62,12 +62,16 @@ export class OverflowSetCustomExample extends React.PureComponent {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: {
+                    iconName: 'Mail'
+                  }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: {
+                    iconName: 'Calendar'
+                  }
                 }
               ]
             }
@@ -75,25 +79,33 @@ export class OverflowSetCustomExample extends React.PureComponent {
           {
             key: 'move',
             name: 'Move to...',
-            icon: 'MoveToFolder',
+            iconProps: {
+              iconName: 'MoveToFolder'
+            },
             onClick: noOp
           },
           {
             key: 'copy',
             name: 'Copy to...',
-            icon: 'Copy',
+            iconProps: {
+              iconName: 'Copy'
+            },
             onClick: noOp
           },
           {
             key: 'rename',
             name: 'Rename...',
-            icon: 'Edit',
+            iconProps: {
+              iconName: 'Edit'
+            },
             onClick: noOp
           },
           {
             key: 'disabled',
             name: 'Disabled...',
-            icon: 'Cancel',
+            iconProps: {
+              iconName: 'Cancel'
+            },
             disabled: true,
             onClick: noOp
           }


### PR DESCRIPTION
This PR is for Fluent UI React 6.X

Similar as recently submitted PR but for version 7.X and 8.X (Master)

From the developer examples of fluent UI for React, the overflowset custom examples overflow icons are not displaying, this PR resolves it.

tested using the codepen link from the website.

Web page in question link v6:
https://developer.microsoft.com/en-us/fluentui?fabricVer=6#/controls/web/commandbar

**NOTE**
The code styling in examples of version 6.X use a different styling than 7.X and 8.X, where it uses new lines between iconProps and iconName, so I made the PR in the same style as the rest of 6.X code.

## Previous Behavior

the React FluentUI overflowset example does not show the icons that are in the code

## New Behavior

Resolves the missing icon issues

## Related Issue(s)

None