### PR TITLE
Update CODEOWNERS to add catch-all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,10 @@
 # users just like we do for commit author emails.
 # docs/  docs@example.com
 
+##### Catch All Rule ######
+#### Later rules will override this, if you are hitting this rule often add a rule to a sub-folder
+* @microsoft/fluentui-admins
+
 ###### Build Section ######
 #### Repo-wide build files - Note these will only be applied if another rule below does not apply
 *.sh @microsoft/fluentui-react-build


### PR DESCRIPTION
Add a catch-all rule for any newly added files that aren't already covered by existing rules.

We already have extensive rules in place covering all the important files in the repo, so we shouldn't hit this rule often. However, if we find that we're hitting this rule, we can add more rules to sub-folders. I would like to get this in place first and follow up with additional rules as we see fit. 