### PR TITLE
add support for React 17 and situation where Event is Object

### DIFF
--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -206,7 +206,9 @@ const useMenuOpenState = (
 
   const setOpen = useEventCallback((e: MenuOpenEvent, data: MenuOpenChangeData) => {
     clearTimeout(setOpenTimeout.current);
-    if (!(e instanceof Event) && e.persist) {
+    // https://www.npmjs.com/package/is-react-synthetic-event
+    const isSyntheticEvent = typeof e !== 'object' || e === null ? false : '_dispatchListeners' in e;
+    if (isSyntheticEvent && e.persist) {
       // < React 17 still uses pooled synthetic events
       e.persist();
     }

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -64,7 +64,9 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 
   const setOpen = useEventCallback((e: OpenPopoverEvents, shouldOpen: boolean) => {
     clearTimeout(setOpenTimeoutRef.current);
-    if (!(e instanceof Event) && e.persist) {
+    // https://www.npmjs.com/package/is-react-synthetic-event
+    const isSyntheticEvent = typeof e !== 'object' || e === null ? false :  '_dispatchListeners' in e;
+    if (isSyntheticEvent && e.persist) {
       // < React 17 still uses pooled synthetic events
       e.persist();
     }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1380,7 +1380,9 @@ function overrideTarget(
   ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined,
   target?: Target,
 ): void {
-  if (ev && target) {
+  // https://www.npmjs.com/package/is-react-synthetic-event
+  const isSyntheticEvent = typeof ev !== 'object' || ev === null ? false : '_dispatchListeners' in ev;
+  if (ev && target && isSyntheticEvent) {
     ev.persist();
 
     if (target instanceof Event) {


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally

PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

With React 17 the program can crash to TypeError VM161:1 Uncaught TypeError: Right-hand side of 'instanceof' is not callable

## New Behavior

instanceof is no longer called, using the method used in 
https://www.npmjs.com/package/is-react-synthetic-event

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
