### PR TITLE
perf: use path aliases and swc for test:perf tasks to improve build speeds

### DIFF
--- a/apps/perf-test-react-components/just.config.ts
+++ b/apps/perf-test-react-components/just.config.ts
@@ -5,4 +5,4 @@ import { config } from './config/perf-test';
 preset();
 
 task('run-perf-test', () => getPerfRegressions(config));
-task('perf-test', series('build', 'bundle', 'run-perf-test'));
+task('perf-test', series('clean', 'copy', 'bundle', 'run-perf-test'));

--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -4,17 +4,18 @@
   "version": "9.0.0-rc.0",
   "private": true,
   "scripts": {
-    "build": "just-scripts build",
     "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style"
+    "code-style": "just-scripts code-style",
+    "type-check": "tsc -p . --noEmit",
+    "test:perf": "just-scripts perf-test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-tasks": "*",
-    "@fluentui/scripts-webpack": "*"
+    "@fluentui/scripts-storybook": "*"
   },
   "dependencies": {
     "@fluentui/scripts-perf-test-flamegrill": "*",

--- a/apps/perf-test-react-components/tsconfig.json
+++ b/apps/perf-test-react-components/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",
-    "declaration": true,
     "experimentalDecorators": true,
     "preserveConstEnums": true,
     "lib": ["ES2015", "DOM"],

--- a/apps/perf-test-react-components/webpack.config.js
+++ b/apps/perf-test-react-components/webpack.config.js
@@ -1,4 +1,8 @@
-const { resources } = require('@fluentui/scripts-webpack');
+// @ts-check
+const path = require('path');
+const { rules, registerTsPaths } = require('@fluentui/scripts-storybook');
+
+const tsConfigPath = path.resolve(__dirname, '../../tsconfig.base.json');
 
 // The issue here is making readable Flamegraphs that don't have complicated paths like:
 //  ~Fabric.../../packages/react/lib/components/DetailsList/DetailsRow.base.js.DetailsRowBase.render
@@ -6,13 +10,22 @@ const { resources } = require('@fluentui/scripts-webpack');
 //  ~DetailsRowBase.render (22.16%, 168 samples)
 // The only way found to do this so far has been to use a webpack serve config for bundling.
 // TODO: Should root cause why this only works as a serve config.
-module.exports = resources.createServeConfig(
-  {
-    entry: './src/app.tsx',
-    mode: 'production',
-    output: {
-      filename: 'perf-test.js',
-    },
+const config = /** @type {import('webpack').Configuration}*/ ({
+  mode: 'production',
+  target: ['web', 'es5'],
+  entry: './src/app.tsx',
+  output: {
+    filename: 'perf-test.js',
+    libraryTarget: 'umd',
+    path: path.join(__dirname, 'dist'),
   },
-  'dist',
-);
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  devtool: 'eval',
+  module: {
+    rules: [rules.cssRule, rules.scssRule, rules.tsRule],
+  },
+});
+
+module.exports = registerTsPaths({ config, configFile: tsConfigPath });

--- a/apps/perf-test/just.config.ts
+++ b/apps/perf-test/just.config.ts
@@ -5,4 +5,4 @@ import { config } from './config/perf-test';
 preset();
 
 task('run-perf-test', () => getPerfRegressions(config));
-task('perf-test', series('build', 'bundle', 'run-perf-test'));
+task('perf-test', series('clean', 'copy', 'bundle', 'run-perf-test'));

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -4,17 +4,18 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "just-scripts build",
     "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style"
+    "code-style": "just-scripts code-style",
+    "type-check": "tsc -p . --noEmit",
+    "test:perf": "just-scripts perf-test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-tasks": "*",
-    "@fluentui/scripts-webpack": "*"
+    "@fluentui/scripts-storybook": "*"
   },
   "dependencies": {
     "@fluentui/scripts-perf-test-flamegrill": "*",

--- a/apps/perf-test/tsconfig.json
+++ b/apps/perf-test/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "lib",
     "module": "commonjs",
     "jsx": "react",
-    "declaration": true,
     "experimentalDecorators": true,
     "preserveConstEnums": true,
     "lib": ["ES2015", "DOM"],

--- a/apps/perf-test/webpack.config.js
+++ b/apps/perf-test/webpack.config.js
@@ -1,4 +1,9 @@
-const { resources } = require('@fluentui/scripts-webpack');
+// @ts-check
+const path = require('path');
+
+const { rules, registerTsPaths } = require('@fluentui/scripts-storybook');
+
+const tsConfigPath = path.resolve(__dirname, '../../tsconfig.base.v8.json');
 
 // The issue here is making readable Flamegraphs that don't have complicated paths like:
 //  ~Fabric.../../packages/react/lib/components/DetailsList/DetailsRow.base.js.DetailsRowBase.render
@@ -6,13 +11,22 @@ const { resources } = require('@fluentui/scripts-webpack');
 //  ~DetailsRowBase.render (22.16%, 168 samples)
 // The only way found to do this so far has been to use a webpack serve config for bundling.
 // TODO: Should root cause why this only works as a serve config.
-module.exports = resources.createServeConfig(
-  {
-    entry: './src/app.tsx',
-    mode: 'production',
-    output: {
-      filename: 'perf-test.js',
-    },
+const config = /** @type {import('webpack').Configuration}*/ ({
+  mode: 'production',
+  target: ['web', 'es5'],
+  entry: './src/app.tsx',
+  output: {
+    filename: 'perf-test.js',
+    libraryTarget: 'umd',
+    path: path.join(__dirname, 'dist'),
   },
-  'dist',
-);
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  devtool: 'eval',
+  module: {
+    rules: [rules.cssRule, rules.scssRule, rules.tsRule],
+  },
+});
+
+module.exports = registerTsPaths({ config, configFile: tsConfigPath });

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -50,12 +50,6 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      # - script: |
-      #     # yarn lage build --to @fluentui/perf-test-northstar --to @fluentui/react-conformance --verbose
-      #     yarn workspace @fluentui/digest build
-      #   condition: eq(variables.isPR, true)
-      #   displayName: Build to Perf Test (Northstar)
-
       - script: |
           yarn workspace @fluentui/perf-test-northstar perf:test --base
         condition: eq(variables.isPR, false)

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - template: .devops/templates/cleanup.yml
 
-  - job: PerfTestV8
+  - job: PerfTestReact
     displayName: Perf test for @fluentui/react
     dependsOn: CheckIfPackagesAffected
     condition: eq(dependencies.CheckIfPackagesAffected.outputs['PackagesAffected.V8PackageAffected'], true)
@@ -121,14 +121,8 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn lage build --to perf-test --verbose
+          yarn workspace @fluentui/perf-test test:perf
         condition: eq(variables.isPR, true)
-        displayName: Build to Perf Test
-
-      - script: |
-          yarn just perf-test
-        condition: eq(variables.isPR, true)
-        workingDirectory: apps/perf-test
         displayName: Run Perf Test
 
       - task: AzureUpload@2
@@ -167,14 +161,8 @@ jobs:
         displayName: yarn
 
       - script: |
-          yarn lage build --to perf-test-react-components --verbose
+          yarn workspace @fluentui/perf-test-react-components test:perf
         condition: eq(variables.isPR, true)
-        displayName: Build to Perf Test
-
-      - script: |
-          yarn just perf-test
-        condition: eq(variables.isPR, true)
-        workingDirectory: apps/perf-test-react-components
         displayName: Run Perf Test
 
       - task: AzureUpload@2

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -36,7 +36,7 @@ jobs:
         name: PackagesAffected
         displayName: Check if v8, v9 and/or northstar packages were affected
 
-  - job: PerfTestNorthstar
+  - job: PerfTestReactNorthstar
     displayName: Perf test for @fluentui/react-northstar
     dependsOn: CheckIfPackagesAffected
     condition: eq(dependencies.CheckIfPackagesAffected.outputs['PackagesAffected.NorthstarPackageAffected'], true)
@@ -50,21 +50,20 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      - script: |
-          yarn lage build --to @fluentui/perf-test-northstar --to @fluentui/react-conformance --verbose
-        condition: eq(variables.isPR, true)
-        displayName: Build to Perf Test (Northstar)
+      # - script: |
+      #     # yarn lage build --to @fluentui/perf-test-northstar --to @fluentui/react-conformance --verbose
+      #     yarn workspace @fluentui/digest build
+      #   condition: eq(variables.isPR, true)
+      #   displayName: Build to Perf Test (Northstar)
 
       - script: |
-          yarn perf:test --base
+          yarn workspace @fluentui/perf-test-northstar perf:test --base
         condition: eq(variables.isPR, false)
-        workingDirectory: packages/fluentui/perf-test-northstar
         displayName: Run Perf Test Base (Northstar)
 
       - script: |
-          yarn perf:test
+          yarn workspace @fluentui/perf-test-northstar perf:test
         condition: eq(variables.isPR, true)
-        workingDirectory: packages/fluentui/perf-test-northstar
         displayName: Run Perf Test (Northstar)
 
       - task: AzureUpload@2

--- a/packages/fluentui/digest/package.json
+++ b/packages/fluentui/digest/package.json
@@ -5,9 +5,6 @@
   "main": "lib/digest.js",
   "module": "lib/digest.js",
   "license": "MIT",
-  "bin": {
-    "digest": "./bin/digest.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/digest"

--- a/packages/fluentui/digest/src/digest.tsx
+++ b/packages/fluentui/digest/src/digest.tsx
@@ -12,6 +12,7 @@ export async function digestStories(digestConfig: DigestConfig) {
   console.log('Bundling digest..');
 
   const defaultConfigs = defaultConfig(digestConfig);
+
   const webpackConfigs = [];
 
   // TODO: use a real merge. or move this merge into webpack.config.ts and use webpackMerge there.

--- a/packages/fluentui/digest/src/webpack.config.ts
+++ b/packages/fluentui/digest/src/webpack.config.ts
@@ -1,7 +1,31 @@
+import { registerTsPaths, rules } from '@fluentui/scripts-storybook';
 import * as path from 'path';
 
 // TODO: remove just as a dependency. should only be a dev dependency when used.
-import { webpackConfig, webpackMerge, htmlOverlay } from 'just-scripts';
+import { webpackMerge, htmlOverlay, stylesOverlay, fileOverlay, basicWebpackConfig } from 'just-scripts';
+import type { Configuration } from 'webpack';
+
+const tsConfigPath = path.resolve(__dirname, '../../../../tsconfig.base.v0.json');
+
+const webpackConfig = (config: Partial<Configuration>): Configuration => {
+  const mergedConfig = webpackMerge.merge(
+    basicWebpackConfig,
+    stylesOverlay(),
+    {
+      resolve: {
+        extensions: ['.js', '.ts', '.tsx'],
+      },
+      module: { rules: [rules.tsRule] },
+    },
+    fileOverlay(),
+    config,
+  );
+
+  return registerTsPaths({
+    config: mergedConfig,
+    configFile: tsConfigPath,
+  });
+};
 
 const IgnoreNotFoundExportWebpackPlugin = require('ignore-not-found-export-webpack-plugin');
 

--- a/packages/fluentui/perf-test-northstar/just.config.ts
+++ b/packages/fluentui/perf-test-northstar/just.config.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { execSync } from 'child_process';
 import { series, task, argv, taskPresets } from 'just-scripts';
 import { config } from './tasks/perf-test.config';
 
@@ -11,6 +12,7 @@ taskPresets.lib();
 // - Existing perf story format diverges from CSF format, requiring special loader.
 function bundleStories() {
   return async function () {
+    buildDependencies();
     // delay require in case digest isn't built yet
     const { digestStories } = require('@fluentui/digest');
     await digestStories({
@@ -18,6 +20,12 @@ function bundleStories() {
       outputDir: path.join(__dirname, 'dist'),
     });
   };
+}
+
+function buildDependencies() {
+  const cmd = 'yarn workspace @fluentui/digest build';
+  console.log(`exec: ${cmd}`);
+  execSync(cmd, { stdio: 'inherit' });
 }
 
 // TODO: how should this be integrated with the default 'build' task?
@@ -32,9 +40,8 @@ task('perf-test:run', () => {
   return getPerfRegressions(config, (argv() as { base?: boolean }).base);
 });
 
-// TOOD: is build doing anything meaningful? only if there's source that's not a just script?
 // TODO: if stories/scenarios are added in this package, make sure build catches type errors
-task('perf-test', series('build', 'perf-test:bundle', 'perf-test:run'));
+task('perf-test', series('perf-test:bundle', 'perf-test:run'));
 
 // TODO: Uncomment once stories can be referred to in a dependency.
 // This command will not be reliable until perf stories are in a package that can be set as a dep.

--- a/packages/fluentui/perf-test-northstar/package.json
+++ b/packages/fluentui/perf-test-northstar/package.json
@@ -4,7 +4,7 @@
   "version": "0.66.4",
   "private": true,
   "scripts": {
-    "build": "just-scripts build",
+    "type-check": "tsc -p . --noEmit",
     "bundle": "just-scripts perf-test:bundle",
     "clean": "just-scripts clean",
     "test": "just-scripts test",

--- a/packages/fluentui/perf-test-northstar/tasks/fluentPerfRegressions.ts
+++ b/packages/fluentui/perf-test-northstar/tasks/fluentPerfRegressions.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as path from 'path';
-import { workspaceRoot } from 'nx/src/utils/app-root';
+import { workspaceRoot } from '@nrwl/devkit';
 import { perfTestEnv } from '@fluentui/scripts-tasks';
 
 import { config } from './perf-test.config';

--- a/scripts/storybook/src/rules.js
+++ b/scripts/storybook/src/rules.js
@@ -1,6 +1,42 @@
 const { _createCodesandboxRule } = require('./utils');
 
 /**
+ * @type {import("webpack").RuleSetRule}
+ */
+const tsRule = {
+  test: [/\.tsx?$/],
+  use: {
+    loader: 'swc-loader',
+    options: {
+      jsc: {
+        target: 'es2015',
+        parser: {
+          syntax: 'typescript',
+          tsx: true,
+          decorators: true,
+          dynamicImport: true,
+        },
+        transform: {
+          decoratorMetadata: true,
+          legacyDecorator: true,
+        },
+        keepClassNames: true,
+        externalHelpers: true,
+        loose: true,
+      },
+    },
+  },
+};
+
+/**
+ * @type {import("webpack").RuleSetRule}
+ */
+const cssRule = {
+  test: /\.css$/,
+  use: ['style-loader', 'css-loader'],
+};
+
+/**
  * v8 uses SCSS/CSS modules
  * @type {import("webpack").RuleSetRule}
  */
@@ -61,6 +97,8 @@ const griffelRule = {
  */
 const codesandboxRule = _createCodesandboxRule();
 
+exports.tsRule = tsRule;
 exports.scssRule = scssRule;
+exports.cssRule = cssRule;
 exports.griffelRule = griffelRule;
 exports.codesandboxRule = codesandboxRule;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->



<table role="table">
  <thead>
    <tr>
      <th>Test suite</th>
      <th>Build time</th>
      <th>Delta</th>
      <th>Test time</th>
      <th>Delta</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>react-components: Before</td>
      <td>186s</td>
      <td rowspan="2">+96% 🚅</td>
      <td>163s</td>
      <td rowspan="2"><del>-63%</del>/ after rebase 0%</td>
    </tr>
    <tr>
      <td>react-components: After</td>
      <td>8s</td>
      <td><del>262s</del> / after rebase 162s</td>
    </tr>
    <tr>
      <td>react: Before</td>
      <td>134s</td>
      <td rowspan="2">+92% 🚅</td>
      <td>1231s</td>
      <td rowspan="2"><del>-65%</del> / after rebase ~0%</td>
    </tr>
    <tr>
      <td>react: After</td>
      <td>11s</td>
      <td><del>1800s</del> / after rebase 1227s</td>
    </tr>
    <tr>
      <td>react-northstar: Before</td>
      <td>490s</td>
      <td rowspan="2" style="background-color: greenyellow;">+93% 🚅</td>
      <td>402s</td>
      <td rowspan="2" style="background-color: greenyellow;">+16.5% 🚅</td>
    </tr>
    <tr>
      <td>react-northstart: After</td>
      <td>35s</td>
      <td>345s</td>
    </tr>
  </tbody>
</table>

## Previous Behavior

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/1223799/219710589-6da5b9c1-1654-4c42-baab-61dea8b4b19b.png">

## New Behavior

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/1223799/220085111-83d875fd-319b-403d-8450-dc3be0f9b1e6.png">

-  perf improvements
-  every perf app has unified `type-check` npm alias

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/26559
