### PR TITLE
fix: Fix vertical alignment of inline Checkbox when checked vs. unchecked

### DIFF
--- a/change/@fluentui-react-checkbox-4ebdfb9d-a372-4ce7-99f4-c66d376885b1.json
+++ b/change/@fluentui-react-checkbox-4ebdfb9d-a372-4ce7-99f4-c66d376885b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fix vertical alignment of inline Checkbox when checked vs. unchecked",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckboxStyles.ts
@@ -19,6 +19,7 @@ const useRootBaseClassName = makeResetStyles({
   position: 'relative',
   display: 'inline-flex',
   cursor: 'pointer',
+  verticalAlign: 'middle',
   color: tokens.colorNeutralForeground3,
   ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
 });


### PR DESCRIPTION
## Previous Behavior

When multiple Checkboxes are inline, the unchecked and checked ones have different alignments.

![image](https://user-images.githubusercontent.com/48106640/227653925-af801060-5e9d-4fe9-b671-4babaaf8032a.png)

## New Behavior

Add `vertical-align: middle` to the Checkbox, to force it to always have the same alignment.

## Related Issue(s)

- Fixes #27176
