### PR TITLE
Exports MenuItemRole From MenuItem

### DIFF
--- a/change/@fluentui-web-components-fe7f57a9-65bb-4816-9f01-0aded96e8ce9.json
+++ b/change/@fluentui-web-components-fe7f57a9-65bb-4816-9f01-0aded96e8ce9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added additional export in component.",
+  "packageName": "@fluentui/web-components",
+  "email": "harankin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -1,6 +1,8 @@
-import { FASTMenuItem } from '@microsoft/fast-foundation';
+import { FASTMenuItem, MenuItemRole } from '@microsoft/fast-foundation';
 
 export type MenuItemColumnCount = 0 | 1 | 2;
+
+export { MenuItemRole };
 
 /**
  * The base class used for constructing a fluent-menu-item custom element


### PR DESCRIPTION
This PR imports from FAST and exports MenuItemRole from the MenuItem component so that the Fluent web component Angular and React wrappers can utilize `role`. The component README shows three inputs: `role`, `disabled` and `checked`. When creating wrappers in Angular and React, the `role` attribute cannot be reached.

Without this export, I would have to import from FAST in both my React and Angular wrappers:
`import { roleForMenuItem } from '@microsoft/fast-foundation';`

It would be less convoluted to simply leverage the existing property directly from the Fluent web component.