### PR TITLE
fix: constrain ChoiceGroup horizontal width

### DIFF
--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -282,6 +282,9 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
     ],
     choiceFieldWrapper: [
       classNames.choiceFieldWrapper,
+      {
+        position: 'relative',
+      },
       focused && getChoiceGroupFocusStyle(focusBorderColor, hasIcon || hasImage),
     ],
     // The hidden input

--- a/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -26,7 +26,11 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=
@@ -153,7 +157,11 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=
@@ -282,7 +290,11 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=
@@ -420,7 +432,11 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=
@@ -552,6 +568,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       className=
           ms-ChoiceField-wrapper
           is-inFocus
+          {
+            position: relative;
+          }
           .ms-Fabric--isFocusVisible & {
             outline: transparent;
             position: relative;
@@ -704,6 +723,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       className=
           ms-ChoiceField-wrapper
           is-inFocus
+          {
+            position: relative;
+          }
           .ms-Fabric--isFocusVisible & {
             outline: transparent;
             position: relative;
@@ -860,7 +882,11 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=
@@ -975,7 +1001,11 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         checked={true}
@@ -1108,7 +1138,11 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=
@@ -1313,6 +1347,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       className=
           ms-ChoiceField-wrapper
           is-inFocus
+          {
+            position: relative;
+          }
           .ms-Fabric--isFocusVisible & {
             outline: transparent;
             position: relative;
@@ -1535,7 +1572,11 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         checked={true}
@@ -1762,7 +1803,11 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+          {
+            position: relative;
+          }
     >
       <input
         className=

--- a/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -48,6 +48,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             class=
                 ms-ChoiceField-wrapper
                 is-inFocus
+                {
+                  position: relative;
+                }
                 .ms-Fabric--isFocusVisible & {
                   outline: transparent;
                   position: relative;
@@ -200,7 +203,11 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
               }
         >
           <div
-            class="ms-ChoiceField-wrapper"
+            class=
+                ms-ChoiceField-wrapper
+                {
+                  position: relative;
+                }
           >
             <input
               class=
@@ -331,7 +338,11 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
               }
         >
           <div
-            class="ms-ChoiceField-wrapper"
+            class=
+                ms-ChoiceField-wrapper
+                {
+                  position: relative;
+                }
           >
             <input
               class=
@@ -526,6 +537,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             class=
                 ms-ChoiceField-wrapper
                 is-inFocus
+                {
+                  position: relative;
+                }
                 .ms-Fabric--isFocusVisible & {
                   outline: transparent;
                   position: relative;
@@ -678,7 +692,11 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
               }
         >
           <div
-            class="ms-ChoiceField-wrapper"
+            class=
+                ms-ChoiceField-wrapper
+                {
+                  position: relative;
+                }
           >
             <input
               class=
@@ -809,7 +827,11 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
               }
         >
           <div
-            class="ms-ChoiceField-wrapper"
+            class=
+                ms-ChoiceField-wrapper
+                {
+                  position: relative;
+                }
           >
             <input
               class=


### PR DESCRIPTION
**NOTE:** I'm posting this PR for discussion, I'm not sure it's a change we should make.

For example, the Fluent docs show a "ChoiceGroup with custom option rendering" where the custom green border extends to the full width of the ChoiceGroup ([link](https://developer.microsoft.com/en-us/fluentui#/controls/web/choicegroup)). With the existing behavior this area is clickable, with the new behavior it is not. Anyone relying on this visual customization will now have a broken option as there is a space that is implied to be clickable that is no longer interactive.


## Previous Behavior

ChoiceGroup options expand to the full width of the ChoiceGroup (i.e., you can click empty whitespace to select an item in the group).

## New Behavior

ChoiceGroup options are constrained to the wrapper width (i.e., you can only click on the visible part of the option to select it).

## Related Issue(s)


- Fixes #26898
