### PR TITLE
doc(web-components): Add storybook landing page

### DIFF
--- a/change/@fluentui-web-components-ce5121f7-b7b0-48c8-862f-50a4684330a9.json
+++ b/change/@fluentui-web-components-ce5121f7-b7b0-48c8-862f-50a4684330a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Add landing page",
+  "packageName": "@fluentui/web-components",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/.storybook/preview.mjs
+++ b/packages/web-components/.storybook/preview.mjs
@@ -20,8 +20,15 @@ export const parameters = {
   },
   options: {
     storySort: {
-      order: [],
       method: 'alphabetical',
+      order: [
+        'Concepts',
+        [
+          'Introduction',
+        ],
+        'Components',
+        'Theme',
+      ],
     },
   },
   docs: {

--- a/packages/web-components/src/_docs/concepts/introduction.stories.mdx
+++ b/packages/web-components/src/_docs/concepts/introduction.stories.mdx
@@ -1,0 +1,26 @@
+import { Meta } from '@storybook/addon-docs';
+import pkg from '../../../package.json';
+
+<Meta title="Concepts/Introduction" />
+
+<h2>
+  Fluent UI Web Components <span>v{pkg.version}</span>
+</h2>
+
+⚠️ These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+
+Microsoft's [Fluent UI Web Components](https://github.com/microsoft/fluentui/tree/master/packages/web-components) is designed to help you build Fluent web apps using extensible Web Components. The package composes the `@microsoft/fast-foundation` Web Component package and styles it with the [Fluent design language](https://github.com/microsoft/fluentui).
+
+### What are Web Components?
+
+"Web Components" is an umbrella term that refers to a collection of web standards focused on enabling the creation of custom HTML elements. Some of the standards that are under the umbrella include the ability to define new HTML tags, plug into a standard component lifecycle, encapsulate HTML rendering and CSS, parameterize CSS, skin components, and more. Each of these platform features is defined by the W3C and has shipped in every major browser today.
+
+### How does Fluent UI Web Components leverage Web Components?
+
+Fluent UI Web Components is built directly on the W3C Web Component standards, and does not create its own component model. This allows our components to function the same as built-in, native HTML elements. You do not need a framework to use Fluent UI components but you can use them in combination with any framework or library of your choice.
+
+### Joining the community
+
+Looking to get answers to questions or engage with us in realtime? Submit requests and issues on [GitHub](https://github.com/Microsoft/fast/issues/new/choose).
+
+We look forward to building an amazing open source community with you!


### PR DESCRIPTION
Adds a landing page to the storybook docs for web-components.
The purpose of this PR is to (1) setup the stories structure and (2) add a version information to the published docsite.

👀 Open [live demo](https://fluentuipr.z22.web.core.windows.net/pull/26911/web-components/storybook/index.html?path=/docs/concepts-introduction--page).

Screenshot:
![image](https://user-images.githubusercontent.com/9615899/220077371-90fea6e8-040a-4d8b-b4f5-5f85be7453e6.png)
