### PR TITLE
Adds Fluent 2 focus styles to search box

### DIFF
--- a/change/@fluentui-fluent2-theme-9c27a1c0-3c80-4f47-89b5-6ac9da027257.json
+++ b/change/@fluentui-fluent2-theme-9c27a1c0-3c80-4f47-89b5-6ac9da027257.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adds focus styles to SearchBox, extracts duplicated focus and disabled code from TextField to utils.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/SearchBox.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/SearchBox.styles.ts
@@ -1,32 +1,50 @@
 import type { ISearchBoxStyleProps, ISearchBoxStyles, IStyleFunctionOrObject } from '@fluentui/react';
-import { getInputFocusStyle } from '@fluentui/react';
+import { getFluent2InputDisabledStyles, getFluent2InputFocusStyles } from './inputStyleHelpers.utils';
 
 export function getSearchBoxStyles(
   props: ISearchBoxStyleProps,
 ): IStyleFunctionOrObject<ISearchBoxStyleProps, ISearchBoxStyles> {
-  const { hasFocus, underlined, theme } = props;
+  const { hasFocus, underlined, disabled, theme } = props;
+  const { palette } = theme;
+
+  const restBottomBorder = `1px solid ${palette.neutralPrimary}`;
 
   const styles: Partial<ISearchBoxStyles> = {
     root: [
       {
         borderRadius: underlined ? 0 : theme.effects.roundedCorner4,
+        borderBottom: restBottomBorder,
       },
 
       hasFocus && [
         'is-active',
         {
           position: 'relative',
+          borderColor: 'unset',
         },
-        getInputFocusStyle(
-          theme.semanticColors.inputFocusBorderAlt,
-          underlined ? 0 : theme.effects.roundedCorner4,
-          underlined ? 'borderBottom' : 'border',
-        ),
+        getFluent2InputFocusStyles(theme),
+      ],
+
+      disabled && ['is-disabled', getFluent2InputDisabledStyles(theme)],
+    ],
+    field: [
+      disabled && {
+        '::placeholder': {
+          color: palette.neutralQuaternaryAlt,
+        },
+      },
+    ],
+    iconContainer: [
+      {
+        color: theme.palette.neutralPrimary,
+      },
+      disabled && [
+        'is-disabled',
+        {
+          color: palette.neutralQuaternaryAlt,
+        },
       ],
     ],
-    iconContainer: {
-      color: theme.palette.neutralPrimary,
-    },
   };
 
   return styles;

--- a/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
@@ -1,6 +1,6 @@
 import type { IStyleFunctionOrObject, ITextFieldStyleProps, ITextFieldStyles } from '@fluentui/react';
 import { FontWeights } from '@fluentui/react';
-import { IExtendedSemanticColors } from '../types';
+import { getFluent2InputDisabledStyles, getFluent2InputFocusStyles } from './inputStyleHelpers.utils';
 
 export function getTextFieldStyles(
   props: ITextFieldStyleProps,
@@ -10,33 +10,11 @@ export function getTextFieldStyles(
 
   const unsetBackgroundColor = { backgroundColor: 'unset' };
 
-  const bottomBorderFocusColor =
-    (semanticColors as IExtendedSemanticColors)?.inputBottomBorderFocus ?? theme.palette.themePrimary;
-  const focusBottomBorder = `2px solid ${hasErrorMessage ? semanticColors.errorText : bottomBorderFocusColor}`;
-
-  let borderBottomColor = palette.neutralPrimary;
-
-  if (hasErrorMessage) {
-    borderBottomColor = semanticColors.errorText;
-  }
-  if (disabled) {
-    // There is no 'inputBorderDisabled' in the v8 semantic colors.
-    // Disabled border color is assigned to 'disabledBackground' in the base style file :-(
-    // Which gets mapped to 'neutralLighter'
-    // And I'd prefer to assign a palette color than add 2 new semantic colors or assign an incorrect semantic.
-    // Bottom border color should match the rest of the border color.
-    borderBottomColor = palette.neutralLighter;
-  }
+  const borderBottomColor = hasErrorMessage ? semanticColors.errorText : palette.neutralPrimary;
 
   const restBottomBorder = borderless || underlined ? 'unset' : `1px solid ${borderBottomColor}`;
 
   const styles: Partial<ITextFieldStyles> = {
-    root: {
-      '.ms-Fabric--isFocusVisible &:focus::after': {
-        borderRadius: effects.roundedCorner4,
-        borderBottom: focusBottomBorder,
-      },
-    },
     subComponentStyles: {
       label: {
         root: {
@@ -71,17 +49,8 @@ export function getTextFieldStyles(
           borderRadius: effects.roundedCorner4,
         },
       },
-      focused && {
-        borderColor: semanticColors.focusBorder,
-        ':after': {
-          borderBottom: underlined ? 'unset' : focusBottomBorder,
-          clipPath: 'inset(calc(100% - 2px) 0 0 0)',
-        },
-      },
-      disabled && {
-        borderBottom: `1px solid ${borderBottomColor}`,
-        backgroundColor: 'unset',
-      },
+      focused && getFluent2InputFocusStyles(theme, underlined, hasErrorMessage),
+      disabled && getFluent2InputDisabledStyles(theme),
     ],
   };
 

--- a/packages/fluent2-theme/src/componentStyles/inputStyleHelpers.utils.ts
+++ b/packages/fluent2-theme/src/componentStyles/inputStyleHelpers.utils.ts
@@ -1,0 +1,32 @@
+import { IRawStyle, ITheme } from '@fluentui/react';
+import { IExtendedSemanticColors } from '../types';
+
+export const getFluent2InputFocusStyles = (
+  theme: ITheme,
+  isUnderline: boolean = false,
+  isError: boolean = false,
+): IRawStyle => {
+  const { semanticColors } = theme;
+
+  const bottomBorderFocusColor =
+    (semanticColors as IExtendedSemanticColors)?.inputBottomBorderFocus ?? theme.palette.themePrimary;
+
+  const focusBottomBorder = `2px solid ${isError ? semanticColors.errorText : bottomBorderFocusColor}`;
+
+  return {
+    borderColor: semanticColors.focusBorder,
+    ':after': {
+      borderColor: semanticColors.focusBorder,
+      borderBottom: isUnderline ? 'unset' : focusBottomBorder,
+      clipPath: 'inset(calc(100% - 2px) 0 0 0)',
+    },
+  };
+};
+
+export const getFluent2InputDisabledStyles = (theme: ITheme): IRawStyle => {
+  return {
+    borderBottom: `1px solid ${theme.palette.neutralQuaternaryAlt}`,
+    color: theme.palette.neutralQuaternaryAlt,
+    backgroundColor: 'unset',
+  };
+};

--- a/packages/fluent2-theme/src/index.ts
+++ b/packages/fluent2-theme/src/index.ts
@@ -2,3 +2,4 @@ export type { IExtendedEffects, IExtendedSemanticColors } from './types';
 export { Fluent2WebDarkTheme } from './fluent2WebDarkTheme';
 export { Fluent2WebLightTheme } from './fluent2WebLightTheme';
 export { fluent2ComponentStyles } from './fluent2ComponentStyles';
+export { getFluent2InputDisabledStyles, getFluent2InputFocusStyles } from './componentStyles/inputStyleHelpers.utils';


### PR DESCRIPTION
Adds Fluent 2 focus and disabled styling to SearchBox.
Extracts duplicate code to helper functions.

Before

![image](https://user-images.githubusercontent.com/17346018/224125302-0e0890d7-bd19-401e-8874-7e45bfe7c9f3.png)
![image](https://user-images.githubusercontent.com/17346018/224125156-08338be6-a8ca-40ab-81a6-1e5f7c08dd4e.png)


After

![image](https://user-images.githubusercontent.com/17346018/224124744-0822ee24-cd0a-43ec-b1df-51d44ff78738.png)
![image](https://user-images.githubusercontent.com/17346018/224124876-48f4230a-e053-4da5-ba9f-39d856a57755.png)
