### PR TITLE
feat: defers useControllableState state to initializer method

### DIFF
--- a/change/@fluentui-react-utilities-3e7e29b4-ccde-4269-ac7f-8adf2333171e.json
+++ b/change/@fluentui-react-utilities-3e7e29b4-ccde-4269-ac7f-8adf2333171e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: defers useControllableState state to initializer method",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/useControllableState.ts
+++ b/packages/react-components/react-utilities/src/hooks/useControllableState.ts
@@ -48,12 +48,12 @@ export const useControllableState = <State>(
   return useIsControlled(options.state) ? [options.state, noop] : [internalState, setInternalState];
 };
 
-function noop() {
-  /* noop */
+function isInitializer<State>(value: State | (() => State)): value is () => State {
+  return typeof value === 'function';
 }
 
-function isInitializer<Value>(value: Value | (() => Value)): value is () => Value {
-  return typeof value === 'function';
+function noop() {
+  /* noop */
 }
 
 /**

--- a/packages/react-components/react-utilities/src/hooks/useControllableState.ts
+++ b/packages/react-components/react-utilities/src/hooks/useControllableState.ts
@@ -39,8 +39,12 @@ export type UseControllableStateOptions<State> = {
 export const useControllableState = <State>(
   options: UseControllableStateOptions<State>,
 ): [State, React.Dispatch<React.SetStateAction<State>>] => {
-  const initialState = typeof options.defaultState === 'undefined' ? options.initialState : options.defaultState;
-  const [internalState, setInternalState] = React.useState<State>(initialState);
+  const [internalState, setInternalState] = React.useState<State>(() => {
+    if (options.defaultState === undefined) {
+      return options.initialState;
+    }
+    return isInitializer(options.defaultState) ? options.defaultState() : options.defaultState;
+  });
   return useIsControlled(options.state) ? [options.state, noop] : [internalState, setInternalState];
 };
 
@@ -48,12 +52,16 @@ function noop() {
   /* noop */
 }
 
+function isInitializer<Value>(value: Value | (() => Value)): value is () => Value {
+  return typeof value === 'function';
+}
+
 /**
  * Helper hook to handle previous comparison of controlled/uncontrolled
  * Prints an error when isControlled value switches between subsequent renders
  * @returns - whether the value is controlled
  */
-const useIsControlled = <V>(controlledValue?: V): controlledValue is V => {
+const useIsControlled = <V>(controlledValue: V | undefined): controlledValue is V => {
   const [isControlled] = React.useState<boolean>(() => controlledValue !== undefined);
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. defers initialization of internal state of the `useControllableState` hook to the init method provided by `useState` hook
