### PR TITLE
fix(react-datepicker-compat): Do not move focus to the input on first render

### DIFF
--- a/change/@fluentui-react-datepicker-compat-39a831ff-e1f1-48df-af17-ffcd7fdf7883.json
+++ b/change/@fluentui-react-datepicker-compat-39a831ff-e1f1-48df-af17-ffcd7fdf7883.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Do not move focus to the input on first render.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.cy.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.cy.tsx
@@ -16,6 +16,8 @@ const popoverSelector = '[role="dialog"]';
 describe('DatePicker', () => {
   it('opens a default datepicker', () => {
     mount(<DatePicker />);
+
+    cy.focused().should('not.exist');
     cy.get(inputSelector).click().get(popoverSelector).should('be.visible');
   });
 

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -421,7 +421,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     }
     // Focus function keeps changing, so we need to skip it in the deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, props.disabled]);
+  }, [isFirstMount, open, props.disabled]);
 
   const calendarShorthand = resolveShorthand(props.calendar, {
     required: true,

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -9,6 +9,7 @@ import {
   mergeCallbacks,
   resolveShorthand,
   useControllableState,
+  useFirstMount,
   useId,
   useMergedRefs,
   useOnClickOutside,
@@ -412,9 +413,10 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     }
   }, [disableAutoFocus, open, props.disabled]);
 
+  const isFirstMount = useFirstMount();
   // When the popup is closed, focus should go back to the input.
   React.useEffect(() => {
-    if (!open && !props.disabled) {
+    if (!open && !props.disabled && !isFirstMount) {
       focus();
     }
     // Focus function keeps changing, so we need to skip it in the deps


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When DatePicker is rendered, focus is moved to the input. This is done as a side effect of moving focus to the input when the popup is closed.

## New Behavior

To avoid moving focus on first render, a check for first render has been added to the effect that moves focus to the input. Now the focus is moved to the input only when the popup is closed rather than on initial state as well.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28148
