### PR TITLE
update fast-element to 2.0.0-beta.23 and fast-foundation to 3.0.0-alpha.27

### DIFF
--- a/change/@fluentui-web-components-9d8d0650-6506-4332-97ba-4f96836470e2.json
+++ b/change/@fluentui-web-components-9d8d0650-6506-4332-97ba-4f96836470e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update fast-element and fast-foundation dependencies",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -129,8 +129,8 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^2.0.0-beta.22",
-    "@microsoft/fast-foundation": "^3.0.0-alpha.26",
+    "@microsoft/fast-element": "^2.0.0-beta.23",
+    "@microsoft/fast-foundation": "^3.0.0-alpha.27",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@fluentui/tokens": "1.0.0-alpha.2",
     "tslib": "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,23 +3041,23 @@
     eslint-plugin-react "7.24.0"
     eslint-plugin-security "1.4.0"
 
+"@microsoft/fast-element@2.0.0-beta.23", "@microsoft/fast-element@^2.0.0-beta.23":
+  version "2.0.0-beta.23"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-2.0.0-beta.23.tgz#08cc4b40f9d2b418a27727d2604635c46c2b123c"
+  integrity sha512-ZNrWz+qY6kYSiiy6TdMV9p94QbxNILWuFgDndf24/is+aB+IemYwqLVPUKzTb8tX/zUMQz8aOtJ06/qvYbIdAQ==
+
 "@microsoft/fast-element@^1.10.4":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.11.0.tgz#494f6c87057bcbb42406982d68a92887d6b5acb1"
   integrity sha512-VKJYMkS5zgzHHb66sY7AFpYv6IfFhXrjQcAyNgi2ivD65My1XOhtjfKez5ELcLFRJfgZNAxvI8kE69apXERTkw==
 
-"@microsoft/fast-element@^2.0.0-beta.22":
-  version "2.0.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-2.0.0-beta.22.tgz#e8a508544b2af9db387e9e728d0de1fb9b8f1a12"
-  integrity sha512-uyNiiTp59BN0uiRE5f2avwTR5vNoPavTFvPQ+v8UcWgL4Zi206dTfIOEH/hR0eeY8Jw3w0C6FHNSc/ehetkzWg==
-
-"@microsoft/fast-foundation@^3.0.0-alpha.26":
-  version "3.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-3.0.0-alpha.26.tgz#eb21b5f9ee5d4dccf17da1e709a78775ce1278ad"
-  integrity sha512-78UJIbS20lCQ9rOyUZMwjXIeEDFBjJZM0DJ7bYUIXgx7JDXygYi8RxnmCFiO0h9XABubiuOJrGDJtqro5sgS7g==
+"@microsoft/fast-foundation@^3.0.0-alpha.27":
+  version "3.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-3.0.0-alpha.27.tgz#cb91af92fb231710f7c346b11db7afe241ff8bb4"
+  integrity sha512-tYDrHWMDNpi3+3RaRZ79T+6VQubYSxxutxELD88WXPEYiafjgext4AH9MvR+2pUpdfrNPcJLyuEQKVvcx6oWuQ==
   dependencies:
     "@floating-ui/dom" "^1.0.3"
-    "@microsoft/fast-element" "^2.0.0-beta.22"
+    "@microsoft/fast-element" "2.0.0-beta.23"
     "@microsoft/fast-web-utilities" "^6.0.0"
     tabbable "^5.2.0"
     tslib "^2.4.0"


### PR DESCRIPTION
## Fast-Element2.0.0-beta.23

Tue, 28 Mar 2023 22:14:10 GMT

### Changes

- docs: add missing API docs
- fix: correct types for a break in TypeScript 5 legacy decorators

## Fast-Foundation 3.0.0-alpha.27

### Changes

- update @microsoft/fast-element to be fixed for foundation package
- update slider changed methods to protected
- support row selection in data grid
- remove activeindicator from tabs component
- Bump @microsoft/fast-element to v2.0.0-beta.23

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
