### PR TITLE
feat(react-conformance): add new TS config api to be able to specify configName and configDir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,6 +133,7 @@ apps/recipes-react-components @microsoft/cxe-red @microsoft/cxe-coastal @microso
 #### Packages
 packages/azure-themes @Jacqueline-ms @robtaft-ms
 packages/bundle-size @microsoft/teams-prg
+packages/react-conformance @microsoft/fluentui-react-build
 packages/date-time-utilities @microsoft/cxe-red
 packages/eslint-plugin @microsoft/fluentui-react-build
 packages/foundation-legacy @microsoft/cxe-red @khmakoto

--- a/change/@fluentui-react-conformance-9b875b33-ced4-434a-9690-448766658f08.json
+++ b/change/@fluentui-react-conformance-9b875b33-ced4-434a-9690-448766658f08.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add new TS config api to be able to specify configName and configDir",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -8,14 +8,28 @@ import { getComponentDoc } from './utils/getComponentDoc';
 
 export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptions<TProps>>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);
-  const { componentPath, displayName, disabledTests = [], extraTests, tsconfigDir } = mergedOptions;
+
+  const {
+    componentPath,
+    displayName,
+    disabledTests = [],
+    extraTests,
+    tsConfig,
+    // eslint-disable-next-line deprecation/deprecation
+    tsconfigDir,
+  } = mergedOptions;
+
+  const mergedTsConfig = {
+    configDir: tsConfig?.configDir ?? tsconfigDir,
+    configName: tsConfig?.configName,
+  };
 
   describe('isConformant', () => {
     if (!fs.existsSync(componentPath)) {
       throw new Error(`Path ${componentPath} does not exist`);
     }
 
-    const tsProgram = createTsProgram(componentPath, tsconfigDir);
+    const tsProgram = createTsProgram(componentPath, mergedTsConfig);
 
     const components = getComponentDoc(componentPath, tsProgram);
     const mainComponents = components.filter(comp => comp.displayName === displayName);

--- a/packages/react-conformance/src/types.ts
+++ b/packages/react-conformance/src/types.ts
@@ -92,10 +92,16 @@ export interface IsConformantOptions<TProps = {}> {
   primarySlot?: keyof TProps | 'root';
 
   /**
+   * @deprecated - use `tsConfig` property
+   *
    * Test will load the first tsconfig.json file working upwards from `tsconfigDir`.
    * @defaultvalue the directory of the component being tested
    */
   tsconfigDir?: string;
+  /**
+   * replaces tsconfigDir
+   */
+  tsConfig?: Partial<{ configName: string; configDir: string }>;
 }
 
 export type ConformanceTest<TProps = {}> = (

--- a/packages/react-conformance/src/utils/createTsProgram.ts
+++ b/packages/react-conformance/src/utils/createTsProgram.ts
@@ -5,18 +5,23 @@ import * as ts from 'typescript';
 let program: ts.Program;
 
 /**
- * Creates a cached TS Program.
+ * Creates a ~cached~ TS Program.
+ * @remarks this will be never cached with current use/setup as jest creates this for every it/describe() block 🐌
  */
-export function createTsProgram(componentPath: string, tsconfigDir?: string): ts.Program {
+export function createTsProgram(
+  sourcePath: string,
+  options: Partial<{ configDir: string; configName: string }> = {},
+): ts.Program {
+  const { configName, configDir } = options;
   if (!program) {
     // Calling parse() from react-docgen-typescript would create a new ts.Program for every component,
     // which can take multiple seconds in a large project. For better performance, we create a single
     // ts.Program per package and pass it to parseWithProgramProvider().
 
-    const tsconfigPath = ts.findConfigFile(tsconfigDir ?? componentPath, fs.existsSync);
+    const tsconfigPath = ts.findConfigFile(configDir ?? sourcePath, fs.existsSync, configName);
 
     if (!tsconfigPath) {
-      throw new Error('Cannot find tsconfig.json');
+      throw new Error(`Cannot find ${configName}`);
     }
 
     const compilerOptions = getCompilerOptions(tsconfigPath);
@@ -33,9 +38,9 @@ export function createTsProgram(componentPath: string, tsconfigDir?: string): ts
     program = ts.createProgram([rootFile], compilerOptions);
   }
 
-  if (!program.getSourceFile(componentPath)) {
+  if (!program.getSourceFile(sourcePath)) {
     // See earlier comment for why it's handled this way (can reconsider if it becomes a problem)
-    throw new Error(`Component file "${componentPath}" does not appear to be referenced from the project index file`);
+    throw new Error(`Component file "${sourcePath}" does not appear to be referenced from the project index file`);
   }
 
   return program;


### PR DESCRIPTION
## Previous Behavior

Conformance test used within projects that use TS path aliases are slow and cause various OOMemory leaks on CI.

This is caused by:
- bad architecture / technology constraints (jest as conformance env) 
- creation of TS Program, which in case of solution config file is forced to construct huge TS tree (all cy,unit,implementation,stories)

## New Behavior

This PR adds new generic conformance config API which needs to be used for projects with ts solution configs. By leveraging this new API we get following benchmark improvements:

**Demo:**
```diff
const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+  tsConfig: { configName: 'tsconfig.spec.json' },
   componentPath: require.main?.filename.replace('.test', ''),
     ...
}
```

**Speed metrics::**

_Legend:_

- optimization v1 = fixing react-conformance to consume tsconfig.lib.json for ts solution projects

| command: `yarn workspace @fluentui/react-text --no-cache --runInBand` | time  | delta | remarks |
| --------------------------------------------------------------------- | ----- | ----- | ------- |
| 1) ts-jest (current state)                                            | 69s   | BASE  |         |
| 2) optimization v1 + ts-jest                                          | 37.43 | 46%   |         |
| 3) optimization v1 + swc                                              | 28.79 | 58%   |     not part of this PR    |

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes partially https://github.com/microsoft/fluentui/issues/27359
- Pre-requirement of https://github.com/microsoft/fluentui/issues/27660
