### PR TITLE
fix(react-virtualizer): remove disallowed v9 react-fabric/v8 from dependencies to mitigate dep-tree creep

### DIFF
--- a/change/@fluentui-react-virtualizer-32407628-78bb-4307-bbf4-d0a366f48deb.json
+++ b/change/@fluentui-react-virtualizer-32407628-78bb-4307-bbf4-d0a366f48deb.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix(reat-virtualizer): remove disallowed v9 react-fabric/v8 from dependency to mitigate dep-tree creep",
+  "comment": "fix: remove disallowed v9 react-fabric/v8 from dependency to mitigate dep-tree creep",
   "packageName": "@fluentui/react-virtualizer",
   "email": "martinhochel@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-virtualizer-32407628-78bb-4307-bbf4-d0a366f48deb.json
+++ b/change/@fluentui-react-virtualizer-32407628-78bb-4307-bbf4-d0a366f48deb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(reat-virtualizer): remove disallowed v9 react-fabric/v8 from dependency to mitigate dep-tree creep",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/package.json
+++ b/packages/react-components/react-virtualizer/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@fluentui/react-utilities": "^9.7.2",
-    "@fluentui/react": "^8.106.9",
     "@griffel/react": "^1.5.2",
     "@swc/helpers": "^0.4.14"
   },

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
+// @ts-expect-error - we don support path aliases for libraries with both v8 and v9 as dependencies
 import { ThemeProvider } from '@fluentui/react';
 
 import { useFluent } from '@fluentui/react-components';

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
 import { makeStyles, useFluent } from '@fluentui/react-components';
+// @ts-expect-error - we don support path aliases for libraries with both v8 and v9 as dependencies
 import { ThemeProvider } from '@fluentui/react';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/Default.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
+// @ts-expect-error - we don support path aliases for libraries with both v8 and v9 as dependencies
 import { ThemeProvider } from '@fluentui/react';
 
 const useStyles = makeStyles({


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`react-virtualizer` introduced a forbidden project dependency on react(v8), which caused pipeline creep ( on any v8 change all v9 project would be affected).

**Simplified Example:**

- user makes changes within `@fluentui/react`
- this triggers build/lint/test task on following packages because their dependency tree
  - `@fluentui/ssr-test-v9` -->  `@fluentui/react-components` --> `@fluentui/react-virtualizer` --> `@fluentui/react`

This caused Out of memory/timeout issues for both PR pipelines and release pipelines

Example of failing PR/pipeline that triggers everything because of this: https://github.com/microsoft/fluentui/pull/27323

## New Behavior

react v8 is no longer a v9 package direct or indirect dependency.

**Notes:** 
- We have currently no tooling in place that explicitly fails pipeline when such a violation occurs.
- To be able to start/build storybook locally for this package, one needs to manually build react project `lage build --to @fluentui/react`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
