### PR TITLE
feature: introduces `inertTrapfocus` property and deprecates `legacyTrapFocus`

### DIFF
--- a/change/@fluentui-react-dialog-38f69b56-be72-4380-8325-4fa430483d93.json
+++ b/change/@fluentui-react-dialog-38f69b56-be72-4380-8325-4fa430483d93.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: introduces legacyTrapFocus property",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-38f69b56-be72-4380-8325-4fa430483d93.json
+++ b/change/@fluentui-react-dialog-38f69b56-be72-4380-8325-4fa430483d93.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feature: introduces legacyTrapFocus property",
+  "comment": "feature: introduces innerTrapFocus",
   "packageName": "@fluentui/react-dialog",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-popover-c8f02f2c-1573-4b58-b7b2-e75b0ca9eb74.json
+++ b/change/@fluentui-react-popover-c8f02f2c-1573-4b58-b7b2-e75b0ca9eb74.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: introduces innerTrapFocus and deprecates legacyTrapFocus",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -17,7 +17,7 @@ import { ReactElement } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
-import { UseModalAttributesOptions } from '@fluentui/react-tabster/src/index';
+import { UseModalAttributesOptions } from '@fluentui/react-tabster';
 
 // @public
 export const Dialog: React_2.FC<DialogProps>;

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -17,6 +17,7 @@ import { ReactElement } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
+import { UseModalAttributesOptions } from '@fluentui/react-tabster/src/index';
 
 // @public
 export const Dialog: React_2.FC<DialogProps>;
@@ -107,6 +108,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
     defaultOpen?: boolean;
     onOpenChange?: DialogOpenChangeEventHandler;
     children: [JSX.Element, JSX.Element] | JSX.Element;
+    legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -17,7 +17,6 @@ import { ReactElement } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
-import { UseModalAttributesOptions } from '@fluentui/react-tabster';
 
 // @public
 export const Dialog: React_2.FC<DialogProps>;
@@ -108,7 +107,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
     defaultOpen?: boolean;
     onOpenChange?: DialogOpenChangeEventHandler;
     children: [JSX.Element, JSX.Element] | JSX.Element;
-    legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+    inertTrapFocus?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -327,6 +327,69 @@ describe('Dialog', () => {
       cy.get(dialogTriggerOpenSelector).realClick();
       cy.get('body').should('have.css', 'overflow', 'hidden');
     });
