### PR TITLE
chore: update babel:postprocess

### DIFF
--- a/scripts/tasks/src/babel.ts
+++ b/scripts/tasks/src/babel.ts
@@ -17,7 +17,7 @@ export function hasBabel() {
 }
 
 export async function babel() {
-  const files = glob.sync('{lib,lib-commonjs}/**/*.js');
+  const files = glob.sync('lib/**/*.js');
 
   for (const filename of files) {
     const filePath = path.resolve(process.cwd(), filename);


### PR DESCRIPTION
# Previous Behavior

Order of tasks:
- `ts:esm`
- `ts:cjs`
- `babel:postprocess` (both ESM & CJS)

## New Behavior

- `swc:esm`
- `babel:postprocess` (only ESM)
- `swc:cjs`

Removes `lib-commonjs` from the glob as now the order of tasks is different.

## Related issues

- Follows https://github.com/microsoft/fluentui/pull/27250
