### PR TITLE
fix(resolveShorthand): resolving an object should return its copy instead of the object itself

### DIFF
--- a/change/@fluentui-react-utilities-d78eb4e5-edce-495c-9f39-61908b540af1.json
+++ b/change/@fluentui-react-utilities-d78eb4e5-edce-495c-9f39-61908b540af1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: `resolveShorthand` should resolve an object as its copy",
+  "packageName": "@fluentui/react-utilities",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
@@ -32,6 +32,15 @@ describe('resolveShorthand', () => {
     expect(resolvedProps).toEqual({ children: 42 });
   });
 
+  it('resolves an object as its copy', () => {
+    const slotA = {};
+    const props: TestProps = { slotA };
+    const resolvedProps = resolveShorthand(props.slotA);
+
+    expect(resolvedProps).toEqual(slotA);
+    expect(resolvedProps).not.toBe(slotA);
+  });
+
   it('resolves "null" without creating a child element', () => {
     const props: TestProps = { slotA: null, slotB: null };
 

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
@@ -33,7 +33,7 @@ export const resolveShorthand: ResolveShorthandFunction = (value, options) => {
   if (typeof value === 'string' || typeof value === 'number' || Array.isArray(value) || isValidElement(value)) {
     resolvedShorthand.children = value;
   } else if (typeof value === 'object') {
-    resolvedShorthand = value;
+    resolvedShorthand = { ...value };
   }
 
   return defaultProps ? { ...defaultProps, ...resolvedShorthand } : resolvedShorthand;


### PR DESCRIPTION
 


If a slot is a stable object, it gets 1 extra fluent ui className every time the component re-renders.
[beautiful-bohr-r2w8ot - codeSandbox](https://codesandbox.io/s/beautiful-bohr-r2w8ot?file=/example.tsx)
Clicking on 'force re-render' button, and observe the fluent ui className on button's icon slot increases 1 per render

This happens because:
if a slot is an object, `resolveShorthand` resolves it as itself. But instead it should resolve into a copy of the object.


 
