### PR TITLE
fix(react-utilities): adjust IntrinsicElementProps type to properly support void elements

### DIFF
--- a/change/@fluentui-react-utilities-df14dd64-64ee-4c93-9065-d048bc306cb2.json
+++ b/change/@fluentui-react-utilities-df14dd64-64ee-4c93-9065-d048bc306cb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: adjust IntrinsicElementProps type to properly support void elements",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -132,10 +132,10 @@ export type ResolveShorthandOptions<Props, Required extends boolean = false> = {
 // @public
 export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentType | React_2.VoidFunctionComponent | UnknownSlotProps, AlternateAs extends keyof JSX.IntrinsicElements = never> = IsSingleton<Extract<Type, string>> extends true ? WithSlotShorthandValue<Type extends keyof JSX.IntrinsicElements ? {
     as?: Type;
-} & WithSlotRenderFunction<IntrisicElementProps<Type>> : Type extends React_2.ComponentType<infer Props> ? WithSlotRenderFunction<Props> : Type> | {
+} & WithSlotRenderFunction<IntrinsicElementProps<Type>> : Type extends React_2.ComponentType<infer Props> ? WithSlotRenderFunction<Props> : Type> | {
     [As in AlternateAs]: {
         as: As;
-    } & WithSlotRenderFunction<IntrisicElementProps<As>>;
+    } & WithSlotRenderFunction<IntrinsicElementProps<As>>;
 }[AlternateAs] | null : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
 // @public

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -39,8 +39,8 @@ type WithSlotShorthandValue<Props extends { children?: unknown }> =
  * Helper type for {@link Slot}. Takes the props we want to support for a slot and adds the ability for `children`
  * to be a render function that takes those props.
  */
-type WithSlotRenderFunction<Props extends { children?: unknown }> = Props & {
-  children?: Props['children'] | SlotRenderFunction<Props>;
+type WithSlotRenderFunction<Props> = Props & {
+  children?: (Props extends { children?: unknown } ? Props['children'] : never) | SlotRenderFunction<Props>;
 };
 
 /**
@@ -48,7 +48,7 @@ type WithSlotRenderFunction<Props extends { children?: unknown }> = Props & {
  *
  * Reference: https://developer.mozilla.org/en-US/docs/Glossary/Empty_element
  */
-type EmptyIntrisicElements =
+type EmptyIntrinsicElements =
   | 'area'
   | 'base'
   | 'br'
@@ -69,8 +69,9 @@ type EmptyIntrisicElements =
  * * Removes legacy string ref.
  * * Disallows children for empty tags like 'img'.
  */
-type IntrisicElementProps<Type extends keyof JSX.IntrinsicElements> = React.PropsWithRef<JSX.IntrinsicElements[Type]> &
-  (Type extends EmptyIntrisicElements ? { children?: never } : {});
+type IntrinsicElementProps<Type extends keyof JSX.IntrinsicElements> = Type extends EmptyIntrinsicElements
+  ? PropsWithoutChildren<React.PropsWithRef<JSX.IntrinsicElements[Type]>>
+  : React.PropsWithRef<JSX.IntrinsicElements[Type]>;
 
 /**
  * The props type and shorthand value for a slot. Type is either a single intrinsic element like `'div'`,
@@ -101,13 +102,13 @@ export type Slot<
   ?
       | WithSlotShorthandValue<
           Type extends keyof JSX.IntrinsicElements // Intrinsic elements like `div`
-            ? { as?: Type } & WithSlotRenderFunction<IntrisicElementProps<Type>>
+            ? { as?: Type } & WithSlotRenderFunction<IntrinsicElementProps<Type>>
             : Type extends React.ComponentType<infer Props> // Component types like `typeof Button`
             ? WithSlotRenderFunction<Props>
             : Type // Props types like `ButtonProps`
         >
       | {
-          [As in AlternateAs]: { as: As } & WithSlotRenderFunction<IntrisicElementProps<As>>;
+          [As in AlternateAs]: { as: As } & WithSlotRenderFunction<IntrinsicElementProps<As>>;
         }[AlternateAs]
       | null
   : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
@@ -145,6 +146,15 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
  * types, to prevent unions from being expanded.
  */
 export type PropsWithoutRef<P> = 'ref' extends keyof P ? (P extends unknown ? Omit<P, 'ref'> : P) : P;
+
+/**
+ * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
+ * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
+ *
+ * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
+ * types, to prevent unions from being expanded.
+ */
+export type PropsWithoutChildren<P> = 'children' extends keyof P ? (P extends unknown ? Omit<P, 'children'> : P) : P;
 
 /**
  * Removes SlotShorthandValue and null from the slot type, extracting just the slot's Props object.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

To disable the usage of `children` as a property on [Void Elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) our internal typings would mark `children` as `never`. This would work for the normal use cases of `children` and errors would pop if you tried using `children`, as expected:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/5483269/223129306-687b5a8d-cba9-4212-a471-293496d6049b.png">


When supporting slot API, `children` can receive a render function as value to allow the case of [Replacing the entire slot](https://react.fluentui.dev/?path=/docs/concepts-developer-customizing-components-with-slots--page#replacing-the-entire-slot). This is currently broken as void elements `children` props are marked as `never`:


<img width="650" alt="image" src="https://user-images.githubusercontent.com/5483269/223129223-89f759c2-4536-4988-86b3-59d0dad267e7.png">


## New Behavior


Instead of marking `children` as never, filtering the original children value out of the types solves this problem, allowing the slot API and properly emitting an error on any other cases:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/5483269/223129594-04b73e38-0304-4467-b29d-516a85d21e93.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/5483269/223129666-62b537ca-5e44-4cd5-8a79-6f1d125f3dd6.png">


1. filters children out instead of using `never`
2. fix typo on `IntrinsicElement` types


## Related Issue(s)


- Fixes #27092
