### PR TITLE
fix website links to crossplatform that are now cross

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/ControlsPage/docs/windows/ControlsOverview.md
+++ b/apps/public-docsite/src/pages/Overviews/ControlsPage/docs/windows/ControlsOverview.md
@@ -4,4 +4,4 @@ To build Fluent experiences on Windows using WinUI controls, please see our [Win
 
 ### Fluent UI React Native
 
-To build Fluent experiences on Windows using Fluent UI React Native, please see our [Cross-platform Controls page](#/controls/crossplatform).
+To build Fluent experiences on Windows using Fluent UI React Native, please see our [Cross-platform Controls page](#/controls/cross).

--- a/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/cross/GetStartedOverview.md
+++ b/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/cross/GetStartedOverview.md
@@ -4,7 +4,7 @@ Fluent UI React Native is an [open-source](https://github.com/microsoft/fluentui
 
 Fluent UI React Native includes an expanding library of controls written in JavaScript. These controls implement the Fluent Design language and provide consistency across Microsoft experiences.
 
-Fluent UI React Native is still in the early stages of development, and currently only supports Windows and macOS components, with iOS and Android component support coming soon. Documentation for the controls is a work in progress. Some controls can be found in the <a href="#/controls/crossplatform">Controls section</a> of the site. To view the full list, see the [Fluent UI React Native Github source folder](https://github.com/microsoft/fluentui-react-native/tree/master/packages/components).
+Fluent UI React Native is still in the early stages of development, and currently only supports Windows and macOS components, with iOS and Android component support coming soon. Documentation for the controls is a work in progress. Some controls can be found in the <a href="#/controls/cross">Controls section</a> of the site. To view the full list, see the [Fluent UI React Native Github source folder](https://github.com/microsoft/fluentui-react-native/tree/master/packages/components).
 
 ### Start developing
 


### PR DESCRIPTION
we use 'cross' for the crossplatform links, not 'crossplatform'. Seems we missed that new spelling in a couple spots. I searched for all instances and only found these two. 