### PR TITLE
fix(DialogBody): Remove `maxWidth` style

### DIFF
--- a/change/@fluentui-react-dialog-265d3f30-f8c2-4813-89cd-389f8b99d67c.json
+++ b/change/@fluentui-react-dialog-265d3f30-f8c2-4813-89cd-389f8b99d67c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(DialogBody): Remove `maxWidth` style",
+  "packageName": "@fluentui/react-dialog",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.ts
@@ -27,7 +27,6 @@ const useStyles = makeStyles({
     },
     width: `100%`,
     height: 'fit-content',
-    maxWidth: '600px',
     maxHeight: `calc(100vh - 2 * ${SURFACE_PADDING})`,
     boxSizing: 'border-box',
     gridTemplateRows: 'auto 1fr auto',


### PR DESCRIPTION
This style is redundant because the DialogBody will not exceed the DialogSurface which sets the exact same maxWidth.

Removing this style will also make it easier for users to modify the width of the dialog by only neededing to override one component instead of 2.

Fixes #27222
