### PR TITLE
chore(react-tabster): updates useModalAttributes flags

### DIFF
--- a/change/@fluentui-react-dialog-b1dd1b91-b909-4e79-96b5-6012f8e43ff5.json
+++ b/change/@fluentui-react-dialog-b1dd1b91-b909-4e79-96b5-6012f8e43ff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: updates useModalAttributes flags for legacyTrapFocus",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-85dddf2c-1330-4920-81af-254a7972fd9b.json
+++ b/change/@fluentui-react-popover-85dddf2c-1330-4920-81af-254a7972fd9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: updates useModalAttributes flags for legacyTrapFocus",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-a38a7a64-a7f8-484b-810b-2c29f7b34b52.json
+++ b/change/@fluentui-react-tabster-a38a7a64-a7f8-484b-810b-2c29f7b34b52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: updates useModalAttributes flags for legacyTrapFocus",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -23,7 +23,6 @@ import type { SetVirtualMouseTarget } from '@fluentui/react-positioning';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
-import type { UseModalAttributesOptions } from '@fluentui/react-tabster';
 
 // @public (undocumented)
 export const arrowHeights: Record<PopoverSize, number>;
@@ -57,8 +56,8 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
     openOnHover?: boolean;
     positioning?: PositioningShorthand;
     size?: PopoverSize;
-    trapFocus?: UseModalAttributesOptions['trapFocus'];
-    legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+    trapFocus?: boolean;
+    legacyTrapFocus?: boolean;
     inertTrapFocus?: boolean;
     unstable_disableAutoFocus?: boolean;
 };

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -5,7 +5,6 @@ import type {
   SetVirtualMouseTarget,
 } from '@fluentui/react-positioning';
 import type { PortalProps } from '@fluentui/react-portal';
-import type { UseModalAttributesOptions } from '@fluentui/react-tabster';
 
 /**
  * Determines popover padding and arrow size
@@ -105,7 +104,7 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
    *
    * @default false
    */
-  trapFocus?: UseModalAttributesOptions['trapFocus'];
+  trapFocus?: boolean;
 
   /**
    * Must be used with the `trapFocus` prop
@@ -116,7 +115,7 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
    *
    * @deprecated this behavior is default provided now, to opt-out of it in favor of standard behavior use the `inertTrapFocus` property
    */
-  legacyTrapFocus?: UseModalAttributesOptions['legacyTrapFocus'];
+  legacyTrapFocus?: boolean;
   /**
    * Enables standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
    * where the focus trap involves setting outside elements inert,

--- a/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`PopoverSurface renders a default state 1`] = `
 <div
   aria-label="test"
   class="fui-PopoverSurface"
-  data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true,\\"isAlwaysAccessible\\":true,\\"isTrapped\\":true}}"
+  data-tabster="{\\"deloser\\":{},\\"modalizer\\":{\\"id\\":\\"modal-1\\",\\"isOthersAccessible\\":true,\\"isAlwaysAccessible\\":true}}"
   data-testid="component"
   role="group"
 >

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -56,7 +56,7 @@ export const useModalAttributes = (
       id,
       isOthersAccessible: !trapFocus,
       isAlwaysAccessible: alwaysFocusable,
-      isTrapped: legacyTrapFocus,
+      isTrapped: legacyTrapFocus && trapFocus,
     },
   });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. updates `isTrapped` flag to follow up `inertTrapFocus`
2. update `Popover` and `Dialog` components accordingly

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follow ups on https://github.com/microsoft/fluentui/pull/26942
