### PR TITLE
Add export for FolderCover.scss

### DIFF
--- a/change/@fluentui-react-experiments-cedaca06-5cf3-4161-9c45-b13850f8a5cd.json
+++ b/change/@fluentui-react-experiments-cedaca06-5cf3-4161-9c45-b13850f8a5cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add export for FolderCover.scss",
+  "packageName": "@fluentui/react-experiments",
+  "email": "jaschieb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/package.json
+++ b/packages/react-experiments/package.json
@@ -112,6 +112,11 @@
       "import": "./lib/FolderCover.js",
       "require": "./lib-commonjs/FolderCover.js"
     },
+    "./lib/components/FolderCover/FolderCover.scss": {
+      "types": "./lib/components/FolderCover/FolderCover.scss.d.ts",
+      "import": "./lib/components/FolderCover/FolderCover.scss.js",
+      "require": "./lib-commonjs/components/FolderCover/FolderCover.scss.js"
+    },
     "./lib/Foundation": {
       "types": "./lib/Foundation.d.ts",
       "import": "./lib/Foundation.js",


### PR DESCRIPTION
Adds export for `FolderCover.scss`. Similar export updates have been done in the past, ex: to Signals.scss: https://github.com/microsoft/fluentui/commit/aa4de2b58ad22f0f093e52343380b9fc37325b21

The OneDrive web team is working on a new experimental feature which requires us to create our own `FolderCover` component, adding an export for `FolderCover.scss` in react-experiments package so that we can re-use it 1-1 in our local version.