### PR TITLE
intervention error

### DIFF
--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -61,16 +61,20 @@ export const allowScrollOnElement = (element: HTMLElement | null, events: EventG
       _element = scrollableParent;
     }
 
-    // if the element is scrolled to the top,
-    // prevent the user from scrolling up
-    if (_element.scrollTop === 0 && clientY > 0) {
-      event.preventDefault();
-    }
+    if (event.cancelable){
+      
+      // if the element is scrolled to the top,
+      // prevent the user from scrolling up
+      if (_element.scrollTop === 0 && clientY > 0) {
+        event.preventDefault();
+      }
 
-    // if the element is scrolled to the bottom,
-    // prevent the user from scrolling down
-    if (_element.scrollHeight - Math.ceil(_element.scrollTop) <= _element.clientHeight && clientY < 0) {
-      event.preventDefault();
+      // if the element is scrolled to the bottom,
+      // prevent the user from scrolling down
+      if (_element.scrollHeight - Math.ceil(_element.scrollTop) <= _element.clientHeight && clientY < 0) {
+        event.preventDefault();
+      }
+      
     }
   };
 


### PR DESCRIPTION
bug: [Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
