### PR TITLE
bugfix(react-utilities): change SlotRenderFunction signature to include children

### DIFF
--- a/change/@fluentui-react-utilities-370bb4f7-0783-4acf-bd47-07b1e38dcd19.json
+++ b/change/@fluentui-react-utilities-370bb4f7-0783-4acf-bd47-07b1e38dcd19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: increments SlotRenderFunction signature to include children",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -152,7 +152,7 @@ export type SlotClassNames<Slots> = {
 export type SlotPropsRecord = Record<string, UnknownSlotProps | SlotShorthandValue | null | undefined>;
 
 // @public (undocumented)
-export type SlotRenderFunction<Props> = (Component: React_2.ElementType<Props>, props: Omit<Props, 'children' | 'as'>) => React_2.ReactNode;
+export type SlotRenderFunction<Props> = (Component: React_2.ElementType<Props>, props: Omit<Props, 'as'>) => React_2.ReactNode;
 
 // @public (undocumented)
 export type Slots<S extends SlotPropsRecord> = {

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -84,7 +84,7 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
     return [
       React.Fragment,
       {
-        children: render(slot, rest as Omit<R[K], 'children' | 'as'>),
+        children: render(slot, rest as Omit<R[K], 'as'>),
       } as unknown as R[K],
     ];
   }

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export type SlotRenderFunction<Props> = (
   Component: React.ElementType<Props>,
-  props: Omit<Props, 'children' | 'as'>,
+  props: Omit<Props, 'as'>,
 ) => React.ReactNode;
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

This is a bug fix! types for `SlotRenderFunction` should properly include `children` as an option, and they currently don't.

1. Adds `children` as a possible value on the properties for `SlotRenderFunction`
2. This PR is solely about type fixing no functionality will change.

## Related Issue(s)

https://github.com/microsoft/fluentui/issues/27089
