### PR TITLE
Dont inline setcallbackmap with terser to prevent memory leaks

### DIFF
--- a/change/@fluentui-utilities-935d72bf-a3ff-428f-b440-fe912842be69.json
+++ b/change/@fluentui-utilities-935d72bf-a3ff-428f-b440-fe912842be69.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Avoid inlining setCallbackMap with terser to prevent memory leaks.",
+  "comment": "fix: Avoid inlining setCallbackMap with terser to prevent memory leaks.",
   "packageName": "@fluentui/utilities",
   "email": "andrew.stegmaier@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-utilities-935d72bf-a3ff-428f-b440-fe912842be69.json
+++ b/change/@fluentui-utilities-935d72bf-a3ff-428f-b440-fe912842be69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Avoid inlining setCallbackMap with terser to prevent memory leaks.",
+  "packageName": "@fluentui/utilities",
+  "email": "andrew.stegmaier@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -110,7 +110,9 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
     let onKeyUp: (ev: KeyboardEvent) => void;
     if (context?.providerRef?.current) {
       el = context.providerRef.current;
-      const callbacks = setCallbackMap(context);
+      // The NOINLINE directive tells terser not to move the setCallbackMap implementation into the call site during minification.
+      // This is prevents the function from capturing additional variables in the closure, which has been a source of memory leaks.
+      const callbacks = /*@__NOINLINE__*/ setCallbackMap(context);
       onMouseDown = callbacks.onMouseDown;
       onPointerDown = callbacks.onPointerDown;
       onKeyDown = callbacks.onKeyDown;

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -110,8 +110,9 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
     let onKeyUp: (ev: KeyboardEvent) => void;
     if (context?.providerRef?.current) {
       el = context.providerRef.current;
-      // The NOINLINE directive tells terser not to move the setCallbackMap implementation into the call site during minification.
-      // This is prevents the function from capturing additional variables in the closure, which has been a source of memory leaks.
+      // The NOINLINE directive tells terser not to move the setCallbackMap implementation into the call site during
+      // minification.
+      // This prevents the function from capturing additional variables in the closure, which can cause memory leaks.
       const callbacks = /*@__NOINLINE__*/ setCallbackMap(context);
       onMouseDown = callbacks.onMouseDown;
       onPointerDown = callbacks.onPointerDown;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible) - this isn't necessary
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When `useFocusRects` is minified with terser, the default behavior would inline the function definition for `setCallbackMap` into the call site within the hook. This would cause it to capture additional variables in its closure, which would in turn be stored by the functions on the `callbackMap` WeakMap. This can cause memory leaks for some host applications.

## New Behavior

We use the [NOINLINE terser directive](https://github.com/terser/terser#annotations) to prevent the inlining behavior.