### PR TITLE
bugfix(react-utilities): removes HTMLDialogElement from isHTMLElement…

### DIFF
--- a/change/@fluentui-react-utilities-8124ad98-f41b-48be-8ca6-823fd17285ec.json
+++ b/change/@fluentui-react-utilities-8124ad98-f41b-48be-8ca6-823fd17285ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: removes HTMLDialogElement from isHTMLElement type",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
+++ b/packages/react-components/react-utilities/src/utils/isHTMLElement.ts
@@ -45,7 +45,6 @@ export type HTMLElementConstructorName =
   | 'HTMLDataElement'
   | 'HTMLDataListElement'
   | 'HTMLDetailsElement'
-  | 'HTMLDialogElement'
   | 'HTMLDivElement'
   | 'HTMLDListElement'
   | 'HTMLEmbedElement'


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Follow up on https://github.com/microsoft/fluentui/issues/27951

## New Behavior

1. removes `HTMLDialogElement` from union of possible element types to be supported by `isHTMLElement` method

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27951
