### PR TITLE
feat: Implement Toast pause

### DIFF
--- a/packages/react-components/react-toast/src/components/Toast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { Transition } from 'react-transition-group';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useIsomorphicLayoutEffect, useMergedRefs } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { useToast, Toast as ToastProps } from '../state';
 import { Timer } from './Timer';
@@ -77,9 +77,10 @@ const useStyles = makeStyles({
 
 export const Toast: React.FC<Omit<ToastProps, 'content'> & { visible: boolean }> = props => {
   const styles = useStyles();
-  const { visible, children, close, remove, timeout } = props;
-  const { play, running } = useToast();
-  const toastRef = React.useRef<HTMLDivElement>(null);
+  const { visible, children, close, remove, ...toastOptions } = props;
+  const { timeout } = toastOptions;
+  const { play, running, toastRef: toastRefBase } = useToast(toastOptions);
+  const toastRef = useMergedRefs<HTMLElement | null>(React.useRef<HTMLDivElement>(null), toastRefBase);
 
   // start the toast once it's fully in
   useIsomorphicLayoutEffect(() => {

--- a/packages/react-components/react-toast/src/components/Toast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { Transition } from 'react-transition-group';
-import { useIsomorphicLayoutEffect, useMergedRefs } from '@fluentui/react-utilities';
+import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { useToast, Toast as ToastProps } from '../state';
 import { Timer } from './Timer';
@@ -79,8 +79,7 @@ export const Toast: React.FC<Omit<ToastProps, 'content'> & { visible: boolean }>
   const styles = useStyles();
   const { visible, children, close, remove, ...toastOptions } = props;
   const { timeout } = toastOptions;
-  const { play, running, toastRef: toastRefBase } = useToast(toastOptions);
-  const toastRef = useMergedRefs<HTMLElement | null>(React.useRef<HTMLDivElement>(null), toastRefBase);
+  const { play, running, toastRef } = useToast<HTMLDivElement>(toastOptions);
 
   // start the toast once it's fully in
   useIsomorphicLayoutEffect(() => {

--- a/packages/react-components/react-toast/src/components/Toaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster.tsx
@@ -27,11 +27,7 @@ export const Toaster: React.FC = () => {
             <div key={position} style={getPositionStyles(position)} className={mergeClasses(styles.container)}>
               {toasts.map(({ content, ...toastProps }) => {
                 return (
-                  <Toast
-                    {...toastProps}
-                    key={`toast-${toastProps.toastId}`}
-                    visible={isToastVisible(toastProps.toastId)}
-                  >
+                  <Toast {...toastProps} key={toastProps.toastId} visible={isToastVisible(toastProps.toastId)}>
                     {content as React.ReactNode}
                   </Toast>
                 );

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -9,9 +9,16 @@ export interface ToastOptions {
   position?: ToastPosition;
   content?: unknown;
   timeout?: number;
+  pauseOnWindowBlur?: boolean;
+  pauseOnHover?: boolean;
 }
 
-export interface Toast extends Required<Omit<ToastOptions, 'toasterId'>> {
+export interface DefaultToastOptions
+  extends Pick<ToastOptions, 'position' | 'timeout' | 'pauseOnWindowBlur' | 'pauseOnHover'> {}
+
+export interface ValidatedToastOptions extends Required<DefaultToastOptions> {}
+
+export interface Toast extends Required<ToastOptions> {
   close: () => void;
   remove: () => void;
 }

--- a/packages/react-components/react-toast/src/state/useToast.ts
+++ b/packages/react-components/react-toast/src/state/useToast.ts
@@ -4,30 +4,26 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import { Toast } from './vanilla/toast';
 import { ValidatedToastOptions } from './types';
 
-export function useToast(options: ValidatedToastOptions) {
+export function useToast<TElement extends HTMLElement>(options: ValidatedToastOptions) {
   const toastOptions = useToastOptions(options);
   const forceRender = useForceUpdate();
   const { targetDocument } = useFluent();
   const [toast] = React.useState(() => {
     if (targetDocument) {
-      const newToast = new Toast(targetDocument, toastOptions);
+      const newToast = new Toast();
       newToast.onUpdate = forceRender;
       return newToast;
     }
   });
 
-  React.useEffect(() => {
-    return () => toast?.dispose();
-  }, [toast]);
+  const toastRef = React.useRef<TElement>(null);
 
-  const toastRef = React.useCallback(
-    (el: HTMLElement | null) => {
-      if (el && toast) {
-        toast.setToastElement(el);
-      }
-    },
-    [toast],
-  );
+  React.useEffect(() => {
+    if (toast && toastRef.current) {
+      toast.connectToDOM(toastRef.current, toastOptions);
+      return () => toast.disconnect();
+    }
+  }, [toast, toastOptions]);
 
   const play = React.useCallback(() => {
     if (toast) {

--- a/packages/react-components/react-toast/src/state/useToast.ts
+++ b/packages/react-components/react-toast/src/state/useToast.ts
@@ -4,6 +4,8 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import { Toast } from './vanilla/toast';
 import { ValidatedToastOptions } from './types';
 
+const noop = () => null;
+
 export function useToast<TElement extends HTMLElement>(options: ValidatedToastOptions) {
   const toastOptions = useToastOptions(options);
   const forceRender = useForceUpdate();
@@ -25,23 +27,20 @@ export function useToast<TElement extends HTMLElement>(options: ValidatedToastOp
     }
   }, [toast, toastOptions]);
 
-  const play = React.useCallback(() => {
-    if (toast) {
-      toast.play();
-    }
-  }, [toast]);
-
-  const pause = React.useCallback(() => {
-    if (toast) {
-      toast.pause();
-    }
-  }, [toast]);
+  if (!toast) {
+    return {
+      toastRef,
+      play: noop,
+      pause: noop,
+      running: false,
+    };
+  }
 
   return {
     toastRef,
-    play,
-    pause,
-    running: toast?.running ?? false,
+    play: toast.play,
+    pause: toast.pause,
+    running: toast.running,
   };
 }
 

--- a/packages/react-components/react-toast/src/state/useToast.ts
+++ b/packages/react-components/react-toast/src/state/useToast.ts
@@ -5,15 +5,20 @@ import { Toast } from './vanilla/toast';
 import { ValidatedToastOptions } from './types';
 
 export function useToast(options: ValidatedToastOptions) {
+  const toastOptions = useToastOptions(options);
   const forceRender = useForceUpdate();
   const { targetDocument } = useFluent();
   const [toast] = React.useState(() => {
     if (targetDocument) {
-      const newToast = new Toast(targetDocument, options);
+      const newToast = new Toast(targetDocument, toastOptions);
       newToast.onUpdate = forceRender;
       return newToast;
     }
   });
+
+  React.useEffect(() => {
+    return () => toast?.dispose();
+  }, [toast]);
 
   const toastRef = React.useCallback(
     (el: HTMLElement | null) => {
@@ -42,4 +47,18 @@ export function useToast(options: ValidatedToastOptions) {
     pause,
     running: toast?.running ?? false,
   };
+}
+
+function useToastOptions(options: ValidatedToastOptions) {
+  const { pauseOnHover, pauseOnWindowBlur, position, timeout } = options;
+
+  return React.useMemo<ValidatedToastOptions>(
+    () => ({
+      pauseOnHover,
+      pauseOnWindowBlur,
+      position,
+      timeout,
+    }),
+    [pauseOnHover, pauseOnWindowBlur, position, timeout],
+  );
 }

--- a/packages/react-components/react-toast/src/state/useToast.ts
+++ b/packages/react-components/react-toast/src/state/useToast.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useForceUpdate } from '@fluentui/react-utilities';
-import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { Toast } from './vanilla/toast';
 import { ValidatedToastOptions } from './types';
 
@@ -9,23 +8,17 @@ const noop = () => null;
 export function useToast<TElement extends HTMLElement>(options: ValidatedToastOptions) {
   const toastOptions = useToastOptions(options);
   const forceRender = useForceUpdate();
-  const { targetDocument } = useFluent();
-  const [toast] = React.useState(() => {
-    if (targetDocument) {
-      const newToast = new Toast();
-      newToast.onUpdate = forceRender;
-      return newToast;
-    }
-  });
+  const [toast] = React.useState(() => new Toast());
 
   const toastRef = React.useRef<TElement>(null);
 
   React.useEffect(() => {
     if (toast && toastRef.current) {
+      toast.onUpdate = forceRender;
       toast.connectToDOM(toastRef.current, toastOptions);
       return () => toast.disconnect();
     }
-  }, [toast, toastOptions]);
+  }, [toast, toastOptions, forceRender]);
 
   if (!toast) {
     return {

--- a/packages/react-components/react-toast/src/state/useToast.ts
+++ b/packages/react-components/react-toast/src/state/useToast.ts
@@ -1,18 +1,45 @@
 import * as React from 'react';
-import { Toast } from './vanilla/toast';
 import { useForceUpdate } from '@fluentui/react-utilities';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { Toast } from './vanilla/toast';
+import { ValidatedToastOptions } from './types';
 
-export function useToast() {
+export function useToast(options: ValidatedToastOptions) {
   const forceRender = useForceUpdate();
+  const { targetDocument } = useFluent();
   const [toast] = React.useState(() => {
-    const newToast = new Toast();
-    newToast.onUpdate = forceRender;
-    return newToast;
+    if (targetDocument) {
+      const newToast = new Toast(targetDocument, options);
+      newToast.onUpdate = forceRender;
+      return newToast;
+    }
   });
 
+  const toastRef = React.useCallback(
+    (el: HTMLElement | null) => {
+      if (el && toast) {
+        toast.setToastElement(el);
+      }
+    },
+    [toast],
+  );
+
+  const play = React.useCallback(() => {
+    if (toast) {
+      toast.play();
+    }
+  }, [toast]);
+
+  const pause = React.useCallback(() => {
+    if (toast) {
+      toast.pause();
+    }
+  }, [toast]);
+
   return {
-    play: toast.play,
-    pause: toast.pause,
-    running: toast.running,
+    toastRef,
+    play,
+    pause,
+    running: toast?.running ?? false,
   };
 }

--- a/packages/react-components/react-toast/src/state/vanilla/toast.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/toast.ts
@@ -1,13 +1,58 @@
+import { ValidatedToastOptions } from '../types';
+
 // TODO convert to closure
 export class Toast {
-  public running = false;
-  public onUpdate: () => void = () => null;
+  public running: boolean;
+  public onUpdate: () => void;
+  private targetDocument: Document;
+  private toastElement?: HTMLElement;
+  private pauseOnWindowBlur: ValidatedToastOptions['pauseOnWindowBlur'];
+  private pauseOnHover: ValidatedToastOptions['pauseOnHover'];
 
-  public play() {
-    this.running = true;
-  }
-
-  public pause() {
+  constructor(targetDocument: Document, options: ValidatedToastOptions) {
     this.running = false;
+    this.onUpdate = () => null;
+    this.targetDocument = targetDocument;
+
+    const { pauseOnHover, pauseOnWindowBlur } = options;
+    this.pauseOnHover = pauseOnHover;
+    this.pauseOnWindowBlur = pauseOnWindowBlur;
+
+    if (this.pauseOnWindowBlur) {
+      this.targetDocument.defaultView?.addEventListener('focus', this.play);
+      this.targetDocument.defaultView?.addEventListener('blur', this.pause);
+    }
   }
+
+  public dispose() {
+    if (this.pauseOnWindowBlur) {
+      this.targetDocument.defaultView?.removeEventListener('focus', this.play);
+      this.targetDocument.defaultView?.removeEventListener('blur', this.pause);
+    }
+
+    if (this.toastElement && this.pauseOnHover) {
+      this.toastElement.addEventListener('mouseenter', this.pause);
+      this.toastElement.addEventListener('mouseleave', this.play);
+    }
+
+    this.toastElement = undefined;
+  }
+
+  public setToastElement = (element: HTMLElement) => {
+    this.toastElement = element;
+    if (this.pauseOnHover) {
+      this.toastElement.addEventListener('mouseenter', this.pause);
+      this.toastElement.addEventListener('mouseleave', this.play);
+    }
+  };
+
+  public play = () => {
+    this.running = true;
+    this.onUpdate();
+  };
+
+  public pause = () => {
+    this.running = false;
+    this.onUpdate();
+  };
 }

--- a/packages/react-components/react-toast/src/state/vanilla/toaster.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/toaster.ts
@@ -74,7 +74,14 @@ export class Toaster {
   }
 
   private _buildToast(toastOptions: ToastOptions) {
-    const { toastId = '', position = 'bottom-right', timeout = 3000, content = '' } = toastOptions;
+    const {
+      toastId = '',
+      position = 'bottom-right',
+      timeout = 3000,
+      content = '',
+      pauseOnHover = false,
+      pauseOnWindowBlur = false,
+    } = toastOptions;
     if (this.toasts.has(toastId)) {
       return;
     }
@@ -90,6 +97,8 @@ export class Toaster {
     };
 
     const toast: Toast = {
+      pauseOnHover,
+      pauseOnWindowBlur,
       position,
       toastId,
       timeout,

--- a/packages/react-components/react-toast/stories/Toast/PauseOnHover.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnHover.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Toaster, useToastController } from '@fluentui/react-toast';
+
+export const PauseOnHover = () => {
+  const { dispatchToast } = useToastController();
+  const notify = () => dispatchToast('Hover me!', { pauseOnHover: true });
+
+  return (
+    <>
+      <Toaster />
+      <button onClick={notify}>Make toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Toaster, useToastController } from '@fluentui/react-toast';
+
+export const PauseOnWindowBlur = () => {
+  const { dispatchToast } = useToastController();
+  const notify = () => dispatchToast('Click on another window!', { pauseOnWindowBlur: true });
+
+  return (
+    <>
+      <Toaster />
+      <button onClick={notify}>Make toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -3,6 +3,8 @@ export { CustomTimeout } from './CustomTimeout.stories';
 export { ToastPositions } from './ToastPositions.stories';
 export { DismissToast } from './DismissToast.stories';
 export { DismissAll } from './DismissAll.stories';
+export { PauseOnWindowBlur } from './PauseOnWindowBlur.stories';
+export { PauseOnHover } from './PauseOnHover.stories';
 
 export default {
   title: 'Preview Components/Toast',


### PR DESCRIPTION
Implements two new options:

* pauseOnWindowBlur - pauses toast timeout when window is not focused
* pauseOnHover - pauses toast when cursor enters the toast surface

Addresses  https://github.com/microsoft/fluentui/issues/27776
