### PR TITLE
fix: Drowdown in HC theme no longer has extra outline

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams-forced-colors/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-forced-colors/componentStyles.ts
@@ -1,5 +1,6 @@
 export { buttonStyles as Button } from './components/Button/buttonStyles';
 export { checkboxStyles as Checkbox } from './components/Checkbox/checkboxStyles';
+export { dropdownStyles as Dropdown } from './components/Dropdown/dropdownStyles';
 export { dropdownItemStyles as DropdownItem } from './components/Dropdown/dropdownItemStyles';
 export { svgIconStyles as SvgIcon } from './components/SvgIcon/svgIconStyles';
 export { menuItemWrapperStyles as MenuItemWrapper } from './components/Menu/menuItemWrapperStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-forced-colors/components/Dropdown/dropdownStyles.ts
@@ -1,0 +1,9 @@
+import { ComponentSlotStylesPrepared } from '@fluentui/styles';
+import { DropdownStylesProps } from '../../../../components/Dropdown/Dropdown';
+import { DropdownVariables } from '../../../teams/components/Dropdown/dropdownVariables';
+
+export const dropdownStyles: ComponentSlotStylesPrepared<DropdownStylesProps, DropdownVariables> = {
+  triggerButton: () => ({
+    border: 'none', // there is already border around the whole Dropdown
+  }),
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
In HC theme, the Dropdown trigger has unnecessary outline.

<img width="509" alt="Screenshot 2023-06-09 at 12 13 44" src="https://github.com/microsoft/fluentui/assets/2070479/8bb11a4a-26c2-4c6e-ad45-2815c380beff">


## New Behavior
Default:

<img width="439" alt="Screenshot 2023-06-09 at 12 13 54" src="https://github.com/microsoft/fluentui/assets/2070479/c9153d0d-1b3e-4bc5-bedb-8a9802746061">

Focused:
<img width="484" alt="Screenshot 2023-06-09 at 12 14 36" src="https://github.com/microsoft/fluentui/assets/2070479/2bea8e12-6fad-45ec-a579-77a7f56cfec2">




## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27877
