### PR TITLE
feat: animation control for FluentProvider

### DIFF
--- a/packages/react-components/react-popover/stories/Popover/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverDefault.stories.tsx
@@ -1,32 +1,40 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
-import type { PopoverProps } from '@fluentui/react-components';
+import { makeStyles, shorthands, mergeClasses } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
-  contentHeader: {
-    marginTop: '0',
+  root: {
+    width: '64px',
+    height: '64px',
+    ...shorthands.margin('10px'),
+    ...shorthands.borderRadius('50%'),
+    backgroundColor: 'silver',
+    ...shorthands.outline('1px', 'solid', 'transparent'),
+
+    transitionProperty: 'outline',
+    transitionDuration: '500ms, 100ms',
+    transitionDelay: 'cubic-bezier(0.80,0.00,0.20,1.00), linear',
+  },
+  x: {
+    ...shorthands.outline('10px', 'solid', 'cornflowerblue'),
   },
 });
 
-const ExampleContent = () => {
-  const styles = useStyles();
-  return (
-    <div>
-      <h3 className={styles.contentHeader}>Popover content</h3>
-
-      <div>This is some popover content</div>
-    </div>
-  );
+const onTransitionEnd = () => {
+  console.log('transitionEnd');
 };
 
-export const Default = (props: PopoverProps) => (
-  <Popover {...props}>
-    <PopoverTrigger disableButtonEnhancement>
-      <Button>Popover trigger</Button>
-    </PopoverTrigger>
+export const Default = () => {
+  const classes = useStyles();
+  const [border, setBorder] = React.useState(false);
 
-    <PopoverSurface>
-      <ExampleContent />
-    </PopoverSurface>
-  </Popover>
-);
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setBorder(b => !b);
+    }, 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return <div onTransitionEnd={onTransitionEnd} className={mergeClasses(classes.root, border && classes.x)} />;
+};

--- a/packages/react-components/react-provider/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/etc/react-provider.api.md
@@ -24,6 +24,7 @@ export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentPro
     targetDocument?: Document | undefined;
     theme?: Partial<Theme> | undefined;
     overrides_unstable?: OverridesContextValue_unstable | undefined;
+    animations?: "disabled" | "enabled" | "reduced" | undefined;
 } & React_2.RefAttributes<HTMLElement>>;
 
 // @public (undocumented)
@@ -44,6 +45,7 @@ export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir
     targetDocument?: Document;
     theme?: PartialTheme;
     overrides_unstable?: OverridesContextValue_unstable;
+    animations?: 'enabled' | 'disabled' | 'reduced';
 };
 
 // @public (undocumented)
@@ -52,7 +54,7 @@ export type FluentProviderSlots = {
 };
 
 // @public (undocumented)
-export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'applyStylesToPortals' | 'dir' | 'overrides_unstable'>> & {
+export type FluentProviderState = ComponentState<FluentProviderSlots> & Pick<FluentProviderProps, 'targetDocument'> & Required<Pick<FluentProviderProps, 'applyStylesToPortals' | 'dir' | 'overrides_unstable' | 'animations'>> & {
     theme: ThemeContextValue_unstable;
     themeClassName: string;
 };

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -30,11 +30,20 @@ export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   overrides_unstable?: OverridesContextValue;
+
+  /**
+   * Some global control of how animations are applied.
+   * - enabled - All animations are applied normally.
+   * - reduced - Animations have extremely short durations which are harder to perceive.
+   * - disabled - Animations are disabled and transition events will not be triggered.
+   * @default enabled
+   */
+  animations?: 'enabled' | 'disabled' | 'reduced';
 };
 
 export type FluentProviderState = ComponentState<FluentProviderSlots> &
   Pick<FluentProviderProps, 'targetDocument'> &
-  Required<Pick<FluentProviderProps, 'applyStylesToPortals' | 'dir' | 'overrides_unstable'>> & {
+  Required<Pick<FluentProviderProps, 'applyStylesToPortals' | 'dir' | 'overrides_unstable' | 'animations'>> & {
     theme: ThemeContextValue;
     themeClassName: string;
   };

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -38,6 +38,7 @@ export const useFluentProvider_unstable = (
     targetDocument = parentContext.targetDocument,
     theme,
     overrides_unstable: overrides = {},
+    animations = 'enabled',
   } = props;
   const mergedTheme = shallowMerge(parentTheme, theme);
 
@@ -63,6 +64,7 @@ export const useFluentProvider_unstable = (
     // eslint-disable-next-line @typescript-eslint/naming-convention
     overrides_unstable: mergedOverrides,
     themeClassName: useFluentProviderThemeStyleTag({ theme: mergedTheme, targetDocument }),
+    animations,
 
     components: {
       root: 'div',

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderStyles.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderStyles.ts
@@ -8,12 +8,46 @@ export const fluentProviderClassNames: SlotClassNames<FluentProviderSlots> = {
   root: 'fui-FluentProvider',
 };
 
+const reducedAnimationsStyles = {
+  animationDelay: '-1ms !important',
+  animationDuration: '-1ms !important',
+  animationIterationCount: '-1ms !important',
+  scrollBehavior: 'auto !important' as 'auto',
+  transitionDuration: '0.1s !important',
+  transitionDelay: '0.1s !important',
+};
+
+const disabledAnimationsStyles = {
+  animationDelay: '-1ms !important',
+  animationDuration: '-1ms !important',
+  animationIterationCount: '-1ms !important',
+  scrollBehavior: 'auto !important' as 'auto',
+  transitionDuration: '0s !important',
+  transitionDelay: '0s !important',
+};
+
 const useStyles = makeStyles({
   root: {
     color: tokens.colorNeutralForeground1,
     backgroundColor: tokens.colorNeutralBackground1,
     textAlign: 'left',
     ...typographyStyles.body1,
+  },
+
+  reducedAnimations: {
+    '& *': reducedAnimationsStyles,
+
+    '& *::before': reducedAnimationsStyles,
+
+    '& *::after': reducedAnimationsStyles,
+  },
+
+  disabledAnimations: {
+    '& *': disabledAnimationsStyles,
+
+    '& *::before': disabledAnimationsStyles,
+
+    '& *::after': disabledAnimationsStyles,
   },
 });
 
@@ -27,6 +61,8 @@ export const useFluentProviderStyles_unstable = (state: FluentProviderState) => 
     state.themeClassName,
     styles.root,
     state.root.className,
+    state.animations === 'disabled' && styles.disabledAnimations,
+    state.animations === 'reduced' && styles.reducedAnimations,
   );
 
   return state;


### PR DESCRIPTION
Implements an `animations` prop for the Fluent provider to support the following animation modes:

* reduced - reduces the duration of all animation and transitions but will still trigger transition events
* disabled - disables all animations and transitions and will no longer trigger transition events

- Fixes #26913
