### PR TITLE
chore(tools): use es2019 target instead of browser matrix target

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -1101,7 +1101,6 @@ describe('migrate-converged-pkg generator', () => {
 
       expect(swcConfig).toEqual({
         $schema: 'https://json.schemastore.org/swcrc',
-        env: { targets: { chrome: '84', edge: '84', firefox: '75', opera: '73', safari: '14.1' }, bugfixes: true },
         exclude: [
           '/testing',
           '/**/*.cy.ts',
@@ -1125,6 +1124,7 @@ describe('migrate-converged-pkg generator', () => {
               useSpread: true,
             },
           },
+          target: 'es2019',
         },
         minify: false,
         sourceMaps: true,

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -396,7 +396,6 @@ const templates = {
   swcConfig: () => {
     return {
       $schema: 'https://json.schemastore.org/swcrc',
-      env: { targets: { chrome: '84', edge: '84', firefox: '75', opera: '73', safari: '14.1' }, bugfixes: true },
       exclude: [
         '/testing',
         '/**/*.cy.ts',
@@ -420,6 +419,7 @@ const templates = {
             useSpread: true,
           },
         },
+        target: 'es2019',
       },
       minify: false,
       sourceMaps: true,


### PR DESCRIPTION
## Changes:
- use `es2019` target instead of browser matrix target to unblock (for the time being) migration towards `swc` transpilation

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Part of #26170
