### PR TITLE
fix(react-avatar): Do not render the image when src prop is undefined

### DIFF
--- a/change/@fluentui-react-avatar-d8ee1b7d-ba8b-46a7-8aa6-bf5d84ebdbfe.json
+++ b/change/@fluentui-react-avatar-d8ee1b7d-ba8b-46a7-8aa6-bf5d84ebdbfe.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "\"fix: Do not render the image when src prop is undefined.",
+  "comment": "fix: Do not render the image when src prop is undefined.",
   "packageName": "@fluentui/react-avatar",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-avatar-d8ee1b7d-ba8b-46a7-8aa6-bf5d84ebdbfe.json
+++ b/change/@fluentui-react-avatar-d8ee1b7d-ba8b-46a7-8aa6-bf5d84ebdbfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\"fix: Do not render the image when src prop is undefined.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.test.tsx
@@ -247,4 +247,10 @@ describe('Avatar', () => {
     expect(root.getAttribute('aria-label')).toBe('First Last');
     expect(root.getAttribute('aria-labelledby')).toBeFalsy();
   });
+
+  it('does not render an image when the src attribute is undefined', () => {
+    render(<Avatar image={{ src: undefined, alt: 'test-image' }} />);
+
+    expect(screen.queryByAltText('test-image')).toBeNull();
+  });
 });

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -45,17 +45,19 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   );
 
   const [imageHidden, setImageHidden] = React.useState<true | undefined>(undefined);
-  // Image shouldn't be resolved if its src is undefined
-  const image: AvatarState['image'] = props.image?.src
-    ? resolveShorthand(props.image, {
-        defaultProps: {
-          alt: '',
-          role: 'presentation',
-          'aria-hidden': true,
-          hidden: imageHidden,
-        },
-      })
-    : undefined;
+  let image: AvatarState['image'] = resolveShorthand(props.image, {
+    defaultProps: {
+      alt: '',
+      role: 'presentation',
+      'aria-hidden': true,
+      hidden: imageHidden,
+    },
+  });
+
+  // Image shouldn't be rendered if its src is not set
+  if (!image?.src) {
+    image = undefined;
+  }
 
   // Hide the image if it fails to load and restore it on a successful load
   if (image) {

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -45,14 +45,17 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   );
 
   const [imageHidden, setImageHidden] = React.useState<true | undefined>(undefined);
-  const image: AvatarState['image'] = resolveShorthand(props.image, {
-    defaultProps: {
-      alt: '',
-      role: 'presentation',
-      'aria-hidden': true,
-      hidden: imageHidden,
-    },
-  });
+  // Image shouldn't be resolved if its src is undefined
+  const image: AvatarState['image'] = props.image?.src
+    ? resolveShorthand(props.image, {
+        defaultProps: {
+          alt: '',
+          role: 'presentation',
+          'aria-hidden': true,
+          hidden: imageHidden,
+        },
+      })
+    : undefined;
 
   // Hide the image if it fails to load and restore it on a successful load
   if (image) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Avatar renders an image even if src is undefined `<Avatar image={{ src: undefined }} />`
![image](https://github.com/microsoft/fluentui/assets/5953191/fc973883-97f3-4fc9-9c90-7b676560880c)


## New Behavior

Avatar no longer renders undefined image:
![image](https://github.com/microsoft/fluentui/assets/5953191/f606daa8-dc01-49aa-8c9f-9450608ea2ba)

