### PR TITLE
ci: add build task back as lint pre-requirement to unblock temporarily import plugin lint rule issues

### DIFF
--- a/lage.config.js
+++ b/lage.config.js
@@ -5,7 +5,8 @@ module.exports = {
     'build:info': [],
     bundle: ['build'],
     'bundle-size': ['build'],
-    lint: [],
+    // adding temporary back until import plugin rule is resolved https://github.com/microsoft/fluentui/issues/27727
+    lint: ['build'],
     clean: [],
     test: ['build'],
     'type-check': ['build'],


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

lint task doesn't depend on any other task

## New Behavior

adding "2. add back build pre-requirement to be able to run lint ( will slow down PR pipeline )" as temporary workaround

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes temporarily https://github.com/microsoft/fluentui/issues/27727
