### PR TITLE
RFC: Fluent UI Web Components should not provide custom attributes for presentational changes which can be accomplished via a single CSS property

### DIFF
--- a/rfcs/web-components/no-style-override-attributes.md
+++ b/rfcs/web-components/no-style-override-attributes.md
@@ -1,0 +1,103 @@
+# RFC: No attributes for presentational changes which can be accomplished via a single CSS property
+
+---
+
+_@chrisdholt_
+
+## Summary
+
+This RFC aims to standardize the default method of applying "trivial" styles to components. For the sake of definition, "trivial" should be considered styles which can be modified by a single CSS Property on the element itself.
+
+## Background
+
+Currently, certain components have attributes which apply conditional styles. If the attribute is present or of a certain value, we apply a secific style.
+
+### Example
+
+The Fluent "Label" spec currently enumerates support for "weight". The font-weight of the component can have a value of "regular" or "semibold". Currently, we don't set default values for components to avoid cluttering the DOM (attributes reflect by default) which means that the default value is set in CSS. When the attribute is set, the other value is set via CSS.
+
+**Attribute implementation**
+
+```ts
+const LabelWeight = {
+  regular: "regular",
+  semibold: "sembold",
+} as const;
+
+type LabelWeight =  ValuesOf<typeof LabelWeight>;
+
+@attr
+public weight?: LabelWeight;
+```
+
+**CSS**
+
+```css
+:host {
+  font-weight: ${fontWeightRegular};
+}
+
+:host([weight="semibold"]) {
+  font-weight: ${fontWeightSemibold};
+}
+```
+
+## Problem statement
+
+In order to apply a value to a single CSS property, we add a non-trivial amount of JavaScript (decorator, observable property, bindings...). At what cost do we add JavaScript for convenience where documentation would do the trick?
+
+## Detailed Design or Proposal
+
+This RFC proposes that we remove attrbutes which change a single CSS property in favor of guidance on applying style changes to components using "vanilla" CSS.
+
+Put simply, when a component can support variationis of a single property such as font-weight, the default should be set in CSS as it is today, and _guidance_ should be the primary method of conveying design support. While an attrbute enumerates such guidance as a priority, it does nothing to prevent someone applyinig an unsuppported value for font-weight. Developers can target one or all Label components within a document and override their font-weight. Attributes are not free and should be reserved for style changes which require more than a single line of CSS (appearances, states, etc).
+
+### Updated implementation
+
+In favor of adding a costly attribute to describe guidance, guidance is enumerated in documentation.
+
+**Attribute implementation**
+
+```ts
+// None
+```
+
+**CSS**
+
+```css
+:host {
+  font-weight: ${fontWeightRegular};
+}
+```
+
+**User-land CSS**
+
+```ts
+// All instances
+css`
+  fluent-label {
+    font-weight: ${fontWeightSemibold};
+  }
+`;
+
+// Class instances
+css`
+  fluent-label.semibold {
+    font-weight: ${fontWeightSemibold};
+  }
+`;
+```
+
+## Pros and Cons
+
+### Pros
+
+- leverages the web platform
+- no unnecessary js
+- attributes don't pollute the DOM
+- guidance over explicit support encourages applying web best practices
+
+### Cons
+
+- misalignment with react
+- relies on guidance rather than explicit "support" (not totally a con...)


### PR DESCRIPTION
This RFC proposes that the Fluent UI Web Components should not provide custom attributes for presentational changes which can be accomplished via a single CSS property.