### PR TITLE
Add explicit children prop to Window Provider

### DIFF
--- a/change/@fluentui-react-window-provider-9713a8ed-37d1-474e-91c3-7e0f62ab88a4.json
+++ b/change/@fluentui-react-window-provider-9713a8ed-37d1-474e-91c3-7e0f62ab88a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add explicit children to window provider to ensure react 18 type compat",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-window-provider/etc/react-window-provider.api.md
+++ b/packages/react-window-provider/etc/react-window-provider.api.md
@@ -21,8 +21,8 @@ export const WindowProvider: React_2.FunctionComponent<WindowProviderProps>;
 // @public
 export type WindowProviderProps = {
     window: Window | undefined;
+    children?: React_2.ReactNode;
 };
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-window-provider/src/WindowProvider.tsx
+++ b/packages/react-window-provider/src/WindowProvider.tsx
@@ -8,6 +8,7 @@ export type WindowProviderProps = {
    * Provide the active window.
    */
   window: Window | undefined;
+  children?: React.ReactNode;
 };
 
 /**


### PR DESCRIPTION
We bumped window provider to support React 18, but it seems it wasn't used in any of the components we tested, so we didn't notice the typing error here. 