### PR TITLE
fix: ColorPicker preview color updated to ignore forced colors

### DIFF
--- a/change/@fluentui-react-8e2d7e7a-c47a-459d-8184-f5744bc1d88e.json
+++ b/change/@fluentui-react-8e2d7e7a-c47a-459d-8184-f5744bc1d88e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ColorPicker preview box updated to ignore forced colors to display chosen color",
+  "packageName": "@fluentui/react",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ColorPicker/ColorPicker.styles.ts
+++ b/packages/react/src/components/ColorPicker/ColorPicker.styles.ts
@@ -55,6 +55,7 @@ export const getStyles = (props: IColorPickerStyleProps): IColorPickerStyles => 
         height: 48,
         margin: '0 0 0 8px',
         border: '1px solid #c8c6c4',
+        forcedColorAdjust: 'none',
       },
     ],
     flexContainer: {

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -1428,6 +1428,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                 is-preview
                 {
                   border: 1px solid #c8c6c4;
+                  forced-color-adjust: none;
                   height: 48px;
                   margin-bottom: 0;
                   margin-left: 8px;


### PR DESCRIPTION
## Problem
The ColorPicker preview color is not shown in force-colors mode

## Change
forced-color-adjust: none added to preview color box style

## Testing
Verified in browser emulating forced-colors

## Issue
Fixes: #27333