### PR TITLE
chore: temporarily remove Field's InfoLabel story until render functions are fixed

### DIFF
--- a/packages/react-components/react-field/stories/Field/index.stories.tsx
+++ b/packages/react-components/react-field/stories/Field/index.stories.tsx
@@ -5,7 +5,8 @@ import { Field } from '@fluentui/react-components';
 export { Default } from './FieldDefault.stories';
 export { Horizontal } from './FieldHorizontal.stories';
 export { Required } from './FieldRequired.stories';
-export { Info } from './FieldInfo.stories';
+// TODO restore Info story once render functions are fixed (https://github.com/microsoft/fluentui/issues/27559)
+// export { Info } from './FieldInfo.stories';
 export { Disabled } from './FieldDisabled.stories';
 export { Size } from './FieldSize.stories';
 export { ValidationMessage } from './FieldValidationMessage.stories';


### PR DESCRIPTION
## New Behavior

Slot render functions are currently broken, and https://github.com/microsoft/fluentui/issues/27559 tracks their fix.
This PR temporarily removes a Field story that relies on render functions.

## Related Issue(s)

- #27559 
