### PR TITLE
fix(react): exclude React.HTMLAttributes defined `content` prop for Tooltip and TooltipHost Prop types to mitigate @types/react breaking changes

### DIFF
--- a/apps/ts-minbar-test-react/src/index.ts
+++ b/apps/ts-minbar-test-react/src/index.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 
 import {
@@ -25,13 +24,10 @@ async function performTest() {
     tempPaths = prepareTempDirs(`${testName}-`);
     logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
-    // https://github.com/microsoft/fluentui/issues/27425 - remove related logic once issue will be resolved
-    const pinnedReactTypesVersion = '17.0.55';
-
     // Install dependencies, using the minimum TS version supported for consumers
     const dependencies = [
       '@types/node@14',
-      `@types/react@${pinnedReactTypesVersion}`,
+      `@types/react@17`,
       '@types/react-dom@17',
       'react@17',
       'react-dom@17',
@@ -43,13 +39,6 @@ async function performTest() {
     const lernaRoot = workspaceRoot;
     const packedPackages = await packProjectPackages(logger, lernaRoot, ['@fluentui/react']);
     await addResolutionPathsForProjectPackages(tempPaths.testApp);
-
-    // Remove Start - once will be resolved https://github.com/microsoft/fluentui/issues/27425
-    const jsonPath = path.resolve(tempPaths.testApp, 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
-    packageJson.resolutions['@types/react-dom/@types/react'] = pinnedReactTypesVersion;
-    fs.writeFileSync(jsonPath, JSON.stringify(packageJson), 'utf-8');
-    // Remove End
 
     await shEcho(`yarn add ${packedPackages['@fluentui/react']}`, tempPaths.testApp);
     logger(`✔️ Fluent UI packages were added to dependencies`);

--- a/change/@fluentui-react-46a490a8-de1f-44df-84dc-99f9d17a8db8.json
+++ b/change/@fluentui-react-46a490a8-de1f-44df-84dc-99f9d17a8db8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: exclude HTMLAttributes defined 'content' for  Tooltip and TooltipHost Prop types to mitigate @types/react breaking changes",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -9462,7 +9462,7 @@ export interface ITooltipHost {
 }
 
 // @public
-export interface ITooltipHostProps extends React_2.HTMLAttributes<HTMLDivElement | TooltipHostBase> {
+export interface ITooltipHostProps extends Omit<React_2.HTMLAttributes<HTMLDivElement | TooltipHostBase>, 'content'> {
     calloutProps?: ICalloutProps;
     className?: string;
     closeDelay?: number;
@@ -9504,7 +9504,7 @@ export interface ITooltipHostStyles {
 }
 
 // @public (undocumented)
-export interface ITooltipProps extends React_2.HTMLAttributes<HTMLDivElement | TooltipBase> {
+export interface ITooltipProps extends Omit<React_2.HTMLAttributes<HTMLDivElement | TooltipBase>, 'content'> {
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITooltip>;
     content?: string | JSX.Element | JSX.Element[];

--- a/packages/react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react/src/components/Tooltip/Tooltip.types.ts
@@ -13,7 +13,7 @@ export interface ITooltip {}
 /**
  * {@docCategory Tooltip}
  */
-export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | TooltipBase> {
+export interface ITooltipProps extends Omit<React.HTMLAttributes<HTMLDivElement | TooltipBase>, 'content'> {
   /**
    * Optional callback to access the ITooltip interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/react/src/components/Tooltip/TooltipHost.types.ts
@@ -41,7 +41,7 @@ export enum TooltipOverflowMode {
  * passed through to the Tooltip itself, rather than being used on the host element.
  * {@docCategory Tooltip}
  */
-export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement | TooltipHostBase> {
+export interface ITooltipHostProps extends Omit<React.HTMLAttributes<HTMLDivElement | TooltipHostBase>, 'content'> {
   /**
    * Optional callback to access the ITooltipHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64999#discussioncomment-5519075

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Reverts https://github.com/microsoft/fluentui/pull/27426
- Fixes https://github.com/microsoft/fluentui/issues/27425
