### PR TITLE
fix(DialogContent): adds padding to allow focus visibility

### DIFF
--- a/change/@fluentui-react-dialog-b286942f-21da-4936-947b-6daf42db80ab.json
+++ b/change/@fluentui-react-dialog-b286942f-21da-4936-947b-6daf42db80ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(DialogContent): adds padding to allow focus visibility",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
@@ -2,7 +2,7 @@ import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { DialogContentSlots, DialogContentState } from './DialogContent.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { CONTENT_GRID_AREA } from '../../contexts/constants';
-import { typographyStyles } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 
 export const dialogContentClassNames: SlotClassNames<DialogContentSlots> = {
   root: 'fui-DialogContent',
@@ -18,6 +18,8 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     minHeight: '32px',
     boxSizing: 'border-box',
+    ...shorthands.padding(tokens.strokeWidthThick),
+    ...shorthands.margin(`calc(${tokens.strokeWidthThick} * -1)`),
     ...shorthands.gridArea(CONTENT_GRID_AREA),
     ...typographyStyles.body1,
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Without proper padding the border of focusable elements inside `DialogContent` would be lost.

<img width="682" alt="image" src="https://user-images.githubusercontent.com/5483269/225923072-b0d0f982-a99e-4525-9a8c-ef8ce8dce260.png">

## New Behavior


<img width="682" alt="image" src="https://user-images.githubusercontent.com/5483269/225922992-40e1da45-0e55-4bf9-a986-8037b543ec7c.png">

## Related Issue(s)

- Fixes #25843
