### PR TITLE
chore(react-dialog): removes native dialog types

### DIFF
--- a/change/@fluentui-react-dialog-299ad8d3-d339-460e-8e78-cb3547dab151.json
+++ b/change/@fluentui-react-dialog-299ad8d3-d339-460e-8e78-cb3547dab151.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: removes native dialog types",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -125,10 +125,10 @@ export const DialogSurface: ForwardRefComponent<DialogSurfaceProps>;
 export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots>;
 
 // @public
-export type DialogSurfaceElement = HTMLDialogElement | HTMLDivElement;
+export type DialogSurfaceElement = HTMLElement;
 
 // @public
-export type DialogSurfaceProps = Omit<ComponentProps<DialogSurfaceSlots>, 'open' | 'onCancel' | 'onClose'>;
+export type DialogSurfaceProps = ComponentProps<DialogSurfaceSlots>;
 
 // @public (undocumented)
 export type DialogSurfaceSlots = {

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
@@ -8,8 +8,6 @@ export type DialogSurfaceSlots = {
    * This slot expects a `<div>` element which will replace the default backdrop.
    * The backdrop should have `aria-hidden="true"`.
    *
-   * By default if `DialogSurface` is `<dialog>` element the backdrop is ignored,
-   * since native `<dialog>` element supports [::backdrop](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)
    */
   backdrop?: Slot<'div'>;
   root: Slot<'div'>;
@@ -18,18 +16,12 @@ export type DialogSurfaceSlots = {
 /**
  * Union between all possible semantic element that represent a DialogSurface
  */
-export type DialogSurfaceElement = HTMLDialogElement | HTMLDivElement;
-
-/** @internal */
-export type DialogSurfaceElementIntersection = HTMLDialogElement & HTMLDivElement;
+export type DialogSurfaceElement = HTMLElement;
 
 /**
  * DialogSurface Props
- *
- * Omits basic types from native `dialog` (`open`, `onCancel` and `onClose`)
- * to ensure `onOpenChange`, `open` and `defaultOpen` from `Dialog` is used instead
  */
-export type DialogSurfaceProps = Omit<ComponentProps<DialogSurfaceSlots>, 'open' | 'onCancel' | 'onClose'>;
+export type DialogSurfaceProps = ComponentProps<DialogSurfaceSlots>;
 
 export type DialogSurfaceContextValues = {
   dialogSurface: DialogSurfaceContextValue;

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -6,12 +6,7 @@ import {
   useMergedRefs,
   isResolvedShorthand,
 } from '@fluentui/react-utilities';
-import type {
-  DialogSurfaceElement,
-  DialogSurfaceElementIntersection,
-  DialogSurfaceProps,
-  DialogSurfaceState,
-} from './DialogSurface.types';
+import type { DialogSurfaceElement, DialogSurfaceProps, DialogSurfaceState } from './DialogSurface.types';
 import { useDialogContext_unstable } from '../../contexts';
 import { isEscapeKeyDismiss } from '../../utils';
 import { useModalAttributes } from '@fluentui/react-tabster';
@@ -50,7 +45,7 @@ export const useDialogSurface_unstable = (
     }
   });
 
-  const handleKeyDown = useEventCallback((event: React.KeyboardEvent<DialogSurfaceElementIntersection>) => {
+  const handleKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     props.onKeyDown?.(event);
 
     if (isEscapeKeyDismiss(event, modalType)) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

As an implementation legacy `DialogSurface` types were supporting native dialog types, although our API never supported the usage of native dialog element.

## New Behavior

1. Removes unsupported native dialog types
2. Generalizes type for `DialogSurfaceElement` from `HTMLDivElement` to `HTMLElement`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27281
