### PR TITLE
Manual bump of web components version

### DIFF
--- a/change/@fluentui-web-components-4b3e5f7a-32b1-4a3e-9879-415aac98fc88.json
+++ b/change/@fluentui-web-components-4b3e5f7a-32b1-4a3e-9879-415aac98fc88.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: run manually to bump wc to fix failed CI release",
+  "packageName": "@fluentui/web-components",
+  "email": "jslone@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-516db34f-7e06-4348-a459-507ea3b7c881.json
+++ b/change/@fluentui-web-components-516db34f-7e06-4348-a459-507ea3b7c881.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore(web-components): introduce ts-solution configs and monorepo setup/DX",
-  "packageName": "@fluentui/web-components",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@fluentui-web-components-c9bafa19-7bba-4e91-a34b-ef812e450e99.json
+++ b/change/@fluentui-web-components-c9bafa19-7bba-4e91-a34b-ef812e450e99.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "fix(web-components): dont ship non production assets to npm registry",
-  "packageName": "@fluentui/web-components",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/web-components/CHANGELOG.json
+++ b/packages/web-components/CHANGELOG.json
@@ -2,6 +2,29 @@
   "name": "@fluentui/web-components",
   "entries": [
     {
+      "date": "Thu, 16 Feb 2023 16:51:48 GMT",
+      "tag": "@fluentui/web-components_v3.0.0-alpha.4",
+      "version": "3.0.0-alpha.4",
+      "comments": {
+        "none": [
+          {
+            "author": "martinhochel@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "ae03f3eec389aca7e15fde295868aacd51eb1822",
+            "comment": "chore(web-components): introduce ts-solution configs and monorepo setup/DX"
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "martinhochel@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "226b7af089cea03d27ec722cabc73d018f263fd1",
+            "comment": "fix(web-components): dont ship non production assets to npm registry"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 15 Feb 2023 04:24:51 GMT",
       "tag": "@fluentui/web-components_v3.0.0-alpha.3",
       "version": "3.0.0-alpha.3",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/web-components
 
-This log was last generated on Wed, 15 Feb 2023 04:24:51 GMT and should not be manually modified.
+This log was last generated on Thu, 16 Feb 2023 16:51:48 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [3.0.0-alpha.4](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-alpha.4)
+
+Thu, 16 Feb 2023 16:51:48 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/web-components_v3.0.0-alpha.3..@fluentui/web-components_v3.0.0-alpha.4)
+
+### Changes
+
+- fix(web-components): dont ship non production assets to npm registry ([PR #26854](https://github.com/microsoft/fluentui/pull/26854) by martinhochel@microsoft.com)
 
 ## [3.0.0-alpha.3](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-alpha.3)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui/web-components",
   "description": "A library of Fluent Web Components",
   "sideEffects": false,
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0-alpha.4",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"


### PR DESCRIPTION
Followed pattern from #26498 

Commands used:
` yarn beachball bump -b origin/web-components-v3 --access public --no-fetch --no-publish --no-push --no-git-tags --verbose --config ./scripts/beachball/release-web-components.config.js`
With Internet connection turned off

followed by 
`yarn change`

## Previous Behavior

CI was blocked due to a failed release that published a version to npm but did not update local version number

`3.0.0-alpha.4` is already on NPM
https://www.npmjs.com/package/@fluentui/web-components/v/3.0.0-alpha.4

## New Behavior

This fixes the repo to have the right version without updating NPM or anything else. 
