### PR TITLE
fix(react-skeleton): Stories should import from react-components

### DIFF
--- a/packages/react-components/react-progress/stories/ProgressBar/index.stories.tsx
+++ b/packages/react-components/react-progress/stories/ProgressBar/index.stories.tsx
@@ -1,4 +1,4 @@
-import { ProgressBar } from '@fluentui/react-progress';
+import { ProgressBar } from '@fluentui/react-components';
 
 import descriptionMd from './ProgressBarDescription.md';
 import bestPracticesMd from './ProgressBarBestPractices.md';

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAnimation.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAnimation.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-skeleton';
-import { Field } from '@fluentui/react-field';
 import { makeStyles, tokens } from '@fluentui/react-components';
+import { Field, Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   invertedWrapper: {

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAnimation.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAnimation.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { makeStyles, tokens } from '@fluentui/react-components';
-import { Field, Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-components/unstable';
+import type { SkeletonProps } from '@fluentui/react-components/unstable';
+import { Field, Skeleton, SkeletonItem } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   invertedWrapper: {

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAppearance.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAppearance.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-skeleton';
-import { Field } from '@fluentui/react-field';
 import { makeStyles, tokens } from '@fluentui/react-components';
+import { Field, Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   invertedWrapper: {

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAppearance.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonAppearance.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { makeStyles, tokens } from '@fluentui/react-components';
-import { Field, Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-components/unstable';
+import type { SkeletonProps } from '@fluentui/react-components/unstable';
+import { Field, Skeleton, SkeletonItem } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   invertedWrapper: {

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonDefault.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Skeleton, SkeletonItem } from '@fluentui/react-skeleton';
-import type { SkeletonProps } from '@fluentui/react-skeleton';
+import { Skeleton, SkeletonItem } from '@fluentui/react-components/unstable';
+import type { SkeletonProps } from '@fluentui/react-components/unstable';
 
 export const Default = (props: Partial<SkeletonProps>) => (
   <Skeleton {...props}>

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonRow.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonRow.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-skeleton';
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   invertedWrapper: {

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonRow.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonRow.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
-import { Skeleton, SkeletonItem, SkeletonProps } from '@fluentui/react-components/unstable';
+import type { SkeletonProps } from '@fluentui/react-components/unstable';
+import { Skeleton, SkeletonItem } from '@fluentui/react-components/unstable';
 
 const useStyles = makeStyles({
   invertedWrapper: {

--- a/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@fluentui/react-skeleton';
+import { Skeleton } from '@fluentui/react-components/unstable';
 
 import descriptionMd from './SkeletonDescription.md';
 import bestPracticesMd from './SkeletonBestPractices.md';


### PR DESCRIPTION
## Previous Behavior

Skeleton stories import directly from individual packages: react-skeleton and react-field.

## New Behavior

Change Skeleton stories to import from react-components instead of individual packages.

## Related Issue(s)

Similar fix in react-progress: #27497