### PR TITLE
fix: Make checked switch more visible in high contrast mode

### DIFF
--- a/change/@fluentui-react-switch-9ee5312c-b459-4881-a942-2c61eb55f229.json
+++ b/change/@fluentui-react-switch-9ee5312c-b459-4881-a942-2c61eb55f229.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make checked switch more visible in high contrast mode",
+  "packageName": "@fluentui/react-switch",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -197,19 +197,6 @@ const useInputBaseClassName = makeResetStyles({
         color: 'Canvas',
       },
     },
-
-    ':disabled:checked': {
-      ':hover': {
-        [`& ~ .${switchClassNames.indicator}`]: {
-          backgroundColor: 'GrayText',
-          color: 'Canvas',
-        },
-      },
-      [`& ~ .${switchClassNames.indicator}`]: {
-        backgroundColor: 'GrayText',
-        color: 'Canvas',
-      },
-    },
   },
 });
 

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.ts
@@ -184,6 +184,32 @@ const useInputBaseClassName = makeResetStyles({
         color: 'GrayText',
       },
     },
+
+    ':enabled:checked': {
+      ':hover': {
+        [`& ~ .${switchClassNames.indicator}`]: {
+          backgroundColor: 'Highlight',
+          color: 'Canvas',
+        },
+      },
+      [`& ~ .${switchClassNames.indicator}`]: {
+        backgroundColor: 'Highlight',
+        color: 'Canvas',
+      },
+    },
+
+    ':disabled:checked': {
+      ':hover': {
+        [`& ~ .${switchClassNames.indicator}`]: {
+          backgroundColor: 'GrayText',
+          color: 'Canvas',
+        },
+      },
+      [`& ~ .${switchClassNames.indicator}`]: {
+        backgroundColor: 'GrayText',
+        color: 'Canvas',
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Adds styles so that enabled checked state are more more obvious in high contrast mode.

## Previous Behavior

![image](https://user-images.githubusercontent.com/20744592/226281451-67b1f29e-0850-4219-9370-5bfd40eec3f3.png)


## New Behavior

![image](https://user-images.githubusercontent.com/20744592/226281367-5a3abce7-a057-45cc-aec4-813a9cc1b9f5.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
