### PR TITLE
Export getFocusOutlineStyles

### DIFF
--- a/change/@fluentui-react-components-0c3cec1a-1916-4068-9c40-00e9d268dcbe.json
+++ b/change/@fluentui-react-components-0c3cec1a-1916-4068-9c40-00e9d268dcbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "export getFocusOutlineStyles from react-tabster",
+  "packageName": "@fluentui/react-components",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-366bb35c-76b2-444c-9726-2708bec79d79.json
+++ b/change/@fluentui-react-tabster-366bb35c-76b2-444c-9726-2708bec79d79.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "export getFocusOutlineStyles",
+  "packageName": "@fluentui/react-tabster",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -32,6 +32,7 @@ export type {
 export {
   createCustomFocusIndicatorStyle,
   createFocusOutlineStyle,
+  getFocusOutlineStyles,
   useArrowNavigationGroup,
   useFocusableGroup,
   useFocusFinders,

--- a/packages/react-components/react-tabster/src/focus/createFocusOutlineStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createFocusOutlineStyle.ts
@@ -34,7 +34,7 @@ export interface CreateFocusOutlineStyleOptions extends Omit<CreateCustomFocusIn
  * @param options - Configures the style of the focus outline
  * @returns focus outline styles object
  */
-const getFocusOutlineStyles = (options: FocusOutlineStyleOptions): GriffelStyle => {
+export const getFocusOutlineStyles = (options: FocusOutlineStyleOptions): GriffelStyle => {
   const { outlineRadius, outlineColor, outlineOffset, outlineWidth } = options;
 
   const outlineOffsetTop = (outlineOffset as FocusOutlineOffset)?.top || outlineOffset;

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -14,7 +14,7 @@ export type {
   UseModalAttributesOptions,
 } from './hooks/index';
 
-export { createCustomFocusIndicatorStyle, createFocusOutlineStyle } from './focus/index';
+export { createCustomFocusIndicatorStyle, createFocusOutlineStyle, getFocusOutlineStyles } from './focus/index';
 
 export type {
   CreateCustomFocusIndicatorStyleOptions,


### PR DESCRIPTION
This is related to https://github.com/microsoft/fluentui/issues/27665

To apply "focus" style when the element is not actually in focus (but being resized), we need to use the function that defines the focus style. 

This is not possible now, because its not exported, only `createFocusOutlineStyle` is exported (which uses this function), but that creates styles specific to `focus` selectors.

We only need the CSS properties and values.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`getFocusOutlineStyles` was not exported

## New Behavior

`getFocusOutlineStyles` is exported 🥳

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
