### PR TITLE
fix: v8 Picker had incorrect element selector when setting focus

### DIFF
--- a/change/@fluentui-react-a7b86699-056a-47f4-bd3e-f194277114b8.json
+++ b/change/@fluentui-react-a7b86699-056a-47f4-bd3e-f194277114b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: BasePicker selects correct focus target in selected items",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/react/src/components/pickers/BasePicker.test.tsx
@@ -586,9 +586,9 @@ describe('BasePicker', () => {
     document.body.appendChild(root);
 
     const onRenderFocusableItem = (props: IPickerItemProps<ISimple>): JSX.Element => (
-      <button key={props.item.name} data-selection-index={props.index}>
-        {basicRenderer(props)}
-      </button>
+      <div key={props.item.name} data-selection-index={props.index}>
+        <button>{basicRenderer(props)}</button>
+      </div>
     );
     ReactDOM.render(
       <BasePickerWithType
@@ -609,7 +609,7 @@ describe('BasePicker', () => {
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     ReactTestUtils.Simulate.click(suggestionOptions[0]);
 
-    const selectedItem = document.querySelector('button[data-selection-index]');
+    const selectedItem = document.querySelector('[data-selection-index] > button');
 
     expect(document.activeElement).toBe(selectedItem);
   });
@@ -620,9 +620,9 @@ describe('BasePicker', () => {
 
     const onRenderFocusableItem = (props: IPickerItemProps<ISimple>): JSX.Element => {
       return (
-        <button key={props.item.name} onClick={props.onRemoveItem} data-selection-index={props.index}>
-          {basicRenderer(props)}
-        </button>
+        <div key={props.item.name} data-selection-index={props.index}>
+          <button onClick={props.onRemoveItem}>{basicRenderer(props)}</button>
+        </div>
       );
     };
     ReactDOM.render(
@@ -638,7 +638,7 @@ describe('BasePicker', () => {
       root,
     );
 
-    const selectedEls = document.querySelectorAll('button[data-selection-index]');
+    const selectedEls = document.querySelectorAll('[data-selection-index] > button');
     (selectedEls[0] as HTMLButtonElement).focus();
     ReactTestUtils.Simulate.click(selectedEls[0]);
 

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -405,7 +405,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
   protected resetFocus(index?: number) {
     const { items } = this.state;
 
-    if (items.length && index! >= 0) {
+    if (items.length) {
+      // default to focusing the last item
+      index = index ?? items.length - 1;
       const newEl: HTMLElement | null =
         this.root.current &&
         (this.root.current.querySelectorAll('[data-selection-index] > button')[
@@ -414,8 +416,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
       if (newEl) {
         newEl.focus();
       }
-    } else if (items.length && !this.canAddItems()) {
-      this.resetFocus(items.length - 1);
     } else {
       if (this.input.current) {
         this.input.current.focus();

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -408,7 +408,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
     if (items.length && index! >= 0) {
       const newEl: HTMLElement | null =
         this.root.current &&
-        (this.root.current.querySelectorAll('[data-selection-index]')[
+        (this.root.current.querySelectorAll('[data-selection-index] > button')[
           Math.min(index!, items.length - 1)
         ] as HTMLElement | null);
       if (newEl) {


### PR DESCRIPTION
## Previous Behavior

BasePicker attempted to set focus to an unfocusable `<div>` when managing focus in selected tags. This stemmed from earlier changes to make the interactive element within tags the remove button.

## New Behavior

Updated the focus selector to point to the inner button, now focus is correctly set when a tag is removed.

## Related Issue(s)

- Fixes [16207](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16207)
