### PR TITLE
fix: add default heading level to DialogTitle

### DIFF
--- a/change/@fluentui-react-dialog-f9dfeb62-a482-488e-920e-6964233f20f5.json
+++ b/change/@fluentui-react-dialog-f9dfeb62-a482-488e-920e-6964233f20f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add default heading role and level to DialogTitle",
+  "packageName": "@fluentui/react-dialog",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogTitle/__snapshots__/DialogTitle.test.tsx.snap
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/__snapshots__/DialogTitle.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`DialogTitle renders a default state 1`] = `
 <div>
   <div
+    aria-level="2"
     class="fui-DialogTitle"
+    role="heading"
   >
     Default DialogTitle
   </div>

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -29,6 +29,8 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
     root: getNativeElementProps(as ?? 'div', {
       ref,
       id: useDialogContext_unstable(ctx => ctx.dialogTitleId),
+      role: 'heading',
+      'aria-level': '2',
       ...props,
     }),
     action: resolveShorthand(action, {


### PR DESCRIPTION
## Previous Behavior

Our v9 DialogTitle defaults to generic text, even though it is displayed as a heading.

## New Behavior

By default, it has `role=heading aria-level=2`. I didn't want to change the default tag, though if we go for a major version change in the future, defaulting to `as: h2` would be better.