### PR TITLE
Remove V8 Theme Provider from virtualizer demos

### DIFF
--- a/packages/react-components/react-virtualizer/.storybook/preview-body.html
+++ b/packages/react-components/react-virtualizer/.storybook/preview-body.html
@@ -1,0 +1,5 @@
+<style>
+  body {
+    max-height: 100vh;
+  }
+</style>

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
-// @ts-expect-error - we don support path aliases for libraries with both v8 and v9 as dependencies
-import { ThemeProvider } from '@fluentui/react';
 
 import { useFluent } from '@fluentui/react-components';
 
@@ -46,32 +44,30 @@ export const DefaultUnbounded = () => {
   }
 
   return (
-    <ThemeProvider className={styles.root} applyTo="body">
-      <div aria-label="Virtualizer Example" className={styles.container} role={'list'}>
-        <div key={`virtualizer-header`} className={styles.block}>{`Virtualizer`}</div>
-        <Virtualizer
-          numItems={childLength}
-          virtualizerLength={virtualizerLength}
-          bufferItems={bufferItems}
-          bufferSize={bufferSize}
-          itemSize={100}
-        >
-          {index => {
-            return (
-              <span
-                role={'listitem'}
-                aria-posinset={index}
-                aria-setsize={childLength}
-                key={`test-virtualizer-child-${index}`}
-                className={styles.child}
-              >{`Node-${index}`}</span>
-            );
-          }}
-        </Virtualizer>
-        <div key={`virtualizer-footer`} className={styles.block}>
-          Footer
-        </div>
+    <div aria-label="Virtualizer Example" className={styles.container} role={'list'}>
+      <div key={`virtualizer-header`} className={styles.block}>{`Virtualizer`}</div>
+      <Virtualizer
+        numItems={childLength}
+        virtualizerLength={virtualizerLength}
+        bufferItems={bufferItems}
+        bufferSize={bufferSize}
+        itemSize={100}
+      >
+        {index => {
+          return (
+            <span
+              role={'listitem'}
+              aria-posinset={index}
+              aria-setsize={childLength}
+              key={`test-virtualizer-child-${index}`}
+              className={styles.child}
+            >{`Node-${index}`}</span>
+          );
+        }}
+      </Virtualizer>
+      <div key={`virtualizer-footer`} className={styles.block}>
+        Footer
       </div>
-    </ThemeProvider>
+    </div>
   );
 };

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
 import { makeStyles, useFluent } from '@fluentui/react-components';
-// @ts-expect-error - we don support path aliases for libraries with both v8 and v9 as dependencies
-import { ThemeProvider } from '@fluentui/react';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
@@ -5,9 +5,6 @@ import { makeStyles, useFluent } from '@fluentui/react-components';
 import { ThemeProvider } from '@fluentui/react';
 
 const useStyles = makeStyles({
-  root: {
-    maxHeight: '100vh',
-  },
   container: {
     display: 'flex',
     flexDirection: 'column',
@@ -84,18 +81,16 @@ export const MultiUnbounded = () => {
   };
 
   return (
-    <ThemeProvider className={styles.root} applyTo="body" key={'virtualizer-unbounded-theme-provider'}>
-      <div
-        aria-label="Virtualizer Example"
-        className={styles.container}
-        role={'list'}
-        key={'multi-virtualizer-container'}
-      >
-        {renderVirtualizerLoop()}
-        <div key={`virtualizer-footer`} className={styles.block}>
-          Footer
-        </div>
+    <div
+      aria-label="Virtualizer Example"
+      className={styles.container}
+      role={'list'}
+      key={'multi-virtualizer-container'}
+    >
+      {renderVirtualizerLoop()}
+      <div key={`virtualizer-footer`} className={styles.block}>
+        Footer
       </div>
-    </ThemeProvider>
+    </div>
   );
 };

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/Default.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
-// @ts-expect-error - we don support path aliases for libraries with both v8 and v9 as dependencies
-import { ThemeProvider } from '@fluentui/react';
 
 const useStyles = makeStyles({
   root: {
@@ -20,24 +18,22 @@ export const Default = () => {
   const childLength = 1000;
 
   return (
-    <ThemeProvider className={styles.root} applyTo="body">
-      <VirtualizerScrollView
-        numItems={childLength}
-        itemSize={100}
-        container={{ role: 'list', style: { maxHeight: '100vh' } }}
-      >
-        {(index: number) => {
-          return (
-            <div
-              role={'listitem'}
-              aria-posinset={index}
-              aria-setsize={childLength}
-              key={`test-virtualizer-child-${index}`}
-              className={styles.child}
-            >{`Node-${index}`}</div>
-          );
-        }}
-      </VirtualizerScrollView>
-    </ThemeProvider>
+    <VirtualizerScrollView
+      numItems={childLength}
+      itemSize={100}
+      container={{ role: 'list', style: { maxHeight: '100vh' } }}
+    >
+      {(index: number) => {
+        return (
+          <div
+            role={'listitem'}
+            aria-posinset={index}
+            aria-setsize={childLength}
+            key={`test-virtualizer-child-${index}`}
+            className={styles.child}
+          >{`Node-${index}`}</div>
+        );
+      }}
+    </VirtualizerScrollView>
   );
 };


### PR DESCRIPTION
## Previous Behavior
We had a v8 ThemeProvider in the virtualizer examples (v( codebase)

## New Behavior
ThemeProvider has been replaced with a more native storybook styling option for all Virtualizer demo containers (Max 100VH to ensure scroll viewport is window sized).

## Related Issue(s)
v8 theme provider caused dep tree issues (https://github.com/microsoft/fluentui/pull/27334/files) - dep tree issues have been resolved, so now just cleaning up storybook
