### PR TITLE
fix(react-conformance): custom classname prefix test option now works 

### DIFF
--- a/change/@fluentui-react-conformance-09db4fc5-2f5c-4dbe-a602-2c226cff5bab.json
+++ b/change/@fluentui-react-conformance-09db4fc5-2f5c-4dbe-a602-2c226cff5bab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: testOptions custom classname prefix now works as intended.",
+  "packageName": "@fluentui/react-conformance",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -254,10 +254,11 @@ export const defaultTests: TestObject = {
 
   /** Component file has assigned and exported static classnames object */
   'component-has-static-classnames-object': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
-    const { componentPath, Component, requiredProps, renderOptions } = testInfo;
+    const { componentPath, Component, testOptions = {}, requiredProps, renderOptions } = testInfo;
 
     const componentName = componentInfo.displayName;
-    const componentClassName = `fui-${componentName}`;
+    const classNamePrefix = testOptions?.['component-has-static-classname']?.prefix ?? 'fui';
+    const componentClassName = `${classNamePrefix}-${componentName}`;
     const exportName = `${componentName[0].toLowerCase()}${componentName.slice(1)}ClassNames`;
     const indexPath = path.join(getPackagePath(componentPath), 'src', 'index');
     let handledClassNamesObjectExport = false;
@@ -309,7 +310,6 @@ export const defaultTests: TestObject = {
         return;
       }
 
-      const { testOptions = {} } = testInfo;
       const staticClassNameVariants = testOptions['has-static-classnames'] ?? [{ props: {} }];
 
       for (const staticClassNames of staticClassNameVariants) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- Passing in custom classname prefix like below does **not** do anything:
	
```js
    testOptions: {
      'component-has-static-classname': {
        /** Prefix for the classname, if not `fui-` */
        prefix: 'fai',
      },
	}
```

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- Passing in custom classname prefix (like the one outlined above) now works:

![image](https://github.com/microsoft/fluentui/assets/8649804/7649adcd-f157-4df9-97eb-9f192beeb906)


