### PR TITLE
fix(hooks): cleanup event listeners only when "disabled" is false

### DIFF
--- a/change/@fluentui-react-utilities-b6365940-5030-4940-81cd-01dbfdf2964b.json
+++ b/change/@fluentui-react-utilities-b6365940-5030-4940-81cd-01dbfdf2964b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(hooks): cleanup event listeners only when \"disabled\" is false",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -33,7 +33,7 @@ describe('useOnClickOutside', () => {
     expect(element.removeEventListener).toHaveBeenCalledWith(event, expect.anything(), true);
   });
 
-  it('should not add event listeners when disabled', () => {
+  it('should not add or remove event listeners when disabled', () => {
     // Arrange
     const element = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as Document;
 
@@ -42,6 +42,7 @@ describe('useOnClickOutside', () => {
 
     // Assert
     expect(element.addEventListener).toHaveBeenCalledTimes(0);
+    expect(element.removeEventListener).toHaveBeenCalledTimes(0);
   });
 
   it('should invoke callback when active element is an iframe', () => {

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
@@ -16,7 +16,8 @@ export type UseOnClickOrScrollOutsideOptions = {
 
   /**
    * By default uses element.contains, but custom contain function can be provided
-   * @param parentRef - provided parent ref
+   *
+   * @param parent - provided parent element
    * @param child - event target element
    */
   contains?(parent: HTMLElement | null, child: HTMLElement): boolean;
@@ -52,6 +53,10 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
   });
 
   React.useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
     // Store the current event to avoid triggering handlers immediately
     // Note this depends on a deprecated but extremely well supported quirk of the web platform
     // https://github.com/facebook/react/issues/20074
@@ -67,12 +72,10 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
       listener(event);
     };
 
-    if (!disabled) {
-      // use capture phase because React can update DOM before the event bubbles to the document
-      element?.addEventListener('click', conditionalHandler, true);
-      element?.addEventListener('touchstart', conditionalHandler, true);
-      element?.addEventListener('contextmenu', conditionalHandler, true);
-    }
+    // use capture phase because React can update DOM before the event bubbles to the document
+    element?.addEventListener('click', conditionalHandler, true);
+    element?.addEventListener('touchstart', conditionalHandler, true);
+    element?.addEventListener('contextmenu', conditionalHandler, true);
 
     // Garbage collect this event after it's no longer useful to avoid memory leaks
     timeoutId.current = window.setTimeout(() => {
@@ -145,25 +148,32 @@ const useIFrameFocus = (options: UseIFrameFocusOptions) => {
 
   // Adds listener to the custom iframe focus event
   React.useEffect(() => {
-    if (!disabled) {
-      targetDocument?.addEventListener(FUI_FRAME_EVENT, listener, true);
-      return () => {
-        targetDocument?.removeEventListener(FUI_FRAME_EVENT, listener, true);
-      };
+    if (disabled) {
+      return;
     }
+
+    targetDocument?.addEventListener(FUI_FRAME_EVENT, listener, true);
+
+    return () => {
+      targetDocument?.removeEventListener(FUI_FRAME_EVENT, listener, true);
+    };
   }, [targetDocument, disabled, listener]);
 
   // Starts polling for the active element
   React.useEffect(() => {
-    if (!disabled) {
-      timeoutRef.current = targetDocument?.defaultView?.setInterval(() => {
-        const activeElement = targetDocument?.activeElement;
-        if (activeElement?.tagName === 'IFRAME' || activeElement?.tagName === 'WEBVIEW') {
-          const event = new CustomEvent(FUI_FRAME_EVENT, { bubbles: true });
-          activeElement.dispatchEvent(event);
-        }
-      }, pollDuration);
+    if (disabled) {
+      return;
     }
+
+    timeoutRef.current = targetDocument?.defaultView?.setInterval(() => {
+      const activeElement = targetDocument?.activeElement;
+
+      if (activeElement?.tagName === 'IFRAME' || activeElement?.tagName === 'WEBVIEW') {
+        const event = new CustomEvent(FUI_FRAME_EVENT, { bubbles: true });
+        activeElement.dispatchEvent(event);
+      }
+    }, pollDuration);
+
     return () => {
       targetDocument?.defaultView?.clearTimeout(timeoutRef.current);
     };

--- a/packages/react-components/react-utilities/src/hooks/useOnScrollOutside.test.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnScrollOutside.test.ts
@@ -29,14 +29,18 @@ describe('useOnScrollOutside', () => {
     expect(element.removeEventListener).toHaveBeenCalledWith(event, expect.anything());
   });
 
-  it('should not add event listeners when disabled', () => {
+  it('should not add or remove event listeners when disabled', () => {
     // Arrange
     const element = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as Document;
 
     // Act
-    renderHook(() => useOnScrollOutside({ disabled: true, element, callback: jest.fn(), refs: [] }));
+    const { unmount } = renderHook(() =>
+      useOnScrollOutside({ disabled: true, element, callback: jest.fn(), refs: [] }),
+    );
+    unmount();
 
     // Assert
     expect(element.addEventListener).toHaveBeenCalledTimes(0);
+    expect(element.removeEventListener).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/react-components/react-utilities/src/hooks/useOnScrollOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnScrollOutside.ts
@@ -20,10 +20,12 @@ export const useOnScrollOutside = (options: UseOnClickOrScrollOutsideOptions) =>
   });
 
   React.useEffect(() => {
-    if (!disabled) {
-      element?.addEventListener('wheel', listener);
-      element?.addEventListener('touchmove', listener);
+    if (disabled) {
+      return;
     }
+
+    element?.addEventListener('wheel', listener);
+    element?.addEventListener('touchmove', listener);
 
     return () => {
       element?.removeEventListener('wheel', listener);


### PR DESCRIPTION
## Previous Behavior

We cleanup listeners and timeouts always.

```
> Mount Popover
> useEffect() [open: false] ➡️ skip addEventListener
> unmount()
> useEffect() [open: false] ➡️ do removeEventListener
>               👆 what?!
```

## New Behavior

We will cleanup listeners and timeouts only when it's needed.

```
> Mount Popover
> useEffect() [open: false] ➡️ skip addEventListener
> unmount()
> useEffect() [open: false] ➡️ skip removeEventListener
>               ✅
```
