### PR TITLE
fix: update Skeleton stories path

### DIFF
--- a/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
@@ -9,7 +9,7 @@ export { Animation } from './SkeletonAnimation.stories';
 export { Row } from './SkeletonRow.stories';
 
 export default {
-  title: 'Skeleton',
+  title: 'Components/Skeleton',
   component: Skeleton,
   parameters: {
     docs: {


### PR DESCRIPTION
This PR is to fix the filet path for the `Skeleton` stories to put them under `Components`