### PR TITLE
bugfix(react-dialog): `DialogTitle` root as `h2` by default

### DIFF
--- a/change/@fluentui-react-dialog-4035cb74-88c2-4411-b3ac-9e1e049e2d69.json
+++ b/change/@fluentui-react-dialog-4035cb74-88c2-4411-b3ac-9e1e049e2d69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: DialogTitle root as h2 by default",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -150,7 +150,7 @@ export type DialogTitleProps = ComponentProps<DialogTitleSlots>;
 
 // @public (undocumented)
 export type DialogTitleSlots = {
-    root: Slot<'div', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>;
+    root: Slot<'h2', 'h1' | 'h3' | 'h4' | 'h5' | 'h6' | 'div'>;
     action?: Slot<'div'>;
 };
 

--- a/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.types.ts
@@ -2,7 +2,8 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 
 export type DialogTitleSlots = {
   /**
-   * By default this is a h2, but can be any heading or div
+   * By default this is a h2, but can be any heading or div,
+   * if `div` is provided do not forget to also provide proper `role="heading"` and `aria-level` attributes
    */
   root: Slot<'h2', 'h1' | 'h3' | 'h4' | 'h5' | 'h6' | 'div'>;
   /**

--- a/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.types.ts
@@ -2,9 +2,9 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 
 export type DialogTitleSlots = {
   /**
-   * By default this is a div, but can be a heading.
+   * By default this is a h2, but can be any heading or div
    */
-  root: Slot<'div', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>;
+  root: Slot<'h2', 'h1' | 'h3' | 'h4' | 'h5' | 'h6' | 'div'>;
   /**
    * By default a Dialog with modalType='non-modal' will have a close button action
    */

--- a/packages/react-components/react-dialog/src/components/DialogTitle/__snapshots__/DialogTitle.test.tsx.snap
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/__snapshots__/DialogTitle.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`DialogTitle renders a default state 1`] = `
 <div>
-  <div
+  <h2
     class="fui-DialogTitle"
   >
     Default DialogTitle
-  </div>
+  </h2>
 </div>
 `;

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -23,10 +23,10 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
 
   return {
     components: {
-      root: 'div',
+      root: 'h2',
       action: 'div',
     },
-    root: getNativeElementProps(as ?? 'div', {
+    root: getNativeElementProps(as ?? 'h2', {
       ref,
       id: useDialogContext_unstable(ctx => ctx.dialogTitleId),
       ...props,

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitleStyles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitleStyles.ts
@@ -17,6 +17,7 @@ const useStyles = makeStyles({
   root: {
     ...typographyStyles.subtitle1,
     ...shorthands.gridArea(TITLE_GRID_AREA),
+    ...shorthands.margin(0),
   },
   rootWithoutCloseButton: {
     ...shorthands.gridArea(TITLE_GRID_AREA, TITLE_GRID_AREA, TITLE_ACTION_GRID_AREA, TITLE_ACTION_GRID_AREA),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`DialogTitle` root element was a `div` by default. This conflicts with design spec.

## New Behavior

1. default `DialogTitle` root element as `h2`
2. add styles to ensure no visual regressions
