### PR TITLE
fix: Pivot focus outline is visible on link-as-tab variant

### DIFF
--- a/change/@fluentui-react-be1fc47e-c473-4abf-98b8-38adda0aab8b.json
+++ b/change/@fluentui-react-be1fc47e-c473-4abf-98b8-38adda0aab8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Links in tab style shows focus outline on selected tab",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-be1fc47e-c473-4abf-98b8-38adda0aab8b.json
+++ b/change/@fluentui-react-be1fc47e-c473-4abf-98b8-38adda0aab8b.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Links in tab style shows focus outline on selected tab",
+  "comment": "fix: Links in tab style show focus outline on selected tab",
   "packageName": "@fluentui/react",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/react/src/components/Pivot/Pivot.styles.ts
@@ -142,7 +142,7 @@ const getLinkStyles = (
                   height: 0,
                 },
                 ':hover': {
-                  backgroundColor: 'red',
+                  backgroundColor: semanticColors.primaryButtonBackgroundHovered,
                   color: semanticColors.primaryButtonText,
                 },
                 ':active': {

--- a/packages/react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/react/src/components/Pivot/Pivot.styles.ts
@@ -111,7 +111,7 @@ const getLinkStyles = (
 
           selectors: {
             ':focus': {
-              outlineOffset: '-1px',
+              outlineOffset: '-2px',
             },
             [`.${IsFocusVisibleClassName} &:focus::before`]: {
               height: 'auto',
@@ -142,10 +142,10 @@ const getLinkStyles = (
                   height: 0,
                 },
                 ':hover': {
-                  backgroundColor: semanticColors.primaryButtonBackgroundHovered,
+                  backgroundColor: 'red',
                   color: semanticColors.primaryButtonText,
                 },
-                '&:active': {
+                ':active': {
                   backgroundColor: semanticColors.primaryButtonBackgroundPressed,
                   color: semanticColors.primaryButtonText,
                 },
@@ -156,6 +156,9 @@ const getLinkStyles = (
                   ...getHighContrastNoAdjustStyle(),
                 },
               },
+            },
+            [`.${IsFocusVisibleClassName} &.${classNames.linkIsSelected}:focus`]: {
+              outlineColor: semanticColors.primaryButtonText,
             },
           },
         },

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -2421,11 +2421,11 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           }
           &:focus {
             color: #000000;
-            outline-offset: -1px;
+            outline-offset: -2px;
             outline: none;
           }
           &:active {
-            background-color: #005a9e;
+            background-color: #0078d4;
             color: #ffffff;
           }
           &:active .ms-Button-icon {
@@ -2479,12 +2479,19 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
+          &.is-selected:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
             font-weight: 600;
             forced-color-adjust: none;
+          }
+          .ms-Fabric--isFocusVisible &.is-selected:focus {
+            outline-color: #ffffff;
           }
           &[data-is-overflowing='true'] {
             display: none;
@@ -2624,11 +2631,11 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           }
           &:focus {
             color: #000000;
-            outline-offset: -1px;
+            outline-offset: -2px;
             outline: none;
           }
           &:active {
-            background-color: #005a9e;
+            background-color: #0078d4;
             color: #ffffff;
           }
           &:active .ms-Button-icon {
@@ -2682,12 +2689,19 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
+          &.is-selected:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
             font-weight: 600;
             forced-color-adjust: none;
+          }
+          .ms-Fabric--isFocusVisible &.is-selected:focus {
+            outline-color: #ffffff;
           }
           &[data-is-overflowing='true'] {
             display: none;
@@ -3258,11 +3272,11 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           }
           &:focus {
             color: #000000;
-            outline-offset: -1px;
+            outline-offset: -2px;
             outline: none;
           }
           &:active {
-            background-color: #005a9e;
+            background-color: #0078d4;
             color: #ffffff;
           }
           &:active .ms-Button-icon {
@@ -3316,12 +3330,19 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
+          &.is-selected:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
             font-weight: 600;
             forced-color-adjust: none;
+          }
+          .ms-Fabric--isFocusVisible &.is-selected:focus {
+            outline-color: #ffffff;
           }
           &[data-is-overflowing='true'] {
             display: none;
@@ -3461,11 +3482,11 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           }
           &:focus {
             color: #000000;
-            outline-offset: -1px;
+            outline-offset: -2px;
             outline: none;
           }
           &:active {
-            background-color: #005a9e;
+            background-color: #0078d4;
             color: #ffffff;
           }
           &:active .ms-Button-icon {
@@ -3519,12 +3540,19 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             background-color: #106ebe;
             color: #ffffff;
           }
+          &.is-selected:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){&.is-selected {
             -ms-high-contrast-adjust: none;
             background: Highlight;
             color: HighlightText;
             font-weight: 600;
             forced-color-adjust: none;
+          }
+          .ms-Fabric--isFocusVisible &.is-selected:focus {
+            outline-color: #ffffff;
           }
           &[data-is-overflowing='true'] {
             display: none;


### PR DESCRIPTION

## Previous Behavior

The focus outline on the selected tab was not adequately distinguishable from the background (dark grey on dark blue):
<img width="217" alt="Screenshot of a tab with a dark blue background, white text, and an almost invisible dark border around the blue background" src="https://github.com/microsoft/fluentui/assets/3819570/29d1c36d-c54f-476c-8099-a69fe28ae49f">

## New Behavior

The focus style for the selected link-as-tab is now an inset white outline:
<img width="199" alt="Screenshot of the same blue tab with a 1px white outline inset by 1px" src="https://github.com/microsoft/fluentui/assets/3819570/bb4227bd-09fb-4aad-9ccc-be7d8a805742">

## Related Issue(s)

- Fixes [16120](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16120)
