### PR TITLE
fix: react-popover compatibility with screen reader

### DIFF
--- a/change/@fluentui-react-popover-54e46725-d634-43de-961b-a174b511fa9a.json
+++ b/change/@fluentui-react-popover-54e46725-d634-43de-961b-a174b511fa9a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix screenreader compatibility",
+  "comment": "fix: Screen reader compatibility",
   "packageName": "@fluentui/react-popover",
   "email": "eysjiang@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-popover-54e46725-d634-43de-961b-a174b511fa9a.json
+++ b/change/@fluentui-react-popover-54e46725-d634-43de-961b-a174b511fa9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix screenreader compatibility",
+  "packageName": "@fluentui/react-popover",
+  "email": "eysjiang@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, useMergedRefs } from '@fluentui/react-utilities';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
@@ -17,6 +17,7 @@ export const usePopoverSurface_unstable = (
   props: PopoverSurfaceProps,
   ref: React.Ref<HTMLDivElement>,
 ): PopoverSurfaceState => {
+  const id = 'popover-' + useId();
   const contentRef = usePopoverContext_unstable(context => context.contentRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
@@ -45,10 +46,13 @@ export const usePopoverSurface_unstable = (
       root: 'div',
     },
     root: getNativeElementProps('div', {
+      id,
+      'aria-labelledby': id,
       ref: useMergedRefs(ref, contentRef),
       role: trapFocus ? 'dialog' : 'group',
       'aria-modal': trapFocus ? true : undefined,
       ...modalAttributes,
+      tabIndex: '-1',
       ...props,
     }),
   };

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useId, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
@@ -17,7 +17,6 @@ export const usePopoverSurface_unstable = (
   props: PopoverSurfaceProps,
   ref: React.Ref<HTMLDivElement>,
 ): PopoverSurfaceState => {
-  const id = 'popover-' + useId();
   const contentRef = usePopoverContext_unstable(context => context.contentRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
@@ -46,8 +45,6 @@ export const usePopoverSurface_unstable = (
       root: 'div',
     },
     root: getNativeElementProps('div', {
-      id,
-      'aria-labelledby': id,
       ref: useMergedRefs(ref, contentRef),
       role: trapFocus ? 'dialog' : 'group',
       'aria-modal': trapFocus ? true : undefined,

--- a/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import {
+  makeStyles,
+  shorthands,
+  Button,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+  useId,
+} from '@fluentui/react-components';
 import type { PositioningImperativeRef } from '@fluentui/react-components';
 const useStyles = makeStyles({
   container: {
@@ -27,6 +35,7 @@ export const AnchorToCustomTarget = () => {
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const positioningRef = React.useRef<PositioningImperativeRef>(null);
   const styles = useStyles();
+  const id = useId();
 
   React.useEffect(() => {
     if (buttonRef.current) {
@@ -41,7 +50,7 @@ export const AnchorToCustomTarget = () => {
           <Button>Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface id={id} aria-labelledby={id}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverAppearance.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger, tokens } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger, tokens, useId } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   contentHeader: {
@@ -28,6 +28,7 @@ const ExampleContent = () => {
 
 export const Appearance = () => {
   const layoutStyles = useLayoutStyles();
+  const id = useId();
 
   return (
     <div className={layoutStyles.root}>
@@ -36,7 +37,7 @@ export const Appearance = () => {
           <Button>Default appearance Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface id={id} aria-labelledby={id}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>
@@ -46,7 +47,7 @@ export const Appearance = () => {
           <Button>Brand appearance Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface id={id} aria-labelledby={id}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>
@@ -56,7 +57,7 @@ export const Appearance = () => {
           <Button>Inverted appearance Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface id={id} aria-labelledby={id}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverControllingOpenAndClose.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger, useId } from '@fluentui/react-components';
 import type { PopoverProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -20,6 +20,7 @@ const ExampleContent = () => {
 };
 
 export const ControllingOpenAndClose = () => {
+  const id = useId();
   const [open, setOpen] = React.useState(false);
   const handleOpenChange: PopoverProps['onOpenChange'] = (e, data) => setOpen(data.open || false);
 
@@ -33,7 +34,7 @@ export const ControllingOpenAndClose = () => {
         <PopoverTrigger disableButtonEnhancement>
           <Button>Controlled trigger</Button>
         </PopoverTrigger>
-        <PopoverSurface>
+        <PopoverSurface id={id} aria-labelledby={id}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverCustomTrigger.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverCustomTrigger.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger, useId } from '@fluentui/react-components';
 import type { PopoverTriggerChildProps } from '@fluentui/react-components';
 const useStyles = makeStyles({
   contentHeader: {
@@ -27,12 +27,13 @@ const CustomPopoverTrigger = React.forwardRef<HTMLButtonElement, Partial<Popover
 });
 
 export const CustomTrigger = () => {
+  const id = useId();
   return (
     <Popover>
       <PopoverTrigger>
         <CustomPopoverTrigger />
       </PopoverTrigger>
-      <PopoverSurface>
+      <PopoverSurface id={id} aria-labelledby={id}>
         <ExampleContent />
       </PopoverSurface>
     </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverDefault.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger, useId } from '@fluentui/react-components';
 import type { PopoverProps } from '@fluentui/react-components';
+
+const id = useId();
 
 const useStyles = makeStyles({
   contentHeader: {
@@ -25,7 +27,7 @@ export const Default = (props: PopoverProps) => (
       <Button>Popover trigger</Button>
     </PopoverTrigger>
 
-    <PopoverSurface>
+    <PopoverSurface id={id} aria-labelledby={id}>
       <ExampleContent />
     </PopoverSurface>
   </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverInternalUpdateContent.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverInternalUpdateContent.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger, useId } from '@fluentui/react-components';
 import type { PopoverProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -20,6 +20,7 @@ const ExampleContent = () => {
 };
 
 export const InternalUpdateContent = () => {
+  const id = useId();
   const [visible, setVisible] = React.useState(false);
 
   const changeContent = () => setVisible(true);
@@ -35,7 +36,7 @@ export const InternalUpdateContent = () => {
         <Button>Popover trigger</Button>
       </PopoverTrigger>
 
-      <PopoverSurface>
+      <PopoverSurface id={id} aria-labelledby={id}>
         <ExampleContent />
 
         {visible ? (

--- a/packages/react-components/react-popover/stories/Popover/PopoverNestedPopovers.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverNestedPopovers.stories.tsx
@@ -67,7 +67,7 @@ export const NestedPopovers = () => {
         <Button>Root trigger</Button>
       </PopoverTrigger>
 
-      <PopoverSurface>
+      <PopoverSurface aria-labelledby={id}>
         <div>
           <h3 id={id} className={styles.contentHeader}>
             Popover content

--- a/packages/react-components/react-popover/stories/Popover/PopoverWithArrow.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverWithArrow.stories.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverTrigger, PopoverSurface, useId } from '@fluentui/react-components';
+
+const id = useId();
 
 const useStyles = makeStyles({
   contentHeader: {
@@ -24,7 +26,7 @@ export const WithArrow = () => (
       <Button>Popover trigger</Button>
     </PopoverTrigger>
 
-    <PopoverSurface>
+    <PopoverSurface id={id} aria-labelledby={id}>
       <ExampleContent />
     </PopoverSurface>
   </Popover>


### PR DESCRIPTION
Allows the popover created by react-popover to be read by screen readers despite having no focusable content.