### PR TITLE
fix: MenuList is a single tabstop

### DIFF
--- a/change/@fluentui-react-menu-abe1574c-76eb-4b00-8d0e-324a355edb99.json
+++ b/change/@fluentui-react-menu-abe1574c-76eb-4b00-8d0e-324a355edb99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuList is a single tabstop",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuList/MenuList.cy.tsx
+++ b/packages/react-components/react-menu/src/components/MenuList/MenuList.cy.tsx
@@ -67,5 +67,19 @@ describe('MenuList', () => {
       mount(<Example />);
       cy.get(menuItemSelector).eq(3).focus().type('{rightarrow}').get(menuSelector).should('have.length', 2);
     });
+
+    it('should be able to tab in/out of the MenuList', () => {
+      mount(
+        <>
+          <button>Foo</button>
+          <Example />
+          <button>Foo</button>
+        </>,
+      );
+
+      cy.get('button').first().focus().realPress('Tab');
+      cy.get(menuItemSelector).first().should('be.focused').realPress('Tab');
+      cy.get('button').eq(1).should('be.focused');
+    });
   });
 });

--- a/packages/react-components/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/packages/react-components/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`MenuList renders a default state 1`] = `
 <div
   aria-labelledby=""
   className="fui-MenuList"
-  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Tab\\":true}}}"
+  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Tab\\":false}}}"
   role="menu"
 >
   Default MenuList

--- a/packages/react-components/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/useMenuList.ts
@@ -15,10 +15,10 @@ import type { MenuListProps, MenuListState } from './MenuList.types';
  * Returns the props and state required to render the component
  */
 export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLElement>): MenuListState => {
-  const focusAttributes = useArrowNavigationGroup({ circular: true, ignoreDefaultKeydown: { Tab: true } });
   const { findAllFocusable } = useFocusFinders();
   const menuContext = useMenuContextSelectors();
   const hasMenuContext = useHasParentContext(MenuContext);
+  const focusAttributes = useArrowNavigationGroup({ circular: true, ignoreDefaultKeydown: { Tab: hasMenuContext } });
 
   if (usingPropsAndMenuContext(props, menuContext, hasMenuContext)) {
     // TODO throw warnings in development safely

--- a/packages/react-components/react-menu/stories/MenuList/MenuListDefault.stories.tsx
+++ b/packages/react-components/react-menu/stories/MenuList/MenuListDefault.stories.tsx
@@ -18,11 +18,13 @@ export const Default = () => {
   const styles = useMenuListContainerStyles();
   return (
     <div className={styles.container}>
+      <button>Foo</button>
       <MenuList>
         <MenuItem>Cut</MenuItem>
         <MenuItem>Paste</MenuItem>
         <MenuItem>Edit</MenuItem>
       </MenuList>
+      <button>Foo</button>
     </div>
   );
 };


### PR DESCRIPTION
Since Menu needs to handle tab because it is a positionined element in a Portal, the MenuList does not need to. Disabling tabster's default handling for Tab in MenuList broke tabbing in that components.

Fixes #26776 this by only disabling tabster's Tab behaviour when the MenuList is wrapped by a Menu.