### PR TITLE
Fix wrong state narration for multiple selected legends

### DIFF
--- a/change/@fluentui-react-charting-f2c52d6b-db33-4e09-b29c-a8aacddd7667.json
+++ b/change/@fluentui-react-charting-f2c52d6b-db33-4e09-b29c-a8aacddd7667.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix wrong state narration for multiple selected legends",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -45,6 +45,7 @@ export interface ILegendState {
 export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _hoverCardRef: HTMLDivElement;
   private _classNames: IProcessedStyleSet<ILegendsStyles>;
+  private _selectedLegendsSet: { [key: string]: boolean };
 
   public constructor(props: ILegendsProps) {
     super(props);
@@ -62,6 +63,12 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       theme: theme!,
       className,
     });
+
+    this._selectedLegendsSet = {};
+    this.state.selectedLegends.forEach(legend => {
+      this._selectedLegendsSet[legend] = true;
+    });
+
     const dataToRender = this._generateData();
     return (
       <div className={this._classNames.root}>
@@ -318,7 +325,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       opacity: data.opacity,
     };
     const color = this._getColor(legend.title, legend.color);
-    const { theme, className, styles } = this.props;
+    const { theme, className, styles, canSelectMultipleLegends = false } = this.props;
     const classNames = getClassNames(styles!, {
       theme: theme!,
       className,
@@ -342,7 +349,9 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     return (
       <button
         {...(allowFocusOnLegends && {
-          'aria-selected': this.state.selectedLegend === legend.title,
+          'aria-selected': canSelectMultipleLegends
+            ? !!this._selectedLegendsSet[legend.title]
+            : this.state.selectedLegend === legend.title,
           role: 'option',
           'aria-label': `${legend.title}`,
           'aria-setsize': data['aria-setsize'],

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -40,12 +40,12 @@ export interface ILegendState {
   isHoverCardVisible: boolean;
   /** Set of legends selected when multiple selection is allowed */
   selectedLegends: { [key: string]: boolean };
-  /** Boolean variable to check if one or more legends are selected */
-  isLegendSelected: boolean;
 }
 export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _hoverCardRef: HTMLDivElement;
   private _classNames: IProcessedStyleSet<ILegendsStyles>;
+  /** Boolean variable to check if one or more legends are selected */
+  private _isLegendSelected = false;
 
   public constructor(props: ILegendsProps) {
     super(props);
@@ -54,7 +54,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       activeLegend: '',
       isHoverCardVisible: false,
       selectedLegends: {},
-      isLegendSelected: false,
     };
   }
 
@@ -64,6 +63,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       theme: theme!,
       className,
     });
+    this._isLegendSelected = this.state.selectedLegend !== '' || Object.keys(this.state.selectedLegends).length > 0;
     const dataToRender = this._generateData();
     return (
       <div className={this._classNames.root}>
@@ -79,17 +79,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         )}
       </div>
     );
-  }
-
-  public componentDidUpdate(prevProps: Readonly<ILegendsProps>): void {
-    // Reset legend selections when multiple selection is toggled on or off
-    if (this.props.canSelectMultipleLegends !== prevProps.canSelectMultipleLegends) {
-      this.setState({
-        selectedLegend: '',
-        selectedLegends: {},
-        isLegendSelected: false,
-      });
-    }
   }
 
   private _generateData(): ILegendOverflowData {
@@ -186,10 +175,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         selectedLegends = {};
       }
     }
-    this.setState({
-      selectedLegends,
-      isLegendSelected: Object.keys(selectedLegends).length > 0,
-    });
+    this.setState({ selectedLegends });
   };
 
   /**
@@ -200,15 +186,9 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
 
   private _canSelectOnlySingleLegend = (legend: ILegend): void => {
     if (this.state.selectedLegend === legend.title) {
-      this.setState({
-        selectedLegend: '',
-        isLegendSelected: false,
-      });
+      this.setState({ selectedLegend: '' });
     } else {
-      this.setState({
-        selectedLegend: legend.title,
-        isLegendSelected: true,
-      });
+      this.setState({ selectedLegend: legend.title });
     }
   };
 
@@ -421,7 +401,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { palette } = theme!;
     let legendColor = color;
     // if one or more legends are selected
-    if (this.state.isLegendSelected) {
+    if (this._isLegendSelected) {
       // if the given legend (title) is one of the selected legends
       if (this.state.selectedLegend === title || this.state.selectedLegends[title]) {
         legendColor = color;


### PR DESCRIPTION
## Previous Behavior

Screen reader announces wrong state information for legends when multiple selection is allowed

## New Behavior

Screen reader announces correct state information for legends when multiple selection is allowed