### PR TITLE
Updated migration documentation

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/KeepingDesignConsistent.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/KeepingDesignConsistent.stories.mdx
@@ -80,11 +80,16 @@ See _Extending themes with new tokens_ section in [Theming](/docs/concepts-devel
 ## You can make v0, v8, v9 components have the same style
 
 While you have both old and new components together in your application, you may see some differences in the theme and styling of components.
-You can choose to live with the minor discrepancies until you have fully migrated to v9.
-You can also choose to make everything look like a previous version or like v9.
+You can choose to live with the minor discrepancies during migration, or make everything look the same.
 
-> We recommend moving to v9's Fluent 2 design.
-> It has improved accessibility and has consistent style across components.
+> We recommend moving to v9's Fluent 2 design. It has improved accessibility and has consistent style across components.
+
+### You can use the Fluent 2 theme for v8
+
+If you want to make v8 components look like v9, you can pass the Fluent 2 theme for v8 to the ThemeProvider.
+For more information read the [v8 Fluent 2 theme documentation](https://developer.microsoft.com/en-us/fluentui#/controls/web/themes).
+
+In the v8 documentation for each component, you can select the Fluent 2 theme to see how it looks.
 
 ### You can create custom themes
 


### PR DESCRIPTION
## Changes
- Updated migration design documentation to mention v8 Fluent2 theme and link to the v8 documentation.

<img width="1572" alt="image" src="https://github.com/microsoft/fluentui/assets/28762486/82436ff3-48d5-4ee2-ad91-047999d08097">
