### PR TITLE
fix: Fix slot render functions

### DIFF
--- a/change/@fluentui-react-utilities-1e1f8bd6-b059-4823-9a8d-f58d44482c6e.json
+++ b/change/@fluentui-react-utilities-1e1f8bd6-b059-4823-9a8d-f58d44482c6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fix slot render functions",
+  "packageName": "@fluentui/react-utilities",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -78,10 +78,10 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
 
   const {
     children,
-    [SLOT_RENDER_FUNCTION_SYMBOL]: renderOrChildren = children,
     as: asProp,
+    [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
     ...rest
-  } = props as typeof props & { [SLOT_RENDER_FUNCTION_SYMBOL]: SlotRenderFunction<R[K]> };
+  } = props as typeof props & { [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<R[K]> };
 
   const slot = (
     state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
@@ -89,8 +89,8 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
       : state.components[slotName]
   ) as React.ElementType<R[K]>;
 
-  if (typeof renderOrChildren === 'function') {
-    const render = renderOrChildren as SlotRenderFunction<R[K]>;
+  if (renderFunction || typeof children === 'function') {
+    const render = renderFunction || (children as SlotRenderFunction<R[K]>);
     return [
       React.Fragment,
       {

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { omit } from '../utils/omit';
+import { SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 import type {
   AsIntrinsicElement,
   ComponentState,
@@ -75,7 +76,12 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
     return [null, undefined as R[K]];
   }
 
-  const { children, as: asProp, ...rest } = props;
+  const {
+    children,
+    [SLOT_RENDER_FUNCTION_SYMBOL]: renderOrChildren = children,
+    as: asProp,
+    ...rest
+  } = props as typeof props & { [SLOT_RENDER_FUNCTION_SYMBOL]: SlotRenderFunction<R[K]> };
 
   const slot = (
     state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
@@ -83,8 +89,8 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
       : state.components[slotName]
   ) as React.ElementType<R[K]>;
 
-  if (typeof children === 'function') {
-    const render = children as SlotRenderFunction<R[K]>;
+  if (typeof renderOrChildren === 'function') {
+    const render = renderOrChildren as SlotRenderFunction<R[K]>;
     return [
       React.Fragment,
       {


### PR DESCRIPTION
## Previous Behavior

Slot render functions don't work. This was caused by the change to `resolveShorthand` in #27472. It now sets the render function on `SLOT_RENDER_FUNCTION_SYMBOL` instead of `children`. The existing `getSlots` function is unaware of `SLOT_RENDER_FUNCTION_SYMBOL`, and thus ignores the render function.

## New Behavior

Make `getSlots` check for `SLOT_RENDER_FUNCTION_SYMBOL` and use that as the render function instead of `children`, if present.

## Related Issue(s)

- Fixes #27559

Note: This PR is a quick fix and doesn't include tests. There should be tests written that would have caught this bug. I logged this to track adding tests:
- #27566