### PR TITLE
Theme provider docs

### DIFF
--- a/change/@fluentui-react-ace62892-08c9-4f65-9069-b9df20bb9cc0.json
+++ b/change/@fluentui-react-ace62892-08c9-4f65-9069-b9df20bb9cc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "change theme provider as prop docs to better define valid values",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/src/utilities/ThemeProvider/ThemeProvider.types.ts
+++ b/packages/react/src/utilities/ThemeProvider/ThemeProvider.types.ts
@@ -10,7 +10,7 @@ import type { ICustomizerContext } from '@fluentui/utilities';
  */
 export interface ThemeProviderProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * A component that should be used as the root element of the ThemeProvider component.
+   * The element that should be used as the root of the ThemeProvider component.
    */
   as?: React.ElementType;
 


### PR DESCRIPTION
Theme provider docs don't make it clear that it only accepts standard HTML elements. (Issue here https://github.com/microsoft/fluentui/issues/28016)

This PR improves the docs to make it more clear, but also curious if we need to address the type.