### PR TITLE
chore(storybook): set background for WC stories

### DIFF
--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -13,8 +13,8 @@
 
   .sbdocs-preview,
   div.docs-story {
-    background: var(--colorNeutralBackground2) !important;
-    color: var(--colorNeutralForeground2) !important;
+    background: var(--colorNeutralBackground2);
+    color: var(--colorNeutralForeground2);
   }
 
   div.docs-story > div:first-child {

--- a/packages/web-components/.storybook/preview-head.html
+++ b/packages/web-components/.storybook/preview-head.html
@@ -13,7 +13,8 @@
 
   .sbdocs-preview,
   div.docs-story {
-    background: var(--fill-color) !important;
+    background: var(--colorNeutralBackground2) !important;
+    color: var(--colorNeutralForeground2) !important;
   }
 
   div.docs-story > div:first-child {

--- a/packages/web-components/src/text/text.stories.ts
+++ b/packages/web-components/src/text/text.stories.ts
@@ -1,6 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import type { Args, Meta } from '@storybook/html';
 import { renderComponent } from '../helpers.stories.js';
+import { colorNeutralBackground6 } from '../theme/design-tokens.js';
 import type { Text as FluentText } from './text.js';
 import './define.js';
 import { TextAlign, TextFont, TextSize, TextWeight } from './text.options.js';
@@ -159,9 +160,13 @@ export const Strikethrough = renderComponent(html<TextStoryArgs>`
 
 export const Block = renderComponent(html<TextStoryArgs>`
   <span>
-    <fluent-text style="background: #ddd"><span>Fluent text is inline by default. Setting</span></fluent-text>
-    <fluent-text style="background: #ddd" block><span>block</span></fluent-text>
-    <fluent-text style="background: #ddd"><span>will make it behave as a block element.</span></fluent-text>
+    <fluent-text style="background: ${colorNeutralBackground6}"
+      ><span>Fluent text is inline by default. Setting</span></fluent-text
+    >
+    <fluent-text style="background: ${colorNeutralBackground6}" block><span>block</span></fluent-text>
+    <fluent-text style="background: ${colorNeutralBackground6}"
+      ><span>will make it behave as a block element.</span></fluent-text
+    >
   </span>
 `);
 


### PR DESCRIPTION
## Previous Behavior

There is no background set for stories.

It is not obvious for a component whether is uses white or transparent background:
![image](https://user-images.githubusercontent.com/9615899/230969674-691ca987-da2f-4263-8d89-d316907a6948.png)

Stories in dark theme are broken:
![image](https://user-images.githubusercontent.com/9615899/230969735-234a0454-bc1b-443a-8208-a29a5db3215d.png)

## New Behavior

The stories now use `colorNeutralBackground2`, the same as FUIR9 stories.

The difference between white and transparent is visible:
![image](https://user-images.githubusercontent.com/9615899/230969841-1d9c87fb-497f-4198-8a8f-603bb5f205a0.png)

Dark theme works:
![image](https://user-images.githubusercontent.com/9615899/230969916-f4beecee-667f-43c6-b003-a50f8d605ccf.png)
