### PR TITLE
fix(DialogTitle): adds type="button" to close action

### DIFF
--- a/change/@fluentui-react-dialog-34da2c72-33e6-4d90-b14f-62011862f015.json
+++ b/change/@fluentui-react-dialog-34da2c72-33e6-4d90-b14f-62011862f015.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(DialogTitle): adds type=\"button\" to close action",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -37,6 +37,7 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
         children: (
           <DialogTrigger disableButtonEnhancement action="close">
             <button
+              type="button"
               className={internalStyles.button}
               // TODO: find a better way to add internal labels
               aria-label="close"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Formulary inside of a dialog would cause a submission click on `DialogTitle` close action, since there's no `type` defined on that slot.

## New Behavior

Define type `button` on `action` slot to ensure no submission will happen
