### PR TITLE
fix(react-avatar): AvatarGroupPopover's content now uses column direction

### DIFF
--- a/change/@fluentui-react-avatar-6355cdad-17ab-443b-8a0d-c8499ea34898.json
+++ b/change/@fluentui-react-avatar-6355cdad-17ab-443b-8a0d-c8499ea34898.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make AvatarGroup's content direction column.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.styles.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.styles.ts
@@ -22,6 +22,8 @@ const useContentStyles = makeStyles({
     listStyleType: 'none',
     ...shorthands.margin('0'),
     ...shorthands.padding('0'),
+    display: 'flex',
+    flexDirection: 'column',
   },
 });
 

--- a/packages/react-components/react-avatar/src/utils/getInitials.ts
+++ b/packages/react-components/react-avatar/src/utils/getInitials.ts
@@ -31,7 +31,6 @@ const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;
  * CJK:      CJK Unified Ideographs Extension A, CJK Unified Ideographs, CJK Compatibility Ideographs,
  *             CJK Unified Ideographs Extension B
  */
-// eslint-disable-next-line @fluentui/max-len
 const UNSUPPORTED_TEXT_REGEX: RegExp =
   /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD869][\uDC00-\uDED6]/;
 

--- a/packages/react-components/react-avatar/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { AvatarGroupProps } from '@fluentui/react-components';
 
 const names = [
-  'Johnie',
+  'Johnie McConnell',
   'Allan Munger',
   'Erik Nason',
   'Kristin Patterson',

--- a/packages/react-components/react-avatar/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
+++ b/packages/react-components/react-avatar/stories/AvatarGroup/AvatarGroupDefault.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { AvatarGroupProps } from '@fluentui/react-components';
 
 const names = [
-  'Johnie McConnell',
+  'Johnie',
   'Allan Munger',
   'Erik Nason',
   'Kristin Patterson',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://user-images.githubusercontent.com/5953191/235736812-da2f5adc-eaf4-41c8-a37f-9c610a530e4b.png)

## New Behavior

![image](https://user-images.githubusercontent.com/5953191/235736681-b926d382-e8c1-47e4-9d99-a210be5d3784.png)

