### PR TITLE
Add visual regression test for TilesList

### DIFF
--- a/apps/vr-tests/src/stories/TilesList.stories.tsx
+++ b/apps/vr-tests/src/stories/TilesList.stories.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { Steps, StoryWright } from 'storywright';
+import { storiesOf } from '@storybook/react';
+import { TestWrapperDecorator } from '../utilities/index';
+import {
+  ITilesGridItem,
+  ITilesGridSegment,
+  ITileSize,
+  TilesGridMode,
+  TilesList,
+} from '@fluentui/react-experiments';
+
+export interface IBasicItem {
+  color: string;
+  key: string;
+}
+
+const ITEMS: IBasicItem[] = [];
+
+for (let i = 0; i < 27; i++) {
+  ITEMS.push({
+    color: ['red', 'blue', 'green', 'yellow', 'orange', 'brown', 'purple', 'gray'][i % 8],
+    key: `item-${i}`,
+  });
+}
+
+export interface ITilesListBasicExampleState {
+  items: ITilesGridItem<IBasicItem>[];
+}
+
+export class TilesListBasicExample extends React.Component<{}, ITilesListBasicExampleState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      items: ITEMS.map(
+        (item: IBasicItem): ITilesGridItem<IBasicItem> => {
+          return {
+            content: item,
+            desiredSize: { width: 100, height: 100 },
+            key: item.key,
+            onRender: renderItem,
+          };
+        },
+      ),
+    };
+  }
+
+  public render(): JSX.Element {
+    const gridSegment: ITilesGridSegment<IBasicItem> = {
+      items: this.state.items,
+      key: 'grid',
+      mode: TilesGridMode.fill,
+      minRowHeight: 100,
+      spacing: 10,
+    };
+
+    return <TilesList items={[gridSegment]} />;
+  }
+}
+
+function renderItem(item: IBasicItem, finalSize?: ITileSize): JSX.Element {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        top: '0',
+        left: '0',
+        bottom: '0',
+        right: '0',
+        backgroundColor: item.color,
+      }}
+    >
+      <span>{finalSize ? `${finalSize.width.toFixed(1)}x${finalSize.height.toFixed(1)}` : ''}</span>
+    </div>
+  );
+}
+
+storiesOf('TilesList', module)
+  .addDecorator(TestWrapperDecorator)
+  .addDecorator(story =>
+    // prettier-ignore
+    <StoryWright
+      steps={new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </StoryWright>,
+  )
+  .addStory('Basic', () => <TilesListBasicExample />, { includeRtl: true });

--- a/apps/vr-tests/src/stories/TilesList.stories.tsx
+++ b/apps/vr-tests/src/stories/TilesList.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Steps, StoryWright } from 'storywright';
 import { storiesOf } from '@storybook/react';
-import { TestWrapperDecorator } from '../utilities/index';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/index';
 import {
   ITilesGridItem,
   ITilesGridSegment,
@@ -33,16 +33,14 @@ export class TilesListBasicExample extends React.Component<{}, ITilesListBasicEx
     super(props);
 
     this.state = {
-      items: ITEMS.map(
-        (item: IBasicItem): ITilesGridItem<IBasicItem> => {
-          return {
-            content: item,
-            desiredSize: { width: 100, height: 100 },
-            key: item.key,
-            onRender: renderItem,
-          };
-        },
-      ),
+      items: ITEMS.map((item: IBasicItem): ITilesGridItem<IBasicItem> => {
+        return {
+          content: item,
+          desiredSize: { width: 100, height: 100 },
+          key: item.key,
+          onRender: renderItem,
+        };
+      }),
     };
   }
 
@@ -80,7 +78,7 @@ function renderItem(item: IBasicItem, finalSize?: ITileSize): JSX.Element {
 }
 
 storiesOf('TilesList', module)
-  .addDecorator(TestWrapperDecorator)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
   .addDecorator(story =>
     // prettier-ignore
     <StoryWright


### PR DESCRIPTION
Added a new visual regression test for `TilesList` to ensure that changes to `List` don't break its render behavior, which requires an upfront measurement of the content width before rendering can occur.