### PR TITLE
feat(scripts-executors): support custom base and printing all affected packages for checkIfPackagesAffected

### DIFF
--- a/.devops/templates/runpublishvrscreenshot.yml
+++ b/.devops/templates/runpublishvrscreenshot.yml
@@ -19,7 +19,7 @@ steps:
       isPR=${{lower(eq(variables['Build.Reason'], 'PullRequest'))}}
       echo $isPR
       if [[ $isPR == true ]]; then
-        packageAffected=$(yarn --silent check:affected-package --packages ${{ parameters.vrTestPackageName }} --pr=true)
+        packageAffected=$(yarn --silent check:affected --package ${{ parameters.vrTestPackageName }})
         if [[ $packageAffected == false ]]; then
           echo "In PR pipeline but NOT affecting test package. Skipping test run"
           echo "##vso[task.setvariable variable=vrTestSkip;]yes"

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -21,9 +21,9 @@ jobs:
         displayName: yarn
 
       - script: |
-          NorthstarAffected=$(yarn --silent check:affected-package --packages @fluentui/react-northstar --pr)
-          V8Affected=$(yarn --silent check:affected-package --packages @fluentui/react --pr)
-          ReactComponentsAffected=$(yarn --silent check:affected-package --packages @fluentui/react-components --pr)
+          NorthstarAffected=$(yarn --silent check:affected --package @fluentui/react-northstar)
+          V8Affected=$(yarn --silent check:affected --package @fluentui/react)
+          ReactComponentsAffected=$(yarn --silent check:affected --package @fluentui/react-components)
           if [[ $NorthstarAffected == true ]]; then
             echo "##vso[task.setvariable variable=NorthstarPackageAffected;isOutput=true]true"
           fi

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "change": "beachball change --no-commit",
     "check:change": "beachball check",
     "check:modified-files": "node -r ./scripts/ts-node/register ./scripts/executors/check-for-modified-files",
-    "check:affected-package": "node ./scripts/executors/checkIfPackagesAffected.js",
+    "check:affected": "node ./scripts/executors/checkIfPackagesAffected.js",
     "check:installed-dependencies-versions": "satisfied --no-peers --skip-invalid",
     "clean": "lage clean --verbose",
     "code-style": "lage code-style --verbose",

--- a/scripts/monorepo/src/index.d.ts
+++ b/scripts/monorepo/src/index.d.ts
@@ -7,6 +7,6 @@ export { isConvergedPackage, shipsAMD } from './isConvergedPackage';
 export { getAffectedPackages } from './getAffectedPackages';
 export { getLernaAliases } from './get-lerna-aliases';
 export { getDefaultEnvironmentVars } from './getDefaultEnvironmentVars';
-export { getProjectMetadata, workspaceRoot } from './utils';
+export { getProjectMetadata, workspaceRoot, getUncommittedFiles, getUntrackedFiles } from './utils';
 export * as eslintConstants from './eslint-constants';
 export { getNthCommit } from './getNthCommit';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- check:affected-packages implements internal `-pr` flag which is not used and also wont support configuration
- we don't have reliable CLI to report affected packages for particular branch that would also notify user about lage false positives https://github.com/microsoft/fluentui/issues/26147

## New Behavior

- `check:affected-packages` is refactored in 2 ways:
  - npm script alias changed to `check:affected`
  - `--pr` flag was removed (it is not used anywhere)
  - added configurable `--base` argument
  - will notify user about false positives (lage issue) 
    - <img width="513" alt="image" src="https://user-images.githubusercontent.com/1223799/228523339-8c88221c-1760-43e0-808b-b1d691337640.png">

**Usage:**

```sh
yarn check:affected

> Set(2) {  '@fluentui/perf-test',  '@fluentui/perf-test-react-components' }

```


```sh
yarn check:affected --package @fluentui/react-text

> false
```
 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
