### PR TITLE
feat(react-utilities): isHTMLElement to support all HTMLElement classes

### DIFF
--- a/change/@fluentui-react-menu-f76e8e18-42bd-4e30-92ec-977d7132c7aa.json
+++ b/change/@fluentui-react-menu-f76e8e18-42bd-4e30-92ec-977d7132c7aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: stops using instaceof in favor of isHTMLElement",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-0ba7f9d3-aa7a-40eb-a354-b88eb83ee05b.json
+++ b/change/@fluentui-react-positioning-0ba7f9d3-aa7a-40eb-a354-b88eb83ee05b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: stops using instaceof in favor of isHTMLElement",
+  "packageName": "@fluentui/react-positioning",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-685f2015-ef46-4d86-bedb-154b6516ec96.json
+++ b/change/@fluentui-react-radio-685f2015-ef46-4d86-bedb-154b6516ec96.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: stops using instaceof in favor of isHTMLElement",
+  "packageName": "@fluentui/react-radio",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-ac521080-1e70-44d9-a0d6-2293af91ef5e.json
+++ b/change/@fluentui-react-utilities-ac521080-1e70-44d9-a0d6-2293af91ef5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: isHTMLElement to support all HTMLElement classes",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -8,6 +8,7 @@ import { ArrowRight, ArrowLeft, Escape, ArrowDown } from '@fluentui/keyboard-key
 import {
   applyTriggerPropsToChildren,
   getTriggerChild,
+  isHTMLElement,
   mergeCallbacks,
   useEventCallback,
   useMergedRefs,
@@ -153,12 +154,12 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   };
 };
 
