### PR TITLE
fix the decision condition in dismissOnTargetWindowBlur to handle the…

### DIFF
--- a/change/@fluentui-react-0670c9ba-89d4-45ef-a1a9-e985a92ab991.json
+++ b/change/@fluentui-react-0670c9ba-89d4-45ef-a1a9-e985a92ab991.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix the decision condition in dismissOnTargetWindowBlur to handle the case that clicking inside an iframe.",
+  "packageName": "@fluentui/react",
+  "email": "272097277@qq.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -342,7 +342,7 @@ function useDismissHandlers(
       if (
         ((preventDismissOnEvent && !preventDismissOnEvent(ev)) ||
           (!preventDismissOnEvent && !preventDismissOnLostFocus)) &&
-        !targetWindow?.document.hasFocus() &&
+        (!targetWindow?.document.hasFocus() || ev.target === targetRef.current) &&
         ev.relatedTarget === null
       ) {
         onDismiss?.(ev);


### PR DESCRIPTION
… case that clicking inside an iframe.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
When clicking inside an iframe (but outside of the callout), the callout is not dismissed.
<!-- This is the behavior we have today -->

## New Behavior
When clicking outside the callout, the onDismiss handler should be triggered, and the callout should disappear.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
https://github.com/microsoft/fluentui/issues/26927
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
