### PR TITLE
chore(codeowners): Update owners from fluentui-react-build to fluentui-react

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -116,7 +116,7 @@ apps/public-docsite-v9 @microsoft/cxe-red @microsoft/cxe-coastal @microsoft/flue
 apps/theming-designer @microsoft/fluentui-react
 apps/ssr-tests-v9 @microsoft/fluentui-react-build
 apps/stress-test @microsoft/cxe-red @spmonahan @micahgodbolt
-apps/recipes-react-components @microsoft/cxe-red @microsoft/cxe-coastal @microsoft/fluentui-react-build @sopranopillow
+apps/recipes-react-components @microsoft/cxe-red @microsoft/cxe-coastal @microsoft/fluentui-react @sopranopillow
 
 #### Packages
 packages/azure-themes @Jacqueline-ms


### PR DESCRIPTION
As per #26594, I'm updating the codeowners for recipes-react-components from fluentui-react-build to fluentui-react since this doesn't impact build directly.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Related #26594