### PR TITLE
feat: Implement state management for toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "@types/react-dom": "17.0.15",
     "@types/react-is": "17.0.3",
     "@types/react-test-renderer": "17.0.2",
+    "@types/react-transition-group": "4.4.6",
     "@types/request-promise-native": "1.0.18",
     "@types/scheduler": "0.16.2",
     "@types/semver": "^6.2.0",

--- a/packages/react-components/react-toast/.storybook/main.js
+++ b/packages/react-components/react-toast/.storybook/main.js
@@ -1,0 +1,14 @@
+const rootMain = require('../../../../.storybook/main');
+
+module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+  ...rootMain,
+  stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+  addons: [...rootMain.addons],
+  webpackFinal: (config, options) => {
+    const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+    // add your own webpack tweaks if needed
+
+    return localConfig;
+  },
+});

--- a/packages/react-components/react-toast/.storybook/preview.js
+++ b/packages/react-components/react-toast/.storybook/preview.js
@@ -1,0 +1,7 @@
+import * as rootPreview from '../../../../.storybook/preview';
+
+/** @type {typeof rootPreview.decorators} */
+export const decorators = [...rootPreview.decorators];
+
+/** @type {typeof rootPreview.parameters} */
+export const parameters = { ...rootPreview.parameters };

--- a/packages/react-components/react-toast/.storybook/tsconfig.json
+++ b/packages/react-components/react-toast/.storybook/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "",
+    "allowJs": true,
+    "checkJs": true,
+    "types": ["static-assets", "environment", "storybook__addons"]
+  },
+  "include": ["../stories/**/*.stories.ts", "../stories/**/*.stories.tsx", "*.js"]
+}

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -4,6 +4,47 @@
 
 ```ts
 
+import * as React_2 from 'react';
+
+// @public (undocumented)
+export function toast<TData = unknown>(content: ToastContent<TData>, options?: ToastOptions): Id;
+
+// @public (undocumented)
+export namespace toast {
+    var // (undocumented)
+    loading: <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    promise: typeof handlePromise;
+    var // (undocumented)
+    success: <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    info: <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    error: <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    warning: <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    warn: <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    dark: (content: ToastContent<unknown>, options?: ToastOptions<{}> | undefined) => Id;
+    var // (undocumented)
+    dismiss: (id?: Id | undefined) => void;
+    var // (undocumented)
+    clearWaitingQueue: (params?: ClearWaitingQueueParams) => void;
+    var // (undocumented)
+    isActive: (id: Id) => boolean;
+    var // (undocumented)
+    update: <TData = unknown>(toastId: Id, options?: UpdateOptions<TData>) => void;
+    var // (undocumented)
+    onChange: (callback: OnChangeCallback) => () => void;
+}
+
+// @public (undocumented)
+export const Toaster: React_2.FC<ToasterProps>;
+
+// @public (undocumented)
+export type ToastPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-toast/package.json
+++ b/packages/react-components/react-toast/package.json
@@ -21,7 +21,9 @@
     "test": "jest --passWithNoTests",
     "test-ssr": "test-ssr ./stories/**/*.stories.tsx",
     "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api"
+    "generate-api": "just-scripts generate-api",
+    "storybook": "start-storybook",
+    "start": "yarn storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
@@ -32,10 +34,12 @@
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.2",
+    "@fluentui/react-portal": "^9.2.6",
     "@fluentui/react-theme": "^9.1.7",
     "@fluentui/react-utilities": "^9.8.0",
     "@griffel/react": "^1.5.2",
-    "@swc/helpers": "^0.4.14"
+    "@swc/helpers": "^0.4.14",
+    "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <19.0.0",

--- a/packages/react-components/react-toast/src/components/Timer.tsx
+++ b/packages/react-components/react-toast/src/components/Timer.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { makeStyles } from '@griffel/react';
+
+const useStyles = makeStyles({
+  progress: {
+    animationName: {
+      from: {
+        opacity: 0,
+      },
+      to: {
+        opacity: 0,
+      },
+    },
+  },
+});
+
+export const Timer: React.FC<{
+  isRunning: boolean;
+  timeout: number;
+  onTimeout: () => void;
+}> = props => {
+  const styles = useStyles();
+  const { isRunning, timeout, onTimeout } = props;
+  const cleanupRef = React.useRef<() => void>(() => null);
+
+  const bindEventListeners = React.useCallback(
+    (el: HTMLElement) => {
+      cleanupRef.current();
+      if (el) {
+        el.addEventListener('animationend', onTimeout);
+        cleanupRef.current = () => el.removeEventListener('animationend', onTimeout);
+      }
+    },
+    [onTimeout],
+  );
+
+  const style: React.CSSProperties = {
+    animationDuration: `${timeout}ms`,
+    animationPlayState: isRunning ? 'running' : 'paused',
+  };
+
+  if (timeout < 0) {
+    return null;
+  }
+
+  return <span ref={bindEventListeners} style={style} className={styles.progress} />;
+};

--- a/packages/react-components/react-toast/src/components/Toast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast.tsx
@@ -1,0 +1,110 @@
+/**
+ * ⚠️ This is temporary and WILL be removed
+ */
+
+import * as React from 'react';
+import { Transition } from 'react-transition-group';
+import { useIsomorphicLayoutEffect, useMergedRefs } from '@fluentui/react-utilities';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { useToast, ToastProps } from '../state';
+import { Timer } from './Timer';
+
+const useStyles = makeStyles({
+  toast: {
+    ...shorthands.border('2px', 'dashed', 'red'),
+    ...shorthands.padding('4px'),
+    display: 'flex',
+    minHeight: '40px',
+    maxHeight: '40px',
+    minWidth: '200px',
+    maxWidth: '200px',
+    alignItems: 'center',
+    backgroundColor: 'white',
+  },
+
+  slide: {
+    animationDuration: '200ms, 400ms',
+    animationDelay: '0ms, 200ms',
+    animationName: [
+      {
+        from: {
+          height: '0',
+          minHeight: '0',
+          maxHeight: '0',
+          opacity: 0,
+        },
+        to: {
+          opacity: 0,
+        },
+      },
+      {
+        from: {
+          opacity: 0,
+        },
+        to: {
+          opacity: 1,
+        },
+      },
+    ],
+  },
+
+  fadeOut: {
+    animationDuration: '400ms, 200ms',
+    animationDelay: '0ms, 400ms',
+    animationName: [
+      {
+        from: {
+          opacity: 1,
+        },
+        to: {
+          opacity: 0,
+        },
+      },
+      {
+        from: {
+          opacity: 0,
+        },
+        to: {
+          opacity: 0,
+          height: 0,
+          maxHeight: 0,
+          minHeight: 0,
+        },
+      },
+    ],
+  },
+});
+
+export const Toast: React.FC<ToastProps> = props => {
+  const styles = useStyles();
+  const { isIn, children, closeToast, deleteToast, autoClose } = props;
+  const { eventHandlers, toastRef, playToast, isRunning } = useToast(props);
+  const nodeRef = React.useRef<HTMLDivElement>(null);
+
+  // start the toast once it's fully in
+  useIsomorphicLayoutEffect(() => {
+    if (toastRef.current) {
+      const toast = toastRef.current;
+      toast.addEventListener('animationend', playToast, {
+        once: true,
+      });
+
+      return () => {
+        toast.removeEventListener('animationend', playToast);
+      };
+    }
+  }, [playToast, toastRef]);
+
+  return (
+    <Transition in={isIn} unmountOnExit mountOnEnter timeout={500} onExited={deleteToast} nodeRef={nodeRef}>
+      <div
+        ref={useMergedRefs(nodeRef, toastRef)}
+        className={mergeClasses(styles.toast, isIn && styles.slide, !isIn && styles.fadeOut)}
+        {...eventHandlers}
+      >
+        {children as React.ReactNode}
+        <Timer onTimeout={closeToast} timeout={!autoClose ? -1 : autoClose} isRunning={isRunning} />
+      </div>
+    </Transition>
+  );
+};

--- a/packages/react-components/react-toast/src/components/Toaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster.tsx
@@ -1,0 +1,53 @@
+/**
+ * ⚠️ This is temporary and WILL be removed
+ */
+
+import * as React from 'react';
+import { Portal } from '@fluentui/react-portal';
+import { ToastContainerProps, ToastPosition, useToaster } from '../state';
+import { Toast } from './Toast';
+import { makeStyles, mergeClasses } from '@griffel/react';
+
+interface ToasterProps extends Pick<ToastContainerProps, 'offset'> {
+  position: ToastPosition;
+  targetDocument: Document | null | undefined;
+  limit?: number;
+}
+
+const useStyles = makeStyles({
+  container: {
+    position: 'fixed',
+  },
+});
+
+export const Toaster: React.FC<ToasterProps> = props => {
+  const { targetDocument, limit, offset } = props;
+  const { containerRef, getToastToRender, isToastActive, getPositionStyles } = useToaster({
+    targetDocument,
+    limit,
+    offset,
+    autoClose: 3000,
+  });
+
+  const styles = useStyles();
+
+  return (
+    <Portal>
+      <div ref={containerRef}>
+        {getToastToRender((position, toasts) => {
+          return (
+            <div key={position} style={getPositionStyles(position)} className={mergeClasses(styles.container)}>
+              {toasts.map(({ content, props: toastProps }, i) => {
+                return (
+                  <Toast {...toastProps} key={`toast-${toastProps.key}`} isIn={isToastActive(toastProps.toastId)}>
+                    {content as React.ReactNode}
+                  </Toast>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </Portal>
+  );
+};

--- a/packages/react-components/react-toast/src/index.ts
+++ b/packages/react-components/react-toast/src/index.ts
@@ -1,2 +1,3 @@
-// TODO: replace with real exports
-export {};
+export { Toaster } from './components/Toaster';
+export { toast } from './state';
+export type { ToastPosition } from './state';

--- a/packages/react-components/react-toast/src/state/eventManager.ts
+++ b/packages/react-components/react-toast/src/state/eventManager.ts
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import {
+  Id,
+  ToastContent,
+  ClearWaitingQueueParams,
+  NotValidatedToastProps,
+  ToastItem,
+  ContainerInstance,
+} from './types';
+
+export const enum Event {
+  Show,
+  Clear,
+  DidMount,
+  WillUnmount,
+  Change,
+  ClearWaitingQueue,
+}
+
+type OnShowCallback = (content: ToastContent, options: NotValidatedToastProps) => void;
+type OnClearCallback = (id?: Id) => void;
+type OnClearWaitingQueue = (params: ClearWaitingQueueParams) => void;
+type OnDidMountCallback = (containerInstance: ContainerInstance) => void;
+type OnWillUnmountCallback = OnDidMountCallback;
+
+export type OnChangeCallback = (toast: ToastItem) => void;
+
+type Callback =
+  | OnShowCallback
+  | OnClearCallback
+  | OnClearWaitingQueue
+  | OnDidMountCallback
+  | OnWillUnmountCallback
+  | OnChangeCallback;
+type TimeoutId = ReturnType<typeof setTimeout>;
+
+export interface EventManager {
+  list: Map<Event, Callback[]>;
+  emitQueue: Map<Event, TimeoutId[]>;
+  on(event: Event.Show, callback: OnShowCallback): EventManager;
+  on(event: Event.Clear, callback: OnClearCallback): EventManager;
+  on(event: Event.ClearWaitingQueue, callback: OnClearWaitingQueue): EventManager;
+  on(event: Event.DidMount, callback: OnDidMountCallback): EventManager;
+  on(event: Event.WillUnmount, callback: OnWillUnmountCallback): EventManager;
+  on(event: Event.Change, callback: OnChangeCallback): EventManager;
+  off(event: Event, callback?: Callback): EventManager;
+  cancelEmit(event: Event): EventManager;
+  emit<TData>(event: Event.Show, content: React.ReactNode | ToastContent<TData>, options: NotValidatedToastProps): void;
+  emit(event: Event.Clear, id?: string | number): void;
+  emit(event: Event.ClearWaitingQueue, params: ClearWaitingQueueParams): void;
+  emit(event: Event.DidMount, containerInstance: ContainerInstance): void;
+  emit(event: Event.WillUnmount, containerInstance: ContainerInstance): void;
+  emit(event: Event.Change, data: ToastItem): void;
+}
+
+export const eventManager: EventManager = {
+  list: new Map(),
+  emitQueue: new Map(),
+
+  on(event: Event, callback: Callback) {
+    this.list.has(event) || this.list.set(event, []);
+    this.list.get(event)!.push(callback);
+    return this;
+  },
+
+  off(event, callback) {
+    if (callback) {
+      const remainingCallbacks = this.list.get(event)?.filter(cb => cb !== callback) ?? [];
+      this.list.set(event, remainingCallbacks);
+      return this;
+    }
+    this.list.delete(event);
+    return this;
+  },
+
+  cancelEmit(event) {
+    const timers = this.emitQueue.get(event);
+    if (timers) {
+      timers.forEach(clearTimeout);
+      this.emitQueue.delete(event);
+    }
+
+    return this;
+  },
+
+  /**
+   * Enqueue the event at the end of the call stack
+   * Doing so let the user call toast as follow:
+   * toast('1')
+   * toast('2')
+   * toast('3')
+   * Without setTimemout the code above will not work
+   */
+  emit(event: Event, ...args: unknown[]) {
+    this.list.has(event) &&
+      this.list.get(event)?.forEach((callback: Callback) => {
+        const timer: TimeoutId = setTimeout(() => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          callback(...args);
+        }, 0);
+
+        this.emitQueue.has(event) || this.emitQueue.set(event, []);
+        this.emitQueue.get(event)!.push(timer);
+      });
+  },
+};

--- a/packages/react-components/react-toast/src/state/index.ts
+++ b/packages/react-components/react-toast/src/state/index.ts
@@ -1,0 +1,4 @@
+export * from './useToast';
+export * from './useToaster';
+export * from './types';
+export { toast } from './toast';

--- a/packages/react-components/react-toast/src/state/toast.ts
+++ b/packages/react-components/react-toast/src/state/toast.ts
@@ -1,0 +1,284 @@
+import { isStr, isNum, isFn, Type } from './utils';
+import { eventManager, OnChangeCallback, Event } from './eventManager';
+import {
+  ToastContent,
+  ToastOptions,
+  ToastProps,
+  Id,
+  UpdateOptions,
+  ClearWaitingQueueParams,
+  NotValidatedToastProps,
+  TypeOptions,
+  ContainerInstance,
+} from './types';
+
+interface EnqueuedToast {
+  content: ToastContent<unknown>;
+  options: NotValidatedToastProps;
+}
+
+const containers = new Map<ContainerInstance | Id, ContainerInstance>();
+let latestInstance: ContainerInstance | Id;
+let queue: EnqueuedToast[] = [];
+let TOAST_ID = 1;
+
+/**
+ * Get the toast by id, given it's in the DOM, otherwise returns null
+ */
+function getToast(toastId: Id, { containerId }: ToastOptions) {
+  const container = containers.get(containerId || latestInstance);
+  return container && container.getToast(toastId);
+}
+
+/**
+ * Generate a random toastId
+ */
+function generateToastId() {
+  return `${TOAST_ID++}`;
+}
+
+/**
+ * Generate a toastId or use the one provided
+ */
+function getToastId(options?: ToastOptions) {
+  return options && (isStr(options.toastId) || isNum(options.toastId)) ? options.toastId : generateToastId();
+}
+
+/**
+ * If the container is not mounted, the toast is enqueued and
+ * the container lazy mounted
+ */
+function dispatchToast<TData>(content: ToastContent<TData>, options: NotValidatedToastProps): Id {
+  if (containers.size > 0) {
+    eventManager.emit(Event.Show, content, options);
+  } else {
+    queue.push({ content, options });
+  }
+
+  return options.toastId;
+}
+
+/**
+ * Merge provided options with the defaults settings and generate the toastId
+ */
+function mergeOptions(type: string, options?: ToastOptions) {
+  return {
+    ...options,
+    type: (options && options.type) || type,
+    toastId: getToastId(options),
+  } as NotValidatedToastProps;
+}
+
+function createToastByType(type: string) {
+  return <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(type, options));
+}
+
+function toast<TData = unknown>(content: ToastContent<TData>, options?: ToastOptions) {
+  return dispatchToast(content, mergeOptions(Type.DEFAULT, options));
+}
+
+toast.loading = <TData = unknown>(content: ToastContent<TData>, options?: ToastOptions) =>
+  dispatchToast(
+    content,
+    mergeOptions(Type.DEFAULT, {
+      isLoading: true,
+      autoClose: false,
+      closeOnClick: false,
+      ...options,
+    }),
+  );
+
+export interface ToastPromiseParams<TData = unknown, TError = unknown, TPending = unknown> {
+  pending?: string | UpdateOptions<TPending>;
+  success?: string | UpdateOptions<TData>;
+  error?: string | UpdateOptions<TError>;
+}
+
+function handlePromise<TData = unknown, TError = unknown, TPending = unknown>(
+  promise: Promise<TData> | (() => Promise<TData>),
+  { pending, error, success }: ToastPromiseParams<TData, TError, TPending>,
+  options?: ToastOptions,
+) {
+  let id: Id;
+
+  if (pending) {
+    id = isStr(pending)
+      ? toast.loading(pending, options)
+      : toast.loading(pending.render, {
+          ...options,
+          ...(pending as ToastOptions),
+        });
+  }
+
+  const resetParams = {
+    isLoading: null,
+    autoClose: null,
+    closeOnClick: null,
+    closeButton: null,
+    draggable: null,
+  };
+
+  const resolver = <T>(type: TypeOptions, input: string | UpdateOptions<T> | undefined, result: T) => {
+    // Remove the toast if the input has not been provided. This prevents the toast from hanging
+    // in the pending state if a success/error toast has not been provided.
+    if (!input) {
+      toast.dismiss(id);
+      return;
+    }
+
+    const baseParams = {
+      type,
+      ...resetParams,
+      ...options,
+      data: result,
+    };
+    const params = isStr(input) ? { render: input } : input;
+
+    // if the id is set we know that it's an update
+    if (id) {
+      toast.update(id, {
+        ...baseParams,
+        ...params,
+      } as UpdateOptions);
+    } else {
+      // using toast.promise without loading
+      toast(params!.render, {
+        ...baseParams,
+        ...params,
+      } as ToastOptions);
+    }
+
+    return result;
+  };
+
+  const p = isFn(promise) ? promise() : promise;
+
+  //call the resolvers only when needed
+  p.then(result => resolver('success', success, result)).catch(err => resolver('error', error, err));
+
+  return p;
+}
+
+toast.promise = handlePromise;
+toast.success = createToastByType(Type.SUCCESS);
+toast.info = createToastByType(Type.INFO);
+toast.error = createToastByType(Type.ERROR);
+toast.warning = createToastByType(Type.WARNING);
+toast.warn = toast.warning;
+toast.dark = (content: ToastContent, options?: ToastOptions) =>
+  dispatchToast(
+    content,
+    mergeOptions(Type.DEFAULT, {
+      ...options,
+    }),
+  );
+
+/**
+ * Remove toast programmaticaly
+ */
+toast.dismiss = (id?: Id) => {
+  if (containers.size > 0) {
+    eventManager.emit(Event.Clear, id);
+  } else {
+    queue = queue.filter(t => id === undefined && t.options.toastId !== id);
+  }
+};
+
+/**
+ * Clear waiting queue when limit is used
+ */
+toast.clearWaitingQueue = (params: ClearWaitingQueueParams = {}) => eventManager.emit(Event.ClearWaitingQueue, params);
+
+/**
+ * return true if one container is displaying the toast
+ */
+toast.isActive = (id: Id) => {
+  let isToastActive = false;
+
+  containers.forEach(container => {
+    if (container.isToastActive && container.isToastActive(id)) {
+      isToastActive = true;
+    }
+  });
+
+  return isToastActive;
+};
+
+toast.update = <TData = unknown>(toastId: Id, options: UpdateOptions<TData> = {}) => {
+  setTimeout(() => {
+    const toastInstance = getToast(toastId, options as ToastOptions);
+    if (toastInstance) {
+      const { props: oldOptions, content: oldContent } = toastInstance;
+
+      const nextOptions = {
+        delay: 100,
+        ...oldOptions,
+        ...options,
+        toastId: options.toastId || toastId,
+        updateId: generateToastId(),
+      } as ToastProps & UpdateOptions;
+
+      if (nextOptions.toastId !== toastId) {
+        nextOptions.staleId = toastId;
+      }
+
+      const content = nextOptions.render || oldContent;
+      delete nextOptions.render;
+
+      dispatchToast(content, nextOptions);
+    }
+  }, 0);
+};
+
+/**
+ * Subscribe to change when a toast is added, removed and updated
+ *
+ * Usage:
+ * ```
+ * const unsubscribe = toast.onChange((payload) => {
+ *   switch (payload.status) {
+ *   case "added":
+ *     // new toast added
+ *     break;
+ *   case "updated":
+ *     // toast updated
+ *     break;
+ *   case "removed":
+ *     // toast has been removed
+ *     break;
+ *   }
+ * })
+ * ```
+ */
+toast.onChange = (callback: OnChangeCallback) => {
+  eventManager.on(Event.Change, callback);
+  return () => {
+    eventManager.off(Event.Change, callback);
+  };
+};
+
+/**
+ * Wait until the ToastContainer is mounted to dispatch the toast
+ * and attach isActive method
+ */
+eventManager
+  .on(Event.DidMount, (containerInstance: ContainerInstance) => {
+    latestInstance = containerInstance.containerId || containerInstance;
+    containers.set(latestInstance, containerInstance);
+
+    queue.forEach(item => {
+      eventManager.emit(Event.Show, item.content, item.options);
+    });
+
+    queue = [];
+  })
+  .on(Event.WillUnmount, (containerInstance: ContainerInstance) => {
+    containers.delete(containerInstance.containerId || containerInstance);
+
+    if (containers.size === 0) {
+      eventManager.off(Event.Show).off(Event.Clear).off(Event.ClearWaitingQueue);
+    }
+  });
+
+export { toast };

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -1,0 +1,197 @@
+import * as React from 'react';
+
+type Nullable<T> = {
+  [P in keyof T]: T[P] | null;
+};
+
+export type TypeOptions = 'info' | 'success' | 'warning' | 'error' | 'default';
+
+export type ToastPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+
+export interface ToastContentProps<Data = {}> {
+  closeToast?: () => void;
+  toastProps: ToastProps;
+  data?: Data;
+}
+
+export type ToastContent<T = unknown> = React.ReactNode | ((props: ToastContentProps<T>) => React.ReactNode);
+
+export type Id = number | string;
+
+export interface ClearWaitingQueueParams {
+  containerId?: Id;
+}
+
+interface CommonOptions {
+  /**
+   * Pause the timer when the mouse hover the toast.
+   * `Default: true`
+   */
+  pauseOnHover?: boolean;
+
+  /**
+   * Pause the toast when the window loses focus.
+   * `Default: true`
+   */
+  pauseOnFocusLoss?: boolean;
+
+  /**
+   * Remove the toast when clicked.
+   * `Default: true`
+   */
+  closeOnClick?: boolean;
+
+  /**
+   * Set the delay in ms to close the toast automatically.
+   * Use `false` to prevent the toast from closing.
+   * `Default: 5000`
+   */
+  autoClose?: number | false;
+
+  /**
+   * Set the default position to use.
+   * `One of: 'top-right', 'top-center', 'top-left', 'bottom-right', 'bottom-center', 'bottom-left'`
+   * `Default: 'top-right'`
+   */
+  position?: ToastPosition;
+
+  /**
+   * Set id to handle multiple container
+   */
+  containerId?: Id;
+
+  /**
+   * Support right to left display.
+   * `Default: false`
+   */
+  rtl?: boolean;
+}
+
+export interface ToastOptions<Data = {}> extends CommonOptions {
+  /**
+   * An optional inline style to apply.
+   */
+  style?: React.CSSProperties;
+
+  /**
+   * Set the toast type.
+   * `One of: 'info', 'success', 'warning', 'error', 'default'`
+   */
+  type?: TypeOptions;
+
+  /**
+   * Set a custom `toastId`
+   */
+  toastId?: Id;
+
+  /**
+   * Used during update
+   */
+  updateId?: Id;
+
+  /**
+   * Add a delay in ms before the toast appear.
+   */
+  delay?: number;
+
+  isLoading?: boolean;
+
+  data?: Data;
+}
+
+export interface UpdateOptions<T = unknown> extends Nullable<ToastOptions<T>> {
+  /**
+   * Used to update a toast.
+   * Pass any valid ReactNode(string, number, component)
+   */
+  render?: ToastContent<T>;
+}
+
+export interface ToastContainerProps extends CommonOptions {
+  /**
+   * Show the toast only if it includes containerId and it's the same as containerId
+   * `Default: false`
+   */
+  enableMultiContainer?: boolean;
+
+  /**
+   * Limit the number of toast displayed at the same time
+   */
+  limit?: number;
+
+  targetDocument: Document | null | undefined;
+
+  offset?: {
+    horizontal: number;
+    vertical: number;
+  };
+}
+
+export interface ToastTransitionProps {
+  isIn: boolean;
+  done: () => void;
+  position: ToastPosition | string;
+  preventExitTransition: boolean;
+  nodeRef: React.RefObject<HTMLElement>;
+  children?: React.ReactNode;
+}
+
+/**
+ * @INTERNAL
+ */
+export interface ToastProps extends ToastOptions {
+  isIn: boolean;
+  staleId?: Id;
+  toastId: Id;
+  key: Id;
+  closeToast: () => void;
+  position: ToastPosition;
+  children?: ToastContent;
+  deleteToast: () => void;
+  type: TypeOptions;
+  targetDocument: Document | null | undefined;
+}
+
+/**
+ * @INTERNAL
+ */
+export interface NotValidatedToastProps extends Partial<ToastProps> {
+  toastId: Id;
+}
+
+/**
+ * @INTERNAL
+ */
+export interface Toast {
+  content: ToastContent;
+  props: ToastProps;
+}
+
+export type ToastItemStatus = 'added' | 'removed' | 'updated';
+
+export interface ToastItem<Data = {}> {
+  content: ToastContent<Data>;
+  id: Id;
+  type?: TypeOptions;
+  isLoading?: boolean;
+  containerId?: Id;
+  data: Data;
+  status: ToastItemStatus;
+}
+
+export interface QueuedToast {
+  toastContent: ToastContent;
+  toastProps: ToastProps;
+  staleId?: Id;
+}
+
+export interface ContainerInstance {
+  toastKey: number;
+  displayedToast: number;
+  props: ToastContainerProps;
+  containerId?: Id | null;
+  isToastActive: (toastId: Id) => boolean;
+  getToast: (id: Id) => Toast | null | undefined;
+  queue: QueuedToast[];
+  count: number;
+}

--- a/packages/react-components/react-toast/src/state/useToast.ts
+++ b/packages/react-components/react-toast/src/state/useToast.ts
@@ -1,0 +1,61 @@
+import * as React from 'react';
+
+import { ToastProps } from './types';
+
+export function useToast(props: ToastProps) {
+  const [isRunning, setIsRunning] = React.useState(false);
+  const toastRef = React.useRef<HTMLDivElement>(null);
+
+  const syncProps = React.useRef(props);
+  const { autoClose, pauseOnHover, closeToast, closeOnClick, targetDocument } = props;
+
+  const playToast = React.useCallback(() => {
+    setIsRunning(true);
+  }, [setIsRunning]);
+
+  const pauseToast = React.useCallback(() => {
+    setIsRunning(false);
+  }, [setIsRunning]);
+
+  React.useEffect(() => {
+    syncProps.current = props;
+  });
+
+  React.useEffect(() => {
+    if (!props.pauseOnFocusLoss) {
+      return;
+    }
+
+    if (!targetDocument?.hasFocus()) {
+      pauseToast();
+    }
+    const win = targetDocument?.defaultView;
+
+    win?.addEventListener('focus', playToast);
+    win?.addEventListener('blur', pauseToast);
+
+    return () => {
+      win?.removeEventListener('focus', playToast);
+      win?.removeEventListener('blur', pauseToast);
+    };
+  }, [props.pauseOnFocusLoss, playToast, pauseToast, targetDocument]);
+
+  const eventHandlers: React.DOMAttributes<HTMLElement> = {};
+
+  if (autoClose && pauseOnHover) {
+    eventHandlers.onMouseEnter = pauseToast;
+    eventHandlers.onMouseLeave = playToast;
+  }
+
+  if (closeOnClick) {
+    eventHandlers.onClick = closeToast;
+  }
+
+  return {
+    playToast,
+    pauseToast,
+    isRunning,
+    toastRef,
+    eventHandlers,
+  };
+}

--- a/packages/react-components/react-toast/src/state/useToaster.ts
+++ b/packages/react-components/react-toast/src/state/useToaster.ts
@@ -1,0 +1,266 @@
+import * as React from 'react';
+import { canBeRendered, isNum, getAutoCloseDelay, toToastItem } from './utils';
+import { eventManager, Event } from './eventManager';
+
+import {
+  Id,
+  ToastContainerProps,
+  ToastProps,
+  ToastContent,
+  Toast,
+  ToastPosition,
+  ClearWaitingQueueParams,
+  NotValidatedToastProps,
+  ContainerInstance,
+  QueuedToast,
+} from './types';
+
+export function useToaster(props: ToastContainerProps) {
+  const [, forceUpdate] = React.useReducer(x => x + 1, 0);
+  const [toastIds, setToastIds] = React.useState<Id[]>([]);
+  const containerRef = React.useRef(null);
+  const toastToRender = React.useState(() => new Map<Id, Toast>())[0];
+  const isToastActive = (id: Id) => toastIds.indexOf(id) !== -1;
+  const instance = React.useState<ContainerInstance>(() => ({
+    toastKey: 1,
+    displayedToast: 0,
+    count: 0,
+    queue: [],
+    props,
+    containerId: null,
+    isToastActive,
+    getToast: id => toastToRender.get(id),
+  }))[0];
+
+  const clearWaitingQueue = React.useCallback(
+    ({ containerId }: ClearWaitingQueueParams) => {
+      const { limit } = instance.props;
+      if (limit && (!containerId || instance.containerId === containerId)) {
+        instance.count -= instance.queue.length;
+        instance.queue = [];
+      }
+    },
+    [instance],
+  );
+
+  const removeToast = React.useCallback((toastId?: Id) => {
+    setToastIds(state => (toastId === undefined ? [] : state.filter(id => id !== toastId)));
+  }, []);
+
+  const appendToast = React.useCallback(
+    (content: ToastContent, toastProps: ToastProps, staleId?: Id) => {
+      const { toastId } = toastProps;
+
+      if (staleId) {
+        toastToRender.delete(staleId);
+      }
+
+      const toast = {
+        content,
+        props: toastProps,
+      };
+      toastToRender.set(toastId, toast);
+
+      setToastIds(state => [...state, toastId].filter(id => id !== staleId));
+      eventManager.emit(Event.Change, toToastItem(toast, toast.props.updateId === undefined ? 'added' : 'updated'));
+    },
+    [setToastIds, toastToRender],
+  );
+
+  const dequeueToast = React.useCallback(() => {
+    const { toastContent, toastProps, staleId } = instance.queue.shift() as QueuedToast;
+    appendToast(toastContent, toastProps, staleId);
+  }, [instance, appendToast]);
+
+  /**
+   * check if a container is attached to the dom
+   * check for multi-container, build only if associated
+   * check for duplicate toastId if no update
+   */
+  const isNotValid = React.useCallback(
+    (options: NotValidatedToastProps) => {
+      return (
+        !containerRef.current ||
+        (instance.props.enableMultiContainer && options.containerId !== instance.props.containerId) ||
+        (toastToRender.has(options.toastId) && options.updateId === undefined)
+      );
+    },
+    [instance, toastToRender],
+  );
+
+  const deleteToast = React.useCallback(
+    (toastId: Id) => {
+      const removed = toToastItem(toastToRender.get(toastId)!, 'removed');
+      toastToRender.delete(toastId);
+
+      eventManager.emit(Event.Change, removed);
+
+      const queueLen = instance.queue.length;
+      instance.count = toastId === undefined ? instance.count - instance.displayedToast : instance.count - 1;
+
+      if (instance.count < 0) {
+        instance.count = 0;
+      }
+
+      if (queueLen > 0) {
+        const freeSlot = toastId === undefined ? instance.props.limit! : 1;
+
+        if (queueLen === 1 || freeSlot === 1) {
+          instance.displayedToast++;
+          dequeueToast();
+        } else {
+          const toDequeue = freeSlot > queueLen ? queueLen : freeSlot;
+          instance.displayedToast = toDequeue;
+
+          for (let i = 0; i < toDequeue; i++) {
+            dequeueToast();
+          }
+        }
+      } else {
+        forceUpdate();
+      }
+    },
+    [dequeueToast, instance, toastToRender],
+  );
+
+  // this function and all the function called inside needs to rely on refs
+  const buildToast = React.useCallback(
+    (content: ToastContent, { delay, staleId, ...options }: NotValidatedToastProps) => {
+      if (!canBeRendered(content) || isNotValid(options)) {
+        return;
+      }
+
+      const { toastId, updateId, data } = options;
+      const { props: instanceProps } = instance;
+      const closeToast = () => removeToast(toastId);
+      const isNotAnUpdate = updateId === null || updateId === undefined;
+
+      if (isNotAnUpdate) {
+        instance.count++;
+      }
+
+      const toastProps: ToastProps = {
+        ...instanceProps,
+        position: instanceProps.position ?? 'bottom-right',
+        type: 'default',
+        key: instance.toastKey++,
+        ...Object.fromEntries(Object.entries(options).filter(([_, v]) => v !== null || v !== undefined)),
+        toastId,
+        updateId,
+        data,
+        closeToast,
+        isIn: false,
+        autoClose: options.isLoading ? false : getAutoCloseDelay(options.autoClose, instanceProps.autoClose),
+        deleteToast: () => deleteToast(toastId),
+      };
+
+      // not handling limit + delay by design. Waiting for user feedback first
+      if (instanceProps.limit && instanceProps.limit > 0 && instance.count > instanceProps.limit && isNotAnUpdate) {
+        instance.queue.push({ toastContent: content, toastProps, staleId });
+      } else if (isNum(delay)) {
+        setTimeout(() => {
+          appendToast(content, toastProps, staleId);
+        }, delay);
+      } else {
+        appendToast(content, toastProps, staleId);
+      }
+    },
+    [appendToast, instance, isNotValid, removeToast, deleteToast],
+  );
+
+  React.useEffect(() => {
+    instance.containerId = props.containerId;
+    const clearToasts = (toastId: Id | undefined) => containerRef.current && removeToast(toastId);
+    eventManager
+      .cancelEmit(Event.WillUnmount)
+      .on(Event.Show, buildToast)
+      .on(Event.Clear, clearToasts)
+      .on(Event.ClearWaitingQueue, clearWaitingQueue)
+      .emit(Event.DidMount, instance);
+
+    return () => {
+      eventManager
+        .off(Event.Show, buildToast)
+        .off(Event.Clear, clearToasts)
+        .off(Event.ClearWaitingQueue, clearWaitingQueue);
+      toastToRender.clear();
+      eventManager.emit(Event.WillUnmount, instance);
+    };
+  }, [buildToast, clearWaitingQueue, instance, props.containerId, toastToRender, removeToast]);
+
+  React.useEffect(() => {
+    instance.props = props;
+    instance.isToastActive = isToastActive;
+    instance.displayedToast = toastIds.length;
+  });
+
+  const getToastToRender = React.useCallback(
+    <T>(cb: (position: ToastPosition, toastList: Toast[]) => T) => {
+      const toRender = new Map<ToastPosition, Toast[]>();
+      const collection = Array.from(toastToRender.values());
+
+      collection.forEach(toast => {
+        const { position } = toast.props;
+        toRender.has(position) || toRender.set(position, []);
+        toRender.get(position)!.push(toast);
+      });
+
+      return Array.from(toRender, ([position, toasts]) => {
+        if (position.startsWith('top')) {
+          toasts.reverse();
+        }
+
+        return cb(position, toasts);
+      });
+    },
+    [toastToRender],
+  );
+
+  const getPositionStyles = React.useCallback(
+    (position: ToastPosition) => {
+      const containerStyles: React.CSSProperties = {
+        position: 'fixed',
+      };
+
+      let positionStyles: React.CSSProperties = {};
+      const { horizontal = 0, vertical = 0 } = instance.props.offset ?? {};
+      switch (position) {
+        case 'top-left':
+          positionStyles = {
+            top: 0 + vertical,
+            left: 0 + horizontal,
+          };
+          break;
+        case 'top-right':
+          positionStyles = {
+            top: 0 + vertical,
+            right: 0 + horizontal,
+          };
+          break;
+        case 'bottom-left':
+          positionStyles = {
+            bottom: 0 + vertical,
+            left: 0 + horizontal,
+          };
+          break;
+        case 'bottom-right':
+          positionStyles = {
+            bottom: 0 + vertical,
+            right: 0 + horizontal,
+          };
+          break;
+      }
+
+      Object.assign(containerStyles, positionStyles);
+      return containerStyles;
+    },
+    [instance],
+  );
+
+  return {
+    getToastToRender,
+    containerRef,
+    isToastActive,
+    getPositionStyles,
+  };
+}

--- a/packages/react-components/react-toast/src/state/utils/collapseToast.ts
+++ b/packages/react-components/react-toast/src/state/utils/collapseToast.ts
@@ -1,0 +1,21 @@
+import { Default } from './constant';
+
+/**
+ * Used to collapse toast after exit animation
+ */
+export function collapseToast(node: HTMLElement, done: () => void, duration = Default.COLLAPSE_DURATION) {
+  const { scrollHeight, style } = node;
+
+  requestAnimationFrame(() => {
+    style.minHeight = 'initial';
+    style.height = scrollHeight + 'px';
+    style.transition = `all ${duration}ms`;
+
+    requestAnimationFrame(() => {
+      style.height = '0';
+      style.padding = '0';
+      style.margin = '0';
+      setTimeout(done, duration as number);
+    });
+  });
+}

--- a/packages/react-components/react-toast/src/state/utils/constant.ts
+++ b/packages/react-components/react-toast/src/state/utils/constant.ts
@@ -1,0 +1,23 @@
+export const enum Type {
+  INFO = 'info',
+  SUCCESS = 'success',
+  WARNING = 'warning',
+  ERROR = 'error',
+  DEFAULT = 'default',
+}
+
+export const enum Default {
+  COLLAPSE_DURATION = 300,
+  DEBOUNCE_DURATION = 50,
+  CSS_NAMESPACE = 'Toastify',
+  DRAGGABLE_PERCENT = 80,
+}
+
+export const enum Direction {
+  X = 'x',
+  Y = 'y',
+}
+
+export const enum SyntheticEvent {
+  ENTRANCE_ANIMATION_END = 'd',
+}

--- a/packages/react-components/react-toast/src/state/utils/index.ts
+++ b/packages/react-components/react-toast/src/state/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './propValidator';
+export * from './constant';
+export * from './collapseToast';
+export * from './mapper';

--- a/packages/react-components/react-toast/src/state/utils/mapper.ts
+++ b/packages/react-components/react-toast/src/state/utils/mapper.ts
@@ -1,0 +1,13 @@
+import { Toast, ToastItem, ToastItemStatus } from '../types';
+
+export function toToastItem(toast: Toast, status: ToastItemStatus): ToastItem {
+  return {
+    content: toast.content,
+    containerId: toast.props.containerId,
+    id: toast.props.toastId,
+    type: toast.props.type,
+    data: toast.props.data || {},
+    isLoading: toast.props.isLoading,
+    status,
+  };
+}

--- a/packages/react-components/react-toast/src/state/utils/propValidator.ts
+++ b/packages/react-components/react-toast/src/state/utils/propValidator.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export const isNum = (v: unknown): v is number => typeof v === 'number' && !isNaN(v);
+
+export const isStr = (v: unknown): v is String => typeof v === 'string';
+
+export const isFn = (v: unknown): v is Function => typeof v === 'function';
+
+export const getAutoCloseDelay = (toastAutoClose?: false | number, containerAutoClose?: false | number) =>
+  toastAutoClose === false || (isNum(toastAutoClose) && toastAutoClose > 0) ? toastAutoClose : containerAutoClose;
+
+export const canBeRendered = <T>(content: T): boolean =>
+  React.isValidElement(content) || isStr(content) || isFn(content) || isNum(content);

--- a/packages/react-components/react-toast/stories/Toast/Default.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Default.stories.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { Toaster, toast } from '@fluentui/react-toast';
+
+export const Default = () => {
+  const notify = () => toast('This is a toast');
+
+  return (
+    <>
+      <Toaster position="bottom-right" targetDocument={document} />
+      <button onClick={notify}>Make toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/DismissAll.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissAll.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Toaster, toast } from '@fluentui/react-toast';
+
+export const DismissAll = () => {
+  const notify = () => toast('This is a toast');
+
+  return (
+    <>
+      <Toaster position="bottom-right" targetDocument={document} />
+      <button onClick={() => notify()}>Make toast</button>
+      <button onClick={() => toast.dismiss()}>Dismiss all</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/Limit.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Limit.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Toaster, toast } from '@fluentui/react-toast';
+
+let count = 0;
+export const Limit = () => {
+  const notify = () => toast(`This is toast ${count++}`);
+
+  return (
+    <>
+      <Toaster limit={3} position="bottom-right" targetDocument={document} />
+      <button onClick={notify}>Make toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/Offset.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Offset.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { ToastPosition, toast, Toaster } from '@fluentui/react-toast';
+
+export const Offset = () => {
+  const notify = (position: ToastPosition) => toast('This is a toast', { position });
+  const [horizontal, setHorizontal] = React.useState(10);
+  const [vertical, setVertical] = React.useState(10);
+
+  return (
+    <>
+      <Toaster offset={{ horizontal, vertical }} position="bottom-right" targetDocument={document} />
+      <button onClick={() => notify('bottom-left')}>bottom-left</button>
+      <button onClick={() => notify('bottom-right')}>bottom-right</button>
+      <button onClick={() => notify('top-left')}>top-left</button>
+      <button onClick={() => notify('top-right')}>top-right</button>
+      <div>
+        <label htmlFor="horizntal">horizontal</label>
+        <input id="horizontal" type="number" value={horizontal} onChange={e => setHorizontal(Number(e.target.value))} />
+      </div>
+      <div>
+        <label htmlFor="vertical">vertical</label>
+        <input id="vertical" type="number" value={vertical} onChange={e => setVertical(Number(e.target.value))} />
+      </div>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { toast, Toaster } from '@fluentui/react-toast';
+
+export const PauseOnWindowBlur = () => {
+  const notify = () => toast('This is a toast', { pauseOnFocusLoss: true, pauseOnHover: true });
+
+  return (
+    <>
+      <Toaster position="bottom-right" targetDocument={document} />
+      <button onClick={notify}>Make toast</button>
+      Pauses on hover and window blur
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Toaster, toast, ToastPosition } from '@fluentui/react-toast';
+
+export const ToastPositions = () => {
+  const notify = (position: ToastPosition) => toast('This is a toast', { position });
+
+  return (
+    <>
+      <Toaster position="bottom-right" targetDocument={document} />
+      <button onClick={() => notify('bottom-left')}>bottom-left</button>
+      <button onClick={() => notify('bottom-right')}>bottom-right</button>
+      <button onClick={() => notify('top-left')}>top-left</button>
+      <button onClick={() => notify('top-right')}>top-right</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/UpdateToast.tories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/UpdateToast.tories.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { toast, Toaster } from '@fluentui/react-toast';
+
+const toastId = 'foo';
+
+export const UpdateToast = () => {
+  const notify = () => toast('Loading', { toastId, autoClose: false });
+
+  const update = () => toast.update(toastId, { render: 'Downloaded file', autoClose: 3000 });
+
+  return (
+    <>
+      <Toaster position="bottom-right" targetDocument={document} />
+      <button onClick={notify}>Make toast</button>
+      <button onClick={update}>Update toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -1,0 +1,11 @@
+export { Default } from './Default.stories';
+export { DismissAll } from './DismissAll.stories';
+export { Limit } from './Limit.stories';
+export { ToastPositions } from './ToastPositions.stories';
+export { Offset } from './Offset.stories';
+export { UpdateToast } from './UpdateToast.tories';
+export { PauseOnWindowBlur } from './PauseOnWindowBlur.stories';
+
+export default {
+  title: 'Preview Components/Toast',
+};

--- a/packages/react-components/react-toast/tsconfig.json
+++ b/packages/react-components/react-toast/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
     }
   ]
 }

--- a/packages/react-components/react-toast/tsconfig.lib.json
+++ b/packages/react-components/react-toast/tsconfig.lib.json
@@ -9,6 +9,14 @@
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": [
+    "./src/testing/**",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-toast/tsconfig.spec.json
+++ b/packages/react-components/react-toast/tsconfig.spec.json
@@ -5,5 +5,13 @@
     "outDir": "dist",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts",
+    "./src/testing/**/*.ts",
+    "./src/testing/**/*.tsx"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5929,6 +5929,13 @@
   dependencies:
     "@types/react" "^17"
 
+"@types/react-transition-group@4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.6.tgz#18187bcda5281f8e10dfc48f0943e2fdf4f75e2e"
+  integrity sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-virtualized@^9.21.8":
   version "9.21.8"
   resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.8.tgz#dc0150a75fd6e42f33729886463ece04d03367ea"


### PR DESCRIPTION
Implements `useToast` and `useToaster` hooks along with imperative `toast` function.

The code is modified based on [react-toastify](https://www.npmjs.com/package/react-toastify) since there was no response to fkhadra/react-toastify#941.

Adds temporary Toast and Toaster components so that we scenarios can be demonstrated.

Addresses #
