### PR TITLE
bugfix(react-dialog): change DialogTitle default action icon size

### DIFF
--- a/change/@fluentui-react-dialog-c5aaea70-5d6e-43f8-8ac5-f846042dfcce.json
+++ b/change/@fluentui-react-dialog-c5aaea70-5d6e-43f8-8ac5-f846042dfcce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: change DialogTitle default action icon from 24x24 to 20x20",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { getNativeElementProps } from '@fluentui/react-utilities';
 import type { DialogTitleProps, DialogTitleState } from './DialogTitle.types';
 import { useDialogContext_unstable } from '../../contexts/dialogContext';
-import { Dismiss24Regular } from '@fluentui/react-icons';
+import { Dismiss20Regular } from '@fluentui/react-icons';
 import { resolveShorthand } from '@fluentui/react-utilities';
 import { DialogTrigger } from '../DialogTrigger/DialogTrigger';
 import { useDialogTitleInternalStyles } from './useDialogTitleStyles.styles';
@@ -42,7 +42,7 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
               // TODO: find a better way to add internal labels
               aria-label="close"
             >
-              <Dismiss24Regular />
+              <Dismiss20Regular />
             </button>
           </DialogTrigger>
         ),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

DialogTitle default action icon size is 24x24

## New Behavior

DialogTitle default action icon size is 20x20

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27726
