### PR TITLE
Add CODEOWNERS for packages/react-examples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,6 +150,7 @@ packages/react-components/react-conformance-griffel @microsoft/teams-prg
 packages/react-components/react-context-selector @microsoft/teams-prg
 packages/react-date-time @microsoft/cxe-red
 packages/react-docsite-components @microsoft/fluentui-v8-website
+packages/react-examples @microsoft/cxe-red @microsoft/cxe-coastal
 packages/react-file-type-icons @microsoft/cxe-red @jahnp @bigbadcapers
 packages/react-hooks @microsoft/cxe-red
 packages/react-icons-mdl2 @microsoft/cxe-red @microsoft/cxe-coastal


### PR DESCRIPTION
## Previous Behavior

`packages/react-examples` did not have any CODEOWNERS defined, causing it to default to FluentUI Admins

## New Behavior

Set CODEOWNERS of `packages/react-examples` to `@microsoft/cxe-red @microsoft/cxe-coastal`.
