### PR TITLE
fix: BasePickerListBelow aria-describedby with values

### DIFF
--- a/change/@fluentui-react-cc684d1e-b561-490a-a648-47ece08bdc45.json
+++ b/change/@fluentui-react-cc684d1e-b561-490a-a648-47ece08bdc45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: the BasePicker with List Below variant now sets aria-describedby pointing to selected values",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -1113,6 +1113,9 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
       <div ref={this.root} onBlur={this.onBlur} onFocus={this.onFocus}>
         <div className={classNames.root} onKeyDown={this.onKeyDown}>
           {this.renderCustomAlert(classNames.screenReaderText)}
+          <span id={`${this._ariaMap.selectedItems}-label`} hidden>
+            {selectionAriaLabel || comboLabel}
+          </span>
           <div className={classNames.text} aria-owns={suggestionsAvailable}>
             <Autofill
               {...(inputProps as any)}
@@ -1128,6 +1131,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
               aria-expanded={suggestionsVisible}
               aria-haspopup="listbox"
               aria-label={comboLabel}
+              aria-describedby={this.state.items.length > 0 ? this._ariaMap.selectedItems : undefined}
               role="combobox"
               id={inputProps?.id ? inputProps.id : this._ariaMap.combobox}
               disabled={disabled}
@@ -1141,7 +1145,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
             id={this._ariaMap.selectedItems}
             className="ms-BasePicker-selectedItems" // just a className hook without any styles applied to it.
             role={selectionRole}
-            aria-label={selectionAriaLabel || comboLabel}
+            aria-labelledby={`${this._ariaMap.selectedItems}-label`}
           >
             {this.renderItems()}
           </div>


### PR DESCRIPTION
## Previous Behavior

The Picker input does not include selected items in its name or description in the ListBelow variant. This was fixed for the regular BasePicker as part of #17723.

## New Behavior

The ListBelow variant now uses the same `aria-describedby` approach as the regular BasePicker.

## Related Issue(s)

- Fixes [16181](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16181)
