### PR TITLE
docs: add horizontal scrolling answer to DetailsList FAQ

### DIFF
--- a/packages/react-examples/src/react/DetailsList/docs/DetailsListBestPractices.md
+++ b/packages/react-examples/src/react/DetailsList/docs/DetailsListBestPractices.md
@@ -81,3 +81,11 @@ public render(): JSX.Element {
 ```
 
 By re-creating the items array without mutating the values, the inner List will correctly determine its contents have changed and it should then re-render with the new values.
+
+#### My List does not display a horizontal scrollbar when columns overflow the viewport. How can I display the scrollbar?
+
+Set `constrainMode` to `unconstrained` to allow the page to manage scrolling:
+
+```tsx
+<DetailsList constrainMode={ConstrainMode.unconstrained} {...otherProps} />
+```


### PR DESCRIPTION
## New Behavior

Adds new `DetailsList` FAQ entry explaining how to use `constrainMode` to enable horizontal scrolling.

## Related Issue(s)

#16715