### PR TITLE
Fix sev1 tabs accessibility

### DIFF
--- a/change/@fluentui-react-tabs-106a456b-4f3d-457f-93f2-c6bd95ad999e.json
+++ b/change/@fluentui-react-tabs-106a456b-4f3d-457f-93f2-c6bd95ad999e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed missing outline when forced-colors active",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.ts
@@ -174,17 +174,20 @@ const useFocusStyles = makeStyles({
   // Tab creates a custom focus indicator because the default focus indicator
   // is applied using an ::after pseudo-element on the root. Since the selection
   // indicator uses an ::after pseudo-element on the root, there is a conflict.
-  base: createCustomFocusIndicatorStyle({
-    ...shorthands.borderColor('transparent'),
-    outlineWidth: tokens.strokeWidthThick,
-    outlineColor: 'transparent',
-    outlineStyle: 'solid',
-    boxShadow: `
+  base: createCustomFocusIndicatorStyle(
+    {
+      ...shorthands.borderColor('transparent'),
+      outlineWidth: tokens.strokeWidthThick,
+      outlineColor: 'transparent',
+      outlineStyle: 'solid',
+      boxShadow: `
       ${tokens.shadow4},
       0 0 0 ${tokens.strokeWidthThick} ${tokens.colorStrokeFocus2}
     `,
-    zIndex: 1,
-  }),
+      zIndex: 1,
+    },
+    { enableOutline: true },
+  ),
 });
 
 /** Indicator styles for when pending selection */


### PR DESCRIPTION
## Changes
- Added enableOutline: true to the focus indicator in Tab to allow the focus indicator to show in high contrast mode.

## Issues
Fixes #27122

## Screenshots

Default light theme
<img width="285" alt="image" src="https://user-images.githubusercontent.com/28762486/223768850-adf88633-f3f7-4c3e-9b10-e741c02ed779.png">

Fixed high contrast
<img width="303" alt="image" src="https://user-images.githubusercontent.com/28762486/223769003-fa9f2dc5-d5fa-46d8-b32d-a2186e51ca60.png">