+
+    it('should focus trap by default', () => {
+      mount(
+        <Dialog modalType="modal">
+          <DialogTrigger disableButtonEnhancement>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
+          </DialogTrigger>
+          <DialogSurface>
+            <DialogTitle>Dialog title</DialogTitle>
+            <DialogBody>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+              est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+              cumque eaque?
+            </DialogBody>
+            <DialogActions>
+              <DialogTrigger disableButtonEnhancement>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
+              </DialogTrigger>
+              <Button id="do-something-btn" appearance="primary">
+                Do Something
+              </Button>
+            </DialogActions>
+          </DialogSurface>
+        </Dialog>,
+      );
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogTriggerCloseSelector).should('be.focused').realPress('Tab');
+      cy.get('#do-something-btn').should('be.focused').realPress('Tab');
+      cy.get(dialogTriggerCloseSelector).should('be.focused');
+    });
+    it('should focus on window after last element when inertTrapFocus=true', () => {
+      mount(
+        <Dialog inertTrapFocus modalType="modal">
+          <DialogTrigger disableButtonEnhancement>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
+          </DialogTrigger>
+          <DialogSurface>
+            <DialogTitle>Dialog title</DialogTitle>
+            <DialogBody>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+              est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+              cumque eaque?
+            </DialogBody>
+            <DialogActions>
+              <DialogTrigger disableButtonEnhancement>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
+              </DialogTrigger>
+              <Button id="do-something-btn" appearance="primary">
+                Do Something
+              </Button>
+            </DialogActions>
+          </DialogSurface>
+        </Dialog>,
+      );
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogTriggerCloseSelector).should('be.focused').realPress('Tab');
+      cy.get('#do-something-btn').should('be.focused').realPress('Tab');
+      cy.focused().should('not.exist');
+    });
   });
   describe('modalType = non-modal', () => {
     it('should close with escape keydown', () => {
@@ -448,6 +511,68 @@ describe('Dialog', () => {
       );
       cy.get(dialogTriggerOpenSelector).realClick();
       cy.get('body').should('have.css', 'overflow', 'hidden');
+    });
+    it('should focus trap by default', () => {
+      mount(
+        <Dialog modalType="alert">
+          <DialogTrigger disableButtonEnhancement>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
+          </DialogTrigger>
+          <DialogSurface>
+            <DialogTitle>Dialog title</DialogTitle>
+            <DialogBody>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+              est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+              cumque eaque?
+            </DialogBody>
+            <DialogActions>
+              <DialogTrigger disableButtonEnhancement>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
+              </DialogTrigger>
+              <Button id="do-something-btn" appearance="primary">
+                Do Something
+              </Button>
+            </DialogActions>
+          </DialogSurface>
+        </Dialog>,
+      );
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogTriggerCloseSelector).should('be.focused').realPress('Tab');
+      cy.get('#do-something-btn').should('be.focused').realPress('Tab');
+      cy.get(dialogTriggerCloseSelector).should('be.focused');
+    });
+    it('should focus on window after last element when inertTrapFocus=true', () => {
+      mount(
+        <Dialog inertTrapFocus modalType="alert">
+          <DialogTrigger disableButtonEnhancement>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
+          </DialogTrigger>
+          <DialogSurface>
+            <DialogTitle>Dialog title</DialogTitle>
+            <DialogBody>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+              est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+              cumque eaque?
+            </DialogBody>
+            <DialogActions>
+              <DialogTrigger disableButtonEnhancement>
+                <Button id={dialogTriggerCloseId} appearance="secondary">
+                  Close
+                </Button>
+              </DialogTrigger>
+              <Button id="do-something-btn" appearance="primary">
+                Do Something
+              </Button>
+            </DialogActions>
+          </DialogSurface>
+        </Dialog>,
+      );
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogTriggerCloseSelector).should('be.focused').realPress('Tab');
+      cy.get('#do-something-btn').should('be.focused').realPress('Tab');
+      cy.focused().should('not.exist');
     });
   });
 

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -2,7 +2,6 @@ import type * as React from 'react';
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
 import type { DialogSurfaceElement } from '../DialogSurface/DialogSurface.types';
-import { UseModalAttributesOptions } from '@fluentui/react-tabster';
 
 export type DialogSlots = {};
 
@@ -89,14 +88,12 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
    */
   children: [JSX.Element, JSX.Element] | JSX.Element;
   /**
-   * Enables older Fluent UI focus trap behavior where the user
-   * cannot tab into the window outside of the document. This is now
-   * non-standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
+   * Enables standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
    * where the focus trap involves setting outside elements inert.
    *
    * @default false
    */
-  legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+  inertTrapFocus?: boolean;
 };
 
 export type DialogState = ComponentState<DialogSlots> &

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -2,7 +2,7 @@ import type * as React from 'react';
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
 import type { DialogSurfaceElement } from '../DialogSurface/DialogSurface.types';
-import { UseModalAttributesOptions } from '@fluentui/react-tabster/src/index';
+import { UseModalAttributesOptions } from '@fluentui/react-tabster';
 
 export type DialogSlots = {};
 

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -2,6 +2,7 @@ import type * as React from 'react';
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
 import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
 import type { DialogSurfaceElement } from '../DialogSurface/DialogSurface.types';
+import { UseModalAttributesOptions } from '@fluentui/react-tabster/src/index';
 
 export type DialogSlots = {};
 
