### PR TITLE
Virtualizer: ScrollTo hooks & callbacks

### DIFF
--- a/change/@fluentui-react-components-bdaf87d0-783b-403a-a2fe-d4d1f43890c4.json
+++ b/change/@fluentui-react-components-bdaf87d0-783b-403a-a2fe-d4d1f43890c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "[FEATURE] Imperative scrolling functionality for react-virtualizer",
+  "packageName": "@fluentui/react-components",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-132ffdc3-4c38-49e6-a75e-a019828a0ec8.json
+++ b/change/@fluentui-react-virtualizer-132ffdc3-4c38-49e6-a75e-a019828a0ec8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feature: Add scrollTo index hook and callbacks, isScrolling flag",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.unstable.api.md
+++ b/packages/react-components/react-components/etc/react-components.unstable.api.md
@@ -80,6 +80,11 @@ import { renderVirtualizer_unstable } from '@fluentui/react-virtualizer';
 import { renderVirtualizerScrollView_unstable } from '@fluentui/react-virtualizer';
 import { renderVirtualizerScrollViewDynamic_unstable } from '@fluentui/react-virtualizer';
 import { ResizeCallbackWithRef } from '@fluentui/react-virtualizer';
+import { ScrollToInterface } from '@fluentui/react-virtualizer';
+import { scrollToItemDynamic } from '@fluentui/react-virtualizer';
+import { ScrollToItemDynamicParams } from '@fluentui/react-virtualizer';
+import { scrollToItemStatic } from '@fluentui/react-virtualizer';
+import { ScrollToItemStaticParams } from '@fluentui/react-virtualizer';
 import { Tree } from '@fluentui/react-tree';
 import { treeClassNames } from '@fluentui/react-tree';
 import { TreeContextValue } from '@fluentui/react-tree';
@@ -330,6 +335,16 @@ export { renderVirtualizerScrollView_unstable }
 export { renderVirtualizerScrollViewDynamic_unstable }
 
 export { ResizeCallbackWithRef }
+
+export { ScrollToInterface }
+
+export { scrollToItemDynamic }
+
+export { ScrollToItemDynamicParams }
+
+export { scrollToItemStatic }
+
+export { ScrollToItemStaticParams }
 
 export { Tree }
 

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -52,7 +52,10 @@ export {
   useVirtualizerScrollViewDynamic_unstable,
   renderVirtualizerScrollViewDynamic_unstable,
   useVirtualizerScrollViewDynamicStyles_unstable,
+  scrollToItemDynamic,
+  scrollToItemStatic,
 } from '@fluentui/react-virtualizer';
