### PR TITLE
chore: add test-ssr to buildci script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,8 +63,8 @@ jobs:
           DANGER_GITHUB_API_TOKEN: $(DANGER_GITHUB_API_TOKEN)
 
       - script: |
-          yarn buildci  $(sinceArg)
-        displayName: build, test, lint
+          yarn buildci $(sinceArg)
+        displayName: build, test, lint, test-ssr
 
       - template: .devops/templates/cleanup.yml
 

--- a/lage.config.js
+++ b/lage.config.js
@@ -9,6 +9,7 @@ module.exports = {
     lint: ['build'],
     clean: [],
     test: ['build'],
+    'test-ssr': [],
     'type-check': ['build'],
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "lage build --verbose",
     "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components",
     "build:fluentui:docs": "gulp build:docs",
-    "buildci": "lage build test lint type-check --verbose",
+    "buildci": "lage build test lint type-check test-ssr --verbose",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",
     "buildto:lerna": "node ./scripts/executors/buildTo.js",


### PR DESCRIPTION
## New Behavior

This PR adds `test-ssr` script to "buildci" script and modifies Lage's config, so the scripts will start to run on CI.

## Related Issue(s)

Previous PRs: #27444, #27463, #27690

Next steps:

- Add implementation to `@fluentui/scripts-test-ssr`
- Drop testing logic from `@fluentui/ssr-tests-v9`