### PR TITLE
Fix styling to allow Progressbar to have width when display is flex

### DIFF
--- a/change/@fluentui-react-progress-dc31d0f2-6038-4cbf-bbc0-5b1aadf202c7.json
+++ b/change/@fluentui-react-progress-dc31d0f2-6038-4cbf-bbc0-5b1aadf202c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Update ProgressBar styling to have width when display is set to flex",
+  "packageName": "@fluentui/react-progress",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
@@ -43,7 +43,6 @@ const useRootStyles = makeStyles({
     display: 'block',
     backgroundColor: tokens.colorNeutralBackground6,
     width: '100%',
-    //justifySelf: 'stretch',
     ...shorthands.overflow('hidden'),
 
     '@media screen and (forced-colors: active)': {
@@ -75,12 +74,6 @@ const useBarStyles = makeStyles({
     ...shorthands.borderRadius('inherit'),
     height: '100%',
   },
-  // medium: {
-  //   height: '100%',
-  // },
-  // large: {
-  //   height: barThicknessValues.large,
-  // },
   nonZeroDeterminate: {
     transitionProperty: 'width',
     transitionDuration: '0.3s',

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBarStyles.ts
@@ -42,7 +42,8 @@ const useRootStyles = makeStyles({
   root: {
     display: 'block',
     backgroundColor: tokens.colorNeutralBackground6,
-    justifySelf: 'stretch',
+    width: '100%',
+    //justifySelf: 'stretch',
     ...shorthands.overflow('hidden'),
 
     '@media screen and (forced-colors: active)': {
@@ -72,13 +73,14 @@ const useBarStyles = makeStyles({
       backgroundColor: 'Highlight',
     },
     ...shorthands.borderRadius('inherit'),
+    height: '100%',
   },
-  medium: {
-    height: barThicknessValues.medium,
-  },
-  large: {
-    height: barThicknessValues.large,
-  },
+  // medium: {
+  //   height: '100%',
+  // },
+  // large: {
+  //   height: barThicknessValues.large,
+  // },
   nonZeroDeterminate: {
     transitionProperty: 'width',
     transitionDuration: '0.3s',
@@ -145,7 +147,6 @@ export const useProgressBarStyles_unstable = (state: ProgressBarState): Progress
       barStyles.brand,
       value === undefined && barStyles.indeterminate,
       value === undefined && dir === 'rtl' && barStyles.rtl,
-      barStyles[thickness],
       value !== undefined && value > ZERO_THRESHOLD && barStyles.nonZeroDeterminate,
       color && value !== undefined && barStyles[color],
       state.bar.className,


### PR DESCRIPTION
This PR is to fix an issue where the `ProgressBar` renders with `width: 0` when its container has `display` set to flex. This was due to the default styling on `justifySelf: 'stretch'` which does not work on a flex display.

The style has been changed to have the default `width` be set to 100%.

This PR also updates the `height` styling to remove the `height` styles from the `bar` slot, so you only need to apply a style override to the `root` slot to change the default height.

Fixes #27096 