### PR TITLE
fix: v8 Combobox role and accname for non-hidden icon button

### DIFF
--- a/change/@fluentui-react-f3d82f9f-d152-455c-914e-71cf2dfe554b.json
+++ b/change/@fluentui-react-f3d82f9f-d152-455c-914e-71cf2dfe554b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update role and accname for non-hidden icon button",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1680,7 +1680,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
         onKeyUp={[Function]}
         onMouseDown={[Function]}
         onMouseUp={[Function]}
-        role="presentation"
         tabIndex={-1}
         type="button"
       >

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -221,7 +221,7 @@ describe('ComboBox', () => {
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'f{enter}');
 
-    const caretdownButton = getByRole('presentation', { hidden: true });
+    const caretdownButton = getByRole('button');
     userEvent.click(caretdownButton);
 
     expect(getAllByRole('option')).toHaveLength(DEFAULT_OPTIONS.length);
@@ -233,7 +233,7 @@ describe('ComboBox', () => {
     const combobox = getByRole('combobox');
     userEvent.type(combobox, 'f{enter}');
 
-    const caretdownButton = getByRole('presentation', { hidden: true });
+    const caretdownButton = getByRole('button');
     userEvent.click(caretdownButton);
 
     const options = getAllByRole('option');
@@ -555,7 +555,7 @@ describe('ComboBox', () => {
     const { getByRole, queryAllByRole } = render(
       <ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} disabled />,
     );
-    const caretdownButton = getByRole('presentation', { hidden: true });
+    const caretdownButton = getByRole('button');
     userEvent.click(caretdownButton);
     expect(queryAllByRole('option')).toHaveLength(0);
   });
@@ -1189,7 +1189,7 @@ describe('ComboBox', () => {
       <ComboBox multiSelect options={DEFAULT_OPTIONS} allowFreeform />,
     );
     const combobox = getByRole('combobox');
-    const caretdownButton = getByRole('presentation', { hidden: true });
+    const caretdownButton = getByRole('button');
     userEvent.type(combobox, comboBoxOption.text);
     //click on container to trigger onBlur
     userEvent.click(container);
@@ -1215,7 +1215,7 @@ describe('ComboBox', () => {
 
     const { container, getByRole, getAllByRole } = render(<ComboBox options={DEFAULT_OPTIONS} allowFreeform />);
     const combobox = getByRole('combobox');
-    const caretdownButton = getByRole('presentation', { hidden: true });
+    const caretdownButton = getByRole('button');
     userEvent.type(combobox, comboBoxOption.text);
     userEvent.click(container);
     expect(combobox.getAttribute('value')).toEqual(comboBoxOption.text);

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -591,6 +591,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         : placeholderProp;
 
     const labelledBy = [this.props['aria-labelledby'], label && this._id + '-label'].join(' ').trim();
+    const labelProps = {
+      'aria-labelledby': labelledBy ? labelledBy : undefined,
+      'aria-label': ariaLabel && !label ? ariaLabel : undefined,
+    };
 
     return (
       <div
@@ -618,8 +622,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           aria-autocomplete={this._getAriaAutoCompleteValue()}
           role="combobox"
           readOnly={disabled}
-          aria-labelledby={labelledBy ? labelledBy : undefined}
-          aria-label={ariaLabel && !label ? ariaLabel : undefined}
+          {...labelProps}
           aria-describedby={
             errorMessage !== undefined ? mergeAriaAttributeValues(ariaDescribedBy, errorMessageId) : ariaDescribedBy
           }
@@ -643,8 +646,9 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         <IconButton
           className={'ms-ComboBox-CaretDown-button'}
           styles={this._getCaretButtonStyles()}
-          role="presentation"
+          role={isButtonAriaHidden ? 'presentation' : undefined}
           aria-hidden={isButtonAriaHidden}
+          {...(isButtonAriaHidden ? {} : labelProps)}
           data-is-focusable={false}
           tabIndex={-1}
           onClick={this._onComboBoxClick}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -648,7 +648,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           styles={this._getCaretButtonStyles()}
           role={isButtonAriaHidden ? 'presentation' : undefined}
           aria-hidden={isButtonAriaHidden}
-          {...(isButtonAriaHidden ? {} : labelProps)}
+          {...(!isButtonAriaHidden ? labelProps : undefined)}
           data-is-focusable={false}
           tabIndex={-1}
           onClick={this._onComboBoxClick}

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -290,7 +290,6 @@ exports[`ComboBox Renders correctly 1`] = `
               forced-color-adjust: none;
             }
         data-is-focusable="false"
-        role="presentation"
         tabindex="-1"
         type="button"
       >
@@ -609,7 +608,6 @@ exports[`ComboBox Renders correctly when open 1`] = `
               forced-color-adjust: none;
             }
         data-is-focusable="false"
-        role="presentation"
         tabindex="-1"
         type="button"
       >
@@ -1377,7 +1375,6 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
               forced-color-adjust: none;
             }
         data-is-focusable="false"
-        role="presentation"
         tabindex="-1"
         type="button"
       >
@@ -2284,7 +2281,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               forced-color-adjust: none;
             }
         data-is-focusable="false"
-        role="presentation"
         tabindex="-1"
         type="button"
       >


### PR DESCRIPTION
When the Combobox icon button isn't hidden, it should have an appropriate role and accname

- Fixes #26897
