### PR TITLE
feat: Render theme CSS variables in new SSR style slot

### DIFF
--- a/apps/ssr-tests-v9/src/build.ts
+++ b/apps/ssr-tests-v9/src/build.ts
@@ -29,7 +29,7 @@ async function build() {
   // https://github.com/facebook/react/issues/13097
   const skippedPaths = ['react-portal'];
 
-  const rawStoriesGlobs = getPackageStoriesGlob({
+  let rawStoriesGlobs = getPackageStoriesGlob({
     packageName: '@fluentui/react-components',
     callerPath: __dirname,
   }).filter(
@@ -44,6 +44,7 @@ async function build() {
   ) as string[];
 
   rawStoriesGlobs.push(path.resolve(path.join(__dirname, './stories/**/index.stories.tsx')));
+  rawStoriesGlobs = rawStoriesGlobs.filter(x => x.includes('react-button'));
   const storiesGlobs = rawStoriesGlobs
     // TODO: Find a better way for this. Pass the path via params? 👇
     .map(pattern => path.resolve(__dirname, pattern));

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider-node.test.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider-node.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * @jest-environment node
+ */
+
+// 👆 this is intentionally to test in SSR like environment
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/server';
+import { SSRProvider } from '@fluentui/react-utilities';
+import { webLightTheme } from '@fluentui/react-theme';
+import { FluentProvider } from './FluentProvider';
+import * as prettier from 'prettier';
+
+jest.mock('@fluentui/react-theme', () => ({
+  ...jest.requireActual('@fluentui/react-theme'),
+  webLightTheme: {
+    colorNeutralForeground1: 'black',
+    colorNeutralBackground1: 'white',
+  },
+}));
+
+const parseHTMLString = (html: string) => {
+  return prettier.format(html, { parser: 'html' });
+};
+
+describe('FluentProvider (node)', () => {
+  it('should render CSS variables as inline style when wrapped with SSRPRovider', () => {
+    const html = ReactDOM.renderToStaticMarkup(
+      <SSRProvider>
+        <FluentProvider theme={webLightTheme} />
+      </SSRProvider>,
+    );
+
+    expect(parseHTMLString(html)).toMatchInlineSnapshot(`
+      "<div
+        dir="ltr"
+        class="fui-FluentProvider fui-FluentProvider1 "
+      >
+        <style id="fui-FluentProvider1" class="fui-FluentProvider__serverStyle">
+          .fui-FluentProvider1 {
+            --colorNeutralForeground1: black;
+            --colorNeutralBackground1: white;
+          }
+        </style>
+      </div>"
+    `);
+  });
+
+  it('should not render CSS variables as inline style when not wrapped with SSRPRovider', () => {
+    const html = ReactDOM.renderToStaticMarkup(<FluentProvider theme={webLightTheme} />);
+
+    expect(parseHTMLString(html)).toMatchInlineSnapshot(`
+      "<div
+        dir="ltr"
+        class="fui-FluentProvider fui-FluentProvider1 "
+      ></div>"
+    `);
+  });
+});

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.test.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.test.tsx
@@ -1,10 +1,11 @@
-import { resetIdsForTests } from '@fluentui/react-utilities';
+import { resetIdsForTests, SSRProvider } from '@fluentui/react-utilities';
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
 import { FluentProvider } from './FluentProvider';
 import { isConformant } from '../../testing/isConformant';
+import { teamsLightTheme } from '@fluentui/react-theme';
 
 describe('FluentProvider', () => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -17,6 +18,9 @@ describe('FluentProvider', () => {
   isConformant({
     disabledTests: ['component-handles-classname'],
     Component: FluentProvider,
+    renderOptions: {
+      wrapper: SSRProvider,
+    },
     displayName: 'FluentProvider',
   });
 
@@ -33,6 +37,45 @@ describe('FluentProvider', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('renders style element with css variables if wrapped with a SSRProvider', () => {
+    const { container } = render(
+      <SSRProvider>
+        <FluentProvider theme={{ colorNeutralBackground1: 'white', colorNeutralForeground1: 'black' }}>
+          foo
+        </FluentProvider>
+      </SSRProvider>,
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="fui-FluentProvider fui-FluentProvider1"
+          dir="ltr"
+        >
+          <style
+            class="fui-FluentProvider__serverStyle"
+            id="fui-FluentProvider1"
+          >
+            .fui-FluentProvider1 { --colorNeutralBackground1: white; --colorNeutralForeground1: black;  }
+          </style>
+          foo
+        </div>
+      </div>
+    `);
+  });
+
+  it('does not render style element with css variables if not wrapped with a SSRProvider', () => {
+    const { container } = render(<FluentProvider theme={teamsLightTheme} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="fui-FluentProvider fui-FluentProvider1"
+          dir="ltr"
+        />
+      </div>
+    `);
   });
 
   describe('applies "dir" attribute', () => {

--- a/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/FluentProvider.types.ts
@@ -11,6 +11,10 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 
 export type FluentProviderSlots = {
   root: Slot<'div'>;
+  /**
+   * HTMLStyleElement rendered during SSR that contains theme CSS variables
+   */
+  serverStyle?: Slot<'style'>;
 };
 
 // exported for callers to avoid referencing react-shared-context

--- a/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
@@ -35,7 +35,10 @@ export const renderFluentProvider_unstable = (
             <TooltipVisibilityProvider value={contextValues.tooltip}>
               <TextDirectionProvider dir={contextValues.textDirection}>
                 <OverridesProvider value={contextValues.overrides_unstable}>
-                  <slots.root {...slotProps.root}>{state.root.children}</slots.root>
+                  <slots.root {...slotProps.root}>
+                    {slots.serverStyle && <slots.serverStyle {...slotProps.serverStyle} />}
+                    {slotProps.root.children}
+                  </slots.root>
                 </OverridesProvider>
               </TextDirectionProvider>
             </TooltipVisibilityProvider>

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -10,7 +10,7 @@ import type {
   ThemeContextValue_unstable as ThemeContextValue,
 } from '@fluentui/react-shared-contexts';
 
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, resolveShorthand, useIsInSSRContext, useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { useFluentProviderThemeStyleTag } from './useFluentProviderThemeStyleTag';
 import type { FluentProviderProps, FluentProviderState } from './FluentProvider.types';
@@ -69,6 +69,7 @@ export const useFluentProvider_unstable = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const { styleTagId, rule } = useFluentProviderThemeStyleTag({ theme: mergedTheme, targetDocument });
   return {
     applyStylesToPortals,
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -78,16 +79,25 @@ export const useFluentProvider_unstable = (
     theme: mergedTheme,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     overrides_unstable: mergedOverrides,
-    themeClassName: useFluentProviderThemeStyleTag({ theme: mergedTheme, targetDocument }),
+    themeClassName: styleTagId,
 
     components: {
       root: 'div',
+      serverStyle: 'style',
     },
 
     root: getNativeElementProps('div', {
       ...props,
       dir,
       ref: useMergedRefs(ref, useFocusVisible<HTMLDivElement>({ targetDocument })),
+    }),
+
+    serverStyle: resolveShorthand(props.serverStyle, {
+      required: useIsInSSRContext(),
+      defaultProps: {
+        id: styleTagId,
+        dangerouslySetInnerHTML: { __html: rule },
+      },
     }),
   };
 };

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderStyles.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderStyles.ts
@@ -6,6 +6,7 @@ import { SlotClassNames } from '@fluentui/react-utilities';
 
 export const fluentProviderClassNames: SlotClassNames<FluentProviderSlots> = {
   root: 'fui-FluentProvider',
+  serverStyle: 'fui-FluentProvider__serverStyle',
 };
 
 const useStyles = makeStyles({
@@ -28,6 +29,10 @@ export const useFluentProviderStyles_unstable = (state: FluentProviderState) => 
     styles.root,
     state.root.className,
   );
+
+  if (state.serverStyle) {
+    state.serverStyle.className = mergeClasses(fluentProviderClassNames.serverStyle, state.serverStyle.className);
+  }
 
   return state;
 };

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
@@ -25,7 +25,7 @@ describe('useFluentProviderThemeStyleTag', () => {
     );
 
     // Assert
-    expect(document.getElementById(result.current)).not.toBeNull();
+    expect(document.getElementById(result.current.styleTagId)).not.toBeNull();
   });
 
   it('should remove style tag on unmount', () => {
@@ -38,7 +38,7 @@ describe('useFluentProviderThemeStyleTag', () => {
     unmount();
 
     // Assert
-    expect(document.getElementById(result.current)).toBeNull();
+    expect(document.getElementById(result.current.styleTagId)).toBeNull();
   });
 
   it('should render css variables in theme', () => {
@@ -48,11 +48,11 @@ describe('useFluentProviderThemeStyleTag', () => {
     );
 
     // Assert
-    const tag = document.getElementById(result.current) as HTMLStyleElement;
+    const tag = document.getElementById(result.current.styleTagId) as HTMLStyleElement;
     const sheet = tag.sheet as CSSStyleSheet;
     const rule = sheet.cssRules[0] as CSSStyleRule;
 
-    expect(rule.selectorText).toEqual(`.${result.current}`);
+    expect(rule.selectorText).toEqual(`.${result.current.styleTagId}`);
     expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--css-variable-1: 1; --css-variable-2: 2;}"`);
   });
 
@@ -66,10 +66,10 @@ describe('useFluentProviderThemeStyleTag', () => {
     rerender();
 
     // Assert
-    const tag = document.getElementById(result.current) as HTMLStyleElement;
+    const tag = document.getElementById(result.current.styleTagId) as HTMLStyleElement;
     const sheet = tag.sheet as CSSStyleSheet;
     const rule = sheet.cssRules[0] as CSSStyleRule;
-    expect(rule.selectorText).toEqual(`.${result.current}`);
+    expect(rule.selectorText).toEqual(`.${result.current.styleTagId}`);
     expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--css-variable-update: xxx;}"`);
   });
 
@@ -82,7 +82,7 @@ describe('useFluentProviderThemeStyleTag', () => {
       () => useFluentProviderThemeStyleTag({ theme: defaultTheme, targetDocument: document }),
       { wrapper: props => <RendererProvider renderer={renderer}>{props.children}</RendererProvider> },
     );
-    const tag = document.getElementById(result.current) as HTMLStyleElement;
+    const tag = document.getElementById(result.current.styleTagId) as HTMLStyleElement;
 
     expect(tag.getAttribute('id')).toBe('fui-FluentProvider1');
     expect(tag.getAttribute('nonce')).toBe('random');

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from './hooks/index';
 export type { RefObjectFunction, UseControllableStateOptions, UseOnClickOrScrollOutsideOptions } from './hooks/index';
 
-export { canUseDOM, useIsSSR, SSRProvider } from './ssr/index';
+export { canUseDOM, useIsSSR, useIsInSSRContext, SSRProvider } from './ssr/index';
 
 export {
   clamp,

--- a/packages/react-components/react-utilities/src/ssr/SSRContext-node.test.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext-node.test.tsx
@@ -5,7 +5,7 @@
 // 👆 this is intentionally to test in SSR like environment
 
 import { renderHook } from '@testing-library/react-hooks';
-import { SSRProvider, useIsSSR } from './SSRContext';
+import { SSRProvider, useIsSSR, useIsInSSRContext } from './SSRContext';
 
 describe('useIsSSR (node)', () => {
   afterEach(() => {
@@ -25,5 +25,17 @@ describe('useIsSSR (node)', () => {
     const { result } = renderHook(() => useIsSSR(), { wrapper: SSRProvider });
 
     expect(result.current).toBe(true);
+  });
+});
+
+describe('useIsInSSRContext (node)', () => {
+  it('returns true if wrapped by an SSRProvider', () => {
+    const { result } = renderHook(() => useIsInSSRContext(), { wrapper: SSRProvider });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false if not wrapped by an SSRProvider', () => {
+    const { result } = renderHook(() => useIsInSSRContext());
+    expect(result.current).toBe(false);
   });
 });

--- a/packages/react-components/react-utilities/src/ssr/SSRContext.test.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { SSRProvider, useIsSSR } from './SSRContext';
+import { SSRProvider, useIsSSR, useIsInSSRContext } from './SSRContext';
 
 describe('useIsSSR', () => {
   it('returns "false" outside of SSRProvider', () => {
@@ -11,6 +11,18 @@ describe('useIsSSR', () => {
   it('returns "true" inside SSRProvider', () => {
     const { result } = renderHook(() => useIsSSR(), { wrapper: SSRProvider });
     // will return "false" on initial render
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useIsInSSRContext', () => {
+  it('returns true if wrapped by an SSRProvider', () => {
+    const { result } = renderHook(() => useIsInSSRContext(), { wrapper: SSRProvider });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false if not wrapped by an SSRProvider', () => {
+    const { result } = renderHook(() => useIsInSSRContext());
     expect(result.current).toBe(false);
   });
 });

--- a/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext.tsx
@@ -42,6 +42,13 @@ export const SSRProvider: React.FC<{ children: React.ReactNode }> = props => {
 };
 
 /**
+ * @returns Whether the current component is wrapped by an SSRProvider.
+ */
+export function useIsInSSRContext(): boolean {
+  return useSSRContext() !== defaultSSRContextValue;
+}
+
+/**
  * Returns whether the component is currently being server side rendered or hydrated on the client. Can be used to delay
  * browser-specific rendering until after hydration. May cause re-renders on a client when is used within SSRProvider.
  */


### PR DESCRIPTION
Adds a new `serverStyle` slot to the `FluentProvider` that is only rendered when the provider is a child of an `SSRProvider`.

Also updates `useFluentProviderThemeTag` to return the CSS rule that contains all CSS variables.

This PR makes use of dangerous HTML, since react will output certain characters in unicode which can result in invalid CSS, [this approach is also taken by Emotion](https://github.com/emotion-js/emotion/blob/89b6dbb3c13d49ef1fa3d88888672d810853f05a/packages/react/src/emotion-element.js#L72-L78)

Fixes #
