### PR TITLE
chore: Remove the use of ContextSelector in RadioGroupContext

### DIFF
--- a/change/@fluentui-react-radio-5f8bbebb-118d-433d-a9a8-f4bd20be6d3e.json
+++ b/change/@fluentui-react-radio-5f8bbebb-118d-433d-a9a8-f4bd20be6d3e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: RadioGroup forwards aria-describedby to each of the Radio items inside",
+  "comment": "fix: Have RadioGroup forward aria-describedby to each of the Radio items inside",
   "packageName": "@fluentui/react-radio",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-radio-5f8bbebb-118d-433d-a9a8-f4bd20be6d3e.json
+++ b/change/@fluentui-react-radio-5f8bbebb-118d-433d-a9a8-f4bd20be6d3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: RadioGroup forwards aria-describedby to each of the Radio items inside",
+  "packageName": "@fluentui/react-radio",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-radio/etc/react-radio.api.md
+++ b/packages/react-components/react-radio/etc/react-radio.api.md
@@ -32,7 +32,7 @@ export const RadioGroup: ForwardRefComponent<RadioGroupProps>;
 export const radioGroupClassNames: SlotClassNames<RadioGroupSlots>;
 
 // @public (undocumented)
-export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required'>;
+export type RadioGroupContextValue = Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required' | 'aria-describedby'>;
 
 // @public (undocumented)
 export type RadioGroupContextValues = {
@@ -80,7 +80,7 @@ export type RadioGroupSlots = {
 };
 
 // @public
-export type RadioGroupState = ComponentState<RadioGroupSlots> & Required<Pick<RadioGroupProps, 'layout'>> & Partial<Exclude<RadioGroupProps, 'onChange' | 'layout'>>;
+export type RadioGroupState = ComponentState<RadioGroupSlots> & Required<Pick<RadioGroupProps, 'layout'>> & Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required'>;
 
 // @public
 export type RadioOnChangeData = {

--- a/packages/react-components/react-radio/etc/react-radio.api.md
+++ b/packages/react-components/react-radio/etc/react-radio.api.md
@@ -8,13 +8,9 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import { ContextSelector } from '@fluentui/react-context-selector';
 import { DeprecatedFieldProps } from '@fluentui/react-field';
-import { FC } from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { Label } from '@fluentui/react-label';
-import { Provider } from 'react';
-import { ProviderProps } from 'react';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -72,7 +68,7 @@ export type RadioGroupProps = Omit<ComponentProps<Partial<RadioGroupSlots>>, 'on
 };
 
 // @public (undocumented)
-export const RadioGroupProvider: Provider<RadioGroupContextValue> & FC<ProviderProps<RadioGroupContextValue>>;
+export const RadioGroupProvider: React_2.Provider<RadioGroupContextValue | undefined>;
 
 // @public (undocumented)
 export type RadioGroupSlots = {
@@ -118,8 +114,11 @@ export const useRadio_unstable: (props: RadioProps, ref: React_2.Ref<HTMLInputEl
 // @public
 export const useRadioGroup_unstable: (props: RadioGroupProps, ref: React_2.Ref<HTMLDivElement>) => RadioGroupState;
 
-// @public (undocumented)
-export const useRadioGroupContext_unstable: <T>(selector: ContextSelector<RadioGroupContextValue, T>) => T;
+// @public
+export function useRadioGroupContext_unstable(): RadioGroupContextValue;
+
+// @public @deprecated (undocumented)
+export function useRadioGroupContext_unstable<T>(selector: (value: RadioGroupContextValue) => T): T;
 
 // @public (undocumented)
 export const useRadioGroupContextValues: (state: RadioGroupState) => RadioGroupContextValues;

--- a/packages/react-components/react-radio/src/components/Radio/useRadio.tsx
+++ b/packages/react-components/react-radio/src/components/Radio/useRadio.tsx
@@ -16,21 +16,15 @@ import type { RadioProps, RadioState } from './Radio.types';
  * @param ref - reference to `<input>` element of Radio
  */
 export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputElement>): RadioState => {
-  const nameGroup = useRadioGroupContext_unstable(ctx => ctx.name);
-  const value = useRadioGroupContext_unstable(ctx => ctx.value);
-  const defaultValue = useRadioGroupContext_unstable(ctx => ctx.defaultValue);
-  const disabledGroup = useRadioGroupContext_unstable(ctx => ctx.disabled);
-  const layout = useRadioGroupContext_unstable(ctx => ctx.layout);
-  const requiredGroup = useRadioGroupContext_unstable(ctx => ctx.required);
-  const describedByGroup = useRadioGroupContext_unstable(ctx => ctx['aria-describedby']);
+  const group = useRadioGroupContext_unstable();
 
   const {
-    name = nameGroup,
-    checked = value !== undefined ? value === props.value : undefined,
-    defaultChecked = defaultValue !== undefined ? defaultValue === props.value : undefined,
-    labelPosition = layout === 'horizontal-stacked' ? 'below' : 'after',
-    disabled = disabledGroup,
-    required = requiredGroup,
+    name = group.name,
+    checked = group.value !== undefined ? group.value === props.value : undefined,
+    defaultChecked = group.defaultValue !== undefined ? group.defaultValue === props.value : undefined,
+    labelPosition = group.layout === 'horizontal-stacked' ? 'below' : 'after',
+    disabled = group.disabled,
+    required = group.required,
     onChange,
   } = props;
 
@@ -59,7 +53,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
       defaultChecked,
       disabled,
       required,
-      'aria-describedby': describedByGroup,
+      'aria-describedby': group['aria-describedby'],
       ...nativeProps.primary,
     },
   });

