### PR TITLE
fix: Updating peer dependencies of react-virtualizer to support React 18

### DIFF
--- a/change/@fluentui-react-virtualizer-f4f74084-b93e-4113-8e45-29229d62546e.json
+++ b/change/@fluentui-react-virtualizer-f4f74084-b93e-4113-8e45-29229d62546e.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix peer deps of react virtualizer",
+  "comment": "fix: Updating peer dependencies to support React 18.",
   "packageName": "@fluentui/react-virtualizer",
   "email": "mgodbolt@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-virtualizer-f4f74084-b93e-4113-8e45-29229d62546e.json
+++ b/change/@fluentui-react-virtualizer-f4f74084-b93e-4113-8e45-29229d62546e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix peer deps of react virtualizer",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/package.json
+++ b/packages/react-components/react-virtualizer/package.json
@@ -36,10 +36,10 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <18.0.0",
-    "@types/react-dom": ">=16.8.0 <18.0.0",
-    "react": ">=16.8.0 <18.0.0",
-    "react-dom": ">=16.8.0 <18.0.0"
+    "@types/react": ">=16.8.0 <19.0.0",
+    "@types/react-dom": ">=16.8.0 <19.0.0",
+    "react": ">=16.8.0 <19.0.0",
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
fixes #26859