### PR TITLE
fix: [text] block breaks the style attribute

### DIFF
--- a/change/@fluentui-web-components-91a1543a-10b0-4b10-9d32-0535f7a8e631.json
+++ b/change/@fluentui-web-components-91a1543a-10b0-4b10-9d32-0535f7a8e631.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: [text] block breaks the style attribute",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -46,7 +46,6 @@ export const styles = css`
     overflow: visible;
     text-overflow: clip;
     margin: 0;
-    display: inherit;
   }
   :host([nowrap]) ::slotted(*) {
     white-space: nowrap;

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -36,17 +36,22 @@ import {
 export const styles = css`
   ${display('inline')}
 
+  ${/* slot defaults display to contents, this ensures slotted items inherit from the host */ ''}
+  slot {
+    display: inherit;
+  }
+
   ::slotted(*) {
     font-family: ${fontFamilyBase};
     font-size: ${fontSizeBase300};
     line-height: ${lineHeightBase300};
     font-weight: ${fontWeightRegular};
     text-align: start;
-    display: inline;
     white-space: normal;
     overflow: visible;
     text-overflow: clip;
     margin: 0;
+    display: inherit;
   }
   :host([nowrap]) ::slotted(*) {
     white-space: nowrap;
@@ -55,7 +60,7 @@ export const styles = css`
   :host([truncate]) ::slotted(*) {
     text-overflow: ellipsis;
   }
-  :host([block]) ::slotted(*) {
+  :host([block]) {
     display: block;
   }
   :host([italic]) ::slotted(*) {

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -36,11 +36,6 @@ import {
 export const styles = css`
   ${display('inline')}
 
-  ${/* slot defaults display to contents, this ensures slotted items inherit from the host */ ''}
-  slot {
-    display: inherit;
-  }
-
   ::slotted(*) {
     font-family: ${fontFamilyBase};
     font-size: ${fontSizeBase300};
@@ -60,7 +55,8 @@ export const styles = css`
   :host([truncate]) ::slotted(*) {
     text-overflow: ellipsis;
   }
-  :host([block]) {
+  :host([block]),
+  :host([block]) ::slotted(*) {
     display: block;
   }
   :host([italic]) ::slotted(*) {

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -46,7 +46,9 @@ export const styles = css`
     overflow: visible;
     text-overflow: clip;
     margin: 0;
+    display: inline;
   }
+
   :host([nowrap]) ::slotted(*) {
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The `style` attribute is not applied to the text when `block` is set.

## New Behavior

 The `style` should be applied to the text, as it is when `block` is not set.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/37851214/223815865-6edd12a2-d527-4ff4-827e-b7dfdab5985a.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27048 
