### PR TITLE
chore(react-infobutton): Renaming content slot to info and updating InfoLabel to use InfoButton's shorthand

### DIFF
--- a/apps/perf-test-react-components/src/scenarios/InfoButton.tsx
+++ b/apps/perf-test-react-components/src/scenarios/InfoButton.tsx
@@ -3,7 +3,7 @@ import { InfoButton } from '@fluentui/react-infobutton';
 import { FluentProvider } from '@fluentui/react-provider';
 import { webLightTheme } from '@fluentui/react-theme';
 
-const Scenario = () => <InfoButton content={"This is an InfoButton's content."} />;
+const Scenario = () => <InfoButton>This is an InfoButton's content.</InfoButton>;
 
 Scenario.decorator = (props: { children: React.ReactNode }) => {
   <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>;

--- a/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
@@ -26,7 +26,7 @@ storiesOf('InfoButton', module)
     'default',
     () => (
       <div style={{ display: 'flex', alignItems: 'flex-end', padding: '10px', minHeight: '80px' }}>
-        <InfoButton className="info-button" content="This is the content of an InfoButton." />
+        <InfoButton className="info-button" info="This is the content of an InfoButton." />
       </div>
     ),
     {
@@ -52,8 +52,8 @@ storiesOf('InfoButton', module)
         alignItems: 'start',
       }}
     >
-      <InfoButton size="small" content="This is the content of an InfoButton." popover={{ open: true }} />
-      <InfoButton size="medium" content="This is the content of an InfoButton." popover={{ open: true }} />
-      <InfoButton size="large" content="This is the content of an InfoButton." popover={{ open: true }} />
+      <InfoButton size="small" info="This is the content of an InfoButton." popover={{ open: true }} />
+      <InfoButton size="medium" info="This is the content of an InfoButton." popover={{ open: true }} />
+      <InfoButton size="large" info="This is the content of an InfoButton." popover={{ open: true }} />
     </div>
   ));

--- a/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/InfoButton.stories.tsx
@@ -26,7 +26,7 @@ storiesOf('InfoButton', module)
     'default',
     () => (
       <div style={{ display: 'flex', alignItems: 'flex-end', padding: '10px', minHeight: '80px' }}>
-        <InfoButton className="info-button" info="This is the content of an InfoButton." />
+        <InfoButton className="info-button">This is the content of an InfoButton.</InfoButton>
       </div>
     ),
     {
@@ -52,8 +52,14 @@ storiesOf('InfoButton', module)
         alignItems: 'start',
       }}
     >
-      <InfoButton size="small" info="This is the content of an InfoButton." popover={{ open: true }} />
-      <InfoButton size="medium" info="This is the content of an InfoButton." popover={{ open: true }} />
-      <InfoButton size="large" info="This is the content of an InfoButton." popover={{ open: true }} />
+      <InfoButton size="small" popover={{ open: true }}>
+        This is the content of an InfoButton.
+      </InfoButton>
+      <InfoButton size="medium" popover={{ open: true }}>
+        This is the content of an InfoButton.
+      </InfoButton>
+      <InfoButton size="large" popover={{ open: true }}>
+        This is the content of an InfoButton.
+      </InfoButton>
     </div>
   ));

--- a/change/@fluentui-react-infobutton-d4b92f9d-bdf3-44d0-be75-074ba1facfba.json
+++ b/change/@fluentui-react-infobutton-d4b92f9d-bdf3-44d0-be75-074ba1facfba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Renaming content slot to info and updating InfoLabel to use InfoButton's shorthand.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/README.md
+++ b/packages/react-components/react-infobutton/README.md
@@ -24,6 +24,6 @@ import { InfoButton } from '@fluentui/react-components';
 
 ```jsx
 const InfoButtonExample = () => {
-  return <InfoButton content="This is an InfoButton's content." />;
+  return <InfoButton>This is an InfoButton's content.</InfoButton>;
 };
 ```

