### PR TITLE
Message bar zoom

### DIFF
--- a/change/@fluentui-react-bf3bb0f5-64ca-4492-be5c-82e7a6808157.json
+++ b/change/@fluentui-react-bf3bb0f5-64ca-4492-be5c-82e7a6808157.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MessageBar: Add SmallScreenSelector styles to use grid layout to properly place buttons",
+  "packageName": "@fluentui/react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/react/src/components/MessageBar/MessageBar.styles.ts
@@ -177,6 +177,15 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         display: 'flex',
         width: '100%',
         lineHeight: 'normal',
+        [SmallScreenSelector]: {
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr auto',
+          gridTemplateRows: '1fr auto',
+          gridTemplateAreas: `
+            "icon text close"
+            "action action action"
+          `,
+        },
       },
     ],
     iconContainer: [
@@ -188,6 +197,9 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         display: 'flex',
         flexShrink: 0,
         margin: '8px 0 8px 12px',
+        [SmallScreenSelector]: {
+          gridArea: 'icon',
+        },
       },
     ],
     icon: {
@@ -207,6 +219,9 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         flexGrow: 1,
         margin: 8,
         ...fonts.small,
+        [SmallScreenSelector]: {
+          gridArea: 'text',
+        },
         selectors: {
           [HighContrastSelector]: {
             ...getHighContrastNoAdjustStyle(),
@@ -252,7 +267,14 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         whiteSpace: 'pre-wrap',
       },
     ],
-    dismissSingleLine: classNames.dismissSingleLine,
+    dismissSingleLine: [
+      classNames.dismissSingleLine,
+      {
+        [SmallScreenSelector]: {
+          gridArea: 'close',
+        },
+      },
+    ],
     expandSingleLine: classNames.expandSingleLine,
     dismissal: [classNames.dismissal, dismissalAndExpandStyle],
     expand: [classNames.expand, dismissalAndExpandStyle],
@@ -269,9 +291,17 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         // reset forced colors to browser control for inner actions
         forcedColorAdjust: 'auto',
         MsHighContrastAdjust: 'auto',
+        [SmallScreenSelector]: {
+          gridArea: 'action',
+          marginRight: 8,
+          marginBottom: 8,
+        },
         selectors: {
           '& button:nth-child(n+2)': {
             marginLeft: 8,
+            [SmallScreenSelector]: {
+              marginBottom: 0,
+            },
           },
         },
       },

