### PR TITLE
fix(react-datepicker-compat): Fix styles to look more like v9

### DIFF
--- a/packages/react-components/react-datepicker-compat/src/components/Calendar/useCalendarStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/Calendar/useCalendarStyles.ts
@@ -84,7 +84,6 @@ const useGoTodayButtonStyles = makeStyles({
       pointerEvents: 'none',
     },
   },
-  // getFocusStyle(theme, { inset: -1 }),
 });
 
 const useLiveRegionStyles = makeStyles({

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDay/CalendarDay.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Enter } from '@fluentui/keyboard-keys';
-import { ArrowDownRegular, ArrowUpRegular, DismissRegular } from '@fluentui/react-icons';
+import { ChevronLeftRegular, ChevronRightRegular, DismissRegular } from '@fluentui/react-icons';
 import { useId } from '@fluentui/react-utilities';
 import { mergeClasses } from '@griffel/react';
 import { addMonths, compareDatePart, getMonthEnd, getMonthStart } from '../../utils';
@@ -137,7 +137,7 @@ const CalendarDayNavigationButtons = (props: CalendarDayNavigationButtonsProps):
         }
         type="button"
       >
-        <ArrowUpRegular />
+        <ChevronLeftRegular />
       </button>
       <button
         className={mergeClasses(classNames.headerIconButton, !nextMonthInBounds && classNames.disabledStyle)}
@@ -152,7 +152,7 @@ const CalendarDayNavigationButtons = (props: CalendarDayNavigationButtonsProps):
         }
         type="button"
       >
