### PR TITLE
fix: High contrast mode hover style icon fixes in react-button components

### DIFF
--- a/change/@fluentui-react-button-2730412f-d6ac-4017-b757-ced56c7f214f.json
+++ b/change/@fluentui-react-button-2730412f-d6ac-4017-b757-ced56c7f214f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: high contrast mode hover style icon fixes",
+  "packageName": "@fluentui/react-button",
+  "email": "eysjiang@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -208,6 +208,23 @@ const useRootStyles = makeStyles({
         color: tokens.colorNeutralForeground2BrandPressed,
       },
     },
+
+    '@media (forced-colors: active)': {
+      ':hover': {
+        color: 'canvas',
+
+        [`& .${buttonClassNames.icon}`]: {
+          color: 'canvas',
+        },
+      },
+      ':hover:active': {
+        color: 'canvas',
+
+        [`& .${buttonClassNames.icon}`]: {
+          color: 'canvas',
+        },
+      },
+    },
   },
   transparent: {
     backgroundColor: tokens.colorTransparentBackground,
@@ -224,6 +241,19 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorTransparentBackgroundPressed,
       ...shorthands.borderColor('transparent'),
       color: tokens.colorNeutralForeground2BrandPressed,
+    },
+
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: tokens.colorTransparentBackgroundHover,
+        ...shorthands.borderColor('transparent'),
+        color: 'Highlight',
+      },
+      ':hover:active': {
+        backgroundColor: tokens.colorTransparentBackgroundHover,
+        ...shorthands.borderColor('transparent'),
+        color: 'Highlight',
+      },
     },
   },
 

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -211,17 +211,17 @@ const useRootStyles = makeStyles({
 
     '@media (forced-colors: active)': {
       ':hover': {
-        color: 'canvas',
+        color: 'Canvas',
 
         [`& .${buttonClassNames.icon}`]: {
-          color: 'canvas',
+          color: 'Canvas',
         },
       },
       ':hover:active': {
-        color: 'canvas',
+        color: 'Canvas',
 
         [`& .${buttonClassNames.icon}`]: {
-          color: 'canvas',
+          color: 'Canvas',
         },
       },
     },

--- a/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
@@ -100,12 +100,12 @@ const useRootStyles = makeStyles({
     '@media (forced-colors: active)': {
       ':hover': {
         [`& .${compoundButtonClassNames.secondaryContent}`]: {
-          color: 'canvas',
+          color: 'Canvas',
         },
       },
       ':hover:active': {
         [`& .${compoundButtonClassNames.secondaryContent}`]: {
-          color: 'canvas',
+          color: 'Canvas',
         },
       },
     },

--- a/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
@@ -96,6 +96,19 @@ const useRootStyles = makeStyles({
         color: tokens.colorNeutralForeground2Pressed,
       },
     },
+
+    '@media (forced-colors: active)': {
+      ':hover': {
+        [`& .${compoundButtonClassNames.secondaryContent}`]: {
+          color: 'canvas',
+        },
+      },
+      ':hover:active': {
+        [`& .${compoundButtonClassNames.secondaryContent}`]: {
+          color: 'canvas',
+        },
+      },
+    },
   },
   transparent: {
     [`& .${compoundButtonClassNames.secondaryContent}`]: {

--- a/packages/react-components/react-button/src/components/MenuButton/useMenuButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/MenuButton/useMenuButtonStyles.styles.ts
@@ -66,7 +66,7 @@ const useIconExpandedStyles = makeStyles({
     // High contrast styles
     '@media (forced-colors: active)': {
       ':hover': {
-        color: 'canvas',
+        color: 'Canvas',
       },
     },
   },

--- a/packages/react-components/react-button/src/components/MenuButton/useMenuButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/MenuButton/useMenuButtonStyles.styles.ts
@@ -62,6 +62,14 @@ const useIconExpandedStyles = makeStyles({
   transparent: {
     color: tokens.colorNeutralForeground2BrandSelected,
   },
+  highContrast: {
+    // High contrast styles
+    '@media (forced-colors: active)': {
+      ':hover': {
+        color: 'canvas',
+      },
+    },
+  },
 });
 
 const useMenuIconStyles = makeStyles({
@@ -110,7 +118,7 @@ export const useMenuButtonStyles_unstable = (state: MenuButtonState): MenuButton
   if (state.icon) {
     state.icon.className = mergeClasses(
       menuButtonClassNames.icon,
-      state.root['aria-expanded'] && iconExpandedStyles[state.appearance],
+      state.root['aria-expanded'] && iconExpandedStyles[state.appearance] && iconExpandedStyles.highContrast,
       state.icon.className,
     );
   }

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.styles.ts
@@ -215,6 +215,12 @@ const useIconCheckedStyles = makeStyles({
   subtleOrTransparent: {
     color: tokens.colorNeutralForeground2BrandSelected,
   },
+  // High contrast styles
+  highContrast: {
+    '@media (forced-colors: active)': {
+      forcedColorAdjust: 'auto',
+    },
+  },
 });
 
 const usePrimaryHighContrastStyles = makeStyles({
@@ -272,7 +278,9 @@ export const useToggleButtonStyles_unstable = (state: ToggleButtonState): Toggle
   if (state.icon) {
     state.icon.className = mergeClasses(
       toggleButtonClassNames.icon,
-      (appearance === 'subtle' || appearance === 'transparent') && iconCheckedStyles.subtleOrTransparent,
+      (appearance === 'subtle' || appearance === 'transparent') &&
+        iconCheckedStyles.subtleOrTransparent &&
+        iconCheckedStyles.highContrast,
       state.icon.className,
     );
   }


### PR DESCRIPTION
This PR corrects the contrast of the icon on subtle buttons and text on transparent buttons in high contrast mode.

Before:
<img width="87" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/6bb525b4-ed09-4751-80c3-90002c6fb505">
<img width="106" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/d4f00de3-9245-44f6-b843-1a6cea15ae88">

After:
<img width="88" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/dca0b80b-8763-4315-9b5d-763a16bc0f6c">
<img width="111" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/de3b6803-543e-4e53-8ef8-280b260507d5">

Also corrects the color of the secondary text for CompoundButton.
Before:
<img width="130" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/3fd0e496-359a-4a00-9aa8-ff962d7984fa">

After:
<img width="145" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/8fe120dd-5125-4f5d-a2c4-947ff2260ba8">

Removes the high contrast MenuButton bug that causes icons to change colors when the menu is open.
Before:
<img width="128" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/be11512f-7292-44c3-a126-e3d92fb63e5a">

After:
<img width="509" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/7db6170c-fdfe-4b56-8ea7-fef558bf2c4a">

Removes the high contrast ToggleButton bug that caused the Subtle and Transparent variants to have low contrast icons.
Before:
<img width="185" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/8297fd8a-9fcb-4ab2-9f11-35822cada5f5">

After:
<img width="195" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/e47e6d6c-4446-451e-b0c1-2ea9cb6d006c">
