### PR TITLE
fix(react-combobox): Option's checkIcon adds provided className at the end to avoid overrides

### DIFF
--- a/change/@fluentui-react-combobox-a0ef5216-e89a-420a-9879-ec97275c3f1f.json
+++ b/change/@fluentui-react-combobox-a0ef5216-e89a-420a-9879-ec97275c3f1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Option's checkIcon adds provided className at the end to avoid overrides.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
@@ -140,11 +140,11 @@ export const useOptionStyles_unstable = (state: OptionState): OptionState => {
     state.checkIcon.className = mergeClasses(
       optionClassNames.checkIcon,
       styles.checkIcon,
-      state.checkIcon.className,
       multiselect && styles.multiselectCheck,
       selected && styles.selectedCheck,
       selected && multiselect && styles.selectedMultiselectCheck,
       disabled && styles.checkDisabled,
+      state.checkIcon.className,
     );
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The provided className for checkIcon is not added at the end, this causes issues when trying to override styles.

## New Behavior

The provided className for checkIcon is added at the end, allowing overrides for the slot.

