### PR TITLE
chore(react-accordion): ensures AccordionHeader expandIcon supports null

### DIFF
--- a/change/@fluentui-react-accordion-f25a187c-893c-4c69-a270-b1a405788277.json
+++ b/change/@fluentui-react-accordion-f25a187c-893c-4c69-a270-b1a405788277.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensures AccordionHeader expandIcon supports null",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-components/react-accordion/etc/react-accordion.api.md
@@ -67,9 +67,9 @@ export type AccordionHeaderSize = 'small' | 'medium' | 'large' | 'extra-large';
 
 // @public (undocumented)
 export type AccordionHeaderSlots = {
-    root: Slot<'div', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>;
+    root: NonNullable<Slot<'div', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>>;
     button: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
-    expandIcon: Slot<'span'>;
+    expandIcon?: Slot<'span'>;
     icon?: Slot<'div'>;
 };
 
@@ -107,7 +107,7 @@ export const AccordionItemProvider: React_2.Provider<AccordionItemContextValue>;
 
 // @public (undocumented)
 export type AccordionItemSlots = {
-    root: Slot<'div'>;
+    root: NonNullable<Slot<'div'>>;
 };
 
 // @public (undocumented)
@@ -127,7 +127,7 @@ export type AccordionPanelProps = ComponentProps<AccordionPanelSlots>;
 
 // @public (undocumented)
 export type AccordionPanelSlots = {
-    root: Slot<'div'>;
+    root: NonNullable<Slot<'div'>>;
 };
 
 // @public (undocumented)
