### PR TITLE
Updates drop down to Fluent 2 focus and disabled styling

### DIFF
--- a/change/@fluentui-fluent2-theme-04317380-4380-49b5-9a39-ba3a88d9f9de.json
+++ b/change/@fluentui-fluent2-theme-04317380-4380-49b5-9a39-ba3a88d9f9de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating drown down focused and disabled styles.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Dropdown.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Dropdown.styles.ts
@@ -1,20 +1,36 @@
-import type { IDropdownStyleProps, IDropdownStyles, IStyleFunctionOrObject } from '@fluentui/react';
+import { IDropdownStyleProps, IDropdownStyles, IStyleFunctionOrObject } from '@fluentui/react';
 import { FontWeights } from '@fluentui/react';
+import { IExtendedSemanticColors } from '../types';
+import { getFluent2InputDisabledStyles } from './inputStyleHelpers.utils';
 
 export function getDropdownStyles(
   props: IDropdownStyleProps,
 ): IStyleFunctionOrObject<IDropdownStyleProps, IDropdownStyles> {
-  const { theme } = props;
+  const { theme, disabled } = props;
+  const { semanticColors, palette } = theme!;
+
+  const bottomBorderFocusColor =
+    (semanticColors as IExtendedSemanticColors)?.inputBottomBorderFocus ?? palette.themePrimary;
+
+  const focusBottomBorder = `2px solid ${bottomBorderFocusColor}`;
 
   return {
-    dropdown: {
-      selectors: {
-        '&:focus:after': {
-          borderRadius: theme?.effects.roundedCorner4,
+    dropdown: [
+      disabled && getFluent2InputDisabledStyles(theme!),
+      !disabled && {
+        selectors: {
+          '&:focus:after': [
+            {
+              borderRadius: theme?.effects.roundedCorner4,
+              borderColor: semanticColors.focusBorder,
+              borderBottom: focusBottomBorder,
+              clipPath: 'inset(calc(100% - 2px) 0 0 0)',
+            },
+          ],
         },
       },
-    },
-    title: { borderRadius: theme?.effects.roundedCorner4 },
+    ],
+    title: [{ borderRadius: theme?.effects.roundedCorner4 }, disabled && { backgroundColor: 'unset' }],
     caretDown: { color: theme?.palette.neutralQuaternary },
     label: { fontWeight: FontWeights.regular },
   };

--- a/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
@@ -51,6 +51,7 @@ export function getTextFieldStyles(
       },
       focused && getFluent2InputFocusStyles(theme, underlined, hasErrorMessage),
       disabled && getFluent2InputDisabledStyles(theme),
+      disabled && { borderBottom: `1px solid ${palette.neutralQuaternaryAlt}` },
     ],
   };
 

--- a/packages/fluent2-theme/src/componentStyles/inputStyleHelpers.utils.ts
+++ b/packages/fluent2-theme/src/componentStyles/inputStyleHelpers.utils.ts
@@ -25,7 +25,8 @@ export const getFluent2InputFocusStyles = (
 
 export const getFluent2InputDisabledStyles = (theme: ITheme): IRawStyle => {
   return {
-    borderBottom: `1px solid ${theme.palette.neutralQuaternaryAlt}`,
+    borderRadius: theme?.effects.roundedCorner4,
+    border: `1px solid ${theme.palette.neutralQuaternaryAlt}`,
     color: theme.palette.neutralQuaternaryAlt,
     backgroundColor: 'unset',
   };


### PR DESCRIPTION
Updates Drop Down focuse and disabled styling.

Couldn't use the previous input focus styling method because of the way focus behavior was handled.

Before:

![image](https://user-images.githubusercontent.com/17346018/224163096-cb0b04e7-b828-4981-baf2-00c075dfc392.png)

After:
![image](https://user-images.githubusercontent.com/17346018/224163230-3c310b09-32da-4f24-ace9-a8d8e999322a.png)
