### PR TITLE
Fix bad release mismatch of react-select

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -44,7 +44,7 @@
     "@fluentui/react-progress": "^9.1.6",
     "@fluentui/react-provider": "^9.5.0",
     "@fluentui/react-radio": "^9.1.6",
-    "@fluentui/react-select": "^9.1.5",
+    "@fluentui/react-select": "^9.1.6",
     "@fluentui/react-shared-contexts": "^9.3.3",
     "@fluentui/react-skeleton": "9.0.0-beta.5",
     "@fluentui/react-slider": "^9.1.6",

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -56,7 +56,7 @@
     "@fluentui/react-progress": "^9.1.6",
     "@fluentui/react-provider": "^9.5.0",
     "@fluentui/react-radio": "^9.1.6",
-    "@fluentui/react-select": "^9.1.5",
+    "@fluentui/react-select": "^9.1.6",
     "@fluentui/react-shared-contexts": "^9.3.3",
     "@fluentui/react-skeleton": "9.0.0-beta.5",
     "@fluentui/react-slider": "^9.1.6",

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-select",
-  "version": "9.1.5",
+  "version": "9.1.6",
   "description": "Fluent UI React Select component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
`yarn beachball sync` missed this mismatch with npm (I don't know why) so doing a manual bump.

* No changefile for @fluentui/react-select because it's syncing it with master
* changefile for react-components because a new release is necessary to bump react-select

Follow up of #27317 