### PR TITLE
fix(build): configure path to tokens package

### DIFF
--- a/change/@fluentui-web-components-76d84908-f96c-4637-a826-cc63b8a4798e.json
+++ b/change/@fluentui-web-components-76d84908-f96c-4637-a826-cc63b8a4798e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fix package paths",
+  "packageName": "@fluentui/web-components",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/.storybook/main.cjs
+++ b/packages/web-components/.storybook/main.cjs
@@ -1,4 +1,6 @@
 const CircularDependencyPlugin = require('circular-dependency-plugin');
+const path = require('path');
+const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 const tsBin = require.resolve('typescript');
 
@@ -24,6 +26,11 @@ module.exports = /** @type {Omit<import('../../../.storybook/main').StorybookCon
     },
   ],
   webpackFinal: async config => {
+    const tsPaths = new TsconfigPathsPlugin({
+      configFile: path.resolve(__dirname, '../tsconfig.json'),
+    });
+    config.resolve.plugins ? config.resolve.plugins.push(tsPaths) : (config.resolve.plugins = [tsPaths]);
+
     config.resolve.extensionAlias = {
       '.js': ['.ts', '.js'],
       '.mjs': ['.mts', '.mjs'],

--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -14,7 +14,11 @@
     "skipLibCheck": true,
     "importHelpers": true,
     "types": ["node", "mocha", "webpack-env"],
-    "lib": ["DOM", "ES2015", "ES2016.Array.Include"]
+    "lib": ["DOM", "ES2015", "ES2016.Array.Include"],
+    "baseUrl": "../..",
+    "paths": {
+      "@fluentui/tokens": ["packages/tokens/src/index.ts"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
After branch rebase on top of the latest master, `@fluentui/tokens` is no longer an external package.
This PR adds ts path to that package.