-        <ArrowDownRegular />
+        <ChevronRightRegular />
       </button>
       {showCloseButton && (
         <button

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDay/useCalendarDayStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDay/useCalendarDayStyles.ts
@@ -44,7 +44,7 @@ const useMonthAndYearStyles = makeStyles({
   base: {
     alignItems: 'center',
     backgroundColor: tokens.colorTransparentBackground,
-    ...shorthands.border('none'),
+    ...shorthands.borderStyle('none'),
     ...shorthands.borderRadius('2px'),
     color: tokens.colorNeutralForeground1,
     display: 'inline-block',
@@ -67,12 +67,14 @@ const useMonthAndYearStyles = makeStyles({
   },
   headerIsClickable: {
     '&:hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorBrandBackground2,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
     },
+    '&:active': {
+      backgroundColor: tokens.colorBrandBackground2,
+    },
   },
-  // getFocusStyle(theme, { inset: 1 }),
 });
 
 const useMonthComponentsStyles = makeStyles({
@@ -87,8 +89,10 @@ const useHeaderIconButtonStyles = makeStyles({
     backgroundColor: tokens.colorTransparentBackground,
     ...shorthands.borderStyle('none'),
     ...shorthands.borderRadius('2px'),
-    color: tokens.colorNeutralForeground1,
-    display: 'block',
+    color: tokens.colorNeutralForeground3,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     fontFamily: 'inherit',
     fontSize: tokens.fontSizeBase200,
     height: '28px',
@@ -100,13 +104,15 @@ const useHeaderIconButtonStyles = makeStyles({
     width: '28px',
 
     '&:hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorBrandBackground2,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
+    '&:active': {
+      backgroundColor: tokens.colorBrandBackground2,
+    },
   },
-  // getFocusStyle(theme, { inset: -1 }),
 });
 
 const useDisabledStyleStyles = makeStyles({

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -2,42 +2,13 @@ import * as React from 'react';
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Enter } from '@fluentui/keyboard-keys';
 import { getRTLSafeKey } from '@fluentui/react-utilities';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { mergeClasses } from '@griffel/react';
 import { addDays, addWeeks, compareDates, findAvailableDate, DateRangeType } from '../../utils';
 import { weekCornersClassNames } from './useWeekCornerStyles';
-import { tokens } from '@fluentui/react-theme';
 import type { AvailableDateOptions } from '../../utils';
 import type { DayInfo } from './CalendarDayGrid';
 import type { CalendarGridRowProps } from './CalendarGridRow';
-
-const useCornersDateAndPositionStyles = makeStyles({
-  corners: {
-    [`&.${weekCornersClassNames.topRightCornerDate}`]: {
-      borderTopRightRadius: '2px',
-    },
-    [`&.${weekCornersClassNames.topLeftCornerDate}`]: {
-      borderTopLeftRadius: '2px',
-    },
-    [`&.${weekCornersClassNames.bottomRightCornerDate}`]: {
-      borderBottomRightRadius: '2px',
-    },
-    [`&.${weekCornersClassNames.bottomLeftCornerDate}`]: {
-      borderBottomLeftRadius: '2px',
-    },
-    [`&.${weekCornersClassNames.datesAbove}::before`]: {
-      ...shorthands.borderTop('1px', 'solid', tokens.colorNeutralStrokeAccessible),
-    },
-    [`&.${weekCornersClassNames.datesBelow}::before`]: {
-      ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStrokeAccessible),
-    },
-    [`&.${weekCornersClassNames.datesLeft}::before`]: {
-      ...shorthands.borderLeft('1px', 'solid', tokens.colorNeutralStrokeAccessible),
-    },
-    [`&.${weekCornersClassNames.datesRight}::before`]: {
-      ...shorthands.borderRight('1px', 'solid', tokens.colorNeutralStrokeAccessible),
-    },
-  },
-});
+import { extraCalendarDayGridClassNames } from './useCalendarDayGridStyles';
 
 export interface CalendarGridDayCellProps extends CalendarGridRowProps {
   day: DayInfo;
@@ -143,7 +114,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
 
     dayRefs.forEach((dayRef: HTMLElement | null, index: number) => {
       if (dayRef) {
-        dayRef.classList.add('ms-CalendarDay-hoverStyle');
+        dayRef.classList.add(extraCalendarDayGridClassNames.hoverStyle);
         if (
           !dayInfos[index].isSelected &&
           dateRangeType === DateRangeType.Day &&
@@ -173,7 +144,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
 
     dayRefs.forEach((dayRef: HTMLElement | null) => {
       if (dayRef) {
-        dayRef.classList.add('ms-CalendarDay-pressedStyle');
+        dayRef.classList.add(extraCalendarDayGridClassNames.pressedStyle);
       }
     });
   };
@@ -184,7 +155,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
 
     dayRefs.forEach((dayRef: HTMLElement | null) => {
       if (dayRef) {
-        dayRef.classList.remove('ms-CalendarDay-pressedStyle');
+        dayRef.classList.remove(extraCalendarDayGridClassNames.pressedStyle);
       }
     });
   };
@@ -195,8 +166,8 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
 
     dayRefs.forEach((dayRef: HTMLElement | null, index: number) => {
       if (dayRef) {
-        dayRef.classList.remove('ms-CalendarDay-hoverStyle');
-        dayRef.classList.remove('ms-CalendarDay-pressedStyle');
+        dayRef.classList.remove(extraCalendarDayGridClassNames.hoverStyle);
+        dayRef.classList.remove(extraCalendarDayGridClassNames.pressedStyle);
         if (
           !dayInfos[index].isSelected &&
           dateRangeType === DateRangeType.Day &&
@@ -231,14 +202,12 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
     ariaLabel = ariaLabel + ', ' + strings.dayMarkedAriaLabel;
   }
 
-  const cornersDateAndPositionStyles = useCornersDateAndPositionStyles();
   const isFocusable = !ariaHidden && (allFocusable || (day.isInBounds ? true : undefined));
 
   return (
     <td
       className={mergeClasses(
         classNames.dayCell,
-        cornersDateAndPositionStyles.corners,
         weekCorners && cornerStyle,
         day.isSelected && classNames.daySelected,
         day.isSelected && 'ms-CalendarDay-daySelected',

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
@@ -81,7 +81,7 @@ const useDayCellStyles = makeStyles({
     },
 
     '&:hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
         ...shorthands.outline('1px', 'solid', 'Highlight'),
@@ -90,7 +90,7 @@ const useDayCellStyles = makeStyles({
     },
 
     '&:active': {
-      backgroundColor: tokens.colorNeutralBackground1Pressed,
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
         ...shorthands.borderColor('Highlight'),
@@ -105,24 +105,14 @@ const useDayCellStyles = makeStyles({
       },
     },
   },
-  // getFocusStyle(theme, { inset: -3 }),
 });
 
 const useDaySelectedStyles = makeStyles({
   dateRangeTypeNotMonth: {
-    backgroundColor: tokens.colorNeutralBackground1Selected,
-
-    '&::before': {
-      bottom: 0,
-      content: '""',
-      left: 0,
-      position: 'absolute',
-      right: 0,
-      top: 0,
-    },
+    backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
 
     '&:hover, &:active': {
-      backgroundColor: tokens.colorNeutralBackground1Selected + ' !important',
+      backgroundColor: tokens.colorBrandBackgroundInvertedSelected + ' !important',
       '@media (forced-colors: active)': {
         backgroundColor: 'Highlight!important',
         color: 'HighlightText!important',
@@ -169,7 +159,7 @@ const useWeekDayLabelCellStyles = makeStyles({
 
 const useWeekNumberCellStyles = makeStyles({
   base: {
-    backgroundColor: tokens.colorNeutralBackground2,
+    backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
     ...shorthands.borderColor(tokens.colorNeutralStroke2),
     ...shorthands.borderRight('1px', 'solid'),
     boxSizing: 'border-box',

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
@@ -19,6 +19,7 @@ import {
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { CalendarDayGridStyles, CalendarDayGridStyleProps } from './CalendarDayGrid.types';
 import { AnimationDirection } from '../Calendar/Calendar.types';
+import { weekCornersClassNames } from './useWeekCornerStyles';
 
 export const calendarDayGridClassNames: SlotClassNames<CalendarDayGridStyles> = {
   wrapper: 'fui-CalendarDayGrid__wrapper',
@@ -35,6 +36,11 @@ export const calendarDayGridClassNames: SlotClassNames<CalendarDayGridStyles> = 
   firstTransitionWeek: 'fui-CalendarDayGrid__firstTransitionWeek',
   lastTransitionWeek: 'fui-CalendarDayGrid__lastTransitionWeek',
   dayMarker: 'fui-CalendarDayGrid__dayMarker',
+};
+
+export const extraCalendarDayGridClassNames = {
+  hoverStyle: 'fui-CalendarDayGrid__hoverStyle',
+  pressedStyle: 'fui-CalendarDayGrid__pressedStyle',
 };
 
 const useWrapperStyles = makeStyles({
@@ -62,7 +68,7 @@ const useTableStyles = makeStyles({
 
 const useDayCellStyles = makeStyles({
   base: {
-    color: tokens.colorNeutralForeground1,
+    color: tokens.colorNeutralForeground3,
     cursor: 'pointer',
     fontSize: tokens.fontSizeBase200,
     fontWeight: tokens.fontWeightRegular,
@@ -80,7 +86,8 @@ const useDayCellStyles = makeStyles({
       zIndex: 0,
     },
 
-    '&:hover': {
+    [`&.${extraCalendarDayGridClassNames.hoverStyle}`]: {
+      color: tokens.colorNeutralForeground2,
       backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
@@ -89,7 +96,8 @@ const useDayCellStyles = makeStyles({
       },
     },
 
-    '&:active': {
+    [`&.${extraCalendarDayGridClassNames.pressedStyle}`]: {
+      color: tokens.colorNeutralForeground2,
       backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
@@ -98,7 +106,7 @@ const useDayCellStyles = makeStyles({
       },
     },
 
-    '&:active:hover': {
+    [`&.${extraCalendarDayGridClassNames.pressedStyle}.${extraCalendarDayGridClassNames.hoverStyle}`]: {
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
         ...shorthands.outline('1px', 'solid', 'Highlight'),
@@ -111,7 +119,8 @@ const useDaySelectedStyles = makeStyles({
   dateRangeTypeNotMonth: {
     backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
 
-    '&:hover, &:active': {
+    [`&:hover, &.${extraCalendarDayGridClassNames.hoverStyle}, &.${extraCalendarDayGridClassNames.pressedStyle}`]: {
+      color: tokens.colorNeutralForeground2,
       backgroundColor: tokens.colorBrandBackgroundInvertedSelected + ' !important',
       '@media (forced-colors: active)': {
         backgroundColor: 'Highlight!important',
@@ -293,6 +302,48 @@ const useDayMarkerStyles = makeStyles({
   },
 });
 
+const useCornerBorderAndRadiusStyles = makeStyles({
+  borderBase: {
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      // ...shorthands.borderStyle('none'),
+    },
+  },
+  corners: {
+    [`&.${weekCornersClassNames.topRightCornerDate}`]: {
+      borderTopRightRadius: '2px',
+    },
+    [`&.${weekCornersClassNames.topLeftCornerDate}`]: {
+      borderTopLeftRadius: '2px',
+    },
+    [`&.${weekCornersClassNames.bottomRightCornerDate}`]: {
+      borderBottomRightRadius: '2px',
+    },
+    [`&.${weekCornersClassNames.bottomLeftCornerDate}`]: {
+      borderBottomLeftRadius: '2px',
+    },
+  },
+  borders: {
+    [`&.${weekCornersClassNames.datesAbove}::before`]: {
+      ...shorthands.borderTop('1px', 'solid', tokens.colorNeutralStrokeAccessible),
+    },
+    [`&.${weekCornersClassNames.datesBelow}::before`]: {
+      ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStrokeAccessible),
+    },
+    [`&.${weekCornersClassNames.datesLeft}::before`]: {
+      ...shorthands.borderLeft('1px', 'solid', tokens.colorNeutralStrokeAccessible),
+    },
+    [`&.${weekCornersClassNames.datesRight}::before`]: {
+      ...shorthands.borderRight('1px', 'solid', tokens.colorNeutralStrokeAccessible),
+    },
+  },
+});
+
 /**
  * Apply styling to the CalendarDayGrid slots based on the state
  */
@@ -311,6 +362,7 @@ export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStylePro
   const firstTransitionWeekStyles = useFirstTransitionWeekStyles();
   const lastTransitionWeekStyles = useLastTransitionWeekStyles();
   const dayMarkerStyles = useDayMarkerStyles();
+  const cornerBorderAndRadiusStyles = useCornerBorderAndRadiusStyles();
 
   const { animateBackwards, animationDirection, dateRangeType, lightenDaysOutsideNavigatedMonth, showWeekNumbers } =
     props;
@@ -322,9 +374,15 @@ export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStylePro
       tableStyles.base,
       showWeekNumbers && tableStyles.showWeekNumbers,
     ),
-    dayCell: mergeClasses(calendarDayGridClassNames.dayCell, dayCellStyles.base),
+    dayCell: mergeClasses(
+      calendarDayGridClassNames.dayCell,
+      dayCellStyles.base,
+      cornerBorderAndRadiusStyles.corners,
+      cornerBorderAndRadiusStyles.borders,
+    ),
     daySelected: mergeClasses(
       calendarDayGridClassNames.daySelected,
+      dateRangeType !== DateRangeType.Month && cornerBorderAndRadiusStyles.borderBase,
       dateRangeType !== DateRangeType.Month && daySelectedStyles.dateRangeTypeNotMonth,
     ),
     weekRow: mergeClasses(

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useWeekCornerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useWeekCornerStyles.ts
@@ -88,11 +88,11 @@ export function useWeekCornerStyles(props: CalendarDayGridProps) {
             day.isSelected,
           );
 
-        const style = [];
-        style.push(calculateRoundedStyles(above, below, left, right));
-        style.push(calculateBorderStyles(above, below, left, right));
-
-        weekCornersStyled[weekIndex + '_' + dayIndex] = style.join(' ');
+        const style = mergeClasses(
+          calculateRoundedStyles(above, below, left, right),
+          calculateBorderStyles(above, below, left, right),
+        );
+        weekCornersStyled[weekIndex + '_' + dayIndex] = style;
       });
     });
 
@@ -123,7 +123,7 @@ export function useWeekCornerStyles(props: CalendarDayGridProps) {
       );
     }
 
-    return style.join(' ');
+    return mergeClasses(...style);
   };
 
   const calculateBorderStyles = (above: boolean, below: boolean, left: boolean, right: boolean): string => {

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarMonth/CalendarMonth.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Enter } from '@fluentui/keyboard-keys';
-import { ArrowDownRegular, ArrowUpRegular } from '@fluentui/react-icons';
+import { ChevronLeftRegular, ChevronRightRegular } from '@fluentui/react-icons';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { mergeClasses } from '@griffel/react';
@@ -226,7 +226,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
             }
             type="button"
           >
-            {dir === 'ltr' ? <ArrowUpRegular /> : <ArrowDownRegular />}
+            {dir === 'ltr' ? <ChevronLeftRegular /> : <ChevronRightRegular />}
           </button>
           <button
             className={mergeClasses(classNames.navigationButton, !isNextYearInBounds && classNames.disabled)}
@@ -241,7 +241,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
             }
             type="button"
           >
-            {dir === 'ltr' ? <ArrowDownRegular /> : <ArrowUpRegular />}
+            {dir === 'ltr' ? <ChevronRightRegular /> : <ChevronLeftRegular />}
           </button>
         </div>
       </div>

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
@@ -71,19 +71,18 @@ const useCurrentItemButtonStyles = makeStyles({
   },
   hasHeaderClickCallback: {
     '&:hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
     '&:active': {
-      backgroundColor: tokens.colorNeutralBackground1Pressed,
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
       color: tokens.colorNeutralForeground1Pressed,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
   },
-  // getFocusStyle(theme, { inset: -1 }),
 });
 
 const useNavigationButtonsContainerStyles = makeStyles({
@@ -113,13 +112,16 @@ const useNavigationButtonStyles = makeStyles({
     width: '28px',
 
     '&:hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
+
+    '&:active': {
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
+    },
   },
-  //  getFocusStyle(theme, { inset: -1 }),
 });
 
 const useGridContainerStyles = makeStyles({
@@ -131,7 +133,7 @@ const useGridContainerStyles = makeStyles({
 const useButtonRowStyles = makeStyles({
   base: {
     marginBottom: '16px',
-    '&:nth-child(n + 3)': {
+    '&:last-of-type': {
       marginBottom: 0,
     },
   },
@@ -181,7 +183,7 @@ const useItemButtonStyles = makeStyles({
       fontWeight: tokens.fontWeightRegular,
     },
     '&:hover': {
-      backgroundColor: tokens.colorNeutralBackground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
@@ -203,7 +205,6 @@ const useItemButtonStyles = makeStyles({
       },
     },
   },
-  // getFocusStyle(theme, { inset: -1 }),
 });
 
 const useCurrentStyles = makeStyles({

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
@@ -71,13 +71,13 @@ const useCurrentItemButtonStyles = makeStyles({
   },
   hasHeaderClickCallback: {
     '&:hover': {
-      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
+      backgroundColor: tokens.colorBrandBackground2,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
     '&:active': {
-      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
+      backgroundColor: tokens.colorBrandBackground2,
       color: tokens.colorNeutralForeground1Pressed,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
@@ -98,7 +98,9 @@ const useNavigationButtonStyles = makeStyles({
     ...shorthands.borderStyle('none'),
     ...shorthands.borderRadius('2px'),
     color: tokens.colorNeutralForeground1,
-    display: 'block',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     fontFamily: 'inherit',
     fontSize: tokens.fontSizeBase200,
     height: '28px',
@@ -112,14 +114,10 @@ const useNavigationButtonStyles = makeStyles({
     width: '28px',
 
     '&:hover': {
-      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
+      backgroundColor: tokens.colorBrandBackground2,
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
-    },
-
-    '&:active': {
-      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
     },
   },
 });

--- a/packages/react-components/react-datepicker-compat/stories/Calendar/CalendarDefault.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/Calendar/CalendarDefault.stories.tsx
@@ -1,4 +1,15 @@
 import * as React from 'react';
 import { Calendar, CalendarProps } from '@fluentui/react-datepicker-compat';
+import { tokens } from '@fluentui/react-components';
+import { makeResetStyles } from '@griffel/react';
 
-export const Default = (props: Partial<CalendarProps>) => <Calendar {...props} />;
+const useStyles = makeResetStyles({
+  backgroundColor: tokens.colorNeutralBackground1,
+  padding: '30px',
+});
+
+export const Default = (props: Partial<CalendarProps>) => (
+  <div className={useStyles()}>
+    <Calendar {...props} />
+  </div>
+);

--- a/packages/react-components/react-datepicker-compat/stories/Calendar/CalendarDefault.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/Calendar/CalendarDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, CalendarProps } from '@fluentui/react-datepicker-compat';
+import { Calendar, CalendarProps, DateRangeType } from '@fluentui/react-datepicker-compat';
 import { tokens } from '@fluentui/react-components';
 import { makeResetStyles } from '@griffel/react';
 
@@ -10,6 +10,7 @@ const useStyles = makeResetStyles({
 
 export const Default = (props: Partial<CalendarProps>) => (
   <div className={useStyles()}>
-    <Calendar {...props} />
+    {/* <Calendar {...props} /> */}
+    <Calendar dateRangeType={DateRangeType.Month} highlightSelectedMonth showGoToToday {...props} />
   </div>
 );

--- a/packages/react-components/react-datepicker-compat/stories/Calendar/CalendarDefault.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/Calendar/CalendarDefault.stories.tsx
@@ -1,16 +1,4 @@
 import * as React from 'react';
-import { Calendar, CalendarProps, DateRangeType } from '@fluentui/react-datepicker-compat';
-import { tokens } from '@fluentui/react-components';
-import { makeResetStyles } from '@griffel/react';
+import { Calendar, CalendarProps } from '@fluentui/react-datepicker-compat';
 
-const useStyles = makeResetStyles({
-  backgroundColor: tokens.colorNeutralBackground1,
-  padding: '30px',
-});
-
-export const Default = (props: Partial<CalendarProps>) => (
-  <div className={useStyles()}>
-    {/* <Calendar {...props} /> */}
-    <Calendar dateRangeType={DateRangeType.Month} highlightSelectedMonth showGoToToday {...props} />
-  </div>
-);
+export const Default = (props: Partial<CalendarProps>) => <Calendar {...props} />;


### PR DESCRIPTION
This PR aligns Calendar with v9 to look closer to what the actual Calendar might look like.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #26235
