### PR TITLE
bugfix(react-tree): fix VisibleFlatTreeItemGenerator omitting visible items

### DIFF
--- a/change/@fluentui-react-tree-e91902ae-b031-47c0-99be-2f7450c3f3f7.json
+++ b/change/@fluentui-react-tree-e91902ae-b031-47c0-99be-2f7450c3f3f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: fix VisibleFlatTreeItemGenerator omitting visible items",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/utils/createFlatTreeItems.ts
+++ b/packages/react-components/react-tree/src/utils/createFlatTreeItems.ts
@@ -109,12 +109,12 @@ export function* VisibleFlatTreeItemGenerator<Props extends FlatTreeItemProps<un
 ) {
   for (let index = 0, visibleIndex = 0; index < flatTreeItems.size; index++) {
     const item = flatTreeItems.getByIndex(index) as FlatTreeItem<Props>;
-    const parent = item.parentValue ? flatTreeItems.get(item.parentValue) ?? flatTreeItems.root : flatTreeItems.root;
     if (isItemVisible(item, openItems, flatTreeItems)) {
       item.index = visibleIndex++;
       yield item;
     } else {
-      index += parent.childrenSize - 1 + item.childrenSize;
+      // Jump the amount of children the current item has, since those items will also be hidden
+      index += item.childrenSize;
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Seems like some visible items are being omitted https://codesandbox.io/s/useflat-repro-forked-w04vpv?file=/example.tsx . In this example `Level 1, item 2` should be visible by default, but it's filtered out by `VisibleFlatTreeItemGenerator`

## New Behavior

1. Ensure `VisibleFlatTreeItemGenerator` doesn't jump any visible item.
2. TODO: add tests to ensure this won't happen again