@@ -87,6 +88,15 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
    * Alternatively can only contain {@link DialogSurface} if using trigger outside dialog, or controlling state.
    */
   children: [JSX.Element, JSX.Element] | JSX.Element;
+  /**
+   * Enables older Fluent UI focus trap behavior where the user
+   * cannot tab into the window outside of the document. This is now
+   * non-standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
+   * where the focus trap involves setting outside elements inert.
+   *
+   * @default false
+   */
+  legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
 };
 
 export type DialogState = ComponentState<DialogSlots> &

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -15,7 +15,7 @@ import type { DialogOpenChangeData, DialogProps, DialogState } from './Dialog.ty
  * @param props - props from this instance of Dialog
  */
 export const useDialog_unstable = (props: DialogProps): DialogState => {
-  const { children, modalType = 'modal', onOpenChange } = props;
+  const { children, modalType = 'modal', onOpenChange, legacyTrapFocus = false } = props;
 
   const [trigger, content] = childrenToTriggerAndContent(children);
 
@@ -49,6 +49,7 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     components: {
       backdrop: 'div',
     },
+    legacyTrapFocus,
     open,
     modalType,
     content: open ? content : null,

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -15,7 +15,7 @@ import type { DialogOpenChangeData, DialogProps, DialogState } from './Dialog.ty
  * @param props - props from this instance of Dialog
  */
 export const useDialog_unstable = (props: DialogProps): DialogState => {
-  const { children, modalType = 'modal', onOpenChange, legacyTrapFocus = false } = props;
+  const { children, modalType = 'modal', onOpenChange, inertTrapFocus = false } = props;
 
   const [trigger, content] = childrenToTriggerAndContent(children);
 
@@ -49,7 +49,7 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     components: {
       backdrop: 'div',
     },
-    legacyTrapFocus,
+    inertTrapFocus,
     open,
     modalType,
     content: open ? content : null,

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
@@ -2,7 +2,7 @@ import type { DialogContextValue, DialogSurfaceContextValue } from '../../contex
 import type { DialogContextValues, DialogState } from './Dialog.types';
 
 export function useDialogContextValues_unstable(state: DialogState): DialogContextValues {
-  const { modalType, open, dialogRef, dialogTitleId, isNestedDialog, legacyTrapFocus, requestOpenChange } = state;
+  const { modalType, open, dialogRef, dialogTitleId, isNestedDialog, inertTrapFocus, requestOpenChange } = state;
 
   /**
    * This context is created with "@fluentui/react-context-selector",
@@ -14,7 +14,7 @@ export function useDialogContextValues_unstable(state: DialogState): DialogConte
     dialogRef,
     dialogTitleId,
     isNestedDialog,
-    legacyTrapFocus,
+    inertTrapFocus,
     requestOpenChange,
   };
 

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
@@ -2,7 +2,7 @@ import type { DialogContextValue, DialogSurfaceContextValue } from '../../contex
 import type { DialogContextValues, DialogState } from './Dialog.types';
 
 export function useDialogContextValues_unstable(state: DialogState): DialogContextValues {
-  const { modalType, open, dialogRef, dialogTitleId, isNestedDialog, requestOpenChange } = state;
+  const { modalType, open, dialogRef, dialogTitleId, isNestedDialog, legacyTrapFocus, requestOpenChange } = state;
 
   /**
    * This context is created with "@fluentui/react-context-selector",
@@ -14,6 +14,7 @@ export function useDialogContextValues_unstable(state: DialogState): DialogConte
     dialogRef,
     dialogTitleId,
     isNestedDialog,
+    legacyTrapFocus,
     requestOpenChange,
   };
 

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -31,7 +31,7 @@ export const useDialogSurface_unstable = (
 ): DialogSurfaceState => {
   const { backdrop, as } = props;
   const modalType = useDialogContext_unstable(ctx => ctx.modalType);
-  const legacyTrapFocus = useDialogContext_unstable(ctx => ctx.legacyTrapFocus);
+  const inertTrapFocus = useDialogContext_unstable(ctx => ctx.inertTrapFocus);
   const dialogRef = useDialogContext_unstable(ctx => ctx.dialogRef);
   const open = useDialogContext_unstable(ctx => ctx.open);
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
@@ -67,7 +67,7 @@ export const useDialogSurface_unstable = (
 
   const { modalAttributes } = useModalAttributes({
     trapFocus: modalType !== 'non-modal',
-    legacyTrapFocus,
+    legacyTrapFocus: !inertTrapFocus,
   });
 
   return {

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -31,6 +31,7 @@ export const useDialogSurface_unstable = (
 ): DialogSurfaceState => {
   const { backdrop, as } = props;
   const modalType = useDialogContext_unstable(ctx => ctx.modalType);
+  const legacyTrapFocus = useDialogContext_unstable(ctx => ctx.legacyTrapFocus);
   const dialogRef = useDialogContext_unstable(ctx => ctx.dialogRef);
   const open = useDialogContext_unstable(ctx => ctx.open);
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
@@ -64,7 +65,10 @@ export const useDialogSurface_unstable = (
     }
   });
 
-  const { modalAttributes } = useModalAttributes({ trapFocus: modalType !== 'non-modal' });
+  const { modalAttributes } = useModalAttributes({
+    trapFocus: modalType !== 'non-modal',
+    legacyTrapFocus,
+  });
 
   return {
     components: {

--- a/packages/react-components/react-dialog/src/contexts/dialogContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogContext.ts
@@ -6,7 +6,7 @@ import type { DialogModalType, DialogOpenChangeData } from '../Dialog';
 
 export type DialogContextValue = {
   open: boolean;
-  legacyTrapFocus: boolean;
+  inertTrapFocus: boolean;
   dialogTitleId?: string;
   isNestedDialog: boolean;
   dialogRef: React.Ref<DialogSurfaceElement>;
@@ -19,7 +19,7 @@ export type DialogContextValue = {
 
 const defaultContextValue: DialogContextValue = {
   open: false,
-  legacyTrapFocus: false,
+  inertTrapFocus: false,
   modalType: 'modal',
   isNestedDialog: false,
   dialogRef: { current: null },

--- a/packages/react-components/react-dialog/src/contexts/dialogContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogContext.ts
@@ -6,6 +6,7 @@ import type { DialogModalType, DialogOpenChangeData } from '../Dialog';
 
 export type DialogContextValue = {
   open: boolean;
+  legacyTrapFocus: boolean;
   dialogTitleId?: string;
   isNestedDialog: boolean;
   dialogRef: React.Ref<DialogSurfaceElement>;
@@ -18,6 +19,7 @@ export type DialogContextValue = {
 
 const defaultContextValue: DialogContextValue = {
   open: false,
+  legacyTrapFocus: false,
   modalType: 'modal',
   isNestedDialog: false,
   dialogRef: { current: null },

--- a/packages/react-components/react-dialog/src/testing/mockUseDialogContext.ts
+++ b/packages/react-components/react-dialog/src/testing/mockUseDialogContext.ts
@@ -10,7 +10,7 @@ export const mockUseDialogContext = (options: Partial<DialogContextValue> = {}) 
   const mockContext: DialogContextValue = {
     open: false,
     modalType: 'modal',
-    legacyTrapFocus: false,
+    inertTrapFocus: false,
     isNestedDialog: false,
     dialogRef: { current: null },
     requestOpenChange() {

--- a/packages/react-components/react-dialog/src/testing/mockUseDialogContext.ts
+++ b/packages/react-components/react-dialog/src/testing/mockUseDialogContext.ts
@@ -10,6 +10,7 @@ export const mockUseDialogContext = (options: Partial<DialogContextValue> = {}) 
   const mockContext: DialogContextValue = {
     open: false,
     modalType: 'modal',
+    legacyTrapFocus: false,
     isNestedDialog: false,
     dialogRef: { current: null },
     requestOpenChange() {

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -40,7 +40,7 @@ export type OpenPopoverEvents = MouseEvent | TouchEvent | React_2.FocusEvent<HTM
 export const Popover: React_2.FC<PopoverProps>;
 
 // @public
-export type PopoverContextValue = Pick<PopoverState, 'open' | 'toggleOpen' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'withArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus' | 'legacyTrapFocus' | 'inline'>;
+export type PopoverContextValue = Pick<PopoverState, 'open' | 'toggleOpen' | 'setOpen' | 'triggerRef' | 'contentRef' | 'openOnHover' | 'openOnContext' | 'mountNode' | 'withArrow' | 'arrowRef' | 'size' | 'appearance' | 'trapFocus' | 'inertTrapFocus' | 'inline'>;
 
 // @public
 export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
@@ -59,6 +59,7 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
     size?: PopoverSize;
     trapFocus?: UseModalAttributesOptions['trapFocus'];
     legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+    inertTrapFocus?: boolean;
     unstable_disableAutoFocus?: boolean;
 };
 
@@ -69,7 +70,7 @@ export const PopoverProvider: Provider<PopoverContextValue> & FC<ProviderProps<P
 export type PopoverSize = 'small' | 'medium' | 'large';
 
 // @public
-export type PopoverState = Pick<PopoverProps, 'appearance' | 'mountNode' | 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'trapFocus' | 'withArrow' | 'legacyTrapFocus'> & Required<Pick<PopoverProps, 'inline' | 'open'>> & Pick<PopoverProps, 'children'> & {
+export type PopoverState = Pick<PopoverProps, 'appearance' | 'mountNode' | 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'trapFocus' | 'withArrow' | 'inertTrapFocus'> & Required<Pick<PopoverProps, 'inline' | 'open'>> & Pick<PopoverProps, 'children'> & {
     arrowRef: React_2.MutableRefObject<HTMLDivElement | null>;
     contentRef: React_2.MutableRefObject<HTMLElement | null>;
     contextTarget: PositioningVirtualElement | undefined;

--- a/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
@@ -358,7 +358,7 @@ describe('Popover', () => {
     describe('legacy focus trap behaviour', () => {
       it('Tab should not go to the window', () => {
         mount(
-          <Popover trapFocus legacyTrapFocus>
+          <Popover trapFocus>
             <PopoverTrigger disableButtonEnhancement>
               <button>Popover trigger</button>
             </PopoverTrigger>
@@ -378,11 +378,33 @@ describe('Popover', () => {
         cy.contains('Two').should('have.focus');
       });
     });
+    describe('inert focus trap behaviour', () => {
+      it('Tab should go to the window', () => {
+        mount(
+          <Popover inertTrapFocus trapFocus>
+            <PopoverTrigger disableButtonEnhancement>
+              <button>Popover trigger</button>
+            </PopoverTrigger>
+
+            <PopoverSurface>
+              <button>One</button>
+              <button>Two</button>
+            </PopoverSurface>
+          </Popover>,
+        );
+
+        cy.get(popoverTriggerSelector).focus().realPress('Enter');
+
+        cy.contains('One').should('have.focus').realPress('Tab');
+        cy.contains('Two').should('have.focus').realPress('Tab');
+        cy.focused().should('not.exist');
+      });
+    });
 
     describe('trap focus behaviour', () => {
       it('should focus on PopoverSurface when its tabIndex is a number', () => {
         mount(
-          <Popover trapFocus legacyTrapFocus>
+          <Popover trapFocus>
             <PopoverTrigger disableButtonEnhancement>
               <button>Popover trigger</button>
             </PopoverTrigger>

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -114,13 +114,13 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
    * non-standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
    * where the focus trap involves setting outside elements inert.
    *
-   * @default false
    * @deprecated this behavior is default provided now, to opt-out of it in favor of standard behavior use the `inertTrapFocus` property
    */
   legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
   /**
    * Enables standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
-   * where the focus trap involves setting outside elements inert.
+   * where the focus trap involves setting outside elements inert,
+   * making navigation leak from the trapped area back to the browser toolbar and vice-versa.
    *
    * @default false
    */

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -115,8 +115,16 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
    * where the focus trap involves setting outside elements inert.
    *
    * @default false
+   * @deprecated this behavior is default provided now, to opt-out of it in favor of standard behavior use the `inertTrapFocus` property
    */
   legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+  /**
+   * Enables standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
+   * where the focus trap involves setting outside elements inert.
+   *
+   * @default false
+   */
+  inertTrapFocus?: boolean;
 
   /**
    * By default Popover focuses the first focusable element in PopoverSurface on open.
@@ -140,7 +148,7 @@ export type PopoverState = Pick<
   | 'openOnHover'
   | 'trapFocus'
   | 'withArrow'
-  | 'legacyTrapFocus'
+  | 'inertTrapFocus'
 > &
   Required<Pick<PopoverProps, 'inline' | 'open'>> &
   Pick<PopoverProps, 'children'> & {

--- a/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/renderPopover.tsx
@@ -21,7 +21,7 @@ export const renderPopover_unstable = (state: PopoverState) => {
     trapFocus,
     triggerRef,
     withArrow,
-    legacyTrapFocus,
+    inertTrapFocus,
   } = state;
 
   return (
@@ -40,7 +40,7 @@ export const renderPopover_unstable = (state: PopoverState) => {
         triggerRef,
         size,
         trapFocus,
-        legacyTrapFocus,
+        inertTrapFocus,
         withArrow,
       }}
     >

--- a/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`PopoverSurface renders a default state 1`] = `
 <div
   aria-label="test"
   class="fui-PopoverSurface"
-  data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true,\\"isAlwaysAccessible\\":true}}"
+  data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true,\\"isAlwaysAccessible\\":true,\\"isTrapped\\":true}}"
   data-testid="component"
   role="group"
 >

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -26,9 +26,13 @@ export const usePopoverSurface_unstable = (
   const withArrow = usePopoverContext_unstable(context => context.withArrow);
   const appearance = usePopoverContext_unstable(context => context.appearance);
   const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
-  const legacyTrapFocus = usePopoverContext_unstable(context => context.legacyTrapFocus);
+  const inertTrapFocus = usePopoverContext_unstable(context => context.inertTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
-  const { modalAttributes } = useModalAttributes({ trapFocus, legacyTrapFocus, alwaysFocusable: !trapFocus });
+  const { modalAttributes } = useModalAttributes({
+    trapFocus,
+    legacyTrapFocus: !inertTrapFocus,
+    alwaysFocusable: !trapFocus,
+  });
 
   const state: PopoverSurfaceState = {
     inline,

--- a/packages/react-components/react-popover/src/popoverContext.ts
+++ b/packages/react-components/react-popover/src/popoverContext.ts
@@ -39,7 +39,7 @@ export type PopoverContextValue = Pick<
   | 'size'
   | 'appearance'
   | 'trapFocus'
-  | 'legacyTrapFocus'
+  | 'inertTrapFocus'
   | 'inline'
 >;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

By default `Popover` and `Dialog` would support an `inert` focus trap approach, which is similar to what is provided by native elements, such as native `dialog` where the focus would leak to the browser window after the last focusable element on the trap.

To opt out of that behavior and to simply trap the focus completely without letting it leak the property `legacyTrapfocus` was provided in `Popover`

## New Behavior


This PR will provide fixes for both `Dialog` and `Popover` components on this matter.

1. makes the `legacyTrapFocus` behavior the default one, as native `inert` focus presents some edge cases with iframes
2. deprecates `legacyTrapFocus` property as the behavior is the default one
3. introduces `inertTrapFocus` property to opt-out of legacy trap focus behaviour in favor of native `inert` focus one


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #26822
- Fixes #26829
