### PR TITLE
feat(DialogActions): Implement `fluid` prop

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Dialog/Dialog.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Dialog/Dialog.stories.tsx
@@ -442,3 +442,59 @@ ScrollLongContent.storyName = 'scroll long content';
 export const ScrollLongContentDarkMode = getStoryVariant(ScrollLongContent, DARK_MODE);
 export const ScrollLongContentHighContrast = getStoryVariant(ScrollLongContent, HIGH_CONTRAST);
 export const ScrollLongContentRTL = getStoryVariant(ScrollLongContent, RTL);
+
+export const FluidActionsStart = () => {
+  return (
+    <Dialog open>
+      <DialogTrigger disableButtonEnhancement>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogContent>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+            est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+            cumque eaque?
+          </DialogContent>
+          <DialogActions fluid position="start">
+            <Button appearance="secondary">Something Else</Button>
+            <Button appearance="secondary">Something Else</Button>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary">Close</Button>
+            </DialogTrigger>
+            <Button appearance="primary">Do Something</Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+export const FluidActionsEnd = () => {
+  return (
+    <Dialog open>
+      <DialogTrigger disableButtonEnhancement>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogContent>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+            est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+            cumque eaque?
+          </DialogContent>
+          <DialogActions fluid position="end">
+            <Button appearance="secondary">Something Else</Button>
+            <Button appearance="secondary">Something Else</Button>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary">Close</Button>
+            </DialogTrigger>
+            <Button appearance="primary">Do Something</Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};

--- a/change/@fluentui-react-dialog-aa5a8af5-a05d-460d-88d5-6126197983f6.json
+++ b/change/@fluentui-react-dialog-aa5a8af5-a05d-460d-88d5-6126197983f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(DialogActions): Implment `fluid` prop",
+  "packageName": "@fluentui/react-dialog",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -33,6 +33,7 @@ export type DialogActionsPosition = 'start' | 'end';
 // @public
 export type DialogActionsProps = ComponentProps<DialogActionsSlots> & {
     position?: DialogActionsPosition;
+    fluid?: boolean;
 };
 
 // @public (undocumented)
@@ -41,9 +42,7 @@ export type DialogActionsSlots = {
 };
 
 // @public
-export type DialogActionsState = ComponentState<DialogActionsSlots> & {
-    position: DialogActionsPosition;
-};
+export type DialogActionsState = ComponentState<DialogActionsSlots> & Pick<Required<DialogActionsProps>, 'position' | 'fluid'>;
 
 // @public
 export const DialogBody: ForwardRefComponent<DialogBodyProps>;

--- a/packages/react-components/react-dialog/src/components/DialogActions/DialogActions.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/DialogActions.types.ts
@@ -15,11 +15,16 @@ export type DialogActionsProps = ComponentProps<DialogActionsSlots> & {
    * @default 'end'
    */
   position?: DialogActionsPosition;
+
+  /**
+   * Makes the actions expand the entire width of the DialogBody
+   * @default false
+   */
+  fluid?: boolean;
 };
 
 /**
  * State used in rendering DialogActions
  */
-export type DialogActionsState = ComponentState<DialogActionsSlots> & {
-  position: DialogActionsPosition;
-};
+export type DialogActionsState = ComponentState<DialogActionsSlots> &
+  Pick<Required<DialogActionsProps>, 'position' | 'fluid'>;

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActions.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActions.ts
@@ -15,7 +15,7 @@ export const useDialogActions_unstable = (
   props: DialogActionsProps,
   ref: React.Ref<HTMLElement>,
 ): DialogActionsState => {
-  const { position = 'end' } = props;
+  const { position = 'end', fluid = false } = props;
   return {
     components: {
       root: 'div',
@@ -25,5 +25,6 @@ export const useDialogActions_unstable = (
       ...props,
     }),
     position,
+    fluid,
   };
 };

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts
@@ -31,6 +31,12 @@ const useStyles = makeStyles({
     justifySelf: 'start',
     ...shorthands.gridArea(ACTIONS_START_GRID_AREA),
   },
+  fluidStart: {
+    gridColumnEnd: ACTIONS_START_GRID_AREA,
+  },
+  fluidEnd: {
+    gridColumnStart: ACTIONS_START_GRID_AREA,
+  },
 });
 
 /**
@@ -43,6 +49,8 @@ export const useDialogActionsStyles_unstable = (state: DialogActionsState): Dial
     styles.root,
     state.position === 'start' && styles.gridPositionStart,
     state.position === 'end' && styles.gridPositionEnd,
+    state.fluid && state.position === 'start' && styles.fluidStart,
+    state.fluid && state.position === 'end' && styles.fluidEnd,
     state.root.className,
   );
   return state;

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.ts
@@ -32,7 +32,7 @@ const useStyles = makeStyles({
     ...shorthands.gridArea(ACTIONS_START_GRID_AREA),
   },
   fluidStart: {
-    gridColumnEnd: ACTIONS_START_GRID_AREA,
+    gridColumnEnd: ACTIONS_END_GRID_AREA,
   },
   fluidEnd: {
     gridColumnStart: ACTIONS_START_GRID_AREA,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.md
@@ -1,2 +1,4 @@
 Use the `fluid` prop on the `DialogActions` component so that it spans the entire width of the dialog. This
 prop can be useful for having large number of actions.
+
+> A `Dialog` should have no more than **two** actions.

--- a/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.md
@@ -1,0 +1,2 @@
+Use the `fluid` prop on the `DialogActions` component so that it spans the entire width of the dialog. This
+prop can be useful for having large number of actions.

--- a/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.stories.tsx
@@ -9,6 +9,7 @@ import {
   DialogContent,
   Button,
 } from '@fluentui/react-components';
+import story from './DialogFluidDialogActions.md';
 
 export const FluidActions = () => {
   return (
@@ -36,4 +37,12 @@ export const FluidActions = () => {
       </DialogSurface>
     </Dialog>
   );
+};
+
+FluidActions.parameters = {
+  docs: {
+    description: {
+      story,
+    },
+  },
 };

--- a/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.stories.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogSurface,
+  DialogTitle,
+  DialogBody,
+  DialogActions,
+  DialogContent,
+  Button,
+} from '@fluentui/react-components';
+
+export const FluidActions = () => {
+  return (
+    <Dialog>
+      <DialogTrigger disableButtonEnhancement>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogContent>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
+            est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
+            cumque eaque?
+          </DialogContent>
+          <DialogActions fluid>
+            <Button appearance="secondary">Something Else</Button>
+            <Button appearance="secondary">Something Else</Button>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary">Close</Button>
+            </DialogTrigger>
+            <Button appearance="primary">Do Something</Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};

--- a/packages/react-components/react-dialog/stories/Dialog/index.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/index.stories.tsx
@@ -9,6 +9,7 @@ export { Default } from './DialogDefault.stories';
 export { NonModal } from './DialogNonModal.stories';
 export { Alert } from './DialogAlert.stories';
 export { ScrollingLongContent } from './DialogScrollingLongContent.stories';
+export { FluidActions } from './DialogFluidDialogActions.stories';
 export { NoFocusableElement } from './DialogNoFocusableElement.stories';
 export { ControllingOpenAndClose } from './DialogControllingOpenAndClose.stories';
 export { ChangeFocus } from './DialogChangeFocus.stories';


### PR DESCRIPTION
Implements a new `fluid` prop so that the actions will span the entire width of the dialog without needing to do style overrides to the grid layout.

Fixes #27228

## Previous Behavior

![image](https://user-images.githubusercontent.com/20744592/225596156-69afdaa0-d96b-4290-a733-9d8ad15ff07e.png)

## New Behavior

![image](https://user-images.githubusercontent.com/20744592/225596053-ff7a796d-fe8b-4e20-9783-d0fe8e794db8.png)

## Related Issue(s)

Fixes #27228
