### PR TITLE
fix: useFocusVisible() should use proper document

### DIFF
--- a/change/@fluentui-react-provider-830b9ca5-f5b6-42cd-9c8c-7ac7dce3c6ff.json
+++ b/change/@fluentui-react-provider-830b9ca5-f5b6-42cd-9c8c-7ac7dce3c6ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: pass proper document instance to useFocusVisible()",
+  "packageName": "@fluentui/react-provider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-15bd7e2e-e514-4577-8ce7-6df09dfa88c6.json
+++ b/change/@fluentui-react-tabster-15bd7e2e-e514-4577-8ce7-6df09dfa88c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add options to useFocusVisible() hook",
+  "packageName": "@fluentui/react-tabster",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -87,7 +87,7 @@ export const useFluentProvider_unstable = (
     root: getNativeElementProps('div', {
       ...props,
       dir,
-      ref: useMergedRefs(ref, useFocusVisible<HTMLDivElement>()),
+      ref: useMergedRefs(ref, useFocusVisible<HTMLDivElement>({ targetDocument })),
     }),
   };
 };

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -11,7 +11,7 @@ import type { RefObject } from 'react';
 import { Types } from 'tabster';
 
 // @internal (undocumented)
-export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () => void;
+export function applyFocusVisiblePolyfill(scope: HTMLElement, targetWindow: Window): () => void;
 
 // @public
 export function createCustomFocusIndicatorStyle<TStyle extends GriffelStyle | GriffelResetStyle>(style: TStyle, { selector, enableOutline, }?: CreateCustomFocusIndicatorStyleOptions): TStyle extends GriffelStyle ? GriffelStyle : GriffelResetStyle;
@@ -74,7 +74,7 @@ export const useFocusFinders: () => {
 };
 
 // @public (undocumented)
-export function useFocusVisible<TElement extends HTMLElement = HTMLElement>(): React_2.RefObject<TElement>;
+export function useFocusVisible<TElement extends HTMLElement = HTMLElement>(options?: UseFocusVisibleOptions): React_2.RefObject<TElement>;
 
 // @public
 export function useFocusWithin<TElement extends HTMLElement = HTMLElement>(): React_2.RefObject<TElement>;

--- a/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
@@ -1,4 +1,6 @@
+import { isHTMLElement } from '@fluentui/react-utilities';
 import { KEYBORG_FOCUSIN, KeyborgFocusInEvent, createKeyborg, disposeKeyborg } from 'keyborg';
+
 import { FOCUS_VISIBLE_ATTR } from './constants';
 
 /**
@@ -22,9 +24,9 @@ type HTMLElementWithFocusVisibleScope = {
 /**
  * @internal
  * @param scope - Applies the ponyfill to all DOM children
- * @param win - window
+ * @param targetWindow - window
  */
-export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () => void {
+export function applyFocusVisiblePolyfill(scope: HTMLElement, targetWindow: Window): () => void {
   if (alreadyInScope(scope)) {
     // Focus visible polyfill already applied at this scope
     return () => undefined;
@@ -34,7 +36,7 @@ export function applyFocusVisiblePolyfill(scope: HTMLElement, win: Window): () =
     current: undefined,
   };
 
-  const keyborg = createKeyborg(win);
+  const keyborg = createKeyborg(targetWindow);
 
   // When navigation mode changes remove the focus-visible selector
   keyborg.subscribe(isNavigatingWithKeyboard => {
@@ -88,13 +90,6 @@ function applyFocusVisibleClass(el: HTMLElement) {
 
 function removeFocusVisibleClass(el: HTMLElement) {
   el.removeAttribute(FOCUS_VISIBLE_ATTR);
-}
-
-function isHTMLElement(target: EventTarget | null): target is HTMLElement {
-  if (!target) {
-    return false;
-  }
-  return Boolean(target && typeof target === 'object' && 'classList' in target && 'contains' in target);
 }
 
 function alreadyInScope(el: HTMLElement | null | undefined): boolean {

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.test.tsx
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.test.tsx
@@ -1,0 +1,54 @@
+import { Provider_unstable } from '@fluentui/react-shared-contexts';
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+jest.mock('../focus/focusVisiblePolyfill', () => ({ applyFocusVisiblePolyfill: jest.fn() }));
+
+import { applyFocusVisiblePolyfill } from '../focus/focusVisiblePolyfill';
+import { useFocusVisible } from './useFocusVisible';
+
+describe('useFocusVisible', () => {
+  describe('targetWindow', () => {
+    it('uses a window from context by default', () => {
+      const Wrapper: React.FC<{ targetDocument: Document | undefined }> = props => (
+        <Provider_unstable value={{ dir: 'ltr', targetDocument: props.targetDocument }}>
+          {props.children}
+        </Provider_unstable>
+      );
+      const element = document.createElement('div');
+
+      const { result, rerender } = renderHook<
+        { targetDocument: Document | undefined },
+        React.MutableRefObject<HTMLElement | null>
+      >(() => useFocusVisible(), {
+        wrapper: Wrapper,
+        initialProps: { targetDocument: undefined },
+      });
+
+      result.current.current = element;
+      rerender({ targetDocument: document });
+
+      expect(applyFocusVisiblePolyfill).toHaveBeenCalledTimes(1);
+      expect(applyFocusVisiblePolyfill).toHaveBeenCalledWith(element, document.defaultView);
+    });
+
+    it('uses a window from options', () => {
+      const element = document.createElement('div');
+      const { result, rerender } = renderHook<
+        { targetDocument: Document | undefined },
+        React.MutableRefObject<HTMLElement | null>
+      >(props => useFocusVisible({ targetDocument: props.targetDocument }), {
+        wrapper: props => (
+          <Provider_unstable value={{ dir: 'ltr', targetDocument: undefined }}>{props.children}</Provider_unstable>
+        ),
+        initialProps: { targetDocument: undefined },
+      });
+
+      result.current.current = element;
+      rerender({ targetDocument: document });
+
+      expect(applyFocusVisiblePolyfill).toHaveBeenCalledTimes(1);
+      expect(applyFocusVisiblePolyfill).toHaveBeenCalledWith(element, document.defaultView);
+    });
+  });
+});

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.ts
@@ -1,10 +1,17 @@
 import * as React from 'react';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+
 import { applyFocusVisiblePolyfill } from '../focus/focusVisiblePolyfill';
 
-export function useFocusVisible<TElement extends HTMLElement = HTMLElement>() {
-  const { targetDocument } = useFluent();
+type UseFocusVisibleOptions = {
+  targetDocument?: HTMLDocument;
+};
+
+export function useFocusVisible<TElement extends HTMLElement = HTMLElement>(options: UseFocusVisibleOptions = {}) {
+  const contentValue = useFluent();
   const scopeRef = React.useRef<TElement>(null);
+
+  const targetDocument = options.targetDocument ?? contentValue.targetDocument;
 
   React.useEffect(() => {
     if (targetDocument?.defaultView && scopeRef.current) {


### PR DESCRIPTION
## New Behavior

Fixes #27197.

This PR extends `useFocusVisible()` to accept `options` that contains `targetDocument`. `useFluentProvider()` passes a proper instance of `targetDocument` directly to `useFocusVisible()` to avoid chicken-egg problem with React Contexts.

### Chicken-egg problem

Before the fix `useFocusVisible()` used a `targetDocument` from `useFluent()` i.e. used a value from context. The problem is that in this case it will use always a value of parent context or a default value instead of a proper one.
