### PR TITLE
bugfix: fix horizontal overflow on tree

### DIFF
--- a/change/@fluentui-react-tree-e43c53f4-8d36-486e-a2df-4a0f3da1c4d1.json
+++ b/change/@fluentui-react-tree-e43c53f4-8d36-486e-a2df-4a0f3da1c4d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: fix horizontal overflow on tree",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemStyles.styles.ts
@@ -23,8 +23,9 @@ const useRootStyles = makeStyles({
     position: 'relative',
     cursor: 'pointer',
     display: 'grid',
+    boxSizing: 'border-box',
     gridTemplateRows: 'auto auto',
-    gridTemplateColumns: 'auto min-content',
+    gridTemplateColumns: 'minmax(0, 100%) minmax(0px, min-content)',
     gridTemplateAreas: `
     "layout  aside"
     "subtree subtree"

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -21,6 +21,8 @@ const useRootStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     minHeight: '32px',
+    boxSizing: 'border-box',
+    ...shorthands.gridArea('layout'),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     ':active': {
       color: tokens.colorNeutralForeground2Pressed,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Currently provided column size on tree item grid `auto min-content` doesn't allow proper overflowing of the layout content

<img width="465" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/f969b670-7c66-4246-bcc3-d3fb852ec234">

<img width="465" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/bbe081ce-5678-4a58-861a-147f93fde3a9">


## New Behavior

1. grid column size redefined to `minmax(0px, 100%) minmax(0px, min-content)`  that allows proper overflowing of the content

<img width="465" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/460b56d8-ce2c-4597-ad0f-7a919767170c">


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27714
