### PR TITLE
fix: Combobox adds aria-invalid when in an error state

### DIFF
--- a/change/@fluentui-react-dd546ed0-e453-4f25-8149-7f3f79e30e17.json
+++ b/change/@fluentui-react-dd546ed0-e453-4f25-8149-7f3f79e30e17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Combobox adds aria-invalid when in an error state\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -122,6 +122,15 @@ describe('ComboBox', () => {
     expect(combobox.getAttribute('aria-disabled')).toEqual('true');
   });
 
+  it('Sets aria-invalid when an error message is passed in.', () => {
+    const { getByRole, rerender } = render(<ComboBox errorMessage="error" options={DEFAULT_OPTIONS} />);
+    const combobox = getByRole('combobox');
+    expect(combobox.getAttribute('aria-invalid')).toEqual('true');
+
+    rerender(<ComboBox errorMessage={undefined} options={DEFAULT_OPTIONS} />);
+    expect(combobox.getAttribute('aria-invalid')).toBeNull();
+  });
+
   it('Renders no selected item in default case', () => {
     const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS} />);
     expect(getByRole('combobox').getAttribute('value')).toEqual('');

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -659,6 +659,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           aria-describedby={
             errorMessage !== undefined ? mergeAriaAttributeValues(ariaDescribedBy, errorMessageId) : ariaDescribedBy
           }
+          aria-invalid={errorMessage !== undefined ? 'true' : undefined}
           aria-activedescendant={ariaActiveDescendantValue}
           aria-required={required}
           aria-disabled={disabled}


### PR DESCRIPTION
This fixes a bug I noticed while we were discussing timepicker validation. Combobox currently doesn't set `aria-invalid` when in an errored state.

Now it is set based on whether `errorMessage` is defined, which is also how the red border styling is determined.