### PR TITLE
feat(scripts-babel): implement v9 babel preset to properly resolve griffel module mappings

### DIFF
--- a/.babelrc-v9.json
+++ b/.babelrc-v9.json
@@ -1,22 +1,9 @@
 {
   "presets": [
     [
-      "@griffel",
+      "@fluentui/scripts-babel/preset-v9",
       {
-        "babelOptions": {
-          "plugins": [
-            [
-              "babel-plugin-module-resolver",
-              {
-                "root": ["../../../"],
-                "alias": {
-                  "@fluentui/tokens": "packages/tokens/lib/index.js",
-                  "^@fluentui/(?!react-icons)(.+)": "packages/react-components/\\1/lib/index.js"
-                }
-              }
-            ]
-          ]
-        }
+        "tsBaseConfigPath": "./tsconfig.base.json"
       }
     ]
   ]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,7 @@
 /yarn.lock @microsoft/fluentui-react-build
 /*.config.js @microsoft/fluentui-react-build
 /typings @microsoft/fluentui-react-build
+/.babelrc-v9.json @microsoft/fluentui-react-build
 
 #### NX related files
 /nx.json @microsoft/fluentui-react-build

--- a/scripts/babel/jest.config.js
+++ b/scripts/babel/jest.config.js
@@ -9,6 +9,12 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      isolatedModules: true,
+    },
+  },
   coverageDirectory: './coverage',
   testEnvironment: 'node',
 };

--- a/scripts/babel/preset-v9.js
+++ b/scripts/babel/preset-v9.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+
+const { workspaceRoot } = require('@nrwl/devkit');
+
+const cwd = process.cwd();
+const rootOffset = path.relative(cwd, workspaceRoot);
+
+/**
+ *
+ * @param {{tsBaseConfigPath:string}} options
+ * @returns
+ */
+function createModuleResolverAliases(options) {
+  const { tsBaseConfigPath } = options;
+  const tsBaseConfigPathAbsolute = path.join(workspaceRoot, tsBaseConfigPath);
+  const tsConfigBase = JSON.parse(fs.readFileSync(tsBaseConfigPathAbsolute, 'utf-8'));
+
+  /**
+   * @type {Record<string,[string]>}
+   */
+  const allPathAliases = tsConfigBase.compilerOptions.paths;
+  return Object.entries(allPathAliases).reduce((acc, [packageName, aliasTuple]) => {
+    const tsSourceRoot = aliasTuple[0];
+    const jsSourceRoot = tsSourceRoot.replace('src', 'lib').replace('.ts', '.js');
+    const aliasRegex = `^${packageName}$`;
+    acc[aliasRegex] = `${rootOffset}/${jsSourceRoot}`;
+    return acc;
+  }, /** @type {Record<string,string>} */ ({}));
+}
+
+/** @type {Array<import('./types').BabelPluginItem>} */
+const presets = [];
+
+/** @type {Array<import('./types').BabelPluginItem>} */
+const plugins = [];
+
+/**
+ * @param {import('@babel/core').ConfigAPI} api
+ * @param {import('./types').BabelPresetOptions} options
+ */
+const preset = (api, options) => {
+  const moduleResolverAliasMappings = createModuleResolverAliases(options);
+  /** @type {Array<import('./types').BabelPluginItem>} */
+  const dynamicPresets = [
+    [
+      '@griffel',
+      {
+        babelOptions: {
+          plugins: [
+            [
+              'babel-plugin-module-resolver',
+              {
+                alias: moduleResolverAliasMappings,
+              },
+            ],
+          ],
+        },
+      },
+    ],
+  ];
+
+  presets.push(...dynamicPresets);
+
+  return { presets, plugins };
+};
+
+module.exports = preset;

--- a/scripts/babel/preset-v9.spec.ts
+++ b/scripts/babel/preset-v9.spec.ts
@@ -1,0 +1,44 @@
+import preset from './preset-v9';
+
+describe(`babel preset v9`, () => {
+  const babelMockedApi = {
+    assertVersion: jest.fn(),
+    caller: jest.fn(),
+    env: jest.fn(),
+    cache: {},
+    version: '0',
+  } as unknown as import('@babel/core').ConfigAPI;
+  it(`should generate module-resolve alias mappings for @griffel preset`, () => {
+    const presetConfig = preset(babelMockedApi, { tsBaseConfigPath: './tsconfig.base.json' });
+
+    const griffelPreset = presetConfig.presets.find(presetItem => presetItem[0] === '@griffel')!;
+    const griffelPresetConfig = griffelPreset[1];
+
+    expect(griffelPresetConfig).toEqual({
+      babelOptions: {
+        plugins: [
+          [
+            'babel-plugin-module-resolver',
+            {
+              alias: expect.any(Object),
+            },
+          ],
+        ],
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const alias = (griffelPresetConfig as any).babelOptions.plugins[0][1].alias;
+    const aliasesEntries = Object.entries(alias);
+
+    /**
+     * we pick 5th entry from the big list of path aliases entries. there is nothing special about it and we can pick any existing entry index.
+     * I chose to not pick first nor last. In general this is an integration test that checks if we would introduce some violation within tsconfig.base.json path aliases config
+     */
+    const aliasDeclaration = aliasesEntries[5];
+    const [aliasKey, aliasPath] = aliasDeclaration;
+
+    expect(aliasKey).toEqual(expect.stringContaining('^@fluentui/'));
+    expect(aliasPath).toEqual(expect.stringMatching(/[../]+[a-z-/]+\/lib\/index\.js/));
+  });
+});

--- a/scripts/babel/types.ts
+++ b/scripts/babel/types.ts
@@ -1,0 +1,7 @@
+import type { PluginTarget } from '@babel/core';
+
+export interface BabelPresetOptions {
+  tsBaseConfigPath: string;
+}
+
+export type BabelPluginItem = [PluginTarget, Record<string, unknown>];


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

v9 packages that use babelrc preset-v9 trigger warnings caused by invalid module path created by module-resolver within griffel preset transform.

## New Behavior

v9 packages trigger no warnings.

preset-v9 has been completely refactored to match true mappings based on `tsconfig.base.json`.

**Performance:**

Processing tsconfig json within babel execution adds some perf owerhead ( around 500ms ) but this is acceptable taking into consideration that mappings are 100% correct all the time. When griffel will migrate to linaria 4 this overhead will be mitigated as griffel will be able to transrorm swc commonjs module output.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27304
