### PR TITLE
[Fluent 2 theme for v8] Fix spinner sizes

### DIFF
--- a/change/@fluentui-fluent2-theme-9fc83052-67a5-4a19-8327-ec4dfd93565d.json
+++ b/change/@fluentui-fluent2-theme-9fc83052-67a5-4a19-8327-ec4dfd93565d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing bugs in the spinner size. All 4 sizes were hard coded to 32px. Now Medium and large are 32px & 36px respectivley.xSmall back to 12px and small to 16px.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Spinner.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Spinner.styles.ts
@@ -1,18 +1,27 @@
-import type { ISpinnerStyleProps, ISpinnerStyles, IStyleFunctionOrObject } from '@fluentui/react';
+import { ISpinnerStyleProps, ISpinnerStyles, IStyleFunctionOrObject, SpinnerSize } from '@fluentui/react';
 import { FontWeights } from '@fluentui/react';
 
 export function getSpinnerStyles(
   props: ISpinnerStyleProps,
 ): IStyleFunctionOrObject<ISpinnerStyleProps, ISpinnerStyles> {
-  const { theme } = props;
+  const { theme, size } = props;
 
   const styles: Partial<ISpinnerStyles> = {
     label: [theme.fonts.mediumPlus, { color: theme.semanticColors.bodyText, fontWeight: FontWeights.semibold }],
-    circle: {
-      borderWidth: 3,
-      height: 32,
-      width: 32,
-    },
+    circle: [
+      {
+        borderWidth: 3,
+      },
+      size === SpinnerSize.large && {
+        height: 36,
+        width: 36,
+      },
+      size === SpinnerSize.medium && {
+        // default
+        height: 32,
+        width: 32,
+      },
+    ],
   };
 
   return styles;


### PR DESCRIPTION
We hard coded the spinner size to 32px as the size prop had been deprecated, and we expected most consumers to have coded their own size via the styles prop, as was recommended by the Fluent documentation.

Turns out many folks are still using the size prop, and our hard coding broke the UX in places where small or extra small had been used:

![image](https://user-images.githubusercontent.com/17346018/224778908-0b97fd38-a502-4ba4-91f6-94553fed8c65.png)

![image](https://user-images.githubusercontent.com/17346018/224778944-0f6f1f5f-b801-42de-9d42-d734e7c54bb5.png)

So now we're leaving small & xSmall untouched, and just changing medium (default) and large to 32 and 36.

Vanilla Fluent:
![image](https://user-images.githubusercontent.com/17346018/224781822-4990710d-4ba3-42e3-b83a-e5ff57a097f8.png)


Before Fluent 2 Theme:
![image](https://user-images.githubusercontent.com/17346018/224781712-a208cb7f-9af7-433d-b895-e5d9487013e6.png)


After:
![image](https://user-images.githubusercontent.com/17346018/224780253-0ffc83b0-2981-49df-a4c7-f50f1ac9422d.png)
