### PR TITLE
fix: Autofill queries the inputElement ownerDocument instead of document

### DIFF
--- a/change/@fluentui-react-588a569e-53b5-4cc8-85e3-2d9c073109c2.json
+++ b/change/@fluentui-react-588a569e-53b5-4cc8-85e3-2d9c073109c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Autofill looks up owner document for inputElement",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -471,6 +471,8 @@ export class Autofill extends React_2.Component<IAutofillProps, IAutofillState> 
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
+    static contextType: React_2.Context<WindowProviderProps>;
+    // (undocumented)
     get cursorLocation(): number | null;
     // (undocumented)
     static defaultProps: {

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -8,6 +8,7 @@ import {
   isIE11,
   KeyCodes,
 } from '../../Utilities';
+import { WindowContext } from '@fluentui/react-window-provider';
 import type { IAutofill, IAutofillProps } from './Autofill.types';
 
 export interface IAutofillState {
@@ -31,6 +32,8 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
   public static defaultProps = {
     enableAutofillOnKeyPress: [KeyCodes.down, KeyCodes.up] as KeyCodes[],
   };
+  // need to check WindowContext to get the provided document
+  public static contextType = WindowContext;
 
   private _inputElement = React.createRef<HTMLInputElement>();
   private _autoFillEnabled = true;
@@ -103,7 +106,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
       return;
     }
 
-    const document = getDocument(this._inputElement.current);
+    const document = this.context?.window.document || getDocument(this._inputElement.current);
     const isFocused = this._inputElement.current && this._inputElement.current === document?.activeElement;
 
     if (

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Async, getNativeProps, initializeComponentRef, inputProperties, isIE11, KeyCodes } from '../../Utilities';
+import {
+  Async,
+  getDocument,
+  getNativeProps,
+  initializeComponentRef,
+  inputProperties,
+  isIE11,
+  KeyCodes,
+} from '../../Utilities';
 import type { IAutofill, IAutofillProps } from './Autofill.types';
 
 export interface IAutofillState {
@@ -95,7 +103,8 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
       return;
     }
 
-    const isFocused = this._inputElement.current && this._inputElement.current === document.activeElement;
+    const document = getDocument(this._inputElement.current);
+    const isFocused = this._inputElement.current && this._inputElement.current === document?.activeElement;
 
     if (
       isFocused &&


### PR DESCRIPTION
## Previous Behavior

Autofill compared `this._inputElement.current === document.activeElement`, which was causing issues when used in a child window.

## New Behavior

Autofill uses `getDocument(this._inputElement.current)`

## Related Issue(s)

- Fixes #27099
