### PR TITLE
Re-enable DetailsList column resize

### DIFF
--- a/change/@fluentui-react-dc639fb6-da75-4193-960d-f7e6a73c7d67.json
+++ b/change/@fluentui-react-dc639fb6-da75-4193-960d-f7e6a73c7d67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: revert column resize behavior for DetailsList",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
@@ -42,27 +42,13 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
       this._allItems.push({
         key: i,
         name: 'Item ' + i,
-        value: 'VALUE Very very long long text to test this experience ' + i,
-        value1: 'VALUE1 Very very long long text to test this experience ' + i,
-        value2: 'VALUE2 Very very long long text to test this experience ' + i,
-        value3: 'VALUE3 Very very long long text to test this experience ' + i,
+        value: i,
       });
     }
 
     this._columns = [
-      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 200, maxWidth: 500, isResizable: true },
-      {
-        key: 'column2',
-        name: 'Value',
-        fieldName: 'value',
-        minWidth: 250,
-        maxWidth: 500,
-        isResizable: true,
-        isCollapsable: true,
-      },
-      { key: 'column3', name: 'Value', fieldName: 'value1', minWidth: 250, maxWidth: 500, isResizable: true },
-      { key: 'column4', name: 'Value', fieldName: 'value2', minWidth: 250, maxWidth: 500, isResizable: true },
-      { key: 'column5', name: 'Value', fieldName: 'value3', minWidth: 250, maxWidth: 500, isResizable: true },
+      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+      { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true },
     ];
 
     this.state = {

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
@@ -51,7 +51,15 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
 
     this._columns = [
       { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 200, maxWidth: 500, isResizable: true },
-      { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 250, maxWidth: 500, isResizable: true },
+      {
+        key: 'column2',
+        name: 'Value',
+        fieldName: 'value',
+        minWidth: 250,
+        maxWidth: 500,
+        isResizable: true,
+        isCollapsable: true,
+      },
       { key: 'column3', name: 'Value', fieldName: 'value1', minWidth: 250, maxWidth: 500, isResizable: true },
       { key: 'column4', name: 'Value', fieldName: 'value2', minWidth: 250, maxWidth: 500, isResizable: true },
       { key: 'column5', name: 'Value', fieldName: 'value3', minWidth: 250, maxWidth: 500, isResizable: true },

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Basic.Example.tsx
@@ -42,13 +42,19 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
       this._allItems.push({
         key: i,
         name: 'Item ' + i,
-        value: i,
+        value: 'VALUE Very very long long text to test this experience ' + i,
+        value1: 'VALUE1 Very very long long text to test this experience ' + i,
+        value2: 'VALUE2 Very very long long text to test this experience ' + i,
+        value3: 'VALUE3 Very very long long text to test this experience ' + i,
       });
     }
 
     this._columns = [
-      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
-      { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true },
+      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 200, maxWidth: 500, isResizable: true },
+      { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 250, maxWidth: 500, isResizable: true },
+      { key: 'column3', name: 'Value', fieldName: 'value1', minWidth: 250, maxWidth: 500, isResizable: true },
+      { key: 'column4', name: 'Value', fieldName: 'value2', minWidth: 250, maxWidth: 500, isResizable: true },
+      { key: 'column5', name: 'Value', fieldName: 'value3', minWidth: 250, maxWidth: 500, isResizable: true },
     ];
 
     this.state = {

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -1350,7 +1350,6 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     });
 
     if (skipViewportMeasures) {
-      // if (minimumWidth > availableWidth) {
       return adjustedColumns;
     }
 

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -1326,6 +1326,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden ? CHECKBOX_WIDTH : 0;
     const groupExpandWidth = this._getGroupNestingDepth() * GROUP_EXPAND_WIDTH;
     let totalWidth = 0; // offset because we have one less inner padding.
+    let minimumWidth = 0;
     const availableWidth = viewportWidth - (rowCheckWidth + groupExpandWidth);
     const adjustedColumns: IColumn[] = newColumns.map((column, i) => {
       const baseColumn = {
@@ -1338,12 +1339,18 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
         ...this._columnOverrides[column.key],
       };
 
+      // eslint-disable-next-line deprecation/deprecation
+      if (!(baseColumn.isCollapsible || baseColumn.isCollapsable)) {
+        minimumWidth += getPaddedWidth(baseColumn, props);
+      }
+
       totalWidth += getPaddedWidth(newColumn, props);
 
       return newColumn;
     });
 
     if (skipViewportMeasures) {
+      // if (minimumWidth > availableWidth) {
       return adjustedColumns;
     }
 
@@ -1359,8 +1366,11 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       // eslint-disable-next-line deprecation/deprecation
       if (column.calculatedWidth! - minWidth >= overflowWidth || !(column.isCollapsible || column.isCollapsable)) {
         const originalWidth = column.calculatedWidth!;
-        column.calculatedWidth = Math.max(column.calculatedWidth! - overflowWidth, minWidth);
-        totalWidth -= originalWidth - column.calculatedWidth;
+        if (minimumWidth < availableWidth) {
+          // Only adjust in cases where all the columns fit within the viewport
+          column.calculatedWidth = Math.max(column.calculatedWidth! - overflowWidth, minWidth);
+        }
+        totalWidth -= originalWidth - column.calculatedWidth!;
       } else {
         totalWidth -= getPaddedWidth(column, props);
         adjustedColumns.splice(lastIndex, 1);


### PR DESCRIPTION
## Previous Behavior

When a justified DetailsList is smaller in width than the available visible space the columns cannot be resized.

## New Behavior

When a justified DetailsList is smaller in width than the available visible space the columns can be resized.

## Related Issue(s)

- Fixes [#26832](https://github.com/microsoft/fluentui/issues/26832)
