### PR TITLE
fix(scripts-storybook): make sure to exclude our custom v9 babel preset from storybook babel-loader

### DIFF
--- a/scripts/storybook/src/loaders/custom-loader.js
+++ b/scripts/storybook/src/loaders/custom-loader.js
@@ -1,4 +1,4 @@
-const excludePresets = ['@griffel'];
+const excludePresets = ['@griffel', '@fluentui/scripts-babel/preset-v9'];
 
 /**
  * Custom babel loader used with [`customize` babel-loader config](https://github.com/babel/babel-loader#customized-loader)

--- a/scripts/storybook/src/rules.spec.ts
+++ b/scripts/storybook/src/rules.spec.ts
@@ -15,6 +15,7 @@ describe(`rules`, () => {
       });
 
       const options = (codesandboxRule.use as { options: Record<string, unknown> }).options;
+
       expect(options).toEqual(
         expect.objectContaining({
           customize: expect.stringContaining('loaders/custom-loader.js'),
@@ -22,6 +23,7 @@ describe(`rules`, () => {
             [
               expect.any(Function),
               expect.objectContaining({
+                '@fluentui/react-migration-v8-v9': { replace: '@fluentui/react-migration-v8-v9' },
                 '@fluentui/react-utilities': { replace: '@fluentui/react-components' },
                 ...(unstablePackage
                   ? { [unstablePackage.packageJson.name]: { replace: '@fluentui/react-components/unstable' } }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

[Introduction  of `extends` with custom v9 preset within `babelrc` configs](https://github.com/microsoft/fluentui/pull/27313) broke  `_processBabelLoaderOptions`, thus griffel  preset was used during storybook builds. While on pure v9 packages, things mostly still worked as expected cross project storybooks stopped working triggering following build errors:

_Failure for `@fluentui/react-migration-v8-v9`:_

<img width="1513" alt="image" src="https://user-images.githubusercontent.com/1223799/229576273-8844d03e-53e1-4cba-a183-0ec9d837117a.png">



## New Behavior

- we now exclude custom `'@fluentui/scripts-babel/preset-v9'` for storybook `babel-loader`. This mitigates any issues
- identity aliases for codesandbox babel plugin has been refactored, including excluding non relevant packages from mapping

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/27313
