### PR TITLE
fix(react-progress): Stories should import from react-components

### DIFF
--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarColor.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarColor.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Field } from '@fluentui/react-field';
-import { makeStyles } from '@fluentui/react-components';
-import { ProgressBar } from '@fluentui/react-progress';
+import { ProgressBar, makeStyles } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarDefault.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Field } from '@fluentui/react-field';
-import { ProgressBar, ProgressBarProps } from '@fluentui/react-progress';
+import { ProgressBar, ProgressBarProps } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
 
 export const Default = (props: Partial<ProgressBarProps>) => {
   return (

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarIndeterminate.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarIndeterminate.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Field } from '@fluentui/react-field';
-import { ProgressBar } from '@fluentui/react-progress';
+import { ProgressBar } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
 
 export const Indeterminate = () => {
   return (

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarMax.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarMax.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Field } from '@fluentui/react-field';
-import { ProgressBar } from '@fluentui/react-progress';
+import { ProgressBar } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
 
 const intervalDelay = 100;
 const intervalIncrement = 1;

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarShape.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarShape.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Field } from '@fluentui/react-field';
-import { makeStyles, shorthands } from '@fluentui/react-components';
-import { ProgressBar } from '@fluentui/react-progress';
+import { ProgressBar, makeStyles, shorthands } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-progress/stories/ProgressBar/ProgressBarThickness.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/ProgressBarThickness.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Field } from '@fluentui/react-field';
-import { makeStyles, shorthands } from '@fluentui/react-components';
-import { ProgressBar } from '@fluentui/react-progress';
+import { ProgressBar, makeStyles, shorthands } from '@fluentui/react-components';
+import { Field } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   container: {


### PR DESCRIPTION
## Previous Behavior

ProgressBar stories import directly from individual packages: react-progress and react-field. This causes lint errors in unrelated PRs, such as https://github.com/microsoft/fluentui/pull/27492.

## New Behavior

Change ProgressBar stories to import from react-components instead of individual packages.

## Related Issue(s)

Similar fix in react-skeleton: #27498
