### PR TITLE
fix: Adding the correct icons to away+out-of-office PresenceBadges and adding the correct icons to use in large PresenceBadges

### DIFF
--- a/change/@fluentui-react-badge-cb6be496-2ef2-40b2-835f-f1e6e99710de.json
+++ b/change/@fluentui-react-badge-cb6be496-2ef2-40b2-835f-f1e6e99710de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Adding the correct icons to away+out-of-office PresenceBadges and adding the correct icons to use in large PresenceBadges.",
+  "packageName": "@fluentui/react-badge",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/src/components/PresenceBadge/presenceIcons.ts
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/presenceIcons.ts
@@ -3,35 +3,62 @@ import {
   PresenceAvailable10Regular,
   PresenceAvailable12Regular,
   PresenceAvailable16Regular,
+  PresenceAvailable20Regular,
   PresenceAvailable10Filled,
   PresenceAvailable12Filled,
   PresenceAvailable16Filled,
+  PresenceAvailable20Filled,
+  PresenceAway10Regular,
+  PresenceAway12Regular,
+  PresenceAway16Regular,
+  PresenceAway20Regular,
   PresenceAway10Filled,
   PresenceAway12Filled,
   PresenceAway16Filled,
+  PresenceAway20Filled,
   PresenceBlocked10Regular,
   PresenceBlocked12Regular,
   PresenceBlocked16Regular,
+  PresenceBlocked20Regular,
   PresenceBusy10Filled,
   PresenceBusy12Filled,
   PresenceBusy16Filled,
+  PresenceBusy20Filled,
   PresenceDnd10Regular,
   PresenceDnd12Regular,
   PresenceDnd16Regular,
+  PresenceDnd20Regular,
   PresenceDnd10Filled,
   PresenceDnd12Filled,
   PresenceDnd16Filled,
+  PresenceDnd20Filled,
   PresenceOof10Regular,
   PresenceOof12Regular,
   PresenceOof16Regular,
+  PresenceOof20Regular,
   PresenceOffline10Regular,
   PresenceOffline12Regular,
   PresenceOffline16Regular,
+  PresenceOffline20Regular,
   PresenceUnknown10Regular,
   PresenceUnknown12Regular,
   PresenceUnknown16Regular,
+  PresenceUnknown20Regular,
 } from '@fluentui/react-icons';
 import type { PresenceBadgeState } from './PresenceBadge.types';
