### PR TITLE
fix: add change files to force package publish

### DIFF
--- a/change/@fluentui-utilities-3e11088e-0de6-44c6-afa4-176d678d0629.json
+++ b/change/@fluentui-utilities-3e11088e-0de6-44c6-afa4-176d678d0629.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "chore: Removing deprecated React.Props from DelayedRender.",
   "packageName": "@fluentui/utilities",
   "email": "jimsleon@hotmail.com",

--- a/change/@fluentui-utilities-3e11088e-0de6-44c6-afa4-176d678d0629.json
+++ b/change/@fluentui-utilities-3e11088e-0de6-44c6-afa4-176d678d0629.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Removing deprecated React.Props from DelayedRender.",
+  "packageName": "@fluentui/utilities",
+  "email": "jimsleon@hotmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
#26821 moved the `IReactProps` interface to `@fluentui/utilities` but [the changefile](https://github.com/microsoft/fluentui/pull/26821/files#diff-39867d6dfbe2d281e0592a9029972c52836029820e71b124b41deed03e84f911) had the wrong `dependentChangeType` value so the package was not published.

Since the interface was removed from `@fluentui/react` the type is now missing and causing build errors for partners.