### PR TITLE
feat(react-textarea): Add content above and before

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Textarea.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Textarea.stories.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Steps, StoryWright } from 'storywright';
 import { storiesOf } from '@storybook/react';
+import { Button } from '@fluentui/react-button';
 import { Textarea } from '@fluentui/react-textarea';
 import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
 import { FluentProvider } from '@fluentui/react-provider';
+import { AttachFilled, DrawTextRegular, EmojiRegular, SendRegular } from '@fluentui/react-icons';
 
 storiesOf('Textarea Converged', module)
   .addDecorator(TestWrapperDecoratorFixedWidth)
@@ -56,4 +58,29 @@ storiesOf('Textarea Converged', module)
         <Textarea appearance="outline" placeholder="Outline appearance" />
       </div>
     </FluentProvider>
+  ))
+  .addStory('contentAbove', () => (
+    <Textarea
+      contentAbove={
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, max-content) 1fr' }}>
+          <Button appearance="transparent" icon={<DrawTextRegular />} />
+          <Button appearance="transparent" icon={<EmojiRegular />} />
+          <Button appearance="transparent" icon={<AttachFilled />} />
+        </div>
+      }
+      placeholder="Placeholder"
+    />
+  ))
+  .addStory('contentBelow', () => (
+    <Textarea
+      contentBelow={
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, max-content) 1fr' }}>
+          <Button appearance="transparent" icon={<DrawTextRegular />} />
+          <Button appearance="transparent" icon={<EmojiRegular />} />
+          <Button appearance="transparent" icon={<AttachFilled />} />
+          <Button style={{ justifySelf: 'flex-end' }} appearance="transparent" icon={<SendRegular />} />
+        </div>
+      }
+      placeholder="Placeholder"
+    />
   ));

--- a/change/@fluentui-react-textarea-64d4777e-3f1a-4abb-8aa6-84a40ef1c712.json
+++ b/change/@fluentui-react-textarea-64d4777e-3f1a-4abb-8aa6-84a40ef1c712.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add contentAbove and contentBelow slots.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/etc/react-textarea.api.md
+++ b/packages/react-components/react-textarea/etc/react-textarea.api.md
@@ -58,6 +58,8 @@ export type TextareaProps = Omit<ComponentProps<Partial<TextareaSlots>, 'textare
 export type TextareaSlots = {
     root: NonNullable<Slot<'span'>>;
     textarea: NonNullable<Slot<'textarea'>>;
+    contentAbove?: Slot<'span'>;
+    contentBelow?: Slot<'span'>;
 };
 
 // @public

--- a/packages/react-components/react-textarea/src/components/Textarea/Textarea.test.tsx
+++ b/packages/react-components/react-textarea/src/components/Textarea/Textarea.test.tsx
@@ -21,6 +21,7 @@ describe('Textarea', () => {
     Component: Textarea,
     displayName: 'Textarea',
     primarySlot: 'textarea',
+    requiredProps: { contentAbove: 'foo', contentBelow: 'bar' },
   });
 
   // TODO create visual regression tests in /apps/vr-tests

--- a/packages/react-components/react-textarea/src/components/Textarea/Textarea.types.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/Textarea.types.ts
@@ -15,7 +15,14 @@ export type TextareaSlots = {
    */
   textarea: NonNullable<Slot<'textarea'>>;
 
+  /**
+   * Element above the textarea, within the Textarea border.
+   */
   contentAbove?: Slot<'span'>;
+
+  /**
+   * Element below the textarea, within the Textarea border.
+   */
   contentBelow?: Slot<'span'>;
 };
 

