### PR TITLE
Updating Fluent 2 Theme TextField styles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,5 +74,5 @@
   "typescript.preferences.importModuleSpecifierEnding": "index",
   "typescript.tsdk": "./node_modules/typescript/lib",
   "typescript.reportStyleChecksAsWarnings": false,
-  "cSpell.words": ["beachball", "fluentui", "griffel", "spinbutton", "tabster"]
+  "cSpell.words": ["beachball", "borderless", "fluentui", "griffel", "spinbutton", "tabster"]
 }

--- a/apps/public-docsite/src/components/Site/AppThemes.ts
+++ b/apps/public-docsite/src/components/Site/AppThemes.ts
@@ -3,10 +3,10 @@ import { Fluent2WebLightTheme, Fluent2WebDarkTheme } from '@fluentui/fluent2-the
 import { IAppThemes, IExampleCardTheme } from '@fluentui/react-docsite-components';
 
 const exampleCardTheme: IExampleCardTheme[] = [
-  { title: 'Default', theme: DefaultTheme },
-  { title: 'Dark', theme: DarkTheme },
   { title: 'Fluent 2 Web Light', theme: Fluent2WebLightTheme },
   { title: 'Fluent 2 Web Dark', theme: Fluent2WebDarkTheme },
+  { title: 'Default', theme: DefaultTheme },
+  { title: 'Dark', theme: DarkTheme },
 ];
 
 export const AppThemes: IAppThemes = {

--- a/apps/public-docsite/src/components/Site/AppThemes.ts
+++ b/apps/public-docsite/src/components/Site/AppThemes.ts
@@ -3,10 +3,10 @@ import { Fluent2WebLightTheme, Fluent2WebDarkTheme } from '@fluentui/fluent2-the
 import { IAppThemes, IExampleCardTheme } from '@fluentui/react-docsite-components';
 
 const exampleCardTheme: IExampleCardTheme[] = [
-  { title: 'Fluent 2 Web Light', theme: Fluent2WebLightTheme },
-  { title: 'Fluent 2 Web Dark', theme: Fluent2WebDarkTheme },
   { title: 'Default', theme: DefaultTheme },
   { title: 'Dark', theme: DarkTheme },
+  { title: 'Fluent 2 Web Light', theme: Fluent2WebLightTheme },
+  { title: 'Fluent 2 Web Dark', theme: Fluent2WebDarkTheme },
 ];
 
 export const AppThemes: IAppThemes = {

--- a/change/@fluentui-fluent2-theme-b800a8a9-5bc5-4e44-9e22-4dbb916cb1aa.json
+++ b/change/@fluentui-fluent2-theme-b800a8a9-5bc5-4e44-9e22-4dbb916cb1aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding IExtendedSemanticColors with properties for inputBottomBorders since the treatment is different in Fluent 2. Updating focus behavior for TextField to more closley match Fluent 2.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
@@ -1,16 +1,40 @@
 import type { IStyleFunctionOrObject, ITextFieldStyleProps, ITextFieldStyles } from '@fluentui/react';
 import { FontWeights } from '@fluentui/react';
+import { IExtendedSemanticColors } from '../types';
 
 export function getTextFieldStyles(
   props: ITextFieldStyleProps,
 ): IStyleFunctionOrObject<ITextFieldStyleProps, ITextFieldStyles> {
-  const { theme } = props;
-  const { effects } = theme;
+  const { theme, focused, borderless, underlined, hasErrorMessage, disabled } = props;
+  const { effects, semanticColors, palette } = theme;
+
+  const unsetBackgroundColor = { backgroundColor: 'unset' };
+
+  const bottomBorderFocusColor =
+    (semanticColors as IExtendedSemanticColors)?.inputBottomBorderFocus ?? theme.palette.themePrimary;
+  const focusBottomBorder = `2px solid ${hasErrorMessage ? semanticColors.errorText : bottomBorderFocusColor}`;
+
+  let borderBottomColor = palette.neutralPrimary;
+
+  if (hasErrorMessage) {
+    borderBottomColor = semanticColors.errorText;
+  }
+  if (disabled) {
+    // There is no 'inputBorderDisabled' in the v8 semantic colors.
+    // Disabled border color is assigned to 'disabledBackground' in the base style file :-(
+    // Which gets mapped to 'neutralLighter'
+    // And I'd prefer to assign a palette color than add 2 new semantic colors or assign an incorrect semantic.
+    // Bottom border color should match the rest of the border color.
+    borderBottomColor = palette.neutralLighter;
+  }
+
+  const restBottomBorder = borderless || underlined ? 'unset' : `1px solid ${borderBottomColor}`;
 
   const styles: Partial<ITextFieldStyles> = {
     root: {
       '.ms-Fabric--isFocusVisible &:focus::after': {
         borderRadius: effects.roundedCorner4,
+        borderBottom: focusBottomBorder,
       },
     },
     subComponentStyles: {
@@ -20,12 +44,45 @@ export function getTextFieldStyles(
         },
       },
     },
-    fieldGroup: {
-      borderRadius: effects.roundedCorner4,
-      ':after': {
-        borderRadius: effects.roundedCorner4,
+    prefix: unsetBackgroundColor,
+    suffix: unsetBackgroundColor,
+    field: [
+      focused && {
+        border: 'unset',
+        ':after': {
+          border: 'unset',
+        },
       },
-    },
+      disabled && {
+        backgroundColor: 'unset',
+      },
+      {
+        borderRadius: effects.roundedCorner4,
+        ':after': {
+          borderRadius: effects.roundedCorner4,
+        },
+      },
+    ],
+    fieldGroup: [
+      {
+        borderBottom: restBottomBorder,
+        borderRadius: effects.roundedCorner4,
+        ':after': {
+          borderRadius: effects.roundedCorner4,
+        },
+      },
+      focused && {
+        borderColor: semanticColors.focusBorder,
+        ':after': {
+          borderBottom: underlined ? 'unset' : focusBottomBorder,
+          clipPath: 'inset(calc(100% - 2px) 0 0 0)',
+        },
+      },
+      disabled && {
+        borderBottom: `1px solid ${borderBottomColor}`,
+        backgroundColor: 'unset',
+      },
+    ],
   };
 
   return styles;

--- a/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
@@ -1,6 +1,6 @@
-import type { IPalette, ISemanticColors, ITheme } from '@fluentui/react';
+import type { IPalette, ITheme } from '@fluentui/react';
 import { createTheme } from '@fluentui/react';
-import { IExtendedEffects } from './types';
+import { IExtendedEffects, IExtendedSemanticColors } from './types';
 import { fluent2ComponentStyles } from './fluent2ComponentStyles';
 
 const fluent2ForV8DarkEffects: IExtendedEffects = {
@@ -46,7 +46,12 @@ const p = fluent2ForV8DarkPalette;
 // shortcut since the gray scale isn't part of the v8 palette.
 const grey36 = '#5C5C5C';
 
-const semanticColorMappingOverridesForDark: Partial<ISemanticColors> = {
+const semanticColorMappingOverridesForDark: Partial<IExtendedSemanticColors> = {
+  // Extended semantic colors
+  inputBottomBorderFocus: p.themePrimary,
+  inputBottomBorderRest: p.neutralLighter,
+
+  // Base semantic mapping overrides
   primaryButtonText: p.black,
   primaryButtonTextHovered: p.black,
   primaryButtonTextPressed: p.black,
@@ -54,9 +59,12 @@ const semanticColorMappingOverridesForDark: Partial<ISemanticColors> = {
   primaryButtonBackgroundDisabled: p.neutralLighter,
   accentButtonText: p.black,
   accentButtonBackground: p.themePrimary,
+
   inputPlaceholderText: p.neutralSecondaryAlt,
   inputForegroundChecked: p.black,
+  inputFocusBorderAlt: p.neutralTertiary,
   inputBorder: p.neutralQuaternary,
+  focusBorder: p.neutralTertiary,
 
   // Checkbox
   inputBackgroundChecked: p.themePrimary,

--- a/packages/fluent2-theme/src/fluent2WebLightTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebLightTheme.ts
@@ -1,6 +1,6 @@
-import type { IPalette, ISemanticColors, ITheme } from '@fluentui/react';
+import type { IPalette, ITheme } from '@fluentui/react';
 import { createTheme } from '@fluentui/react';
-import { IExtendedEffects } from './types';
+import { IExtendedEffects, IExtendedSemanticColors } from './types';
 
 import { fluent2ComponentStyles } from './fluent2ComponentStyles';
 
@@ -58,7 +58,15 @@ const fluent2LightPalette: Partial<IPalette> = {
 
 const p = fluent2LightPalette;
 
-const semanticColorMappingOverridesForLight: Partial<ISemanticColors> = {
+const semanticColorMappingOverridesForLight: Partial<IExtendedSemanticColors> = {
+  // Extended slots
+  inputBottomBorderFocus: p.themePrimary,
+  inputBottomBorderRest: p.neutralLighter,
+
+  // Base slot mapping changes
+  // focusBorder seems to be used for keyboard focus on components that don't have text input.
+  // inputFocusBorder seems to be used for keyboard focus on text input components.
+  focusBorder: p.neutralTertiary,
   inputBorder: p.neutralQuaternary,
 
   // Checkbox

--- a/packages/fluent2-theme/src/index.ts
+++ b/packages/fluent2-theme/src/index.ts
@@ -1,4 +1,4 @@
-export type { IExtendedEffects } from './types';
+export type { IExtendedEffects, IExtendedSemanticColors } from './types';
 export { Fluent2WebDarkTheme } from './fluent2WebDarkTheme';
 export { Fluent2WebLightTheme } from './fluent2WebLightTheme';
 export { fluent2ComponentStyles } from './fluent2ComponentStyles';

--- a/packages/fluent2-theme/src/types.ts
+++ b/packages/fluent2-theme/src/types.ts
@@ -1,6 +1,12 @@
-import { IEffects } from '@fluentui/react';
+import { IEffects, ISemanticColors } from '@fluentui/react';
 
 export interface IExtendedEffects extends IEffects {
   roundedCorner8?: string;
   roundedCornerCircle?: string;
+}
+
+export interface IExtendedSemanticColors extends ISemanticColors {
+  // no disabledBottomBorder, it should match the rest of the border.
+  inputBottomBorderFocus?: string;
+  inputBottomBorderRest?: string;
 }


### PR DESCRIPTION
The focus behavior in Fluent 2 is dramatically different than Fluent 1. This PR updates the behavior for just the text field, though there are several more input fields that will need to be touched before we're adequately aligned. This PR is more about rehydrating and learning about what needs to be done and the existing space. Subsequent PR's will both update more components and create the shared logic to do so.

Things to review for:
Are all the names clear and sensible?
Is the behavior accurate and bug free?
- known gaps: background color in dark theme, animation

This is my first PR against OUIFR in quite a while. Anything else I should pay attention to?

Before:
![image](https://user-images.githubusercontent.com/17346018/223244012-7694058b-6ebe-477b-b336-633624007525.png)

After:
![image](https://user-images.githubusercontent.com/17346018/223244342-ab0bbb30-dd1d-4c38-82e3-4c0395cad87f.png)

