### PR TITLE
feat(react-tags): use simple button for TagButton content instead of aria button

### DIFF
--- a/packages/react-components/react-tags/etc/react-tags.api.md
+++ b/packages/react-components/react-tags/etc/react-tags.api.md
@@ -10,7 +10,6 @@ import { AvatarShape } from '@fluentui/react-avatar';
 import { AvatarSize } from '@fluentui/react-avatar';
 import { ComponentProps } from '@fluentui/react-utilities';
 import { ComponentState } from '@fluentui/react-utilities';
-import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import { Slot } from '@fluentui/react-utilities';
@@ -41,7 +40,7 @@ export type TagButtonProps = ComponentProps<Partial<TagButtonSlots>> & Omit<TagP
 export type TagButtonSlots = Omit<TagSlots, 'root' | 'dismissIcon'> & {
     root: NonNullable<Slot<'div'>>;
     dismissButton?: Slot<'button'>;
-    content: NonNullable<ARIAButtonSlotProps<'div'>>;
+    content: Slot<'button'>;
 };
 
 // @public

--- a/packages/react-components/react-tags/src/components/TagButton/TagButton.types.ts
+++ b/packages/react-components/react-tags/src/components/TagButton/TagButton.types.ts
@@ -1,13 +1,12 @@
 import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { TagContextValues, TagProps, TagSlots, TagState } from '../Tag/index';
-import { ARIAButtonSlotProps } from '../../../../react-aria/src/index';
 
 export type TagButtonContextValues = TagContextValues;
 
 export type TagButtonSlots = Omit<TagSlots, 'root' | 'dismissIcon'> & {
   root: NonNullable<Slot<'div'>>;
   dismissButton?: Slot<'button'>;
-  content: NonNullable<ARIAButtonSlotProps<'div'>>;
+  content: Slot<'button'>;
 };
 
 /**

--- a/packages/react-components/react-tags/src/components/TagButton/useTagButton.tsx
+++ b/packages/react-components/react-tags/src/components/TagButton/useTagButton.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { getNativeElementProps, resolveShorthand, useEventCallback, useId } from '@fluentui/react-utilities';
 import { DismissRegular, bundleIcon, DismissFilled } from '@fluentui/react-icons';
 import type { TagButtonProps, TagButtonState } from './TagButton.types';
-import { useARIAButtonShorthand } from '@fluentui/react-aria';
 import { Delete, Backspace } from '@fluentui/keyboard-keys';
 import { useTagGroupContext_unstable } from '../../contexts/TagGroupContext';
 
@@ -76,7 +75,7 @@ export const useTagButton_unstable = (props: TagButtonProps, ref: React.Ref<HTML
 
     components: {
       root: 'div',
-      content: 'div',
+      content: 'button',
       media: 'span',
       icon: 'span',
       primaryText: 'span',
@@ -90,11 +89,10 @@ export const useTagButton_unstable = (props: TagButtonProps, ref: React.Ref<HTML
       id,
     }),
 
-    content: useARIAButtonShorthand(props.content, {
+    content: resolveShorthand(props.content, {
       required: true,
       defaultProps: {
         disabled,
-        tabIndex: 0,
         type: 'button',
       },
     }),

--- a/packages/react-components/react-tags/src/components/TagButton/useTagButtonStyles.styles.ts
+++ b/packages/react-components/react-tags/src/components/TagButton/useTagButtonStyles.styles.ts
@@ -124,6 +124,7 @@ export const useTagButtonStyles_unstable = (state: TagButtonState): TagButtonSta
     state.content.className = mergeClasses(
       tagButtonClassNames.content,
 
+      resetButtonStyles.resetButton,
       styles.content,
       state.shape === 'circular' && styles.circularContent,
       !state.media && !state.icon && styles.contentWithoutMedia,


### PR DESCRIPTION
Update TagButton `content` slot:
`content: NonNullable<ARIAButtonSlotProps<'div'>>;` → `content: Slot<'button'>;`

I like simple button. I've no idea why I used `div` with aria button before 🤷‍♀️