### PR TITLE
docs(avatargroup): add tooltip example

### DIFF
--- a/packages/react-components/react-avatar/stories/AvatarGroup/AvatarGroupTooltip.stories.tsx
+++ b/packages/react-components/react-avatar/stories/AvatarGroup/AvatarGroupTooltip.stories.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import {
+  AvatarGroup,
+  AvatarGroupItem,
+  AvatarGroupPopover,
+  partitionAvatarGroupItems,
+} from '@fluentui/react-components';
+import type { AvatarGroupProps } from '@fluentui/react-components';
+
+const names = [
+  'Johnie McConnell',
+  'Allan Munger',
+  'Erik Nason',
+  'Kristin Patterson',
+  'Daisy Phillips',
+  'Carole Poland',
+  'Carlos Slattery',
+  'Robert Tolbert',
+  'Kevin Sturgis',
+  'Charlotte Waltson',
+  'Elliot Woodward',
+];
+
+export const Tooltip = (props: Partial<AvatarGroupProps>) => {
+  const { inlineItems, overflowItems } = partitionAvatarGroupItems({ items: names });
+
+  return (
+    <AvatarGroup {...props}>
+      {inlineItems.map(name => (
+        <AvatarGroupItem name={name} key={name} />
+      ))}
+      {overflowItems && (
+        <AvatarGroupPopover tooltip={{ content: 'My custom tooltip', relationship: 'label' }}>
+          {overflowItems.map(name => (
+            <AvatarGroupItem name={name} key={name} />
+          ))}
+        </AvatarGroupPopover>
+      )}
+    </AvatarGroup>
+  );
+};
+
+Tooltip.parameters = {
+  docs: {
+    description: {
+      story: 'You can customize the tooltip of the AvatarGroupPopover, for example for translations.',
+    },
+  },
+};

--- a/packages/react-components/react-avatar/stories/AvatarGroup/index.stories.tsx
+++ b/packages/react-components/react-avatar/stories/AvatarGroup/index.stories.tsx
@@ -9,6 +9,7 @@ export { Indicator } from './AvatarGroupIndicator.stories';
 export { SizeSpread } from './AvatarGroupSizeSpread.stories';
 export { SizeStack } from './AvatarGroupSizeStack.stories';
 export { SizePie } from './AvatarGroupSizePie.stories';
+export { Tooltip } from './AvatarGroupTooltip.stories';
 
 export default {
   title: 'Components/AvatarGroup',


### PR DESCRIPTION
Adds an example to AvatarGroup that show how
you can customize the tooltip of the AvatarGroupPopover.

![2023-05-24_10-25](https://github.com/microsoft/fluentui/assets/7765599/5b2b666b-fabd-401a-ae23-a16f1b5a88fa)

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27696 
