### PR TITLE
fix(react): Add explicit children prop to fix React 18.

### DIFF
--- a/change/@fluentui-react-8015b863-f1a0-4ef5-aa0a-cb9058b1a7d2.json
+++ b/change/@fluentui-react-8015b863-f1a0-4ef5-aa0a-cb9058b1a7d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(DialogFooter): Add explicit children to work with React 18.",
+  "packageName": "@fluentui/react",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -5042,6 +5042,8 @@ export interface IDialogFooter {
 
 // @public (undocumented)
 export interface IDialogFooterProps extends IReactProps<DialogFooterBase> {
+    // (undocumented)
+    children?: React_2.ReactNode;
     className?: string;
     componentRef?: IRefObject<IDialogFooter>;
     styles?: IStyleFunctionOrObject<IDialogFooterStyleProps, IDialogFooterStyles>;

--- a/packages/react/src/components/Dialog/DialogFooter.types.ts
+++ b/packages/react/src/components/Dialog/DialogFooter.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { DialogFooterBase } from './DialogFooter.base';
 import type { IStyle, ITheme } from '../../Styling';
 import type { IReactProps, IRefObject, IStyleFunctionOrObject } from '../../Utilities';
@@ -11,6 +12,8 @@ export interface IDialogFooter {}
  * {@docCategory Dialog}
  */
 export interface IDialogFooterProps extends IReactProps<DialogFooterBase> {
+  children?: React.ReactNode;
+
   /**
    * Gets the component ref.
    */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Children was not explicitly declared, so this created an issue for React 18.

## New Behavior

DialogFooter now has explicit children which will fix React 18 issues.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27986
