### PR TITLE
feat: react-combobox space conditionally inserts character when freeform is true

### DIFF
--- a/change/@fluentui-react-combobox-aa8ff159-8fa3-4a0b-acf2-8b9bad6c66b7.json
+++ b/change/@fluentui-react-combobox-aa8ff159-8fa3-4a0b-acf2-8b9bad6c66b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: allow space character insertion while typing in freeform combobox",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -662,6 +662,58 @@ describe('Combobox', () => {
     });
   });
 
+  /* Freeform space key behavior */
+  it('inserts space character when typing in a freeform combobox', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole } = render(
+      <Combobox onOptionSelect={onOptionSelect} freeform>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    userEvent.type(getByRole('combobox'), 're ');
+
+    expect(onOptionSelect).not.toHaveBeenCalled();
+    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('re ');
+  });
+
+  it('uses space to select after arrowing through options in a freeform combobox', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole } = render(
+      <Combobox onOptionSelect={onOptionSelect} freeform>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    userEvent.type(getByRole('combobox'), 're{ArrowDown} ');
+
+    expect(onOptionSelect).toHaveBeenCalledTimes(1);
+    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Green');
+  });
+
+  it('inserts space character in closed freeform combobox', () => {
+    const onOptionSelect = jest.fn();
+
+    const { getByRole } = render(
+      <Combobox onOptionSelect={onOptionSelect} freeform>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    userEvent.type(getByRole('combobox'), 'r{ArrowDown}{Escape} ');
+
+    expect(onOptionSelect).not.toHaveBeenCalled();
+    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('r ');
+  });
+
   /* Active option */
   it('should set active option on click', () => {
     const { getByTestId } = render(

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -63,7 +63,8 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   const [hideActiveDescendant, setHideActiveDescendant] = React.useState(false);
 
   // save the typing vs. navigating options state, as the space key should behave differently in each case
-  const [typing, setTyping] = React.useState(false);
+  // we do not want to update the combobox when this changes, just save the value between renders
+  const isTyping = React.useRef(false);
 
   // calculate listbox width style based on trigger width
   const [popupDimensions, setPopupDimensions] = React.useState<{ width: string }>();
@@ -232,7 +233,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     // update typing state to true if the user is typing
     const action = getDropdownActionFromKey(ev, { open, multiselect });
     if (action === 'Type') {
-      setTyping(true);
+      isTyping.current = true;
     }
     // otherwise, update the typing state to false if opening or navigating dropdown options
     // other actions, like closing the dropdown, should not impact typing state.
@@ -245,11 +246,11 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
       action === 'PageUp' ||
       action === 'PageDown'
     ) {
-      setTyping(false);
+      isTyping.current = false;
     }
 
     // allow space to insert a character if freeform & the last action was typing, or if the popup is closed
-    if (freeform && (typing || !open) && ev.key === ' ') {
+    if (freeform && (isTyping.current || !open) && ev.key === ' ') {
       resolvedPropsOnKeyDown?.(ev);
       return;
     }


### PR DESCRIPTION
## Previous Behavior

Out of the box, the space key always selected the current option.

## New Behavior

Only for freeform comboboxes, a separate typing/not typing state is tracked, and when the user is typing the space key inserts a character instead of selecting an option. The conditions for this to happen are:
- If the freeform combobox is closed, space always inserts a character
- If the user's previous keyboard interaction was to insert characters into the text input, space while also insert a character
- If the user has typed, and not used up/down/page up/page down/home/end, or opened the combobox with enter or alt+down since the last typing interaction.

An example: if the user types "hello" and then space, the space character will be inserted. If the user types "hello" and then moves the text insertion character to "h" and presses space, the space character will also be inserted (since they didn't open the dropdown or navigate options since they last typed).

If the user types "hello" and then arrows through a few options and then presses space, the space key will select the highlighted option.

Non-freeform comboboxes do not change behavior and always use space to select.

## Related Issue(s)

- Fixes #26295
