### PR TITLE
Badge and PresenceBadge: update to use `makeResetStyles`

### DIFF
--- a/change/@fluentui-react-badge-bd7ce6fd-4495-46a0-9d19-6aa724e86cc7.json
+++ b/change/@fluentui-react-badge-bd7ce6fd-4495-46a0-9d19-6aa724e86cc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update Badge and PresenceBadge to use makeResetStyles",
+  "packageName": "@fluentui/react-badge",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -33,7 +33,9 @@ const useRootClassName = makeResetStyles({
     left: 0,
     bottom: 0,
     right: 0,
-    border: `${tokens.strokeWidthThin} solid inherit`,
+    borderStyle: 'solid',
+    borderColor: 'inherit',
+    borderWidth: tokens.strokeWidthThin,
     borderRadius: 'inherit',
   },
 });

--- a/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, mergeClasses, makeStyles } from '@griffel/react';
+import { shorthands, mergeClasses, makeResetStyles, makeStyles } from '@griffel/react';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import type { BadgeSlots, BadgeState } from './Badge.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -12,16 +12,35 @@ export const badgeClassNames: SlotClassNames<BadgeSlots> = {
 // Instead, add extra padding to the root, and a negative margin on the icon to "remove" the extra padding on the icon.
 const textPadding = tokens.spacingHorizontalXXS;
 
