### PR TITLE
fix(Datepicker): Make aria-current date only when the day is today instead of when it's selected

### DIFF
--- a/change/@fluentui-react-b9a960f6-2d91-47d9-95ab-3239e4940491.json
+++ b/change/@fluentui-react-b9a960f6-2d91-47d9-95ab-3239e4940491.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Set aria-current to date when the day is today instead of when it's selected.",
+  "packageName": "@fluentui/react",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-b9a960f6-2d91-47d9-95ab-3239e4940491.json
+++ b/change/@fluentui-react-b9a960f6-2d91-47d9-95ab-3239e4940491.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Set aria-current to date when the day is today instead of when it's selected.",
+  "comment": "fix(Datepicker): Set aria-current to date when the day is today instead of when it's selected.",
   "packageName": "@fluentui/react",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-datepicker/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-datepicker/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -237,7 +237,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
       onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
       role="gridcell"
       tabIndex={isNavigatedDate ? 0 : undefined}
-      aria-current={day.isSelected ? 'date' : undefined}
+      aria-current={day.isToday ? 'date' : undefined}
       aria-selected={day.isInBounds ? day.isSelected : undefined}
       data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
     >

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -237,7 +237,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
       onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
       role="gridcell"
       tabIndex={isNavigatedDate ? 0 : undefined}
-      aria-current={day.isSelected ? 'date' : undefined}
+      aria-current={day.isToday ? 'date' : undefined}
       aria-selected={day.isInBounds ? day.isSelected : undefined}
       data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
     >


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`aria-current` is set to date when the day is selected.

## New Behavior

`aria-current` is set to date when the day is today. For more information about this change, see the issue linked below and the [mdn docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current).

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #26750