### PR TITLE
chore: add .swcrc to .npmignore (generator)

### DIFF
--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -1045,6 +1045,7 @@ describe('migrate-converged-pkg generator', () => {
         .eslint*
         .git*
         .prettierignore
+        .swcrc
         "
       `);
     });

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -391,6 +391,7 @@ const templates = {
     .eslint*
     .git*
     .prettierignore
+    .swcrc
   ` + os.EOL,
   swcConfig: () => {
     return {


### PR DESCRIPTION
## Previous Behavior

<img width="357" alt="image" src="https://user-images.githubusercontent.com/14183168/235638380-4f2041de-3fc8-42bf-928f-65169d1404cb.png">

## New Behavior

`.swcrc` is excluded from publishing. This PR updates only a generator, a PR that updates `.npmignore` will be done separately.