### PR TITLE
Add DraggableZone into export map

### DIFF
--- a/change/@fluentui-react-3469d3b8-ceaa-47ad-af92-c5e1db22d1e0.json
+++ b/change/@fluentui-react-3469d3b8-ceaa-47ad-af92-c5e1db22d1e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export DraggableZone component",
+  "packageName": "@fluentui/react",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -430,6 +430,11 @@
       "import": "./lib/DragDrop.js",
       "require": "./lib-commonjs/DragDrop.js"
     },
+    "./lib/DraggableZone": {
+      "types": "./lib/DraggableZone.d.ts",
+      "import": "./lib/DraggableZone.js",
+      "require": "./lib-commonjs/DraggableZone.js"
+    },
     "./lib/Dropdown": {
       "types": "./lib/Dropdown.d.ts",
       "import": "./lib/Dropdown.js",
@@ -1150,6 +1155,10 @@
     "./lib-commonjs/DragDrop": {
       "types": "./lib-commonjs/DragDrop.d.ts",
       "require": "./lib-commonjs/DragDrop.js"
+    },
+    "./lib-commonjs/DraggableZone": {
+      "types": "./lib-commonjs/DraggableZone.d.ts",
+      "require": "./lib-commonjs/DraggableZone.js"
     },
     "./lib-commonjs/Dropdown": {
       "types": "./lib-commonjs/Dropdown.d.ts",

--- a/packages/react/src/DraggableZone.ts
+++ b/packages/react/src/DraggableZone.ts
@@ -1,0 +1,1 @@
+export * from './utilities/DraggableZone/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`DraggableZone` is not in the export map of `@fluentui/react` package, resulting in errors like:
```
Module not found: Error: Package path ./lib/utilities/DraggableZone is not exported from package
D:\js4\...\node_modules\@fluentui\react
(see exports field in D:\js4\...\node_modules\@fluentui\react\package.json)
```
when this component is imports with:
`import { DraggableZone } from "@fluentui/react/lib/utilities/DraggableZone";`

## New Behavior

With this PR, `DraggableZone` component is exposed and can be import like other components:
`import { DraggableZone } from "@fluentui/react/lib/DraggableZone";`

