### PR TITLE
Fix/changes check

### DIFF
--- a/scripts/beachball/check-wc-3-changefiles.js
+++ b/scripts/beachball/check-wc-3-changefiles.js
@@ -27,6 +27,11 @@ if (isExecutedFromCli) {
  * - Usage needs to be removed from .github/workflows/check-packages.yml
  */
 function main(/** @type {string} */ root) {
+  if (!fs.existsSync(root)) {
+    console.log('✅ Changes folder does not exist, skipping check.');
+    return;
+  }
+
   const changeFiles = fs.readdirSync(root, 'utf8');
 
   const invalidChangeFiles = /** @type string [] */ (changeFiles

--- a/scripts/beachball/check-wc-3-changefiles.spec.ts
+++ b/scripts/beachball/check-wc-3-changefiles.spec.ts
@@ -63,6 +63,14 @@ describe(`Name of the group`, () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it(`should pass if changes folder is empty`, () => {
+    const { root, consoleErrorSpy, processExitSpy } = setup([]);
+    main(root);
+
+    expect(processExitSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
   it(`should fail if there is invalid changefile`, () => {
     const changeFiles: Array<ChangeFile> = [
       {

--- a/scripts/beachball/check-wc-3-changefiles.spec.ts
+++ b/scripts/beachball/check-wc-3-changefiles.spec.ts
@@ -55,6 +55,14 @@ describe(`Name of the group`, () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it(`should pass if changes folder does not exist`, () => {
+    const { root, consoleErrorSpy, processExitSpy } = setup([]);
+    main(path.join(root, 'invalid'));
+
+    expect(processExitSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
   it(`should fail if there is invalid changefile`, () => {
     const changeFiles: Array<ChangeFile> = [
       {


### PR DESCRIPTION
## Previous Behavior

CI for web-components-v3 PR fails if there is no `changes` folder:
![image](https://user-images.githubusercontent.com/9615899/220595286-377a2ee7-e419-47d8-996e-463e1d2630e4.png)

## New Behavior

`check-wc-3-changefiles` checks the folder exists first
