### PR TITLE
[Fluent 2 Theme for v8] spin button focus styles

### DIFF
--- a/change/@fluentui-fluent2-theme-71e4fd17-0fdb-4693-b2bc-85dc055bd43c.json
+++ b/change/@fluentui-fluent2-theme-71e4fd17-0fdb-4693-b2bc-85dc055bd43c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating spin button focused and disabled styles.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/SearchBox.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/SearchBox.styles.ts
@@ -5,7 +5,7 @@ export function getSearchBoxStyles(
   props: ISearchBoxStyleProps,
 ): IStyleFunctionOrObject<ISearchBoxStyleProps, ISearchBoxStyles> {
   const { hasFocus, underlined, disabled, theme } = props;
-  const { palette } = theme;
+  const { palette, semanticColors } = theme;
 
   const restBottomBorder = `1px solid ${palette.neutralPrimary}`;
 
@@ -25,12 +25,16 @@ export function getSearchBoxStyles(
         getFluent2InputFocusStyles(theme),
       ],
 
-      disabled && ['is-disabled', getFluent2InputDisabledStyles(theme)],
+      disabled && [
+        'is-disabled',
+        getFluent2InputDisabledStyles(theme),
+        { borderBottom: `1px solid ${semanticColors.disabledBorder}` },
+      ],
     ],
     field: [
       disabled && {
         '::placeholder': {
-          color: palette.neutralQuaternaryAlt,
+          color: semanticColors.disabledText,
         },
       },
     ],
@@ -41,7 +45,7 @@ export function getSearchBoxStyles(
       disabled && [
         'is-disabled',
         {
-          color: palette.neutralQuaternaryAlt,
+          color: semanticColors.disabledText,
         },
       ],
     ],

--- a/packages/fluent2-theme/src/componentStyles/SpinButton.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/SpinButton.styles.ts
@@ -1,20 +1,32 @@
 import type { ISpinButtonStyleProps, ISpinButtonStyles, IStyleFunctionOrObject } from '@fluentui/react';
-import { FontWeights, getInputFocusStyle } from '@fluentui/react';
+import { FontWeights } from '@fluentui/react';
 
 export function getSpinButtonStyles(
   props: ISpinButtonStyleProps,
 ): IStyleFunctionOrObject<ISpinButtonStyleProps, ISpinButtonStyles> {
   const { theme, isFocused, disabled } = props;
   const { semanticColors } = theme;
-  const SpinButtonRootBorderColor = semanticColors.inputBorder;
-  const SpinButtonRootBorderColorHovered = semanticColors.inputBorderHovered;
-  const SpinButtonRootBorderColorFocused = semanticColors.inputFocusBorderAlt;
+  const SpinButtonRootBorderColorFocused = semanticColors.disabledBorder; // sorry for the broken semantics
+  let SpinButtonRootBorderColor = semanticColors.inputBorder;
+  let SpinButtonBorderBottomColor = isFocused ? theme.palette.themePrimary : theme.palette.neutralPrimary;
+
+  if (disabled) {
+    SpinButtonBorderBottomColor = semanticColors.disabledBorder;
+    SpinButtonRootBorderColor = semanticColors.disabledBorder;
+  }
 
   const styles: Partial<ISpinButtonStyles> = {
     label: {
       fontWeight: FontWeights.regular,
     },
+    input: {
+      backgroundColor: 'unset',
+    },
     spinButtonWrapper: [
+      {
+        borderBottomColor: SpinButtonBorderBottomColor,
+        backgroundColor: 'unset',
+      },
       {
         // setting border using pseudo-element here in order to prevent:
         // input and chevron buttons to overlap border under certain resolutions
@@ -29,19 +41,31 @@ export function getSpinButtonStyles(
           borderWidth: '1px',
           borderStyle: 'solid',
           borderColor: SpinButtonRootBorderColor,
-          borderBottomColor: theme.palette.neutralPrimary,
+          borderBottomColor: SpinButtonBorderBottomColor,
           borderRadius: theme.effects.roundedCorner4,
         },
       },
       !disabled && [
         {
-          ':hover :': { ':after': { borderColor: SpinButtonRootBorderColorHovered } },
-        },
-        isFocused && {
-          selectors: {
-            '&&': getInputFocusStyle(SpinButtonRootBorderColorFocused, theme.effects.roundedCorner4),
+          ':hover :': {
+            ':after': {
+              borderStyle: 'solid',
+              borderColor: SpinButtonRootBorderColorFocused,
+              borderBottom: theme.palette.themePrimary,
+              borderWidth: '1px',
+            },
           },
         },
+        isFocused && [
+          {
+            ':hover:after, :after': {
+              borderStyle: 'solid',
+              borderColor: SpinButtonRootBorderColorFocused,
+              borderBottomColor: SpinButtonBorderBottomColor,
+              borderWidth: '1px',
+            },
+          },
+        ],
       ],
     ],
   };

--- a/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/TextField.styles.ts
@@ -51,7 +51,7 @@ export function getTextFieldStyles(
       },
       focused && getFluent2InputFocusStyles(theme, underlined, hasErrorMessage),
       disabled && getFluent2InputDisabledStyles(theme),
-      disabled && { borderBottom: `1px solid ${palette.neutralQuaternaryAlt}` },
+      disabled && { borderBottom: `1px solid ${semanticColors.disabledText}` },
     ],
   };
 

--- a/packages/fluent2-theme/src/componentStyles/inputStyleHelpers.utils.ts
+++ b/packages/fluent2-theme/src/componentStyles/inputStyleHelpers.utils.ts
@@ -24,10 +24,11 @@ export const getFluent2InputFocusStyles = (
 };
 
 export const getFluent2InputDisabledStyles = (theme: ITheme): IRawStyle => {
+  const { semanticColors } = theme;
   return {
     borderRadius: theme?.effects.roundedCorner4,
-    border: `1px solid ${theme.palette.neutralQuaternaryAlt}`,
-    color: theme.palette.neutralQuaternaryAlt,
+    border: `1px solid ${semanticColors.disabledBorder}`,
+    color: semanticColors.disabledText,
     backgroundColor: 'unset',
   };
 };


### PR DESCRIPTION
Updating spin button to use Fluent 2 focused and disabled styles.

Updating other fields to use proper semantic slots.

Before:
![image](https://user-images.githubusercontent.com/17346018/224834099-1d43d0fb-7e6b-40e3-91aa-ccc724b4dada.png)

After:
![image](https://user-images.githubusercontent.com/17346018/224833883-f0871599-0af1-41f3-a6af-1ddbbabaceb2.png)