--- a/packages/react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -45,6 +45,15 @@ exports[`MessageBar snapshots renders MessageBar correctly 1`] = `
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -60,6 +69,9 @@ exports[`MessageBar snapshots renders MessageBar correctly 1`] = `
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -103,6 +115,9 @@ exports[`MessageBar snapshots renders MessageBar correctly 1`] = `
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -176,6 +191,15 @@ exports[`MessageBar snapshots renders a error MessageBar correctly 1`] = `
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -191,6 +215,9 @@ exports[`MessageBar snapshots renders a error MessageBar correctly 1`] = `
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -234,6 +261,9 @@ exports[`MessageBar snapshots renders a error MessageBar correctly 1`] = `
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -306,6 +336,15 @@ exports[`MessageBar snapshots renders a info MessageBar correctly 1`] = `
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -321,6 +360,9 @@ exports[`MessageBar snapshots renders a info MessageBar correctly 1`] = `
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -364,6 +406,9 @@ exports[`MessageBar snapshots renders a info MessageBar correctly 1`] = `
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -436,6 +481,15 @@ exports[`MessageBar snapshots renders a multiline MessageBar correctly 1`] = `
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -451,6 +505,9 @@ exports[`MessageBar snapshots renders a multiline MessageBar correctly 1`] = `
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -494,6 +551,9 @@ exports[`MessageBar snapshots renders a multiline MessageBar correctly 1`] = `
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -567,6 +627,15 @@ exports[`MessageBar snapshots renders a multiline error MessageBar correctly 1`]
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -582,6 +651,9 @@ exports[`MessageBar snapshots renders a multiline error MessageBar correctly 1`]
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -625,6 +697,9 @@ exports[`MessageBar snapshots renders a multiline error MessageBar correctly 1`]
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -697,6 +772,15 @@ exports[`MessageBar snapshots renders a multiline info MessageBar correctly 1`] 
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -712,6 +796,9 @@ exports[`MessageBar snapshots renders a multiline info MessageBar correctly 1`] 
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -755,6 +842,9 @@ exports[`MessageBar snapshots renders a multiline info MessageBar correctly 1`] 
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -828,6 +918,15 @@ exports[`MessageBar snapshots renders a multiline severeWarning MessageBar corre
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -843,6 +942,9 @@ exports[`MessageBar snapshots renders a multiline severeWarning MessageBar corre
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -886,6 +988,9 @@ exports[`MessageBar snapshots renders a multiline severeWarning MessageBar corre
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -959,6 +1064,15 @@ exports[`MessageBar snapshots renders a multiline success MessageBar correctly 1
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -974,6 +1088,9 @@ exports[`MessageBar snapshots renders a multiline success MessageBar correctly 1
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -1017,6 +1134,9 @@ exports[`MessageBar snapshots renders a multiline success MessageBar correctly 1
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -1090,6 +1210,15 @@ exports[`MessageBar snapshots renders a multiline warning MessageBar correctly 1
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -1105,6 +1234,9 @@ exports[`MessageBar snapshots renders a multiline warning MessageBar correctly 1
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -1148,6 +1280,9 @@ exports[`MessageBar snapshots renders a multiline warning MessageBar correctly 1
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -1221,6 +1356,15 @@ exports[`MessageBar snapshots renders a severeWarning MessageBar correctly 1`] =
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -1236,6 +1380,9 @@ exports[`MessageBar snapshots renders a severeWarning MessageBar correctly 1`] =
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -1279,6 +1426,9 @@ exports[`MessageBar snapshots renders a severeWarning MessageBar correctly 1`] =
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -1352,6 +1502,15 @@ exports[`MessageBar snapshots renders a success MessageBar correctly 1`] = `
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -1367,6 +1526,9 @@ exports[`MessageBar snapshots renders a success MessageBar correctly 1`] = `
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -1410,6 +1572,9 @@ exports[`MessageBar snapshots renders a success MessageBar correctly 1`] = `
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;
@@ -1483,6 +1648,15 @@ exports[`MessageBar snapshots renders a warning MessageBar correctly 1`] = `
           line-height: normal;
           width: 100%;
         }
+        @media only screen and (min-width: 0px) and (max-width: 479px){& {
+          display: grid;
+          grid-template-areas: 
+                    "icon text close"
+                    "action action action"
+                  ;
+          grid-template-columns: auto 1fr auto;
+          grid-template-rows: 1fr auto;
+        }
   >
     <div
       aria-hidden={true}
@@ -1498,6 +1672,9 @@ exports[`MessageBar snapshots renders a warning MessageBar correctly 1`] = `
             margin-top: 8px;
             min-height: 16px;
             min-width: 16px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: icon;
           }
     >
       <i
@@ -1541,6 +1718,9 @@ exports[`MessageBar snapshots renders a warning MessageBar correctly 1`] = `
             margin-right: 12px;
             margin-top: 8px;
             min-width: 0px;
+          }
+          @media only screen and (min-width: 0px) and (max-width: 479px){& {
+            grid-area: text;
           }
           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
             -ms-high-contrast-adjust: none;


### PR DESCRIPTION
fixes #27749

Single line message bars are now layed out like multi line message bars when shown on small screen sizes or high zoom

![image](https://github.com/microsoft/fluentui/assets/1434956/e00b673d-6c1b-46aa-869e-0135e3fba822)
