### PR TITLE
chore(react-table): use `Iterable` instead of a `Set` for table selection API surface

### DIFF
--- a/change/@fluentui-react-table-94087703-4140-4a9c-8847-19940bb0fbe3.json
+++ b/change/@fluentui-react-table-94087703-4140-4a9c-8847-19940bb0fbe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: exports UseTableSelectionOptions",
+  "packageName": "@fluentui/react-table",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-94087703-4140-4a9c-8847-19940bb0fbe3.json
+++ b/change/@fluentui-react-table-94087703-4140-4a9c-8847-19940bb0fbe3.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "chore: exports UseTableSelectionOptions",
+  "comment": "chore: use Iterable instead of a Set for table selection API surface",
   "packageName": "@fluentui/react-table",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -665,6 +665,14 @@ export const useTableSelectionCell_unstable: (props: TableSelectionCellProps, re
 export const useTableSelectionCellStyles_unstable: (state: TableSelectionCellState) => TableSelectionCellState;
 
 // @public (undocumented)
+export interface UseTableSelectionOptions {
+    defaultSelectedItems?: Iterable<TableRowId>;
+    onSelectionChange?(e: React_2.SyntheticEvent, data: OnSelectionChangeData): void;
+    selectedItems?: Iterable<TableRowId>;
+    selectionMode: SelectionMode_2;
+}
+
+// @public (undocumented)
 export function useTableSort<TItem>(options: UseTableSortOptions): (tableState: TableFeaturesState<TItem>) => TableFeaturesState<TItem>;
 
 // @public

--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -167,11 +167,11 @@ export interface UseTableSelectionOptions {
   /**
    * Used in uncontrolled mode to set initial selected rows on mount
    */
-  defaultSelectedItems?: Set<TableRowId>;
+  defaultSelectedItems?: Iterable<TableRowId>;
   /**
    * Used to control row selection
    */
-  selectedItems?: Set<TableRowId>;
+  selectedItems?: Iterable<TableRowId>;
   /**
    * Called when selection changes
    */

--- a/packages/react-components/react-table/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useTableSelection.ts
@@ -31,10 +31,10 @@ export function useTableSelectionState<TItem>(
   const { items, getRowId } = tableState;
   const { selectionMode, defaultSelectedItems, selectedItems, onSelectionChange } = options;
 
-  const [selected, setSelected] = useControllableState({
-    initialState: new Set<TableRowId>(),
-    defaultState: defaultSelectedItems,
-    state: selectedItems,
+  const [selected, setSelected] = useControllableState<Set<TableRowId>>({
+    initialState: new Set(),
+    defaultState: React.useMemo(() => defaultSelectedItems && new Set(defaultSelectedItems), [defaultSelectedItems]),
+    state: React.useMemo(() => selectedItems && new Set(selectedItems), [selectedItems]),
   });
 
   const selectionManager = React.useMemo(() => {

--- a/packages/react-components/react-table/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useTableSelection.ts
@@ -33,8 +33,10 @@ export function useTableSelectionState<TItem>(
 
   const [selected, setSelected] = useControllableState<Set<TableRowId>>({
     initialState: new Set(),
-    defaultState: React.useMemo(() => defaultSelectedItems && new Set(defaultSelectedItems), [defaultSelectedItems]),
-    state: React.useMemo(() => selectedItems && new Set(selectedItems), [selectedItems]),
+    defaultState: React.useMemo(() => defaultSelectedItems && createSetFromIterable(defaultSelectedItems), [
+      defaultSelectedItems,
+    ]),
+    state: React.useMemo(() => selectedItems && createSetFromIterable(selectedItems), [selectedItems]),
   });
 
   const selectionManager = React.useMemo(() => {
@@ -84,4 +86,11 @@ export function useTableSelectionState<TItem>(
       isRowSelected,
     },
   };
+}
+
+/**
+ * Creates a set from a given iterable, in case the iterable is a set itself, returns the given set instead.
+ */
+function createSetFromIterable<V>(iterable: Iterable<V>): Set<V> {
+  return iterable instanceof Set ? iterable : new Set(iterable);
 }

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -18,6 +18,7 @@ export type {
   TableSortState,
   TableFeaturePlugin,
   TableColumnSizingOptions,
+  UseTableSelectionOptions,
 } from './hooks';
 
 export {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`UseTableSelectionOptions` `selectedItems` was based on receiving a `Set` from the user

## New Behavior

1. `selectedItems` and `defaultSelectedItems` now accepts a `Iterable` instead of a `Set`, which internally will be converted to a `Set`
3. exports  `UseTableSelectionOptions` type.

