### PR TITLE
Fix shape of triangle and pyramid

### DIFF
--- a/change/@fluentui-react-charting-b2276f17-5bf5-4574-8ed6-a32817b67107.json
+++ b/change/@fluentui-react-charting-b2276f17-5bf5-4574-8ed6-a32817b67107.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix shape of triangle and pyramid",
+  "packageName": "@fluentui/react-charting",
+  "email": "atishay.jain@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/shape.tsx
+++ b/packages/react-charting/src/components/Legends/shape.tsx
@@ -36,7 +36,7 @@ export const Shape: React.FC<IShapeProps> = ({ svgProps, pathProps, shape, class
       height={14}
       viewBox={'-1 -1 14 14'}
       {...svgProps}
-      transform={`rotate(${shape === Points[Points.diamond] ? 45 : shape === Points[Points.triangle] ? 180 : 0}, 0, 0)`}
+      transform={`rotate(${shape === Points[Points.diamond] ? 45 : shape === Points[Points.pyramid] ? 180 : 0}, 0, 0)`}
     >
       <path d={pointPath[shape]} {...pathProps} />
     </svg>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
The triangle shape in line chart is matching with the pyramid shape in legends and hover card.
Similarly pyramid shape in line chart is matching with triangle shape in legends and hover card.
<!-- This is the behavior we have today -->
(See Third and Fifth legends)
![image](https://user-images.githubusercontent.com/98592573/230919768-056693ab-60de-4e9b-8915-b4f39d59f4b9.png)


## New Behavior
Triangle and pyramid in line chart match with the corresponding entries in legend and hover card.
![image](https://user-images.githubusercontent.com/98592573/230920076-57324c08-0845-4759-ab2b-75e600688d80.png)
Fixes #27483 
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
