### PR TITLE
[Feature]: allow aria-description attribute on v9

### DIFF
--- a/apps/ssr-tests-v9/src/utils/helpers.ts
+++ b/apps/ssr-tests-v9/src/utils/helpers.ts
@@ -3,3 +3,9 @@ export function hrToSeconds(hrtime: ReturnType<typeof process.hrtime>): string {
 
   return raw.toFixed(2) + 's';
 }
+
+export function containsAriaDescriptionWarning(message: string): boolean {
+  return message.startsWith(
+    'Warning: Invalid aria prop %s on <%s> tag. For details, see https://reactjs.org/link/invalid-aria-props%s `aria-description`',
+  );
+}

--- a/apps/ssr-tests-v9/src/utils/visitPage.ts
+++ b/apps/ssr-tests-v9/src/utils/visitPage.ts
@@ -1,6 +1,7 @@
 import type { Browser } from 'puppeteer';
 import { visitUrl } from '@fluentui/scripts-puppeteer';
 import { PROVIDER_ID } from './constants';
+import { version } from 'react';
 
 class RenderError extends Error {
   public name = 'RangeError';
@@ -14,9 +15,21 @@ export async function visitPage(browser: Browser, url: string) {
 
   page.on('console', message => {
     if (message.type() === 'error') {
+      const messageContent = message.text();
+
+      // Ignoring 'aria-description' warning from react 17 as it's a valid prop
+      // https://github.com/facebook/react/issues/21035
+      if (
+        messageContent.startsWith('Warning: Invalid aria prop %s on <%s> tag.') &&
+        messageContent.includes('`aria-description`') &&
+        version.startsWith('17')
+      ) {
+        return;
+      }
+
       // Ignoring network errors as we have an interceptor that prevents loading everything except our JS bundle
-      if (!message.text().includes('net::ERR_FAILED')) {
-        error = new RenderError(message.text());
+      if (!messageContent.includes('net::ERR_FAILED')) {
+        error = new RenderError(messageContent);
       }
     }
   });

--- a/apps/ssr-tests-v9/src/utils/visitPage.ts
+++ b/apps/ssr-tests-v9/src/utils/visitPage.ts
@@ -2,6 +2,7 @@ import type { Browser } from 'puppeteer';
 import { visitUrl } from '@fluentui/scripts-puppeteer';
 import { PROVIDER_ID } from './constants';
 import * as React from 'react';
+import { containsAriaDescriptionWarning } from './helpers';
 
 class RenderError extends Error {
   public name = 'RangeError';
@@ -19,11 +20,7 @@ export async function visitPage(browser: Browser, url: string) {
 
       // Ignoring 'aria-description' warning from react 17 as it's a valid prop
       // https://github.com/facebook/react/issues/21035
-      if (
-        messageContent.startsWith('Warning: Invalid aria prop %s on <%s> tag.') &&
-        messageContent.includes('`aria-description`') &&
-        React.version.startsWith('17')
-      ) {
+      if (containsAriaDescriptionWarning(messageContent) && React.version.startsWith('17')) {
         return;
       }
 

--- a/apps/ssr-tests-v9/src/utils/visitPage.ts
+++ b/apps/ssr-tests-v9/src/utils/visitPage.ts
@@ -1,7 +1,7 @@
 import type { Browser } from 'puppeteer';
 import { visitUrl } from '@fluentui/scripts-puppeteer';
 import { PROVIDER_ID } from './constants';
-import { version } from 'react';
+import * as React from 'react';
 
 class RenderError extends Error {
   public name = 'RangeError';

--- a/apps/ssr-tests-v9/src/utils/visitPage.ts
+++ b/apps/ssr-tests-v9/src/utils/visitPage.ts
@@ -22,7 +22,7 @@ export async function visitPage(browser: Browser, url: string) {
       if (
         messageContent.startsWith('Warning: Invalid aria prop %s on <%s> tag.') &&
         messageContent.includes('`aria-description`') &&
-        version.startsWith('17')
+        React.version.startsWith('17')
       ) {
         return;
       }


### PR DESCRIPTION
## Previous Behavior

Currently React 17 throws a warning when `aria-description` prop is used, which results in SSR tests throwing error and blocking build (https://github.com/microsoft/fluentui/pull/27443)

## New Behavior

The warning is a bug in React 17 (https://github.com/facebook/react/issues/21035) and will be removed once upgraded to React 18.


## Related Issue(s)

Fixes #27464
