### PR TITLE
bugfix(react-tree): fix parent navigation after independency from id

### DIFF
--- a/change/@fluentui-react-tree-409b60b2-2543-40ee-9e92-f53b02cecb5d.json
+++ b/change/@fluentui-react-tree-409b60b2-2543-40ee-9e92-f53b02cecb5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: fix parent navigation after independency from id",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
@@ -18,40 +18,42 @@ const mount = (element: JSX.Element) => {
   mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
 };
 
+const treeItems = (
+  <>
+    <TreeItem value="item1" data-testid="item1">
+      <TreeItemLayout>level 1, item 1</TreeItemLayout>
+      <Tree>
+        <TreeItem value="item1__item1" data-testid="item1__item1">
+          <TreeItemLayout>level 2, item 1</TreeItemLayout>
+        </TreeItem>
+        <TreeItem value="item1__item2" data-testid="item1__item2">
+          <TreeItemLayout>level 2, item 2</TreeItemLayout>
+        </TreeItem>
+        <TreeItem value="item1__item3" data-testid="item1__item3">
+          <TreeItemLayout>level 2, item 3</TreeItemLayout>
+        </TreeItem>
+      </Tree>
+    </TreeItem>
+    <TreeItem value="item2" data-testid="item2">
+      <TreeItemLayout>level 1, item 2</TreeItemLayout>
+      <Tree>
+        <TreeItem value="item2__item1" data-testid="item2__item1">
+          <TreeItemLayout>level 2, item 1</TreeItemLayout>
+          <Tree>
+            <TreeItem value="item2__item1__item1" data-testid="item2__item1__item1">
+              <TreeItemLayout>level 3, item 1</TreeItemLayout>
+            </TreeItem>
+          </Tree>
+        </TreeItem>
+      </Tree>
+    </TreeItem>
+  </>
+);
+
 const NestedTree: React.FC<TreeProps> = props => {
   return (
     <Tree id="tree" aria-label="Tree" {...props}>
-      {props.children ?? (
-        <>
-          <TreeItem id="item1">
-            <TreeItemLayout>level 1, item 1</TreeItemLayout>
-            <Tree>
-              <TreeItem id="item1__item1">
-                <TreeItemLayout>level 2, item 1</TreeItemLayout>
-              </TreeItem>
-              <TreeItem id="item1__item2">
-                <TreeItemLayout>level 2, item 2</TreeItemLayout>
-              </TreeItem>
-              <TreeItem id="item1__item3">
-                <TreeItemLayout>level 2, item 3</TreeItemLayout>
-              </TreeItem>
-            </Tree>
-          </TreeItem>
-          <TreeItem id="item2">
-            <TreeItemLayout>level 1, item 2</TreeItemLayout>
-            <Tree>
-              <TreeItem id="item2__item1">
-                <TreeItemLayout>level 2, item 1</TreeItemLayout>
-                <Tree>
-                  <TreeItem id="item2__item1__item1">
-                    <TreeItemLayout>level 3, item 1</TreeItemLayout>
-                  </TreeItem>
-                </Tree>
-              </TreeItem>
-            </Tree>
-          </TreeItem>
-        </>
-      )}
+      {props.children ?? treeItems}
     </Tree>
   );
 };
