### PR TITLE
Fix toolbar divider styles

### DIFF
--- a/change/@fluentui-react-toolbar-cd3d2025-51f1-430b-b2b1-eaa3b885de3b.json
+++ b/change/@fluentui-react-toolbar-cd3d2025-51f1-430b-b2b1-eaa3b885de3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed a bug where ToolbarDivider default styles were prioritized",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/src/components/ToolbarDivider/useToolbarDividerStyles.styles.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarDivider/useToolbarDividerStyles.styles.ts
@@ -22,9 +22,9 @@ export const useToolbarDividerStyles_unstable = (state: ToolbarDividerState): To
   const { vertical } = state;
   const toolbarDividerStyles = useBaseStyles();
   state.root.className = mergeClasses(
-    state.root.className,
     toolbarDividerStyles.root,
     !vertical && toolbarDividerStyles.vertical,
+    state.root.className,
   );
   return state;
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

ToolbarDivider didn't have proper style order, meaning that the passed styles would be overriden by the default ones.

## New Behavior

The passed styles have priority.

## Related Issue(s)

- Fixes #28042 
