### PR TITLE
feat(react-jsx-runtime): adds runtime to create-package generator

### DIFF
--- a/scripts/generators/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/generators/create-package/plop-templates-react/package.json.hbs
@@ -31,6 +31,7 @@
     "@fluentui/scripts-tasks": ""
   },
   "dependencies": {
+    "@fluentui/react-jsx-runtime": "",
     "@fluentui/react-theme": "",
     "@fluentui/react-utilities": "",
     "@griffel/react": "",


### PR DESCRIPTION


## New Behavior

Adds `@fluentui/react-jsx-runtime` as a dependency for `create-package` v9 generator

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27446
