### PR TITLE
fix: SplitButton should display correctly in high contrast mode

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - `Datepicker`: indicators should be visible in high contrast mode. @ling1726 ([#27107](https://github.com/microsoft/fluentui/pull/27107))
+- `SplitButton`: should display correctly in high contrast mode @ling1726 ([#27137](https://github.com/microsoft/fluentui/pull/27137))
 
 <!--------------------------------[ v0.66.3 ]------------------------------- -->
 ## [v0.66.3](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.66.3) (2023-02-27)

--- a/packages/fluentui/react-northstar/src/themes/teams-forced-colors/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-forced-colors/componentStyles.ts
@@ -6,6 +6,9 @@ export { menuItemWrapperStyles as MenuItemWrapper } from './components/Menu/menu
 export { toolbarItemStyles as ToolbarItem } from './components/Toolbar/toolbarItemStyles';
 export { sliderStyles as Slider } from './components/Slider/sliderStyles';
 
+export { splitButtonToggleStyles as SplitButtonToggle } from './components/SplitButton/splitButtonToggleStyles';
+export { splitButtonDividerStyles as SplitButtonDivider } from './components/SplitButton/splitButtonDividerStyles';
+
 export { datepickerCalendarCellButtonStyles as DatepickerCalendarCellButton } from './components/Datepicker/datepickerCalendarCellButtonStyles';
 export { datepickerCalendarCellStyles as DatepickerCalendarCell } from './components/Datepicker/datepickerCalendarCellStyles';
 export { datepickerCalendarGridRowStyles as DatepickerCalendarGridRow } from './components/Datepicker/datepickerCalendarGridRowStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/SplitButton/splitButtonDividerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/SplitButton/splitButtonDividerStyles.ts
@@ -1,0 +1,16 @@
+import { SplitButtonVariables } from '../../../teams/components/SplitButton/splitButtonVariables';
+import { SplitButtonDividerStylesProps } from './../../../../components/SplitButton/SplitButtonDivider';
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+
+export const splitButtonDividerStyles: ComponentSlotStylesPrepared<
+  SplitButtonDividerStylesProps,
+  SplitButtonVariables
+> = {
+  root: ({ props, variables }): ICSSInJSStyle => {
+    return {
+      '::before': {
+        background: 'ButtonText',
+      },
+    };
+  },
+};

--- a/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/SplitButton/splitButtonToggleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/SplitButton/splitButtonToggleStyles.ts
@@ -1,0 +1,25 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { SplitButtonToggleStylesProps } from '../../../../components/SplitButton/SplitButtonToggle';
+import { SplitButtonVariables } from '../../../teams/components/SplitButton/splitButtonVariables';
+import { toggleIndicatorUrl } from '../../../teams/components/SplitButton/toggleIndicatorUrl';
+
+const getIndicatorStyles = (color: string, outline: boolean, size: string): ICSSInJSStyle => {
+  return {
+    content: '""',
+    width: size,
+    height: size,
+    backgroundImage: toggleIndicatorUrl(color, outline),
+    backgroundRepeat: 'no-repeat',
+  };
+};
+
+export const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonToggleStylesProps, SplitButtonVariables> =
+  {
+    root: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
+      return {
+        ':before': {
+          ...getIndicatorStyles(p.disabled ? 'GrayText' : 'ButtonText', true, v.toggleButtonIndicatorSize),
+        },
+      };
+    },
+  };

--- a/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/SplitButton/splitButtonToggleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/SplitButton/splitButtonToggleStyles.ts
@@ -16,10 +16,23 @@ const getIndicatorStyles = (color: string, outline: boolean, size: string): ICSS
 export const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonToggleStylesProps, SplitButtonVariables> =
   {
     root: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
+      const { siteVariables } = theme;
+      const { borderWidth } = siteVariables;
+
       return {
         ':before': {
           ...getIndicatorStyles(p.disabled ? 'GrayText' : 'ButtonText', true, v.toggleButtonIndicatorSize),
         },
+
+        ...(p.primary && {
+          borderWidth,
+          borderColor: `transparent`,
+        }),
+
+        ...(p.disabled && {
+          borderWidth,
+          borderColor: `transparent`,
+        }),
       };
     },
   };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
@@ -107,8 +107,7 @@ export const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonTog
         ...(p.primary && {
           color: v.toggleButtonPrimaryColor,
           backgroundColor: v.toggleButtonPrimaryBackgroundColor,
-          borderWidth: `0 0 0 ${siteVariables.borderWidth}`,
-          borderColor: v.toggleButtonPrimaryBorderColor,
+          borderColor: `transparent transparent transparent ${v.toggleButtonPrimaryBorderColor}`,
 
           ':active': {
             backgroundColor: v.toggleButtonPrimaryBackgroundColorActive,
@@ -138,8 +137,7 @@ export const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonTog
 
           backgroundColor: v.toggleButtonBackgroundColorDisabled,
 
-          borderWidth: `0 0 0 ${siteVariables.borderWidth}`,
-          borderColor: v.borderColorDisabled,
+          borderColor: `transparent transparent transparent ${v.borderColorDisabled}`,
         }),
 
         ...(p.size === 'small' && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
@@ -107,7 +107,8 @@ export const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonTog
         ...(p.primary && {
           color: v.toggleButtonPrimaryColor,
           backgroundColor: v.toggleButtonPrimaryBackgroundColor,
-          borderColor: `transparent transparent transparent ${v.toggleButtonPrimaryBorderColor}`,
+          borderWidth: `0 0 0 ${siteVariables.borderWidth}`,
+          borderColor: v.toggleButtonPrimaryBorderColor,
 
           ':active': {
             backgroundColor: v.toggleButtonPrimaryBackgroundColorActive,
@@ -137,7 +138,8 @@ export const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonTog
 
           backgroundColor: v.toggleButtonBackgroundColorDisabled,
 
-          borderColor: `transparent transparent transparent ${v.borderColorDisabled}`,
+          borderWidth: `0 0 0 ${siteVariables.borderWidth}`,
+          borderColor: v.borderColorDisabled,
         }),
 
         ...(p.size === 'small' && {


### PR DESCRIPTION
Added the following changes so that SplitButton would display correctly in windows high contrast mode:

* Applied transparent border in forced colours theme theme for primary split buttons
* Applied transparent border in forced colours theme theme for disabled split buttons
* Created a new data-url for the toggle indicator in forced colours theme
* Add explicit system colour for the divider in forced colours theme

## Previous Behavior
![image](https://user-images.githubusercontent.com/20744592/223967450-6963fc97-ce84-4cc7-b861-c57543e14a4c.png)

![image](https://user-images.githubusercontent.com/20744592/223969369-8ac08ecb-0fff-4eb0-aa47-70ed7874933c.png)



## New Behavior
![image](https://user-images.githubusercontent.com/20744592/223967519-e261eb56-eca5-46ea-bd2d-5aa251e3ba18.png)

![image](https://user-images.githubusercontent.com/20744592/223969326-92b77b87-1039-4335-bf7f-1f1b51d0ecd4.png)


Fixes #27123
