### PR TITLE
fix: Detailslist fixed header example virtualization, DetailsList allows className in focusZoneProps, fix typing for selectionZoneProps

### DIFF
--- a/change/@fluentui-react-5ce5a831-eb0f-4ea3-8c98-1b3c5237cb8a.json
+++ b/change/@fluentui-react-5ce5a831-eb0f-4ea3-8c98-1b3c5237cb8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: DetailsList allows className in focusZoneProps, fix typing for selectionZoneProps\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-5ce5a831-eb0f-4ea3-8c98-1b3c5237cb8a.json
+++ b/change/@fluentui-react-5ce5a831-eb0f-4ea3-8c98-1b3c5237cb8a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "fix: DetailsList allows className in focusZoneProps, fix typing for selectionZoneProps\"",
+  "comment": "fix: DetailsList allows className in focusZoneProps, fix typing for selectionZoneProps",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-examples/src/react/ScrollablePane/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/react-examples/src/react/ScrollablePane/ScrollablePane.DetailsList.Example.tsx
@@ -41,8 +41,7 @@ const gridStyles: Partial<IDetailsListStyles> = {
   },
   contentWrapper: {
     flex: '1 1 auto',
-    overflowY: 'auto',
-    overflowX: 'hidden',
+    overflow: 'hidden',
   },
 };
 
@@ -52,6 +51,15 @@ const classNames = mergeStyleSets({
   },
   row: {
     flex: '0 0 auto',
+  },
+  focusZone: {
+    height: '100%',
+    overflowY: 'auto',
+    overflowX: 'hidden',
+  },
+  selectionZone: {
+    height: '100%',
+    overflow: 'hidden',
   },
 });
 
@@ -128,6 +136,11 @@ const onRenderDetailsFooter: IRenderFunction<IDetailsFooterProps> = (props, defa
 };
 
 export const ScrollablePaneDetailsListExample: React.FunctionComponent = () => {
+  const focusZoneProps = {
+    className: classNames.focusZone,
+    'data-is-scrollable': 'true',
+  } as React.HTMLAttributes<HTMLElement>;
+
   return (
     <div>
       <h1 className={classNames.header}>Item list</h1>
@@ -145,6 +158,10 @@ export const ScrollablePaneDetailsListExample: React.FunctionComponent = () => {
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         checkButtonAriaLabel="select row"
         onItemInvoked={onItemInvoked}
+        focusZoneProps={focusZoneProps}
+        selectionZoneProps={{
+          className: classNames.selectionZone,
+        }}
       />
     </div>
   );

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4753,7 +4753,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     selection?: ISelection;
     selectionMode?: SelectionMode_2;
     selectionPreservedOnEmptyClick?: boolean;
-    selectionZoneProps?: ISelectionZoneProps;
+    selectionZoneProps?: Partial<ISelectionZoneProps>;
     setKey?: string;
     // @deprecated
     shouldApplyApplicationRole?: boolean;

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -8,6 +8,7 @@ import {
   elementContains,
   getRTLSafeKeyCode,
   classNamesFunction,
+  css,
   memoizeFunction,
 } from '../../Utilities';
 import {
@@ -597,7 +598,10 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
   const focusZoneInnerProps: IFocusZoneProps = {
     ...focusZoneProps,
     componentRef: focusZoneProps && focusZoneProps.componentRef ? focusZoneProps.componentRef : focusZoneRef,
-    className: classNames.focusZone,
+    className:
+      focusZoneProps && focusZoneProps.className
+        ? css(classNames.focusZone, focusZoneProps.className)
+        : classNames.focusZone,
     direction: focusZoneProps ? focusZoneProps.direction : FocusZoneDirection.vertical,
     shouldEnterInnerZone:
       focusZoneProps && focusZoneProps.shouldEnterInnerZone ? focusZoneProps.shouldEnterInnerZone : isRightArrow,

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -125,7 +125,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /**
    * Additional props to pass through to the SelectionZone created by default.
    */
-  selectionZoneProps?: ISelectionZoneProps;
+  selectionZoneProps?: Partial<ISelectionZoneProps>;
 
   /** Controls how the columns are adjusted. */
   layoutMode?: DetailsListLayoutMode;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The DetailsList w/ fixed header & footer example did not work with virtualization, since the `data-is-scrollable` prop was not added to the new scrolling region.

Since DetailsList only allows misc props to be added in certain places, I moved the scroll area to be the FocusZone, and added `data-is-scrollable` to the focusZoneProps.

Doing this required adding classNames to the inner focusZone and selectionZone, so there was also some prop spread & type cleanup:
- the `focusZoneProps.className` prop is respected now
- DetailsList's `selectionZoneProps` should be typed as a `Partial<>`, since DetailsList already provides all the required props to SelectionZone.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [15441](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15441)
