### PR TITLE
fix(getSlots): stops slotProps.slot to be typed as never

### DIFF
--- a/change/@fluentui-react-utilities-b426918d-10c6-4a75-ada8-22a181ac8670.json
+++ b/change/@fluentui-react-utilities-b426918d-10c6-4a75-ada8-22a181ac8670.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(getSlots): stops slotProps.slot to be typed as never",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -23,10 +23,10 @@ type ObjectSlotProps<S extends SlotPropsRecord> = {
   [K in keyof S]-?: ExtractSlotProps<S[K]> extends AsIntrinsicElement<infer As>
     ? // For intrinsic element types, return the intersection of all possible
       // element's props, to be compatible with the As type returned by Slots<>
-      UnionToIntersection<JSX.IntrinsicElements[As]>
+      UnionToIntersection<JSX.IntrinsicElements[As]> // Slot<'div', 'span'>
     : ExtractSlotProps<S[K]> extends React.ComponentType<infer P>
-    ? P
-    : never;
+    ? P // Slot<typeof Button>
+    : ExtractSlotProps<S[K]>; // Slot<ButtonProps>
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`ObjectSlotProps` would return `never` as the inference of slots defined as `Slot<ComponentProps>`

## New Behavior

`ObjectSlotProps` returns `ComponentProps` for those cases.

## Related Issue(s)

As presented by @marcosmoura

![image](https://user-images.githubusercontent.com/5483269/225613318-5453a539-8fe2-4a20-b082-0c7a85884560.png)