--- a/packages/react-components/react-textarea/src/components/Textarea/Textarea.types.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/Textarea.types.ts
@@ -14,6 +14,9 @@ export type TextareaSlots = {
    * The `<textarea>` element. This is the primary slot, all native props and ref are applied to this slot.
    */
   textarea: NonNullable<Slot<'textarea'>>;
+
+  contentAbove?: Slot<'span'>;
+  contentBelow?: Slot<'span'>;
 };
 
 /**

--- a/packages/react-components/react-textarea/src/components/Textarea/renderTextarea.tsx
+++ b/packages/react-components/react-textarea/src/components/Textarea/renderTextarea.tsx
@@ -10,7 +10,9 @@ export const renderTextarea_unstable = (state: TextareaState) => {
 
   return (
     <slots.root {...slotProps.root}>
+      {slots.contentAbove && <slots.contentAbove {...slotProps.contentAbove} />}
       <slots.textarea {...slotProps.textarea} />
+      {slots.contentBelow && <slots.contentBelow {...slotProps.contentBelow} />}
     </slots.root>
   );
 };

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextarea.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextarea.ts
@@ -57,6 +57,8 @@ export const useTextarea_unstable = (props: TextareaProps, ref: React.Ref<HTMLTe
     components: {
       root: 'span',
       textarea: 'textarea',
+      contentAbove: 'span',
+      contentBelow: 'span',
     },
     textarea: resolveShorthand(props.textarea, {
       required: true,
@@ -69,6 +71,8 @@ export const useTextarea_unstable = (props: TextareaProps, ref: React.Ref<HTMLTe
       required: true,
       defaultProps: nativeProps.root,
     }),
+    contentAbove: resolveShorthand(props.contentAbove),
+    contentBelow: resolveShorthand(props.contentBelow),
   };
 
   state.textarea.value = value;

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.ts
@@ -6,6 +6,8 @@ import type { TextareaSlots, TextareaState } from './Textarea.types';
 export const textareaClassNames: SlotClassNames<TextareaSlots> = {
   root: 'fui-Textarea',
   textarea: 'fui-Textarea__textarea',
+  contentAbove: 'fui-Textarea__contentAbove',
+  contentBelow: 'fui-Textarea__contentBelow',
 };
 
 const textareaHeight = {
@@ -19,9 +21,11 @@ const textareaHeight = {
  */
 const useRootStyles = makeStyles({
   base: {
-    display: 'inline-flex',
     boxSizing: 'border-box',
+    display: 'inline-flex',
+    flexDirection: 'column',
     position: 'relative',
+    rowGap: tokens.spacingVerticalXS,
     // Padding needed so the focus indicator does not overlap the resize handle, this should match focus indicator size.
     ...shorthands.padding('0', '0', tokens.strokeWidthThick, '0'),
     ...shorthands.margin('0'),
@@ -160,7 +164,7 @@ const useRootStyles = makeStyles({
 const useTextareaStyles = makeStyles({
   base: {
     ...shorthands.borderStyle('none'),
-    ...shorthands.margin('0'),
+    ...shorthands.margin(0),
     backgroundColor: 'transparent',
     boxSizing: 'border-box',
     color: tokens.colorNeutralForeground1,
@@ -211,6 +215,47 @@ const useTextareaStyles = makeStyles({
     ),
     ...typographyStyles.body2,
   },
+
+  contentAbove: {
+    paddingTop: 0,
+  },
+  contentBelow: {
+    paddingBottom: 0,
+  },
+});
+
+const useContentAboveStyles = makeStyles({
+  small: {
+    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalSNudge, 0, tokens.spacingHorizontalSNudge),
+  },
+  medium: {
+    ...shorthands.padding(
+      tokens.spacingVerticalSNudge,
+      tokens.spacingHorizontalMNudge,
+      0,
+      tokens.spacingHorizontalMNudge,
+    ),
+  },
+  large: {
+    ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalM, 0, tokens.spacingHorizontalM),
+  },
+});
+
+const useContentBelowStyles = makeStyles({
+  small: {
+    ...shorthands.padding(0, tokens.spacingHorizontalSNudge, tokens.spacingVerticalXS, tokens.spacingHorizontalSNudge),
+  },
+  medium: {
+    ...shorthands.padding(
+      0,
+      tokens.spacingHorizontalMNudge,
+      tokens.spacingVerticalSNudge,
+      tokens.spacingHorizontalMNudge,
+    ),
+  },
+  large: {
+    ...shorthands.padding(0, tokens.spacingHorizontalM, tokens.spacingVerticalS, tokens.spacingHorizontalM),
+  },
 });
 
 /**
@@ -260,8 +305,28 @@ export const useTextareaStyles_unstable = (state: TextareaState): TextareaState 
     textareaStyles.base,
     textareaStyles[size],
     textareaResizeStyles[resize],
+    state.contentAbove && textareaStyles.contentAbove,
+    state.contentBelow && textareaStyles.contentBelow,
     state.textarea.className,
   );
+
+  const contentAboveStyles = useContentAboveStyles();
+  if (state.contentAbove) {
+    state.contentAbove.className = mergeClasses(
+      textareaClassNames.contentAbove,
+      contentAboveStyles[size],
+      state.contentAbove.className,
+    );
+  }
+
+  const contentBelowStyles = useContentBelowStyles();
+  if (state.contentBelow) {
+    state.contentBelow.className = mergeClasses(
+      textareaClassNames.contentBelow,
+      contentBelowStyles[size],
+      state.contentBelow.className,
+    );
+  }
 
   return state;
 };

--- a/packages/react-components/react-textarea/stories/Textarea/TextareaContentAboveBelow.stories.tsx
+++ b/packages/react-components/react-textarea/stories/Textarea/TextareaContentAboveBelow.stories.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import {
+  Button,
+  Label,
+  Link,
+  makeStyles,
+  Textarea,
+  Toolbar,
+  ToolbarButton,
+  ToolbarDivider,
+  useId,
+} from '@fluentui/react-components';
+import {
+  AttachFilled,
+  DrawTextRegular,
+  EmojiRegular,
+  FontDecrease24Regular,
+  FontIncrease24Regular,
+  Highlight24Filled,
+  SendRegular,
+  TextBold24Regular,
+  TextFont24Regular,
+  TextItalic24Regular,
+  TextUnderline24Regular,
+} from '@fluentui/react-icons';
+
+const useContentBelowStyles = makeStyles({
+  root: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, max-content) 1fr',
+  },
+  sendButton: {
+    justifySelf: 'flex-end',
+  },
+});
+
+const ContentBelow = () => {
+  const styles = useContentBelowStyles();
+  return (
+    <div className={styles.root}>
+      <Button appearance="transparent" icon={<DrawTextRegular />} />
+      <Button appearance="transparent" icon={<EmojiRegular />} />
+      <Button appearance="transparent" icon={<AttachFilled />} />
+      <Button className={styles.sendButton} appearance="transparent" icon={<SendRegular />} />
+    </div>
+  );
+};
+
+const ContentAbove = () => (
+  <Toolbar aria-label="Text formatting">
+    <ToolbarButton aria-label="Increase Font Size" icon={<FontIncrease24Regular />} />
+    <ToolbarButton aria-label="Decrease Font Size" icon={<FontDecrease24Regular />} />
+    <ToolbarButton aria-label="Reset Font Size" icon={<TextFont24Regular />} />
+    <ToolbarDivider />
+    <ToolbarButton aria-label="Bold text" icon={<TextBold24Regular />} />
+    <ToolbarButton aria-label="Italizise text" icon={<TextItalic24Regular />} />
+    <ToolbarButton aria-label="Underline text" icon={<TextUnderline24Regular />} />
+    <ToolbarDivider />
+    <ToolbarButton aria-label="Highlight text" icon={<Highlight24Filled />} />
+  </Toolbar>
+);
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+  },
+});
+
+export const ContentAboveBelow = () => {
+  const textareaId = useId();
+  const styles = useStyles();
+  return (
+    <>
+      <Label htmlFor={textareaId}>Content above/below Textarea.</Label>
+      <Textarea
+        id={textareaId}
+        className={styles.root}
+        contentAbove={<ContentAbove />}
+        contentBelow={<ContentBelow />}
+        placeholder="Type text here..."
+      />
+    </>
+  );
+};
+
+ContentAboveBelow.parameters = {
+  docs: {
+    description: {
+      story:
+        `A textarea can have elements above or below the entered text. These elements are displayed inside the` +
+        `textarea border.`,
+    },
+  },
+};
+
+ContentAboveBelow.storyName = 'Content above/below';

--- a/packages/react-components/react-textarea/stories/Textarea/TextareaContentAboveBelow.stories.tsx
+++ b/packages/react-components/react-textarea/stories/Textarea/TextareaContentAboveBelow.stories.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Button,
   Label,
-  Link,
   makeStyles,
   Textarea,
   Toolbar,

--- a/packages/react-components/react-textarea/stories/Textarea/index.stories.tsx
+++ b/packages/react-components/react-textarea/stories/Textarea/index.stories.tsx
@@ -5,6 +5,7 @@ import bestPracticesMd from './TextareaBestPractices.md';
 
 export { Default } from './TextareaDefault.stories';
 export { Appearance } from './TextareaAppearance.stories';
+export { ContentAboveBelow } from './TextareaContentAboveBelow.stories';
 export { Disabled } from './TextareaDisabled.stories';
 export { Placeholder } from './TextareaPlaceholder.stories';
 export { Resize } from './TextareaResize.stories';


### PR DESCRIPTION
This PR adds `contentAbove` and `contentBelow` for Textarea. Similarly to `Input`, these slots render an element above and below the textarea within the wrapper bounds.

![image](https://user-images.githubusercontent.com/5953191/223284379-a410b064-8e92-46ea-b6c7-0795e053e71c.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27039