+
 export type {
   VirtualizerProps,
   VirtualizerState,
@@ -68,6 +71,9 @@ export type {
   VirtualizerMeasureDynamicProps,
   VirtualizerMeasureProps,
   ResizeCallbackWithRef,
+  ScrollToInterface,
+  ScrollToItemDynamicParams,
+  ScrollToItemStaticParams,
 } from '@fluentui/react-virtualizer';
 
 export {

--- a/packages/react-components/react-virtualizer/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/etc/react-virtualizer.api.md
@@ -4,14 +4,15 @@
 
 ```ts
 
-import { ComponentProps } from '@fluentui/react-utilities';
-import { ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
 import type { Dispatch } from 'react';
 import type { FC } from 'react';
 import { MutableRefObject } from 'react';
 import * as React_2 from 'react';
+import type { RefObject } from 'react';
 import type { SetStateAction } from 'react';
-import { Slot } from '@fluentui/react-utilities';
+import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public (undocumented)
@@ -28,6 +29,39 @@ export interface ResizeCallbackWithRef {
     // (undocumented)
     (entries: ResizeObserverEntry[], observer: ResizeObserver, scrollRef?: MutableRefObject<HTMLElement | null>): void;
 }
+
+// @public (undocumented)
+export type ScrollToInterface = {
+    scrollTo: (index: number, behavior?: ScrollBehavior, callback?: (index: number) => void) => void;
+};
+
+// @public (undocumented)
+export const scrollToItemDynamic: (params: ScrollToItemDynamicParams) => void;
+
+// @public (undocumented)
+export type ScrollToItemDynamicParams = {
+    index: number;
+    itemSizes: RefObject<number[]>;
+    totalSize: number;
+    scrollViewRef: RefObject<HTMLDivElement>;
+    axis?: 'horizontal' | 'vertical';
+    reversed?: boolean;
+    behavior?: ScrollBehavior;
+};
+
+// @public (undocumented)
+export const scrollToItemStatic: (params: ScrollToItemStaticParams) => void;
+
+// @public (undocumented)
+export type ScrollToItemStaticParams = {
+    index: number;
+    itemSize: number;
+    totalItems: number;
+    scrollViewRef: RefObject<HTMLDivElement>;
+    axis?: 'horizontal' | 'vertical';
+    reversed?: boolean;
+    behavior?: ScrollBehavior;
+};
 
 // @public
 export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtualizerProps: VirtualizerMeasureDynamicProps) => {
@@ -80,7 +114,7 @@ export const useVirtualizerStyles_unstable: (state: VirtualizerState) => Virtual
 export const Virtualizer: FC<VirtualizerProps>;
 
 // @public (undocumented)
-export type VirtualizerChildRenderFunction = (index: number) => React_2.ReactNode;
+export type VirtualizerChildRenderFunction = (index: number, isScrolling: boolean) => React_2.ReactNode;
 
 // @public (undocumented)
 export const virtualizerClassNames: SlotClassNames<VirtualizerSlots>;
@@ -93,6 +127,13 @@ export type VirtualizerContextProps = {
 
 // @public (undocumented)
 export const VirtualizerContextProvider: React_2.Provider<VirtualizerContextProps>;
+
+// @public (undocumented)
+export type VirtualizerDataRef = {
+    progressiveSizes: RefObject<number[]>;
+    nodeSizes: RefObject<number[]>;
+    setFlaggedIndex: (index: number | null) => void;
+};
 
 // @public (undocumented)
 export type VirtualizerMeasureDynamicProps = {
@@ -125,11 +166,12 @@ export const VirtualizerScrollViewDynamic: React_2.FC<VirtualizerScrollViewDynam
 export const virtualizerScrollViewDynamicClassNames: SlotClassNames<VirtualizerScrollViewDynamicSlots>;
 
 // @public (undocumented)
-export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children'>> & {
+export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex'>> & {
     itemSize: number;
     getItemSize: (index: number) => number;
     numItems: number;
     children: VirtualizerChildRenderFunction;
+    imperativeRef?: RefObject<ScrollToInterface>;
 };
 
 // @public (undocumented)
@@ -139,10 +181,11 @@ export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;
 export type VirtualizerScrollViewDynamicState = ComponentState<VirtualizerScrollViewDynamicSlots> & VirtualizerConfigState;
 
 // @public (undocumented)
-export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrollViewSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children'>> & {
+export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrollViewSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex' | 'imperativeVirtualizerRef'>> & {
     itemSize: number;
     numItems: number;
     children: VirtualizerChildRenderFunction;
+    imperativeRef?: RefObject<ScrollToInterface>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/Virtualizer.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { VirtualizerContextProps } from '../../Utilities';
+import type { VirtualizerContextProps } from '../../Utilities';
+import type { RefObject, MutableRefObject } from 'react';
 
 export type VirtualizerSlots = {
   /**
@@ -62,7 +63,13 @@ export type VirtualizerState = ComponentState<VirtualizerSlots> & VirtualizerCon
 
 // Virtualizer render function to procedurally generate children elements as rows or columns via index.
 // Q: Use generic typing and passing through object data or a simple index system?
-export type VirtualizerChildRenderFunction = (index: number) => React.ReactNode;
+export type VirtualizerChildRenderFunction = (index: number, isScrolling: boolean) => React.ReactNode;
+
+export type VirtualizerDataRef = {
+  progressiveSizes: RefObject<number[]>;
+  nodeSizes: RefObject<number[]>;
+  setFlaggedIndex: (index: number | null) => void;
+};
 
 export type VirtualizerConfigProps = {
   /**
@@ -139,6 +146,21 @@ export type VirtualizerConfigProps = {
    * Virtualizer context can be passed as a prop for extended class use
    */
   virtualizerContext?: VirtualizerContextProps;
+
+  /**
+   * Callback for notifying when a flagged index has been rendered
+   */
+  onRenderedFlaggedIndex?: (index: number) => void;
+
+  /*
+   * Callback for notifying when a flagged index has been rendered
+   */
+  flaggedIndex?: MutableRefObject<number | null>;
+
+  /**
+   * Imperative ref contains our scrollTo index functionality for user control.
+   */
+  imperativeVirtualizerRef?: RefObject<VirtualizerDataRef>;
 };
 
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/renderVirtualizer.tsx
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/renderVirtualizer.tsx
@@ -2,10 +2,11 @@
 /** @jsx createElement */
 
 import * as React from 'react';
+import type { VirtualizerSlots, VirtualizerState } from './Virtualizer.types';
+import type { ReactNode } from 'react';
+
 import { createElement } from '@fluentui/react-jsx-runtime';
 import { getSlotsNext } from '@fluentui/react-utilities';
-import { VirtualizerSlots, VirtualizerState } from './Virtualizer.types';
-import { ReactNode } from 'react';
 
 export const renderVirtualizer_unstable = (state: VirtualizerState) => {
   const { slots, slotProps } = getSlotsNext<VirtualizerSlots>(state);

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/VirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/VirtualizerScrollView.ts
@@ -1,4 +1,4 @@
-import { VirtualizerScrollViewProps } from './VirtualizerScrollView.types';
+import type { VirtualizerScrollViewProps } from './VirtualizerScrollView.types';
 import { useVirtualizerScrollView_unstable } from './useVirtualizerScrollView';
 import { renderVirtualizerScrollView_unstable } from './renderVirtualizerScrollView';
 import { useVirtualizerScrollViewStyles_unstable } from './useVirtualizerScrollViewStyles.styles';

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
@@ -1,10 +1,12 @@
-import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import {
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type {
   VirtualizerSlots,
   VirtualizerConfigProps,
   VirtualizerConfigState,
   VirtualizerChildRenderFunction,
 } from '../Virtualizer/Virtualizer.types';
+import type { ScrollToInterface } from '../../Utilities';
+import type { RefObject } from 'react';
 
 export type VirtualizerScrollViewSlots = VirtualizerSlots & {
   /**
@@ -14,7 +16,12 @@ export type VirtualizerScrollViewSlots = VirtualizerSlots & {
 };
 
 export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrollViewSlots>> &
-  Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children'>> & {
+  Partial<
+    Omit<
+      VirtualizerConfigProps,
+      'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex' | 'imperativeVirtualizerRef'
+    >
+  > & {
     /**
      * Virtualizer item size in pixels - static.
      * Axis: 'vertical' = Height
@@ -31,6 +38,10 @@ export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrol
      * Will act as a row or column indexer depending on Virtualizer settings.
      */
     children: VirtualizerChildRenderFunction;
+    /**
+     * Imperative ref contains our scrollTo index functionality for user control.
+     */
+    imperativeRef?: RefObject<ScrollToInterface>;
   };
 
 export type VirtualizerScrollViewState = ComponentState<VirtualizerScrollViewSlots> & VirtualizerConfigState;

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
@@ -3,8 +3,9 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
+import type { VirtualizerScrollViewSlots, VirtualizerScrollViewState } from './VirtualizerScrollView.types';
+
 import { getSlotsNext } from '@fluentui/react-utilities';
-import { VirtualizerScrollViewSlots, VirtualizerScrollViewState } from './VirtualizerScrollView.types';
 import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
 export const renderVirtualizerScrollView_unstable = (state: VirtualizerScrollViewState) => {

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -1,23 +1,59 @@
 import * as React from 'react';
 import { resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
 import { useVirtualizer_unstable } from '../Virtualizer/useVirtualizer';
-import { VirtualizerScrollViewProps, VirtualizerScrollViewState } from './VirtualizerScrollView.types';
+import type { VirtualizerScrollViewProps, VirtualizerScrollViewState } from './VirtualizerScrollView.types';
 import { useStaticVirtualizerMeasure } from '../../Hooks';
+import { useImperativeHandle } from 'react';
+import { scrollToItemStatic } from '../../Utilities';
+import type { VirtualizerDataRef } from '../Virtualizer/Virtualizer.types';
 
 export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewProps): VirtualizerScrollViewState {
+  const { imperativeRef, itemSize, numItems, axis = 'vertical', reversed } = props;
   const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
     defaultItemSize: props.itemSize,
     direction: props.axis ?? 'vertical',
   });
 
-  const iScrollRef = useMergedRefs(React.useRef<HTMLDivElement>(null), scrollRef);
+  const scrollViewRef = useMergedRefs(React.useRef<HTMLDivElement>(null), scrollRef) as React.RefObject<HTMLDivElement>;
+  const imperativeVirtualizerRef = React.useRef<VirtualizerDataRef | null>(null);
+  const scrollCallbackRef = React.useRef<null | ((index: number) => void)>(null);
+
+  useImperativeHandle(
+    imperativeRef,
+    () => {
+      return {
+        scrollTo(index: number, behavior = 'auto', callback: ((index: number) => void) | undefined) {
+          scrollCallbackRef.current = callback ?? null;
+          imperativeVirtualizerRef.current?.setFlaggedIndex(index);
+          scrollToItemStatic({
+            index,
+            itemSize,
+            totalItems: numItems,
+            scrollViewRef,
+            axis,
+            reversed,
+            behavior,
+          });
+        },
+      };
+    },
+    [axis, scrollViewRef, itemSize, numItems, reversed],
+  );
+
+  const handleRenderedIndex = (index: number) => {
+    if (scrollCallbackRef.current) {
+      scrollCallbackRef.current(index);
+    }
+  };
 
   const virtualizerState = useVirtualizer_unstable({
     ...props,
     virtualizerLength,
     bufferItems,
     bufferSize,
-    scrollViewRef: iScrollRef,
+    scrollViewRef,
+    onRenderedFlaggedIndex: handleRenderedIndex,
+    imperativeVirtualizerRef,
   });
 
   return {
@@ -29,7 +65,7 @@ export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewPr
     container: resolveShorthand(props.container, {
       required: true,
       defaultProps: {
-        ref: iScrollRef as React.RefObject<HTMLDivElement>,
+        ref: scrollViewRef as React.RefObject<HTMLDivElement>,
       },
     }),
   };

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
@@ -1,6 +1,6 @@
-import { VirtualizerScrollViewState } from './VirtualizerScrollView.types';
+import type { VirtualizerScrollViewState } from './VirtualizerScrollView.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import { VirtualizerScrollViewSlots } from './VirtualizerScrollView.types';
+import type { VirtualizerScrollViewSlots } from './VirtualizerScrollView.types';
 import { useVirtualizerStyles_unstable, virtualizerClassNames } from '../Virtualizer/useVirtualizerStyles.styles';
 import { makeStyles, mergeClasses } from '@griffel/react';
 

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.ts
@@ -1,9 +1,9 @@
-import { VirtualizerScrollViewDynamicProps } from './VirtualizerScrollViewDynamic.types';
+import type { VirtualizerScrollViewDynamicProps } from './VirtualizerScrollViewDynamic.types';
 import { useVirtualizerScrollViewDynamic_unstable } from './useVirtualizerScrollViewDynamic';
 import { renderVirtualizerScrollViewDynamic_unstable } from './renderVirtualizerScrollViewDynamic';
 import { useVirtualizerScrollViewDynamicStyles_unstable } from './useVirtualizerScrollViewDynamicStyles.styles';
 import * as React from 'react';
-import { VirtualizerContextProps } from '../../Utilities';
+import type { VirtualizerContextProps } from '../../Utilities';
 
 /**
  * Virtualizer ScrollView

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
@@ -1,16 +1,18 @@
-import { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import {
+import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type {
   VirtualizerConfigProps,
   VirtualizerConfigState,
   VirtualizerChildRenderFunction,
 } from '../Virtualizer/Virtualizer.types';
 
-import { VirtualizerScrollViewSlots } from '../VirtualizerScrollView/VirtualizerScrollView.types';
+import type { VirtualizerScrollViewSlots } from '../VirtualizerScrollView/VirtualizerScrollView.types';
+import type { RefObject } from 'react';
+import type { ScrollToInterface } from '../../Utilities';
 
 export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;
 
 export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> &
-  Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children'>> & {
+  Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex'>> & {
     /**
      * Set as the minimum item size.
      * Axis: 'vertical' = Height
@@ -32,6 +34,10 @@ export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<Virtualiz
      * Will act as a row or column indexer depending on Virtualizer settings.
      */
     children: VirtualizerChildRenderFunction;
+    /**
+     * Imperative ref contains our scrollTo index functionality for user control.
+     */
+    imperativeRef?: RefObject<ScrollToInterface>;
   };
 
 export type VirtualizerScrollViewDynamicState = ComponentState<VirtualizerScrollViewDynamicSlots> &

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.ts
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import { resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
 import { useVirtualizer_unstable } from '../Virtualizer/useVirtualizer';
-import {
+import type {
   VirtualizerScrollViewDynamicProps,
   VirtualizerScrollViewDynamicState,
 } from './VirtualizerScrollViewDynamic.types';
 import { useDynamicVirtualizerMeasure } from '../../Hooks';
-import { useVirtualizerContextState_unstable } from '../../Utilities';
+import { useVirtualizerContextState_unstable, scrollToItemDynamic } from '../../Utilities';
+import type { VirtualizerDataRef } from '../Virtualizer/Virtualizer.types';
+import { useImperativeHandle } from 'react';
 
 export function useVirtualizerScrollViewDynamic_unstable(
   props: VirtualizerScrollViewDynamicProps,
 ): VirtualizerScrollViewDynamicState {
   const contextState = useVirtualizerContextState_unstable(props.virtualizerContext);
+  const { imperativeRef, axis = 'vertical', reversed, imperativeVirtualizerRef } = props;
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useDynamicVirtualizerMeasure({
     defaultItemSize: props.itemSize,
@@ -21,15 +24,56 @@ export function useVirtualizerScrollViewDynamic_unstable(
     numItems: props.numItems,
   });
 
-  const iScrollRef = useMergedRefs(React.useRef<HTMLDivElement>(null), scrollRef) as React.RefObject<HTMLDivElement>;
+  const scrollViewRef = useMergedRefs(React.useRef<HTMLDivElement>(null), scrollRef) as React.RefObject<HTMLDivElement>;
+  const scrollCallbackRef = React.useRef<null | ((index: number) => void)>(null);
+
+  const _imperativeVirtualizerRef = useMergedRefs(React.useRef<VirtualizerDataRef>(null), imperativeVirtualizerRef);
+
+  useImperativeHandle(
+    imperativeRef,
+    () => {
+      return {
+        scrollTo(index: number, behavior = 'auto', callback: undefined | ((index: number) => void)) {
+          scrollCallbackRef.current = callback ?? null;
+          if (_imperativeVirtualizerRef.current) {
+            const progressiveSizes = _imperativeVirtualizerRef.current.progressiveSizes.current;
+            const totalSize =
+              progressiveSizes && progressiveSizes?.length > 0
+                ? progressiveSizes[Math.max(progressiveSizes.length - 1, 0)]
+                : 0;
+
+            _imperativeVirtualizerRef.current.setFlaggedIndex(index);
+            scrollToItemDynamic({
+              index,
+              itemSizes: _imperativeVirtualizerRef.current?.nodeSizes,
+              totalSize,
+              scrollViewRef,
+              axis,
+              reversed,
+              behavior,
+            });
+          }
+        },
+      };
+    },
+    [axis, scrollViewRef, reversed, _imperativeVirtualizerRef],
+  );
+
+  const handleRenderedIndex = (index: number) => {
+    if (scrollCallbackRef.current) {
+      scrollCallbackRef.current(index);
+    }
+  };
 
   const virtualizerState = useVirtualizer_unstable({
     ...props,
     virtualizerLength,
     bufferItems,
     bufferSize,
-    scrollViewRef: iScrollRef,
+    scrollViewRef,
     virtualizerContext: contextState,
+    imperativeVirtualizerRef: _imperativeVirtualizerRef,
+    onRenderedFlaggedIndex: handleRenderedIndex,
   });
 
   return {
@@ -41,7 +85,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
     container: resolveShorthand(props.container, {
       required: true,
       defaultProps: {
-        ref: iScrollRef,
+        ref: scrollViewRef,
       },
     }),
   };

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
@@ -1,5 +1,5 @@
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import {
+import type {
   VirtualizerScrollViewDynamicSlots,
   VirtualizerScrollViewDynamicState,
 } from './VirtualizerScrollViewDynamic.types';

--- a/packages/react-components/react-virtualizer/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useResizeObserverRef.ts
@@ -20,6 +20,7 @@ export const useResizeObserverRef_unstable = (resizeCallback: ResizeCallbackWith
 
   React.useEffect(() => {
     // Update our state when resizeCallback changes
+    container.current = null;
     resizeObserver?.disconnect();
     setResizeObserver(canUseDOM() ? new ResizeObserver(handleResize) : undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -27,6 +28,7 @@ export const useResizeObserverRef_unstable = (resizeCallback: ResizeCallbackWith
 
   React.useEffect(() => {
     return () => {
+      container.current = null;
       resizeObserver?.disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-components/react-virtualizer/src/index.ts
+++ b/packages/react-components/react-virtualizer/src/index.ts
@@ -5,11 +5,13 @@ export {
   renderVirtualizer_unstable,
   useVirtualizerStyles_unstable,
 } from './Virtualizer';
+
 export type {
   VirtualizerProps,
   VirtualizerState,
   VirtualizerSlots,
   VirtualizerChildRenderFunction,
+  VirtualizerDataRef,
 } from './Virtualizer';
 
 export {
@@ -21,7 +23,14 @@ export {
 
 export type { ResizeCallbackWithRef, VirtualizerMeasureDynamicProps, VirtualizerMeasureProps } from './Hooks';
 
-export { VirtualizerContextProvider, useVirtualizerContext_unstable } from './Utilities';
+export type { ScrollToItemDynamicParams, ScrollToItemStaticParams, ScrollToInterface } from './Utilities';
+
+export {
+  VirtualizerContextProvider,
+  useVirtualizerContext_unstable,
+  scrollToItemStatic,
+  scrollToItemDynamic,
+} from './Utilities';
 
 export type { VirtualizerContextProps } from './Utilities';
 

--- a/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrolling.ts
+++ b/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrolling.ts
@@ -1,0 +1,31 @@
+import { ScrollToItemStaticParams } from './imperativeScrolling.types';
+
+export const scrollToItemStatic = (params: ScrollToItemStaticParams) => {
+  const { index, itemSize, totalItems, scrollViewRef, axis = 'vertical', reversed = false, behavior = 'auto' } = params;
+
+  if (axis === 'horizontal') {
+    if (reversed) {
+      scrollViewRef.current?.scrollTo({
+        left: totalItems * itemSize - itemSize * index,
+        behavior,
+      });
+    } else {
+      scrollViewRef.current?.scrollTo({
+        left: itemSize * index,
+        behavior,
+      });
+    }
+  } else {
+    if (reversed) {
+      scrollViewRef.current?.scrollTo({
+        top: totalItems * itemSize - itemSize * index,
+        behavior,
+      });
+    } else {
+      scrollViewRef.current?.scrollTo({
+        top: itemSize * index,
+        behavior,
+      });
+    }
+  }
+};

--- a/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrolling.types.ts
+++ b/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrolling.types.ts
@@ -1,0 +1,25 @@
+import type { RefObject } from 'react';
+
+export type ScrollToItemStaticParams = {
+  index: number;
+  itemSize: number;
+  totalItems: number;
+  scrollViewRef: RefObject<HTMLDivElement>;
+  axis?: 'horizontal' | 'vertical';
+  reversed?: boolean;
+  behavior?: ScrollBehavior;
+};
+
+export type ScrollToItemDynamicParams = {
+  index: number;
+  itemSizes: RefObject<number[]>;
+  totalSize: number;
+  scrollViewRef: RefObject<HTMLDivElement>;
+  axis?: 'horizontal' | 'vertical';
+  reversed?: boolean;
+  behavior?: ScrollBehavior;
+};
+
+export type ScrollToInterface = {
+  scrollTo: (index: number, behavior?: ScrollBehavior, callback?: (index: number) => void) => void;
+};

--- a/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrollingDynamic.ts
+++ b/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/imperativeScrollingDynamic.ts
@@ -1,0 +1,46 @@
+import { ScrollToItemDynamicParams } from './imperativeScrolling.types';
+
+export const scrollToItemDynamic = (params: ScrollToItemDynamicParams) => {
+  const { index, itemSizes, totalSize, scrollViewRef, axis = 'vertical', reversed = false, behavior = 'auto' } = params;
+  if (!itemSizes.current) {
+    return;
+  }
+
+  if (itemSizes.current === null || itemSizes.current.length < index) {
+    // null check - abort
+    return;
+  }
+
+  let itemDepth = 0;
+  for (let i = 0; i < index; i++) {
+    if (i < index) {
+      itemDepth += itemSizes.current[i];
+    }
+  }
+
+  if (axis === 'horizontal') {
+    if (reversed) {
+      scrollViewRef.current?.scrollTo({
+        left: totalSize - itemDepth,
+        behavior,
+      });
+    } else {
+      scrollViewRef.current?.scrollTo({
+        left: itemDepth,
+        behavior,
+      });
+    }
+  } else {
+    if (reversed) {
+      scrollViewRef.current?.scrollTo({
+        top: totalSize - itemDepth,
+        behavior,
+      });
+    } else {
+      scrollViewRef.current?.scrollTo({
+        top: itemDepth,
+        behavior,
+      });
+    }
+  }
+};

--- a/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/index.ts
+++ b/packages/react-components/react-virtualizer/src/utilities/ImperativeScrolling/index.ts
@@ -1,0 +1,3 @@
+export * from './imperativeScrolling';
+export * from './imperativeScrolling.types';
+export * from './imperativeScrollingDynamic';

--- a/packages/react-components/react-virtualizer/src/utilities/index.ts
+++ b/packages/react-components/react-virtualizer/src/utilities/index.ts
@@ -1,1 +1,2 @@
 export * from './VirtualizerContext';
+export * from './ImperativeScrolling';

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/DefaultUnbounded.stories.tsx
@@ -6,9 +6,16 @@ import { useFluent } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
+    /*
+     * This is an 'unbounded' example intended to show virtualization in Body doc scroll
+     * However, we need a sensible height limit
+     * this would be enforced by a browser window,
+     * but iFrames can break this if not capped.
+     */
     display: 'flex',
     flexDirection: 'column',
     overflowAnchor: 'none',
+    maxHeight: '300VH',
     width: '100%',
     height: '100%',
   },
@@ -30,7 +37,6 @@ const useStyles = makeStyles({
 export const DefaultUnbounded = () => {
   const styles = useStyles();
   const childLength = 1000;
-
   const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
     defaultItemSize: 100,
   });
@@ -50,7 +56,7 @@ export const DefaultUnbounded = () => {
         bufferSize={bufferSize}
         itemSize={100}
       >
-        {index => {
+        {(index, isScrolling) => {
           return (
             <span
               role={'listitem'}

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/MultiUnbounded.stories.tsx
@@ -4,9 +4,16 @@ import { makeStyles, useFluent } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
+    /*
+     * This is an 'unbounded' example intended to show virtualization in Body doc scroll
+     * However, we need a sensible height limit
+     * this would be enforced by a browser window,
+     * but iFrames can break this if not capped.
+     */
     display: 'flex',
     flexDirection: 'column',
     overflowAnchor: 'none',
+    maxHeight: '300VH',
     width: '100%',
     height: '100%',
   },

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/ScrollTo.stories.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
+import { Text, Input, makeStyles } from '@fluentui/react-components';
+import { Button } from '@fluentui/react-components';
+import { ScrollToInterface } from '../../src/Utilities';
+
+const useStyles = makeStyles({
+  child: {
+    height: '100px',
+    lineHeight: '100px',
+    width: '100%',
+  },
+});
+
+export const ScrollTo = () => {
+  const styles = useStyles();
+  const childLength = 1000;
+  const scrollRef = React.useRef<ScrollToInterface>(null);
+  const [goToIndex, setGoToIndex] = React.useState(0);
+  const [message, setMessage] = React.useState('');
+
+  const scrollToIndex = () => {
+    if (scrollRef?.current?.scrollTo) {
+      setMessage(`Going to index: ${goToIndex}`);
+      scrollRef.current.scrollTo(goToIndex, 'smooth', (index: number) => {
+        setMessage(`Reached index: ${index}`);
+      });
+    }
+  };
+
+  const onChangeGoToIndex = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>) => {
+    const indexValue = ev ? (ev.currentTarget as HTMLInputElement).value : '';
+    const newIndex = Math.min(Math.max(parseInt(indexValue, 10), 0), childLength - 1);
+    setGoToIndex(newIndex);
+  };
+
+  return (
+    <div>
+      <Input defaultValue={'0'} onChange={onChangeGoToIndex} />
+      <Button onClick={scrollToIndex}>{'GoTo'}</Button>
+      <Text>{message}</Text>
+      <VirtualizerScrollView
+        numItems={childLength}
+        itemSize={100}
+        container={{ role: 'list', style: { maxHeight: '100vh' } }}
+        imperativeRef={scrollRef}
+      >
+        {(index: number) => {
+          return (
+            <div
+              role={'listitem'}
+              aria-posinset={index}
+              aria-setsize={childLength}
+              key={`test-virtualizer-child-${index}`}
+              className={styles.child}
+            >{`Node-${index}`}</div>
+          );
+        }}
+      </VirtualizerScrollView>
+    </div>
+  );
+};

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/index.stories.ts
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollView/index.stories.ts
@@ -2,6 +2,7 @@ import { VirtualizerScrollView } from '../../src/VirtualizerScrollView';
 import descriptionMd from './VirtualizerScrollViewDescription.md';
 
 export { Default } from './Default.stories';
+export { ScrollTo } from './ScrollTo.stories';
 
 export default {
   title: 'Preview Components/VirtualizerScrollView',

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Default = () => {
+export const ScrollLoading = () => {
   const styles = useStyles();
   const childLength = 1000;
   const minHeight = 42;
@@ -44,9 +44,11 @@ export const Default = () => {
       getItemSize={getItemSizeCallback}
       container={{ role: 'list', style: { maxHeight: '100vh' } }}
     >
-      {(index: number) => {
+      {(index: number, isScrolling = false) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';
-        return (
+        return isScrolling ? (
+          <div style={{ minHeight: arraySize.current[index], backgroundColor }}>LOADING</div>
+        ) : (
           <div
             role={'listitem'}
             aria-posinset={index}

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+import { Button, Input, makeStyles, Text } from '@fluentui/react-components';
+import { useEffect } from 'react';
+import { ScrollToInterface } from '../../src/Utilities';
+import { VirtualizerDataRef } from '../../src/Virtualizer';
+
+const useStyles = makeStyles({
+  child: {
+    lineHeight: '42px',
+    width: '100%',
+    minHeight: '42px',
+  },
+});
+
+export const ScrollTo = () => {
+  const styles = useStyles();
+  const childLength = 1000;
+  const minHeight = 42;
+  // Array size ref stores a list of random num for div sizing and callbacks
+  const arraySize = React.useRef(new Array<number>(childLength).fill(minHeight));
+  // totalSize flag drives our callback update
+  const [totalSize, setTotalSize] = React.useState(minHeight * childLength);
+
+  const scrollRef = React.useRef<ScrollToInterface>(null);
+  const sizeRef = React.useRef<VirtualizerDataRef>(null);
+  const [goToIndex, setGoToIndex] = React.useState(0);
+  const [message, setMessage] = React.useState('');
+
+  const scrollToIndex = () => {
+    if (scrollRef?.current?.scrollTo) {
+      setMessage(`Going to index: ${goToIndex}`);
+      scrollRef.current.scrollTo(goToIndex, 'smooth', (index: number) => {
+        setMessage(`Reached index: ${index}`);
+      });
+    }
+  };
+
+  const onChangeGoToIndex = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>) => {
+    const indexValue = ev ? (ev.currentTarget as HTMLInputElement).value : '';
+    const newIndex = Math.min(Math.max(parseInt(indexValue, 10), 0), childLength - 1);
+    setGoToIndex(newIndex);
+  };
+
+  useEffect(() => {
+    let _totalSize = 0;
+    for (let i = 0; i < childLength; i++) {
+      arraySize.current[i] = Math.random() * 250 + minHeight;
+      _totalSize += arraySize.current[i];
+    }
+    setTotalSize(_totalSize);
+  }, []);
+
+  const getItemSizeCallback = React.useCallback(
+    (index: number) => {
+      return arraySize.current[index];
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [arraySize, totalSize],
+  );
+
+  return (
+    <div>
+      <Input defaultValue={'0'} onChange={onChangeGoToIndex} />
+      <Button onClick={scrollToIndex}>{'GoTo'}</Button>
+      <Text>{message}</Text>
+      <VirtualizerScrollViewDynamic
+        numItems={childLength}
+        itemSize={100}
+        getItemSize={getItemSizeCallback}
+        imperativeRef={scrollRef}
+        imperativeVirtualizerRef={sizeRef}
+        container={{ role: 'list', style: { maxHeight: '100vh' } }}
+      >
+        {(index: number) => {
+          const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';
+          return (
+            <div
+              role={'listitem'}
+              aria-posinset={index}
+              aria-setsize={childLength}
+              key={`test-virtualizer-child-${index}`}
+              className={styles.child}
+              style={{ minHeight: arraySize.current[index], backgroundColor }}
+            >{`Node-${index} - size: ${arraySize.current[index]}`}</div>
+          );
+        }}
+      </VirtualizerScrollViewDynamic>
+    </div>
+  );
+};

--- a/packages/react-components/react-virtualizer/stories/VirtualizerScrollViewDynamic/index.stories.ts
+++ b/packages/react-components/react-virtualizer/stories/VirtualizerScrollViewDynamic/index.stories.ts
@@ -2,6 +2,8 @@ import { VirtualizerScrollViewDynamic } from '../../src/VirtualizerScrollViewDyn
 import descriptionMd from './VirtualizerScrollViewDynamicDescription.md';
 
 export { Default } from './Default.stories';
+export { ScrollTo } from './ScrollTo.stories';
+export { ScrollLoading } from './ScrollLoading.stories';
 
 export default {
   title: 'Preview Components/VirtualizerScrollViewDynamic',


### PR DESCRIPTION
## New Behavior
ScrollTo hooks for scrolling animated or instantly to a specific item index
Callback for when a flagged index has been rendered
Optional isScrolling flag available in the child render function for users to render lightweight placeholders

## Related Issue(s)
https://github.com/microsoft/fluentui/issues/27217
https://github.com/microsoft/fluentui/issues/27218
https://github.com/microsoft/fluentui/issues/27219
