### PR TITLE
chore (scripts): update create-package plop templates to use swc/helpers in deps

### DIFF
--- a/scripts/generators/create-package/plop-templates-node/package.json.hbs
+++ b/scripts/generators/create-package/plop-templates-node/package.json.hbs
@@ -26,6 +26,6 @@
     "@fluentui/scripts-tasks": ""
   },
   "dependencies": {
-    "tslib": ""
+    "@swc/helpers": ""
   }
 }

--- a/scripts/generators/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/generators/create-package/plop-templates-react/package.json.hbs
@@ -34,7 +34,7 @@
     "@fluentui/react-theme": "",
     "@fluentui/react-utilities": "",
     "@griffel/react": "",
-    "tslib": ""
+    "@swc/helpers": ""
   },
   "peerDependencies": {
     "@types/react": "",


### PR DESCRIPTION
## Changes:
- replaces unneeded `tslib` dependency from `create-package` script plop templates in favor of `@swc/helpers` which is what's used for swc transpilation.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Part of #26170