### PR TITLE
Update: Modify Image Web Component Styles

### DIFF
--- a/change/@fluentui-web-components-482b832c-2b9e-4712-a120-a20052caf778.json
+++ b/change/@fluentui-web-components-482b832c-2b9e-4712-a120-a20052caf778.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Image component style updates",
+  "packageName": "@fluentui/web-components",
+  "email": "harankin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/image/image.stories.ts
+++ b/packages/web-components/src/image/image.stories.ts
@@ -99,7 +99,8 @@ export default {
           summary: 'square',
         },
         type: {
-          summary: 'When shape `rounded` is used, default border radius is 8px -- `borderRadiusXLarge`.',
+          summary:
+            'When shape `rounded` is used, default border radius is 4px -- `borderRadiusMedium`. The dev may override the default border radius using one of the following: borderRadiusSmall, borderRadiusLarge, borderRadiusXLarge.',
         },
       },
       options: Object.values(ImageShape),

--- a/packages/web-components/src/image/image.stories.ts
+++ b/packages/web-components/src/image/image.stories.ts
@@ -100,7 +100,7 @@ export default {
         },
         type: {
           summary:
-            'When shape `rounded` is used, default border radius is 4px -- `borderRadiusMedium`. The dev may override the default border radius using one of the following: borderRadiusSmall, borderRadiusLarge, borderRadiusXLarge.',
+            'When shape `rounded` is used, default border radius is `borderRadiusMedium`. The dev may override the default border radius using one of the following: borderRadiusSmall, borderRadiusLarge, borderRadiusXLarge.',
         },
       },
       options: Object.values(ImageShape),

--- a/packages/web-components/src/image/image.stories.ts
+++ b/packages/web-components/src/image/image.stories.ts
@@ -17,7 +17,7 @@ const imageTemplate = html<ImageStoryArgs>`
       ?shadow=${x => x.shadow}
       shape=${x => x.shape}
     >
-      <img alt="Short image description" src="https://via.placeholder.com/300x100/ddd.png" />
+      <img alt="Short image description" src="https://picsum.photos/300/100" />
     </fluent-image>
   </div>
 `;
@@ -98,6 +98,9 @@ export default {
         defaultValue: {
           summary: 'square',
         },
+        type: {
+          summary: 'When shape `rounded` is used, default border radius is 8px -- `borderRadiusXLarge`.',
+        },
       },
       options: Object.values(ImageShape),
       control: 'select',
@@ -119,8 +122,8 @@ export const Image = renderComponent(imageTemplate).bind({});
 const imageLayoutBlock = html<ImageStoryArgs>`
   <div style="border: 1px dotted #43ED35;">
     <fluent-image block bordered>
-      <img role="presentation" src="https://via.placeholder.com/958x20/ddd.png" />
-      <img role="presentation" src="https://via.placeholder.com/100x100/ddd.png" />
+      <img role="presentation" src="https://picsum.photos/958/20" />
+      <img role="presentation" src="https://picsum.photos/100/100" />
     </fluent-image>
   </div>
 `;
@@ -128,18 +131,18 @@ export const BlockLayout = renderComponent(imageLayoutBlock).bind({});
 
 // Fit: None
 const imageFitNoneLarge = html<ImageStoryArgs>`
-  <div style="height: 150px; width: 300px; border: 1px dotted #43ED35;">
+  <div style="height: 200px; width: 300px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="none">
-      <img role="presentation" src="https://via.placeholder.com/600x200/ddd.png" />
+      <img role="presentation" src="https://picsum.photos/600/200" />
     </fluent-image>
   </div>
 `;
 export const ImageFitNoneLarge = renderComponent(imageFitNoneLarge).bind({});
 
 const imageFitNoneSmall = html<ImageStoryArgs>`
-  <div style="height: 150px; width: 300px; border: 1px dotted #43ED35;">
+  <div style="height: 200px; width: 300px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="none">
-      <img alt="200x100 placeholder" src="https://via.placeholder.com/200x100/ddd.png" />
+      <img alt="200x100 placeholder" src="https://picsum.photos/200/100" />
     </fluent-image>
   </div>
 `;
@@ -147,27 +150,27 @@ export const ImageFitNoneSmall = renderComponent(imageFitNoneSmall).bind({});
 
 // Fit: Center
 const imageFitCenterLarge = html<ImageStoryArgs>`
-  <div style="height: 210px; width: 650px; border: 1px dotted #43ED35;">
-    <fluent-image bordered fit="center">
-      <img role="presentation" src="https://via.placeholder.com/600x200/ddd.png" />
+  <div style="height: 200px; width: 300px; border: 1px dotted #43ED35;">
+    <fluent-image fit="center">
+      <img role="presentation" src="https://picsum.photos/600/200" />
     </fluent-image>
   </div>
 `;
 export const ImageFitCenterLarge = renderComponent(imageFitCenterLarge).bind({});
 
 const imageFitCenterSmall = html<ImageStoryArgs>`
-  <div style="height: 210px; width: 650px; border: 1px dotted #43ED35;">
-    <fluent-image bordered fit="center">
-      <img alt="image layout story" src="https://via.placeholder.com/200x100/ddd.png" />
+  <div style="height: 200px; width: 300px; border: 1px dotted #43ED35;">
+    <fluent-image fit="center">
+      <img alt="image layout story" src="https://picsum.photos/200/100" />
     </fluent-image>
   </div>
 `;
 export const ImageFitCenterSmall = renderComponent(imageFitCenterSmall).bind({});
 
 const imageFitContain = html<ImageStoryArgs>`
-  <div style="height: 200px; width: 400px; border: 1px dotted #43ED35;">
+  <div style="height:200px; width: 300px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="contain">
-      <img alt="image layout story" src="https://via.placeholder.com/400x200/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/400/200" />
     </fluent-image>
   </div>
 `;
