### PR TITLE
Remove extra "Font family" text

### DIFF
--- a/packages/react-components/react-theme/stories/Theme/fonts/ThemeFonts.stories.tsx
+++ b/packages/react-components/react-theme/stories/Theme/fonts/ThemeFonts.stories.tsx
@@ -29,7 +29,7 @@ export const FontFamily = () => {
       {fontFamilies.map(fontFamily => [
         <div key={fontFamily}>{fontFamily}</div>,
         <div key={`${fontFamily}-value`} style={{ fontFamily: `${theme[fontFamily]}` }}>
-          {theme[fontFamily]}Font family {fontFamily}
+          {theme[fontFamily]}
         </div>,
       ])}
     </div>


### PR DESCRIPTION
## Previous Behavior

The text "Font family" is appended after the font family values, making it hard to read. (ie "sans-serifFont family" instead of just "sans-serif"). This was probably added by accident as the font family is seen in the adjacent table column. 

<img width="610" alt="image" src="https://user-images.githubusercontent.com/1782266/232636377-3e41e28b-3644-49e2-8de9-63d27437217a.png">

## New Behavior

<img width="609" alt="image" src="https://user-images.githubusercontent.com/1782266/232636505-9a24cd54-2519-407a-b124-dcd1feed3577.png">

Deleted it
![Delete!](https://thumbs.gfycat.com/AlertLegitimateAlligator-size_restricted.gif)
