### PR TITLE
feat(react-tree): creates `TreeItemAside` component

### DIFF
--- a/change/@fluentui-react-tree-6f4ad617-cd80-47d5-a160-020e5bfc3cec.json
+++ b/change/@fluentui-react-tree-6f4ad617-cd80-47d5-a160-020e5bfc3cec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: creates TreeItemAside component",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -75,6 +75,9 @@ export const renderTree_unstable: (state: TreeState, contextValues: TreeContextV
 export const renderTreeItem_unstable: (state: TreeItemState, contextValues: TreeItemContextValues) => JSX.Element;
 
 // @public
+export const renderTreeItemAside_unstable: (state: TreeItemAsideState) => JSX.Element | null;
+
+// @public
 export const renderTreeItemLayout_unstable: (state: TreeItemLayoutState) => JSX.Element;
 
 // @public
@@ -126,6 +129,30 @@ export const TreeItem: React_2.ForwardRefExoticComponent<Omit<Partial<TreeItemSl
     itemType: TreeItemType;
 } & React_2.RefAttributes<HTMLDivElement>> & (<Value = string>(props: TreeItemProps<Value>) => JSX.Element);
 
+// @public
+export const TreeItemAside: ForwardRefComponent<TreeItemAsideProps>;
+
+// @public (undocumented)
+export const treeItemAsideClassNames: SlotClassNames<TreeItemAsideSlots>;
+
+// @public
+export type TreeItemAsideProps = ComponentProps<TreeItemAsideSlots> & {
+    actions?: boolean;
+    visible?: true;
+};
+
+// @public (undocumented)
+export type TreeItemAsideSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type TreeItemAsideState = ComponentState<TreeItemAsideSlots> & {
+    actions: boolean;
+    visible: boolean;
+    buttonContextValue: ButtonContextValue;
+};
+
 // @public (undocumented)
 export const treeItemClassNames: SlotClassNames<TreeItemSlots>;
 
@@ -144,16 +171,10 @@ export type TreeItemLayoutSlots = {
     expandIcon?: Slot<'div'>;
     iconBefore?: Slot<'div'>;
     iconAfter?: Slot<'div'>;
-    aside?: Slot<'div'>;
-    actions?: Slot<'div'>;
 };
 
 // @public
-export type TreeItemLayoutState = ComponentState<TreeItemLayoutSlots> & {
-    buttonContextValue: ButtonContextValue;
-    isActionsVisible: boolean;
-    isAsideVisible: boolean;
-};
+export type TreeItemLayoutState = ComponentState<TreeItemLayoutSlots>;
 
 // @public (undocumented)
 export const treeItemLevelToken: "--fluent-TreeItem--level";
@@ -175,16 +196,11 @@ export type TreeItemPersonaLayoutSlots = {
     main: NonNullable<Slot<'div'>>;
     description?: Slot<'div'>;
     content: NonNullable<Slot<'div'>>;
-    aside?: Slot<'div'>;
-    actions?: Slot<'div'>;
 };
 
 // @public
 export type TreeItemPersonaLayoutState = ComponentState<TreeItemPersonaLayoutSlots> & {
     avatarSize: AvatarSize;
-    buttonContextValue: ButtonContextValue;
-    isActionsVisible: boolean;
-    isAsideVisible: boolean;
 };
 
 // @public
@@ -308,6 +324,12 @@ export function useTreeContextValues_unstable(state: TreeState): TreeContextValu
 
 // @public
 export function useTreeItem_unstable<Value = string>(props: TreeItemProps<Value>, ref: React_2.Ref<HTMLDivElement>): TreeItemState;
+
+// @public
+export const useTreeItemAside_unstable: (props: TreeItemAsideProps, ref: React_2.Ref<HTMLElement>) => TreeItemAsideState;
+
+// @public
+export const useTreeItemAsideStyles_unstable: (state: TreeItemAsideState) => TreeItemAsideState;
 
 // @public (undocumented)
 export const useTreeItemContext_unstable: <T>(selector: ContextSelector<TreeItemContextValue, T>) => T;

--- a/packages/react-components/react-tree/src/TreeItemAside.ts
+++ b/packages/react-components/react-tree/src/TreeItemAside.ts
@@ -1,0 +1,1 @@
+export * from './components/TreeItemAside/index';

