### PR TITLE
fix: v8 ComboBox needs to update aria-activedescendant value

### DIFF
--- a/change/@fluentui-react-d4744099-358e-4a73-991b-8d917fc90753.json
+++ b/change/@fluentui-react-d4744099-358e-4a73-991b-8d917fc90753.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ComboBox updates activeDescendant value",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -530,6 +530,24 @@ describe('ComboBox', () => {
     expect(combobox.getAttribute('value')).toEqual('One');
   });
 
+  it('Updates aria-activedescendant with keyboard', () => {
+    const options: IComboBoxOption[] = [
+      { key: '1', text: '1', id: 'one' },
+      { key: '2', text: '2', id: 'two' },
+      { key: '3', text: '3', id: 'three' },
+    ];
+    const { getByRole } = render(<ComboBox defaultSelectedKey="1" options={options} />);
+    const combobox = getByRole('combobox');
+    // open combobox
+    userEvent.tab();
+    userEvent.keyboard('{enter}');
+    expect(combobox.getAttribute('aria-expanded')).toEqual('true');
+
+    // arrow down
+    userEvent.keyboard('{arrowdown}');
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual('two');
+  });
+
   it('Cannot insert text while disabled', () => {
     const { getByRole } = render(<ComboBox defaultSelectedKey="1" options={DEFAULT_OPTIONS2} disabled />);
     const combobox = getByRole('combobox');

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -542,6 +542,7 @@ describe('ComboBox', () => {
     userEvent.tab();
     userEvent.keyboard('{enter}');
     expect(combobox.getAttribute('aria-expanded')).toEqual('true');
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual('one');
 
     // arrow down
     userEvent.keyboard('{arrowdown}');

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -425,11 +425,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     let descendantText = undefined;
 
-    if (isOpen && selectedIndices.length) {
-      descendantText = options[selectedIndices[0]]?.id ?? this._id + '-list' + selectedIndices[0];
-    } else if (isOpen && this._hasFocus() && newCurrentPendingValueValidIndex !== -1) {
+    if (isOpen && this._hasFocus() && newCurrentPendingValueValidIndex !== -1) {
       descendantText =
         options[newCurrentPendingValueValidIndex].id ?? this._id + '-list' + newCurrentPendingValueValidIndex;
+    } else if (isOpen && selectedIndices.length) {
+      descendantText = options[selectedIndices[0]]?.id ?? this._id + '-list' + selectedIndices[0];
     }
 
     if (descendantText !== this.state.ariaActiveDescendantValue) {


### PR DESCRIPTION
## Previous Behavior

This is a regression introduced in #26574, and causes the `aria-activedescendant` value to not update when arrowing through options, which makes the control fully broken for screen reader users.

The root cause is that the `currentPendingValueValidIndex` needs to take precedence as the index of the active option, but the PR updated the logic to use `selectedIndices[0]` as the primary value, while it should be the fallback value.

## New Behavior

`aria-activedescendant` is now calculated off of `currentPendingValueValidIndex`, falling back to `selectedIndices[0]`. This is what the behavior was prior to the PR.