@@ -150,7 +150,7 @@ export const AccordionProvider: Provider<AccordionContextValue> & FC<ProviderPro
 
 // @public (undocumented)
 export type AccordionSlots = {
-    root: Slot<'div'>;
+    root: NonNullable<Slot<'div'>>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-accordion/src/components/Accordion/Accordion.types.ts
+++ b/packages/react-components/react-accordion/src/components/Accordion/Accordion.types.ts
@@ -26,7 +26,7 @@ export type AccordionContextValues = {
 };
 
 export type AccordionSlots = {
-  root: Slot<'div'>;
+  root: NonNullable<Slot<'div'>>;
 };
 
 export type AccordionToggleData = {

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeader.test.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeader.test.tsx
@@ -36,6 +36,15 @@ describe('AccordionHeader', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  /**
+   * Note: see more visual regression tests for AccordionHeader in /apps/vr-tests.
+   */
+  it('renders when expandIcon is null', () => {
+    const component = renderer.create(<AccordionHeader expandIcon={null}>Default AccordionHeader</AccordionHeader>);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should invoke click and toggle', () => {
     const mockClick = jest.fn();
     const component = renderer.create(

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeader.types.ts
@@ -17,7 +17,7 @@ export type AccordionHeaderSlots = {
   /**
    * The element wrapping the button. By default this is a div, but can be a heading.
    */
-  root: Slot<'div', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>;
+  root: NonNullable<Slot<'div', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'>>;
   /**
    * The component to be used as button in heading
    */
@@ -25,7 +25,7 @@ export type AccordionHeaderSlots = {
   /**
    * Expand icon slot rendered before (or after) children content in heading.
    */
-  expandIcon: Slot<'span'>;
+  expandIcon?: Slot<'span'>;
   /**
    * Expand icon slot rendered before (or after) children content in heading.
    */

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -39,3 +39,19 @@ exports[`AccordionHeader renders a default state 1`] = `
   </button>
 </div>
 `;
+
+exports[`AccordionHeader renders when expandIcon is null 1`] = `
+<div
+  className="fui-AccordionHeader"
+>
+  <button
+    aria-expanded={false}
+    className="fui-AccordionHeader__button"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Default AccordionHeader
+  </button>
+</div>
+`;

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
@@ -20,10 +20,10 @@ export const renderAccordionHeader_unstable = (
     <AccordionHeaderContext.Provider value={contextValues.accordionHeader}>
       <slots.root {...slotProps.root}>
         <slots.button {...slotProps.button}>
-          {state.expandIconPosition === 'start' && <slots.expandIcon {...slotProps.expandIcon} />}
+          {state.expandIconPosition === 'start' && slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
           {slots.icon && <slots.icon {...slotProps.icon} />}
           {slotProps.root.children}
-          {state.expandIconPosition === 'end' && <slots.expandIcon {...slotProps.expandIcon} />}
+          {state.expandIconPosition === 'end' && slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
         </slots.button>
       </slots.root>
     </AccordionHeaderContext.Provider>

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
+import {
+  getNativeElementProps,
+  isResolvedShorthand,
+  resolveShorthand,
+  useEventCallback,
+} from '@fluentui/react-utilities';
 import { useAccordionItemContext_unstable } from '../AccordionItem/index';
-import { useARIAButtonShorthand } from '@fluentui/react-aria';
+import { ARIAButtonSlotProps, useARIAButtonShorthand } from '@fluentui/react-aria';
 import type { AccordionHeaderProps, AccordionHeaderState } from './AccordionHeader.types';
 import { useAccordionContext_unstable } from '../Accordion/AccordionContext';
 import { ChevronRightRegular } from '@fluentui/react-icons';
@@ -37,16 +42,6 @@ export const useAccordionHeader_unstable = (
     expandIconRotation = open ? 90 : dir !== 'rtl' ? 0 : 180;
   }
 
-  const buttonShorthand = useARIAButtonShorthand(button, {
-    required: true,
-    defaultProps: {
-      disabled,
-      disabledFocusable,
-      'aria-expanded': open,
-      type: 'button',
-    },
-  });
-
   return {
     disabled,
     open,
@@ -71,16 +66,27 @@ export const useAccordionHeader_unstable = (
         'aria-hidden': true,
       },
     }),
-    button: {
-      ...buttonShorthand,
-      onClick: useEventCallback(
-        (ev: React.MouseEvent<HTMLButtonElement & HTMLDivElement & HTMLSpanElement & HTMLAnchorElement>) => {
-          buttonShorthand.onClick?.(ev);
+    button: resolveShorthand<ARIAButtonSlotProps<'a'>>(
+      {
+        ...useARIAButtonShorthand(button, {
+          required: true,
+          defaultProps: {
+            disabled,
+            disabledFocusable,
+            'aria-expanded': open,
+            type: 'button',
+          },
+        }),
+        onClick: useEventCallback(ev => {
+          if (isResolvedShorthand(button)) {
+            button.onClick?.(ev);
+          }
           if (!ev.defaultPrevented) {
             onAccordionHeaderClick(ev);
           }
-        },
-      ),
-    },
+        }),
+      },
+      { required: true },
+    ),
   };
 };

--- a/packages/react-components/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionItem/AccordionItem.types.ts
@@ -11,7 +11,7 @@ export type AccordionItemContextValues = {
 };
 
 export type AccordionItemSlots = {
-  root: Slot<'div'>;
+  root: NonNullable<Slot<'div'>>;
 };
 
 export type AccordionItemProps = ComponentProps<AccordionItemSlots> & {

--- a/packages/react-components/react-accordion/src/components/AccordionPanel/AccordionPanel.types.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionPanel/AccordionPanel.types.ts
@@ -1,7 +1,7 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type AccordionPanelSlots = {
-  root: Slot<'div'>;
+  root: NonNullable<Slot<'div'>>;
 };
 
 export type AccordionPanelProps = ComponentProps<AccordionPanelSlots>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

AccordionHeader is broken when `expandIcon={null}` https://codesandbox.io/s/sad-taussig-s7cfkd?file=/example.tsx


## New Behavior

1. ensures verification of nullability for the `expandIcon` slot on `renderAccordionHeader` method.
2. properly declare `Accordion` slot types to include `NonNullable` and `?` (optional) cases
3. adds test to properly map this problem

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27911
