### PR TITLE
fix(react-datepicker-compat): Remove focus function from the deps to avoid constant move of focus

### DIFF
--- a/change/@fluentui-react-datepicker-compat-f276a459-aa9c-4f3b-bb52-ac556558e5ec.json
+++ b/change/@fluentui-react-datepicker-compat-f276a459-aa9c-4f3b-bb52-ac556558e5ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove focus function from the deps to avoid constant move of focus.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -424,7 +424,9 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     if (!open && !props.disabled) {
       focus();
     }
-  }, [open, props.disabled, focus]);
+    // Focus function keeps changing, so we need to skip it in the deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, props.disabled]);
 
   const calendarShorthand = resolveShorthand(props.calendar, {
     required: true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`focus` function used to be part of deps to move focus to the calendar, this cause a constant move of focus to the calendar.

## New Behavior

`focus` has been removed from the deps to stop stealing focus.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28009
