### PR TITLE
fix: dont ignore lib, lib-commonjs and lib-amd files

### DIFF
--- a/change/@fluentui-date-time-utilities-a0aecb7b-3a32-4d59-97be-5a72945950f0.json
+++ b/change/@fluentui-date-time-utilities-a0aecb7b-3a32-4d59-97be-5a72945950f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-dom-utilities-4870503f-6c4c-4f16-8410-849213615530.json
+++ b/change/@fluentui-dom-utilities-4870503f-6c4c-4f16-8410-849213615530.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-font-icons-mdl2-f8af1b54-c711-481b-815b-55c190d712fd.json
+++ b/change/@fluentui-font-icons-mdl2-f8af1b54-c711-481b-815b-55c190d712fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-720281d9-c0bb-41d4-8d52-9931182c2775.json
+++ b/change/@fluentui-foundation-legacy-720281d9-c0bb-41d4-8d52-9931182c2775.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-keyboard-key-7468c9a0-88bd-4f5c-b8c3-19934e6abaf9.json
+++ b/change/@fluentui-keyboard-key-7468c9a0-88bd-4f5c-b8c3-19934e6abaf9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-merge-styles-cbfe751f-e28b-4ebd-b17e-47b4005e9ba1.json
+++ b/change/@fluentui-merge-styles-cbfe751f-e28b-4ebd-b17e-47b4005e9ba1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/merge-styles",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-8a7d357d-1295-4e6a-a77e-790989edaac0.json
+++ b/change/@fluentui-react-8a7d357d-1295-4e6a-a77e-790989edaac0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-4161aa46-456e-4ea9-9d37-011390ee242c.json
+++ b/change/@fluentui-react-focus-4161aa46-456e-4ea9-9d37-011390ee242c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/react-focus",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-b04425c0-6bd7-451a-a420-6349bd78e2ec.json
+++ b/change/@fluentui-react-hooks-b04425c0-6bd7-451a-a420-6349bd78e2ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/react-hooks",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-window-provider-b5677baf-4da6-4fb5-a2b5-a1ae68df3760.json
+++ b/change/@fluentui-react-window-provider-b5677baf-4da6-4fb5-a2b5-a1ae68df3760.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-set-version-6d49c6e7-561b-415f-9817-d602b46fd119.json
+++ b/change/@fluentui-set-version-6d49c6e7-561b-415f-9817-d602b46fd119.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/set-version",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-style-utilities-29d48d59-2b54-4f53-8610-3a12c54b6b71.json
+++ b/change/@fluentui-style-utilities-29d48d59-2b54-4f53-8610-3a12c54b6b71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/style-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-theme-f03403c3-7350-4846-93bf-cf0067b5b68d.json
+++ b/change/@fluentui-theme-f03403c3-7350-4846-93bf-cf0067b5b68d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/theme",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-f0ea6572-c3c2-43ec-9f30-0615063f2bb8.json
+++ b/change/@fluentui-utilities-f0ea6572-c3c2-43ec-9f30-0615063f2bb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: esm, cjs, and amd folders should all be published correctly.",
+  "packageName": "@fluentui/utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/date-time-utilities/.npmignore
+++ b/packages/date-time-utilities/.npmignore
@@ -30,3 +30,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/dom-utilities/.npmignore
+++ b/packages/dom-utilities/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/font-icons-mdl2/.npmignore
+++ b/packages/font-icons-mdl2/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/foundation-legacy/.npmignore
+++ b/packages/foundation-legacy/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/keyboard-key/.npmignore
+++ b/packages/keyboard-key/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/merge-styles/.npmignore
+++ b/packages/merge-styles/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-focus/.npmignore
+++ b/packages/react-focus/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-hooks/.npmignore
+++ b/packages/react-hooks/.npmignore
@@ -30,3 +30,6 @@ tslint.json
 typings
 fabric-test*
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-window-provider/.npmignore
+++ b/packages/react-window-provider/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -30,3 +30,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/set-version/.npmignore
+++ b/packages/set-version/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/style-utilities/.npmignore
+++ b/packages/style-utilities/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/theme/.npmignore
+++ b/packages/theme/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/utilities/.npmignore
+++ b/packages/utilities/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd


### PR DESCRIPTION
## Changes:
- with the repo upgrade to node 16, it seems like certain packages like `lib` and `lib-amd` are not being published despite being built. This PR explicitly adds to the `.npmignore` files of `@fluentui/react` and all packages within its dependency graph so that the `lib` and `lib-amd` folders are always included.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27732
