### PR TITLE
#24280 issueFixed: focus is not set on first item

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -599,7 +599,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
     const isSmall = responsiveMode! <= ResponsiveMode.medium;
 
-    const focusTrapZoneProps: IFocusTrapZoneProps = { firstFocusableTarget: `#${this._listId}1` };
+    const focusTrapZoneProps: IFocusTrapZoneProps = { firstFocusableTarget: `#${this._listId}0` };
     const panelStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.panel as IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>)
       : undefined;


### PR DESCRIPTION
Fixed the issue. Now focus should be on first item.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch


## Previous Behavior

<!-- Dropdown in panel - focus is not set on first item -->

## New Behavior

<!-- Focus should go to the first list option -->

## Related Issue(s)

<!-- [Issue link](https://github.com/microsoft/fluentui/issues/24280) -->

- Fixes #24280
