### PR TITLE
fix: Fix the width of Input's focus border with appearance=underline

### DIFF
--- a/change/@fluentui-react-input-85a7bc9c-40df-4a16-a935-8139ebc12873.json
+++ b/change/@fluentui-react-input-85a7bc9c-40df-4a16-a935-8139ebc12873.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fix the width of Input's focus border with appearance=underline",
+  "packageName": "@fluentui/react-input",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/src/components/Input/useInputStyles.ts
+++ b/packages/react-components/react-input/src/components/Input/useInputStyles.ts
@@ -137,6 +137,11 @@ const useRootStyles = makeStyles({
     borderTopStyle: 'none',
     borderRightStyle: 'none',
     borderLeftStyle: 'none',
+    // Make the focus underline (::after) match the width of the bottom border
+    '::after': {
+      left: 0,
+      right: 0,
+    },
   },
   underlineInteractive: {
     ':hover': {


### PR DESCRIPTION
## Previous Behavior

The width of the focus underline for `<Input appearance="underline" />` is 1px too wide on each side.

## New Behavior

Reduce the width of the focus underline element to match the non-focus underline's width.

## Related Issue(s)

- Resolving the comment by @spmonahan: https://github.com/microsoft/fluentui/pull/26865#discussion_r1108974993
