### PR TITLE
fix(react-textarea): Move disabled styles in textarea selector to the textarea styles

### DIFF
--- a/change/@fluentui-react-textarea-da38b5b6-139a-42de-b425-abceddc48a77.json
+++ b/change/@fluentui-react-textarea-da38b5b6-139a-42de-b425-abceddc48a77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Move disabled styles in textarea selector to the textarea styles.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.styles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.styles.ts
@@ -31,13 +31,7 @@ const useRootStyles = makeStyles({
   disabled: {
     backgroundColor: tokens.colorTransparentBackground,
     ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStrokeDisabled),
-    [`& > textarea`]: {
-      color: tokens.colorNeutralForegroundDisabled,
-      cursor: 'not-allowed',
-      '::placeholder': {
-        color: tokens.colorNeutralForegroundDisabled,
-      },
-    },
+
     '@media (forced-colors: active)': {
       ...shorthands.borderColor('GrayText'),
     },
@@ -183,6 +177,14 @@ const useTextareaStyles = makeStyles({
     outlineStyle: 'none', // disable default browser outline
   },
 
+  disabled: {
+    color: tokens.colorNeutralForegroundDisabled,
+    cursor: 'not-allowed',
+    '::placeholder': {
+      color: tokens.colorNeutralForegroundDisabled,
+    },
+  },
+
   // The padding style adds both content and regular padding (from design spec), this is because the handle is not
   // affected by changing the padding of the root.
   small: {
@@ -261,6 +263,7 @@ export const useTextareaStyles_unstable = (state: TextareaState): TextareaState 
     textareaStyles.base,
     textareaStyles[size],
     textareaResizeStyles[resize],
+    disabled && textareaStyles.disabled,
     state.textarea.className,
   );
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Textarea was applying the disabled textarea styles with a selector on the wrapper.

## New Behavior

Textarea now doesn't use a selector to apply disabled styles for the textarea.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27838
