### PR TITLE
fix: Datepicker renders input description if inputProps.onRenderDescription is set

### DIFF
--- a/change/@fluentui-react-75983ba2-b5ea-4e4e-9578-6fc0293ce309.json
+++ b/change/@fluentui-react-75983ba2-b5ea-4e4e-9578-6fc0293ce309.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Datepicker renders input description if onRenderDescription is passed in\"",
+  "comment": "fix: Datepicker renders input description if onRenderDescription is passed in",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-75983ba2-b5ea-4e4e-9578-6fc0293ce309.json
+++ b/change/@fluentui-react-75983ba2-b5ea-4e4e-9578-6fc0293ce309.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Datepicker renders input description if onRenderDescription is passed in\"",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -410,7 +410,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
   const renderTextfieldDescription = (inputProps: ITextFieldProps, defaultRender: IRenderFunction<ITextFieldProps>) => {
     return (
       <>
-        {inputProps.description ? defaultRender(inputProps) : null}
+        {inputProps.description || inputProps.onRenderDescription ? defaultRender(inputProps) : null}
         <div aria-live="assertive" className={classNames.statusMessage}>
           {statusMessage}
         </div>


### PR DESCRIPTION


## Description
Datepicker respected `inputProps.description`, but not `inputProps.onRenderDescription` on its own. Now both props individually work to render the description


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27021
