### PR TITLE
bugfix(react-accordion): use min-height instead of height

### DIFF
--- a/change/@fluentui-react-accordion-b982fc8e-4dc0-4862-a62d-7945f270b437.json
+++ b/change/@fluentui-react-accordion-b982fc8e-4dc0-4862-a62d-7945f270b437.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: uses min-height instead of height",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.ts
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
     width: '100%',
     ...shorthands.border('1px', 'solid', 'transparent'),
     ...shorthands.padding(0, tokens.spacingHorizontalM, 0, tokens.spacingHorizontalMNudge),
-    height: '44px',
+    minHeight: '44px',
     display: 'flex',
     alignItems: 'center',
     cursor: 'pointer',
@@ -52,7 +52,7 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
   },
   buttonSmall: {
-    height: '32px',
+    minHeight: '32px',
     fontSize: tokens.fontSizeBase200,
   },
   buttonLarge: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Convert styles from using `height` property on `button` slot to use `minHeight` instead.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/26839
