### PR TITLE
feat(react-datepicker-compat): Make package public

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -22,7 +22,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-datepicker-compat": "0.0.0-alpha.0",
+    "@fluentui/react-datepicker-compat": "0.0.0-beta.0",
     "@fluentui/react-migration-v8-v9": "^9.2.7",
     "@fluentui/react-migration-v0-v9": "9.0.0-alpha.0",
     "@fluentui/react": "^8.107.4",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -27,7 +27,7 @@
     "@fluentui/react-card": "^9.0.5",
     "@fluentui/react-checkbox": "^9.1.8",
     "@fluentui/react-combobox": "^9.2.8",
-    "@fluentui/react-datepicker-compat": "0.0.0-alpha.0",
+    "@fluentui/react-datepicker-compat": "0.0.0-beta.0",
     "@fluentui/react-dialog": "^9.5.0",
     "@fluentui/react-divider": "^9.2.7",
     "@fluentui/react-field": "9.0.0-beta.1",

--- a/change/@fluentui-react-datepicker-compat-dad5035c-25c8-4eac-b53a-e758b3850e69.json
+++ b/change/@fluentui-react-datepicker-compat-dad5035c-25c8-4eac-b53a-e758b3850e69.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Make package public.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/package.json
+++ b/packages/react-components/react-datepicker-compat/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-datepicker-compat",
-  "version": "0.0.0-alpha.0",
-  "private": true,
+  "version": "0.0.0-beta.0",
   "description": "React components for building web experiences",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
This PR makes `react-datepicker-compat` public for people interested in using the preview version. Note that `0.0.0-beta.0` is used since this is a compat package.

