### PR TITLE
fix(react-dialog): DialogContent scrollbar always visible

### DIFF
--- a/change/@fluentui-react-dialog-19f431ea-3879-40f6-bf2a-177d37d60310.json
+++ b/change/@fluentui-react-dialog-19f431ea-3879-40f6-bf2a-177d37d60310.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DialogContent scrollbar always visible",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.ts
@@ -25,8 +25,6 @@ const useStyles = makeStyles({
     '&::backdrop': {
       backgroundColor: 'rgba(0, 0, 0, 0.4)',
     },
-    width: `100%`,
-    height: 'fit-content',
     maxHeight: `calc(100vh - 2 * ${SURFACE_PADDING})`,
     boxSizing: 'border-box',
     gridTemplateRows: 'auto 1fr auto',

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
@@ -13,7 +13,6 @@ export const dialogContentClassNames: SlotClassNames<DialogContentSlots> = {
  */
 const useStyles = makeStyles({
   root: {
-    width: '100%',
     overflowY: 'auto',
     minHeight: '32px',
     boxSizing: 'border-box',

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.ts
@@ -14,7 +14,6 @@ export const dialogContentClassNames: SlotClassNames<DialogContentSlots> = {
 const useStyles = makeStyles({
   root: {
     width: '100%',
-    height: '100%',
     overflowY: 'auto',
     minHeight: '32px',
     boxSizing: 'border-box',

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.ts
@@ -34,7 +34,6 @@ const useStyles = makeStyles({
       backgroundColor: 'rgba(0, 0, 0, 0.4)',
     },
     position: 'fixed',
-    width: '100%',
     height: 'fit-content',
     maxWidth: '600px',
     maxHeight: '100vh',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

PR https://github.com/microsoft/fluentui/pull/27248  introduced a regression where the scrollbar would always be visible due to a negative margin.

![image](https://user-images.githubusercontent.com/5483269/228594762-a03c8ef4-9780-415c-98c2-cb5e8492bd13.png)


## New Behavior

1. removes declaration of the `height: 100%` from `DialogContent`, which makes height `auto`, which will properly vary `DialogContent` height taking into account the negative margin in cases where the scrollbar should be visible or not 
2. removes unnecessary `height` and  `width` styles from `DialogContent`, `DialogBody` and `DialogSurface` 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27347
