### PR TITLE
revert: rollback List rendering change

### DIFF
--- a/apps/ssr-tests/test/test.js
+++ b/apps/ssr-tests/test/test.js
@@ -46,12 +46,6 @@ describe('Utilities', () => {
       assert.equal(library.getDocument(), undefined);
     });
   });
-
-  describe('canUseDOM', () => {
-    it('returns false in server environment', () => {
-      assert.equal(library.canUseDOM(), false);
-    });
-  });
 });
 
 function testRender(componentName, component) {
@@ -62,7 +56,7 @@ function testRender(componentName, component) {
       ReactDOMServer.renderToString(elem);
       done();
     } catch (e) {
-      done(e);
+      done(new Error(e));
     }
   });
 }

--- a/change/@fluentui-react-095e69ed-d501-445c-aefa-a2f2ec7f8084.json
+++ b/change/@fluentui-react-095e69ed-d501-445c-aefa-a2f2ec7f8084.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "revert: rollback List rendering change",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6793,6 +6793,8 @@ export interface IListState<T = any> {
     // (undocumented)
     getDerivedStateFromProps(nextProps: IListProps<T>, previousState: IListState<T>): IListState<T>;
     // (undocumented)
+    hasMounted: boolean;
+    // (undocumented)
     isScrolling?: boolean;
     measureVersion?: number;
     // (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -6793,8 +6793,6 @@ export interface IListState<T = any> {
     // (undocumented)
     getDerivedStateFromProps(nextProps: IListProps<T>, previousState: IListState<T>): IListState<T>;
     // (undocumented)
-    hasMounted: boolean;
-    // (undocumented)
     isScrolling?: boolean;
     measureVersion?: number;
     // (undocumented)

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -8114,7 +8114,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone7"
+                                data-focuszone-id="FocusZone9"
                                 data-is-focusable={true}
                                 data-item-index={0}
                                 data-selection-index={0}
@@ -8396,7 +8396,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       flex-shrink: 0;
                                     }
                                 data-automationid="DetailsRow"
-                                data-focuszone-id="FocusZone9"
+                                data-focuszone-id="FocusZone11"
                                 data-is-focusable={true}
                                 data-item-index={1}
                                 data-selection-index={1}
@@ -8622,7 +8622,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                     >
                       <div
                         aria-expanded={true}
-                        aria-labelledby="GroupHeader11"
+                        aria-labelledby="GroupHeader7"
                         aria-rowindex={5}
                         className=
                             ms-GroupHeader
@@ -8814,7 +8814,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                   white-space: nowrap;
                                 }
                             data-selection-invoke={true}
-                            id="GroupHeader11"
+                            id="GroupHeader7"
                             onClick={[Function]}
                             role="gridcell"
                           >
@@ -8841,7 +8841,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       <div
                         aria-label="Group 1"
                         className="ms-List"
-                        id="GroupedListSection10"
+                        id="GroupedListSection6"
                         role="rowgroup"
                       >
                         <div

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -46,6 +46,7 @@ export interface IListState<T = any> {
   getDerivedStateFromProps(nextProps: IListProps<T>, previousState: IListState<T>): IListState<T>;
 
   pagesVersion?: {};
+  hasMounted: boolean;
 }
 
 interface IPageCacheItem<T> {
@@ -159,6 +160,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       pages: [],
       isScrolling: false,
       getDerivedStateFromProps: this._getDerivedStateFromProps,
+      hasMounted: false,
     };
 
     this._async = new Async(this);
@@ -534,7 +536,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
     const pageElement = onRenderPage(
       {
-        page: page,
+        page,
         className: 'ms-List-page',
         key: page.key,
         ref: (newRef: unknown) => {
@@ -552,8 +554,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     // first 30 items did not change, we still re-rendered all of them in this props.items change.
     if (usePageCache && page.startIndex === 0) {
       this._pageCache[page.key] = {
-        page: page,
-        pageElement: pageElement,
+        page,
+        pageElement,
       };
     }
     return pageElement;
@@ -983,7 +985,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     // console.log('materialized: ', materializedRect);
     return {
       ...state,
-      pages: pages,
+      pages,
       measureVersion: this._measureVersion,
     };
   }
@@ -1009,8 +1011,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       const { height = this._getPageHeight(itemIndex, visibleRect, itemCount) } = pageData;
 
       return {
-        itemCount: itemCount,
-        height: height,
+        itemCount,
+        height,
         data: pageData.data,
         key: pageData.key,
       };
@@ -1018,7 +1020,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       const itemCount = this._getItemCountForPage(itemIndex, visibleRect);
 
       return {
-        itemCount: itemCount,
+        itemCount,
         height: this._getPageHeight(itemIndex, visibleRect, itemCount),
       };
     }
@@ -1063,13 +1065,13 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
     return {
       key: pageKey,
-      startIndex: startIndex,
+      startIndex,
       itemCount: count,
-      items: items,
-      style: style,
+      items,
+      style,
       top: 0,
       height: 0,
-      data: data,
+      data,
       isSpacer: isSpacer || false,
     };
   }
@@ -1146,9 +1148,9 @@ function _expandRect(rect: IRectangle, pagesBefore: number, pagesAfter: number):
   const height = rect.height + (pagesBefore + pagesAfter) * rect.height;
 
   return {
-    top: top,
+    top,
     bottom: top + height,
-    height: height,
+    height,
     left: rect.left,
     right: rect.right,
     width: rect.width,


### PR DESCRIPTION
## Previous Behavior

Change to List rendering behavior lead to rendering issues in consuming controls like `TilesList`.

Reverts this PR: https://github.com/microsoft/fluentui/pull/25331
Which is the fix for this issue: https://github.com/microsoft/fluentui/issues/23925

## New Behavior

Rollback rendering to previous behavior.