### PR TITLE
chore(react-dialog): fix useDialogTitle ref argument type

### DIFF
--- a/change/@fluentui-react-dialog-100a6339-0f6d-4d43-ba54-f2c1475a9308.json
+++ b/change/@fluentui-react-dialog-100a6339-0f6d-4d43-ba54-f2c1475a9308.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix useDialogTitle ref argument type",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -229,7 +229,7 @@ export const useDialogSurface_unstable: (props: DialogSurfaceProps, ref: React_2
 export const useDialogSurfaceStyles_unstable: (state: DialogSurfaceState) => DialogSurfaceState;
 
 // @public
-export const useDialogTitle_unstable: (props: DialogTitleProps, ref: React_2.Ref<HTMLElement>) => DialogTitleState;
+export const useDialogTitle_unstable: (props: DialogTitleProps, ref: React_2.Ref<HTMLDivElement>) => DialogTitleState;
 
 // @public
 export const useDialogTitleStyles_unstable: (state: DialogTitleState) => DialogTitleState;

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -16,7 +16,7 @@ import { useDialogTitleInternalStyles } from './useDialogTitleStyles.styles';
  * @param props - props from this instance of DialogTitle
  * @param ref - reference to root HTMLElement of DialogTitle
  */
-export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<HTMLElement>): DialogTitleState => {
+export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<HTMLDivElement>): DialogTitleState => {
   const { as, action } = props;
   const modalType = useDialogContext_unstable(ctx => ctx.modalType);
   const internalStyles = useDialogTitleInternalStyles();

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -184,7 +184,7 @@ export const useDrawerHeaderNavigationStyles_unstable: (state: DrawerHeaderNavig
 export const useDrawerHeaderStyles_unstable: (state: DrawerHeaderState) => DrawerHeaderState;
 
 // @public
-export const useDrawerHeaderTitle_unstable: (props: DrawerHeaderTitleProps, ref: React_2.Ref<HTMLElement>) => DrawerHeaderTitleState;
+export const useDrawerHeaderTitle_unstable: (props: DrawerHeaderTitleProps, ref: React_2.Ref<HTMLDivElement>) => DrawerHeaderTitleState;
 
 // @public
 export const useDrawerHeaderTitleStyles_unstable: (state: DrawerHeaderTitleState) => DrawerHeaderTitleState;

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -14,7 +14,7 @@ import { useDialogTitle_unstable } from '@fluentui/react-dialog';
  */
 export const useDrawerHeaderTitle_unstable = (
   props: DrawerHeaderTitleProps,
-  ref: React.Ref<HTMLElement>,
+  ref: React.Ref<HTMLDivElement>,
 ): DrawerHeaderTitleState => {
   const { root: heading, action, components: titleComponents } = useDialogTitle_unstable(props, ref);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

```ts
export const useDialogTitle_unstable = (
  props: DialogTitleProps,
  ref: React.Ref<HTMLElement>
): DialogTitleState => {}
```

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

```ts
export const useDialogTitle_unstable = (
  props: DialogTitleProps,
  ref: React.Ref<HTMLDivElement>
): DialogTitleState => {}
```

1. changes `ref` argument from `HTMLElement` to `HTMLDivElement` as it's more precise to the actual root type for:
    * `useDialogTitle_unstable`
    * `useDrawerHeaderTitle_unstable`

