### PR TITLE
fix(react-textarea): Remove fixed height so rows prop works and add missing max-height

### DIFF
--- a/change/@fluentui-react-textarea-e76e5d43-0fae-497e-a156-61458b2edcb4.json
+++ b/change/@fluentui-react-textarea-e76e5d43-0fae-497e-a156-61458b2edcb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove fixed height so rows prop works and add missing max-height.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.styles.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextareaStyles.styles.ts
@@ -8,12 +8,6 @@ export const textareaClassNames: SlotClassNames<TextareaSlots> = {
   textarea: 'fui-Textarea__textarea',
 };
 
-const textareaHeight = {
-  small: '24px',
-  medium: '32px',
-  large: '40px',
-};
-
 /**
  * Styles for the root(wrapper) slot
  */
@@ -162,7 +156,6 @@ const useTextareaStyles = makeStyles({
     flexGrow: 1,
     fontFamily: tokens.fontFamilyBase,
     height: '100%',
-    maxHeight: '100%',
 
     '::placeholder': {
       color: tokens.colorNeutralForeground4,
@@ -188,30 +181,30 @@ const useTextareaStyles = makeStyles({
   // The padding style adds both content and regular padding (from design spec), this is because the handle is not
   // affected by changing the padding of the root.
   small: {
-    height: textareaHeight.small,
     minHeight: '40px',
     ...shorthands.padding(
       tokens.spacingVerticalXS,
       `calc(${tokens.spacingHorizontalSNudge} + ${tokens.spacingHorizontalXXS})`,
     ),
+    maxHeight: '200px',
     ...typographyStyles.caption1,
   },
   medium: {
-    height: textareaHeight.medium,
     minHeight: '52px',
     ...shorthands.padding(
       tokens.spacingVerticalSNudge,
       `calc(${tokens.spacingHorizontalMNudge} + ${tokens.spacingHorizontalXXS})`,
     ),
+    maxHeight: '260px',
     ...typographyStyles.body1,
   },
   large: {
-    height: textareaHeight.large,
     minHeight: '64px',
     ...shorthands.padding(
       tokens.spacingVerticalS,
       `calc(${tokens.spacingHorizontalM} + ${tokens.spacingHorizontalXXS})`,
     ),
+    maxHeight: '320px',
     ...typographyStyles.body2,
   },
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`<Textarea rows={6} />` hides the added rows.
![image](https://github.com/microsoft/fluentui/assets/5953191/adda8540-466c-4cd0-81a1-ef1af7aa133e)

## New Behavior

`<Textarea rows={6} />` shows the added rows.
![image](https://github.com/microsoft/fluentui/assets/5953191/c144e155-5e03-489f-91e1-aaa676fb1ba1)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27842
