### PR TITLE
fix(react-badge): Use min-width: max-content on Badge to prevent shrinking smaller than content

### DIFF
--- a/change/@fluentui-react-badge-2a8e666d-e88c-4af4-a503-4a65a4c17316.json
+++ b/change/@fluentui-react-badge-2a8e666d-e88c-4af4-a503-4a65a4c17316.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-badge): Use min-width: max-content on Badge to prevent shrinking smaller than content",
+  "packageName": "@fluentui/react-badge",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
+++ b/packages/react-components/react-badge/src/components/Badge/useBadgeStyles.ts
@@ -20,7 +20,8 @@ const useRootClassName = makeResetStyles({
   position: 'relative',
   ...typographyStyles.caption1Strong,
   height: '20px',
-  minWidth: '20px',
+  width: '20px',
+  minWidth: 'max-content',
   padding: `0 calc(${tokens.spacingHorizontalXS} + ${textPadding})`,
   borderRadius: tokens.borderRadiusCircular,
   // Use a transparent stroke (rather than no border) so the border is visible in high contrast
@@ -64,7 +65,7 @@ const useRootStyles = makeStyles({
     ...shorthands.padding('unset'),
   },
   small: {
-    minWidth: '16px',
+    width: '16px',
     height: '16px',
     ...shorthands.padding(0, `calc(${tokens.spacingHorizontalXXS} + ${textPadding})`),
   },
@@ -72,12 +73,12 @@ const useRootStyles = makeStyles({
     // Set by useRootClassName
   },
   large: {
-    minWidth: '24px',
+    width: '24px',
     height: '24px',
     ...shorthands.padding(0, `calc(${tokens.spacingHorizontalXS} + ${textPadding})`),
   },
   'extra-large': {
-    minWidth: '32px',
+    width: '32px',
     height: '32px',
     ...shorthands.padding(0, `calc(${tokens.spacingHorizontalSNudge} + ${textPadding})`),
   },


### PR DESCRIPTION
## Previous Behavior

Badge sets its size using `min-width: 20px` (or other pixel size). This allows the badge to shrink smaller than its content when space is constrained.

![screenshot of a set of counter badges showing numbers overflowing the bounds of the badges](https://user-images.githubusercontent.com/3819570/169916108-55a64627-ed18-4681-a693-ba5af266cc2b.png)

## New Behavior

Use `min-width: max-content` and set the desired with using `width: 20px`. This causes the badge to be 20px wide, and expand if the content is wider.

## Related Issue(s)

- Fixes #23160
