### PR TITLE
fix: Outline color now respects OS force colors settings

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - `Datepicker`: add onCalendarOpenStateChange prop. @jurokapsiar ([#28136](https://github.com/microsoft/fluentui/pull/28136))
+- Outline color now respects OS force colors settings. @george-cz ([#28182](https://github.com/microsoft/fluentui/pull/28182))
 
 <!--------------------------------[ v0.66.4 ]------------------------------- -->
 ## [v0.66.4](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.66.4) (2023-03-10)

--- a/packages/fluentui/react-northstar/src/themes/teams/getBorderFocusStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/getBorderFocusStyles.ts
@@ -90,6 +90,14 @@ export const getBorderFocusStyles = (args: BorderFocusStyles): Record<':focus' |
             ? `-${focusInnerBorderWidth}`
             : `calc(0px - ${borderPaddingRight} - ${focusInnerBorderWidth})`,
       },
+      '@media(forced-colors: active)': {
+        ':before': {
+          borderColor: 'Highlight',
+        },
+        ':after': {
+          borderColor: 'Highlight',
+        },
+      },
     },
   };
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Outline ignores forced colors by OS. See https://github.com/microsoft/fluentui/issues/27878 for more details.

## New Behavior

The outline styles generated now use system `Highlight` color for outline.

<img width="308" alt="Screenshot 2023-06-09 at 10 55 34" src="https://github.com/microsoft/fluentui/assets/2070479/c2945580-c806-46db-8475-41d8bece88b5">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27878
- Fixes #27877
- Fixes #27579