--- a/packages/react-components/react-infobutton/etc/react-infobutton.api.md
+++ b/packages/react-components/react-infobutton/etc/react-infobutton.api.md
@@ -23,15 +23,16 @@ export const InfoButton: ForwardRefComponent<InfoButtonProps>;
 export const infoButtonClassNames: SlotClassNames<InfoButtonSlots>;
 
 // @public
-export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
+export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled' | 'children'> & {
     size?: 'small' | 'medium' | 'large';
+    children?: React_2.ReactNode;
 };
 
 // @public (undocumented)
 export type InfoButtonSlots = {
     root: NonNullable<Slot<'button'>>;
     popover: NonNullable<Slot<Partial<PopoverProps>>>;
-    content: NonNullable<Slot<typeof PopoverSurface>>;
+    info: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 // @public
@@ -44,15 +45,13 @@ export const InfoLabel: ForwardRefComponent<InfoLabelProps>;
 export const infoLabelClassNames: SlotClassNames<InfoLabelSlots>;
 
 // @public
-export type InfoLabelProps = ComponentProps<Partial<InfoLabelSlots>, 'label'> & {
-    info?: InfoButtonProps['content'];
-};
+export type InfoLabelProps = ComponentProps<Partial<InfoLabelSlots>, 'label'>;
 
 // @public (undocumented)
 export type InfoLabelSlots = {
     root: NonNullable<Slot<'span'>>;
     label: NonNullable<Slot<typeof Label>>;
-    infoButton: Slot<typeof InfoButton>;
+    info?: Slot<typeof InfoButton>;
 };
 
 // @public

--- a/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.test.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.test.tsx
@@ -27,17 +27,17 @@ describe('InfoButton', () => {
     Component: InfoButton,
     displayName: 'InfoButton',
     requiredProps: {
-      content: "This is an InfoButton's Content.",
+      info: "This is an InfoButton's Content.",
     },
     testOptions: {
       'has-static-classnames': [
         {
           props: {
-            content: "This is an InfoButton's Content.",
+            children: "This is an InfoButton's Content.",
           },
           expectedClassNames: {
             root: infoButtonClassNames.root,
-            content: infoButtonClassNames.content,
+            info: infoButtonClassNames.info,
           },
           getPortalElement: getPopoverSurfaceElement,
         },

--- a/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.types.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/InfoButton.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { PopoverProps, PopoverSurface } from '@fluentui/react-popover';
 
@@ -10,21 +11,26 @@ export type InfoButtonSlots = {
   popover: NonNullable<Slot<Partial<PopoverProps>>>;
 
   /**
-   * The content to be displayed in the PopoverSurface when the button is pressed.
+   * The information to be displayed in the PopoverSurface when the button is pressed.
    */
-  content: NonNullable<Slot<typeof PopoverSurface>>;
+  info: NonNullable<Slot<typeof PopoverSurface>>;
 };
 
 /**
  * InfoButton Props
  */
-export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
+export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled' | 'children'> & {
   /**
    * Size of the InfoButton.
    *
    * @default medium
    */
   size?: 'small' | 'medium' | 'large';
+
+  /**
+   * Content to be forwarded to the PopoverSurface.
+   */
+  children?: React.ReactNode;
 };
 
 /**

--- a/packages/react-components/react-infobutton/src/components/InfoButton/renderInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/renderInfoButton.tsx
@@ -15,7 +15,7 @@ export const renderInfoButton_unstable = (state: InfoButtonState) => {
       <PopoverTrigger>
         <slots.root {...slotProps.root} />
       </PopoverTrigger>
-      <slots.content {...slotProps.content} />
+      <slots.info {...slotProps.info} />
     </slots.popover>
   );
 };

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
@@ -28,7 +28,7 @@ const popoverSizeMap = {
  * @param ref - reference to root HTMLElement of InfoButton
  */
 export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HTMLElement>): InfoButtonState => {
-  const { size = 'medium' } = props;
+  const { size = 'medium', children, ...restOfProps } = props;
 
   const state: InfoButtonState = {
     size,
@@ -36,14 +36,14 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
     components: {
       root: 'button',
       popover: Popover as React.FC<Partial<PopoverProps>>,
-      content: PopoverSurface,
+      info: PopoverSurface,
     },
 
     root: getNativeElementProps('button', {
+      'aria-label': 'information',
       children: infoButtonIconMap[size],
       type: 'button',
-      'aria-label': 'information',
-      ...props,
+      ...restOfProps,
       ref,
     }),
     popover: resolveShorthand(props.popover, {
@@ -54,9 +54,10 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
         withArrow: true,
       },
     }),
-    content: resolveShorthand(props.content, {
+    info: resolveShorthand(props.info, {
       required: true,
       defaultProps: {
+        children,
         role: 'note',
         tabIndex: -1,
       },

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.ts
@@ -9,7 +9,7 @@ export const infoButtonClassNames: SlotClassNames<InfoButtonSlots> = {
   root: 'fui-InfoButton',
   // this className won't be used, but it's needed to satisfy the type checker
   popover: 'fui-InfoButton__popover',
-  content: 'fui-InfoButton__content',
+  info: 'fui-InfoButton__info',
 };
 
 /**
@@ -107,10 +107,10 @@ export const useInfoButtonStyles_unstable = (state: InfoButtonState): InfoButton
   const buttonStyles = useButtonStyles();
   const popoverSurfaceStyles = usePopoverSurfaceStyles();
 
-  state.content.className = mergeClasses(
-    infoButtonClassNames.content,
+  state.info.className = mergeClasses(
+    infoButtonClassNames.info,
     size === 'large' && popoverSurfaceStyles.large,
-    state.content.className,
+    state.info.className,
   );
 
   state.root.className = mergeClasses(

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/InfoLabel.test.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/InfoLabel.test.tsx
@@ -26,7 +26,7 @@ describe('InfoLabel', () => {
   });
 
   it("renders an InfoButton when the infoButton slot's content is set", () => {
-    const result = render(<InfoLabel infoButton={{ content: 'Test' }}>Test label</InfoLabel>);
+    const result = render(<InfoLabel info="Test">Test label</InfoLabel>);
     expect(result.getByRole('button')).toBeTruthy();
   });
 

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/InfoLabel.types.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/InfoLabel.types.ts
@@ -1,7 +1,6 @@
 import { Label } from '@fluentui/react-label';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { InfoButton } from '../InfoButton';
-import type { InfoButtonProps } from '../InfoButton';
 
 export type InfoLabelSlots = {
   root: NonNullable<Slot<'span'>>;
@@ -22,18 +21,13 @@ export type InfoLabelSlots = {
    *
    * It is not typically necessary to use this prop. The content can be set using the `info` prop of the InfoLabel.
    */
-  infoButton: Slot<typeof InfoButton>;
+  info?: Slot<typeof InfoButton>;
 };
 
 /**
  * InfoLabel Props
  */
-export type InfoLabelProps = ComponentProps<Partial<InfoLabelSlots>, 'label'> & {
-  /**
-   * The content of the InfoButton's popover.
-   */
-  info?: InfoButtonProps['content'];
-};
+export type InfoLabelProps = ComponentProps<Partial<InfoLabelSlots>, 'label'>;
 
 /**
  * State used in rendering InfoLabel

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/renderInfoLabel.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/renderInfoLabel.tsx
@@ -12,7 +12,7 @@ export const renderInfoLabel_unstable = (state: InfoLabelState) => {
   return (
     <slots.root {...slotProps.root}>
       <slots.label {...slotProps.label} />
-      {slots.infoButton && <slots.infoButton {...slotProps.infoButton} />}
+      {slots.info && <slots.info {...slotProps.info} />}
     </slots.root>
   );
 };

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/useInfoLabel.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/useInfoLabel.ts
@@ -18,9 +18,8 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
   const {
     root: rootShorthand,
     label: labelShorthand,
-    infoButton: infoButtonShorthand,
+    info: infoShorthand,
     size,
-    info,
     className,
     style,
     ...labelProps
@@ -44,17 +43,15 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
     },
   });
 
-  const infoButton = resolveShorthand(infoButtonShorthand, {
-    required: !!info,
+  const info = resolveShorthand(infoShorthand, {
     defaultProps: {
       id: useId('infobutton-'),
-      content: info,
       size,
     },
   });
 
-  if (infoButton) {
-    infoButton['aria-labelledby'] ??= `${label.id} ${infoButton.id}`;
+  if (info) {
+    info['aria-labelledby'] ??= `${label.id} ${info.id}`;
   }
 
   return {
@@ -62,10 +59,10 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
     components: {
       root: 'span',
       label: Label,
-      infoButton: InfoButton,
+      info: InfoButton,
     },
     root,
     label,
-    infoButton,
+    info,
   };
 };

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/useInfoLabelStyles.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/useInfoLabelStyles.ts
@@ -6,7 +6,7 @@ import type { InfoLabelSlots, InfoLabelState } from './InfoLabel.types';
 export const infoLabelClassNames: SlotClassNames<InfoLabelSlots> = {
   root: 'fui-InfoLabel',
   label: 'fui-InfoLabel__label',
-  infoButton: 'fui-InfoLabel__infoButton',
+  info: 'fui-InfoLabel__info',
 };
 
 const useLabelStyles = makeStyles({
@@ -43,12 +43,12 @@ export const useInfoLabelStyles_unstable = (state: InfoLabelState): InfoLabelSta
   state.label.className = mergeClasses(infoLabelClassNames.label, labelStyles.base, state.label.className);
 
   const infoButtonStyles = useInfoButtonStyles();
-  if (state.infoButton) {
-    state.infoButton.className = mergeClasses(
-      infoLabelClassNames.infoButton,
+  if (state.info) {
+    state.info.className = mergeClasses(
+      infoLabelClassNames.info,
       infoButtonStyles.base,
       state.size === 'large' && infoButtonStyles.large,
-      state.infoButton.className,
+      state.info.className,
     );
   }
 

--- a/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonDefault.stories.tsx
+++ b/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonDefault.stories.tsx
@@ -3,12 +3,7 @@ import { InfoButton, InfoButtonProps } from '@fluentui/react-infobutton';
 import { Link } from '@fluentui/react-components';
 
 export const Default = (props: Partial<InfoButtonProps>) => (
-  <InfoButton
-    {...props}
-    content={
-      <>
-        This is example content for an InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>
-      </>
-    }
-  />
+  <InfoButton {...props}>
+    This is example content for an InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>
+  </InfoButton>
 );

--- a/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonSize.stories.tsx
+++ b/packages/react-components/react-infobutton/stories/Infobutton/InfoButtonSize.stories.tsx
@@ -17,32 +17,21 @@ export const Size = () => {
 
   return (
     <div className={styles.base}>
-      <InfoButton
-        size="small"
-        content={
-          <>
-            This is example content for a small InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>.
-          </>
-        }
-      />
-
-      <InfoButton
-        size="medium"
-        content={
-          <>
-            This is example content for a medium InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>.
-          </>
-        }
-      />
-
-      <InfoButton
-        size="large"
-        content={
-          <>
-            This is example content for a large InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>.
-          </>
-        }
-      />
+      <InfoButton size="small">
+        <>
+          This is example content for a small InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>.
+        </>
+      </InfoButton>
+      <InfoButton size="medium">
+        <>
+          This is example content for a medium InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>.
+        </>
+      </InfoButton>
+      <InfoButton size="large">
+        <>
+          This is example content for a large InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>.
+        </>
+      </InfoButton>
     </div>
   );
 };


### PR DESCRIPTION


## Previous Behavior

InfoButton has a content slot.
InfoLabel has a separate info prop to pass down the information to InfoButton.

## New Behavior

InfoButton's content slot is now named info and the children prop is forwarded to the info slot.
InfoLabel now uses InfoButton's shothand instead of having a separate info prop.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27236
