### PR TITLE
fix: make Option's checkIcon slot render conditionally

### DIFF
--- a/change/@fluentui-react-combobox-eae93813-cc10-40eb-9645-8d1ad072f062.json
+++ b/change/@fluentui-react-combobox-eae93813-cc10-40eb-9645-8d1ad072f062.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: make Option's checkIcon slot render conditionally",
+  "packageName": "@fluentui/react-combobox",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
@@ -5,6 +5,7 @@ import { ListboxContext } from '../../contexts/ListboxContext';
 import { Option } from './Option';
 import type { OptionProps } from './Option.types';
 import { isConformant } from '../../testing/isConformant';
+import { optionClassNames } from './useOptionStyles';
 
 describe('Option', () => {
   isConformant<OptionProps>({
@@ -221,5 +222,27 @@ describe('Option', () => {
 
     expect(setActiveOption).toHaveBeenCalledTimes(1);
     expect(setActiveOption).toHaveBeenCalledWith(optionData);
+  });
+
+  describe('checkIcon slot', () => {
+    it('renders the `checkIcon` slot by default', () => {
+      render(
+        <Option id="optionId" value="foo">
+          Option 1
+        </Option>,
+      );
+
+      expect(document.querySelector(`.${optionClassNames.checkIcon}`)).toBeTruthy();
+    });
+
+    it('should not render the `checkIcon` slot when passed `null`', () => {
+      render(
+        <Option id="optionId" value="foo" checkIcon={null}>
+          Option 1
+        </Option>,
+      );
+
+      expect(document.querySelector(`.${optionClassNames.checkIcon}`)).toBeFalsy();
+    });
   });
 });

--- a/packages/react-components/react-combobox/src/components/Option/renderOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/renderOption.tsx
@@ -10,7 +10,7 @@ export const renderOption_unstable = (state: OptionState) => {
 
   return (
     <slots.root {...slotProps.root}>
-      <slots.checkIcon {...slotProps.checkIcon} />
+      {slots.checkIcon && <slots.checkIcon {...slotProps.checkIcon} />}
       {slotProps.root.children}
     </slots.root>
   );


### PR DESCRIPTION
## Previous Behavior

`Option`'s `checkIcon` slot is nullable according to the types but the render code does not null-check the slot so code like

```tsx
<Option checkIcon={null}>...
```

leads to a runtime error.

## New Behavior

`Option`s render code null checks the slot.
Tests added to verify the behavior.

