### PR TITLE
feat: Update existing toasts

### DIFF
--- a/packages/react-components/react-toast/src/components/Toast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast.tsx
@@ -77,7 +77,7 @@ const useStyles = makeStyles({
 
 export const Toast: React.FC<ToastProps & { visible: boolean }> = props => {
   const styles = useStyles();
-  const { visible, children, close, remove, ...toastOptions } = props;
+  const { visible, children, close, remove, updateId, ...toastOptions } = props;
   const { timeout } = toastOptions;
   const { play, running, toastRef } = useToast<HTMLDivElement>({ ...toastOptions, content: children });
 
@@ -99,7 +99,7 @@ export const Toast: React.FC<ToastProps & { visible: boolean }> = props => {
     <Transition in={visible} unmountOnExit mountOnEnter timeout={500} onExited={remove} nodeRef={toastRef}>
       <div ref={toastRef} className={mergeClasses(styles.toast, visible && styles.slide, !visible && styles.fadeOut)}>
         {children}
-        <Timer onTimeout={close} timeout={timeout ?? -1} running={running} />
+        <Timer key={updateId} onTimeout={close} timeout={timeout ?? -1} running={running} />
       </div>
     </Transition>
   );

--- a/packages/react-components/react-toast/src/state/constants.ts
+++ b/packages/react-components/react-toast/src/state/constants.ts
@@ -1,4 +1,5 @@
 export const EVENTS = {
   show: 'fui-toast-show',
   dismiss: 'fui-toast-dismiss',
+  update: 'fui-toast-update',
 } as const;

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -22,9 +22,14 @@ export interface ToasterOptions
 export interface Toast extends ToastOptions {
   close: () => void;
   remove: () => void;
+  updateId: number;
 }
 
 export interface ShowToastEventDetail extends Partial<ToastOptions> {
+  toastId: ToastId;
+}
+
+export interface UpdateToastEventDetail extends Partial<ToastOptions> {
   toastId: ToastId;
 }
 
@@ -37,4 +42,5 @@ type EventListener<TDetail> = (e: CustomEvent<TDetail>) => void;
 export type ToastListenerMap = {
   [EVENTS.show]: EventListener<ShowToastEventDetail>;
   [EVENTS.dismiss]: EventListener<DismissToastEventDetail>;
+  [EVENTS.update]: EventListener<UpdateToastEventDetail>;
 };

--- a/packages/react-components/react-toast/src/state/useToastController.ts
+++ b/packages/react-components/react-toast/src/state/useToastController.ts
@@ -1,31 +1,36 @@
-import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import { dispatchToast as dispatchToastVanilla, dismissToast as dismissToastVanilla } from './vanilla';
 import * as React from 'react';
-import { ToastId, ToastOptions } from './types';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import {
+  dispatchToast as dispatchToastVanilla,
+  dismissToast as dismissToastVanilla,
+  updateToast as updateToastVanilla,
+} from './vanilla';
+import { ToastId, ToastOptions, UpdateToastEventDetail } from './types';
+
+const noop = () => undefined;
 
 export function useToastController() {
   const { targetDocument } = useFluent();
 
-  const dispatchToast = React.useCallback(
-    (content: React.ReactNode, options?: Partial<ToastOptions>) => {
-      if (targetDocument) {
+  return React.useMemo(() => {
+    if (!targetDocument) {
+      return {
+        dispatchToast: noop,
+        dismissToast: noop,
+        updateToast: noop,
+      };
+    }
+
+    return {
+      dispatchToast: (content: React.ReactNode, options?: Partial<ToastOptions>) => {
         dispatchToastVanilla(content, options, targetDocument);
-      }
-    },
-    [targetDocument],
-  );
-
-  const dismissToast = React.useCallback(
-    (toastId?: ToastId) => {
-      if (targetDocument) {
+      },
+      dismissToast: (toastId?: Partial<ToastId>) => {
         dismissToastVanilla(toastId, targetDocument);
-      }
-    },
-    [targetDocument],
-  );
-
-  return {
-    dispatchToast,
-    dismissToast,
-  };
+      },
+      updateToast: (options: UpdateToastEventDetail) => {
+        updateToastVanilla(options, targetDocument);
+      },
+    };
+  }, [targetDocument]);
 }

--- a/packages/react-components/react-toast/src/state/vanilla/index.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/index.ts
@@ -1,5 +1,6 @@
 export * from './dispatchToast';
 export * from './dismissToast';
+export * from './updateToast';
 export * from './toast';
 export * from './toaster';
 export * from './getPositionStyles';

--- a/packages/react-components/react-toast/src/state/vanilla/updateToast.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/updateToast.ts
@@ -1,0 +1,12 @@
+import { UpdateToastEventDetail } from '../types';
+import { EVENTS } from '../constants';
+
+export function updateToast(options: UpdateToastEventDetail, targetDocument: Document) {
+  const event = new CustomEvent<UpdateToastEventDetail>(EVENTS.update, {
+    bubbles: false,
+    cancelable: false,
+    detail: options,
+  });
+
+  targetDocument.dispatchEvent(event);
+}

--- a/packages/react-components/react-toast/stories/Toast/UpdateToast.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/UpdateToast.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Toaster, useToastController, ToastId } from '@fluentui/react-toast';
+
+export const UpdateToast = () => {
+  const { dispatchToast, updateToast } = useToastController();
+  const notify = (id: ToastId) => dispatchToast('This toast never closes', { toastId: id, timeout: -1 });
+  const update = (id: ToastId) => updateToast({ content: 'This toast will close soon', toastId: id, timeout: 1000 });
+
+  return (
+    <>
+      <Toaster />
+      <button onClick={() => notify('example')}>Make toast</button>
+      <button onClick={() => update('example')}>Update toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -6,6 +6,7 @@ export { DismissToast } from './DismissToast.stories';
 export { DismissAll } from './DismissAll.stories';
 export { PauseOnWindowBlur } from './PauseOnWindowBlur.stories';
 export { PauseOnHover } from './PauseOnHover.stories';
+export { UpdateToast } from './UpdateToast.stories';
 
 export default {
   title: 'Preview Components/Toast',


### PR DESCRIPTION
Creates a new `updateToast` controller to content or any options of an existing toast.

Addresses https://github.com/microsoft/fluentui/issues/27776