### PR TITLE
docs: Remove testing code from MenuList example

### DIFF
--- a/packages/react-components/react-menu/stories/MenuList/MenuListDefault.stories.tsx
+++ b/packages/react-components/react-menu/stories/MenuList/MenuListDefault.stories.tsx
@@ -18,13 +18,11 @@ export const Default = () => {
   const styles = useMenuListContainerStyles();
   return (
     <div className={styles.container}>
-      <button>Foo</button>
       <MenuList>
         <MenuItem>Cut</MenuItem>
         <MenuItem>Paste</MenuItem>
         <MenuItem>Edit</MenuItem>
       </MenuList>
-      <button>Foo</button>
     </div>
   );
 };


### PR DESCRIPTION
Removes `Foo` buttons from MenuList examples
