### PR TITLE
fix (v8): update more .npmignore files to resolve node16 regression with npm publishing

### DIFF
--- a/change/@fluentui-azure-themes-8c43c313-f51c-4342-9d83-4e1b5780d129.json
+++ b/change/@fluentui-azure-themes-8c43c313-f51c-4342-9d83-4e1b5780d129.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/azure-themes",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-fluent2-theme-b30b5fc4-9a99-42c2-a2c6-f860cdce6ac2.json
+++ b/change/@fluentui-fluent2-theme-b30b5fc4-9a99-42c2-a2c6-f860cdce6ac2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-monaco-editor-d6b9bc01-a45b-4266-a6fd-d5dd25683e53.json
+++ b/change/@fluentui-monaco-editor-d6b9bc01-a45b-4266-a6fd-d5dd25683e53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-cards-8b422155-478a-467e-a047-43de878ee009.json
+++ b/change/@fluentui-react-cards-8b422155-478a-467e-a047-43de878ee009.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-cards",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-df2940a6-6901-4067-940d-0d9ce74df333.json
+++ b/change/@fluentui-react-charting-df2940a6-6901-4067-940d-0d9ce74df333.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-charting",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-da870d4d-342b-40d0-9a40-44942a3b86b6.json
+++ b/change/@fluentui-react-da870d4d-342b-40d0-9a40-44942a3b86b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-date-time-28c4fee7-3b06-43ef-9d8b-4ee360a0771c.json
+++ b/change/@fluentui-react-date-time-28c4fee7-3b06-43ef-9d8b-4ee360a0771c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-date-time",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-docsite-components-22936b88-d8e1-4e69-90b8-53a035713f03.json
+++ b/change/@fluentui-react-docsite-components-22936b88-d8e1-4e69-90b8-53a035713f03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-4f4e0bc1-e6fc-4f9a-b8b4-c4afc10c0d37.json
+++ b/change/@fluentui-react-experiments-4f4e0bc1-e6fc-4f9a-b8b4-c4afc10c0d37.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-file-type-icons-9214c95d-e717-44bd-bf6f-461acb6afa0b.json
+++ b/change/@fluentui-react-file-type-icons-9214c95d-e717-44bd-bf6f-461acb6afa0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icon-provider-e3f59033-f7e2-4040-8938-31b2636c4bcc.json
+++ b/change/@fluentui-react-icon-provider-e3f59033-f7e2-4040-8938-31b2636c4bcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-mdl2-00a6ffe4-847d-4337-bc8b-6efa14e21e1a.json
+++ b/change/@fluentui-react-icons-mdl2-00a6ffe4-847d-4337-bc8b-6efa14e21e1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-5fd5cecb-2bf1-4682-95b4-d05aa48a47c4.json
+++ b/change/@fluentui-react-icons-mdl2-branded-5fd5cecb-2bf1-4682-95b4-d05aa48a47c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-monaco-editor-9a27eb9e-30d5-42fd-833e-c980e25fe9ca.json
+++ b/change/@fluentui-react-monaco-editor-9a27eb9e-30d5-42fd-833e-c980e25fe9ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-scheme-utilities-bb23e739-4625-4831-b4c4-6f6cb4d5459e.json
+++ b/change/@fluentui-scheme-utilities-bb23e739-4625-4831-b4c4-6f6cb4d5459e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-test-utilities-60e4ff6c-e8cb-48cc-a417-54addb1e6248.json
+++ b/change/@fluentui-test-utilities-60e4ff6c-e8cb-48cc-a417-54addb1e6248.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/test-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-theme-samples-afd27a1e-7802-41cb-8b03-b90fc9222122.json
+++ b/change/@fluentui-theme-samples-afd27a1e-7802-41cb-8b03-b90fc9222122.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/theme-samples",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-webpack-utilities-4bf5a942-76f7-4ca7-94cf-464ff83638c2.json
+++ b/change/@fluentui-webpack-utilities-4bf5a942-76f7-4ca7-94cf-464ff83638c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update npmignore files to fix npm8/node16 regression with how npm publish works.",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/.npmignore
+++ b/packages/azure-themes/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/fluent2-theme/.npmignore
+++ b/packages/fluent2-theme/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/monaco-editor/.npmignore
+++ b/packages/monaco-editor/.npmignore
@@ -33,3 +33,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-cards/.npmignore
+++ b/packages/react-cards/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-charting/.npmignore
+++ b/packages/react-charting/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-date-time/.npmignore
+++ b/packages/react-date-time/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-docsite-components/.npmignore
+++ b/packages/react-docsite-components/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-experiments/.npmignore
+++ b/packages/react-experiments/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-file-type-icons/.npmignore
+++ b/packages/react-file-type-icons/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-icon-provider/.npmignore
+++ b/packages/react-icon-provider/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-icons-mdl2-branded/.npmignore
+++ b/packages/react-icons-mdl2-branded/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-icons-mdl2/.npmignore
+++ b/packages/react-icons-mdl2/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react-monaco-editor/.npmignore
+++ b/packages/react-monaco-editor/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -33,3 +33,4 @@ visualtests
 !lib
 !lib-commonjs
 !lib-amd
+!dist

--- a/packages/scheme-utilities/.npmignore
+++ b/packages/scheme-utilities/.npmignore
@@ -33,3 +33,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/test-utilities/.npmignore
+++ b/packages/test-utilities/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/theme-samples/.npmignore
+++ b/packages/theme-samples/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd

--- a/packages/webpack-utilities/.npmignore
+++ b/packages/webpack-utilities/.npmignore
@@ -32,3 +32,6 @@ tsd.json
 tslint.json
 typings
 visualtests
+!lib
+!lib-commonjs
+!lib-amd


### PR DESCRIPTION
## Changes:
- some v8 packages were missed in the updates from last night so this PR updates the `.npmignore` file of packages missed.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Follows #27736
Fixes #27732
