### PR TITLE
feat(react-datepicker-compat): Add error handling to DatePicker and update popup's padding

### DIFF
--- a/change/@fluentui-react-datepicker-compat-59a888f8-093f-449c-b49e-4f580894da5e.json
+++ b/change/@fluentui-react-datepicker-compat-59a888f8-093f-449c-b49e-4f580894da5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Add error handling to DatePicker.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/etc/react-datepicker-compat.api.md
+++ b/packages/react-components/react-datepicker-compat/etc/react-datepicker-compat.api.md
@@ -153,6 +153,11 @@ export const DatePicker: ForwardRefComponent<DatePickerProps>;
 export const datePickerClassNames: SlotClassNames<DatePickerSlots>;
 
 // @public (undocumented)
+export type DatePickerErrorData = {
+    error: 'required-input' | 'invalid-input' | 'out-of-bounds';
+};
+
+// @public (undocumented)
 export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'defaultValue' | 'value'> & {
     componentRef?: React_2.RefObject<IDatePicker>;
     onSelectDate?: (date: Date | null | undefined) => void;
@@ -167,6 +172,7 @@ export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'de
     defaultOpen?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
+    onValidationError?: (date: DatePickerErrorData) => void;
     inlinePopup?: boolean;
     positioning?: PositioningProps;
     placeholder?: string;
@@ -224,7 +230,10 @@ export enum DayOfWeek {
 export const DAYS_IN_WEEK = 7;
 
 // @public (undocumented)
-export const defaultCalendarStrings: CalendarStrings;
+export const defaultDatePickerErrorStrings: Record<DatePickerErrorData['error'], string>;
+
+// @public (undocumented)
+export const defaultDatePickerStrings: CalendarStrings;
 
 // @public
 export enum FirstWeekOfYear {

--- a/packages/react-components/react-datepicker-compat/etc/react-datepicker-compat.api.md
+++ b/packages/react-components/react-datepicker-compat/etc/react-datepicker-compat.api.md
@@ -152,7 +152,7 @@ export const DatePicker: ForwardRefComponent<DatePickerProps>;
 // @public (undocumented)
 export const datePickerClassNames: SlotClassNames<DatePickerSlots>;
 
-// @public (undocumented)
+// @public
 export type DatePickerErrorData = {
     error: 'invalid-input' | 'out-of-bounds' | 'required-input';
 };
@@ -172,7 +172,7 @@ export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'de
     defaultOpen?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
-    onValidationError?: (date: DatePickerErrorData) => void;
+    onValidationError?: (data: DatePickerErrorData) => void;
     inlinePopup?: boolean;
     positioning?: PositioningProps;
     placeholder?: string;

--- a/packages/react-components/react-datepicker-compat/etc/react-datepicker-compat.api.md
+++ b/packages/react-components/react-datepicker-compat/etc/react-datepicker-compat.api.md
@@ -154,7 +154,7 @@ export const datePickerClassNames: SlotClassNames<DatePickerSlots>;
 
 // @public (undocumented)
 export type DatePickerErrorData = {
-    error: 'required-input' | 'invalid-input' | 'out-of-bounds';
+    error: 'invalid-input' | 'out-of-bounds' | 'required-input';
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-datepicker-compat/package.json
+++ b/packages/react-components/react-datepicker-compat/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.2",
+    "@fluentui/react-field": "^9.0.0",
     "@fluentui/react-icons": "^2.0.196",
     "@fluentui/react-input": "^9.4.10",
     "@fluentui/react-popover": "^9.5.9",

--- a/packages/react-components/react-datepicker-compat/package.json
+++ b/packages/react-components/react-datepicker-compat/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.2",
-    "@fluentui/react-field": "^9.0.0",
+    "@fluentui/react-field": "^9.1.0",
     "@fluentui/react-icons": "^2.0.196",
     "@fluentui/react-input": "^9.4.10",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.1",

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.types.ts
@@ -107,7 +107,7 @@ export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'de
   /**
    * Callback to run when the DatePicker encounters an error when validating the input
    */
-  onValidationError?: (date: DatePickerErrorData) => void;
+  onValidationError?: (data: DatePickerErrorData) => void;
 
   /**
    * Whether the DatePicker should render the popup as inline or in a portal
@@ -229,36 +229,18 @@ export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'de
   showCloseButton?: boolean;
 };
 
+/**
+ * State used in rendering DatePicker.
+ */
 export type DatePickerState = ComponentState<DatePickerSlots> & {
   disabled: boolean;
   inlinePopup: boolean;
 };
 
+/**
+ * Data passed to the `onValidationError` callback.
+ */
 export type DatePickerErrorData = {
+  /** The error found when validating the input. */
   error: 'invalid-input' | 'out-of-bounds' | 'required-input';
 };
-
-// TODO: remove this once we add error handling hook
-export interface DatePickerStrings extends CalendarStrings {
-  /**
-   * Error message to render for Input if isRequired validation fails.
-   */
-  isRequiredErrorMessage?: string;
-
-  /**
-   * Error message to render for Input if input date string parsing fails.
-   */
-  invalidInputErrorMessage?: string;
-
-  /**
-   * Error message to render for Input if date boundary (minDate, maxDate) validation fails.
-   */
-  isOutOfBoundsErrorMessage?: string;
-
-  /**
-   * Status message to render for Input the input date parsing fails,
-   * and the typed value is cleared and reset to the previous value.
-   *  e.g. "Invalid entry `{0}`, date reset to `{1}`"
-   */
-  isResetStatusMessage?: string;
-}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.types.ts
@@ -235,7 +235,7 @@ export type DatePickerState = ComponentState<DatePickerSlots> & {
 };
 
 export type DatePickerErrorData = {
-  error: 'required-input' | 'invalid-input' | 'out-of-bounds';
+  error: 'invalid-input' | 'out-of-bounds' | 'required-input';
 };
 
 // TODO: remove this once we add error handling hook

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.types.ts
@@ -105,6 +105,11 @@ export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'de
   onOpenChange?: (open: boolean) => void;
 
   /**
+   * Callback to run when the DatePicker encounters an error when validating the input
+   */
+  onValidationError?: (date: DatePickerErrorData) => void;
+
+  /**
    * Whether the DatePicker should render the popup as inline or in a portal
    *
    * @default false
@@ -227,6 +232,10 @@ export type DatePickerProps = Omit<ComponentProps<Partial<DatePickerSlots>>, 'de
 export type DatePickerState = ComponentState<DatePickerSlots> & {
   disabled: boolean;
   inlinePopup: boolean;
+};
+
+export type DatePickerErrorData = {
+  error: 'required-input' | 'invalid-input' | 'out-of-bounds';
 };
 
 // TODO: remove this once we add error handling hook

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/defaults.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/defaults.ts
@@ -1,15 +1,18 @@
+import { CalendarStrings } from '../../utils/index';
 import { defaultCalendarStrings } from '../Calendar/defaults';
-import type { DatePickerStrings } from './DatePicker.types';
+import { DatePickerErrorData } from './DatePicker.types';
 
-// TODO: Once we have error handling hook, this needs to be either renamed or removed.
-export const defaultDatePickerStrings: DatePickerStrings = {
+export const defaultDatePickerStrings: CalendarStrings = {
   ...defaultCalendarStrings,
   prevMonthAriaLabel: 'Go to previous month',
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
-  isRequiredErrorMessage: 'Field is required',
-  invalidInputErrorMessage: 'Invalid date format',
-  isResetStatusMessage: 'Invalid entry "{0}", date reset to "{1}"',
+};
+
+export const defaultDatePickerErrorStrings: Record<DatePickerErrorData['error'], string> = {
+  'required-input': 'Field is required',
+  'invalid-input': 'Invalid date format',
+  'out-of-bounds': 'Date is out of bounds',
 };

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/defaults.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/defaults.ts
@@ -1,6 +1,6 @@
 import { CalendarStrings } from '../../utils/index';
 import { defaultCalendarStrings } from '../Calendar/defaults';
-import { DatePickerErrorData } from './DatePicker.types';
+import type { DatePickerErrorData } from './DatePicker.types';
 
 export const defaultDatePickerStrings: CalendarStrings = {
   ...defaultCalendarStrings,
@@ -12,7 +12,7 @@ export const defaultDatePickerStrings: CalendarStrings = {
 };
 
 export const defaultDatePickerErrorStrings: Record<DatePickerErrorData['error'], string> = {
-  'required-input': 'Field is required',
   'invalid-input': 'Invalid date format',
   'out-of-bounds': 'Date is out of bounds',
+  'required-input': 'Field is required',
 };

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/defaults.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/defaults.ts
@@ -1,5 +1,5 @@
-import { CalendarStrings } from '../../utils/index';
 import { defaultCalendarStrings } from '../Calendar/defaults';
+import type { CalendarStrings } from '../../utils/index';
 import type { DatePickerErrorData } from './DatePicker.types';
 
 export const defaultDatePickerStrings: CalendarStrings = {

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { ArrowDown, Enter, Escape } from '@fluentui/keyboard-keys';
+import { Calendar } from '../Calendar/Calendar';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
+import { compareDatePart, DayOfWeek, FirstWeekOfYear } from '../../utils';
+import { defaultDatePickerStrings } from './defaults';
 import { Input } from '@fluentui/react-input';
-import { useFocusFinders, useModalAttributes } from '@fluentui/react-tabster';
 import {
   mergeCallbacks,
   resolveShorthand,
@@ -13,14 +15,13 @@ import {
   useOnClickOutside,
   useOnScrollOutside,
 } from '@fluentui/react-utilities';
-import { compareDatePart, DayOfWeek, FirstWeekOfYear } from '../../utils';
-import { Calendar } from '../Calendar/Calendar';
-import { usePopupPositioning } from '../../utils/usePopupPositioning';
+import { useFieldContext_unstable as useFieldContext } from '@fluentui/react-field';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import type { InputProps, InputOnChangeData } from '@fluentui/react-input';
+import { useFocusFinders, useModalAttributes } from '@fluentui/react-tabster';
+import { usePopupPositioning } from '../../utils/usePopupPositioning';
 import type { CalendarProps, ICalendar } from '../Calendar/Calendar.types';
 import type { DatePickerProps, DatePickerState } from './DatePicker.types';
-import { defaultCalendarStrings } from '../Calendar/defaults';
+import type { InputProps, InputOnChangeData } from '@fluentui/react-input';
 
 function isDateOutOfBounds(date: Date, minDate?: Date, maxDate?: Date): boolean {
   return (!!minDate && compareDatePart(minDate!, date) > 0) || (!!maxDate && compareDatePart(maxDate!, date) < 0);
@@ -128,12 +129,13 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     onOpenChange,
     onSelectDate: onUserSelectDate,
     openOnClick = true,
+    onValidationError,
     parseDateFromString = defaultParseDateFromString,
     showCloseButton = false,
     showGoToToday = true,
     showMonthPickerAsOverlay = false,
     showWeekNumbers = false,
-    strings = defaultCalendarStrings,
+    strings = defaultDatePickerStrings,
     today,
     underlined = false,
     value,
@@ -147,6 +149,8 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     value,
   });
   const [open, setOpenState] = usePopupVisibility(props);
+  const fieldContext = useFieldContext();
+  const required = fieldContext?.required ?? props.required;
   const popupSurfaceId = useId('datePicker-popoverSurface');
 
   const validateTextInput = React.useCallback(
@@ -165,12 +169,23 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
           if (!date || isNaN(date.getTime())) {
             // Reset input if formatting is available
             setSelectedDate(selectedDate);
-          } else if (!isDateOutOfBounds(date, minDate, maxDate)) {
-            setSelectedDate(date);
+            onValidationError?.({ error: 'invalid-input' });
+          } else {
+            if (isDateOutOfBounds(date, minDate, maxDate)) {
+              onValidationError?.({ error: 'out-of-bounds' });
+            } else {
+              setSelectedDate(date);
+            }
           }
-        } else if (onUserSelectDate) {
-          onUserSelectDate(date);
+        } else {
+          if (required) {
+            onValidationError?.({ error: 'required-input' });
+          }
+
+          onUserSelectDate?.(date);
         }
+      } else if (required && !formattedDate) {
+        onValidationError?.({ error: 'required-input' });
       }
     },
     [
@@ -180,7 +195,9 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
       maxDate,
       minDate,
       onUserSelectDate,
+      onValidationError,
       parseDateFromString,
+      required,
       selectedDate,
       setSelectedDate,
     ],

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -165,7 +165,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
           }
           date = date || parseDateFromString!(formattedDate);
 
-          // Check if date is null or date is and invalid date
+          // Check if date is null or date is an invalid date
           if (!date || isNaN(date.getTime())) {
             // Reset input if formatting is available
             setSelectedDate(selectedDate);

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePickerStyles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePickerStyles.ts
@@ -34,7 +34,6 @@ const usePopupSurfaceClassName = makeResetStyles({
   borderColor: tokens.colorTransparentStroke,
   display: 'inline-flex',
   color: tokens.colorNeutralForeground1,
-  padding: '16px',
   ...typographyStyles.body1,
 });
 

--- a/packages/react-components/react-datepicker-compat/src/index.ts
+++ b/packages/react-components/react-datepicker-compat/src/index.ts
@@ -1,4 +1,4 @@
-export { AnimationDirection, defaultCalendarStrings } from './Calendar';
+export { AnimationDirection } from './Calendar';
 export type { CalendarProps, ICalendar } from './Calendar';
 
 export type { CalendarDayProps, ICalendarDay } from './CalendarDay';
@@ -8,11 +8,13 @@ export type { CalendarMonthProps, ICalendarMonth } from './CalendarMonth';
 export {
   DatePicker,
   datePickerClassNames,
+  defaultDatePickerErrorStrings,
+  defaultDatePickerStrings,
   renderDatePicker_unstable,
   useDatePicker_unstable,
   useDatePickerStyles_unstable,
 } from './DatePicker';
-export type { DatePickerProps, IDatePicker } from './DatePicker';
+export type { DatePickerErrorData, DatePickerProps, IDatePicker } from './DatePicker';
 
 export {
   DAYS_IN_WEEK,

--- a/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { addMonths, addYears, DatePicker, defaultDatePickerErrorStrings } from '@fluentui/react-datepicker-compat';
+import { Field, makeStyles } from '@fluentui/react-components';
+import { DatePickerErrorData } from '../../src/DatePicker';
+
+const useStyles = makeStyles({
+  control: {
+    maxWidth: '300px',
+  },
+});
+
+const today = new Date(Date.now());
+const minDate = addMonths(today, -1);
+const maxDate = addYears(today, 1);
+
+export const ErrorHandling = () => {
+  const styles = useStyles();
+  const [error, setError] = React.useState<DatePickerErrorData['error'] | undefined>(undefined);
+
+  return (
+    <Field
+      required
+      label={
+        `Select a date out of bounds (minDate: ${minDate}, maxDate: ${maxDate}),` +
+        ` type an invalid input, or leave the input empty and close the DatePicker.`
+      }
+      validationMessage={error && defaultDatePickerErrorStrings[error]}
+    >
+      <DatePicker
+        minDate={minDate}
+        maxDate={maxDate}
+        placeholder="Select a date..."
+        allowTextInput
+        onValidationError={data => setError(data.error)}
+        className={styles.control}
+      />
+    </Field>
+  );
+};

--- a/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { addMonths, addYears, DatePicker, defaultDatePickerErrorStrings } from '@fluentui/react-datepicker-compat';
 import { Field, makeStyles } from '@fluentui/react-components';
-import { DatePickerErrorData } from '../../src/DatePicker';
+import type { DatePickerErrorData } from '../../src/DatePicker';
 
 const useStyles = makeStyles({
   control: {

--- a/packages/react-components/react-datepicker-compat/stories/DatePicker/index.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/DatePicker/index.stories.tsx
@@ -9,6 +9,7 @@ export { FirstDayOfTheWeek } from './DatePickerFirstDayOfTheWeek.stories';
 export { WeekNumbers } from './DatePickerWeekNumbers.stories';
 export { DateBoundaries } from './DatePickerDateBoundaries.stories';
 export { CustomDateFormatting } from './DatePickerCustomDateFormatting.stories';
+export { ErrorHandling } from './DatePickerErrorHandling.stories';
 export { Controlled } from './DatePickerControlled.stories';
 export { Required } from './DatePickerRequired.stories';
 export { Disabled } from './DatePickerDisabled.stories';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

DatePicker would validate and format dates by default, but this didn't come with a way to handle errors when validating the input.

DatePicker adds a padding to the popup and therefore the padding within calendar clashes and makes the padding look too large:

![image](https://user-images.githubusercontent.com/5953191/233198380-a268b838-9c81-4de1-a2c1-b62582d3b68c.png)


## New Behavior

DatePicker now offers `onValidateError` to provide the dev a way to know when there's an error in the validation of the input. The error may be of time `required-input`, `out-of-bounds`, and `invalid-input`.

without padding: 
![image](https://user-images.githubusercontent.com/5953191/233197651-3eafaec0-3874-4fd7-a885-d74569eab51d.png)

## Related issues

Fixes #27643