### PR TITLE
bugfix: ensure legacyTrapFocus works properly

### DIFF
--- a/change/@fluentui-react-popover-01561782-ac6f-4d45-b87a-0dbc28755256.json
+++ b/change/@fluentui-react-popover-01561782-ac6f-4d45-b87a-0dbc28755256.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensure legacyTrapFocus works properly",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
@@ -377,7 +377,29 @@ describe('Popover', () => {
         cy.contains('One').should('have.focus').realPress(['Shift', 'Tab']);
         cy.contains('Two').should('have.focus');
       });
+
+      it('should work as inertTrapFocus when set to false', () => {
+        mount(
+          <Popover legacyTrapFocus={false} trapFocus>
+            <PopoverTrigger disableButtonEnhancement>
+              <button>Popover trigger</button>
+            </PopoverTrigger>
+
+            <PopoverSurface>
+              <button>One</button>
+              <button>Two</button>
+            </PopoverSurface>
+          </Popover>,
+        );
+
+        cy.get(popoverTriggerSelector).focus().realPress('Enter');
+
+        cy.contains('One').should('have.focus').realPress('Tab');
+        cy.contains('Two').should('have.focus').realPress('Tab');
+        cy.focused().should('not.exist');
+      });
     });
+
     describe('inert focus trap behaviour', () => {
       it('Tab should go to the window', () => {
         mount(

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -136,6 +136,8 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   return {
     ...initialState,
     ...positioningRefs,
+    // eslint-disable-next-line deprecation/deprecation
+    inertTrapFocus: props.inertTrapFocus ?? (props.legacyTrapFocus === undefined ? false : !props.legacyTrapFocus),
     popoverTrigger,
     popoverSurface,
     open,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

After rollout of `inertTrapFocus` property, `legacyTrapFocus` was deprecated and its value completely ignored.

## New Behavior

1. Ensures that `legacyTrapFocus`, although deprecated is still a valid property that will ensure the opposite behaviour of `inertTrapFocus`
2. Adds test that will ensure `legacyTrapFocus` behaviour as equivalent to the opposite of `inertTrapFocus`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27447
