### PR TITLE
fix: Layer sets focus visible classname for its FocusRectsProvider

### DIFF
--- a/change/@fluentui-react-13f13391-8a93-4b11-b3c6-cfccea4fcdee.json
+++ b/change/@fluentui-react-13f13391-8a93-4b11-b3c6-cfccea4fcdee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Layer propagates focus visible classname to its contents",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Layer/Layer.test.tsx
+++ b/packages/react/src/components/Layer/Layer.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { Layer } from './Layer';
 import { LayerHost } from './LayerHost';
+import { FocusRectsProvider, IsFocusVisibleClassName } from '../../Utilities';
 import { mount } from 'enzyme';
 import { safeCreate } from '@fluentui/test-utilities';
 import { render } from '@testing-library/react';
@@ -261,6 +262,41 @@ describe('Layer', () => {
 
     // The 1 time is for when it was mounted
     expect(onLayerDidMountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets focus visibility className from parent context', () => {
+    const parentFocusEl = document.createElement('div');
+    parentFocusEl.classList.add(IsFocusVisibleClassName);
+    const parentFocusRef = { current: parentFocusEl };
+    const FocusProviderTest = () => (
+      <div id="app">
+        <FocusRectsProvider providerRef={parentFocusRef}>
+          <div id="parent">
+            <Layer hostId="focusTest" fabricProps={{ className: 'innerFocusProvider' }}>
+              content
+            </Layer>
+          </div>
+        </FocusRectsProvider>
+        <LayerHost id="focusTest" />
+      </div>
+    );
+
+    const appElement = document.createElement('div');
+
+    try {
+      document.body.appendChild(appElement);
+
+      ReactTestUtils.act(() => {
+        ReactDOM.render(<FocusProviderTest />, appElement);
+      });
+
+      const focusProvider = appElement.querySelector('.innerFocusProvider');
+      expect(focusProvider).toBeTruthy();
+      expect(focusProvider?.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
+    } finally {
+      ReactDOM.unmountComponentAtNode(appElement);
+      appElement.remove();
+    }
   });
 
   describe('compat', () => {


### PR DESCRIPTION

## Previous Behavior

Focus outlines would not show up when opening a Modal, Dialog, Panel, etc. in a new Layer, since the layer contents would be under a new `FocusRectsProvider`.

## New Behavior

Layer now checks whether the focus visible classname is present in its own context, then sets it (if applicable) on the new provider it instantiates.

## Related Issue(s)

- Fixes [15778](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/15778)
