### PR TITLE
feat(scripts-storybook): unify workspace addon loading for dev and prod builds

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Visual regression tests for @fluentui/react-components",
   "scripts": {
-    "build": "build-storybook -o dist/storybook",
+    "build": "build-storybook --no-manager-cache -o dist/storybook",
     "clean": "just-scripts clean",
     "format": "prettier . -w --ignore-path ../../.prettierignore",
     "lint": "just-scripts lint",

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Visual regression tests for Fluent UI React",
   "scripts": {
-    "build": "build-storybook -o dist/storybook",
+    "build": "build-storybook --no-manager-cache -o dist/storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/azure-pipelines.vrt-baseline.yml
+++ b/azure-pipelines.vrt-baseline.yml
@@ -26,7 +26,7 @@ jobs:
           fluentVersion: v9
           vrTestPackageName: '@fluentui/vr-tests-react-components'
           vrTestPackagePath: 'apps/vr-tests-react-components'
-          shouldBuildstorybookaddon: true
+          shouldBuildstorybookaddon: false
 
       - bash: node node_modules/vrscreenshotdiff/lib/index.js release --clientType "fluentuiv9" --buildId $(Build.BuildId)
         displayName: 'Run Screenshotdiff update baseline'

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -227,7 +227,7 @@ jobs:
           vrTestPackageName: '@fluentui/docs'
           vrTestPackagePath: 'packages/fluentui/docs'
           shouldBuildstorybookaddon: false
-          shouldBuildNorthstar: true
+          shouldBuildNorthstar: false
 
       - powershell: |
           $url = "https://dev.azure.com/uifabric/fabricpublic/_apis/build/builds?definitions=$env:BASELINE_PIPELINE_ID&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&`$top=1"

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -63,7 +63,7 @@ jobs:
           fluentVersion: v9
           vrTestPackageName: '@fluentui/vr-tests-react-components'
           vrTestPackagePath: 'apps/vr-tests-react-components'
-          shouldBuildstorybookaddon: true
+          shouldBuildstorybookaddon: false
 
       - powershell: |
           $url = "https://dev.azure.com/uifabric/fabricpublic/_apis/build/builds?definitions=$env:BASELINE_PIPELINE_ID&statusFilter=completed&resultFilter=succeeded&queryOrder=finishTimeDescending&`$top=1"

--- a/change/@fluentui-react-components-efef013e-42c3-4754-ad30-88a5fc4354e7.json
+++ b/change/@fluentui-react-components-efef013e-42c3-4754-ad30-88a5fc4354e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove unnecessary devDeps on workspace addon",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "build": "gulp build:docs",
-    "build:storybook": "build-storybook -o dist/storybook",
+    "build:storybook": "build-storybook --no-manager-cache -o dist/storybook",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
     "start": "gulp docs",

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -67,11 +67,13 @@
   },
   "scripts": {
     "build": "gulp build:docs",
+    "prebuild:storybook": "lage build:info --to @fluentui/react-northstar @fluentui/react-component-ref @fluentui/react-bindings",
     "build:storybook": "build-storybook --no-manager-cache -o dist/storybook",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
     "start": "gulp docs",
     "start:profile": "cross-env NODE_ENV=production PERF=true gulp docs",
+    "prestart:storybook": "lage build:info --to @fluentui/react-northstar @fluentui/react-component-ref @fluentui/react-bindings",
     "start:storybook": "start-storybook",
     "vr:build": "yarn build:storybook",
     "vr:test": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true"

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/react-storybook-addon": "9.0.0-rc.1",
     "react-hook-form": "^5.7.2",
     "@fluentui/scripts-api-extractor": "*",
     "@fluentui/scripts-tasks": "*"

--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -32,10 +32,6 @@ function loadWorkspaceAddon(addonName, options) {
   /* eslint-disable no-shadow */
   const { workspaceRoot, tsConfigPath } = { ...loadWorkspaceAddonDefaultOptions, ...options };
 
-  if (process.env.NODE_ENV === 'production') {
-    return addonName;
-  }
-
   function getPaths() {
     const workspaceJson = JSON.parse(fs.readFileSync(path.join(workspaceRoot, 'workspace.json'), 'utf-8'));
     const addonMetadata = workspaceJson.projects[addonName];

--- a/scripts/storybook/src/utils.spec.js
+++ b/scripts/storybook/src/utils.spec.js
@@ -85,20 +85,6 @@ describe(`utils`, () => {
       };
     }
 
-    it(`should behave as identity function in prod env`, () => {
-      const originalEnv = process.env;
-      process.env = { ...originalEnv, NODE_ENV: 'production' };
-
-      const { tsConfigRoot } = setup({ packageName: 'storybook-custom-addon' });
-
-      const actual = loadWorkspaceAddon('@myorg/storybook-custom-addon', { tsConfigPath: tsConfigRoot });
-      const expected = '@myorg/storybook-custom-addon';
-
-      expect(actual).toBe(expected);
-
-      process.env = originalEnv;
-    });
-
     it(`should return path to in memory preset loader root`, () => {
       const { npmScope, workspaceRoot, tsConfigRoot } = setup({ packageName: 'storybook-custom-addon' });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- workspace storybook addons  need to be manually build prior to execute `build-storybook`
- this might have caused some issues as manager and preview was being build from 2 different sources (javascript / typescript)
- building storybooks on CI is slower as manual addon builds needs to happen first

## New Behavior

- workpsace addon dont need to build manually
- manager and preview uses same bundling and same code to execute
- building storybook on CI doesn't need any pre-requirements thus fully leveraging `swc` + TS path aliases transpilation speed 
- building v0 VR storybook is no longer building whole v0 dep tree which reduces **CI time by approx 9 minutes** for v0 VR test execution
  - this results in **27% faster pipeline** for VR tests
  -  BEFORE: <img width="316" alt="image" src="https://user-images.githubusercontent.com/1223799/221832264-d8cc53ea-fea1-4bd2-8cdf-995e46c552a7.png">
  - BEFORE: whole v0 vr pipeline  <img width="342" alt="image" src="https://user-images.githubusercontent.com/1223799/221832356-786712a8-8985-4278-a967-442d81daa582.png">

 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/26925