+
+export const presenceAwayRegular: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
+  // FIXME not all presence icon sizes are available
+  // https://github.com/microsoft/fluentui/issues/20650
+  tiny: PresenceAway10Regular,
+  'extra-small': PresenceAway10Regular,
+  small: PresenceAway12Regular,
+  medium: PresenceAway16Regular,
+  large: PresenceAway20Regular,
+  // FIXME not all presence icon sizes are available
+  // https://github.com/microsoft/fluentui/issues/20650
+  'extra-large': PresenceAway16Regular,
+};
 
 export const presenceAwayFilled: Record<PresenceBadgeState['size'], React.FunctionComponent> = {
   // FIXME not all presence icon sizes are available
@@ -40,9 +67,7 @@ export const presenceAwayFilled: Record<PresenceBadgeState['size'], React.Functi
   'extra-small': PresenceAway10Filled,
   small: PresenceAway12Filled,
   medium: PresenceAway16Filled,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceAway16Filled,
+  large: PresenceAway20Filled,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceAway16Filled,
@@ -55,9 +80,7 @@ export const presenceAvailableRegular: Record<PresenceBadgeState['size'], React.
   'extra-small': PresenceAvailable10Regular,
   small: PresenceAvailable12Regular,
   medium: PresenceAvailable16Regular,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceAvailable16Regular,
+  large: PresenceAvailable20Regular,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceAvailable16Regular,
@@ -70,9 +93,7 @@ export const presenceAvailableFilled: Record<PresenceBadgeState['size'], React.F
   'extra-small': PresenceAvailable10Filled,
   small: PresenceAvailable12Filled,
   medium: PresenceAvailable16Filled,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceAvailable16Filled,
+  large: PresenceAvailable20Filled,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceAvailable16Filled,
@@ -85,9 +106,7 @@ export const presenceBlockedRegular: Record<PresenceBadgeState['size'], React.Fu
   'extra-small': PresenceBlocked10Regular,
   small: PresenceBlocked12Regular,
   medium: PresenceBlocked16Regular,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceBlocked16Regular,
+  large: PresenceBlocked20Regular,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceBlocked16Regular,
@@ -100,9 +119,7 @@ export const presenceBusyFilled: Record<PresenceBadgeState['size'], React.Functi
   'extra-small': PresenceBusy10Filled,
   small: PresenceBusy12Filled,
   medium: PresenceBusy16Filled,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceBusy16Filled,
+  large: PresenceBusy20Filled,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceBusy16Filled,
@@ -115,9 +132,7 @@ export const presenceDndFilled: Record<PresenceBadgeState['size'], React.Functio
   'extra-small': PresenceDnd10Filled,
   small: PresenceDnd12Filled,
   medium: PresenceDnd16Filled,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceDnd16Filled,
+  large: PresenceDnd20Filled,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceDnd16Filled,
@@ -130,9 +145,7 @@ export const presenceDndRegular: Record<PresenceBadgeState['size'], React.Functi
   'extra-small': PresenceDnd10Regular,
   small: PresenceDnd12Regular,
   medium: PresenceDnd16Regular,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceDnd16Regular,
+  large: PresenceDnd20Regular,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceDnd16Regular,
@@ -145,9 +158,7 @@ export const presenceOofRegular: Record<PresenceBadgeState['size'], React.Functi
   'extra-small': PresenceOof10Regular,
   small: PresenceOof12Regular,
   medium: PresenceOof16Regular,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceOof16Regular,
+  large: PresenceOof20Regular,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceOof16Regular,
@@ -160,9 +171,7 @@ export const presenceOfflineRegular: Record<PresenceBadgeState['size'], React.Fu
   'extra-small': PresenceOffline10Regular,
   small: PresenceOffline12Regular,
   medium: PresenceOffline16Regular,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceOffline16Regular,
+  large: PresenceOffline20Regular,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceOffline16Regular,
@@ -175,9 +184,7 @@ export const presenceUnknownRegular: Record<PresenceBadgeState['size'], React.Fu
   'extra-small': PresenceUnknown10Regular,
   small: PresenceUnknown12Regular,
   medium: PresenceUnknown16Regular,
-  // FIXME not all presence icon sizes are available
-  // https://github.com/microsoft/fluentui/issues/20650
-  large: PresenceUnknown16Regular,
+  large: PresenceUnknown20Regular,
   // FIXME not all presence icon sizes are available
   // https://github.com/microsoft/fluentui/issues/20650
   'extra-large': PresenceUnknown16Regular,

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -4,6 +4,7 @@ import {
   presenceAvailableFilled,
   presenceAvailableRegular,
   presenceAwayFilled,
+  presenceAwayRegular,
   presenceBlockedRegular,
   presenceBusyFilled,
   presenceDndFilled,
@@ -20,7 +21,7 @@ const iconMap = (status: PresenceBadgeState['status'], outOfOffice: boolean, siz
     case 'available':
       return outOfOffice ? presenceAvailableRegular[size] : presenceAvailableFilled[size];
     case 'away':
-      return outOfOffice ? presenceOofRegular[size] : presenceAwayFilled[size];
+      return outOfOffice ? presenceAwayRegular[size] : presenceAwayFilled[size];
     case 'blocked':
       return presenceBlockedRegular[size];
     case 'busy':


### PR DESCRIPTION
## Previous Behavior

`PresenceBadges` that were `away` + `out-of-office` used the incorrect set of icons, only using the `out-of-office` icons instead of the `away` ones.

Large `PresenceBadges` also used a wrong set of `16px` sized icons, instead of the `20px` sized ones called by the design spec.

## New Behavior

`PresenceBadges` that are `away` + `out-of-office` now use the correct set of `away` icons instead of the `out-of-office` ones.

Large `PresenceBadges` now use the correct `20px` sized icons instead of the wrong `16px` sized ones.

## Related Issue(s)

- Fixes #26036
- Fixes part of #20650
