### PR TITLE
(web-components): add css containment to v3 components

### DIFF
--- a/change/@fluentui-web-components-904258a8-cd16-4d42-be2e-d6179a4afd76.json
+++ b/change/@fluentui-web-components-904258a8-cd16-4d42-be2e-d6179a4afd76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds css containment to implemented web components",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.styles.ts
@@ -28,6 +28,7 @@ export const styles = css`
 
   :host {
     max-width: fit-content;
+    contain: content;
   }
 
   .heading {

--- a/packages/web-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/src/accordion/accordion.styles.ts
@@ -7,5 +7,6 @@ export const styles = css`
   :host {
     flex-direction: column;
     width: 100%;
+    contain: content;
   }
 `;

--- a/packages/web-components/src/avatar/avatar.styles.ts
+++ b/packages/web-components/src/avatar/avatar.styles.ts
@@ -131,6 +131,7 @@ export const styles = css`
     border-radius: ${borderRadiusCircular};
     color: ${colorNeutralForeground3};
     background-color: ${colorNeutralBackground6};
+    contain: content;
   }
 
   .default-icon,

--- a/packages/web-components/src/avatar/avatar.styles.ts
+++ b/packages/web-components/src/avatar/avatar.styles.ts
@@ -131,7 +131,7 @@ export const styles = css`
     border-radius: ${borderRadiusCircular};
     color: ${colorNeutralForeground3};
     background-color: ${colorNeutralBackground6};
-    contain: content;
+    contain: layout style;
   }
 
   .default-icon,

--- a/packages/web-components/src/divider/divider.styles.ts
+++ b/packages/web-components/src/divider/divider.styles.ts
@@ -21,6 +21,10 @@ import {
 export const styles = css`
   ${display('flex')}
 
+  :host {
+    contain: content;
+  }
+
   :host::after,
   :host::before {
     align-self: center;

--- a/packages/web-components/src/image/image.styles.ts
+++ b/packages/web-components/src/image/image.styles.ts
@@ -6,6 +6,10 @@ import { borderRadiusCircular, colorNeutralStroke2, shadow4, strokeWidthThin } f
  * @public
  */
 export const styles = css`
+  :host {
+    contain: content;
+  }
+
   :host ::slotted(img) {
     box-sizing: border-box;
     min-height: 8px;

--- a/packages/web-components/src/progress-bar/progress-bar.styles.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.styles.ts
@@ -24,6 +24,7 @@ export const styles = css`
     height: 2px;
     overflow-x: hidden;
     border-radius: ${borderRadiusMedium};
+    contain: content;
   }
 
   :host([thickness='large']),

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -10,6 +10,7 @@ export const styles = css`
     align-items: center;
     height: 32px;
     width: 32px;
+    contain: content;
   }
   :host([size='tiny']) {
     height: 20px;

--- a/packages/web-components/src/styles/partials/badge.partials.ts
+++ b/packages/web-components/src/styles/partials/badge.partials.ts
@@ -69,6 +69,7 @@ export const badgeBaseStyles = css.partial`
     border-color: ${colorTransparentStroke};
     background-color: ${colorBrandBackground};
     color: ${colorNeutralForegroundOnBrand};
+    contain: content;
   }
 
   ::slotted(svg) {

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -40,6 +40,7 @@ export const styles = css`
     flex-direction: row-reverse;
     outline: none;
     user-select: none;
+    contain: content;
   }
   :host([label-position='before']) {
     flex-direction: row;

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -36,6 +36,10 @@ import {
 export const styles = css`
   ${display('inline')}
 
+  :host {
+    contain: content;
+  }
+
   ::slotted(*) {
     font-family: ${fontFamilyBase};
     font-size: ${fontSizeBase300};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
No CSS Containment
<!-- This is the behavior we have today -->

## New Behavior
Adds `contain: content` to all components except Avatar which implements `contain: layout style` (paint cannot be applied due to the presence badge).
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
n/a
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
