### PR TITLE
Update CODEOWNERS for change files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,9 @@
 *.sh @microsoft/fluentui-react-build
 *.yml @microsoft/fluentui-react-build
 
+#### Change files (no owner)
+/change
+
 #### Build folders
 /.codesandbox @microsoft/fluentui-react-build
 /.devcontainer @microsoft/fluentui-react-build


### PR DESCRIPTION
## Previous Behavior

Change files were included in the catch-all rule `*`, resulting in most PRs requiring approval from fluentui-admins.

## New Behavior

Update the change directory to have no codeowner specified. The change directory contains files from every package, and doesn't have a specific owner. Other code changes in a PR will still require owner approval. If a PR contains only change files, then it still requires approval from a maintainer.