### PR TITLE
fix(scripts-update-release-notes): properly handle git for-each-ref cmd call to not fail release notes update

### DIFF
--- a/scripts/update-release-notes/changelogsAndTags.ts
+++ b/scripts/update-release-notes/changelogsAndTags.ts
@@ -87,7 +87,11 @@ export function getTags(maxAgeDays?: number): string[] {
 
     return tags;
   } catch (err) {
-    throw new Error(`maxBuffer ${TEN_MEGABYTES}MB was reached. Increase its size in the codebase`);
+    if (err.code === 'ENOBUFS') {
+      throw new Error(`maxBuffer ${TEN_MEGABYTES}MB was reached. Increase its size in the codebase`);
+    }
+
+    throw err;
   }
 }
 

--- a/scripts/update-release-notes/changelogsAndTags.ts
+++ b/scripts/update-release-notes/changelogsAndTags.ts
@@ -1,8 +1,10 @@
-import * as path from 'path';
-import * as fs from 'fs-extra';
 import { execSync } from 'child_process';
+import * as path from 'path';
+
 import { ChangelogJson } from 'beachball';
+import * as fs from 'fs-extra';
 import { rollup as lernaAliases } from 'lerna-alias';
+
 import { IChangelogEntry } from './types';
 
 const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;
@@ -49,28 +51,44 @@ export function getTagToChangelogMap(maxAgeDays?: number): Map<string, IChangelo
  * @returns List of tags
  */
 export function getTags(maxAgeDays?: number): string[] {
+  const ONE_MEGABYTE = 1024 * 1000;
+  const TEN_MEGABYTES = ONE_MEGABYTE * 10;
   console.log(`Getting tags${maxAgeDays ? ` up to ${maxAgeDays} days old` : ''}...`);
 
-  const cmd = 'git for-each-ref --sort=-creatordate --format="%(refname:short) -- %(creatordate)" refs/tags';
+  try {
+    const cmd = 'git for-each-ref --sort=-creatordate --format="%(refname:short) -- %(creatordate)" refs/tags';
+    const gitForEachRefBuffer = execSync(cmd, {
+      // execSync buffer is by default 1MB (node 16). Our git refs tog is much bigger than that, thus setting for 10MB
+      maxBuffer: TEN_MEGABYTES,
+    });
+    const currentBufferSize = (gitForEachRefBuffer.byteLength / ONE_MEGABYTE).toFixed(2);
 
-  let tagsAndDates = execSync(cmd, { cwd: process.cwd() })
-    .toString()
-    .split(/\r?\n/g)
-    .map(tag => tag.split(' -- '))
-    .filter(arr => arr.length === 2);
+    console.warn(`
+  📣 NOTE: "git for-each-ref" current buffer size is ${currentBufferSize}MB.
+  If this will be more than maxBuffer ${TEN_MEGABYTES}MB this command will fail and you'll have to increase maxBuffer!
+  `);
 
-  if (maxAgeDays) {
-    const endIndex = tagsAndDates.findIndex(([, date]) => !_isNewEnough(date, maxAgeDays));
-    if (endIndex !== -1) {
-      tagsAndDates = tagsAndDates.slice(0, endIndex);
+    let tagsAndDates = gitForEachRefBuffer
+      .toString()
+      .split(/\r?\n/g)
+      .map(tag => tag.split(' -- '))
+      .filter(arr => arr.length === 2);
+
+    if (maxAgeDays) {
+      const endIndex = tagsAndDates.findIndex(([, date]) => !_isNewEnough(date, maxAgeDays));
+      if (endIndex !== -1) {
+        tagsAndDates = tagsAndDates.slice(0, endIndex);
+      }
     }
+
+    const tags = tagsAndDates.map(([tag]) => tag);
+
+    console.log(`Found ${tags.length} tag(s).\n`);
+
+    return tags;
+  } catch (err) {
+    throw new Error(`maxBuffer ${TEN_MEGABYTES}MB was reached. Increase its size in the codebase`);
   }
-
-  const tags = tagsAndDates.map(([tag]) => tag);
-
-  console.log(`Found ${tags.length} tag(s).\n`);
-
-  return tags;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

v8 releases were broken for quite some time but because we used node 14 which was allowing unhandled promise rejections it never blocked release so nobody noticed

_Example:_

1. node 14:

https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=299747&view=logs&j=8d802004-fbbb-5f17-b73e-f23de0c1dec8&t=ba6db26e-7b20-5e89-5cf3-08c91a4eaf9b

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/1223799/236185649-dbdad833-31d4-44c4-b491-2f41966b421d.png">

2. node 16:

After we migrated to node 16, these unhandled rejections start to process exit thus failing pipelines

https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=301085&view=logs&j=8d802004-fbbb-5f17-b73e-f23de0c1dec8

<img width="806" alt="image" src="https://user-images.githubusercontent.com/1223799/236185863-cc7ef7dd-0332-45a8-a7e2-3a01f1522ae9.png">


## New Behavior

`update-release-notes` processing for tags from git now properly works. It will also print notification on every release run so v-build has more easier troubleshooting experience.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/27711
