### PR TITLE
docs(react-skeleton): fix section and update description

### DIFF
--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonDescription.md
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonDescription.md
@@ -1,10 +1,1 @@
-<!-- Don't allow prettier to collapse code block into single line -->
-<!-- prettier-ignore -->
->
-> ```jsx
->
-> import { Skeleton, SkeletonItem } from '@fluentui/react-components';
->
-> ```
-
 The `Skeleton` component is a temporary animation placeholder for when a service call takes time to return data and we don't want to block rendering the rest of the UI.

--- a/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
@@ -9,7 +9,7 @@ export { Animation } from './SkeletonAnimation.stories';
 export { Row } from './SkeletonRow.stories';
 
 export default {
-  title: 'Preview Components/Skeleton',
+  title: 'Skeleton',
   component: Skeleton,
   parameters: {
     docs: {


### PR DESCRIPTION
`Skeleton` was promoted to stable (#27767), but it's still under "Preview". This PR fixes that:

<img width="283" alt="image" src="https://github.com/microsoft/fluentui/assets/14183168/7b17ebc5-c6db-46ce-bf6d-efdaa74c7486">
