### PR TITLE
feat: Implement support for multiple toaster on a page

### DIFF
--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -18,7 +18,8 @@ export type ToastPosition = 'top-right' | 'top-center' | 'top-left' | 'bottom-ri
 // @public (undocumented)
 export function useToastController(): {
     dispatchToast: (content: React_2.ReactNode, options?: Partial<ToastOptions> | undefined) => void;
-    dismissToast: (toastId?: string | undefined) => void;
+    dismissToast: (toastId: ToastId, toasterId?: string | undefined) => void;
+    dismissAllToasts: (toasterId?: string | undefined) => void;
     updateToast: (options: UpdateToastEventDetail) => void;
 };
 

--- a/packages/react-components/react-toast/src/state/constants.ts
+++ b/packages/react-components/react-toast/src/state/constants.ts
@@ -1,5 +1,6 @@
 export const EVENTS = {
   show: 'fui-toast-show',
   dismiss: 'fui-toast-dismiss',
+  dismissAll: 'fui-toast-dismiss-all',
   update: 'fui-toast-update',
 } as const;

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -1,6 +1,7 @@
 import { EVENTS } from './constants';
 
 export type ToastId = string;
+export type ToasterId = string;
 
 export type ToastPosition = 'top-right' | 'top-center' | 'top-left' | 'bottom-right' | 'bottom-center' | 'bottom-left';
 
