### PR TITLE
RFC: v9 Combobox spacebar behavior

### DIFF
--- a/rfcs/react-components/components/combobox-spacebar.md
+++ b/rfcs/react-components/components/combobox-spacebar.md
@@ -90,8 +90,6 @@ Since options visually look like they have check marks and semantically use `ari
 
 #### Cons
 
-g
-
 - There is no way to opt into space-to-select on single-select combos, or space-to-type on multiselect combos
 
 ### 5. Provide a context that sets spacebar default behavior

--- a/rfcs/react-components/components/combobox-spacebar.md
+++ b/rfcs/react-components/components/combobox-spacebar.md
@@ -69,7 +69,7 @@ We would keep the behavior where if the user is actively interacting with the op
 
 - There is no way to opt into space-to-select behavior
 
-### 4. ALways allow space to insert a character on single-select Comboboxes, always select on multi-select comboboxes
+### 4. Always allow space to insert a character on single-select Comboboxes, always select on multi-select comboboxes
 
 Since options visually look like they have check marks and semantically use `aria-checked` instead of `aria-selected`, there is a stronger expectation of space-to-select. Additionally, multiselect comboboxes are already hitting a limit of too much complexity for one component, and most use cases would benefit from using either the multiselect Dropdown or single-select Combobox + tags instead. Opting into a simpler, more intuitive but less feature-rich UX might result in a less error-prone UX in this variant in particular.
 

--- a/rfcs/react-components/components/combobox-spacebar.md
+++ b/rfcs/react-components/components/combobox-spacebar.md
@@ -4,34 +4,101 @@
 
 ## Summary
 
-<!-- Explain the proposed change -->
+This RFC deals with how to provide space-to-type behavior in v9 Comboboxes.
 
 ## Background
 
-<!-- If there is relevant background include it here -->
+The central issue is that spacebar is both a common selection key and a typeable character, and Combobox is a control with both selection and typing functionality.
+
+While this RFC deals only with Combobox and not Dropdown, it is important to note that semantically Combobox and Dropdown are essentially the same. Expectations among screen reader users for keyboard behavior seem to easily carry over between the two. Non-editable comboboxes are a more common and simple control, and are likely influencing keyboard expectations with editable comboboxes.
+
+Another important factor to note is that using Enter to select is not as common as might be expected, since it is also the key that submits a form, and often avoided within forms for that reason. This is less of an issue with a standalone combobox where selection and submission are not different interactions.
+
+## Precedence
+
+- In v8 Combobox and v0 Dropdown, spacebar did not select
+- Office editable comboboxes select on space when opened with alt+down, but not when opened with the down arrow alone
+- On Windows, non-editable comboboxes (similar to v9 Dropdown) in Settings select with space. Editable comboboxes in apps like Explorer and Activity monitor allow space as a character
+
+## User study
+
+In an A/B user study focusing primarily on screen reader users and alternative input users (keyboard, switch, voice control), people using the keyboard overwhelmingly expected space to select in all comboboxes. In variations where space did not select, this was called out as one of the primary confusing things about the component, particularly strongly with multiselect comboboxes.
+
+## Context
+
+The surrounding context of an app or website is also likely to influence user expectations on keyboard behavior. Typing a name into a `To: ` input in Outlook or Teams is likely to influence users to expect space to insert a character. Moving through multiple fields in a form is more likely to influence users to expect space to select. The ideal spacebar behavior is likely to differ based on how and where the v9 Combobox is being used.
 
 ## Problem statement
 
-<!--
-Why are we making this change? What problem are we solving? What do we expect to gain from this?
+We cannot fully know whether the ideal spacebar behavior is to select or insert a character, since we don't know the full context of usage. Our choices mostly revolve around balancing providing more flexibility vs. more consistency, and choosing the best default if we do provide flexibility.
 
-This section is important as the motivation or problem statement is indepenent from the proposed change. Even if this RFC is not accepted this Motivation can be used for alternative solutions.
+## Options
 
-In the end, please make sure to present a neutral Problem statement, rather than one that motivates a particular solution
--->
+### 1. `allowSpaceCharacter` prop, default to `true`
 
-## Detailed Design or Proposal
+This is the option that allows authors to choose the best behavior for their use case, defaulting to allowing space to insert a character. This borrows the behavior from the freeform PR, where space will still select if the user is actively interacting with the dropdown listbox (i.e. it is open, and the last interaction was to navigate through options).
 
-<!-- This is the bulk of the RFC. Explain the proposal or design in enough detail for the inteded audience to understand. -->
+We would likely include author guidance that all Comboboxes within their app use the same behavior for `allowSpaceCharacter`.
 
-### Pros and Cons
+#### Pros
 
-<!-- Enumerate the pros and cons of the proposal. Make sure to think about and be clear on the cons or drawbacks of this propsoal. If there are multiple proposals include this for each. -->
+- Allows authors to choose the best behavior per use case
+- Defaulting to `true` means the default probably(?) matches the majority of Combobox usage
+- Defaulting to `true` means that often-missed use cases like spaces in translated strings or user-generated options won't cause issues
 
-## Discarded Solutions
+#### Cons
 
-<!-- As you enumerate possible solutions, try to keep track of the discarded ones. This should include why we discarded the solution. -->
+- Defaulting to `true` means the simplest/most basic use case is not the default
+- Defaulting to `true` means the Combobox space behavior is different from Dropdown by default, which primarily affects keyboard and screen reader users.
+- Providing a prop to alter the space key behavior potentially means inconsistent behavior within an app, or across related apps
+
+### 2. `allowSpaceCharacter` prop, default to `false`
+
+This is the same as (1), but with a different default. The Pros/Cons list is essentially the same, but reversed.
+
+### 3. Always allow space to insert a character
+
+We would keep the behavior where if the user is actively interacting with the options in the dropdown listbox, space will select. Otherwise, space will insert a character in the input.
+
+#### Pros
+
+- Authors don't need to try to figure out what the ideal space key behavior is on a case-by-case basis / less authoring overhead for an already complex component
+- Consistent behavior across all apps using Fluent
+
+#### Cons
+
+- There is no way to opt into space-to-select behavior
+
+### 4. ALways allow space to insert a character on single-select Comboboxes, always select on multi-select comboboxes
+
+Since options visually look like they have check marks and semantically use `aria-checked` instead of `aria-selected`, there is a stronger expectation of space-to-select. Additionally, multiselect comboboxes are already hitting a limit of too much complexity for one component, and most use cases would benefit from using either the multiselect Dropdown or single-select Combobox + tags instead. Opting into a simpler, more intuitive but less feature-rich UX might result in a less error-prone UX in this variant in particular.
+
+#### Pros
+
+- Authors don't need to figure out ideal space key behavior on a case-by-case basis
+- Consistent behavior across all apps using Fluent
+- The variant with the strongest expectation of space-to-select keeps that behavior
+
+#### Cons
+
+- There is no way to opt into space-to-select on single-select combos, or space-to-type on multiselect combos
+
+### 5. Provide a context that sets spacebar default behavior
+
+In this option, we would still have an `allowSpaceCharacter` prop with one of the defaults in (1) or (2), but also provide a context that allows an entire app to change the default for all Comboboxes within it.
+
+#### Pros
+
+- Allows an app team to choose the best behavior for all Comboboxes within it
+- Splits some of the difference between choice vs. consistency
+
+#### Cons
+
+- Requires a new top-level context
+- Still has a lack of standardization between apps, which may or may not be an issue
+- Use cases may vary within an app, which still comes with the same pros/cons of options (1) and (2)
 
 ## Open Issues
 
-<!-- Optional section, but useful for first drafts. Use this section to track open issues on unanswered questions regarding the design or proposal.  -->
+Spacebar behavior issues: https://github.com/microsoft/fluentui/issues/26361, https://github.com/microsoft/fluentui/issues/26295
+Freeform PR: https://github.com/microsoft/fluentui/pull/27025

--- a/rfcs/react-components/components/combobox-spacebar.md
+++ b/rfcs/react-components/components/combobox-spacebar.md
@@ -1,0 +1,37 @@
+# RFC: Combobox spacebar behavior
+
+@smhigley
+
+## Summary
+
+<!-- Explain the proposed change -->
+
+## Background
+
+<!-- If there is relevant background include it here -->
+
+## Problem statement
+
+<!--
+Why are we making this change? What problem are we solving? What do we expect to gain from this?
+
+This section is important as the motivation or problem statement is indepenent from the proposed change. Even if this RFC is not accepted this Motivation can be used for alternative solutions.
+
+In the end, please make sure to present a neutral Problem statement, rather than one that motivates a particular solution
+-->
+
+## Detailed Design or Proposal
+
+<!-- This is the bulk of the RFC. Explain the proposal or design in enough detail for the inteded audience to understand. -->
+
+### Pros and Cons
+
+<!-- Enumerate the pros and cons of the proposal. Make sure to think about and be clear on the cons or drawbacks of this propsoal. If there are multiple proposals include this for each. -->
+
+## Discarded Solutions
+
+<!-- As you enumerate possible solutions, try to keep track of the discarded ones. This should include why we discarded the solution. -->
+
+## Open Issues
+
+<!-- Optional section, but useful for first drafts. Use this section to track open issues on unanswered questions regarding the design or proposal.  -->

--- a/rfcs/react-components/components/combobox-spacebar.md
+++ b/rfcs/react-components/components/combobox-spacebar.md
@@ -40,7 +40,25 @@ One of the risks is that the developers and designers may not be in a position t
 
 We cannot fully know whether the ideal spacebar behavior is to select or insert a character, since we don't know the full context of usage. Our choices mostly revolve around balancing providing more flexibility vs. more consistency, and choosing the best default if we do provide flexibility.
 
-## Options
+## Solution
+
+After the offline discussion (happened at 17th May 23) we went with the following solution.
+
+### 3. Always allow space to insert a character
+
+- `Dropdown` does select on space
+- `Combobox` does not select on space, always inserts a character in the input
+
+#### Pros
+
+- Authors don't need to try to figure out what the ideal space key behavior is on a case-by-case basis / less authoring overhead for an already complex component
+- Consistent behavior across all apps using Fluent
+
+#### Cons
+
+- There is no way to opt into space-to-select behavior
+
+## Rejected options
 
 ### 1. `allowSpaceCharacter` prop, default to `true`
 
@@ -64,19 +82,6 @@ We would likely include author guidance that all Comboboxes within their app use
 ### 2. `allowSpaceCharacter` prop, default to `false`
 
 This is the same as (1), but with a different default. The Pros/Cons list is essentially the same, but reversed.
-
-### 3. Always allow space to insert a character
-
-We would keep the behavior where if the user is actively interacting with the options in the dropdown listbox, space will select. Otherwise, space will insert a character in the input.
-
-#### Pros
-
-- Authors don't need to try to figure out what the ideal space key behavior is on a case-by-case basis / less authoring overhead for an already complex component
-- Consistent behavior across all apps using Fluent
-
-#### Cons
-
-- There is no way to opt into space-to-select behavior
 
 ### 4. Always allow space to insert a character on single-select Comboboxes, always select on multi-select comboboxes
 

--- a/rfcs/react-components/components/combobox-spacebar.md
+++ b/rfcs/react-components/components/combobox-spacebar.md
@@ -1,6 +1,6 @@
 # RFC: Combobox spacebar behavior
 
-@smhigley
+@smhigley @jurokapsiar
 
 ## Summary
 
@@ -14,6 +14,8 @@ While this RFC deals only with Combobox and not Dropdown, it is important to not
 
 Another important factor to note is that using Enter to select is not as common as might be expected, since it is also the key that submits a form, and often avoided within forms for that reason. This is less of an issue with a standalone combobox where selection and submission are not different interactions.
 
+Currently, there is an agreement on inserting a space character when freeform variant is used and the user has not interacted with the dropdown list. See [feat: react-combobox space conditionally inserts character when freeform is true](https://github.com/microsoft/fluentui/pull/27025) for details.
+
 ## Precedence
 
 - In v8 Combobox and v0 Dropdown, spacebar did not select
@@ -24,9 +26,15 @@ Another important factor to note is that using Enter to select is not as common 
 
 In an A/B user study focusing primarily on screen reader users and alternative input users (keyboard, switch, voice control), people using the keyboard overwhelmingly expected space to select in all comboboxes. In variations where space did not select, this was called out as one of the primary confusing things about the component, particularly strongly with multiselect comboboxes.
 
+The two caveats to consider when evaluating the user study are that it is impossible to fully and realistically recreate real-world app context and expectations in an isolated test UI, and also that it focused on a small group (~12) of participants who all used some form of assistive tech. It points towards an expected behavior, but is not an absolute conclusion.
+
 ## Context
 
 The surrounding context of an app or website is also likely to influence user expectations on keyboard behavior. Typing a name into a `To: ` input in Outlook or Teams is likely to influence users to expect space to insert a character. Moving through multiple fields in a form is more likely to influence users to expect space to select. The ideal spacebar behavior is likely to differ based on how and where the v9 Combobox is being used.
+
+The content of options also influences user expectations -- there would be a greater expectation of space-to-type when options contain a space in them, for example multi-word options, names, states or cities.
+
+One of the risks is that the developers and designers may not be in a position to make a correct decision on the value of the prop. This is because options are usually either translations or user data, which may contain spaces that the authoring team was not aware of. We generally can't expect authors to understand all possible translations across supported languages or the specific validations of the user data at UI authoring time. While the occaisonal space character does not necessarily mean that space should not select, translations and user data do introduce the possibility of frequent spaces within multiple options.
 
 ## Problem statement
 
@@ -51,6 +59,7 @@ We would likely include author guidance that all Comboboxes within their app use
 - Defaulting to `true` means the simplest/most basic use case is not the default
 - Defaulting to `true` means the Combobox space behavior is different from Dropdown by default, which primarily affects keyboard and screen reader users.
 - Providing a prop to alter the space key behavior potentially means inconsistent behavior within an app, or across related apps
+- This behavior is not aligned with the results of the user study
 
 ### 2. `allowSpaceCharacter` prop, default to `false`
 
@@ -80,6 +89,8 @@ Since options visually look like they have check marks and semantically use `ari
 - The variant with the strongest expectation of space-to-select keeps that behavior
 
 #### Cons
+
+g
 
 - There is no way to opt into space-to-select on single-select combos, or space-to-type on multiselect combos
 


### PR DESCRIPTION
Adds an RFC around how space should behave and what options we should provide in the v9 Combobox component.

[RFC](https://github.com/microsoft/fluentui/blob/a35d2fb62b9769bd8817a32a9981275307ced96f/rfcs/react-components/components/combobox-spacebar.md)

Includes content from #27695