### PR TITLE
Fix react-combobox mismatch after bad release

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -26,7 +26,7 @@
     "@fluentui/react-button": "^9.3.6",
     "@fluentui/react-card": "^9.0.4",
     "@fluentui/react-checkbox": "^9.1.6",
-    "@fluentui/react-combobox": "^9.2.5",
+    "@fluentui/react-combobox": "^9.2.6",
     "@fluentui/react-dialog": "^9.4.2",
     "@fluentui/react-divider": "^9.2.6",
     "@fluentui/react-field": "9.0.0-alpha.28",

--- a/change/@fluentui-react-combobox-9a9272e4-7690-404a-a877-806c8d778178.json
+++ b/change/@fluentui-react-combobox-9a9272e4-7690-404a-a877-806c8d778178.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Sync with latest released version on npm",
+  "packageName": "@fluentui/react-combobox",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-265f5023-f956-40ae-84c5-bd75add60eee.json
+++ b/change/@fluentui-react-components-265f5023-f956-40ae-84c5-bd75add60eee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Bump @fluenti/react-combobox to 9.2.6",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-combobox",
-  "version": "9.2.5",
+  "version": "9.2.6",
   "description": "Fluent UI React Combobox component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-button": "^9.3.6",
     "@fluentui/react-card": "^9.0.4",
     "@fluentui/react-checkbox": "^9.1.6",
-    "@fluentui/react-combobox": "^9.2.5",
+    "@fluentui/react-combobox": "^9.2.6",
     "@fluentui/react-dialog": "^9.4.2",
     "@fluentui/react-divider": "^9.2.6",
     "@fluentui/react-field": "9.0.0-alpha.28",


### PR DESCRIPTION
`yarn beachball sync` missed this mismatch with npm (I don't know why) so doing a manual bump.

* No changefile for @fluentui/react-combobox because it's syncing it with master
* changefile for react-components because a new release is necessary to bump react-combobox

Follow up of #27317 