### PR TITLE
fix(react-combobox): Do not update value if the defaultValue changes

### DIFF
--- a/change/@fluentui-react-combobox-081fc8bd-a2b6-4cc5-80b6-8c445e1e9f6a.json
+++ b/change/@fluentui-react-combobox-081fc8bd-a2b6-4cc5-80b6-8c445e1e9f6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove defaultValue from state's useMemo dependencies to avoid clearing the state.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -922,4 +922,28 @@ describe('Combobox', () => {
     expect(combobox.getAttribute('aria-invalid')).toEqual('true');
     expect(combobox.required).toBe(true);
   });
+
+  it('should ignore changes to defaultValue', () => {
+    const options = ['Red', 'Green', 'Blue'];
+    const result = render(
+      <Combobox defaultValue="Red">
+        {options.map(option => (
+          <Option key={option}>{option}</Option>
+        ))}
+      </Combobox>,
+    );
+
+    const combobox = result.getByRole('combobox') as HTMLInputElement;
+    expect(combobox.value).toEqual('Red');
+
+    result.rerender(
+      <Combobox defaultValue="Blue">
+        {options.map(option => (
+          <Option key={option}>{option}</Option>
+        ))}
+      </Combobox>,
+    );
+
+    expect(combobox.value).toEqual('Red');
+  });
 });

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -71,7 +71,7 @@ export const useComboboxBaseState = (
     // we do not want to accidentally override defaultValue on a second render
     // unless another value is intentionally set
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [controllableValue, editable, getOptionsMatchingValue, multiselect, props.defaultValue, selectedOptions]);
+  }, [controllableValue, editable, getOptionsMatchingValue, multiselect, selectedOptions]);
 
   // Handle open state, which is shared with options in context
   const [open, setOpenState] = useControllableState({


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`value` is updated when the defaultValue has been changed triggering a change in useMemo. The code inside useMemo does ignore the defaultValue change, but it returns `undefined` and therefore another change in useMemo is triggered again to change it back to the previous value.

This is clearing the state and therefore clearing the value of the input.

## New Behavior

Remove defaultValue from the dependencies of useMemo to avoid clearing the state.
