### PR TITLE
fix listbox-option selected indicator position in rtl

### DIFF
--- a/change/@fluentui-web-components-acd8f52d-86c3-4eae-aaf9-51b26fd25288.json
+++ b/change/@fluentui-web-components-acd8f52d-86c3-4eae-aaf9-51b26fd25288.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix listbox-option selected indicator position in RTL instances",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/src/listbox-option/listbox-option.styles.ts
@@ -27,6 +27,7 @@ import {
 } from '../design-tokens';
 import { typeRampBase } from '../styles/patterns/type-ramp';
 import { focusTreatmentBase } from '../styles/focus';
+import { DirectionalStyleSheetBehavior } from '../styles/direction';
 
 export const optionStyles: (
   context: ElementDefinitionContext,
@@ -131,6 +132,11 @@ export const optionStyles: (
       margin-inline-end: 1ch;
     }
   `.withBehaviors(
+    new DirectionalStyleSheetBehavior(null, css`
+      :host::before {
+        right: calc((${focusStrokeWidth} - ${strokeWidth}) * 1px);
+      }
+    `),
     forcedColorsStylesheetBehavior(
       css`
         :host {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
The indicator did not localize correctly

## New Behavior
The indicator localizes as expected

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27893
