### PR TITLE
feat(react-tags): make basic Tag a button instead of div

### DIFF
--- a/packages/react-components/react-tags/etc/react-tags.api.md
+++ b/packages/react-components/react-tags/etc/react-tags.api.md
@@ -8,11 +8,12 @@
 
 import { AvatarShape } from '@fluentui/react-avatar';
 import { AvatarSize } from '@fluentui/react-avatar';
-import type { ComponentProps } from '@fluentui/react-utilities';
-import type { ComponentState } from '@fluentui/react-utilities';
+import { ComponentProps } from '@fluentui/react-utilities';
+import { ComponentState } from '@fluentui/react-utilities';
+import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
-import type { Slot } from '@fluentui/react-utilities';
+import { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
@@ -31,13 +32,17 @@ export const TagButton: ForwardRefComponent<TagButtonProps>;
 export const tagButtonClassNames: SlotClassNames<TagButtonSlots>;
 
 // @public
-export type TagButtonProps = TagProps;
+export type TagButtonProps = ComponentProps<Partial<TagButtonSlots>> & Omit<TagProps, 'root' | 'dismissIcon'>;
 
 // @public (undocumented)
-export type TagButtonSlots = TagSlots;
+export type TagButtonSlots = Omit<TagSlots, 'root' | 'dismissIcon'> & {
+    root: NonNullable<Slot<'div'>>;
+    dismissButton?: Slot<'button'>;
+    content: NonNullable<ARIAButtonSlotProps<'div'>>;
+};
 
 // @public
-export type TagButtonState = TagState;
+export type TagButtonState = ComponentState<TagButtonSlots> & Omit<TagState, 'components' | 'root' | 'dismissIcon'>;
 
 // @public (undocumented)
 export const tagClassNames: SlotClassNames<TagSlots>;
@@ -53,13 +58,12 @@ export type TagProps = ComponentProps<Partial<TagSlots>> & {
 
 // @public (undocumented)
 export type TagSlots = {
-    root: NonNullable<Slot<'div'>>;
-    media: Slot<'span'>;
-    content: Slot<'div'>;
-    icon: Slot<'span'>;
+    root: NonNullable<Slot<'button'>>;
+    media?: Slot<'span'>;
+    icon?: Slot<'span'>;
     primaryText: Slot<'span'>;
-    secondaryText: Slot<'span'>;
-    dismissButton: Slot<'button'>;
+    secondaryText?: Slot<'span'>;
+    dismissIcon?: Slot<'span'>;
 };
 
 // @public

--- a/packages/react-components/react-tags/src/components/Tag/Tag.types.ts
+++ b/packages/react-components/react-tags/src/components/Tag/Tag.types.ts
@@ -9,19 +9,19 @@ export type TagContextValues = {
 };
 
 export type TagSlots = {
-  root: NonNullable<Slot<'div'>>;
+  root: NonNullable<Slot<'button'>>;
 
   /**
    * Slot for an icon or other visual element
    */
-  media: Slot<'span'>;
+  media?: Slot<'span'>;
 
   /**
    * A layout wrapper for the icon slot, the primaryText and secondaryText slots
    */
   content: Slot<'div'>;
 
-  icon: Slot<'span'>;
+  icon?: Slot<'span'>;
 
   /**
    * Main text for the Tag. Children of the root slot are automatically rendered here
@@ -31,9 +31,9 @@ export type TagSlots = {
   /**
    * Secondary text that describes or complements the main text
    */
-  secondaryText: Slot<'span'>;
+  secondaryText?: Slot<'span'>;
 
-  dismissButton: Slot<'button'>;
+  dismissIcon?: Slot<'span'>;
 };
 
 /**

--- a/packages/react-components/react-tags/src/components/Tag/Tag.types.ts
+++ b/packages/react-components/react-tags/src/components/Tag/Tag.types.ts
@@ -16,11 +16,6 @@ export type TagSlots = {
    */
   media?: Slot<'span'>;
 
-  /**
-   * A layout wrapper for the icon slot, the primaryText and secondaryText slots
-   */
-  content: Slot<'div'>;
-
   icon?: Slot<'span'>;
 
   /**

--- a/packages/react-components/react-tags/src/components/Tag/renderTag.tsx
+++ b/packages/react-components/react-tags/src/components/Tag/renderTag.tsx
@@ -23,13 +23,11 @@ export const renderTag_unstable = (state: TagState, contextValues: TagContextVal
             </AvatarContextProvider>
           )}
           {slots.icon && <slots.icon {...slotProps.icon} />}
-          {slots.primaryText && (
-            <slots.primaryText {...slotProps.primaryText}>{slotProps.root.children}</slots.primaryText>
-          )}
+          {slots.primaryText && <slots.primaryText {...slotProps.primaryText} />}
           {slots.secondaryText && <slots.secondaryText {...slotProps.secondaryText} />}
         </slots.content>
       )}
-      {slots.dismissButton && state.dismissible && <slots.dismissButton {...slotProps.dismissButton} />}
+      {slots.dismissIcon && state.dismissible && <slots.dismissIcon {...slotProps.dismissIcon} />}
     </slots.root>
   );
 };

--- a/packages/react-components/react-tags/src/components/Tag/renderTag.tsx
+++ b/packages/react-components/react-tags/src/components/Tag/renderTag.tsx
@@ -15,18 +15,14 @@ export const renderTag_unstable = (state: TagState, contextValues: TagContextVal
 
   return (
     <slots.root {...slotProps.root}>
-      {slots.content && (
-        <slots.content {...slotProps.content}>
-          {slots.media && (
-            <AvatarContextProvider value={contextValues.avatar}>
-              <slots.media {...slotProps.media} />
-            </AvatarContextProvider>
-          )}
-          {slots.icon && <slots.icon {...slotProps.icon} />}
-          {slots.primaryText && <slots.primaryText {...slotProps.primaryText} />}
-          {slots.secondaryText && <slots.secondaryText {...slotProps.secondaryText} />}
-        </slots.content>
+      {slots.media && (
+        <AvatarContextProvider value={contextValues.avatar}>
+          <slots.media {...slotProps.media} />
+        </AvatarContextProvider>
       )}
+      {slots.icon && <slots.icon {...slotProps.icon} />}
+      {slots.primaryText && <slots.primaryText {...slotProps.primaryText} />}
+      {slots.secondaryText && <slots.secondaryText {...slotProps.secondaryText} />}
       {slots.dismissIcon && state.dismissible && <slots.dismissIcon {...slotProps.dismissIcon} />}
     </slots.root>
   );

--- a/packages/react-components/react-tags/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/src/components/Tag/useTag.tsx
@@ -45,7 +45,6 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
 
     components: {
       root: 'button',
-      content: 'div',
       media: 'span',
       icon: 'span',
       primaryText: 'span',
@@ -58,7 +57,6 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
       ...props,
     }),
 
-    content: resolveShorthand(props.content, { required: true }),
     media: resolveShorthand(props.media),
     icon: resolveShorthand(props.icon),
     primaryText: resolveShorthand(props.primaryText, {

--- a/packages/react-components/react-tags/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/src/components/Tag/useTag.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import { DismissRegular, bundleIcon, DismissFilled } from '@fluentui/react-icons';
 import type { TagProps, TagState } from './Tag.types';
-import { useARIAButtonShorthand } from '@fluentui/react-aria';
 
 const tagAvatarSizeMap = {
   medium: 28,
@@ -45,16 +44,16 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
     size,
 
     components: {
-      root: 'div',
+      root: 'button',
       content: 'div',
       media: 'span',
       icon: 'span',
       primaryText: 'span',
       secondaryText: 'span',
-      dismissButton: 'button',
+      dismissIcon: 'span',
     },
 
-    root: getNativeElementProps('div', {
+    root: getNativeElementProps('button', {
       ref,
       ...props,
     }),
@@ -62,13 +61,16 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
     content: resolveShorthand(props.content, { required: true }),
     media: resolveShorthand(props.media),
     icon: resolveShorthand(props.icon),
-    primaryText: resolveShorthand(props.primaryText, { required: true }),
+    primaryText: resolveShorthand(props.primaryText, {
+      required: true,
+      defaultProps: {
+        children: props.children,
+      },
+    }),
     secondaryText: resolveShorthand(props.secondaryText),
-    dismissButton: useARIAButtonShorthand(props.dismissButton, {
+    dismissIcon: resolveShorthand(props.dismissIcon, {
       required: props.dismissible,
       defaultProps: {
-        disabled,
-        type: 'button',
         children: <DismissIcon />,
       },
     }),

--- a/packages/react-components/react-tags/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags/src/components/Tag/useTagStyles.styles.ts
@@ -6,7 +6,6 @@ import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 
 export const tagClassNames: SlotClassNames<TagSlots> = {
   root: 'fui-Tag',
-  content: 'fui-Tag__content',
   media: 'fui-Tag__media',
   icon: 'fui-Tag__icon',
   primaryText: 'fui-Tag__primaryText',
@@ -15,52 +14,19 @@ export const tagClassNames: SlotClassNames<TagSlots> = {
 };
 
 /**
- * Styles for the root slot
+ * Base styles shared by Tag/TagButton
  */
 export const useTagBaseStyles = makeStyles({
-  root: {
-    // TODO use makeResetStyle when styles are settled
-    display: 'inline-flex',
-
-    boxSizing: 'border-box',
-    height: '32px',
-    width: 'fit-content',
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-
-    backgroundColor: tokens.colorNeutralBackground3,
-    color: tokens.colorNeutralForeground2,
-    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
-  },
-  rootCircular: {
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-  },
-
   media: {
     ...shorthands.gridArea('media'),
     alignSelf: 'center',
     paddingLeft: tokens.spacingHorizontalXXS,
     paddingRight: tokens.spacingHorizontalS,
   },
-
-  content: {
-    display: 'inline-grid',
-    gridTemplateRows: '1fr auto auto 1fr',
-    gridTemplateAreas: `
-    "media .        "
-    "media primary  "
-    "media secondary"
-    "media .        "
-    `,
-    paddingRight: tokens.spacingHorizontalS,
-  },
-  textOnlyContent: {
-    paddingLeft: tokens.spacingHorizontalS,
-  },
-
   icon: {
+    ...shorthands.gridArea('media'),
     display: 'flex',
     alignSelf: 'center',
-    ...shorthands.gridArea('media'),
     paddingLeft: '6px',
     paddingRight: '2px',
   },
@@ -82,16 +48,6 @@ export const useTagBaseStyles = makeStyles({
     paddingRight: tokens.spacingHorizontalXXS,
     ...typographyStyles.caption2,
   },
-
-  dismissIcon: {
-    display: 'flex',
-    alignItems: 'center',
-    fontSize: '20px',
-    paddingLeft: '2px',
-    paddingRight: '6px',
-  },
-
-  // TODO add additional classes for fill/outline appearance, different sizes, and state
 });
 
 export const useResetButtonStyles = makeStyles({
@@ -109,8 +65,27 @@ export const useResetButtonStyles = makeStyles({
 });
 
 const useTagStyles = makeStyles({
-  rootButton: {
+  root: {
+    // TODO use makeResetStyle when styles are settled
+    display: 'inline-grid',
     alignItems: 'center',
+    gridTemplateRows: '1fr auto auto 1fr',
+    gridTemplateAreas: `
+    "media .         dismissIcon"
+    "media primary   dismissIcon"
+    "media secondary dismissIcon"
+    "media .         dismissIcon"
+    `,
+
+    boxSizing: 'border-box',
+    height: '32px',
+    width: 'fit-content',
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+
+    backgroundColor: tokens.colorNeutralBackground3,
+    color: tokens.colorNeutralForeground2,
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+
     ...createCustomFocusIndicatorStyle(
       {
         ...shorthands.borderRadius(tokens.borderRadiusMedium),
@@ -119,14 +94,29 @@ const useTagStyles = makeStyles({
       { enableOutline: true },
     ),
   },
-  rootButtonCircular: {
+  rootCircular: {
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
     ...createCustomFocusIndicatorStyle({
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
     }),
   },
-  dismissibleContent: {
-    paddingRight: '2px',
+  rootWithoutMedia: {
+    paddingLeft: tokens.spacingHorizontalS,
   },
+  rootWithoutDismiss: {
+    paddingRight: tokens.spacingHorizontalS,
+  },
+
+  dismissIcon: {
+    ...shorthands.gridArea('dismissIcon'),
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '20px',
+    paddingLeft: '2px',
+    paddingRight: '6px',
+  },
+
+  // TODO add additional classes for fill/outline appearance, different sizes, and state
 });
 /**
  * Apply styling to the Tag slots based on the state
@@ -139,22 +129,14 @@ export const useTagStyles_unstable = (state: TagState): TagState => {
   state.root.className = mergeClasses(
     tagClassNames.root,
     resetButtonStyles.resetButton,
-    baseStyles.root,
-    styles.rootButton,
-    state.shape === 'circular' && baseStyles.rootCircular,
-    state.shape === 'circular' && styles.rootButtonCircular,
+
+    styles.root,
+    state.shape === 'circular' && styles.rootCircular,
+    !state.media && !state.icon && styles.rootWithoutMedia,
+    !state.dismissIcon && styles.rootWithoutDismiss,
+
     state.root.className,
   );
-  if (state.content) {
-    state.content.className = mergeClasses(
-      tagClassNames.content,
-      baseStyles.content,
-      !state.media && !state.icon && baseStyles.textOnlyContent,
-
-      state.dismissIcon && styles.dismissibleContent,
-      state.content.className,
-    );
-  }
 
   if (state.media) {
     state.media.className = mergeClasses(tagClassNames.media, baseStyles.media, state.media.className);
@@ -180,7 +162,7 @@ export const useTagStyles_unstable = (state: TagState): TagState => {
   if (state.dismissIcon) {
     state.dismissIcon.className = mergeClasses(
       tagClassNames.dismissIcon,
-      baseStyles.dismissIcon,
+      styles.dismissIcon,
       state.dismissIcon.className,
     );
   }

--- a/packages/react-components/react-tags/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags/src/components/Tag/useTagStyles.styles.ts
@@ -11,7 +11,7 @@ export const tagClassNames: SlotClassNames<TagSlots> = {
   icon: 'fui-Tag__icon',
   primaryText: 'fui-Tag__primaryText',
   secondaryText: 'fui-Tag__secondaryText',
-  dismissButton: 'fui-Tag__dismissButton',
+  dismissIcon: 'fui-Tag__dismissIcon',
 };
 
 /**
@@ -21,6 +21,8 @@ export const useTagBaseStyles = makeStyles({
   root: {
     // TODO use makeResetStyle when styles are settled
     display: 'inline-flex',
+
+    boxSizing: 'border-box',
     height: '32px',
     width: 'fit-content',
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
@@ -81,8 +83,19 @@ export const useTagBaseStyles = makeStyles({
     ...typographyStyles.caption2,
   },
 
+  dismissIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '20px',
+    paddingLeft: '2px',
+    paddingRight: '6px',
+  },
+
+  // TODO add additional classes for fill/outline appearance, different sizes, and state
+});
+
+export const useResetButtonStyles = makeStyles({
   resetButton: {
-    boxSizing: 'content-box',
     color: 'inherit',
     fontFamily: 'inherit',
     lineHeight: 'normal',
@@ -91,15 +104,13 @@ export const useTagBaseStyles = makeStyles({
     ...shorthands.borderStyle('none'),
     appearance: 'button',
     textAlign: 'unset',
-  },
-  dismissButton: {
-    ...shorthands.padding('0px'),
     backgroundColor: 'transparent',
-    width: '20px',
-    display: 'flex',
-    alignItems: 'center',
-    fontSize: '20px',
+  },
+});
 
+const useTagStyles = makeStyles({
+  rootButton: {
+    alignItems: 'center',
     ...createCustomFocusIndicatorStyle(
       {
         ...shorthands.borderRadius(tokens.borderRadiusMedium),
@@ -108,30 +119,30 @@ export const useTagBaseStyles = makeStyles({
       { enableOutline: true },
     ),
   },
-
-  // TODO add additional classes for fill/outline appearance, different sizes, and state
-});
-
-const useTagStyles = makeStyles({
+  rootButtonCircular: {
+    ...createCustomFocusIndicatorStyle({
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    }),
+  },
   dismissibleContent: {
     paddingRight: '2px',
   },
-  dismissButton: {
-    marginRight: '6px',
-  },
 });
-
 /**
  * Apply styling to the Tag slots based on the state
  */
 export const useTagStyles_unstable = (state: TagState): TagState => {
   const baseStyles = useTagBaseStyles();
+  const resetButtonStyles = useResetButtonStyles();
   const styles = useTagStyles();
 
   state.root.className = mergeClasses(
     tagClassNames.root,
+    resetButtonStyles.resetButton,
     baseStyles.root,
+    styles.rootButton,
     state.shape === 'circular' && baseStyles.rootCircular,
+    state.shape === 'circular' && styles.rootButtonCircular,
     state.root.className,
   );
   if (state.content) {
@@ -140,7 +151,7 @@ export const useTagStyles_unstable = (state: TagState): TagState => {
       baseStyles.content,
       !state.media && !state.icon && baseStyles.textOnlyContent,
 
-      state.dismissButton && styles.dismissibleContent,
+      state.dismissIcon && styles.dismissibleContent,
       state.content.className,
     );
   }
@@ -166,14 +177,11 @@ export const useTagStyles_unstable = (state: TagState): TagState => {
       state.secondaryText.className,
     );
   }
-  if (state.dismissButton) {
-    state.dismissButton.className = mergeClasses(
-      tagClassNames.dismissButton,
-      baseStyles.resetButton,
-      baseStyles.dismissButton,
-
-      styles.dismissButton,
-      state.dismissButton.className,
+  if (state.dismissIcon) {
+    state.dismissIcon.className = mergeClasses(
+      tagClassNames.dismissIcon,
+      baseStyles.dismissIcon,
+      state.dismissIcon.className,
     );
   }
 

--- a/packages/react-components/react-tags/src/components/TagButton/TagButton.types.ts
+++ b/packages/react-components/react-tags/src/components/TagButton/TagButton.types.ts
@@ -1,15 +1,37 @@
-import { TagContextValues, TagProps, TagSlots, TagState } from '../Tag/index';
+import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { TagContextValues, TagProps, TagSlots } from '../Tag/index';
+import { AvatarSize, AvatarShape } from '@fluentui/react-avatar';
+import { ARIAButtonSlotProps } from '../../../../react-aria/src/index';
 
 export type TagButtonContextValues = TagContextValues;
 
-export type TagButtonSlots = TagSlots;
+export type TagButtonSlots = Omit<TagSlots, 'root' | 'dismissIcon' | 'content'> & {
+  root: NonNullable<Slot<'div'>>;
+  dismissButton?: Slot<'button'>;
+  content: NonNullable<ARIAButtonSlotProps<'div'>>;
+};
 
+// TODO amber common props type shared between Tag and TagButton
 /**
  * TagButton Props
  */
-export type TagButtonProps = TagProps;
+export type TagButtonProps = ComponentProps<Partial<TagButtonSlots>> & {
+  appearance?: 'filled-darker' | 'filled-lighter' | 'tint' | 'outline';
+  // TODO implement tag checked state
+  // checked?: boolean;
+  disabled?: boolean;
+  dismissible?: boolean;
+  shape?: 'rounded' | 'circular';
+  size?: 'extra-small' | 'small' | 'medium';
+};
 
 /**
  * State used in rendering TagButton
  */
-export type TagButtonState = TagState;
+export type TagButtonState = ComponentState<TagButtonSlots> &
+  Required<
+    Pick<TagProps, 'appearance' | 'disabled' | 'dismissible' | 'shape' | 'size'> & {
+      avatarSize: AvatarSize | undefined;
+      avatarShape: AvatarShape | undefined;
+    }
+  >;

--- a/packages/react-components/react-tags/src/components/TagButton/TagButton.types.ts
+++ b/packages/react-components/react-tags/src/components/TagButton/TagButton.types.ts
@@ -1,37 +1,21 @@
 import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { TagContextValues, TagProps, TagSlots } from '../Tag/index';
-import { AvatarSize, AvatarShape } from '@fluentui/react-avatar';
+import { TagContextValues, TagProps, TagSlots, TagState } from '../Tag/index';
 import { ARIAButtonSlotProps } from '../../../../react-aria/src/index';
 
 export type TagButtonContextValues = TagContextValues;
 
-export type TagButtonSlots = Omit<TagSlots, 'root' | 'dismissIcon' | 'content'> & {
+export type TagButtonSlots = Omit<TagSlots, 'root' | 'dismissIcon'> & {
   root: NonNullable<Slot<'div'>>;
   dismissButton?: Slot<'button'>;
   content: NonNullable<ARIAButtonSlotProps<'div'>>;
 };
 
-// TODO amber common props type shared between Tag and TagButton
 /**
  * TagButton Props
  */
-export type TagButtonProps = ComponentProps<Partial<TagButtonSlots>> & {
-  appearance?: 'filled-darker' | 'filled-lighter' | 'tint' | 'outline';
-  // TODO implement tag checked state
-  // checked?: boolean;
-  disabled?: boolean;
-  dismissible?: boolean;
-  shape?: 'rounded' | 'circular';
-  size?: 'extra-small' | 'small' | 'medium';
-};
+export type TagButtonProps = ComponentProps<Partial<TagButtonSlots>> & Omit<TagProps, 'root' | 'dismissIcon'>;
 
 /**
  * State used in rendering TagButton
  */
-export type TagButtonState = ComponentState<TagButtonSlots> &
-  Required<
-    Pick<TagProps, 'appearance' | 'disabled' | 'dismissible' | 'shape' | 'size'> & {
-      avatarSize: AvatarSize | undefined;
-      avatarShape: AvatarShape | undefined;
-    }
-  >;
+export type TagButtonState = ComponentState<TagButtonSlots> & Omit<TagState, 'components' | 'root' | 'dismissIcon'>;

--- a/packages/react-components/react-tags/src/components/TagButton/useTagButton.tsx
+++ b/packages/react-components/react-tags/src/components/TagButton/useTagButton.tsx
@@ -1,7 +1,22 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { DismissRegular, bundleIcon, DismissFilled } from '@fluentui/react-icons';
 import type { TagButtonProps, TagButtonState } from './TagButton.types';
-import { useTag_unstable } from '../Tag/index';
+import { useARIAButtonShorthand } from '@fluentui/react-aria';
+
+// TODO: do we wanna share this?
+const tagButtonAvatarSizeMap = {
+  medium: 28,
+  small: 24,
+  'extra-small': 20,
+} as const;
+
+const tagButtonAvatarShapeMap = {
+  rounded: 'square',
+  circular: 'circular',
+} as const;
+
+const DismissIcon = bundleIcon(DismissFilled, DismissRegular);
 
 /**
  * Create the state required to render TagButton.
@@ -13,6 +28,57 @@ import { useTag_unstable } from '../Tag/index';
  * @param ref - reference to root HTMLElement of TagButton
  */
 export const useTagButton_unstable = (props: TagButtonProps, ref: React.Ref<HTMLElement>): TagButtonState => {
-  const content = resolveShorthand(props.content, { required: true, defaultProps: { tabIndex: 0 } });
-  return useTag_unstable({ ...props, content }, ref);
+  const {
+    appearance = 'filled-lighter',
+    disabled = false,
+    dismissible = false,
+    shape = 'rounded',
+    size = 'medium',
+  } = props;
+
+  return {
+    appearance,
+    avatarShape: tagButtonAvatarShapeMap[shape],
+    avatarSize: tagButtonAvatarSizeMap[size],
+    disabled,
+    dismissible,
+    shape,
+    size,
+
+    components: {
+      root: 'div',
+      content: 'div',
+      media: 'span',
+      icon: 'span',
+      primaryText: 'span',
+      secondaryText: 'span',
+      dismissButton: 'button',
+    },
+
+    root: getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+
+    content: useARIAButtonShorthand(props.content, {
+      required: true,
+      defaultProps: {
+        disabled,
+        tabIndex: 0,
+        type: 'button',
+      },
+    }),
+    media: resolveShorthand(props.media),
+    icon: resolveShorthand(props.icon),
+    primaryText: resolveShorthand(props.primaryText, { required: true }),
+    secondaryText: resolveShorthand(props.secondaryText),
+    dismissButton: useARIAButtonShorthand(props.dismissButton, {
+      required: props.dismissible,
+      defaultProps: {
+        disabled,
+        type: 'button',
+        children: <DismissIcon />,
+      },
+    }),
+  };
 };

--- a/packages/react-components/react-tags/src/components/TagButton/useTagButton.tsx
+++ b/packages/react-components/react-tags/src/components/TagButton/useTagButton.tsx
@@ -4,7 +4,6 @@ import { DismissRegular, bundleIcon, DismissFilled } from '@fluentui/react-icons
 import type { TagButtonProps, TagButtonState } from './TagButton.types';
 import { useARIAButtonShorthand } from '@fluentui/react-aria';
 
-// TODO: do we wanna share this?
 const tagButtonAvatarSizeMap = {
   medium: 28,
   small: 24,

--- a/packages/react-components/react-tags/src/components/TagButton/useTagButtonStyles.styles.ts
+++ b/packages/react-components/react-tags/src/components/TagButton/useTagButtonStyles.styles.ts
@@ -15,11 +15,33 @@ export const tagButtonClassNames: SlotClassNames<TagButtonSlots> = {
   dismissButton: 'fui-TagButton__dismissButton',
 };
 
-/**
- * Styles for the root slot
- */
 const useStyles = makeStyles({
+  root: {
+    // TODO use makeResetStyle when styles are settled
+    display: 'inline-flex',
+
+    boxSizing: 'border-box',
+    height: '32px',
+    width: 'fit-content',
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+
+    backgroundColor: tokens.colorNeutralBackground3,
+    color: tokens.colorNeutralForeground2,
+    ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+  },
+  rootCircular: shorthands.borderRadius(tokens.borderRadiusCircular),
+
   content: {
+    display: 'inline-grid',
+    gridTemplateRows: '1fr auto auto 1fr',
+    gridTemplateAreas: `
+    "media .        "
+    "media primary  "
+    "media secondary"
+    "media .        "
+    `,
+    paddingRight: tokens.spacingHorizontalS,
+
     ...createCustomFocusIndicatorStyle(
       {
         ...shorthands.borderRadius(tokens.borderRadiusMedium),
@@ -29,18 +51,24 @@ const useStyles = makeStyles({
       { enableOutline: true },
     ),
   },
-
-  circularContent: createCustomFocusIndicatorStyle(shorthands.borderRadius(tokens.borderRadiusCircular), {
-    enableOutline: true,
-  }),
+  circularContent: createCustomFocusIndicatorStyle(shorthands.borderRadius(tokens.borderRadiusCircular)),
+  contentWithoutMedia: {
+    paddingLeft: tokens.spacingHorizontalS,
+  },
   dismissibleContent: createCustomFocusIndicatorStyle({
     borderTopRightRadius: tokens.borderRadiusNone,
     borderBottomRightRadius: tokens.borderRadiusNone,
   }),
 
   dismissButton: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '20px',
     paddingLeft: '6px',
+    paddingRight: '6px',
+
     ...shorthands.borderLeft(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke1),
+
     borderTopLeftRadius: tokens.borderRadiusNone,
     borderBottomLeftRadius: tokens.borderRadiusNone,
     ...createCustomFocusIndicatorStyle({
@@ -69,18 +97,17 @@ export const useTagButtonStyles_unstable = (state: TagButtonState): TagButtonSta
 
   state.root.className = mergeClasses(
     tagButtonClassNames.root,
-    baseStyles.root,
-    state.shape === 'circular' && baseStyles.rootCircular,
+    styles.root,
+    state.shape === 'circular' && styles.rootCircular,
     state.root.className,
   );
   if (state.content) {
     state.content.className = mergeClasses(
       tagButtonClassNames.content,
-      baseStyles.content,
-      !state.media && !state.icon && baseStyles.textOnlyContent,
 
       styles.content,
       state.shape === 'circular' && styles.circularContent,
+      !state.media && !state.icon && styles.contentWithoutMedia,
       state.dismissButton && styles.dismissibleContent,
 
       state.content.className,
@@ -112,7 +139,6 @@ export const useTagButtonStyles_unstable = (state: TagButtonState): TagButtonSta
     state.dismissButton.className = mergeClasses(
       tagButtonClassNames.dismissButton,
       resetButtonStyles.resetButton,
-      baseStyles.dismissIcon,
 
       styles.dismissButton,
       state.shape === 'circular' && styles.dismissButtonCircular,

--- a/packages/react-components/react-tags/src/components/TagButton/useTagButtonStyles.styles.ts
+++ b/packages/react-components/react-tags/src/components/TagButton/useTagButtonStyles.styles.ts
@@ -3,7 +3,7 @@ import type { TagButtonSlots, TagButtonState } from './TagButton.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
-import { useTagBaseStyles } from '../Tag/index';
+import { useResetButtonStyles, useTagBaseStyles } from '../Tag/index';
 
 export const tagButtonClassNames: SlotClassNames<TagButtonSlots> = {
   root: 'fui-TagButton',
@@ -20,11 +20,11 @@ export const tagButtonClassNames: SlotClassNames<TagButtonSlots> = {
  */
 const useStyles = makeStyles({
   content: {
-    position: 'relative',
     ...createCustomFocusIndicatorStyle(
       {
         ...shorthands.borderRadius(tokens.borderRadiusMedium),
         ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
+        zIndex: 1,
       },
       { enableOutline: true },
     ),
@@ -33,21 +33,22 @@ const useStyles = makeStyles({
   circularContent: createCustomFocusIndicatorStyle(shorthands.borderRadius(tokens.borderRadiusCircular), {
     enableOutline: true,
   }),
-  dismissibleContent: {
-    ...createCustomFocusIndicatorStyle({
-      borderTopRightRadius: tokens.borderRadiusNone,
-      borderBottomRightRadius: tokens.borderRadiusNone,
-    }),
-  },
+  dismissibleContent: createCustomFocusIndicatorStyle({
+    borderTopRightRadius: tokens.borderRadiusNone,
+    borderBottomRightRadius: tokens.borderRadiusNone,
+  }),
 
   dismissButton: {
-    ...shorthands.padding('0px', '6px'),
+    paddingLeft: '6px',
     ...shorthands.borderLeft(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke1),
     borderTopLeftRadius: tokens.borderRadiusNone,
     borderBottomLeftRadius: tokens.borderRadiusNone,
     ...createCustomFocusIndicatorStyle({
+      ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
       borderTopLeftRadius: tokens.borderRadiusNone,
       borderBottomLeftRadius: tokens.borderRadiusNone,
+      borderTopRightRadius: tokens.borderRadiusMedium,
+      borderBottomRightRadius: tokens.borderRadiusMedium,
     }),
   },
   dismissButtonCircular: createCustomFocusIndicatorStyle({
@@ -63,6 +64,7 @@ const useStyles = makeStyles({
  */
 export const useTagButtonStyles_unstable = (state: TagButtonState): TagButtonState => {
   const baseStyles = useTagBaseStyles();
+  const resetButtonStyles = useResetButtonStyles();
   const styles = useStyles();
 
   state.root.className = mergeClasses(
@@ -109,8 +111,8 @@ export const useTagButtonStyles_unstable = (state: TagButtonState): TagButtonSta
   if (state.dismissButton) {
     state.dismissButton.className = mergeClasses(
       tagButtonClassNames.dismissButton,
-      baseStyles.resetButton,
-      baseStyles.dismissButton,
+      resetButtonStyles.resetButton,
+      baseStyles.dismissIcon,
 
       styles.dismissButton,
       state.shape === 'circular' && styles.dismissButtonCircular,

--- a/packages/react-components/react-tags/src/utils/useTagContextValues.ts
+++ b/packages/react-components/react-tags/src/utils/useTagContextValues.ts
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { TagContextValues, TagState } from '../components/Tag/index';
+import { TagButtonContextValues, TagButtonState } from '../TagButton';
 
-export function useTagContextValues_unstable(state: TagState): TagContextValues {
+export function useTagContextValues_unstable(
+  state: TagState | TagButtonState,
+): TagContextValues | TagButtonContextValues {
   const { avatarSize, avatarShape } = state;
 
   const avatar = React.useMemo(

--- a/packages/react-components/react-tags/src/utils/useTagContextValues.ts
+++ b/packages/react-components/react-tags/src/utils/useTagContextValues.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { TagContextValues, TagState } from '../components/Tag/index';
-import { TagButtonContextValues, TagButtonState } from '../TagButton';
+import { TagButtonContextValues } from '../TagButton';
 
 export function useTagContextValues_unstable(
-  state: Pick<TagState, 'avatarSize' | 'avatarShape'>
+  state: Pick<TagState, 'avatarSize' | 'avatarShape'>,
 ): TagContextValues | TagButtonContextValues {
   const { avatarSize, avatarShape } = state;
 

--- a/packages/react-components/react-tags/src/utils/useTagContextValues.ts
+++ b/packages/react-components/react-tags/src/utils/useTagContextValues.ts
@@ -3,7 +3,7 @@ import { TagContextValues, TagState } from '../components/Tag/index';
 import { TagButtonContextValues, TagButtonState } from '../TagButton';
 
 export function useTagContextValues_unstable(
-  state: TagState | TagButtonState,
+  state: Pick<TagState, 'avatarSize' | 'avatarShape'>
 ): TagContextValues | TagButtonContextValues {
   const { avatarSize, avatarShape } = state;
 

--- a/packages/react-components/react-tags/stories/Tag/index.stories.tsx
+++ b/packages/react-components/react-tags/stories/Tag/index.stories.tsx
@@ -11,7 +11,7 @@ export { Dismiss } from './TagDismiss.stories';
 export { Shape } from './TagShape.stories';
 
 export default {
-  title: 'Preview Components/Tag',
+  title: 'Preview Components/Tag/Tag',
   component: Tag,
   parameters: {
     docs: {

--- a/packages/react-components/react-tags/stories/TagButton/index.stories.tsx
+++ b/packages/react-components/react-tags/stories/TagButton/index.stories.tsx
@@ -11,7 +11,7 @@ export { Dismiss } from './TagButtonDismiss.stories';
 export { Shape } from './TagButtonShape.stories';
 
 export default {
-  title: 'Preview Components/TagButton',
+  title: 'Preview Components/Tag/TagButton',
   component: TagButton,
   parameters: {
     docs: {


### PR DESCRIPTION
### Description

Before this PR, basic Tag has `dismissButton` slot to dismiss itself. This PR make the Tag itself a button that does dismiss, and changes `dismissButton` slot to `dismissIcon`. And this PR keeps TagButton unchanged - it's still two buttons.

#### before
```tsx
root: NonNullable<Slot<'div'>>;
dismissButton?: Slot<'button'>;
```
<img width="151" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/3d9d05d6-0ee0-4da1-948c-d6b8e33eb33a">

#### after
```tsx
root: NonNullable<Slot<'button'>>;
dismissIcon?: Slot<'span'>;
```
<img width="169" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/1da76f5d-49f8-41e8-a14e-0501fdebd17f">


- Why this change:
In fluent v0 Pill, the focus ring is around the entire Pill. We would want the same for v9 basic Tag. Also this is useful for user with magnifier that tracks focus.

- What does this mean for #27794:
I will keep two controls Tag/TagButton instead of one Tag, and close PR 27794. Because basic Tag and TagButton have different slots. The differences are:
    1. Basic Tag has dismiss icon (`Slot<span>`), while TagButton has dismiss button (`Slot<button>`)
    2. TagButton has `content` slot that wraps around media/primary and secondary text and act as first tab stop. Basic Tag does not need `content` slot.
