### PR TITLE
chore(react-dialog): hoist tabster modal attributes to Dialog component

### DIFF
--- a/change/@fluentui-react-dialog-ca83b070-5c3c-4820-932f-b8f686d14b66.json
+++ b/change/@fluentui-react-dialog-ca83b070-5c3c-4820-932f-b8f686d14b66.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: hoist tabster modal attributes to Dialog component",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -17,6 +17,7 @@ import { ReactElement } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
+import { useModalAttributes } from '@fluentui/react-tabster';
 
 // @public
 export const Dialog: React_2.FC<DialogProps>;

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -451,6 +451,37 @@ describe('Dialog', () => {
       cy.get(dialogTriggerOpenSelector).realClick();
       cy.get('body').should('not.have.css', 'overflow', 'hidden');
     });
+    it('should be able to focus inside non-modal dialog after navigating outside', () => {
+      mount(
+        <>
+          <Dialog modalType="non-modal">
+            <DialogTrigger disableButtonEnhancement>
+              <Button id={dialogTriggerOpenId}>Open dialog</Button>
+            </DialogTrigger>
+            <DialogSurface>
+              <DialogBody>
+                <DialogActions>
+                  <DialogTrigger disableButtonEnhancement>
+                    <Button id={dialogTriggerCloseId} appearance="secondary">
+                      Close
+                    </Button>
+                  </DialogTrigger>
+                  <Button id="extra-btn-inside" appearance="primary">
+                    Do Something
+                  </Button>
+                </DialogActions>
+              </DialogBody>
+            </DialogSurface>
+          </Dialog>
+          <Button id="extra-btn-outside">Button outside dialog</Button>
+        </>,
+      );
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogTriggerCloseSelector).should('be.focused');
+      cy.get('#extra-btn-outside').realClick().should('be.focused');
+      cy.get('#extra-btn-inside').realClick().should('be.focused').realType('{esc}');
+      cy.get(dialogSurfaceSelector).should('not.exist');
+    });
   });
   describe('modalType = alert', () => {
     it('should not close with escape keydown', () => {

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -5,6 +5,7 @@ import { useDisableBodyScroll, useFocusFirstElement } from '../../utils';
 import { DialogContext } from '../../contexts';
 
 import type { DialogOpenChangeData, DialogProps, DialogState } from './Dialog.types';
+import { useModalAttributes } from '@fluentui/react-tabster';
 
 /**
  * Create the state required to render Dialog.
@@ -45,6 +46,11 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     }
   }, [disableBodyScroll, isBodyScrollLocked]);
 
+  const { modalAttributes, triggerAttributes } = useModalAttributes({
+    trapFocus: modalType !== 'non-modal',
+    legacyTrapFocus: !inertTrapFocus,
+  });
+
   return {
     components: {
       backdrop: 'div',
@@ -58,6 +64,8 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     dialogTitleId: useId('dialog-title-'),
     isNestedDialog: useHasParentContext(DialogContext),
     dialogRef: focusRef,
+    modalAttributes: modalType !== 'non-modal' ? modalAttributes : undefined,
+    triggerAttributes,
   };
 };
 

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialogContextValues.ts
@@ -2,7 +2,17 @@ import type { DialogContextValue, DialogSurfaceContextValue } from '../../contex
 import type { DialogContextValues, DialogState } from './Dialog.types';
 
 export function useDialogContextValues_unstable(state: DialogState): DialogContextValues {
-  const { modalType, open, dialogRef, dialogTitleId, isNestedDialog, inertTrapFocus, requestOpenChange } = state;
+  const {
+    modalType,
+    open,
+    dialogRef,
+    dialogTitleId,
+    isNestedDialog,
+    inertTrapFocus,
+    requestOpenChange,
+    modalAttributes,
+    triggerAttributes,
+  } = state;
 
   /**
    * This context is created with "@fluentui/react-context-selector",
@@ -15,6 +25,8 @@ export function useDialogContextValues_unstable(state: DialogState): DialogConte
     dialogTitleId,
     isNestedDialog,
     inertTrapFocus,
+    modalAttributes,
+    triggerAttributes,
     requestOpenChange,
   };
 

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -9,7 +9,6 @@ import {
 import type { DialogSurfaceElement, DialogSurfaceProps, DialogSurfaceState } from './DialogSurface.types';
 import { useDialogContext_unstable } from '../../contexts';
 import { isEscapeKeyDismiss } from '../../utils';
-import { useModalAttributes } from '@fluentui/react-tabster';
 
 /**
  * Create the state required to render DialogSurface.
@@ -26,7 +25,7 @@ export const useDialogSurface_unstable = (
 ): DialogSurfaceState => {
   const { backdrop, as } = props;
   const modalType = useDialogContext_unstable(ctx => ctx.modalType);
-  const inertTrapFocus = useDialogContext_unstable(ctx => ctx.inertTrapFocus);
+  const modalAttributes = useDialogContext_unstable(ctx => ctx.modalAttributes);
   const dialogRef = useDialogContext_unstable(ctx => ctx.dialogRef);
   const open = useDialogContext_unstable(ctx => ctx.open);
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
@@ -58,11 +57,6 @@ export const useDialogSurface_unstable = (
       // e,g: nested Dialog, Popover, Menu and Tooltip
       event.stopPropagation();
     }
-  });
-
-  const { modalAttributes } = useModalAttributes({
-    trapFocus: modalType !== 'non-modal',
-    legacyTrapFocus: !inertTrapFocus,
   });
 
   return {

--- a/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTrigger/useDialogTrigger.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useModalAttributes } from '@fluentui/react-tabster';
 import { applyTriggerPropsToChildren, getTriggerChild, useEventCallback } from '@fluentui/react-utilities';
 import type { DialogTriggerProps, DialogTriggerState } from './DialogTrigger.types';
 import { useDialogContext_unstable, useDialogSurfaceContext_unstable } from '../../contexts';
@@ -19,8 +18,7 @@ export const useDialogTrigger_unstable = (props: DialogTriggerProps): DialogTrig
   const child = getTriggerChild(children);
 
   const requestOpenChange = useDialogContext_unstable(ctx => ctx.requestOpenChange);
-
-  const { triggerAttributes } = useModalAttributes();
+  const triggerAttributes = useDialogContext_unstable(ctx => ctx.triggerAttributes);
 
   const handleClick = useEventCallback(
     (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {

--- a/packages/react-components/react-dialog/src/contexts/dialogContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogContext.ts
@@ -3,6 +3,7 @@ import { createContext, ContextSelector, useContextSelector } from '@fluentui/re
 import { DialogSurfaceElement } from '../DialogSurface';
 import type { Context } from '@fluentui/react-context-selector';
 import type { DialogModalType, DialogOpenChangeData } from '../Dialog';
+import { useModalAttributes } from '@fluentui/react-tabster';
 
 export type DialogContextValue = {
   open: boolean;
@@ -15,7 +16,7 @@ export type DialogContextValue = {
    * Requests dialog main component to update it's internal open state
    */
   requestOpenChange: (data: DialogOpenChangeData) => void;
-};
+} & Partial<ReturnType<typeof useModalAttributes>>;
 
 const defaultContextValue: DialogContextValue = {
   open: false,

--- a/packages/react-components/react-dialog/src/testing/mockUseDialogContext.ts
+++ b/packages/react-components/react-dialog/src/testing/mockUseDialogContext.ts
@@ -16,6 +16,8 @@ export const mockUseDialogContext = (options: Partial<DialogContextValue> = {}) 
     requestOpenChange() {
       /* noop */
     },
+    modalAttributes: undefined,
+    triggerAttributes: { 'data-tabster': '{"deloser":{}}' },
     ...options,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. hoists tabster `useModalAttributes` invocation from `DialogSurface` and `DialogTrigger` to `Dialog` itself to ensure race conditions
2. stops spreading of tabster modal attributes on `non-modal` dialogs
3. adds test to ensure no regressions for https://github.com/microsoft/fluentui/issues/27468

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27468
