### PR TITLE
chore: unify jest maxWorkers usage on CI and turn off code coverage

### DIFF
--- a/packages/keyboard-key/jest.config.js
+++ b/packages/keyboard-key/jest.config.js
@@ -1,7 +1,6 @@
 const { createV8Config: createConfig } = require('@fluentui/scripts-jest');
 
 const config = createConfig({
-  collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!node_modules/**'],
   coverageDirectory: 'coverage',
   coverageThreshold: {

--- a/scripts/gulp/src/plugins/gulp-jest.ts
+++ b/scripts/gulp/src/plugins/gulp-jest.ts
@@ -2,6 +2,7 @@ import { sh } from '@fluentui/scripts-utils';
 
 export type JestPluginConfig = {
   config: string;
+  cache?: boolean;
   coverage?: boolean;
   detectLeaks?: boolean;
   maxWorkers?: number;
@@ -25,12 +26,12 @@ const jest = (config: JestPluginConfig) => () => {
     config.coverage && '--coverage',
     config.watchAll && '--watchAll',
     config.runInBand && '--runInBand',
-    // eslint-disable-next-line eqeqeq
-    config.maxWorkers != null && `--maxWorkers=${config.maxWorkers}`,
+    config.maxWorkers && `--maxWorkers=${config.maxWorkers}`,
     config.detectLeaks && '--detectLeaks',
     config.testNamePattern && `--testNamePattern="${config.testNamePattern}"`,
     config.rootDir && `--rootDir ${config.rootDir}`,
     config.verbose && '--verbose',
+    config.cache === true ? '' : '--no-cache',
     config.testFilePattern, // !!! THIS ITEM MUST GO LAST IN THE ARRAY !!!
   ]
     .filter(Boolean)

--- a/scripts/gulp/src/tasks/test-unit.ts
+++ b/scripts/gulp/src/tasks/test-unit.ts
@@ -1,17 +1,19 @@
-import { task, series } from 'gulp';
+import { series, task } from 'gulp';
 import yargs from 'yargs';
 
 import jest, { JestPluginConfig } from '../plugins/gulp-jest';
 
 const argv = yargs
+  .option('cache', {})
   .option('runInBand', {})
   .option('maxWorkers', {})
   .option('detectLeaks', {})
-  .option('coverage', { default: true })
+  .option('coverage', {})
   .option('testNamePattern', { alias: 't' })
   .option('testFilePattern', { alias: 'F' }).argv;
 
 const jestConfigFromArgv: Partial<JestPluginConfig> = {
+  cache: argv.cache as boolean,
   runInBand: argv.runInBand as boolean,
   coverage: argv.coverage as boolean,
   maxWorkers: argv.maxWorkers as number,
@@ -19,10 +21,6 @@ const jestConfigFromArgv: Partial<JestPluginConfig> = {
   testNamePattern: argv.testNamePattern as string,
   testFilePattern: argv.testFilePattern as string,
 };
-
-if (process.env.TF_BUILD) {
-  jestConfigFromArgv.maxWorkers = 2;
-}
 
 task(
   'test:jest',

--- a/scripts/jest/src/environment.js
+++ b/scripts/jest/src/environment.js
@@ -1,0 +1,3 @@
+const isCI = Boolean(process.env.TF_BUILD);
+
+exports.isCI = isCI;

--- a/scripts/jest/src/jest.preset.v0.js
+++ b/scripts/jest/src/jest.preset.v0.js
@@ -1,5 +1,8 @@
 const { getWorkspaceProjectsAliases } = require('@fluentui/scripts-monorepo');
 
+const { isCI } = require('./environment');
+const { workersConfig } = require('./shared');
+
 // northstar packages should pull these from npm, not the repo
 const excludedPackages = ['@fluentui/dom-utilities'];
 
@@ -18,6 +21,7 @@ const createConfig = (/** @type {import('@jest/types').Config.InitialOptions} */
   testEnvironment: 'jsdom',
   restoreMocks: true,
   clearMocks: true,
+  ...(isCI ? workersConfig : null),
   ...customConfig,
   moduleNameMapper: {
     ...getWorkspaceProjectsAliases({

--- a/scripts/jest/src/jest.preset.v8.js
+++ b/scripts/jest/src/jest.preset.v8.js
@@ -1,8 +1,11 @@
+const fs = require('fs');
 const path = require('path');
 
 const { findRepoDeps } = require('@fluentui/scripts-monorepo');
 const { findConfig, merge } = require('@fluentui/scripts-utils');
-const fs = require('fs-extra');
+
+const { isCI } = require('./environment');
+const { workersConfig } = require('./shared');
 
 const packageJsonPath = findConfig('package.json') ?? '';
 const packageRoot = path.dirname(packageJsonPath);
@@ -31,7 +34,7 @@ const jestAliases = () => {
   }
 
   // Special aliases to look at src for the current package
-  const packageJson = fs.readJSONSync(packageJsonPath);
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
   aliases[`^${packageJson.name}$`] = '<rootDir>/src/';
   aliases[`^${packageJson.name}/lib/(.*)$`] = '<rootDir>/src/$1';
 
@@ -80,6 +83,8 @@ const createConfig = (customConfig = {}) => {
     testEnvironment: 'jsdom',
     restoreMocks: true,
     clearMocks: true,
+
+    ...(isCI ? workersConfig : null),
 
     watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
     // OLD format for migration to jest 29 - TODO: migrate to new format . https://jestjs.io/blog/2022/04/25/jest-28#future

--- a/scripts/jest/src/shared.js
+++ b/scripts/jest/src/shared.js
@@ -1,0 +1,3 @@
+const workersConfig = { maxWorkers: 4 };
+
+exports.workersConfig = workersConfig;

--- a/scripts/tasks/src/jest.ts
+++ b/scripts/tasks/src/jest.ts
@@ -1,12 +1,11 @@
-import { jestTask, JestTaskOptions } from 'just-scripts';
-import * as path from 'path';
-import unparse from 'yargs-unparser';
-import { getJustArgv, JustArgs } from './argv';
+import { logger } from 'just-scripts';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { spawn } from 'just-scripts-utils';
 
-const commonJestTask = (options: JestTaskOptions = {}) => {
+import { JustArgs, getJustArgv } from './argv';
+
+const commonJestTask = (options: JestTaskConfig = {}) => {
   const {
-    runInBand = !!(process.env.TF_BUILD || process.env.LAGE_PACKAGE_NAME),
-    passWithNoTests = true,
     nodeArgs,
     _ = [],
     // args for our just preset which should not be passed through to jest
@@ -19,40 +18,62 @@ const commonJestTask = (options: JestTaskOptions = {}) => {
     registry,
     // these args without explicit handling will be passed directly through to jest
     ...otherArgs
-  } = getJustArgv() as JustArgs & JestTaskOptions;
+  } = getJustArgv() as JustArgs & JestTaskConfig;
 
-  return jestTask({
-    runInBand,
-    passWithNoTests,
-    nodeArgs, // Just-specific config
-
-    _: [
-      // jestTask doesn't have explicit support for all jest args (https://jestjs.io/docs/en/cli),
-      // so unparse any extra args and pass them through here
-      ...unparse({ ...otherArgs, _: [] }),
-      // and pass any positional args (to narrow down tests to be run)
-      ..._.filter(arg => arg !== 'jest' && arg !== 'jest-watch'),
-    ],
-
-    env: {
-      ...process.env,
-      NODE_ENV: 'test',
-      PACKAGE_NAME: packageName,
-    },
-    ...options,
-  });
+  return jestTask({ ...options, ...otherArgs });
 };
 
 export const jest = () => {
   return commonJestTask();
 };
 
-export const jestDom = () =>
-  jestTask({
-    runInBand: true,
-    config: path.join(process.cwd(), 'jest.dom.config.js'),
-  });
-
 export const jestWatch = () => {
   return commonJestTask({ watch: true });
+};
+
+type JestTaskConfig = {
+  config?: string;
+  passWithNoTests?: boolean;
+  cache?: boolean;
+  clearCache?: boolean;
+  coverage?: boolean;
+  detectLeaks?: boolean;
+  maxWorkers?: number;
+  rootDir?: string;
+  runInBand?: boolean;
+  testNamePattern?: string;
+  testFilePattern?: string;
+  verbose?: boolean;
+  watchAll?: boolean;
+  watch?: boolean;
+};
+
+/**
+ *
+ * custom jest task as just-scripts jest task doesn't support maxWorkers setup and others
+ */
+const jestTask = (config: JestTaskConfig) => () => {
+  const cmd = 'jest';
+  const cache = config.cache !== undefined ? config.cache : true;
+  const passWithNoTests = config.passWithNoTests !== undefined ? config.passWithNoTests : true;
+  const args = [
+    cache === false && '--no-cache',
+    passWithNoTests && '--passWithNoTests',
+    config.config && `--config ${config.config}`,
+    config.rootDir && `--rootDir ${config.rootDir}`,
+    config.watch && '--watch',
+    config.watchAll && '--watchAll',
+    config.clearCache && '--clearCache',
+    config.coverage && '--coverage',
+    config.runInBand && '--runInBand',
+    config.maxWorkers && `--maxWorkers=${config.maxWorkers}`,
+    config.detectLeaks && '--detectLeaks',
+    config.testNamePattern && `--testNamePattern="${config.testNamePattern}"`,
+    config.verbose && '--verbose',
+    config.testFilePattern,
+  ].filter(Boolean) as string[];
+
+  logger.info(cmd, args.join(' '));
+
+  return spawn(cmd, args, { stdio: 'inherit' });
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- v0,v8 have different jest setups in terms of leveraging threads on CI
- some projects run code-coverage in CI which slows down test execution by 10%

## New Behavior

- v0,v8 uses unified `maxWorkers` setup on CI, (based on measurements it looks like ideal setup for our current CI resources )
  - 💡 what about v9? 
    - in my initial experiments this was also enabled for v9. looks like until all perf improvements will land this will cause CI to run over 1 hour - so not part of this PR
- code-coverage has been disabled

**Speed metrics:**

Using code-coverage (react-northstar - up to 10% slowdown)

| Run type        | time  | command                                                                    |
| --------------- | ----- | -------------------------------------------------------------------------- |
| current         | 382 s | `gulp test --config ./jest.config.js --coverage --maxWorkers=2 --no-cache` |
| without codecov | 340 s | `gulp test --config ./jest.config.js --maxWorkers=2`                        |


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
- Blocked by:
  - https://github.com/microsoft/fluentui/pull/27661
  - https://github.com/microsoft/fluentui/pull/27669 
- Fixes partially https://github.com/microsoft/fluentui/issues/27359
- Pre-requirement of https://github.com/microsoft/fluentui/issues/27660
