### PR TITLE
chore(react-migration-v0-v9): adopt custom JSX pragma

### DIFF
--- a/packages/react-components/react-migration-v0-v9/package.json
+++ b/packages/react-components/react-migration-v0-v9/package.json
@@ -36,6 +36,7 @@
     "@fluentui/react-icons": "^2.0.196",
     "@fluentui/react-theme": "^9.1.7",
     "@fluentui/react-utilities": "^9.8.0",
+    "@fluentui/react-jsx-runtime": "9.0.0-alpha.1",
     "@griffel/react": "^1.5.2",
     "@fluentui/react-components": "^9.19.0",
     "@fluentui/react-northstar": "^0.66.4",

--- a/packages/react-components/react-migration-v0-v9/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/react-components/react-migration-v0-v9/src/components/ItemLayout/ItemLayout.tsx
@@ -1,10 +1,14 @@
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
 import * as React from 'react';
 import { mergeClasses } from '@fluentui/react-components';
 import {
   ComponentProps,
   ComponentState,
   getNativeElementProps,
-  getSlots,
+  getSlotsNext,
   Slot,
   resolveShorthand,
 } from '@fluentui/react-utilities';
@@ -78,7 +82,7 @@ export const ItemLayout = React.forwardRef<HTMLDivElement, ItemLayoutProps>((pro
     state.endMedia.className = mergeClasses(styles.endMedia, state.endMedia.className);
   }
 
-  const { slots, slotProps } = getSlots<ItemLayoutSlots>(state);
+  const { slots, slotProps } = getSlotsNext<ItemLayoutSlots>(state);
 
   return (
     <slots.root {...slotProps.root}>


### PR DESCRIPTION
## New Behavior

1. Adopts `react-jsx-runtime` custom pragma on `react-migration-v0-v9`