### PR TITLE
chore: Remove bundle size tests from deprecated *Field components

### DIFF
--- a/packages/react-components/react-checkbox/bundle-size/CheckboxField.fixture.js
+++ b/packages/react-components/react-checkbox/bundle-size/CheckboxField.fixture.js
@@ -1,7 +1,0 @@
-import { CheckboxField_unstable } from '@fluentui/react-checkbox';
-
-console.log(CheckboxField_unstable);
-
-export default {
-  name: 'CheckboxField',
-};

--- a/packages/react-components/react-combobox/bundle-size/ComboboxField.fixture.js
+++ b/packages/react-components/react-combobox/bundle-size/ComboboxField.fixture.js
@@ -1,7 +1,0 @@
-import { ComboboxField_unstable } from '@fluentui/react-combobox';
-
-console.log(ComboboxField_unstable);
-
-export default {
-  name: 'ComboboxField',
-};

--- a/packages/react-components/react-input/bundle-size/InputField.fixture.js
+++ b/packages/react-components/react-input/bundle-size/InputField.fixture.js
@@ -1,7 +1,0 @@
-import { InputField_unstable } from '@fluentui/react-input';
-
-console.log(InputField_unstable);
-
-export default {
-  name: 'InputField',
-};

--- a/packages/react-components/react-progress/bundle-size/ProgressField.fixture.js
+++ b/packages/react-components/react-progress/bundle-size/ProgressField.fixture.js
@@ -1,7 +1,0 @@
-import { ProgressField_unstable } from '@fluentui/react-progress';
-
-console.log(ProgressField_unstable);
-
-export default {
-  name: 'ProgressField',
-};

--- a/packages/react-components/react-radio/bundle-size/RadioGroupField.fixture.js
+++ b/packages/react-components/react-radio/bundle-size/RadioGroupField.fixture.js
@@ -1,7 +1,0 @@
-import { RadioGroupField_unstable } from '@fluentui/react-radio';
-
-console.log(RadioGroupField_unstable);
-
-export default {
-  name: 'RadioGroupField',
-};

--- a/packages/react-components/react-select/bundle-size/SelectField.fixture.js
+++ b/packages/react-components/react-select/bundle-size/SelectField.fixture.js
@@ -1,7 +1,0 @@
-import { SelectField_unstable } from '@fluentui/react-select';
-
-console.log(SelectField_unstable);
-
-export default {
-  name: 'SelectField',
-};

--- a/packages/react-components/react-slider/bundle-size/SliderField.fixture.js
+++ b/packages/react-components/react-slider/bundle-size/SliderField.fixture.js
@@ -1,7 +1,0 @@
-import { SliderField_unstable } from '@fluentui/react-slider';
-
-console.log(SliderField_unstable);
-
-export default {
-  name: 'SliderField',
-};

--- a/packages/react-components/react-spinbutton/bundle-size/SpinButtonField.fixture.js
+++ b/packages/react-components/react-spinbutton/bundle-size/SpinButtonField.fixture.js
@@ -1,7 +1,0 @@
-import { SpinButtonField_unstable } from '@fluentui/react-spinbutton';
-
-console.log(SpinButtonField_unstable);
-
-export default {
-  name: 'SpinButtonField',
-};

--- a/packages/react-components/react-switch/bundle-size/SwitchField.fixture.js
+++ b/packages/react-components/react-switch/bundle-size/SwitchField.fixture.js
@@ -1,7 +1,0 @@
-import { SwitchField_unstable } from '@fluentui/react-switch';
-
-console.log(SwitchField_unstable);
-
-export default {
-  name: 'SwitchField',
-};

--- a/packages/react-components/react-textarea/bundle-size/TextareaField.fixture.js
+++ b/packages/react-components/react-textarea/bundle-size/TextareaField.fixture.js
@@ -1,7 +1,0 @@
-import { TextareaField_unstable } from '@fluentui/react-textarea';
-
-console.log(TextareaField_unstable);
-
-export default {
-  name: 'TextareaField',
-};


### PR DESCRIPTION
## Previous Behavior

There are bundle size tests that refer to the deprecated `*Field` components, which are unnecessary and make it more difficult to read bundle size reports.

## New Behavior

Remove bundle size tests from deprecated `*Field` components.