@@ -59,41 +61,7 @@ NestedTree.displayName = 'NestedTree';
 
 const FlatTree: React.FC<TreeProps> = (props: TreeProps) => {
   const flatTree = useFlatTree_unstable(
-    flattenTreeFromElement(
-      props.children ? (
-        <>{props.children}</>
-      ) : (
-        <>
-          <TreeItem id="item1">
-            <TreeItemLayout>level 1, item 1</TreeItemLayout>
-            <Tree>
-              <TreeItem id="item1__item1">
-                <TreeItemLayout>level 2, item 1</TreeItemLayout>
-              </TreeItem>
-              <TreeItem id="item1__item2">
-                <TreeItemLayout>level 2, item 2</TreeItemLayout>
-              </TreeItem>
-              <TreeItem id="item1__item3">
-                <TreeItemLayout>level 2, item 3</TreeItemLayout>
-              </TreeItem>
-            </Tree>
-          </TreeItem>
-          <TreeItem id="item2">
-            <TreeItemLayout>level 1, item 2</TreeItemLayout>
-            <Tree>
-              <TreeItem id="item2__item1">
-                <TreeItemLayout>level 2, item 1</TreeItemLayout>
-                <Tree>
-                  <TreeItem id="item2__item1__item1">
-                    <TreeItemLayout>level 3, item 1</TreeItemLayout>
-                  </TreeItem>
-                </Tree>
-              </TreeItem>
-            </Tree>
-          </TreeItem>
-        </>
-      ),
-    ),
+    flattenTreeFromElement(props.children ? <>{props.children}</> : treeItems),
     props,
   );
   return (
@@ -110,30 +78,30 @@ for (const TreeTest of [NestedTree, FlatTree]) {
   describe(TreeTest.displayName!, () => {
     it('should have all but first level items hidden', () => {
       mount(<TreeTest />);
-      cy.get('#item1__item1').should('not.exist');
-      cy.get('#item1__item2').should('not.exist');
-      cy.get('#item1__item3').should('not.exist');
-      cy.get('#item2__item1').should('not.exist');
-      cy.get('#item2__item1__item1').should('not.exist');
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+      cy.get('[data-testid="item1__item2"]').should('not.exist');
+      cy.get('[data-testid="item1__item3"]').should('not.exist');
+      cy.get('[data-testid="item2__item1"]').should('not.exist');
+      cy.get('[data-testid="item2__item1__item1"]').should('not.exist');
     });
 
     it('should have all items visible', () => {
       mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
-      cy.get('#item1__item1').should('exist');
-      cy.get('#item1__item2').should('exist');
-      cy.get('#item1__item3').should('exist');
-      cy.get('#item2__item1').should('exist');
-      cy.get('#item2__item1__item1').should('exist');
+      cy.get('[data-testid="item1__item1"]').should('exist');
+      cy.get('[data-testid="item1__item2"]').should('exist');
+      cy.get('[data-testid="item1__item3"]').should('exist');
+      cy.get('[data-testid="item2__item1"]').should('exist');
+      cy.get('[data-testid="item2__item1__item1"]').should('exist');
     });
 
     describe('Mouse interactions', () => {
       it('should expand/collapse item on layout click', () => {
         mount(<TreeTest />);
-        cy.get('#item1__item1').should('not.exist');
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realClick();
-        cy.get('#item1__item1').should('exist');
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realClick();
-        cy.get('#item1__item1').should('not.exist');
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realClick();
+        cy.get('[data-testid="item1__item1"]').should('exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realClick();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
       });
       it('should expand/collapse item on expandIcon click only', () => {
         mount(
@@ -145,14 +113,14 @@ for (const TreeTest of [NestedTree, FlatTree]) {
             }}
           />,
         );
-        cy.get('#item1__item1').should('not.exist');
-        cy.get(`#item1 .${treeItemClassNames.expandIcon}`).realClick();
-        cy.get('#item1__item1').should('exist');
-        cy.get(`#item1 .${treeItemClassNames.expandIcon}`).realClick();
-        cy.get('#item1__item1').should('not.exist');
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
+        cy.get(`[data-testid="item1"] .${treeItemClassNames.expandIcon}`).realClick();
+        cy.get('[data-testid="item1__item1"]').should('exist');
+        cy.get(`[data-testid="item1"] .${treeItemClassNames.expandIcon}`).realClick();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
 
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realClick();
-        cy.get('#item1__item1').should('not.exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realClick();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
       });
       it('should not expand/collapse item on actions click', () => {
         mount(
@@ -163,46 +131,47 @@ for (const TreeTest of [NestedTree, FlatTree]) {
                   <Button id="action">action</Button>
                 </>
               }
-              id="item1"
+              value="item1"
+              data-testid="item1"
             >
               <TreeItemLayout>level 1, item 1</TreeItemLayout>
               <Tree>
-                <TreeItem id="item1__item1">
+                <TreeItem value="item1__item1" data-testid="item1__item1">
                   <TreeItemLayout>level 2, item 1</TreeItemLayout>
                 </TreeItem>
               </Tree>
             </TreeItem>
           </TreeTest>,
         );
-        cy.get('#item1__item1').should('not.exist');
-        cy.get('#item1').focus();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
+        cy.get('[data-testid="item1"]').focus();
         cy.get(`#action`).realClick();
-        cy.get('#item1__item1').should('not.exist');
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
       });
     });
     describe('Keyboard interactions', () => {
       it('should expand/collapse item on Enter key', () => {
         mount(<TreeTest />);
-        cy.get('#item1').focus();
-        cy.get('#item1__item1').should('not.exist');
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realPress('{enter}');
-        cy.get('#item1__item1').should('exist');
+        cy.get('[data-testid="item1"]').focus();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{enter}');
+        cy.get('[data-testid="item1__item1"]').should('exist');
       });
       it('should expand item on Right key', () => {
         mount(<TreeTest />);
-        cy.get('#item1').focus();
-        cy.get('#item1__item1').should('not.exist');
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
-        cy.get('#item1__item1').should('exist');
+        cy.get('[data-testid="item1"]').focus();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
+        cy.get('[data-testid="item1__item1"]').should('exist');
       });
       it('should collapse item on Left key', () => {
         mount(<TreeTest />);
-        cy.get('#item1').focus();
-        cy.get('#item1__item1').should('not.exist');
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
-        cy.get('#item1__item1').should('exist');
-        cy.get(`#item1 .${treeItemLayoutClassNames.root}`).realPress('{leftarrow}');
-        cy.get('#item1__item1').should('not.exist');
+        cy.get('[data-testid="item1"]').focus();
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
+        cy.get('[data-testid="item1__item1"]').should('exist');
+        cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{leftarrow}');
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
       });
       it('should focus on actions when pressing tab key', () => {
         mount(
@@ -213,11 +182,12 @@ for (const TreeTest of [NestedTree, FlatTree]) {
                   <Button id="action">action</Button>
                 </>
               }
-              id="item1"
+              value="item1"
+              data-testid="item1"
             >
               <TreeItemLayout>level 1, item 1</TreeItemLayout>
               <Tree>
-                <TreeItem id="item1__item1">
+                <TreeItem value="item1__item1" data-testid="item1__item1">
                   <TreeItemLayout>level 2, item 1</TreeItemLayout>
                 </TreeItem>
               </Tree>
@@ -226,7 +196,7 @@ for (const TreeTest of [NestedTree, FlatTree]) {
         );
         cy.focused().should('not.exist');
         cy.document().realPress('Tab');
-        cy.get('#item1').should('be.focused');
+        cy.get('[data-testid="item1"]').should('be.focused');
         cy.document().realPress('Tab');
         cy.get('#action').should('be.focused');
       });
@@ -239,11 +209,12 @@ for (const TreeTest of [NestedTree, FlatTree]) {
                   <Button id="action">action</Button>
                 </>
               }
-              id="item1"
+              value="item1"
+              data-testid="item1"
             >
               <TreeItemLayout>level 1, item 1</TreeItemLayout>
               <Tree>
-                <TreeItem id="item1__item1">
+                <TreeItem value="item1__item1" data-testid="item1__item1">
                   <TreeItemLayout>level 2, item 1</TreeItemLayout>
                 </TreeItem>
               </Tree>
@@ -252,53 +223,53 @@ for (const TreeTest of [NestedTree, FlatTree]) {
         );
         cy.focused().should('not.exist');
         cy.document().realPress('Tab');
-        cy.get('#item1').should('be.focused');
+        cy.get('[data-testid="item1"]').should('be.focused');
         cy.document().realPress('Tab');
         cy.get('#action').should('be.focused').realPress('{enter}');
-        cy.get('#item1__item1').should('not.exist');
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
         cy.get('#action').should('be.focused').realPress('Space');
-        cy.get('#item1__item1').should('not.exist');
+        cy.get('[data-testid="item1__item1"]').should('not.exist');
       });
       it('should focus on first item when pressing tab key', () => {
         mount(<TreeTest />);
         cy.focused().should('not.exist');
         cy.document().realPress('Tab');
-        cy.get('#item1').should('be.focused');
+        cy.get('[data-testid="item1"]').should('be.focused');
       });
       it('should focus out of tree when pressing tab key inside tree.', () => {
         mount(<TreeTest />);
         cy.focused().should('not.exist');
         cy.document().realPress('Tab');
-        cy.get('#item1').should('be.focused');
+        cy.get('[data-testid="item1"]').should('be.focused');
         cy.focused().realPress('Tab');
         cy.focused().should('not.exist');
       });
       describe('Navigation', () => {
         it('should move with Up/Down keys', () => {
           mount(<TreeTest />);
-          cy.get('#item1').focus().realPress('{downarrow}');
-          cy.get('#item2').should('be.focused');
+          cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+          cy.get('[data-testid="item2"]').should('be.focused');
           cy.focused().realPress('Tab').should('not.exist');
         });
         it('should move with Left/Right keys', () => {
           mount(<TreeTest defaultOpenItems={['item2', 'item2__item1']} />);
-          cy.get('#item1').focus().realPress('{downarrow}');
-          cy.get('#item2').should('be.focused').realPress('{rightarrow}');
-          cy.get('#item2__item1').should('be.focused').realPress('{rightarrow}');
-          cy.get('#item2__item1__item1').should('be.focused').realPress('{leftarrow}');
-          cy.get('#item2__item1').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
-          cy.get('#item2').should('be.focused');
+          cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+          cy.get('[data-testid="item2"]').should('be.focused').realPress('{rightarrow}');
+          cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{rightarrow}');
+          cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{leftarrow}');
+          cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
+          cy.get('[data-testid="item2"]').should('be.focused');
         });
         it('should move to last item with End key', () => {
           mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
-          cy.get('#item1').focus().realPress('{end}');
-          cy.get('#item2__item1__item1').should('be.focused');
+          cy.get('[data-testid="item1"]').focus().realPress('{end}');
+          cy.get('[data-testid="item2__item1__item1"]').should('be.focused');
         });
         it('should move to first item with Home key', () => {
           mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
-          cy.get('#item1').focus().realPress('{end}');
-          cy.get('#item2__item1__item1').should('be.focused').realPress('{home}');
-          cy.get('#item1').should('be.focused');
+          cy.get('[data-testid="item1"]').focus().realPress('{end}');
+          cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{home}');
+          cy.get('[data-testid="item1"]').should('be.focused');
         });
       });
     });

--- a/packages/react-components/react-tree/src/hooks/useFlatTree.ts
+++ b/packages/react-components/react-tree/src/hooks/useFlatTree.ts
@@ -31,6 +31,7 @@ export type MutableFlatTreeItem<Value = string> = {
   index: number;
   value: Value;
   level: number;
+  ref: React.RefObject<HTMLDivElement>;
   getTreeItemProps(): Required<
     Pick<TreeItemProps<Value>, 'value' | 'aria-setsize' | 'aria-level' | 'aria-posinset' | 'leaf'>
   > &

--- a/packages/react-components/react-tree/src/hooks/useFlatTreeNavigation.ts
+++ b/packages/react-components/react-tree/src/hooks/useFlatTreeNavigation.ts
@@ -25,7 +25,7 @@ export function useFlatTreeNavigation<Value = string>(flatTreeItems: FlatTreeIte
         treeItemWalker.currentElement = data.target;
         return nextTypeAheadElement(treeItemWalker, data.event.key);
       case treeDataTypes.arrowLeft:
-        return parentElement(flatTreeItems, data.value, targetDocument);
+        return parentElement(flatTreeItems, data.value);
       case treeDataTypes.arrowRight:
         treeItemWalker.currentElement = data.target;
         return firstChild(data.target, treeItemWalker);
@@ -66,13 +66,11 @@ function firstChild(target: HTMLElement, treeWalker: HTMLElementWalker): HTMLEle
   return null;
 }
 
-function parentElement<Value = string>(flatTreeItems: FlatTreeItems<Value>, value: Value, document: Document) {
+function parentElement<Value = string>(flatTreeItems: FlatTreeItems<Value>, value: Value) {
   const flatTreeItem = flatTreeItems.get(value);
-  if (flatTreeItem && flatTreeItem.parentValue) {
-    const parentId = flatTreeItems.get(flatTreeItem.parentValue)?.getTreeItemProps().id;
-    if (parentId) {
-      return document.getElementById(parentId);
-    }
+  if (flatTreeItem?.parentValue) {
+    const parentItem = flatTreeItems.get(flatTreeItem.parentValue);
+    return parentItem?.ref.current ?? null;
   }
   return null;
 }

--- a/packages/react-components/react-tree/src/utils/createFlatTreeItems.ts
+++ b/packages/react-components/react-tree/src/utils/createFlatTreeItems.ts
@@ -1,5 +1,6 @@
 import type { ImmutableSet } from './ImmutableSet';
 import type { FlatTreeItem, FlatTreeItemProps, MutableFlatTreeItem } from '../hooks/useFlatTree';
+import * as React from 'react';
 
 /**
  * @internal
@@ -40,8 +41,9 @@ export function createFlatTreeItems<Value = string>(
     const isLeaf = nextItemProps?.parentValue !== treeItemProps.value;
     const currentLevel = (currentParent.level ?? 0) + 1;
     const currentChildrenSize = ++currentParent.childrenSize;
+    const ref = React.createRef<HTMLDivElement>();
 
-    const flatTreeItem: FlatTreeItem<Value> = {
+    const flatTreeItem: MutableFlatTreeItem<Value> = {
       value: treeItemProps.value,
       getTreeItemProps: () => ({
         ...treeItemProps,
@@ -49,7 +51,10 @@ export function createFlatTreeItems<Value = string>(
         'aria-posinset': currentChildrenSize,
         'aria-setsize': currentParent.childrenSize,
         leaf: isLeaf,
+        // a reference to every parent element is necessary to ensure navigation
+        ref: flatTreeItem.childrenSize > 0 ? ref : undefined,
       }),
+      ref,
       level: currentLevel,
       parentValue,
       childrenSize: 0,
@@ -72,6 +77,7 @@ export const flatTreeRootId = '__fuiFlatTreeRoot' as unknown;
 
 function createFlatTreeRootItem<Value = string>(): FlatTreeItem<Value> {
   return {
+    ref: { current: null },
     value: flatTreeRootId as Value,
     getTreeItemProps: () => {
       if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. Fix bugs introduced by https://github.com/microsoft/fluentui/pull/27532
   - PR #27532 introduced a bug where navigation from child element to parent was unable
2. Updates test to work properly without `id`
