### PR TITLE
fix: row border in flex layout should overflow

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Table.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Table.stories.tsx
@@ -593,7 +593,7 @@ const SubtleSelection: React.FC<SharedVrTestArgs> = ({ noNativeElements }) => (
 );
 
 const Truncate: React.FC<SharedVrTestArgs & { truncate?: boolean }> = ({ noNativeElements, truncate }) => (
-  <Table noNativeElements={noNativeElements} style={{ width: '400px' }}>
+  <Table noNativeElements={noNativeElements} style={{ width: '400px', minWidth: 0 }}>
     <TableHeader>
       <TableRow>
         {columns.map(column => (

--- a/change/@fluentui-react-table-bb208d47-ce79-49d3-bb79-3b635f0d5e95.json
+++ b/change/@fluentui-react-table-bb208d47-ce79-49d3-bb79-3b635f0d5e95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: row border in flex layout should overflow",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/Table/useTableStyles.styles.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableStyles.styles.ts
@@ -20,6 +20,7 @@ const useTableLayoutStyles = makeStyles({
 const useFlexLayoutStyles = makeStyles({
   root: {
     display: 'block',
+    minWidth: 'fit-content',
   },
 });
 

--- a/packages/react-components/react-table/src/components/Table/useTableStyles.styles.ts
+++ b/packages/react-components/react-table/src/components/Table/useTableStyles.styles.ts
@@ -20,6 +20,7 @@ const useTableLayoutStyles = makeStyles({
 const useFlexLayoutStyles = makeStyles({
   root: {
     display: 'block',
+    // In flex layout rows/cells can overflow the table without a min width
     minWidth: 'fit-content',
   },
 });

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
@@ -29,7 +29,6 @@ const useFlexLayoutStyles = makeStyles({
  */
 const useStyles = makeStyles({
   root: {
-    // width: 'max-content',
     color: tokens.colorNeutralForeground1,
     boxSizing: 'border-box',
     ...createCustomFocusIndicatorStyle(

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
@@ -29,6 +29,7 @@ const useFlexLayoutStyles = makeStyles({
  */
 const useStyles = makeStyles({
   root: {
+    // width: 'max-content',
     color: tokens.colorNeutralForeground1,
     boxSizing: 'border-box',
     ...createCustomFocusIndicatorStyle(


### PR DESCRIPTION
Currently row border using flex layout in the Table should overflow with cell content. Adds `min-width: fit-content` to flex layout styles of the `Table` so that the cells don't overflow the Table

Fixes #27570