### PR TITLE
feat: Implement limit for toast stacking

### DIFF
--- a/change/@fluentui-react-utilities-22f9b966-d085-4744-a402-a333796c653f.json
+++ b/change/@fluentui-react-utilities-22f9b966-d085-4744-a402-a333796c653f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Implement a priority queue",
+  "packageName": "@fluentui/react-utilities",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -13,12 +13,15 @@ export interface ToastOptions {
   pauseOnWindowBlur: boolean;
   pauseOnHover: boolean;
   toasterId: ToasterId | undefined;
+  priority: number;
+  dispatchedAt: number;
 }
 
 export interface ToasterOptions
-  extends Pick<ToastOptions, 'position' | 'timeout' | 'pauseOnWindowBlur' | 'pauseOnHover'> {
+  extends Pick<ToastOptions, 'position' | 'timeout' | 'pauseOnWindowBlur' | 'pauseOnHover' | 'priority'> {
   offset?: number[];
   toasterId?: ToasterId;
+  limit?: number;
 }
 
 export interface Toast extends ToastOptions {
@@ -31,11 +34,11 @@ export interface CommonToastDetail {
   toasterId?: ToasterId;
 }
 
-export interface ShowToastEventDetail extends Partial<ToastOptions>, CommonToastDetail {
+export interface ShowToastEventDetail extends Partial<Omit<ToastOptions, 'dispatchedAt'>>, CommonToastDetail {
   toastId: ToastId;
 }
 
-export interface UpdateToastEventDetail extends Partial<ToastOptions>, CommonToastDetail {
+export interface UpdateToastEventDetail extends Partial<Omit<ToastOptions, 'dispatchedAt'>>, CommonToastDetail {
   toastId: ToastId;
 }
 

--- a/packages/react-components/react-toast/src/state/useToaster.ts
+++ b/packages/react-components/react-toast/src/state/useToaster.ts
@@ -5,20 +5,19 @@ import { Toast, ToastPosition, ToasterOptions } from './types';
 import { ToasterProps } from '../components/Toaster';
 
 export function useToaster<TElement extends HTMLElement>(options: ToasterProps = {}) {
-  const { toasterId, ...rest } = options;
   const forceRender = useForceUpdate();
-  const defaultToastOptions = useToastOptions(rest);
+  const toasterOptions = useToasterOptions(options);
   const toasterRef = React.useRef<TElement>(null);
-  const [toaster] = React.useState(() => new Toaster(toasterId));
+  const [toaster] = React.useState(() => new Toaster());
 
   React.useEffect(() => {
     if (toasterRef.current) {
-      toaster.connectToDOM(toasterRef.current, defaultToastOptions);
+      toaster.connectToDOM(toasterRef.current, toasterOptions);
       toaster.onUpdate = forceRender;
     }
 
     return () => toaster.disconnect();
-  }, [toaster, defaultToastOptions, forceRender]);
+  }, [toaster, forceRender, toasterOptions]);
 
   const getToastsToRender = React.useCallback(
     <T>(cb: (position: ToastPosition, toasts: Toast[]) => T) => {
@@ -53,8 +52,8 @@ export function useToaster<TElement extends HTMLElement>(options: ToasterProps =
   };
 }
 
-function useToastOptions(options: ToasterProps): Partial<ToasterOptions> {
-  const { pauseOnHover, pauseOnWindowBlur, position, timeout } = options;
+function useToasterOptions(options: ToasterProps): Partial<ToasterOptions> {
+  const { pauseOnHover, pauseOnWindowBlur, position, timeout, limit, toasterId } = options;
 
   return React.useMemo<Partial<ToasterOptions>>(
     () => ({
@@ -62,7 +61,9 @@ function useToastOptions(options: ToasterProps): Partial<ToasterOptions> {
       pauseOnWindowBlur,
       position,
       timeout,
+      limit,
+      toasterId,
     }),
-    [pauseOnHover, pauseOnWindowBlur, position, timeout],
+    [pauseOnHover, pauseOnWindowBlur, position, timeout, limit, toasterId],
   );
 }

--- a/packages/react-components/react-toast/src/state/vanilla/dispatchToast.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/dispatchToast.ts
@@ -3,7 +3,11 @@ import { EVENTS } from '../constants';
 
 let counter = 0;
 
-export function dispatchToast(content: unknown, options: Partial<ToastOptions> = {}, targetDocument: Document) {
+export function dispatchToast(
+  content: unknown,
+  options: Partial<Omit<ToastOptions, 'dispatchedAt'>> = {},
+  targetDocument: Document,
+) {
   const detail: ShowToastEventDetail = {
     ...options,
     content,

--- a/packages/react-components/react-toast/stories/Toast/ToasterLimit.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToasterLimit.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Toaster, useToastController } from '@fluentui/react-toast';
+import { useId } from '@fluentui/react-components';
+
+export const ToasterLimit = () => {
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController();
+  const notify = () => dispatchToast('This is a toast', { toasterId });
+
+  return (
+    <>
+      <Toaster toasterId={toasterId} limit={3} />
+      <button onClick={notify}>Make toast</button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -8,6 +8,7 @@ export { PauseOnWindowBlur } from './PauseOnWindowBlur.stories';
 export { PauseOnHover } from './PauseOnHover.stories';
 export { UpdateToast } from './UpdateToast.stories';
 export { MultipeToasters } from './MultipleToasters.stories';
+export { ToasterLimit } from './ToasterLimit.stories';
 
 export default {
   title: 'Preview Components/Toast',

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -28,6 +28,9 @@ export type ComponentState<Slots extends SlotPropsRecord> = {
     [Key in keyof Slots]: ReplaceNullWithUndefined<Exclude<Slots[Key], SlotShorthandValue | (Key extends 'root' ? null : never)>>;
 };
 
+// @internal (undocumented)
+export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): PriorityQueue<T>;
+
 // @public
 export type ExtractSlotProps<S> = Exclude<S, SlotShorthandValue | null | undefined>;
 

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -116,6 +116,26 @@ export type NativeTouchOrMouseEvent = MouseEvent | TouchEvent;
 // @public
 export function omit<TObj extends Record<string, any>, Exclusions extends (keyof TObj)[]>(obj: TObj, exclusions: Exclusions): Omit<TObj, Exclusions[number]>;
 
+// @internal (undocumented)
+export interface PriorityQueue<T> {
+    // (undocumented)
+    all: () => T[];
+    // (undocumented)
+    clear: () => void;
+    // (undocumented)
+    contains: (item: T) => boolean;
+    // (undocumented)
+    dequeue: () => T;
+    // (undocumented)
+    enqueue: (item: T) => void;
+    // (undocumented)
+    peek: () => T | null;
+    // (undocumented)
+    remove: (item: T) => void;
+    // (undocumented)
+    size: () => number;
+}
+
 // @public (undocumented)
 export type ReactTouchOrMouseEvent = React_2.MouseEvent | React_2.TouchEvent;
 

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -50,7 +50,10 @@ export {
   isHTMLElement,
   isInteractiveHTMLElement,
   omit,
+  createPriorityQueue,
 } from './utils/index';
+
+export type { PriorityQueue } from './utils/priorityQueue';
 
 export { applyTriggerPropsToChildren, getTriggerChild, isFluentTrigger } from './trigger/index';
 

--- a/packages/react-components/react-utilities/src/utils/index.ts
+++ b/packages/react-components/react-utilities/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './omit';
 export * from './properties';
 export * from './isHTMLElement';
 export * from './isInteractiveHTMLElement';
+export * from './priorityQueue';

--- a/packages/react-components/react-utilities/src/utils/priorityQueue.test.ts
+++ b/packages/react-components/react-utilities/src/utils/priorityQueue.test.ts
@@ -1,0 +1,90 @@
+import { createPriorityQueue } from './priorityQueue';
+
+describe('Priority queue', () => {
+  it('can use comparator to order in increasing priority', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    const expected = [];
+    while (priorityQueue.size() > 0) {
+      expected.push(priorityQueue.dequeue());
+    }
+
+    expect(expected.length).toBe(values.length);
+    expect(expected).toEqual([1, 2, 3, 5, 7, 8, 11, 67]);
+  });
+
+  it('can use comparator to order in decreasing priority', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => b - a);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    const expected = [];
+    while (priorityQueue.size() > 0) {
+      expected.push(priorityQueue.dequeue());
+    }
+
+    expect(expected.length).toBe(values.length);
+    expect(expected).toEqual([1, 2, 3, 5, 7, 8, 11, 67].reverse());
+  });
+
+  it('peek should return the same value as dequeue', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    expect(priorityQueue.peek()).toBe(1);
+    expect(priorityQueue.dequeue()).toBe(1);
+  });
+
+  it('clear should empty priority queue', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    priorityQueue.clear();
+    expect(priorityQueue.size()).toBe(0);
+  });
+
+  it('dequeue should throw if the queue is empty', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    priorityQueue.clear();
+    expect(priorityQueue.dequeue).toThrow('Priority queue empty');
+  });
+
+  it('remove should delete item from the queue without affecting order', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    priorityQueue.remove(11);
+
+    const expected = [];
+    while (priorityQueue.size() > 0) {
+      expected.push(priorityQueue.dequeue());
+    }
+
+    expect(expected.length).toBe(values.length - 1);
+    expect(expected).toEqual([1, 2, 3, 5, 7, 8, 67]);
+  });
+
+  it('contains should return true if element is in the queue', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    expect(priorityQueue.contains(1)).toBe(true);
+  });
+
+  it('contains should return true if element is not in the queue', () => {
+    const priorityQueue = createPriorityQueue<number>((a, b) => a - b);
+    const values = [3, 8, 2, 5, 11, 67, 1, 7];
+    values.forEach(value => priorityQueue.enqueue(value));
+
+    expect(priorityQueue.contains(99)).toBe(false);
+  });
+});

--- a/packages/react-components/react-utilities/src/utils/priorityQueue.ts
+++ b/packages/react-components/react-utilities/src/utils/priorityQueue.ts
@@ -1,0 +1,131 @@
+/**
+ * @internal
+ */
+export type PriorityQueueCompareFn<T> = (a: T, b: T) => number;
+
+/**
+ * @internal
+ */
+export interface PriorityQueue<T> {
+  all: () => T[];
+  clear: () => void;
+  contains: (item: T) => boolean;
+  dequeue: () => T;
+  enqueue: (item: T) => void;
+  peek: () => T | null;
+  remove: (item: T) => void;
+  size: () => number;
+}
+
+/**
+ * @internal
+ * @param compare - comparison function for items
+ * @returns Priority queue implemented with a min heap
+ */
+export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): PriorityQueue<T> {
+  const arr: T[] = [];
+  let size = 0;
+
+  const left = (i: number) => {
+    return 2 * i + 1;
+  };
+
+  const right = (i: number) => {
+    return 2 * i + 2;
+  };
+
+  const parent = (i: number) => {
+    return Math.floor((i - 1) / 2);
+  };
+
+  const swap = (a: number, b: number) => {
+    const tmp = arr[a];
+    arr[a] = arr[b];
+    arr[b] = tmp;
+  };
+
+  const heapify = (i: number) => {
+    let smallest = i;
+    const l = left(i);
+    const r = right(i);
+
+    if (l < size && compare(arr[l], arr[smallest]) < 0) {
+      smallest = l;
+    }
+
+    if (r < size && compare(arr[r], arr[smallest]) < 0) {
+      smallest = r;
+    }
+
+    if (smallest !== i) {
+      swap(smallest, i);
+      heapify(smallest);
+    }
+  };
+
+  const dequeue = () => {
+    if (size === 0) {
+      throw new Error('Priority queue empty');
+    }
+
+    const res = arr[0];
+    arr[0] = arr[--size];
+    heapify(0);
+
+    return res;
+  };
+
+  const peek = () => {
+    if (size === 0) {
+      return null;
+    }
+
+    return arr[0];
+  };
+
+  const enqueue = (item: T) => {
+    arr[size++] = item;
+    let i = size - 1;
+    let p = parent(i);
+    while (i > 0 && compare(arr[p], arr[i]) > 0) {
+      swap(p, i);
+      i = p;
+      p = parent(i);
+    }
+  };
+
+  const contains = (item: T) => {
+    const index = arr.indexOf(item);
+    return index >= 0 && index < size;
+  };
+
+  const remove = (item: T) => {
+    const i = arr.indexOf(item);
+
+    if (i === -1 || i >= size) {
+      return;
+    }
+
+    arr[i] = arr[--size];
+    heapify(i);
+  };
+
+  const clear = () => {
+    size = 0;
+  };
+
+  const all = () => {
+    return arr.slice(0, size);
+  };
+
+  return {
+    all,
+    clear,
+    contains,
+    dequeue,
+    enqueue,
+    peek,
+    remove,
+    size: () => size,
+  };
+}

--- a/packages/react-components/react-utilities/src/utils/priorityQueue.ts
+++ b/packages/react-components/react-utilities/src/utils/priorityQueue.ts
@@ -26,18 +26,6 @@ export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): Prio
   const arr: T[] = [];
   let size = 0;
 
-  const left = (i: number) => {
-    return 2 * i + 1;
-  };
-
-  const right = (i: number) => {
-    return 2 * i + 2;
-  };
-
-  const parent = (i: number) => {
-    return Math.floor((i - 1) / 2);
-  };
-
   const swap = (a: number, b: number) => {
     const tmp = arr[a];
     arr[a] = arr[b];
@@ -129,3 +117,15 @@ export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): Prio
     size: () => size,
   };
 }
+
+const left = (i: number) => {
+  return 2 * i + 1;
+};
+
+const right = (i: number) => {
+  return 2 * i + 2;
+};
+
+const parent = (i: number) => {
+  return Math.floor((i - 1) / 2);
+};


### PR DESCRIPTION
Adds the new `limit` prop to `Toaster` which will limit the number of visible toasts on the page.

This is done internally using a priority queue based on the creation date. This will also support toast priorities in the queue.

Addresses #27827