### PR TITLE
chore(ssr-tests): disable "--hide-sidebars"

### DIFF
--- a/apps/ssr-tests-v9/src/test.ts
+++ b/apps/ssr-tests-v9/src/test.ts
@@ -24,7 +24,13 @@ async function test(): Promise<void> {
   let browser: Browser | undefined;
 
   try {
-    browser = await launchBrowser();
+    browser = await launchBrowser({
+      ignoreDefaultArgs: [
+        // If sidebars are hidden, they will have "0px" width. It's not the same as in a real browser
+        // https://github.com/microsoft/fluentui/issues/27357
+        '--hide-scrollbars',
+      ],
+    });
     console.log('Using', await browser.version());
 
     const url =


### PR DESCRIPTION
## New Behavior

This PR disables "--hide-sidebars" option in headless Chromium to prevent false positives reported in #27357.

## Related Issue(s)

- Fixes #27357
