### PR TITLE
chore: Add a Field story showing a disabled control inside a Field

### DIFF
--- a/packages/react-components/react-field/stories/Field/FieldDisabled.stories.tsx
+++ b/packages/react-components/react-field/stories/Field/FieldDisabled.stories.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { Input } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
+
+export const Disabled = () => (
+  <Field label="Field with disabled control">
+    <Input disabled />
+  </Field>
+);
+
+Disabled.storyName = 'Disabled control';
+Disabled.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the control inside the Field is disabled, the label should _not_ be marked disabled. ' +
+        'This ensures the label remains readable to users.',
+    },
+  },
+};

--- a/packages/react-components/react-field/stories/Field/index.stories.tsx
+++ b/packages/react-components/react-field/stories/Field/index.stories.tsx
@@ -3,11 +3,12 @@ import { Meta } from '@storybook/react';
 import { Field } from '@fluentui/react-components/unstable';
 
 export { Default } from './FieldDefault.stories';
-export { ValidationMessage } from './FieldValidationMessage.stories';
-export { Hint } from './FieldHint.stories';
 export { Horizontal } from './FieldHorizontal.stories';
 export { Required } from './FieldRequired.stories';
+export { Disabled } from './FieldDisabled.stories';
 export { Size } from './FieldSize.stories';
+export { ValidationMessage } from './FieldValidationMessage.stories';
+export { Hint } from './FieldHint.stories';
 export { ComponentExamples } from './FieldComponentExamples.stories';
 export { RenderFunction } from './FieldRenderFunction.stories';
 


### PR DESCRIPTION
## Previous Behavior

Field documentation does not show what a disabled control inside a field should look like.

## New Behavior

Add a story showing a disabled control in the Field, along with a description recommending against disabling the label.

https://fluentuipr.z22.web.core.windows.net/pull/27240/public-docsite-v9/storybook/index.html?path=/docs/preview-components-field--default#disabled-control


## Related Issue(s)

- Fixes #26506
