### PR TITLE
Fix for dialog title not taking whole row for dialog without actions

### DIFF
--- a/change/@fluentui-react-dialog-f53ccc8c-8b2f-4726-8d7a-e61990a04769.json
+++ b/change/@fluentui-react-dialog-f53ccc8c-8b2f-4726-8d7a-e61990a04769.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "dialog title now takes whole row when there are no actions. This fixes an earlier regresssion.",
+  "comment": "fix: dialog title now takes whole row when there are no actions. This fixes an earlier regresssion.",
   "packageName": "@fluentui/react-dialog",
   "email": "derdem@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-dialog-f53ccc8c-8b2f-4726-8d7a-e61990a04769.json
+++ b/change/@fluentui-react-dialog-f53ccc8c-8b2f-4726-8d7a-e61990a04769.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "dialog title now takes whole row when there are no actions. This fixes an earlier regresssion.",
+  "packageName": "@fluentui/react-dialog",
+  "email": "derdem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitleStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitleStyles.styles.ts
@@ -21,7 +21,9 @@ const useStyles = makeStyles({
     ...typographyStyles.subtitle1,
     ...shorthands.margin(0),
   },
-  rootWithoutAction: {},
+  rootWithoutAction: {
+    gridColumnEnd: 4,
+  },
   action: {
     gridRowStart: 1,
     gridRowEnd: 1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

For dialog's without actions the title isn't taking up the whole row. This is a regression from an earlier version.
![image](https://github.com/microsoft/fluentui/assets/5321587/049558b6-43ab-4010-a636-dca7a72cc038)

## New Behavior

After the change you can see the title is taking the full row as expected.
![image](https://github.com/microsoft/fluentui/assets/5321587/23cae9a1-92fd-4a43-a159-937f5e0288f3)

Here is also an dialog with action to show there isn't a regression
![image](https://github.com/microsoft/fluentui/assets/5321587/351d59a8-d1a0-4b4c-8132-23f7b31dfd24)

These images are taken from the story book opened by running yarn start @fluentui/react-dialog

## Related Issue(s)

- Fixes #28036
