### PR TITLE
fix(recipes-react-components): Add a FluentProvider to the local storybook

### DIFF
--- a/apps/recipes-react-components/.storybook/preview.js
+++ b/apps/recipes-react-components/.storybook/preview.js
@@ -1,0 +1,7 @@
+import { FluentDocsContainer } from '../src/DocComponents/FluentDocsContainer.stories';
+
+export const parameters = {
+  docs: {
+    container: FluentDocsContainer,
+  },
+};

--- a/apps/recipes-react-components/src/DocComponents/FluentDocsContainer.stories.tsx
+++ b/apps/recipes-react-components/src/DocComponents/FluentDocsContainer.stories.tsx
@@ -9,7 +9,7 @@ type FluentDocsContainerProps = {
 
 export const FluentDocsContainer: React.FC<FluentDocsContainerProps> = ({ children, context }) => {
   return (
-    <FluentProvider style={{ backgroundColor: 'transparent' }} theme={webLightTheme}>
+    <FluentProvider theme={webLightTheme}>
       <DocsContainer context={context}>{children}</DocsContainer>
     </FluentProvider>
   );

--- a/apps/recipes-react-components/src/DocComponents/FluentDocsContainer.stories.tsx
+++ b/apps/recipes-react-components/src/DocComponents/FluentDocsContainer.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { DocsContainer, DocsContextProps } from '@storybook/addon-docs';
+import { FluentStoryContext } from '@fluentui/react-storybook-addon';
+import { webLightTheme, FluentProvider } from '@fluentui/react-components';
+
+type FluentDocsContainerProps = {
+  context: FluentStoryContext & DocsContextProps;
+};
+
+export const FluentDocsContainer: React.FC<FluentDocsContainerProps> = ({ children, context }) => {
+  return (
+    <FluentProvider style={{ backgroundColor: 'transparent' }} theme={webLightTheme}>
+      <DocsContainer context={context}>{children}</DocsContainer>
+    </FluentProvider>
+  );
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When rendering a recipe in the local storybook there was no FluentProvider, therefore the Fluent components weren't styled correctly.

## New Behavior

Recipes are wrapped with a FluentProvider in the local storybook. Note that the provider is added by the local storybook, outside of the local package the change will take no effect.

