### PR TITLE
chore(react-alert): adopt custom JSX pragma

### DIFF
--- a/change/@fluentui-react-alert-935473ef-6eda-4240-b022-e82946cafdee.json
+++ b/change/@fluentui-react-alert-935473ef-6eda-4240-b022-e82946cafdee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: adopt custom JSX pragma",
+  "packageName": "@fluentui/react-alert",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -38,6 +38,7 @@
     "@fluentui/react-tabster": "^9.6.4",
     "@fluentui/react-theme": "^9.1.7",
     "@fluentui/react-utilities": "^9.7.4",
+    "@fluentui/react-jsx-runtime": "^9.0.0-alpha.0",
     "@griffel/react": "^1.5.2",
     "@swc/helpers": "^0.4.14"
   },

--- a/packages/react-components/react-alert/src/components/Alert/renderAlert.tsx
+++ b/packages/react-components/react-alert/src/components/Alert/renderAlert.tsx
@@ -1,11 +1,13 @@
-import * as React from 'react';
+/** @jsxRuntime classic */
+/** @jsx createElement */
 
-import { getSlots } from '@fluentui/react-utilities';
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { getSlotsNext } from '@fluentui/react-utilities';
 
 import type { AlertState, AlertSlots } from './Alert.types';
 
 export const renderAlert_unstable = (state: AlertState) => {
-  const { slots, slotProps } = getSlots<AlertSlots>(state);
+  const { slots, slotProps } = getSlotsNext<AlertSlots>(state);
 
   return (
     <slots.root {...slotProps.root}>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. Adopts `react-jsx-runtime` custom pragma on `react-alert`
2. adds `resolveShorthand` to all slots (some `root` slots were missing it)


