### PR TITLE
fix: Fix babel build error on Windows

### DIFF
--- a/scripts/babel/preset-v9.js
+++ b/scripts/babel/preset-v9.js
@@ -24,7 +24,7 @@ function createModuleResolverAliases(options) {
     const tsSourceRoot = aliasTuple[0];
     const jsSourceRoot = tsSourceRoot.replace('src', 'lib').replace('.ts', '.js');
     const aliasRegex = `^${packageName}$`;
-    acc[aliasRegex] = `${rootOffset}/${jsSourceRoot}`;
+    acc[aliasRegex] = path.resolve(rootOffset, jsSourceRoot);
     return acc;
   }, /** @type {Record<string,string>} */ ({}));
 }


### PR DESCRIPTION
## Previous Behavior

Builds are failing on windows machines, with an error like:

```log
verb @fluentui/react-label build |  [11:12:26 AM] x Error detected while running 'babel:postprocess'
verb @fluentui/react-label build |  [11:12:26 AM] x ------------------------------------
verb @fluentui/react-label build |  [11:12:26 AM] x node:internal/modules/cjs/loader:959
verb @fluentui/react-label build |    throw err;
verb @fluentui/react-label build |    ^
verb @fluentui/react-label build |
verb @fluentui/react-label build |  Error: Cannot find module '..\..\../packages/react-components/react-theme/lib/index.js'
```

## New Behavior

Modify the change from #27313 to use `path.resolve` to ensure the slashes are in the correct direction on Windows.

## Related Issue(s)

- Regression from #27313
