### PR TITLE
fix(Callout): Update useMaxHeight to check if the provided maxHeight is larger than the bounds

### DIFF
--- a/change/@fluentui-react-5d4582c1-8b8f-41aa-8f38-13a0481fda22.json
+++ b/change/@fluentui-react-5d4582c1-8b8f-41aa-8f38-13a0481fda22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Callout): Update useMaxHeight to check if the provided maxHeight will make the callout get cut off.",
+  "packageName": "@fluentui/react",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -124,15 +124,19 @@ function useMaxHeight(
 
   React.useEffect(() => {
     const { top: topBounds, bottom: bottomBounds } = getBounds() ?? {};
+    let calculatedHeight: number | undefined;
 
-    // When the calloutMaxHeight is greater than the bottomBounds, we should calculate the max height as if it wasn't
-    // provided to avoid cutting off the callout.
-    if ((!calloutMaxHeight && !hidden) || (calloutMaxHeight && bottomBounds && calloutMaxHeight > bottomBounds)) {
-      if (typeof top === 'number' && bottomBounds) {
-        setMaxHeight(bottomBounds - top);
-      } else if (typeof bottom === 'number' && typeof topBounds === 'number' && bottomBounds) {
-        setMaxHeight(bottomBounds - topBounds - bottom);
-      }
+    if (typeof top === 'number' && bottomBounds) {
+      calculatedHeight = bottomBounds - top;
+    } else if (typeof bottom === 'number' && typeof topBounds === 'number' && bottomBounds) {
+      calculatedHeight = bottomBounds - topBounds - bottom;
+    }
+
+    if (
+      (!calloutMaxHeight && !hidden) ||
+      (calloutMaxHeight && calculatedHeight && calloutMaxHeight > calculatedHeight)
+    ) {
+      setMaxHeight(calculatedHeight);
     } else if (calloutMaxHeight) {
       setMaxHeight(calloutMaxHeight);
     } else {

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -125,7 +125,9 @@ function useMaxHeight(
   React.useEffect(() => {
     const { top: topBounds, bottom: bottomBounds } = getBounds() ?? {};
 
-    if (!calloutMaxHeight && !hidden) {
+    // When the calloutMaxHeight is greater than the bottomBounds, we should calculate the max height as if it wasn't
+    // provided to avoid cutting off the callout.
+    if ((!calloutMaxHeight && !hidden) || (calloutMaxHeight && bottomBounds && calloutMaxHeight > bottomBounds)) {
       if (typeof top === 'number' && bottomBounds) {
         setMaxHeight(bottomBounds - top);
       } else if (typeof bottom === 'number' && typeof topBounds === 'number' && bottomBounds) {
@@ -476,7 +478,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
     const classNames = getClassNames(styles!, {
       theme: props.theme!,
       className,
-      overflowYHidden: overflowYHidden,
+      overflowYHidden,
       calloutWidth,
       positions,
       beakWidth,

--- a/packages/react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/react/src/components/Callout/CalloutContent.styles.ts
@@ -77,7 +77,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
       },
       getBeakStyle(beakWidth),
       backgroundColor && {
-        backgroundColor: backgroundColor,
+        backgroundColor,
       },
     ],
     beakCurtain: [
@@ -106,7 +106,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
         overflowY: 'hidden',
       },
       backgroundColor && {
-        backgroundColor: backgroundColor,
+        backgroundColor,
       },
     ],
   };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`useMaxHeight` wouldn't check if the provided height is larger than the current bounds causing the callout to be cut off.

![image](https://user-images.githubusercontent.com/5953191/231847153-403207c3-3437-4f65-8d19-08f17f2554d2.png)


## New Behavior

`useMaxHeight` now checks if the provided maxHeight is larger than the bounds and if so, calculates the correct maxHeight.

![image](https://user-images.githubusercontent.com/5953191/231847426-8690d6c8-1be0-4959-a1fe-4be38dd241b2.png)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #26966
