### PR TITLE
fix(MenuItem): Disabled should render correctly in high contrast mode

### DIFF
--- a/change/@fluentui-react-menu-417b3787-772b-41b9-90b3-9a33eb67f0eb.json
+++ b/change/@fluentui-react-menu-417b3787-772b-41b9-90b3-9a33eb67f0eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(MenuItem): Disabled should render correctly in high contrast mode",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.ts
@@ -103,6 +103,19 @@ const useStyles = makeStyles({
     ':focus': {
       color: tokens.colorNeutralForegroundDisabled,
     },
+
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+      ':hover': {
+        color: 'GrayText',
+        [`& .${menuItemClassNames.icon}`]: {
+          color: 'GrayText',
+        },
+      },
+      ':focus': {
+        color: 'GrayText',
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Adds styles so that disabled menuitems and their icons render correctly with gray text in high contrast mode.

## Previous Behavior

![image](https://user-images.githubusercontent.com/20744592/226282953-6f9431e3-8905-4fdd-ac63-2b27babe8de7.png)

## New Behavior

![image](https://user-images.githubusercontent.com/20744592/226283003-25a5fa4f-2f36-49f2-b4e1-ae0f2228e62b.png)

Fixes #27244