@@ -176,7 +179,7 @@ export const ImageFitContain = renderComponent(imageFitContain).bind({});
 const imageFitContainTall = html<ImageStoryArgs>`
   <div style="height: 250px; width: 400px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="contain">
-      <img alt="image layout story" src="https://via.placeholder.com/400x200/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/400/200" />
     </fluent-image>
   </div>
 `;
@@ -185,7 +188,7 @@ export const ImageFitContainTall = renderComponent(imageFitContainTall).bind({})
 const imageFitContainWide = html<ImageStoryArgs>`
   <div style="height: 200px; width: 450px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="contain">
-      <img alt="image layout story" src="https://via.placeholder.com/400x200/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/400/200" />
     </fluent-image>
   </div>
 `;
@@ -195,7 +198,7 @@ export const ImageFitContainWide = renderComponent(imageFitContainWide).bind({})
 const imageFitCoverSmall = html<ImageStoryArgs>`
   <div style="height: 200px; width: 400px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="cover">
-      <img alt="image layout story" src="https://via.placeholder.com/400x250/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/400/250" />
     </fluent-image>
   </div>
 `;
@@ -204,7 +207,7 @@ export const ImageFitCoverSmall = renderComponent(imageFitCoverSmall).bind({});
 const imageFitCoverMedium = html<ImageStoryArgs>`
   <div style="height: 200px; width: 400px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="cover">
-      <img alt="image layout story" src="https://via.placeholder.com/400x300/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/400/300" />
     </fluent-image>
   </div>
 `;
@@ -213,7 +216,7 @@ export const ImageFitCoverMedium = renderComponent(imageFitCoverMedium).bind({})
 const imageFitCoverLarge = html<ImageStoryArgs>`
   <div style="height: 200px; width: 400px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="cover">
-      <img alt="image layout story" src="https://via.placeholder.com/600x200/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/600/200" />
     </fluent-image>
   </div>
 `;
@@ -223,7 +226,7 @@ export const ImageFitCoverLarge = renderComponent(imageFitCoverLarge).bind({});
 const imageFitDefault = html<ImageStoryArgs>`
   <div style="height: 210px; width: 650px; border: 1px dotted #43ED35;">
     <fluent-image bordered fit="default">
-      <img alt="image layout story" src="https://via.placeholder.com/150/ddd.png" />
+      <img alt="image layout story" src="https://picsum.photos/150/150" />
     </fluent-image>
   </div>
 `;

--- a/packages/web-components/src/image/image.styles.ts
+++ b/packages/web-components/src/image/image.styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@microsoft/fast-element';
 import {
   borderRadiusCircular,
-  borderRadiusXLarge,
+  borderRadiusMedium,
   colorNeutralStroke2,
   shadow4,
   strokeWidthThin,
@@ -32,16 +32,14 @@ export const styles = css`
   :host([fit='none']) ::slotted(img) {
     object-fit: none;
     object-position: top left;
-  }
-  :host([fit='center']) {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-    height: 200px;
+    height: 100%;
+    width: 100%;
   }
   :host([fit='center']) ::slotted(img) {
     object-fit: none;
+    object-position: center;
+    height: 100%;
+    width: 100%;
   }
   :host([fit='contain']) ::slotted(img) {
     object-fit: contain;
@@ -62,6 +60,6 @@ export const styles = css`
     border-radius: ${borderRadiusCircular};
   }
   :host([shape='rounded']) ::slotted(img) {
-    border-radius: ${borderRadiusXLarge};
+    border-radius: ${borderRadiusMedium};
   }
 `;

--- a/packages/web-components/src/image/image.styles.ts
+++ b/packages/web-components/src/image/image.styles.ts
@@ -1,5 +1,11 @@
 import { css } from '@microsoft/fast-element';
-import { borderRadiusCircular, colorNeutralStroke2, shadow4, strokeWidthThin } from '../theme/design-tokens.js';
+import {
+  borderRadiusCircular,
+  borderRadiusXLarge,
+  colorNeutralStroke2,
+  shadow4,
+  strokeWidthThin,
+} from '../theme/design-tokens.js';
 
 /** Image styles
  *
@@ -26,14 +32,16 @@ export const styles = css`
   :host([fit='none']) ::slotted(img) {
     object-fit: none;
     object-position: top left;
-    height: 100%;
-    width: 100%;
+  }
+  :host([fit='center']) {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    height: 200px;
   }
   :host([fit='center']) ::slotted(img) {
     object-fit: none;
-    object-position: center;
-    height: 100%;
-    width: 100%;
   }
   :host([fit='contain']) ::slotted(img) {
     object-fit: contain;
@@ -52,5 +60,8 @@ export const styles = css`
   }
   :host([shape='circular']) ::slotted(img) {
     border-radius: ${borderRadiusCircular};
+  }
+  :host([shape='rounded']) ::slotted(img) {
+    border-radius: ${borderRadiusXLarge};
   }
 `;


### PR DESCRIPTION
Updates story with better placeholder images. Sets default border-radius and updates **shape** param description in the story with detail about the default border radius and available values to choose from when implementing.

Please verify that:
* [x] Code is up-to-date with the `web-components-v3` branch
* [x] You've run `yarn change` locally

## Previous Behavior

When **shape**: **rounded** is selected, no border-radius is applied.
**shape** param description in the story does not provide the developer with border-radius implementation details.

## New Behavior
Border radius styles were added, using the 4px default value for when shape: rounded is selected.
The **shape**: **rounded** description in the story now has implementation details for the developer.


## Related Issue(s)
- Fixes #[1043544](https://powerbi.visualstudio.com/Trident/_workitems/edit/1043544)