-const isTargetDisabled = (e: React.SyntheticEvent | Event) => {
+const isTargetDisabled = (event: React.SyntheticEvent | Event) => {
   const isDisabled = (el: HTMLElement) =>
     el.hasAttribute('disabled') || (el.hasAttribute('aria-disabled') && el.getAttribute('aria-disabled') === 'true');
-  if (e.target instanceof HTMLElement && isDisabled(e.target)) {
+  if (isHTMLElement(event.target) && isDisabled(event.target)) {
     return true;
   }
 
-  return e.currentTarget instanceof HTMLElement && isDisabled(e.currentTarget);
+  return isHTMLElement(event.currentTarget) && isDisabled(event.currentTarget);
 };

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -2,6 +2,7 @@ import { computePosition } from '@floating-ui/dom';
 import type { Middleware, Placement, Strategy } from '@floating-ui/dom';
 import type { PositionManager, TargetElement } from './types';
 import { debounce, writeArrowUpdates, writeContainerUpdates, getScrollParent } from './utils';
+import { isHTMLElement } from '@fluentui/react-utilities';
 
 interface PositionManagerOptions {
   /**
@@ -62,7 +63,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
 
     if (isFirstUpdate) {
       scrollParents.add(getScrollParent(container));
-      if (target instanceof HTMLElement) {
+      if (isHTMLElement(target)) {
         scrollParents.add(getScrollParent(target));
       }
 

--- a/packages/react-components/react-positioning/src/utils/toggleScrollListener.ts
+++ b/packages/react-components/react-positioning/src/utils/toggleScrollListener.ts
@@ -1,3 +1,4 @@
+import { isHTMLElement } from '@fluentui/react-utilities';
 import type { PositioningVirtualElement } from '../types';
 import { getScrollParent } from './getScrollParent';
 
@@ -16,11 +17,11 @@ export function toggleScrollListener(
     return;
   }
 
-  if (prev instanceof HTMLElement) {
+  if (isHTMLElement(prev)) {
     const prevScrollParent = getScrollParent(prev);
     prevScrollParent.removeEventListener('scroll', handler);
   }
-  if (next instanceof HTMLElement) {
+  if (isHTMLElement(next)) {
     const scrollParent = getScrollParent(next);
     scrollParent.addEventListener('scroll', handler);
   }

--- a/packages/react-components/react-radio/src/components/RadioGroup/useRadioGroup.ts
+++ b/packages/react-components/react-radio/src/components/RadioGroup/useRadioGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useEventCallback, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, isHTMLElement, useEventCallback, useId } from '@fluentui/react-utilities';
 import { RadioGroupProps, RadioGroupState } from './RadioGroup.types';
 
 /**
@@ -31,7 +31,11 @@ export const useRadioGroup_unstable = (props: RadioGroupProps, ref: React.Ref<HT
       role: 'radiogroup',
       ...getNativeElementProps('div', props, /*excludedPropNames:*/ ['onChange', 'name']),
       onChange: useEventCallback(ev => {
-        if (onChange && ev.target instanceof HTMLInputElement && ev.target.type === 'radio') {
+        if (
+          onChange &&
+          isHTMLElement(ev.target, { constructorName: 'HTMLInputElement' }) &&
+          ev.target.type === 'radio'
+        ) {
           onChange(ev, { value: ev.target.value });
         }
       }),

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -82,7 +82,9 @@ export const IdPrefixProvider: React_2.Provider<string | undefined>;
 export function isFluentTrigger(element: React_2.ReactElement): element is React_2.ReactElement<TriggerProps>;
 
 // @internal
-export function isHTMLElement(element?: unknown): element is HTMLElement;
+export function isHTMLElement<ConstructorName extends HTMLElementConstructorName = 'HTMLElement'>(element?: unknown, options?: {
+    constructorName?: ConstructorName;
+}): element is InstanceType<(typeof globalThis)[ConstructorName]>;
 
 // @internal
 export function isInteractiveHTMLElement(element: unknown): boolean;

--- a/packages/react-components/react-utilities/src/utils/isHTMLElement.test.ts
+++ b/packages/react-components/react-utilities/src/utils/isHTMLElement.test.ts
@@ -17,27 +17,26 @@ const customDocument = {
 describe('isHTMLElement', () => {
   it('should behave the same as instanceof HTMLElement for elements on the same realm', () => {
     const element = document.createElement('div');
-    expect(isHTMLElement(element) === element instanceof HTMLElement).toBe(true);
-    expect(isHTMLElement({}) === {} instanceof HTMLElement).toBe(true);
+    expect(isHTMLElement(element)).toBe(element instanceof HTMLElement);
+    expect(isHTMLElement({})).toBe({} instanceof HTMLElement);
   });
   it('should behave the same as instanceof HTMLInputElement for elements on the same realm', () => {
     const element = document.createElement('input');
     expect(
       isHTMLElement(element, {
         constructorName: 'HTMLInputElement',
-      }) ===
-        element instanceof HTMLInputElement,
-    ).toBe(true);
-    expect(isHTMLElement({}, { constructorName: 'HTMLInputElement' }) === {} instanceof HTMLInputElement).toBe(true);
+      }),
+    ).toBe(element instanceof HTMLInputElement);
+    expect(isHTMLElement({}, { constructorName: 'HTMLInputElement' })).toBe({} instanceof HTMLInputElement);
   });
   it('should return true for instances of HTMLElement on different realms', () => {
     const element = new CustomHTMLElement();
-    expect(isHTMLElement(element)).toBe(true);
     expect(element instanceof HTMLElement).toBe(false);
+    expect(isHTMLElement(element)).toBe(true);
   });
   it('should return true for instances of HTMLInputElement on different realms', () => {
     const element = new CustomHTMLInputElement();
-    expect(isHTMLElement(element, { constructorName: 'HTMLInputElement' })).toBe(true);
     expect(element instanceof HTMLInputElement).toBe(false);
+    expect(isHTMLElement(element, { constructorName: 'HTMLInputElement' })).toBe(true);
   });
 });

--- a/packages/react-components/react-utilities/src/utils/isHTMLElement.test.ts
+++ b/packages/react-components/react-utilities/src/utils/isHTMLElement.test.ts
@@ -1,0 +1,43 @@
+import { isHTMLElement } from './isHTMLElement';
+
+class CustomHTMLElement {
+  public ownerDocument = customDocument;
+}
+class CustomHTMLInputElement {
+  public ownerDocument = customDocument;
+}
+
+const customDocument = {
+  defaultView: {
+    HTMLElement: CustomHTMLElement,
+    HTMLInputElement: CustomHTMLInputElement,
+  },
+} as Document;
+
+describe('isHTMLElement', () => {
+  it('should behave the same as instanceof HTMLElement for elements on the same realm', () => {
+    const element = document.createElement('div');
+    expect(isHTMLElement(element) === element instanceof HTMLElement).toBe(true);
+    expect(isHTMLElement({}) === {} instanceof HTMLElement).toBe(true);
+  });
+  it('should behave the same as instanceof HTMLInputElement for elements on the same realm', () => {
+    const element = document.createElement('input');
+    expect(
+      isHTMLElement(element, {
+        constructorName: 'HTMLInputElement',
+      }) ===
+        element instanceof HTMLInputElement,
+    ).toBe(true);
+    expect(isHTMLElement({}, { constructorName: 'HTMLInputElement' }) === {} instanceof HTMLInputElement).toBe(true);
+  });
+  it('should return true for instances of HTMLElement on different realms', () => {
+    const element = new CustomHTMLElement();
+    expect(isHTMLElement(element)).toBe(true);
+    expect(element instanceof HTMLElement).toBe(false);
+  });
+  it('should return true for instances of HTMLInputElement on different realms', () => {
+    const element = new CustomHTMLInputElement();
+    expect(isHTMLElement(element, { constructorName: 'HTMLInputElement' })).toBe(true);
+    expect(element instanceof HTMLInputElement).toBe(false);
+  });
+});

--- a/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
+++ b/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
@@ -7,11 +7,76 @@
  * might be problematic while operating with [multiple realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms)
  *
  */
-export function isHTMLElement(element?: unknown): element is HTMLElement {
+export function isHTMLElement<ConstructorName extends HTMLElementConstructorName = 'HTMLElement'>(
+  element?: unknown,
+  options?: { constructorName?: ConstructorName },
+): element is InstanceType<(typeof globalThis)[ConstructorName]> {
   const typedElement = element as Node | null | undefined;
   return Boolean(
     typedElement !== null &&
       typedElement?.ownerDocument?.defaultView &&
-      typedElement instanceof typedElement.ownerDocument.defaultView.HTMLElement,
+      typedElement instanceof typedElement.ownerDocument.defaultView[options?.constructorName ?? 'HTMLElement'],
   );
 }
+
+type HTMLElementConstructorName =
+  | 'HTMLElement'
+  | 'HTMLAnchorElement'
+  | 'HTMLAreaElement'
+  | 'HTMLAudioElement'
+  | 'HTMLBaseElement'
+  | 'HTMLBodyElement'
+  | 'HTMLBRElement'
+  | 'HTMLButtonElement'
+  | 'HTMLCanvasElement'
+  | 'HTMLDataElement'
+  | 'HTMLDataListElement'
+  | 'HTMLDetailsElement'
+  | 'HTMLDialogElement'
+  | 'HTMLDivElement'
+  | 'HTMLDListElement'
+  | 'HTMLEmbedElement'
+  | 'HTMLFieldSetElement'
+  | 'HTMLFormElement'
+  | 'HTMLHeadingElement'
+  | 'HTMLHeadElement'
+  | 'HTMLHRElement'
+  | 'HTMLHtmlElement'
+  | 'HTMLIFrameElement'
+  | 'HTMLImageElement'
+  | 'HTMLInputElement'
+  | 'HTMLModElement'
+  | 'HTMLLabelElement'
+  | 'HTMLLegendElement'
+  | 'HTMLLIElement'
+  | 'HTMLLinkElement'
+  | 'HTMLMapElement'
+  | 'HTMLMetaElement'
+  | 'HTMLMeterElement'
+  | 'HTMLObjectElement'
+  | 'HTMLOListElement'
+  | 'HTMLOptGroupElement'
+  | 'HTMLOptionElement'
+  | 'HTMLOutputElement'
+  | 'HTMLParagraphElement'
+  | 'HTMLParamElement'
+  | 'HTMLPreElement'
+  | 'HTMLProgressElement'
+  | 'HTMLQuoteElement'
+  | 'HTMLSlotElement'
+  | 'HTMLScriptElement'
+  | 'HTMLSelectElement'
+  | 'HTMLSourceElement'
+  | 'HTMLSpanElement'
+  | 'HTMLStyleElement'
+  | 'HTMLTableElement'
+  | 'HTMLTableColElement'
+  | 'HTMLTableRowElement'
+  | 'HTMLTableSectionElement'
+  | 'HTMLTemplateElement'
+  | 'HTMLTextAreaElement'
+  | 'HTMLTimeElement'
+  | 'HTMLTitleElement'
+  | 'HTMLTrackElement'
+  | 'HTMLUListElement'
+  | 'HTMLVideoElement';

--- a/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
+++ b/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
@@ -13,8 +13,7 @@ export function isHTMLElement<ConstructorName extends HTMLElementConstructorName
 ): element is InstanceType<(typeof globalThis)[ConstructorName]> {
   const typedElement = element as Node | null | undefined;
   return Boolean(
-    typedElement !== null &&
-      typedElement?.ownerDocument?.defaultView &&
+    typedElement?.ownerDocument?.defaultView &&
       typedElement instanceof typedElement.ownerDocument.defaultView[options?.constructorName ?? 'HTMLElement'],
   );
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

1. Improves `isHTMLElement` helper method to support all `HTMLElement` classes
2. Stops using `instanceof` in favor of `isHTMLElement` on:
   - `react-radio`
   - `react-menu`
   - `react-positioning` 

This is required as simply using `instanceof` might be problematic while operating with [multiple realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms)

Fixes https://github.com/microsoft/fluentui/issues/27159
