### PR TITLE
fix: v8 Dropdown multiselect option hover contrast in WHCM

### DIFF
--- a/change/@fluentui-react-4cf263e9-5a59-4ce0-b9b1-a08d8baa5e67.json
+++ b/change/@fluentui-react-4cf263e9-5a59-4ce0-b9b1-a08d8baa5e67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Dropdown hover high contrast mode colors",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -158,7 +158,10 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
           },
           highContrastItemAndTitleStateMixin,
         ],
-        '&.is-multi-select:hover': [{ backgroundColor: !isSelected ? 'transparent' : selectedItemBackgroundColor }],
+        '&.is-multi-select:hover': [
+          { backgroundColor: !isSelected ? 'transparent' : selectedItemBackgroundColor },
+          highContrastItemAndTitleStateMixin,
+        ],
         '&:active:hover': [
           {
             color: semanticColors.menuItemTextHovered,

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -48,6 +48,11 @@ const highContrastItemAndTitleStateMixin: IRawStyle = {
       borderColor: 'Highlight',
       color: 'HighlightText',
     },
+    ['.ms-Checkbox-checkbox']: {
+      [HighContrastSelector]: {
+        borderColor: 'HighlightText',
+      },
+    },
     ...highContrastAdjustMixin,
   },
 };

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -440,6 +440,15 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           &.is-multi-select:hover {
                             background-color: #edebe9;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover {
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
+                            -ms-high-contrast-adjust: none;
+                            forced-color-adjust: none;
+                          }
                           &:active:hover {
                             background-color: #f3f2f1;
                             color: #201f1e;
@@ -688,6 +697,15 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                         }
                         &.is-multi-select:hover {
                           background-color: transparent;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
                         }
                         &:active:hover {
                           background-color: #edebe9;
@@ -1665,6 +1683,15 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           &.is-multi-select:hover {
                             background-color: #edebe9;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover {
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
+                            -ms-high-contrast-adjust: none;
+                            forced-color-adjust: none;
+                          }
                           &:active:hover {
                             background-color: #f3f2f1;
                             color: #201f1e;
@@ -1829,6 +1856,15 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                         }
                         &.is-multi-select:hover {
                           background-color: transparent;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover {
+                          background-color: Highlight;
+                          border-color: Highlight;
+                          color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
+                          -ms-high-contrast-adjust: none;
+                          forced-color-adjust: none;
                         }
                         &:active:hover {
                           background-color: #edebe9;

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -395,7 +395,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
                             background: Highlight;
-                            border-color: Highlight;
+                            border-color: HighlightText;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:focus .ms-Checkbox-checkbox {
                             background: Highlight;
@@ -445,6 +445,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             border-color: Highlight;
                             color: HighlightText;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
+                          }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
@@ -458,6 +461,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             border-color: Highlight;
                             color: HighlightText;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
+                          }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active:hover {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
@@ -470,6 +476,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             inset: 2px;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){& {
                             -ms-high-contrast-adjust: none;
@@ -655,7 +664,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           border-color: #323130;
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
-                          border-color: Highlight;
+                          border-color: HighlightText;
                         }
                         &:focus .ms-Checkbox-checkbox {
                           border-color: #323130;
@@ -703,6 +712,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           border-color: Highlight;
                           color: HighlightText;
                         }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover .ms-Checkbox-checkbox {
+                          border-color: HighlightText;
+                        }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
@@ -715,6 +727,9 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover .ms-Checkbox-checkbox {
+                          border-color: HighlightText;
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active:hover {
                           -ms-high-contrast-adjust: none;
@@ -1676,6 +1691,9 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           & .ms-Button-flexContainer {
                             width: 100%;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
+                          }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
@@ -1687,6 +1705,9 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             background-color: Highlight;
                             border-color: Highlight;
                             color: HighlightText;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
                             -ms-high-contrast-adjust: none;
@@ -1701,9 +1722,15 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             border-color: Highlight;
                             color: HighlightText;
                           }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
+                          }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active:hover {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& .ms-Checkbox-checkbox {
+                            border-color: HighlightText;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){& {
                             -ms-high-contrast-adjust: none;
@@ -1850,6 +1877,9 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                         & .ms-Button-flexContainer {
                           width: 100%;
                         }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:hover .ms-Checkbox-checkbox {
+                          border-color: HighlightText;
+                        }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
@@ -1861,6 +1891,9 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-multi-select:hover .ms-Checkbox-checkbox {
+                          border-color: HighlightText;
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&.is-multi-select:hover {
                           -ms-high-contrast-adjust: none;
@@ -1874,6 +1907,9 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           background-color: Highlight;
                           border-color: Highlight;
                           color: HighlightText;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&:active:hover .ms-Checkbox-checkbox {
+                          border-color: HighlightText;
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active:hover {
                           -ms-high-contrast-adjust: none;


### PR DESCRIPTION
## Previous Behavior

A non-HCM background style was overriding the background color in HCM, causing the text to be unreadable:
![screenshot of an open dropdown, showing black text on a black background](https://user-images.githubusercontent.com/3819570/227220375-99826432-5a64-42bc-bec7-cfe64d25461b.png)


## New Behavior

This PR resets the HCM colors for the multiselect hover selector, so it matches single-select hover (HighlightText on Highlight background)
![screenshot of an open multiselect dropdown, showing visible text and a visible checkbox border on a highlighted item](https://user-images.githubusercontent.com/3819570/228670871-aeaeb276-12d1-4405-bec8-a4a2bcdc1366.png)


## Related Issue(s)

- Fixes [15910](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15910)
