### PR TITLE
docs(react-card): fix card readme description

### DIFF
--- a/change/@fluentui-react-card-0a817d2d-d46b-4895-b3bb-29566bf747fa.json
+++ b/change/@fluentui-react-card-0a817d2d-d46b-4895-b3bb-29566bf747fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: improve readme description",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/README.md
+++ b/packages/react-components/react-card/README.md
@@ -1,10 +1,8 @@
-# @fluentui/react-card [ALPHA]
+# @fluentui/react-card
 
 **React Card components for [Fluent UI React](https://react.fluentui.dev)**
 
-**⚠️ Please note that functionality is still being added to this package. Due to lockstep versioning, the version of this package is aligned with the others in _react-components_.**
-
-These are not production-ready components and **should never be used in a product**. This space is useful for testing new components whose APIs might change before final release.
+A card is a container that holds information and actions related to a single concept or object, like a document or a contact.
 
 ## Usage
 


### PR DESCRIPTION
This PR fixes react-card README by removing the "preview" banner.