### PR TITLE
User/mifraser/fluent 2 theme details list check styles

### DIFF
--- a/change/@fluentui-fluent2-theme-6b46a788-844b-4b88-885a-1252dac4c4a1.json
+++ b/change/@fluentui-fluent2-theme-6b46a788-844b-4b88-885a-1252dac4c4a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "[FEAT] Add details list checkbox styles that are more inline with V9",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Check.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Check.styles.ts
@@ -1,0 +1,79 @@
+import type { ICheckStyleProps, ICheckStyles } from '@fluentui/react';
+import { FontWeights, warn } from '@fluentui/react';
+
+export const getCheckStyles = ({ checked, theme }: ICheckStyleProps): Partial<ICheckStyles> => {
+  const extendedTheme = theme;
+
+  if (!extendedTheme) {
+    warn('Theme is undefined or null.');
+  }
+
+  return {
+    root: [
+      {
+        cursor: 'pointer',
+        width: '16px',
+        height: '16px',
+        '::before': {
+          transition: 'all ease-in-out 200ms',
+          // Because the ::before element is layering on top of CircleRing <i> border, we are increasing the border
+          // radius here to 3px, so it doesn’t compete. When both are 2px, the contour might look fuzzy.
+          borderRadius: '3px',
+          backgroundColor: 'transparent',
+          inset: 0,
+          height: '100%',
+          width: '100%',
+        },
+      },
+      checked && {
+        ':hover': {
+          '::before': {
+            backgroundColor: theme.semanticColors.inputBackgroundCheckedHovered,
+          },
+          '[data-icon-name="CircleRing"]': {
+            borderColor: theme.semanticColors.inputBackgroundCheckedHovered,
+          },
+        },
+        '::before': {
+          backgroundColor: theme.semanticColors.inputBackgroundChecked,
+        },
+        '[data-icon-name="StatusCircleCheckmark"]': {
+          opacity: 1,
+        },
+      },
+    ],
+    check: [
+      {
+        fontSize: '18px',
+        lineHeight: '16px',
+        margin: '0',
+        width: '16px',
+        height: '16px',
+        fontWeight: FontWeights.regular,
+        transition: 'opacity ease-in-out 100ms',
+        opacity: 0,
+        boxSizing: 'border-box',
+      },
+      checked && {
+        color: theme.semanticColors.bodyTextChecked,
+      },
+    ],
+    circle: [
+      {
+        fontSize: 0,
+        width: '16px',
+        height: '16px',
+        borderRadius: 2,
+        borderColor: theme.semanticColors.inputBorder,
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        transition: 'all ease-in-out 200ms',
+        boxSizing: 'border-box',
+      },
+      checked && {
+        color: theme.semanticColors.bodyTextChecked,
+        borderColor: theme.semanticColors.inputBackgroundChecked,
+      },
+    ],
+  };
+};

--- a/packages/fluent2-theme/src/componentStyles/Check.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Check.styles.ts
@@ -55,7 +55,7 @@ export const getCheckStyles = ({ checked, theme }: ICheckStyleProps): Partial<IC
         boxSizing: 'border-box',
       },
       checked && {
-        color: theme.semanticColors.bodyTextChecked,
+        color: 'white', // Intended to be white in all themes (dark and light modes)
       },
     ],
     circle: [

--- a/packages/fluent2-theme/src/componentStyles/DetailsRowCheck.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/DetailsRowCheck.styles.ts
@@ -1,0 +1,9 @@
+import type { IDetailsRowCheckStyles } from '@fluentui/react';
+
+export const getDetailsRowCheckStyles = (): Partial<IDetailsRowCheckStyles> => ({
+  check: [
+    {
+      opacity: 1,
+    },
+  ],
+});

--- a/packages/fluent2-theme/src/fluent2ComponentStyles.ts
+++ b/packages/fluent2-theme/src/fluent2ComponentStyles.ts
@@ -23,13 +23,17 @@ import { getSpinnerStyles } from './componentStyles/Spinner.styles';
 import { getTagItemStyles } from './componentStyles/TagItem.styles';
 import { getTextFieldStyles } from './componentStyles/TextField.styles';
 import { getToggleStyles } from './componentStyles/Toggle.styles';
-
+import { getDetailsRowCheckStyles } from './componentStyles/DetailsRowCheck.styles';
+import { getCheckStyles } from './componentStyles/Check.styles';
 export const fluent2ComponentStyles: { [key: string]: ISettings } = {
   Breadcrumb: {
     styles: getBreadcrumbStyles,
   },
   CalloutContent: {
     styles: getCalloutContentStyles,
+  },
+  Check: {
+    styles: getCheckStyles,
   },
   Checkbox: {
     styles: getCheckboxStyles,
@@ -57,6 +61,9 @@ export const fluent2ComponentStyles: { [key: string]: ISettings } = {
   },
   DefaultButton: {
     styles: getDefaultButtonStyles,
+  },
+  DetailRowCheck: {
+    styles: getDetailsRowCheckStyles,
   },
   Dialog: {
     styles: getDialogStyles,


### PR DESCRIPTION
## Previous Behavior
Fluent2WebThemes did not have a details list style and so it was defaulting to v8 checks with transparent circles

<img width="639" alt="oldFluent2Theme" src="https://user-images.githubusercontent.com/99835933/232109137-457ed8fd-8b9a-49bb-ab4d-94605edb880a.png">

## New Behavior
Now it should be more in line with v9 data grid checkboxes (square and 1 opacity) - we still respect the 'checkboxVisibility' prop so we have enabled it to always visible for this screenshot:

<img width="1057" alt="newFluentTheme" src="https://user-images.githubusercontent.com/99835933/232109474-25809e80-956f-4b0c-8f09-a7e583a94221.png">
