### PR TITLE
chore(storybook): Add theme to URL

### DIFF
--- a/packages/react-components/react-storybook-addon/etc/react-storybook-addon.api.md
+++ b/packages/react-components/react-storybook-addon/etc/react-storybook-addon.api.md
@@ -48,7 +48,7 @@ export function parameters(options?: FluentParameters): {
 };
 
 // @public (undocumented)
-export const THEME_ID: "storybook/fluentui-react-addon/theme";
+export const THEME_ID: "storybook_fluentui-react-addon_theme";
 
 // @public (undocumented)
 export type ThemeIds = (typeof themes)[number]['id'];

--- a/packages/react-components/react-storybook-addon/src/constants.ts
+++ b/packages/react-components/react-storybook-addon/src/constants.ts
@@ -1,4 +1,4 @@
-export const ADDON_ID = 'storybook/fluentui-react-addon';
-export const THEME_ID = `${ADDON_ID}/theme` as const;
+export const ADDON_ID = 'storybook_fluentui-react-addon';
+export const THEME_ID = `${ADDON_ID}_theme` as const;
 
-export const STRICT_MODE_ID = `${ADDON_ID}/strict-mode` as const;
+export const STRICT_MODE_ID = `${ADDON_ID}_strict-mode` as const;

--- a/packages/react-components/react-storybook-addon/src/preset/preview.ts
+++ b/packages/react-components/react-storybook-addon/src/preset/preview.ts
@@ -14,4 +14,4 @@ import { withReactStrictMode } from '../decorators/withReactStrictMode';
 import { THEME_ID } from '../constants';
 
 export const decorators = [withFluentProvider, withReactStrictMode];
-export const globals = { [THEME_ID]: 'web-dark' }; // allow theme to be set by URL query param
+export const globals = { [THEME_ID]: undefined }; // allow theme to be set by URL query param

--- a/packages/react-components/react-storybook-addon/src/preset/preview.ts
+++ b/packages/react-components/react-storybook-addon/src/preset/preview.ts
@@ -11,5 +11,7 @@
 
 import { withFluentProvider } from '../decorators/withFluentProvider';
 import { withReactStrictMode } from '../decorators/withReactStrictMode';
+import { THEME_ID } from '../constants';
 
 export const decorators = [withFluentProvider, withReactStrictMode];
+export const globals = { [THEME_ID]: 'web-dark' }; // allow theme to be set by URL query param


### PR DESCRIPTION
## Previous Behavior

It was not possible to set a theme in story iframe.

## New Behavior

When a theme is set in Canvas view, it is written to the URL:

![image](https://github.com/microsoft/fluentui/assets/9615899/c3ae15cf-4a9b-4ab1-a818-fb8941b60e91)

Opening the story in an iframe view keeps the theme information in URL and renders the story with the expected theme:

![image](https://github.com/microsoft/fluentui/assets/9615899/31bbf333-d92d-4563-b489-904bb8b14709)

Due to Storybook internals, the theme information in URL is not preserved when navigating between components in docs view.

List of valid theme args:
```
globals=storybook_fluentui-react-addon_theme:web-light
globals=storybook_fluentui-react-addon_theme:web-dark
globals=storybook_fluentui-react-addon_theme:teams-light
globals=storybook_fluentui-react-addon_theme:teams-dark
globals=storybook_fluentui-react-addon_theme:teams-high-contrast
```

With the correct URL, it is now possible to open the iframe stories in any theme in the production docsite.