--- a/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
@@ -5,6 +5,7 @@ import { teamsLightTheme } from '@fluentui/react-theme';
 import {
   Tree,
   TreeItem,
+  TreeItemAside,
   TreeItemLayout,
   TreeProps,
   treeItemLayoutClassNames,
@@ -125,7 +126,10 @@ for (const TreeTest of [NestedTree, FlatTree]) {
         mount(
           <TreeTest id="tree" aria-label="Tree">
             <TreeItem itemType="branch" value="item1" data-testid="item1">
-              <TreeItemLayout actions={<Button id="action">action!</Button>}>level 1, item 1</TreeItemLayout>
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <TreeItemAside actions>
+                <Button id="action">action!</Button>1
+              </TreeItemAside>
               <Tree>
                 <TreeItem itemType="leaf" value="item1__item1" data-testid="item1__item1">
                   <TreeItemLayout>level 2, item 1</TreeItemLayout>
@@ -168,7 +172,10 @@ for (const TreeTest of [NestedTree, FlatTree]) {
         mount(
           <TreeTest id="tree" aria-label="Tree">
             <TreeItem itemType="branch" value="item1" data-testid="item1">
-              <TreeItemLayout actions={<Button id="action">action</Button>}>level 1, item 1</TreeItemLayout>
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <TreeItemAside actions>
+                <Button id="action">action</Button>
+              </TreeItemAside>
               <Tree>
                 <TreeItem itemType="leaf" value="item1__item1" data-testid="item1__item1">
                   <TreeItemLayout>level 2, item 1</TreeItemLayout>
@@ -187,7 +194,10 @@ for (const TreeTest of [NestedTree, FlatTree]) {
         mount(
           <TreeTest id="tree" aria-label="Tree">
             <TreeItem itemType="branch" value="item1" data-testid="item1">
-              <TreeItemLayout actions={<Button id="action">action</Button>}>level 1, item 1</TreeItemLayout>
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <TreeItemAside actions>
+                <Button id="action">action</Button>
+              </TreeItemAside>
               <Tree>
                 <TreeItem itemType="leaf" value="item1__item1" data-testid="item1__item1">
                   <TreeItemLayout>level 2, item 1</TreeItemLayout>

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, useMergedRefs } from '@fluentui/react-utilities';
 import { useEventCallback } from '@fluentui/react-utilities';
 import { elementContains } from '@fluentui/react-portal';
 import type { TreeItemProps, TreeItemState } from './TreeItem.types';
@@ -36,6 +36,11 @@ export function useTreeItem_unstable<Value = string>(
   const requestTreeResponse = useTreeContext_unstable(ctx => ctx.requestTreeResponse);
 
   const [isActionsVisible, setActionsVisible] = React.useState(false);
+  const [isAsideVisible, setAsideVisible] = React.useState(true);
+
+  const handleActionsRef = (actions: HTMLDivElement | null) => {
+    setAsideVisible(actions === null);
+  };
 
   const open = useTreeContext_unstable(ctx => ctx.openItems.has(value));
 
@@ -119,11 +124,12 @@ export function useTreeItem_unstable<Value = string>(
     value,
     open,
     subtreeRef,
-    actionsRef,
+    actionsRef: useMergedRefs(actionsRef, handleActionsRef),
     expandIconRef,
     layoutRef,
     itemType,
     isActionsVisible,
+    isAsideVisible,
     level,
     components: {
       root: 'div',

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
@@ -4,7 +4,8 @@ import type { TreeItemContextValues, TreeItemState } from './TreeItem.types';
 export function useTreeItemContextValues_unstable(
   state: Pick<TreeItemState, keyof TreeItemContextValue>,
 ): TreeItemContextValues {
-  const { value, isActionsVisible, actionsRef, itemType, layoutRef, subtreeRef, expandIconRef, open } = state;
+  const { value, isActionsVisible, isAsideVisible, actionsRef, itemType, layoutRef, subtreeRef, expandIconRef, open } =
+    state;
 
   /**
    * This context is created with "@fluentui/react-context-selector",
@@ -12,6 +13,7 @@ export function useTreeItemContextValues_unstable(
    */
   const treeItem: TreeItemContextValue = {
     isActionsVisible,
+    isAsideVisible,
     value,
     actionsRef,
     itemType,

--- a/packages/react-components/react-tree/src/components/TreeItemAside/TreeItemAside.test.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/TreeItemAside.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { TreeItemAside } from './TreeItemAside';
+import { isConformant } from '../../testing/isConformant';
+
+describe('TreeItemAside', () => {
+  isConformant({
+    Component: TreeItemAside,
+    displayName: 'TreeItemAside',
+    requiredProps: {
+      visible: true,
+    },
+  });
+
+  it('renders a default state', () => {
+    const result = render(<TreeItemAside>Default TreeItemAside</TreeItemAside>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-tree/src/components/TreeItemAside/TreeItemAside.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/TreeItemAside.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { useTreeItemAside_unstable } from './useTreeItemAside';
+import { renderTreeItemAside_unstable } from './renderTreeItemAside';
+import { useTreeItemAsideStyles_unstable } from './useTreeItemAsideStyles.styles';
+import type { TreeItemAsideProps } from './TreeItemAside.types';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+
+/**
+ * TreeItemAside component - represents a custom set of actionable elements that will be visible when a certain
+ * `TreeItem` is currently "active".
+ */
+export const TreeItemAside: ForwardRefComponent<TreeItemAsideProps> = React.forwardRef((props, ref) => {
+  const state = useTreeItemAside_unstable(props, ref);
+
+  useTreeItemAsideStyles_unstable(state);
+  return renderTreeItemAside_unstable(state);
+});
+
+TreeItemAside.displayName = 'TreeItemAside';

--- a/packages/react-components/react-tree/src/components/TreeItemAside/TreeItemAside.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/TreeItemAside.types.ts
@@ -1,0 +1,32 @@
+import { ButtonContextValue } from '@fluentui/react-button';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type TreeItemAsideSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * TreeItemAside Props
+ */
+export type TreeItemAsideProps = ComponentProps<TreeItemAsideSlots> & {
+  /**
+   * boolean indicating if the aside content should behave as "actions"
+   *
+   * actionable elements are normally buttons, menus, or other focusable elements.
+   * Those elements are only visibly available if the given tree item is currently active.
+   */
+  actions?: boolean;
+  /**
+   * Forces visibility of the aside content, even if they're actions
+   */
+  visible?: true;
+};
+
+/**
+ * State used in rendering TreeItemAside
+ */
+export type TreeItemAsideState = ComponentState<TreeItemAsideSlots> & {
+  actions: boolean;
+  visible: boolean;
+  buttonContextValue: ButtonContextValue;
+};

--- a/packages/react-components/react-tree/src/components/TreeItemAside/__snapshots__/TreeItemAside.test.tsx.snap
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/__snapshots__/TreeItemAside.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TreeItemAside renders a default state 1`] = `
+<div>
+  <div
+    class="fui-TreeItemAside"
+  >
+    Default TreeItemAside
+  </div>
+</div>
+`;

--- a/packages/react-components/react-tree/src/components/TreeItemAside/index.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/index.ts
@@ -1,0 +1,5 @@
+export * from './TreeItemAside';
+export * from './TreeItemAside.types';
+export * from './renderTreeItemAside';
+export * from './useTreeItemAside';
+export * from './useTreeItemAsideStyles.styles';

--- a/packages/react-components/react-tree/src/components/TreeItemAside/renderTreeItemAside.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/renderTreeItemAside.tsx
@@ -1,0 +1,24 @@
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { getSlotsNext } from '@fluentui/react-utilities';
+import { ButtonContextProvider } from '@fluentui/react-button';
+import type { TreeItemAsideState, TreeItemAsideSlots } from './TreeItemAside.types';
+
+/**
+ * Render the final JSX of TreeItemAside
+ */
+export const renderTreeItemAside_unstable = (state: TreeItemAsideState) => {
+  const { slots, slotProps } = getSlotsNext<TreeItemAsideSlots>(state);
+
+  if (!state.visible) {
+    return null;
+  }
+
+  return (
+    <slots.root {...slotProps.root}>
+      <ButtonContextProvider value={state.buttonContextValue}>{slotProps.root.children}</ButtonContextProvider>
+    </slots.root>
+  );
+};

--- a/packages/react-components/react-tree/src/components/TreeItemAside/useTreeItemAside.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/useTreeItemAside.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import type { TreeItemAsideProps, TreeItemAsideState } from './TreeItemAside.types';
+import { useTreeItemContext_unstable } from '../../contexts/treeItemContext';
+
+/**
+ * Create the state required to render TreeItemAside.
+ *
+ * The returned state can be modified with hooks such as useTreeItemAsideStyles_unstable,
+ * before being passed to renderTreeItemAside_unstable.
+ *
+ * @param props - props from this instance of TreeItemAside
+ * @param ref - reference to root HTMLElement of TreeItemAside
+ */
+export const useTreeItemAside_unstable = (
+  props: TreeItemAsideProps,
+  ref: React.Ref<HTMLElement>,
+): TreeItemAsideState => {
+  const actionsRef = useTreeItemContext_unstable(ctx => ctx.actionsRef);
+  const contextVisible = useTreeItemContext_unstable(ctx =>
+    props.actions ? ctx.isActionsVisible : ctx.isAsideVisible,
+  );
+  const { actions = false, visible = contextVisible } = props;
+
+  return {
+    actions,
+    visible,
+    buttonContextValue: { size: 'small' },
+    components: {
+      root: 'div',
+    },
+    root: getNativeElementProps('div', {
+      ref: useMergedRefs(ref, actions ? actionsRef : undefined),
+      ...props,
+    }),
+  };
+};

--- a/packages/react-components/react-tree/src/components/TreeItemAside/useTreeItemAsideStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemAside/useTreeItemAsideStyles.styles.ts
@@ -1,0 +1,45 @@
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import type { TreeItemAsideSlots, TreeItemAsideState } from './TreeItemAside.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+
+export const treeItemAsideClassNames: SlotClassNames<TreeItemAsideSlots> = {
+  root: 'fui-TreeItemAside',
+};
+
+/**
+ * Styles for the action icon slot
+ */
+const useStyles = makeStyles({
+  base: {
+    display: 'flex',
+    marginLeft: 'auto',
+    ...shorthands.gridArea('aside'),
+  },
+  actions: {
+    position: 'relative',
+    zIndex: 1,
+    ...shorthands.padding(0, tokens.spacingHorizontalS),
+  },
+  aside: {
+    alignItems: 'center',
+    zIndex: 0,
+    ...shorthands.padding(0, tokens.spacingHorizontalM),
+    ...shorthands.gap(tokens.spacingHorizontalXS),
+  },
+});
+
+/**
+ * Apply styling to the TreeItemAside slots based on the state
+ */
+export const useTreeItemAsideStyles_unstable = (state: TreeItemAsideState): TreeItemAsideState => {
+  const styles = useStyles();
+
+  state.root.className = mergeClasses(
+    treeItemAsideClassNames.root,
+    styles.base,
+    state.actions ? styles.actions : styles.aside,
+    state.root.className,
+  );
+  return state;
+};

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.test.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.test.tsx
@@ -11,10 +11,7 @@ describe('TreeItemLayout', () => {
       expandIcon: 'expandIcon',
       iconAfter: 'iconAfter',
       iconBefore: 'iconBefore',
-      aside: 'aside',
     },
-    // aside and actions slots can't be visible at the same time
-    disabledTests: ['component-has-static-classnames-object'],
   });
 
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.types.ts
@@ -1,4 +1,3 @@
-import { ButtonContextValue } from '@fluentui/react-button';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type TreeItemLayoutSlots = {
@@ -16,8 +15,6 @@ export type TreeItemLayoutSlots = {
    * Icon slot that renders right after main content
    */
   iconAfter?: Slot<'div'>;
-  aside?: Slot<'div'>;
-  actions?: Slot<'div'>;
 };
 
 /**
@@ -28,8 +25,4 @@ export type TreeItemLayoutProps = ComponentProps<Partial<TreeItemLayoutSlots>>;
 /**
  * State used in rendering TreeItemLayout
  */
-export type TreeItemLayoutState = ComponentState<TreeItemLayoutSlots> & {
-  buttonContextValue: ButtonContextValue;
-  isActionsVisible: boolean;
-  isAsideVisible: boolean;
-};
+export type TreeItemLayoutState = ComponentState<TreeItemLayoutSlots>;

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/renderTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/renderTreeItemLayout.tsx
@@ -4,7 +4,6 @@
 import { createElement } from '@fluentui/react-jsx-runtime';
 import { getSlotsNext } from '@fluentui/react-utilities';
 import type { TreeItemLayoutState, TreeItemLayoutSlots } from './TreeItemLayout.types';
-import { ButtonContextProvider } from '@fluentui/react-button';
 
 /**
  * Render the final JSX of TreeItemLayout
@@ -17,10 +16,6 @@ export const renderTreeItemLayout_unstable = (state: TreeItemLayoutState) => {
       {slots.iconBefore && <slots.iconBefore {...slotProps.iconBefore} />}
       {slotProps.root.children}
       {slots.iconAfter && <slots.iconAfter {...slotProps.iconAfter} />}
-      <ButtonContextProvider value={state.buttonContextValue}>
-        {state.isAsideVisible && slots.aside && <slots.aside {...slotProps.aside} />}
-        {state.isActionsVisible && slots.actions && <slots.actions {...slotProps.actions} />}
-      </ButtonContextProvider>
     </slots.root>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -3,7 +3,6 @@ import { getNativeElementProps, isResolvedShorthand, resolveShorthand, useMerged
 import type { TreeItemLayoutProps, TreeItemLayoutState } from './TreeItemLayout.types';
 import { useTreeItemContext_unstable } from '../../contexts/treeItemContext';
 import { TreeItemChevron } from '../TreeItemChevron';
-import { ButtonContextValue } from '@fluentui/react-button';
 
 /**
  * Create the state required to render TreeItemLayout.
@@ -18,37 +17,22 @@ export const useTreeItemLayout_unstable = (
   props: TreeItemLayoutProps,
   ref: React.Ref<HTMLElement>,
 ): TreeItemLayoutState => {
-  const { iconAfter, iconBefore, expandIcon, actions, aside, as = 'span' } = props;
+  const { iconAfter, iconBefore, expandIcon, as = 'span' } = props;
 
   const layoutRef = useTreeItemContext_unstable(ctx => ctx.layoutRef);
   const expandIconRef = useTreeItemContext_unstable(ctx => ctx.expandIconRef);
-  const actionsRef = useTreeItemContext_unstable(ctx => ctx.actionsRef);
   const isBranch = useTreeItemContext_unstable(ctx => ctx.itemType === 'branch');
 
-  const isActionsVisible = useTreeItemContext_unstable(ctx => ctx.isActionsVisible);
-
   return {
-    isActionsVisible,
-    isAsideVisible: Boolean(!actions || !isActionsVisible),
     components: {
       root: 'div',
       expandIcon: 'div',
       iconBefore: 'div',
       iconAfter: 'div',
-      aside: 'div',
-      actions: 'div',
     },
-    buttonContextValue,
     root: getNativeElementProps(as, { ...props, ref: useMergedRefs(ref, layoutRef) }),
     iconBefore: resolveShorthand(iconBefore, { defaultProps: { 'aria-hidden': true } }),
     iconAfter: resolveShorthand(iconAfter, { defaultProps: { 'aria-hidden': true } }),
-    aside: resolveShorthand(aside, { defaultProps: { 'aria-hidden': true } }),
-    actions: resolveShorthand(actions, {
-      defaultProps: {
-        'aria-hidden': true,
-        ref: useMergedRefs(isResolvedShorthand(actions) ? actions.ref : undefined, actionsRef),
-      },
-    }),
     expandIcon: resolveShorthand(expandIcon, {
       required: isBranch,
       defaultProps: {
@@ -59,5 +43,3 @@ export const useTreeItemLayout_unstable = (
     }),
   };
 };
-
-const buttonContextValue: ButtonContextValue = { size: 'small' };

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -11,8 +11,6 @@ export const treeItemLayoutClassNames: SlotClassNames<TreeItemLayoutSlots> = {
   expandIcon: 'fui-TreeItemLayout__expandIcon',
   iconBefore: 'fui-TreeItemLayout__iconBefore',
   iconAfter: 'fui-TreeItemLayout__iconAfter',
-  actions: 'fui-TreeItemLayout__actions',
-  aside: 'fui-TreeItemLayout__aside',
 };
 
 /**
@@ -109,43 +107,13 @@ const useIconStyles = makeStyles({
 });
 
 /**
- * Styles for the action icon slot
- */
-const useAsideStyles = makeStyles({
-  base: {
-    display: 'flex',
-    marginLeft: 'auto',
-    ...shorthands.gridArea('aside'),
-    alignItems: 'center',
-    zIndex: 0,
-    ...shorthands.padding(0, tokens.spacingHorizontalM),
-    ...shorthands.gap(tokens.spacingHorizontalXS),
-  },
-});
-
-/**
- * Styles for the action icon slot
- */
-const useActionsStyles = makeStyles({
-  base: {
-    display: 'flex',
-    marginLeft: 'auto',
-    ...shorthands.gridArea('aside'),
-    zIndex: 1,
-    ...shorthands.padding(0, tokens.spacingHorizontalS),
-  },
-});
-
-/**
  * Apply styling to the TreeItemLayout slots based on the state
  */
 export const useTreeItemLayoutStyles_unstable = (state: TreeItemLayoutState): TreeItemLayoutState => {
-  const { iconAfter, iconBefore, expandIcon, root, aside, actions } = state;
+  const { iconAfter, iconBefore, expandIcon, root } = state;
   const rootStyles = useRootStyles();
   const iconStyles = useIconStyles();
   const expandIconStyles = useExpandIconStyles();
-  const asideStyles = useAsideStyles();
-  const actionsStyles = useActionsStyles();
 
   const size = useTreeContext_unstable(ctx => ctx.size);
   const appearance = useTreeContext_unstable(ctx => ctx.appearance);
@@ -184,13 +152,6 @@ export const useTreeItemLayoutStyles_unstable = (state: TreeItemLayoutState): Tr
       iconStyles.iconAfter,
       iconAfter.className,
     );
-  }
-  if (actions) {
-    actions.className = mergeClasses(treeItemLayoutClassNames.actions, actionsStyles.base, actions.className);
-  }
-
-  if (aside) {
-    aside.className = mergeClasses(treeItemLayoutClassNames.aside, asideStyles.base, aside.className);
   }
 
   return state;

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.test.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.test.tsx
@@ -10,10 +10,7 @@ describe('TreeItemPersonaLayout', () => {
     requiredProps: {
       expandIcon: 'expandIcon',
       description: 'description',
-      aside: 'aside',
     },
-    // aside and actions slots can't be visible at the same time
-    disabledTests: ['component-has-static-classnames-object'],
   });
 
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.types.ts
@@ -1,6 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { AvatarContextValue, AvatarSize } from '@fluentui/react-avatar';
-import { ButtonContextValue } from '@fluentui/react-button';
 
 export type TreeItemPersonaLayoutContextValues = {
   avatar: AvatarContextValue;
@@ -29,8 +28,6 @@ export type TreeItemPersonaLayoutSlots = {
    * A layout wrapper for the main and description slots
    */
   content: NonNullable<Slot<'div'>>;
-  aside?: Slot<'div'>;
-  actions?: Slot<'div'>;
 };
 
 /**
@@ -43,7 +40,4 @@ export type TreeItemPersonaLayoutProps = ComponentProps<Partial<TreeItemPersonaL
  */
 export type TreeItemPersonaLayoutState = ComponentState<TreeItemPersonaLayoutSlots> & {
   avatarSize: AvatarSize;
-  buttonContextValue: ButtonContextValue;
-  isActionsVisible: boolean;
-  isAsideVisible: boolean;
 };

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/renderTreeItemPersonaLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/renderTreeItemPersonaLayout.tsx
@@ -9,7 +9,6 @@ import type {
   TreeItemPersonaLayoutContextValues,
 } from './TreeItemPersonaLayout.types';
 import { AvatarContextProvider } from '@fluentui/react-avatar';
-import { ButtonContextProvider } from '@fluentui/react-button';
 
 /**
  * Render the final JSX of TreeItemPersonaLayout
@@ -30,10 +29,6 @@ export const renderTreeItemPersonaLayout_unstable = (
         <slots.main {...slotProps.main} />
         {slots.description && <slots.description {...slotProps.description} />}
       </slots.content>
-      <ButtonContextProvider value={state.buttonContextValue}>
-        {state.isAsideVisible && slots.aside && <slots.aside {...slotProps.aside} />}
-        {state.isActionsVisible && slots.actions && <slots.actions {...slotProps.actions} />}
-      </ButtonContextProvider>
     </slots.root>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayout.tsx
@@ -39,8 +39,6 @@ export const useTreeItemPersonaLayout_unstable = (
       description: 'div',
       root: 'div',
       media: 'div',
-      actions: 'div',
-      aside: 'div',
     },
     avatarSize: treeAvatarSize[size],
     main: resolveShorthand(main, { required: true, defaultProps: { children } }),

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
@@ -8,8 +8,6 @@ import { useTreeItemContext_unstable } from '../../contexts/treeItemContext';
 export const treeItemPersonaLayoutClassNames: SlotClassNames<TreeItemPersonaLayoutSlots> = {
   root: 'fui-TreeItemPersonaLayout',
   expandIcon: 'fui-TreeItemPersonaLayout__expandIcon',
-  aside: 'fui-TreeItemPersonaLayout__aside',
-  actions: 'fui-TreeItemPersonaLayout__actions',
   media: 'fui-TreeItemPersonaLayout__media',
   content: 'fui-TreeItemPersonaLayout__content',
   description: 'fui-TreeItemPersonaLayout__description',
@@ -101,35 +99,6 @@ const useExpandIconStyles = makeStyles({
 });
 
 /**
- * Styles for the action icon slot
- */
-const useAsideStyles = makeStyles({
-  base: {
-    display: 'flex',
-    marginLeft: 'auto',
-    ...shorthands.gridArea('aside'),
-    alignItems: 'center',
-    zIndex: 0,
-    ...shorthands.padding(0, tokens.spacingHorizontalM),
-    ...shorthands.gap(tokens.spacingHorizontalXS),
-  },
-});
-
-/**
- * Styles for the action icon slot
- */
-const useActionsStyles = makeStyles({
-  base: {
-    display: 'flex',
-    marginLeft: 'auto',
-    ...shorthands.gridArea('aside'),
-    position: 'relative',
-    zIndex: 1,
-    ...shorthands.padding(0, tokens.spacingHorizontalS),
-  },
-});
-
-/**
  * Apply styling to the TreeItemPersonaLayout slots based on the state
  */
 export const useTreeItemPersonaLayoutStyles_unstable = (
@@ -140,8 +109,6 @@ export const useTreeItemPersonaLayoutStyles_unstable = (
   const contentStyles = useContentStyles();
   const descriptionStyles = useDescriptionStyles();
   const expandIconStyles = useExpandIconStyles();
-  const asideStyles = useAsideStyles();
-  const actionsStyles = useActionsStyles();
 
   const itemType = useTreeItemContext_unstable(ctx => ctx.itemType);
 
@@ -176,22 +143,6 @@ export const useTreeItemPersonaLayoutStyles_unstable = (
       treeItemPersonaLayoutClassNames.expandIcon,
       expandIconStyles.base,
       state.expandIcon.className,
-    );
-  }
-
-  if (state.actions) {
-    state.actions.className = mergeClasses(
-      treeItemPersonaLayoutClassNames.actions,
-      actionsStyles.base,
-      state.actions.className,
-    );
-  }
-
-  if (state.aside) {
-    state.aside.className = mergeClasses(
-      treeItemPersonaLayoutClassNames.aside,
-      asideStyles.base,
-      state.aside.className,
     );
   }
 

--- a/packages/react-components/react-tree/src/contexts/treeItemContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeItemContext.ts
@@ -4,6 +4,7 @@ import { TreeItemType } from '../TreeItem';
 
 export type TreeItemContextValue = {
   isActionsVisible: boolean;
+  isAsideVisible: boolean;
   actionsRef: React.Ref<HTMLDivElement>;
   expandIconRef: React.Ref<HTMLDivElement>;
   layoutRef: React.Ref<HTMLDivElement>;
@@ -16,6 +17,7 @@ export type TreeItemContextValue = {
 const defaultContextValue: TreeItemContextValue = {
   value: undefined,
   isActionsVisible: false,
+  isAsideVisible: true,
   actionsRef: React.createRef(),
   expandIconRef: React.createRef(),
   layoutRef: React.createRef(),

--- a/packages/react-components/react-tree/src/index.ts
+++ b/packages/react-components/react-tree/src/index.ts
@@ -52,6 +52,15 @@ export type {
   TreeItemPersonaLayoutState,
 } from './TreeItemPersonaLayout';
 
+export {
+  TreeItemAside,
+  treeItemAsideClassNames,
+  renderTreeItemAside_unstable,
+  useTreeItemAsideStyles_unstable,
+  useTreeItemAside_unstable,
+} from './TreeItemAside';
+export type { TreeItemAsideProps, TreeItemAsideSlots, TreeItemAsideState } from './TreeItemAside';
+
 export { useFlatTree_unstable } from './hooks/index';
 export type { FlatTreeItem, FlatTreeItemProps, FlatTreeProps, FlatTree } from './hooks/index';
 

--- a/packages/react-components/react-tree/stories/B_TreeItem/TreeItemActions.md
+++ b/packages/react-components/react-tree/stories/B_TreeItem/TreeItemActions.md
@@ -1,3 +1,5 @@
-Add custom actions to each `TreeItem` component to add extra functionality, such as buttons or menus. This can be done by passing a component that renders the desired actions as a prop to the `TreeItem`.
+Add custom actions to each `TreeItem` component to add extra functionality, such as buttons or menus. This can be done by passing a component that renders the desired actions with `TreeItemAside` inside of `TreeItem`.
 
 The `actions` are hidden by default and appear on the right-side when the user hovers over the `TreeItem`.
+
+> To force the visibility of `actions` just use the `visible` property from `TreeItemAside` component.

--- a/packages/react-components/react-tree/stories/B_TreeItem/TreeItemActions.stories.tsx
+++ b/packages/react-components/react-tree/stories/B_TreeItem/TreeItemActions.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemAside, TreeItemLayout } from '@fluentui/react-tree';
 import { Edit20Regular, MoreHorizontal20Regular } from '@fluentui/react-icons';
 import { Button, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-components';
 import story from './TreeItemActions.md';
@@ -29,42 +29,75 @@ const ActionsExample = () => {
 export const Actions = () => (
   <Tree aria-label="Tree">
     <TreeItem itemType="branch">
-      <TreeItemLayout actions={<ActionsExample />}>level 1, item 1</TreeItemLayout>
+      <TreeItemLayout>level 1, item 1</TreeItemLayout>
+      <TreeItemAside actions>
+        <ActionsExample />
+      </TreeItemAside>
       <Tree>
         <TreeItem itemType="leaf">
-          <TreeItemLayout actions={<ActionsExample />}>level 2, item 1</TreeItemLayout>
+          <TreeItemLayout>level 2, item 1</TreeItemLayout>
+          <TreeItemAside actions>
+            <ActionsExample />
+          </TreeItemAside>
         </TreeItem>
         <TreeItem itemType="leaf">
-          <TreeItemLayout actions={<ActionsExample />}>level 2, item 2</TreeItemLayout>
+          <TreeItemLayout>level 2, item 2</TreeItemLayout>
+          <TreeItemAside actions>
+            <ActionsExample />
+          </TreeItemAside>
         </TreeItem>
         <TreeItem itemType="leaf">
-          <TreeItemLayout actions={<ActionsExample />}>level 2, item 3</TreeItemLayout>
+          <TreeItemLayout>level 2, item 3</TreeItemLayout>
+          <TreeItemAside actions>
+            <ActionsExample />
+          </TreeItemAside>
         </TreeItem>
       </Tree>
     </TreeItem>
     <TreeItem itemType="branch">
-      <TreeItemLayout actions={<ActionsExample />}>level 1, item 2</TreeItemLayout>
+      <TreeItemLayout>level 1, item 2</TreeItemLayout>
+      <TreeItemAside actions>
+        <ActionsExample />
+      </TreeItemAside>
       <Tree>
         <TreeItem itemType="branch">
-          <TreeItemLayout actions={<ActionsExample />}>level 2, item 1</TreeItemLayout>
+          <TreeItemLayout>level 2, item 1</TreeItemLayout>
+          <TreeItemAside actions>
+            <ActionsExample />
+          </TreeItemAside>
           <Tree>
             <TreeItem itemType="leaf">
-              <TreeItemLayout actions={<ActionsExample />}>level 3, item 1</TreeItemLayout>
+              <TreeItemLayout>level 3, item 1</TreeItemLayout>
+              <TreeItemAside actions>
+                <ActionsExample />
+              </TreeItemAside>
             </TreeItem>
           </Tree>
         </TreeItem>
 
         <TreeItem itemType="branch">
-          <TreeItemLayout actions={<ActionsExample />}>level 1, item 1</TreeItemLayout>
+          <TreeItemLayout>level 1, item 1</TreeItemLayout>
+          <TreeItemAside actions>
+            <ActionsExample />
+          </TreeItemAside>
           <Tree>
             <TreeItem itemType="leaf">
-              <TreeItemLayout actions={<ActionsExample />}>level 2, item 1</TreeItemLayout>
+              <TreeItemLayout>level 2, item 1</TreeItemLayout>
+              <TreeItemAside actions>
+                <ActionsExample />
+              </TreeItemAside>
             </TreeItem>
             <TreeItem itemType="leaf">
-              <TreeItemLayout actions={<ActionsExample />}>level 2, item 2</TreeItemLayout>
+              <TreeItemLayout>level 2, item 2</TreeItemLayout>
+              <TreeItemAside actions>
+                <ActionsExample />
+              </TreeItemAside>
             </TreeItem>
             <TreeItem itemType="leaf">
-              <TreeItemLayout actions={<ActionsExample />}>level 2, item 3</TreeItemLayout>
+              <TreeItemLayout>level 2, item 3</TreeItemLayout>
+              <TreeItemAside actions>
+                <ActionsExample />
+              </TreeItemAside>
             </TreeItem>
           </Tree>
         </TreeItem>

--- a/packages/react-components/react-tree/stories/C_Layouts/LayoutsDefault.stories.tsx
+++ b/packages/react-components/react-tree/stories/C_Layouts/LayoutsDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout, TreeItemPersonaLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemAside, TreeItemLayout, TreeItemPersonaLayout } from '@fluentui/react-tree';
 import {
   CalendarMonthRegular,
   LockClosedRegular,
@@ -33,34 +33,30 @@ export const Default = () => {
               <LinkSquareRegular />
             </>
           }
-          aside={
-            <>
-              <Important16Regular primaryFill="red" />
-              <CounterBadge count={1} color="danger" size="small" />
-            </>
-          }
-          actions={
-            <>
-              <Button aria-label="Edit" appearance="subtle" icon={<FlagRegular />} />
-              <Menu>
-                <MenuTrigger disableButtonEnhancement>
-                  <Button aria-label="More options" appearance="subtle" icon={<MoreHorizontal20Regular />} />
-                </MenuTrigger>
-
-                <MenuPopover>
-                  <MenuList>
-                    <MenuItem>New </MenuItem>
-                    <MenuItem>New Window</MenuItem>
-                    <MenuItem disabled>Open File</MenuItem>
-                    <MenuItem>Open Folder</MenuItem>
-                  </MenuList>
-                </MenuPopover>
-              </Menu>
-            </>
-          }
         >
           Content
         </TreeItemLayout>
+        <TreeItemAside>
+          <Important16Regular primaryFill="red" />
+          <CounterBadge count={1} color="danger" size="small" />
+        </TreeItemAside>
+        <TreeItemAside actions>
+          <Button aria-label="Edit" appearance="subtle" icon={<FlagRegular />} />
+          <Menu>
+            <MenuTrigger disableButtonEnhancement>
+              <Button aria-label="More options" appearance="subtle" icon={<MoreHorizontal20Regular />} />
+            </MenuTrigger>
+
+            <MenuPopover>
+              <MenuList>
+                <MenuItem>New </MenuItem>
+                <MenuItem>New Window</MenuItem>
+                <MenuItem disabled>Open File</MenuItem>
+                <MenuItem>Open Folder</MenuItem>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+        </TreeItemAside>
         <Tree>
           <TreeItem itemType="leaf">
             <TreeItemLayout>level 2, item 1</TreeItemLayout>
@@ -82,28 +78,26 @@ export const Default = () => {
               <LinkSquareRegular />
             </>
           }
-          actions={
-            <>
-              <Button aria-label="Edit" appearance="subtle" icon={<FlagRegular />} />
-              <Menu>
-                <MenuTrigger disableButtonEnhancement>
-                  <Button aria-label="More options" appearance="subtle" icon={<MoreHorizontal20Regular />} />
-                </MenuTrigger>
-
-                <MenuPopover>
-                  <MenuList>
-                    <MenuItem>New </MenuItem>
-                    <MenuItem>New Window</MenuItem>
-                    <MenuItem disabled>Open File</MenuItem>
-                    <MenuItem>Open Folder</MenuItem>
-                  </MenuList>
-                </MenuPopover>
-              </Menu>
-            </>
-          }
         >
           Content
         </TreeItemLayout>
+        <TreeItemAside actions>
+          <Button aria-label="Edit" appearance="subtle" icon={<FlagRegular />} />
+          <Menu>
+            <MenuTrigger disableButtonEnhancement>
+              <Button aria-label="More options" appearance="subtle" icon={<MoreHorizontal20Regular />} />
+            </MenuTrigger>
+
+            <MenuPopover>
+              <MenuList>
+                <MenuItem>New </MenuItem>
+                <MenuItem>New Window</MenuItem>
+                <MenuItem disabled>Open File</MenuItem>
+                <MenuItem>Open Folder</MenuItem>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+        </TreeItemAside>
         <Tree>
           <TreeItem itemType="branch">
             <TreeItemLayout>level 2, item 1</TreeItemLayout>
@@ -116,26 +110,18 @@ export const Default = () => {
         </Tree>
       </TreeItem>
       <TreeItem itemType="leaf">
-        <TreeItemPersonaLayout
-          aside={{
-            style: { flexDirection: 'column' },
-            children: (
-              <>
-                <Text font="numeric" as="span" style={{ whiteSpace: 'nowrap' }}>
-                  00:00 AM
-                </Text>
-                <div style={{ display: 'flex', marginLeft: 'auto', gap: tokens.spacingHorizontalXS }}>
-                  <Important16Regular primaryFill="red" />
-                  <CounterBadge count={1} color="danger" size="small" />
-                </div>
-              </>
-            ),
-          }}
-          description="description"
-          media={<Avatar />}
-        >
+        <TreeItemPersonaLayout description="description" media={<Avatar />}>
           Content
         </TreeItemPersonaLayout>
+        <TreeItemAside style={{ flexDirection: 'column' }}>
+          <Text font="numeric" as="span" style={{ whiteSpace: 'nowrap' }}>
+            00:00 AM
+          </Text>
+          <div style={{ display: 'flex', marginLeft: 'auto', gap: tokens.spacingHorizontalXS }}>
+            <Important16Regular primaryFill="red" />
+            <CounterBadge count={1} color="danger" size="small" />
+          </div>
+        </TreeItemAside>
         <Tree>
           <TreeItem itemType="branch">
             <TreeItemLayout>level 2, item 1</TreeItemLayout>
@@ -148,17 +134,11 @@ export const Default = () => {
         </Tree>
       </TreeItem>
       <TreeItem itemType="branch">
-        <TreeItemPersonaLayout
-          aside={
-            <>
-              <Important16Regular primaryFill="red" />
-              <CounterBadge count={1} color="danger" size="small" />
-            </>
-          }
-          media={<Avatar shape="square" />}
-        >
-          Content
-        </TreeItemPersonaLayout>
+        <TreeItemPersonaLayout media={<Avatar shape="square" />}>Content</TreeItemPersonaLayout>
+        <TreeItemAside>
+          <Important16Regular primaryFill="red" />
+          <CounterBadge count={1} color="danger" size="small" />
+        </TreeItemAside>
         <Tree>
           <TreeItem itemType="branch">
             <TreeItemLayout>level 2, item 1</TreeItemLayout>

--- a/packages/react-components/react-tree/stories/C_Layouts/TreeItemLayout.stories.tsx
+++ b/packages/react-components/react-tree/stories/C_Layouts/TreeItemLayout.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemAside, TreeItemLayout } from '@fluentui/react-tree';
 import {
   Image20Regular,
   Important16Regular,
@@ -20,15 +20,13 @@ export const Layout = () => (
             <SquareMultiple20Regular />
           </>
         }
-        aside={
-          <>
-            <Important16Regular primaryFill="red" />
-            <CounterBadge count={1} color="danger" size="small" />
-          </>
-        }
       >
         Content
       </TreeItemLayout>
+      <TreeItemAside>
+        <Important16Regular primaryFill="red" />
+        <CounterBadge count={1} color="danger" size="small" />
+      </TreeItemAside>
       <Tree>
         <TreeItem itemType="branch">
           <TreeItemLayout>Tree Item</TreeItemLayout>
@@ -61,10 +59,12 @@ export const Layout = () => (
             <SquareMultiple20Regular />
           </>
         }
-        aside={<Important16Regular primaryFill="red" />}
       >
         Content
       </TreeItemLayout>
+      <TreeItemAside>
+        <Important16Regular primaryFill="red" />
+      </TreeItemAside>
       <Tree>
         <TreeItem itemType="branch">
           <TreeItemLayout>level 2, item 1</TreeItemLayout>

--- a/packages/react-components/react-tree/stories/C_Layouts/TreeItemLayoutAside.md
+++ b/packages/react-components/react-tree/stories/C_Layouts/TreeItemLayoutAside.md
@@ -1,3 +1,3 @@
-The `Tree` component allows for an `aside` prop to be added to individual `TreeItemLayout` or `TreeItemPersonaLayout` layout components. This creates an area on the right side of the `TreeItem` where additional information can be displayed, such as a badge with notification count or an icon indicating importance. When actions are specified using the `actions` prop, they will overlay the `aside` area on hover.
+The `Tree` component allows for `aside` content to be provided through the `TreeItemAside` component to be added side by side with `TreeItemLayout` or `TreeItemPersonaLayout` layout components. This creates an area on the right side of the `TreeItem` where additional information can be displayed, such as a badge with notification count or an icon indicating importance. When actions are specified using the `actions` property of `TreeItemAside`, they will overlay the `aside` area on hover.
 
-> ⚠️ Aside content is `aria-hidden` by default in both `TreeItemLayout` and `TreeItemPersonaLayout`
+> ⚠️ Aside content is `aria-hidden` by default

--- a/packages/react-components/react-tree/stories/C_Layouts/TreeItemLayoutAside.stories.tsx
+++ b/packages/react-components/react-tree/stories/C_Layouts/TreeItemLayoutAside.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemAside, TreeItemLayout } from '@fluentui/react-tree';
 import { CounterBadge } from '@fluentui/react-components';
 import { FluentIconsProps, Important16Regular } from '@fluentui/react-icons';
 import story from './TreeItemLayoutAside.md';
@@ -18,33 +18,57 @@ const AsideContent = ({ isImportant, messageCount }: { isImportant?: boolean; me
 export const Aside = () => (
   <Tree aria-label="Tree">
     <TreeItem itemType="branch" aria-description="Important, 3 message">
-      <TreeItemLayout aside={<AsideContent isImportant={true} messageCount={3} />}>level 1, item 1</TreeItemLayout>
+      <TreeItemLayout>level 1, item 1</TreeItemLayout>
+      <TreeItemAside>
+        <AsideContent isImportant={true} messageCount={3} />
+      </TreeItemAside>
       <Tree>
         <TreeItem itemType="leaf" aria-description="Important">
-          <TreeItemLayout aside={<AsideContent isImportant={true} />}>level 2, item 1</TreeItemLayout>
+          <TreeItemLayout>level 2, item 1</TreeItemLayout>
+          <TreeItemAside>
+            <AsideContent isImportant={true} />
+          </TreeItemAside>
         </TreeItem>
         <TreeItem itemType="leaf" aria-description="2 messages">
-          <TreeItemLayout aside={<AsideContent messageCount={2} />}>level 2, item 2</TreeItemLayout>
+          <TreeItemLayout>level 2, item 2</TreeItemLayout>
+          <TreeItemAside>
+            <AsideContent messageCount={2} />
+          </TreeItemAside>
         </TreeItem>
         <TreeItem itemType="leaf" aria-description="1 messages">
-          <TreeItemLayout aside={<AsideContent messageCount={1} />}>level 2, item 3</TreeItemLayout>
+          <TreeItemLayout>level 2, item 3</TreeItemLayout>
+          <TreeItemAside>
+            <AsideContent messageCount={1} />
+          </TreeItemAside>
         </TreeItem>
       </Tree>
     </TreeItem>
     <TreeItem itemType="branch" aria-description="Important, 1 message">
-      <TreeItemLayout aside={<AsideContent isImportant={true} messageCount={1} />}>level 1, item 2</TreeItemLayout>
+      <TreeItemLayout>level 1, item 2</TreeItemLayout>
+      <TreeItemAside>
+        <AsideContent isImportant={true} messageCount={1} />
+      </TreeItemAside>
       <Tree>
         <TreeItem itemType="branch" aria-description="1 message">
-          <TreeItemLayout aside={<AsideContent messageCount={1} />}>level 2, item 1</TreeItemLayout>
+          <TreeItemLayout>level 2, item 1</TreeItemLayout>
+          <TreeItemAside>
+            <AsideContent messageCount={1} />
+          </TreeItemAside>
           <Tree>
             <TreeItem itemType="leaf">
-              <TreeItemLayout aside={<AsideContent />}>level 3, item 1</TreeItemLayout>
+              <TreeItemLayout>level 3, item 1</TreeItemLayout>
+              <TreeItemAside>
+                <AsideContent />
+              </TreeItemAside>
             </TreeItem>
           </Tree>
         </TreeItem>
 
         <TreeItem itemType="branch" aria-description="Important">
-          <TreeItemLayout aside={<AsideContent isImportant={true} />}>level 2, item 2</TreeItemLayout>
+          <TreeItemLayout>level 2, item 2</TreeItemLayout>
+          <TreeItemAside>
+            <AsideContent isImportant={true} />
+          </TreeItemAside>
           <Tree>
             <TreeItem itemType="leaf">
               <TreeItemLayout>level 3, item 1</TreeItemLayout>

--- a/packages/react-components/react-tree/stories/C_Layouts/TreeItemPersonaLayout.stories.tsx
+++ b/packages/react-components/react-tree/stories/C_Layouts/TreeItemPersonaLayout.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Avatar, CounterBadge, makeStyles, shorthands, tokens } from '@fluentui/react-components';
-import { Tree, TreeItem, TreeItemPersonaLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemAside, TreeItemPersonaLayout } from '@fluentui/react-tree';
 import { Important16Regular } from '@fluentui/react-icons';
 import story from './TreeItemPersonaLayout.md';
 
@@ -28,18 +28,13 @@ export const Layout = () => {
   return (
     <Tree aria-label="Tree">
       <TreeItem itemType="branch" aria-description="1 new message, important">
-        <TreeItemPersonaLayout
-          aside={
-            <>
-              <span>00:00 AM</span>
-              <Badges />
-            </>
-          }
-          description="Secondary text slot"
-          media={<Avatar />}
-        >
+        <TreeItemPersonaLayout description="Secondary text slot" media={<Avatar />}>
           Primary text slot
         </TreeItemPersonaLayout>
+        <TreeItemAside>
+          <span>00:00 AM</span>
+          <Badges />
+        </TreeItemAside>
         <Tree>
           <TreeItem itemType="branch">
             <TreeItemPersonaLayout description="description" media={<Avatar />}>
@@ -56,18 +51,13 @@ export const Layout = () => {
         </Tree>
       </TreeItem>
       <TreeItem itemType="branch" aria-description="1 message, important">
-        <TreeItemPersonaLayout
-          aside={
-            <>
-              <span>00:00 AM</span>
-              <Badges />
-            </>
-          }
-          description="Secondary text slot"
-          media={<Avatar />}
-        >
+        <TreeItemPersonaLayout description="Secondary text slot" media={<Avatar />}>
           Primary text slot
         </TreeItemPersonaLayout>
+        <TreeItemAside>
+          <span>00:00 AM</span>
+          <Badges />
+        </TreeItemAside>
         <Tree>
           <TreeItem itemType="leaf">
             <TreeItemPersonaLayout media={<Avatar />}>content</TreeItemPersonaLayout>

--- a/packages/react-components/react-tree/stories/D_flatTree/TreeItemAddRemove.stories.tsx
+++ b/packages/react-components/react-tree/stories/D_flatTree/TreeItemAddRemove.stories.tsx
@@ -3,6 +3,7 @@ import {
   FlatTreeItemProps,
   Tree,
   TreeItem,
+  TreeItemAside,
   TreeItemLayout,
   TreeOpenChangeData,
   TreeOpenChangeEvent,
@@ -86,20 +87,17 @@ export const AddRemoveTreeItem = () => {
         const { content, ...treeItemProps } = item.getTreeItemProps();
         return (
           <TreeItem key={item.value} {...treeItemProps}>
-            <TreeItemLayout
-              actions={
-                isUndeletable ? null : (
-                  <Button
-                    aria-label="Remove item"
-                    appearance="subtle"
-                    onClick={() => removeFlatTreeItem(item.value)}
-                    icon={<Delete20Regular />}
-                  />
-                )
-              }
-            >
-              {content}
-            </TreeItemLayout>
+            <TreeItemLayout>{content}</TreeItemLayout>
+            {isUndeletable ? null : (
+              <TreeItemAside actions>
+                <Button
+                  aria-label="Remove item"
+                  appearance="subtle"
+                  onClick={() => removeFlatTreeItem(item.value)}
+                  icon={<Delete20Regular />}
+                />
+              </TreeItemAside>
+            )}
           </TreeItem>
         );
       })}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. creates `TreeItemAside` component with `visible` property that allows the control of the visibility of actions
2. Updates stories accordingly
3. Removes `actions` and `aside` slots from layout components

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27684
