### PR TITLE
[FIX] Updates selection dot and label positioning for ChoiceGroupOption when an Image or Icon is present.

### DIFF
--- a/change/@fluentui-fluent2-theme-92034fcd-61f0-459e-933b-c0457183fd4c.json
+++ b/change/@fluentui-fluent2-theme-92034fcd-61f0-459e-933b-c0457183fd4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[FIX] Recenters selection dot in choice group with icon.",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/ChoiceGroupOption.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/ChoiceGroupOption.styles.ts
@@ -86,7 +86,6 @@ export const getDefaultChoiceGroupOptionStyles = (
       color: getChoiceGroupTextColor(props),
       '.ms-ChoiceFieldLabel': {
         color: getChoiceGroupTextColor(props),
-        paddingLeft: '32px',
       },
       '&:hover .ms-ChoiceFieldLabel': {
         color: getTextHoverColor(props),

--- a/packages/fluent2-theme/src/componentStyles/ChoiceGroupOption.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/ChoiceGroupOption.styles.ts
@@ -99,9 +99,8 @@ export const getDefaultChoiceGroupOptionStyles = (
           height: '17px',
           margin: '2px',
         },
+        // the inner dot
         '::after': {
-          top: '5px',
-          left: '5px',
           width: '11px',
           height: '11px',
           background: getInnerCircleColor(props, false),


### PR DESCRIPTION
Looks like we missed a case with choice group, and caused a nasty polish bug when an image or icon is passed to the choice group.

Before:
![image](https://github.com/microsoft/fluentui/assets/17346018/f7bb3509-e192-4505-b725-d0645e0fc021)

After:
![image](https://github.com/microsoft/fluentui/assets/17346018/67b96f61-dac0-4b31-bb24-3eec54cfae7c)