--- a/packages/react-components/react-radio/src/components/Radio/useRadio.tsx
+++ b/packages/react-components/react-radio/src/components/Radio/useRadio.tsx
@@ -22,6 +22,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
   const disabledGroup = useRadioGroupContext_unstable(ctx => ctx.disabled);
   const layout = useRadioGroupContext_unstable(ctx => ctx.layout);
   const requiredGroup = useRadioGroupContext_unstable(ctx => ctx.required);
+  const describedByGroup = useRadioGroupContext_unstable(ctx => ctx['aria-describedby']);
 
   const {
     name = nameGroup,
@@ -58,6 +59,7 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
       defaultChecked,
       disabled,
       required,
+      'aria-describedby': describedByGroup,
       ...nativeProps.primary,
     },
   });

--- a/packages/react-components/react-radio/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/react-components/react-radio/src/components/RadioGroup/RadioGroup.test.tsx
@@ -87,6 +87,20 @@ describe('RadioGroup', () => {
     expect(items[2].required).toBe(true);
   });
 
+  it('applies aria-describedby to every radio item', () => {
+    const { getAllByRole } = render(
+      <RadioGroup aria-describedby="test-describedby">
+        <Radio />
+        <Radio />
+        <Radio />
+      </RadioGroup>,
+    );
+    const items = getAllByRole('radio') as HTMLInputElement[];
+    expect(items[0].getAttribute('aria-describedby')).toEqual('test-describedby');
+    expect(items[1].getAttribute('aria-describedby')).toEqual('test-describedby');
+    expect(items[2].getAttribute('aria-describedby')).toEqual('test-describedby');
+  });
+
   it('has no radio item selected by default', () => {
     const { getByDisplayValue } = render(
       <RadioGroup>

--- a/packages/react-components/react-radio/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/react-components/react-radio/src/components/RadioGroup/RadioGroup.types.ts
@@ -68,11 +68,11 @@ export type RadioGroupOnChangeData = {
  */
 export type RadioGroupState = ComponentState<RadioGroupSlots> &
   Required<Pick<RadioGroupProps, 'layout'>> &
-  Partial<Exclude<RadioGroupProps, 'onChange' | 'layout'>>;
+  Pick<RadioGroupProps, 'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required'>;
 
 export type RadioGroupContextValue = Pick<
   RadioGroupProps,
-  'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required'
+  'name' | 'value' | 'defaultValue' | 'disabled' | 'layout' | 'required' | 'aria-describedby'
 >;
 
 export type RadioGroupContextValues = {

--- a/packages/react-components/react-radio/src/contexts/RadioGroupContext.ts
+++ b/packages/react-components/react-radio/src/contexts/RadioGroupContext.ts
@@ -1,17 +1,29 @@
-import { createContext, useContextSelector, ContextSelector } from '@fluentui/react-context-selector';
-import type { Context } from '@fluentui/react-context-selector';
+import * as React from 'react';
+
 import type { RadioGroupContextValue } from '../RadioGroup';
 
 /**
  * RadioGroupContext is provided by RadioGroup, and is consumed by Radio to determine default values of some props.
  */
-export const RadioGroupContext: Context<RadioGroupContextValue> = createContext<RadioGroupContextValue | undefined>(
-  undefined,
-) as Context<RadioGroupContextValue>;
-
-const radioGroupContextDefaultValue: RadioGroupContextValue = {};
+export const RadioGroupContext = React.createContext<RadioGroupContextValue | undefined>(undefined);
 
 export const RadioGroupProvider = RadioGroupContext.Provider;
 
-export const useRadioGroupContext_unstable = <T>(selector: ContextSelector<RadioGroupContextValue, T>): T =>
-  useContextSelector(RadioGroupContext, (ctx = radioGroupContextDefaultValue) => selector(ctx));
+/**
+ * Get the value of the RadioGroupContext.
+ */
+export function useRadioGroupContext_unstable(): RadioGroupContextValue;
+
+/**
+ * @deprecated Call useRadioGroupContext_unstable() with no arguments. RadioGroupContext is now a single context object,
+ * and a selector is no longer needed
+ */
+export function useRadioGroupContext_unstable<T>(selector: (value: RadioGroupContextValue) => T): T;
+
+// Implementation with fallback for deprecated selector
+export function useRadioGroupContext_unstable<T>(
+  selector?: (value: RadioGroupContextValue) => T,
+): T | RadioGroupContextValue {
+  const ctx = React.useContext(RadioGroupContext) || {};
+  return selector ? selector(ctx) : ctx;
+}

--- a/packages/react-components/react-radio/src/contexts/useRadioGroupContextValues.ts
+++ b/packages/react-components/react-radio/src/contexts/useRadioGroupContextValues.ts
@@ -10,6 +10,7 @@ export const useRadioGroupContextValues = (state: RadioGroupState): RadioGroupCo
     disabled,
     layout,
     required,
+    'aria-describedby': state.root['aria-describedby'],
   };
 
   return { radioGroup };

--- a/packages/react-components/react-radio/src/contexts/useRadioGroupContextValues.ts
+++ b/packages/react-components/react-radio/src/contexts/useRadioGroupContextValues.ts
@@ -1,17 +1,23 @@
+import * as React from 'react';
+
 import type { RadioGroupContextValue, RadioGroupContextValues, RadioGroupState } from '../RadioGroup';
 
 export const useRadioGroupContextValues = (state: RadioGroupState): RadioGroupContextValues => {
   const { name, value, defaultValue, disabled, layout, required } = state;
+  const ariaDescribedBy = state.root['aria-describedby'];
 
-  const radioGroup: RadioGroupContextValue = {
-    name,
-    value,
-    defaultValue,
-    disabled,
-    layout,
-    required,
-    'aria-describedby': state.root['aria-describedby'],
-  };
+  const radioGroup = React.useMemo<RadioGroupContextValue>(
+    () => ({
+      name,
+      value,
+      defaultValue,
+      disabled,
+      layout,
+      required,
+      'aria-describedby': ariaDescribedBy,
+    }),
+    [name, value, defaultValue, disabled, layout, required, ariaDescribedBy],
+  );
 
   return { radioGroup };
 };


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
