### PR TITLE
chore: Add caret to react-datepicker-compat dependencies

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -22,7 +22,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-datepicker-compat": "0.0.1",
+    "@fluentui/react-datepicker-compat": "^0.0.1",
     "@fluentui/react-migration-v8-v9": "^9.2.10",
     "@fluentui/react-migration-v0-v9": "9.0.0-alpha.0",
     "@fluentui/react": "^8.108.1",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -27,7 +27,7 @@
     "@fluentui/react-card": "^9.0.8",
     "@fluentui/react-checkbox": "^9.1.11",
     "@fluentui/react-combobox": "^9.2.11",
-    "@fluentui/react-datepicker-compat": "0.0.1",
+    "@fluentui/react-datepicker-compat": "^0.0.1",
     "@fluentui/react-dialog": "^9.5.3",
     "@fluentui/react-divider": "^9.2.10",
     "@fluentui/react-field": "^9.1.1",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Packages with `@fluentui/react-datepicker-compat` have pinned dependencies.

## New Behavior

Packages with `@fluentui/react-datepicker-compat` now use caret for their dependency.

