### PR TITLE
fix(ci): Overwrite existing data in wc storybook deploy

### DIFF
--- a/.github/workflows/azure-storage-web-components.yml
+++ b/.github/workflows/azure-storage-web-components.yml
@@ -36,4 +36,4 @@ jobs:
         uses: Azure/cli@v1.0.7
         with:
           # Specify the script here
-          inlineScript: az storage blob upload-batch --account-name webcomponentsdocsite --auth-mode key -d '$web' -s ./packages/web-components/dist/storybook
+          inlineScript: az storage blob upload-batch --overwrite --account-name webcomponentsdocsite --auth-mode key -d '$web' -s ./packages/web-components/dist/storybook


### PR DESCRIPTION
## Previous Behavior

Web Components v3 storybook deployment silently fails.

## New Behavior

Deploy now overwrites existing data

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
