### PR TITLE
init take on fixing outlined toggle button

### DIFF
--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.ts
@@ -136,7 +136,7 @@ const useRootStyles = makeStyles({
   // Appearance variations
   outline: {
     backgroundColor: tokens.colorTransparentBackground,
-
+    transitionProperty: 'background, color',
     ':hover': {
       backgroundColor: tokens.colorTransparentBackgroundHover,
     },

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.ts
@@ -73,6 +73,7 @@ const useRootCheckedStyles = makeStyles({
     backgroundColor: tokens.colorTransparentBackgroundSelected,
     ...shorthands.borderColor(tokens.colorNeutralStroke1),
     ...shorthands.borderWidth(tokens.strokeWidthThicker),
+    ...shorthands.padding('3px', '10px'),
 
     ':hover': {
       backgroundColor: tokens.colorTransparentBackgroundHover,


### PR DESCRIPTION
![button-test](https://user-images.githubusercontent.com/1434956/231315599-7c3541ff-fd7e-4745-bd97-4f2ee96a4ed5.gif)

reducing padding to match the additional border width (this could be cleaned up with reference to tokens)

removed the border animation for outline buttons because it caused jumps in UI even if you also animated the padding (subpixel rendering type issues)