### PR TITLE
Add cxe-red as a codeowner of react-file-type-icons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,7 +138,7 @@ packages/react-components/react-conformance-griffel @microsoft/teams-prg
 packages/react-components/react-context-selector @microsoft/teams-prg
 packages/react-date-time @microsoft/cxe-red
 packages/react-docsite-components @microsoft/fluentui-v8-website
-packages/react-file-type-icons @jahnp @bigbadcapers
+packages/react-file-type-icons @microsoft/cxe-red @jahnp @bigbadcapers
 packages/react-hooks @microsoft/cxe-red
 packages/react-icons-mdl2 @microsoft/cxe-red @microsoft/cxe-coastal
 packages/react-monaco-editor @microsoft/fluentui-v8-website


### PR DESCRIPTION
## Previous Behavior

The `react-file-type-icons` package had only non-maintainer codeowners listed.

## New Behavior

Add `@microsoft/cxe-red` as a codeowner for the `react-file-type-icons` package.