@@ -11,12 +12,13 @@ export interface ToastOptions {
   timeout: number;
   pauseOnWindowBlur: boolean;
   pauseOnHover: boolean;
+  toasterId: ToasterId | undefined;
 }
 
 export interface ToasterOptions
   extends Pick<ToastOptions, 'position' | 'timeout' | 'pauseOnWindowBlur' | 'pauseOnHover'> {
   offset?: number[];
-  toasterId?: string;
+  toasterId?: ToasterId;
 }
 
 export interface Toast extends ToastOptions {
@@ -25,17 +27,23 @@ export interface Toast extends ToastOptions {
   updateId: number;
 }
 
-export interface ShowToastEventDetail extends Partial<ToastOptions> {
+export interface CommonToastDetail {
+  toasterId?: ToasterId;
+}
+
+export interface ShowToastEventDetail extends Partial<ToastOptions>, CommonToastDetail {
   toastId: ToastId;
 }
 
-export interface UpdateToastEventDetail extends Partial<ToastOptions> {
+export interface UpdateToastEventDetail extends Partial<ToastOptions>, CommonToastDetail {
   toastId: ToastId;
 }
 
-export interface DismissToastEventDetail {
-  toastId: ToastId | undefined;
+export interface DismissToastEventDetail extends CommonToastDetail {
+  toastId: ToastId;
 }
+
+export interface DismissAllToastsEventDetail extends CommonToastDetail {}
 
 type EventListener<TDetail> = (e: CustomEvent<TDetail>) => void;
 

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -50,5 +50,6 @@ type EventListener<TDetail> = (e: CustomEvent<TDetail>) => void;
 export type ToastListenerMap = {
   [EVENTS.show]: EventListener<ShowToastEventDetail>;
   [EVENTS.dismiss]: EventListener<DismissToastEventDetail>;
+  [EVENTS.dismissAll]: EventListener<DismissAllToastsEventDetail>;
   [EVENTS.update]: EventListener<UpdateToastEventDetail>;
 };

--- a/packages/react-components/react-toast/src/state/useToastController.ts
+++ b/packages/react-components/react-toast/src/state/useToastController.ts
@@ -3,9 +3,10 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import {
   dispatchToast as dispatchToastVanilla,
   dismissToast as dismissToastVanilla,
+  dismissAllToasts as dismissAllToastsVanilla,
   updateToast as updateToastVanilla,
 } from './vanilla';
-import { ToastId, ToastOptions, UpdateToastEventDetail } from './types';
+import { ToastId, ToastOptions, ToasterId, UpdateToastEventDetail } from './types';
 
 const noop = () => undefined;
 
@@ -17,6 +18,7 @@ export function useToastController() {
       return {
         dispatchToast: noop,
         dismissToast: noop,
+        dismissAllToasts: noop,
         updateToast: noop,
       };
     }
@@ -25,8 +27,11 @@ export function useToastController() {
       dispatchToast: (content: React.ReactNode, options?: Partial<ToastOptions>) => {
         dispatchToastVanilla(content, options, targetDocument);
       },
-      dismissToast: (toastId?: Partial<ToastId>) => {
-        dismissToastVanilla(toastId, targetDocument);
+      dismissToast: (toastId: ToastId, toasterId?: ToasterId) => {
+        dismissToastVanilla(toastId, toasterId, targetDocument);
+      },
+      dismissAllToasts: (toasterId?: ToasterId) => {
+        dismissAllToastsVanilla(toasterId, targetDocument);
       },
       updateToast: (options: UpdateToastEventDetail) => {
         updateToastVanilla(options, targetDocument);

--- a/packages/react-components/react-toast/src/state/useToaster.ts
+++ b/packages/react-components/react-toast/src/state/useToaster.ts
@@ -5,10 +5,11 @@ import { Toast, ToastPosition, ToasterOptions } from './types';
 import { ToasterProps } from '../components/Toaster';
 
 export function useToaster<TElement extends HTMLElement>(options: ToasterProps = {}) {
+  const { toasterId, ...rest } = options;
   const forceRender = useForceUpdate();
-  const defaultToastOptions = useToastOptions(options);
+  const defaultToastOptions = useToastOptions(rest);
   const toasterRef = React.useRef<TElement>(null);
-  const [toaster] = React.useState(() => new Toaster());
+  const [toaster] = React.useState(() => new Toaster(toasterId));
 
   React.useEffect(() => {
     if (toasterRef.current) {

--- a/packages/react-components/react-toast/src/state/vanilla/dismissAllToasts.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/dismissAllToasts.ts
@@ -1,0 +1,11 @@
+import { EVENTS } from '../constants';
+import { DismissAllToastsEventDetail, ToasterId } from '../types';
+
+export function dismissAllToasts(toasterId: ToasterId | undefined = undefined, targetDocument: Document) {
+  const event = new CustomEvent<DismissAllToastsEventDetail>(EVENTS.dismissAll, {
+    bubbles: false,
+    cancelable: false,
+    detail: { toasterId },
+  });
+  targetDocument.dispatchEvent(event);
+}

--- a/packages/react-components/react-toast/src/state/vanilla/dismissToast.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/dismissToast.ts
@@ -1,11 +1,11 @@
 import { EVENTS } from '../constants';
-import { DismissToastEventDetail, ToastId } from '../types';
+import { DismissToastEventDetail, ToastId, ToasterId } from '../types';
 
-export function dismissToast(toastId: ToastId | undefined = undefined, targetDocument: Document) {
+export function dismissToast(toastId: ToastId, toasterId: ToasterId | undefined = undefined, targetDocument: Document) {
   const event = new CustomEvent<DismissToastEventDetail>(EVENTS.dismiss, {
     bubbles: false,
     cancelable: false,
-    detail: { toastId },
+    detail: { toastId, toasterId },
   });
   targetDocument.dispatchEvent(event);
 }

--- a/packages/react-components/react-toast/src/state/vanilla/index.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/index.ts
@@ -1,5 +1,6 @@
 export * from './dispatchToast';
 export * from './dismissToast';
+export * from './dismissAllToasts';
 export * from './updateToast';
 export * from './toast';
 export * from './toaster';

--- a/packages/react-components/react-toast/src/state/vanilla/toaster.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/toaster.ts
@@ -1,4 +1,14 @@
-import { Toast, ToasterOptions, ToastId, ToastOptions, ToastListenerMap, UpdateToastEventDetail } from '../types';
+import {
+  Toast,
+  ToasterOptions,
+  ToastId,
+  ToastOptions,
+  ToastListenerMap,
+  UpdateToastEventDetail,
+  ToasterId,
+  ShowToastEventDetail,
+  CommonToastDetail,
+} from '../types';
 import { EVENTS } from '../constants';
 
 function assignDefined<T extends object>(a: Partial<T>, b: Partial<T>) {
@@ -18,10 +28,12 @@ export class Toaster {
   public onUpdate: () => void;
   private toasterElement?: HTMLElement;
   private toasterOptions: ToasterOptions;
+  private toasterId?: ToastId;
 
   private listeners = new Map<keyof ToastListenerMap, ToastListenerMap[keyof ToastListenerMap]>();
 
-  constructor() {
+  constructor(toasterId?: ToasterId) {
+    this.toasterId = toasterId;
     this.toasts = new Map<ToastId, Toast>();
     this.visibleToasts = new Set<ToastId>();
     this.onUpdate = () => null;
@@ -50,17 +62,12 @@ export class Toaster {
 
     const buildToast: ToastListenerMap[typeof EVENTS.show] = e => this._buildToast(e.detail);
     const updateToast: ToastListenerMap[typeof EVENTS.update] = e => this._updateToast(e.detail);
-    const dismissToast: ToastListenerMap[typeof EVENTS.dismiss] = e => {
-      const { toastId } = e.detail;
-      if (toastId) {
-        this._dismissToast(toastId);
-      } else {
-        this._dismissAllToasts();
-      }
-    };
+    const dismissToast: ToastListenerMap[typeof EVENTS.dismiss] = e => this._dismissToast(e.detail.toastId);
+    const dismissAllToasts: ToastListenerMap[typeof EVENTS.dismissAll] = e => this._dismissAllToasts();
 
     this._addEventListener(EVENTS.show, buildToast);
     this._addEventListener(EVENTS.dismiss, dismissToast);
+    this._addEventListener(EVENTS.dismissAll, dismissAllToasts);
     this._addEventListener(EVENTS.update, updateToast);
   }
 
@@ -73,9 +80,17 @@ export class Toaster {
       return;
     }
 
-    this.listeners.set(eventType, callback);
+    const listener: ToastListenerMap[TType] = (e: CustomEvent<CommonToastDetail>) => {
+      if (e.detail.toasterId !== this.toasterId) {
+        return;
+      }
+
+      callback(e as CustomEvent<ShowToastEventDetail>);
+    };
+
+    this.listeners.set(eventType, listener);
     const targetDocument = this.toasterElement?.ownerDocument;
-    targetDocument.addEventListener(eventType, callback as () => void);
+    targetDocument.addEventListener(eventType, listener as () => void);
   }
 
   private _removeEventListener<TType extends keyof ToastListenerMap>(
@@ -113,7 +128,7 @@ export class Toaster {
   }
 
   private _buildToast(toastOptions: Partial<ToastOptions> & { toastId: ToastId }) {
-    const { toastId, content } = toastOptions;
+    const { toastId, content, toasterId } = toastOptions;
 
     if (this.toasts.has(toastId)) {
       return;
@@ -136,6 +151,7 @@ export class Toaster {
       toastId,
       content,
       updateId: 0,
+      toasterId,
     };
 
     assignDefined<Toast>(toast, toastOptions);

--- a/packages/react-components/react-toast/src/state/vanilla/toaster.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/toaster.ts
@@ -12,10 +12,10 @@ import {
 import { EVENTS } from '../constants';
 
 function assignDefined<T extends object>(a: Partial<T>, b: Partial<T>) {
-  for (const [key, prop] of Object.entries(b)) {
-    if (prop !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+  // This cast is required, as Object.entries will return string as key which is not indexable
+  for (const [key, prop] of Object.entries(b) as [keyof T, T[keyof T]][]) {
+    // eslint-disable-next-line eqeqeq
+    if (prop != undefined) {
       a[key] = prop;
     }
   }

--- a/packages/react-components/react-toast/stories/Toast/CustomTimeout.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/CustomTimeout.stories.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const CustomTimeout = () => {
+  const toasterId = useId('toaster');
   const { dispatchToast } = useToastController();
-  const notify = () => dispatchToast('This is a toast', { timeout: 1000 });
+  const notify = () => dispatchToast('This is a toast', { timeout: 1000, toasterId });
 
   return (
     <>
-      <Toaster />
+      <Toaster toasterId={toasterId} />
       <button onClick={notify}>Make toast</button>
     </>
   );

--- a/packages/react-components/react-toast/stories/Toast/Default.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Default.stories.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const Default = () => {
+  const toasterId = useId('toaster');
   const { dispatchToast } = useToastController();
-  const notify = () => dispatchToast('This is a toast');
+  const notify = () => dispatchToast('This is a toast', { toasterId });
 
   return (
     <>
-      <Toaster />
+      <Toaster toasterId={toasterId} />
       <button onClick={notify}>Make toast</button>
     </>
   );

--- a/packages/react-components/react-toast/stories/Toast/DefaultToastOptions.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DefaultToastOptions.stories.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const DefaultToastOptions = () => {
+  const toasterId = useId('toaster');
   const { dispatchToast } = useToastController();
-  const notify = () => dispatchToast('This is a toast');
+  const notify = () => dispatchToast('This is a toast', { toasterId });
 
   return (
     <>
-      <Toaster position="top-right" pauseOnHover pauseOnWindowBlur timeout={1000} />
+      <Toaster toasterId={toasterId} position="top-right" pauseOnHover pauseOnWindowBlur timeout={1000} />
       <button onClick={notify}>Make toast</button>
     </>
   );

--- a/packages/react-components/react-toast/stories/Toast/DismissAll.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissAll.stories.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const DismissAll = () => {
-  const { dispatchToast, dismissToast } = useToastController();
-  const notify = () => dispatchToast('This is a toast');
+  const toasterId = useId('toaster');
+  const { dispatchToast, dismissAllToasts } = useToastController();
+  const notify = () => dispatchToast('This is a toast', { toasterId });
+  const dismissAll = () => dismissAllToasts(toasterId);
 
   return (
     <>
-      <Toaster />
-      <button onClick={() => notify()}>Make toast</button>
-      <button onClick={() => dismissToast()}>Dismiss all</button>
+      <Toaster toasterId={toasterId} />
+      <button onClick={notify}>Make toast</button>
+      <button onClick={dismissAll}>Dismiss all</button>
     </>
   );
 };

--- a/packages/react-components/react-toast/stories/Toast/DismissToast.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissToast.stories.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
-import { Toaster, useToastController, ToastId } from '@fluentui/react-toast';
+import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const DismissToast = () => {
+  const toasterId = useId('toaster');
+  const toastId = useId('example');
   const { dispatchToast, dismissToast } = useToastController();
-  const notify = (id: ToastId) => dispatchToast('This is a toast', { toastId: id });
+  const notify = () => dispatchToast('This is a toast', { toastId, toasterId });
+  const dismiss = () => dismissToast(toastId, toasterId);
 
   return (
     <>
-      <Toaster />
-      <button onClick={() => notify('example')}>Make toast</button>
-      <button onClick={() => dismissToast('example')}>Dismiss all</button>
+      <Toaster toasterId={toasterId} />
+      <button onClick={notify}>Make toast</button>
+      <button onClick={dismiss}>Dismiss toast</button>
     </>
   );
 };

--- a/packages/react-components/react-toast/stories/Toast/MultipleToasters.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/MultipleToasters.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
+
+export const MultipeToasters = () => {
+  const first = useId('toaster-1');
+  const second = useId('toaster-2');
+  const { dispatchToast } = useToastController();
+  const notifyFirst = () => dispatchToast('Toaster first', { toasterId: first });
+  const notifySecond = () => dispatchToast('Toaster second', { toasterId: second });
+
+  return (
+    <>
+      <Toaster toasterId={first} position="bottom-right" />
+      <Toaster toasterId={second} position="top-right" />
+      <button onClick={notifyFirst}>Toaster first</button>
+      <button onClick={notifySecond}>Toaster second</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/PauseOnHover.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnHover.stories.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const PauseOnHover = () => {
+  const toasterId = useId('toaster');
   const { dispatchToast } = useToastController();
-  const notify = () => dispatchToast('Hover me!', { pauseOnHover: true });
+  const notify = () => dispatchToast('Hover me!', { pauseOnHover: true, toasterId });
 
   return (
     <>
-      <Toaster />
+      <Toaster toasterId={toasterId} />
       <button onClick={notify}>Make toast</button>
     </>
   );

--- a/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const PauseOnWindowBlur = () => {
+  const toasterId = useId('toaster');
   const { dispatchToast } = useToastController();
-  const notify = () => dispatchToast('Click on another window!', { pauseOnWindowBlur: true });
+  const notify = () => dispatchToast('Click on another window!', { pauseOnWindowBlur: true, toasterId });
 
   return (
     <>
-      <Toaster />
+      <Toaster toasterId={toasterId} />
       <button onClick={notify}>Make toast</button>
     </>
   );

--- a/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Toaster, useToastController, ToastPosition } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const ToastPositions = () => {
+  const toasterId = useId('toaster');
   const { dispatchToast } = useToastController();
-  const notify = (position: ToastPosition) => dispatchToast('This is a toast', { position });
+  const notify = (position: ToastPosition) => dispatchToast('This is a toast', { position, toasterId });
 
   return (
     <>
-      <Toaster />
+      <Toaster toasterId={toasterId} />
       <button onClick={() => notify('bottom-left')}>bottom-left</button>
       <button onClick={() => notify('bottom-right')}>bottom-right</button>
       <button onClick={() => notify('top-left')}>top-left</button>

--- a/packages/react-components/react-toast/stories/Toast/UpdateToast.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/UpdateToast.stories.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
-import { Toaster, useToastController, ToastId } from '@fluentui/react-toast';
+import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
 
 export const UpdateToast = () => {
+  const toasterId = useId('toaster');
+  const toastId = useId('example');
   const { dispatchToast, updateToast } = useToastController();
-  const notify = (id: ToastId) => dispatchToast('This toast never closes', { toastId: id, timeout: -1 });
-  const update = (id: ToastId) => updateToast({ content: 'This toast will close soon', toastId: id, timeout: 1000 });
+  const notify = () => dispatchToast('This toast never closes', { toastId, timeout: -1, toasterId });
+  const update = () => updateToast({ content: 'This toast will close soon', toastId, timeout: 1000, toasterId });
 
   return (
     <>
-      <Toaster />
-      <button onClick={() => notify('EXAMPLE_ID')}>Make toast</button>
-      <button onClick={() => update('EXAMPLE_ID')}>Update toast</button>
+      <Toaster toasterId={toasterId} />
+      <button onClick={notify}>Make toast</button>
+      <button onClick={update}>Update toast</button>
     </>
   );
 };

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -7,6 +7,7 @@ export { DismissAll } from './DismissAll.stories';
 export { PauseOnWindowBlur } from './PauseOnWindowBlur.stories';
 export { PauseOnHover } from './PauseOnHover.stories';
 export { UpdateToast } from './UpdateToast.stories';
+export { MultipeToasters } from './MultipleToasters.stories';
 
 export default {
   title: 'Preview Components/Toast',


### PR DESCRIPTION
Adds the `toasterId` prop to all Toaster components and controllers. If a Toaster has the `toasterId` prop set, then it will ignore any toast events except those with its id.

This change required splitting up the dismissing functionalities into:
- dismissToast - for single toasts
- dismissAllToasts - to dismiss all toasts

Addresses https://github.com/microsoft/fluentui/pull/27827