-const useRootStyles = makeStyles({
-  base: {
-    display: 'inline-flex',
-    boxSizing: 'border-box',
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'relative',
-    ...typographyStyles.caption1Strong,
-  },
+const useRootClassName = makeResetStyles({
+  display: 'inline-flex',
+  boxSizing: 'border-box',
+  alignItems: 'center',
+  justifyContent: 'center',
+  position: 'relative',
+  ...typographyStyles.caption1Strong,
+  height: '20px',
+  minWidth: '20px',
+  padding: `0 calc(${tokens.spacingHorizontalXS} + ${textPadding})`,
+  borderRadius: tokens.borderRadiusCircular,
+  // Use a transparent stroke (rather than no border) so the border is visible in high contrast
+  borderColor: tokens.colorTransparentStroke,
 
+  '::after': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    borderStyle: 'solid',
+    borderWidth: tokens.strokeWidthThin,
+    borderColor: 'inherit',
+    borderRadius: 'inherit',
+  },
+});
+
+const useRootStyles = makeStyles({
   fontSmallToTiny: {
     ...typographyStyles.caption2Strong,
   },
@@ -33,12 +52,16 @@ const useRootStyles = makeStyles({
     height: '6px',
     fontSize: '4px',
     lineHeight: '4px',
+    minWidth: 'unset',
+    ...shorthands.padding('unset'),
   },
   'extra-small': {
     width: '10px',
     height: '10px',
     fontSize: '6px',
     lineHeight: '6px',
+    minWidth: 'unset',
+    ...shorthands.padding('unset'),
   },
   small: {
     minWidth: '16px',
@@ -46,9 +69,7 @@ const useRootStyles = makeStyles({
     ...shorthands.padding(0, `calc(${tokens.spacingHorizontalXXS} + ${textPadding})`),
   },
   medium: {
-    height: '20px',
-    minWidth: '20px',
-    ...shorthands.padding(0, `calc(${tokens.spacingHorizontalXS} + ${textPadding})`),
+    // Set by useRootClassName
   },
   large: {
     minWidth: '24px',
@@ -73,33 +94,23 @@ const useRootStyles = makeStyles({
     ...shorthands.borderRadius(tokens.borderRadiusSmall),
   },
   circular: {
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    // Set by useRootClassName
   },
 
   // border (all appearances except ghost)
 
-  border: {
-    // The border is applied in an :after pseudo-element because it should not affect layout.
+  borderGhost: {
+    // The border is applied in an ::after pseudo-element because it should not affect layout.
     // The padding and size of the badge should be the same regardless of whether or not it has a border.
     '::after': {
-      content: '""',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      bottom: 0,
-      right: 0,
-      ...shorthands.borderStyle('solid'),
-      ...shorthands.borderWidth(tokens.strokeWidthThin),
-      ...shorthands.borderColor('inherit'),
-      ...shorthands.borderRadius('inherit'),
+      display: 'none',
     },
   },
 
   // appearance: filled
 
   filled: {
-    // Use a transparent stroke (rather than no border) so the border is visible in high contrast
-    ...shorthands.borderColor(tokens.colorTransparentStroke),
+    // Set by useRootClassName
   },
   'filled-brand': {
     backgroundColor: tokens.colorBrandBackground,
@@ -245,13 +256,14 @@ const useRootStyles = makeStyles({
   },
 });
 
-const useIconStyles = makeStyles({
-  base: {
-    display: 'flex',
-    lineHeight: '1',
-    ...shorthands.margin(0, `calc(-1 * ${textPadding})`), // Remove text padding added to root
-  },
+const useIconRootClassName = makeResetStyles({
+  display: 'flex',
+  lineHeight: '1',
+  margin: `0 calc(-1 * ${textPadding})`, // Remove text padding added to root
+  fontSize: '12px',
+});
 
+const useIconStyles = makeStyles({
   beforeText: {
     marginRight: `calc(${tokens.spacingHorizontalXXS} + ${textPadding})`,
   },
@@ -278,7 +290,7 @@ const useIconStyles = makeStyles({
     fontSize: '12px',
   },
   medium: {
-    fontSize: '12px',
+    // Set by useIconRootClassName
   },
   large: {
     fontSize: '16px',
@@ -292,23 +304,25 @@ const useIconStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const useBadgeStyles_unstable = (state: BadgeState): BadgeState => {
+  const rootClassName = useRootClassName();
   const rootStyles = useRootStyles();
 
   const smallToTiny = state.size === 'small' || state.size === 'extra-small' || state.size === 'tiny';
 
   state.root.className = mergeClasses(
     badgeClassNames.root,
-    rootStyles.base,
+    rootClassName,
     smallToTiny && rootStyles.fontSmallToTiny,
     rootStyles[state.size],
     rootStyles[state.shape],
     state.shape === 'rounded' && smallToTiny && rootStyles.roundedSmallToTiny,
-    state.appearance !== 'ghost' && rootStyles.border,
+    state.appearance === 'ghost' && rootStyles.borderGhost,
     rootStyles[state.appearance],
     rootStyles[`${state.appearance}-${state.color}` as const],
     state.root.className,
   );
 
+  const iconRootClassName = useIconRootClassName();
   const iconStyles = useIconStyles();
   if (state.icon) {
     let iconPositionClass;
@@ -322,7 +336,7 @@ export const useBadgeStyles_unstable = (state: BadgeState): BadgeState => {
 
     state.icon.className = mergeClasses(
       badgeClassNames.icon,
-      iconStyles.base,
+      iconRootClassName,
       iconPositionClass,
       iconStyles[state.size],
       state.icon.className,

--- a/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -1,4 +1,4 @@
-import { shorthands, mergeClasses, makeResetStyles, makeStyles } from '@griffel/react';
+import { shorthands, makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import type { BadgeSlots, BadgeState } from './Badge.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -33,9 +33,7 @@ const useRootClassName = makeResetStyles({
     left: 0,
     bottom: 0,
     right: 0,
-    borderStyle: 'solid',
-    borderWidth: tokens.strokeWidthThin,
-    borderColor: 'inherit',
+    border: `${tokens.strokeWidthThin} solid inherit`,
     borderRadius: 'inherit',
   },
 });
@@ -97,7 +95,7 @@ const useRootStyles = makeStyles({
     // Set by useRootClassName
   },
 
-  // border (all appearances except ghost)
+  // hide the boder when appearance is "ghost"
 
   borderGhost: {
     // The border is applied in an ::after pseudo-element because it should not affect layout.

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeStyles, shorthands } from '@griffel/react';
+import { mergeClasses, makeResetStyles, makeStyles, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { BadgeSlots } from '../Badge/Badge.types';
@@ -17,20 +17,34 @@ const getIsBusy = (status: PresenceBadgeStatus): boolean => {
   return false;
 };
 
-const useStyles = makeStyles({
-  root: {
-    ...shorthands.padding(0),
-    display: 'inline-flex',
-    boxSizing: 'border-box',
-    alignItems: 'center',
-    justifyContent: 'center',
+const useRootClassName = makeResetStyles({
+  padding: 0,
+  display: 'inline-flex',
+  boxSizing: 'border-box',
+  alignItems: 'center',
+  justifyContent: 'center',
 
-    '& span': {
-      display: 'flex',
-    },
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    backgroundColor: tokens.colorNeutralBackground1,
+  '& span': {
+    display: 'flex',
   },
+  borderRadius: tokens.borderRadiusCircular,
+  backgroundColor: tokens.colorNeutralBackground1,
+});
+
+const useStyles = makeStyles({
+  // root: {
+  //   ...shorthands.padding(0),
+  //   display: 'inline-flex',
+  //   boxSizing: 'border-box',
+  //   alignItems: 'center',
+  //   justifyContent: 'center',
+
+  //   '& span': {
+  //     display: 'flex',
+  //   },
+  //   ...shorthands.borderRadius(tokens.borderRadiusCircular),
+  //   backgroundColor: tokens.colorNeutralBackground1,
+  // },
   statusBusy: {
     color: tokens.colorPaletteRedBackground3,
   },
@@ -89,11 +103,12 @@ const useStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const usePresenceBadgeStyles_unstable = (state: PresenceBadgeState): PresenceBadgeState => {
+  const rootClassName = useRootClassName();
   const styles = useStyles();
   const isBusy = getIsBusy(state.status);
   state.root.className = mergeClasses(
     presenceBadgeClassNames.root,
-    styles.root,
+    rootClassName,
     isBusy && styles.statusBusy,
     state.status === 'away' && styles.statusAway,
     state.status === 'available' && styles.statusAvailable,

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeResetStyles, makeStyles, shorthands } from '@griffel/react';
+import { mergeClasses, makeResetStyles, makeStyles } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { BadgeSlots } from '../Badge/Badge.types';
@@ -32,19 +32,6 @@ const useRootClassName = makeResetStyles({
 });
 
 const useStyles = makeStyles({
-  // root: {
-  //   ...shorthands.padding(0),
-  //   display: 'inline-flex',
-  //   boxSizing: 'border-box',
-  //   alignItems: 'center',
-  //   justifyContent: 'center',
-
-  //   '& span': {
-  //     display: 'flex',
-  //   },
-  //   ...shorthands.borderRadius(tokens.borderRadiusCircular),
-  //   backgroundColor: tokens.colorNeutralBackground1,
-  // },
   statusBusy: {
     color: tokens.colorPaletteRedBackground3,
   },

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadgeStyles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses, makeResetStyles, makeStyles } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { BadgeSlots } from '../Badge/Badge.types';


### PR DESCRIPTION
## Previous Behavior

Badges have many CSS classes on each slot.

## New Behavior

Badge and PresenceBadge have fewer classes on their slots. CounterBadge is left unchanged as its styles won't benefit from this change. Note this improvement will compound with similar changes to Avatar and Persona.

### Badge

Number of classes. In cases where there are multiple components in a story the first component is always used.

| Story | Old | New |
| --- | --- | --- |
| default | 49 | 5 |
| apperance | 49 | 5 | 
| sizes | 45 | 16 |
| shapes | 49 | 9 |
| color | 49 | 5 |
| icon | 62 | 11 |

### PresenceBadge

Number of classes. In cases where there are multiple components in a story the first component is always used.

| Story | Old | New | 
| --- | --- | --- |
| default | 22 | 9 |
| sizes | 26 | 13 |
| status | 22 | 9 |
| out of office | 22 | 9 |

## Related Issues

- #26811
- #26814