### PR TITLE
Revert "fix: Coordinates should be rounded to device pixels to prevent blurriness"

### DIFF
--- a/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
+++ b/packages/react-components/react-positioning/src/utils/writeContainerupdates.ts
@@ -42,13 +42,8 @@ export function writeContainerUpdates(options: {
     container.setAttribute(DATA_POSITIONING_HIDDEN, '');
   }
 
-  // Round so that the coordinates land on device pixels.
-  // This prevents blurriness in cases where the browser doesn't apply pixel snapping, such as when other effects like
-  // `backdrop-filter: blur()` are applied to the container, and the browser is zoomed in.
-  // See https://github.com/microsoft/fluentui/issues/26764 for more info.
-  const devicePixelRatio = container.ownerDocument.defaultView?.devicePixelRatio || 1;
-  const x = Math.round(coordinates.x * devicePixelRatio) / devicePixelRatio;
-  const y = Math.round(coordinates.y * devicePixelRatio) / devicePixelRatio;
+  const x = Math.round(coordinates.x);
+  const y = Math.round(coordinates.y);
 
   Object.assign(container.style, {
     transform: lowPPI ? `translate(${x}px, ${y}px)` : `translate3d(${x}px, ${y}px, 0)`,


### PR DESCRIPTION
Reverts microsoft/fluentui#26766

The `devicePixelRatio` can be an arbitrary float. It's possible that dividing by it will cause blurriness because the result can be a floating number and end up reproducing https://github.com/microsoft/fluentui/issues/25288