### PR TITLE
fix(react-datepicker-compat): Error handling story now doesn't use Date.now to avoid SSR errors

### DIFF
--- a/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles({
   },
 });
 
-const today = new Date(Date.now());
+const today = new Date('05/24/2023');
 const minDate = addMonths(today, -1);
 const maxDate = addYears(today, 1);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Error handling story uses Date.now()

## New Behavior

Error handling story doesn't use Date.now() instead it uses a specific date.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27957
