### PR TITLE
fix: Dropdown and Combobox do not use separator role

### DIFF
--- a/change/@fluentui-react-3572eea0-ee5a-42be-a74b-ecdc134fa6f1.json
+++ b/change/@fluentui-react-3572eea0-ee5a-42be-a74b-ecdc134fa6f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Dropdown and ComboBox do not use separator role",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1521,7 +1521,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     const { index, key } = item;
 
     if (index && index > 0) {
-      return <div role="separator" key={key} className={this._classNames.divider} />;
+      return <div role="presentation" key={key} className={this._classNames.divider} />;
     }
     return null;
   }

--- a/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -945,7 +945,7 @@ exports[`ComboBox Renders correctly when open 1`] = `
                             background-color: #edebe9;
                             height: 1px;
                           }
-                      role="separator"
+                      role="presentation"
                     />
                   </div>
                   <button
@@ -1766,7 +1766,7 @@ exports[`ComboBox Renders correctly when opened in multi-select mode 1`] = `
                             background-color: #edebe9;
                             height: 1px;
                           }
-                      role="separator"
+                      role="presentation"
                     />
                   </div>
                   <div

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -756,7 +756,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     const { index, key } = item;
     const separatorClassName = item.hidden ? this._classNames.dropdownDividerHidden : this._classNames.dropdownDivider;
     if (index! > 0) {
-      return <div role="separator" key={key} className={separatorClassName} />;
+      return <div role="presentation" key={key} className={separatorClassName} />;
     }
     return null;
   }

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -612,7 +612,7 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             background-color: #edebe9;
                             height: 1px;
                           }
-                      role="separator"
+                      role="presentation"
                     />
                   </div>
                   <div
@@ -1729,7 +1729,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             background-color: #edebe9;
                             height: 1px;
                           }
-                      role="separator"
+                      role="presentation"
                     />
                   </div>
                   <button


### PR DESCRIPTION
This PR is purely a semantic change, no behavior or style changes.

## Previous Behavior

The visual line separating groups had the separator role, which isn't valid within a listbox

## New Behavior

The div gets a `role=presentation`.

## Related Issue(s)

- Fixes #26949
