### PR TITLE
chore: Updating v0 to v9 Button migration docs to remove reference to non-existent block prop

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV0/Components/Button.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV0/Components/Button.stories.mdx
@@ -34,7 +34,7 @@ const Component = () => <Button>Here is Button</Button>;
 | disabled          | keep it as is                                                                                            |
 | disabledFocusable | keep it as is                                                                                            |
 | flat              | REMOVED: it's a default view now, we're moving away from shadows                                         |
-| fluid             | replace with `block`                                                                                     |
+| fluid             | REMOVED: use styles to set width to 100% and flex grow to 1                                              |
 | icon              | keep it as is. See Button + Icon integration in this document                                            |
 | iconOnly          | REMOVED: see Migrate iconOnly prop in this document                                                      |
 | iconPosition      | keep it as is                                                                                            |


### PR DESCRIPTION
## Previous Behavior

The v0 to v9 `Button` migration docs referred to the `block` prop when talking about migration of the `fluid` prop in v0. The `block` prop does not exist in v9 after being deprecated and removed before the first stable version of v9.

## New Behavior

The v0 to v9 `Button` migration docs do not reference the `block` prop anymore when talking about migration of the `fluid` prop in v0. The actual recommendation to use styles' customization to achieve this is written now.

## Related Issue(s)

- Fixes #27715
