### PR TITLE
fix(react-datepicker-compat): Only apply aria-owns when popup is rendered

### DIFF
--- a/change/@fluentui-react-datepicker-compat-c7052ce3-4b8a-4668-a7ae-f569d7bf875e.json
+++ b/change/@fluentui-react-datepicker-compat-c7052ce3-4b8a-4668-a7ae-f569d7bf875e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Only apply aria-owns when popup is open.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -6,7 +6,6 @@ Object {
   "baseElement": <body>
     <div>
       <span
-        aria-owns="datePicker-popoverSurface1"
         class="fui-Input fui-DatePicker"
       >
         <input
@@ -41,7 +40,6 @@ Object {
   </body>,
   "container": <div>
     <span
-      aria-owns="datePicker-popoverSurface1"
       class="fui-Input fui-DatePicker"
     >
       <input

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -150,7 +150,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
   const [open, setOpenState] = usePopupVisibility(props);
   const fieldContext = useFieldContext();
   const required = fieldContext?.required ?? props.required;
-  const popupSurfaceId = useId('datePicker-popoverSurface');
+  const popupSurfaceId = useId('datePicker-popupSurface');
 
   const validateTextInput = React.useCallback(
     (date: Date | null = null): void => {

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -365,7 +365,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
       readOnly: !allowTextInput,
       role: 'combobox',
       root: {
-        'aria-owns': popupSurfaceId,
+        'aria-owns': open ? popupSurfaceId : undefined,
         ref: useMergedRefs(triggerWrapperRef, ref),
       },
       input: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`aria-owns` was applied always.

## New Behavior

`aria-owns` is now applied only when popup is open, this will fix an issue with having aria-owns linked to something undefined.

