### PR TITLE
fix(react-datepicker-compat): Fix theming issues with all themes and WHCM

### DIFF
--- a/packages/react-components/react-datepicker-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/Calendar/Calendar.tsx
@@ -196,7 +196,7 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       return (
         showGoToToday && (
           <button
-            className={mergeClasses('js-goToday', classes.goTodayButton)}
+            className={classes.goTodayButton}
             onClick={onGotoToday}
             onKeyDown={onButtonKeyDown(onGotoToday)}
             type="button"

--- a/packages/react-components/react-datepicker-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/Calendar/Calendar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Backspace, Enter, Escape, PageDown, PageUp, Space } from '@fluentui/keyboard-keys';
 import { useControllableState } from '@fluentui/react-utilities';
-import { mergeClasses } from '@griffel/react';
 import {
   addMonths,
   addYears,

--- a/packages/react-components/react-datepicker-compat/src/components/Calendar/useCalendarStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/Calendar/useCalendarStyles.ts
@@ -79,7 +79,7 @@ const useGoTodayButtonStyles = makeStyles({
       color: tokens.colorBrandForeground1,
       cursor: 'pointer',
     },
-    '&:active': {
+    '&:hover:active': {
       color: tokens.colorBrandForeground2,
     },
     '&:disabled': {

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDay/useCalendarDayStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDay/useCalendarDayStyles.ts
@@ -122,10 +122,6 @@ const useDisabledStyleStyles = makeStyles({
       color: tokens.colorNeutralForegroundDisabled,
       pointerEvents: 'none',
     },
-    '@media (forced-colors: active)': {
-      color: 'GrayText',
-      forcedColorAdjust: 'none',
-    },
   },
 });
 

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDay/useCalendarDayStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDay/useCalendarDayStyles.ts
@@ -74,7 +74,7 @@ const useMonthAndYearStyles = makeStyles({
       color: tokens.colorNeutralForeground1Hover,
       cursor: 'pointer',
     },
-    '&:active': {
+    '&:hover:active': {
       backgroundColor: tokens.colorBrandBackground2,
     },
   },
@@ -105,13 +105,14 @@ const useHeaderIconButtonStyles = makeStyles({
     width: '28px',
 
     '&:hover': {
-      backgroundColor: tokens.colorBrandBackground2,
-      color: tokens.colorNeutralForeground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
+      color: tokens.colorBrandForegroundOnLightHover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
-    '&:active': {
-      backgroundColor: tokens.colorBrandBackground2,
+    '&:hover:active': {
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
+      color: tokens.colorBrandForegroundOnLightPressed,
     },
   },
 });

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -216,7 +216,6 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
         classNames.dayCell,
         weekCorners && cornerStyle,
         day.isSelected && classNames.daySelected,
-        day.isSelected && 'ms-CalendarDay-daySelected',
         !day.isInBounds && classNames.dayOutsideBounds,
         !day.isInMonth && classNames.dayOutsideNavigatedMonth,
       )}
@@ -241,11 +240,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
       <button
         key={day.key + 'button'}
         aria-hidden={ariaHidden}
-        className={mergeClasses(
-          classNames.dayButton,
-          day.isToday && classNames.dayIsToday,
-          day.isToday && 'ms-CalendarDay-dayIsToday',
-        )}
+        className={mergeClasses(classNames.dayButton, day.isToday && classNames.dayIsToday)}
         aria-label={ariaLabel}
         id={isNavigatedDate ? activeDescendantId : undefined}
         disabled={!ariaHidden && !day.isInBounds}

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
@@ -117,9 +117,9 @@ const useDaySelectedStyles = makeStyles({
     color: tokens.colorNeutralForeground1Static,
 
     '@media (forced-colors: active)': {
-      backgroundColor: 'Highlight!important',
-      ...shorthands.borderColor('Highlight!important'),
-      color: 'HighlightText!important',
+      backgroundColor: 'Highlight',
+      ...shorthands.borderColor('Highlight'),
+      color: 'HighlightText',
       forcedColorAdjust: 'none',
     },
 
@@ -127,8 +127,8 @@ const useDaySelectedStyles = makeStyles({
       color: tokens.colorNeutralForeground1Static,
       backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
       '@media (forced-colors: active)': {
-        backgroundColor: 'Highlight!important',
-        color: 'HighlightText!important',
+        backgroundColor: 'Highlight',
+        color: 'HighlightText',
       },
     },
 
@@ -234,15 +234,15 @@ const useDayButtonStyles = makeStyles({
 
 const useDayIsTodayStyles = makeStyles({
   base: {
-    backgroundColor: tokens.colorBrandBackground + '!important',
+    backgroundColor: tokens.colorBrandBackground,
     ...shorthands.borderRadius('100%'),
-    color: tokens.colorNeutralForegroundOnBrand + '!important',
-    fontWeight: tokens.fontWeightSemibold + '!important',
+    color: tokens.colorNeutralForegroundOnBrand,
+    fontWeight: tokens.fontWeightSemibold,
 
     '@media (forced-colors: active)': {
-      backgroundColor: 'WindowText!important',
-      ...shorthands.borderColor('WindowText!important'),
-      color: 'Window!important',
+      backgroundColor: 'WindowText',
+      ...shorthands.borderColor('WindowText'),
+      color: 'Window',
       forcedColorAdjust: 'none',
     },
 

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
@@ -1,7 +1,6 @@
 import { tokens } from '@fluentui/react-theme';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import {
-  DateRangeType,
   DURATION_2,
   DURATION_3,
   EASING_FUNCTION_1,
@@ -84,12 +83,9 @@ const useDayCellStyles = makeStyles({
     ...shorthands.padding(0),
     position: 'relative',
     width: '28px',
-
     '@media (forced-colors: active)': {
       backgroundColor: 'Window',
       color: 'WindowText',
-      forcedColorAdjust: 'none',
-      zIndex: 0,
     },
 
     [`&.${extraCalendarDayGridClassNames.hoverStyle}`]: {
@@ -97,6 +93,7 @@ const useDayCellStyles = makeStyles({
       backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
+        color: 'WindowText!important',
         ...shorthands.outline('1px', 'solid', 'Highlight'),
         zIndex: 3,
       },
@@ -111,20 +108,20 @@ const useDayCellStyles = makeStyles({
         color: 'Highlight',
       },
     },
-
-    [`&.${extraCalendarDayGridClassNames.pressedStyle}.${extraCalendarDayGridClassNames.hoverStyle}`]: {
-      '@media (forced-colors: active)': {
-        backgroundColor: 'Window',
-        ...shorthands.outline('1px', 'solid', 'Highlight'),
-      },
-    },
   },
 });
 
 const useDaySelectedStyles = makeStyles({
-  dateRangeTypeNotMonth: {
+  base: {
     backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
     color: tokens.colorNeutralForeground1Static,
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight!important',
+      ...shorthands.borderColor('Highlight!important'),
+      color: 'HighlightText!important',
+      forcedColorAdjust: 'none',
+    },
 
     [`&:hover, &.${extraCalendarDayGridClassNames.hoverStyle}, &.${extraCalendarDayGridClassNames.pressedStyle}`]: {
       color: tokens.colorNeutralForeground1Static,
@@ -135,11 +132,10 @@ const useDaySelectedStyles = makeStyles({
       },
     },
 
-    '@media (forced-colors: active)': {
-      backgroundColor: 'Highlight!important',
-      ...shorthands.borderColor('Highlight!important'),
-      color: 'HighlightText!important',
-      forcedColorAdjust: 'none',
+    [`& > .${calendarDayGridClassNames.dayMarker}`]: {
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Window',
+      },
     },
   },
 });
@@ -195,6 +191,9 @@ const useDayOutsideBoundsStyles = makeStyles({
       color: tokens.colorNeutralForegroundDisabled,
       pointerEvents: 'none',
     },
+    '@media (forced-colors: active)': {
+      color: 'DisabledText',
+    },
   },
 });
 
@@ -202,6 +201,10 @@ const useDayOutsideNavigatedMonthStyles = makeStyles({
   lightenDaysOutsideNavigatedMonth: {
     color: tokens.colorNeutralForeground4,
     fontWeight: tokens.fontWeightRegular,
+
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+    },
   },
 });
 
@@ -237,8 +240,15 @@ const useDayIsTodayStyles = makeStyles({
     '@media (forced-colors: active)': {
       backgroundColor: 'WindowText!important',
       ...shorthands.borderColor('WindowText!important'),
-      color: 'WindowText!important',
+      color: 'Window!important',
       forcedColorAdjust: 'none',
+    },
+
+    [`& > .${calendarDayGridClassNames.dayMarker}`]: {
+      backgroundColor: tokens.colorNeutralForegroundOnBrand,
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Window',
+      },
     },
   },
 });
@@ -278,7 +288,7 @@ const useLastTransitionWeekStyles = makeStyles({
 
 const useDayMarkerStyles = makeStyles({
   base: {
-    backgroundColor: tokens.colorNeutralForeground2,
+    backgroundColor: tokens.colorBrandForeground2,
     ...shorthands.borderRadius('100%'),
     bottom: '1px',
     height: '4px',
@@ -291,19 +301,6 @@ const useDayMarkerStyles = makeStyles({
     '@media (forced-colors: active)': {
       backgroundColor: 'WindowText',
       forcedColorAdjust: 'none',
-    },
-
-    [`&.${calendarDayGridClassNames.dayIsToday}`]: {
-      backgroundColor: tokens.colorNeutralBackground1,
-      '@media (forced-colors: active)': {
-        backgroundColor: 'Window',
-      },
-    },
-
-    [`&.${calendarDayGridClassNames.daySelected}`]: {
-      '@media (forced-colors: active)': {
-        backgroundColor: 'HighlightText',
-      },
     },
   },
 });
@@ -347,8 +344,7 @@ export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStylePro
   const dayMarkerStyles = useDayMarkerStyles();
   const cornerBorderAndRadiusStyles = useCornerBorderAndRadiusStyles();
 
-  const { animateBackwards, animationDirection, dateRangeType, lightenDaysOutsideNavigatedMonth, showWeekNumbers } =
-    props;
+  const { animateBackwards, animationDirection, lightenDaysOutsideNavigatedMonth, showWeekNumbers } = props;
 
   return {
     wrapper: mergeClasses(calendarDayGridClassNames.wrapper, wrapperStyles.base),
@@ -358,10 +354,7 @@ export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStylePro
       showWeekNumbers && tableStyles.showWeekNumbers,
     ),
     dayCell: mergeClasses(calendarDayGridClassNames.dayCell, dayCellStyles.base, cornerBorderAndRadiusStyles.corners),
-    daySelected: mergeClasses(
-      calendarDayGridClassNames.daySelected,
-      dateRangeType !== DateRangeType.Month && daySelectedStyles.dateRangeTypeNotMonth,
-    ),
+    daySelected: mergeClasses(calendarDayGridClassNames.daySelected, daySelectedStyles.base),
     weekRow: mergeClasses(
       calendarDayGridClassNames.weekRow,
       animateBackwards !== undefined && weekRowStyles.base,

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
@@ -125,7 +125,7 @@ const useDaySelectedStyles = makeStyles({
 
     [`&:hover, &.${extraCalendarDayGridClassNames.hoverStyle}, &.${extraCalendarDayGridClassNames.pressedStyle}`]: {
       color: tokens.colorNeutralForeground1Static,
-      backgroundColor: tokens.colorBrandBackgroundInvertedSelected + ' !important',
+      backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
       '@media (forced-colors: active)': {
         backgroundColor: 'Highlight!important',
         color: 'HighlightText!important',
@@ -171,7 +171,7 @@ const useWeekDayLabelCellStyles = makeStyles({
 
 const useWeekNumberCellStyles = makeStyles({
   base: {
-    backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
+    backgroundColor: tokens.colorTransparentBackground,
     ...shorthands.borderColor(tokens.colorNeutralStroke2),
     ...shorthands.borderRight('1px', 'solid'),
     boxSizing: 'border-box',
@@ -187,7 +187,9 @@ const useWeekNumberCellStyles = makeStyles({
 
 const useDayOutsideBoundsStyles = makeStyles({
   base: {
-    '&, &:disabled, & button': {
+    [`&, &:disabled, & button, &.${extraCalendarDayGridClassNames.hoverStyle}` +
+    `, &.${extraCalendarDayGridClassNames.pressedStyle}`]: {
+      backgroundColor: tokens.colorTransparentBackground,
       color: tokens.colorNeutralForegroundDisabled,
       pointerEvents: 'none',
     },

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.ts
@@ -93,7 +93,7 @@ const useDayCellStyles = makeStyles({
       backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       '@media (forced-colors: active)': {
         backgroundColor: 'Window',
-        color: 'WindowText!important',
+        color: 'WindowText',
         ...shorthands.outline('1px', 'solid', 'Highlight'),
         zIndex: 3,
       },
@@ -194,7 +194,7 @@ const useDayOutsideBoundsStyles = makeStyles({
       pointerEvents: 'none',
     },
     '@media (forced-colors: active)': {
-      color: 'DisabledText',
+      color: 'GrayText',
     },
   },
 });

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
@@ -74,14 +74,14 @@ const useCurrentItemButtonStyles = makeStyles({
   },
   hasHeaderClickCallback: {
     '&:hover': {
-      backgroundColor: tokens.colorBrandBackground2,
-      color: tokens.colorNeutralForeground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
+      color: tokens.colorBrandForegroundOnLightHover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
-    '&:active': {
-      backgroundColor: tokens.colorBrandBackground2,
-      color: tokens.colorNeutralForeground1Pressed,
+    '&:hover:active': {
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
+      color: tokens.colorBrandForegroundOnLightPressed,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
@@ -115,10 +115,15 @@ const useNavigationButtonStyles = makeStyles({
     width: '28px',
 
     '&:hover': {
-      backgroundColor: tokens.colorBrandBackground2,
-      color: tokens.colorNeutralForeground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
+      color: tokens.colorBrandForegroundOnLightHover,
       cursor: 'pointer',
       ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
+    },
+
+    '&:hover:active': {
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
+      color: tokens.colorBrandForegroundOnLightPressed,
     },
   },
 });
@@ -194,7 +199,7 @@ const useItemButtonStyles = makeStyles({
         ...shorthands.outline('1px', 'solid', 'Highlight'),
       },
     },
-    '&:active': {
+    '&:hover:active': {
       backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
 
       '@media (forced-colors: active)': {
@@ -253,7 +258,7 @@ const useSelectedStyles = makeStyles({
         forcedColorAdjust: 'none',
       },
     },
-    '&:active': {
+    '&:hover:active': {
       backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
     },
   },

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
@@ -212,6 +212,11 @@ const useCurrentStyles = makeStyles({
     color: tokens.colorNeutralForegroundOnBrand + '!important',
     fontWeight: tokens.fontWeightSemibold,
 
+    '@media (forced-colors: active)': {
+      backgroundColor: 'WindowText',
+      color: 'Window!important',
+      forcedColorAdjust: 'none',
+    },
     '&:hover': {
       backgroundColor: tokens.colorBrandBackground,
 
@@ -220,11 +225,6 @@ const useCurrentStyles = makeStyles({
         color: 'Window',
         forcedColorAdjust: 'none',
       },
-    },
-    '@media (forced-colors: active)': {
-      backgroundColor: 'WindowText',
-      color: 'Window',
-      forcedColorAdjust: 'none',
     },
   },
 });
@@ -235,6 +235,11 @@ const useSelectedStyles = makeStyles({
     color: tokens.colorNeutralForeground1Static,
     fontWeight: tokens.fontWeightSemibold,
 
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight',
+      color: 'Window',
+      forcedColorAdjust: 'none',
+    },
     '& div': {
       fontWeight: tokens.fontWeightSemibold,
     },
@@ -250,17 +255,6 @@ const useSelectedStyles = makeStyles({
     },
     '&:active': {
       backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
-
-      '@media (forced-colors: active)': {
-        backgroundColor: 'Highlight',
-        color: 'Window',
-        forcedColorAdjust: 'none',
-      },
-    },
-    '@media (forced-colors: active)': {
-      backgroundColor: 'Highlight',
-      color: 'Window',
-      forcedColorAdjust: 'none',
     },
   },
 });

--- a/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/CalendarPicker/useCalendarPickerStyles.ts
@@ -214,16 +214,17 @@ const useItemButtonStyles = makeStyles({
 const useCurrentStyles = makeStyles({
   highlightCurrent: {
     backgroundColor: tokens.colorBrandBackground,
-    color: tokens.colorNeutralForegroundOnBrand + '!important',
+    color: tokens.colorNeutralForegroundOnBrand,
     fontWeight: tokens.fontWeightSemibold,
 
     '@media (forced-colors: active)': {
       backgroundColor: 'WindowText',
-      color: 'Window!important',
+      color: 'Window',
       forcedColorAdjust: 'none',
     },
-    '&:hover': {
+    '&:hover, &:hover:active': {
       backgroundColor: tokens.colorBrandBackground,
+      color: tokens.colorNeutralForegroundOnBrand,
 
       '@media (forced-colors: active)': {
         backgroundColor: 'WindowText',


### PR DESCRIPTION
This PR fixes the following issues:
* When clicking grid items, there were unwanted styles left behind if while clicking you move the mouse out of the control.
* Contrast issues with high contrast and dark theme.
* Not showing current selection when the date range is month.
* Contrast issues with marked days.
* Colors didn't feel cohesive and seemed like we had two themes in one.

## Before

![image](https://user-images.githubusercontent.com/5953191/228406861-38f62e2c-b4a6-4171-92f6-abf23e59a0e7.png)
![image](https://user-images.githubusercontent.com/5953191/228406975-b4f7e279-6635-440e-867d-3d8ad93b46d2.png)


## After

![image](https://user-images.githubusercontent.com/5953191/228406482-cf4b0bd4-13f5-493c-b571-bf94bb47c10c.png)
![image](https://user-images.githubusercontent.com/5953191/228407000-b6382f4c-479b-491d-a8a5-5403d40a9e24.png)

