### PR TITLE
chore: update version of react-icons to latest

### DIFF
--- a/apps/recipes-react-components/package.json
+++ b/apps/recipes-react-components/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@fluentui/react-components": "^9.21.0",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-theme": "^9.1.8",
     "@fluentui/react-provider": "^9.7.2",
     "@fluentui/react-storybook-addon": "9.0.0-rc.1",

--- a/apps/stress-test/package.json
+++ b/apps/stress-test/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@fluentui/react": "^8.110.2",
     "@fluentui/react-components": "^9.21.0",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/web-components": "^2.5.15",
     "@microsoft/fast-element": "^1.11.1",
     "afterframe": "1.0.2",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -31,7 +31,7 @@
     "@fluentui/react-dialog": "^9.5.9",
     "@fluentui/react-divider": "^9.2.15",
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-image": "^9.1.12",
     "@fluentui/react-infobutton": "9.0.0-beta.34",
     "@fluentui/react-input": "^9.4.16",

--- a/change/@fluentui-react-accordion-9257ac81-db7d-4fa4-9697-ee88f22fe4b1.json
+++ b/change/@fluentui-react-accordion-9257ac81-db7d-4fa4-9697-ee88f22fe4b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203 ",
+  "packageName": "@fluentui/react-accordion",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-053c9699-fe26-4431-b2a3-a4e6aa8a10d8.json
+++ b/change/@fluentui-react-alert-053c9699-fe26-4431-b2a3-a4e6aa8a10d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-alert",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-6d2b8431-50e1-4505-8b29-000e34096702.json
+++ b/change/@fluentui-react-avatar-6d2b8431-50e1-4505-8b29-000e34096702.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-avatar",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-01f81838-7f5f-4f61-b9d3-42146d93407c.json
+++ b/change/@fluentui-react-badge-01f81838-7f5f-4f61-b9d3-42146d93407c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-badge",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-e7fe5158-369d-4809-82c4-386eaf61731e.json
+++ b/change/@fluentui-react-button-e7fe5158-369d-4809-82c4-386eaf61731e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-button",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-5d7b9deb-d12c-4f30-84bb-4552bdfdd730.json
+++ b/change/@fluentui-react-checkbox-5d7b9deb-d12c-4f30-84bb-4552bdfdd730.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-f2bc965d-ad2d-41c2-9564-852fd1746069.json
+++ b/change/@fluentui-react-combobox-f2bc965d-ad2d-41c2-9564-852fd1746069.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-combobox",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-d5ca61cc-e259-47bf-b7b3-3251154d7232.json
+++ b/change/@fluentui-react-datepicker-compat-d5ca61cc-e259-47bf-b7b3-3251154d7232.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-6748ddfc-dc18-4930-a1a6-4e3fe357931d.json
+++ b/change/@fluentui-react-dialog-6748ddfc-dc18-4930-a1a6-4e3fe357931d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-dialog",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-f6e3df3d-c8d7-49f2-acb6-20895c52cc91.json
+++ b/change/@fluentui-react-field-f6e3df3d-c8d7-49f2-acb6-20895c52cc91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-field",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infobutton-ce74a783-fc10-4634-a052-c2e29c376a26.json
+++ b/change/@fluentui-react-infobutton-ce74a783-fc10-4634-a052-c2e29c376a26.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-1e781eb1-1e70-454d-896b-91e615d13d81.json
+++ b/change/@fluentui-react-menu-1e781eb1-1e70-454d-896b-91e615d13d81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-menu",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-56240770-bac2-4aaf-8d57-6ee6d2104536.json
+++ b/change/@fluentui-react-migration-v0-v9-56240770-bac2-4aaf-8d57-6ee6d2104536.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-c77959b9-6b10-4bd7-a186-e3bb9f5eafa4.json
+++ b/change/@fluentui-react-migration-v8-v9-c77959b9-6b10-4bd7-a186-e3bb9f5eafa4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-d7d8f0a9-3303-41e6-bb84-59eeec3924ad.json
+++ b/change/@fluentui-react-radio-d7d8f0a9-3303-41e6-bb84-59eeec3924ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-radio",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-2bda5a8d-90e7-4700-93ae-4336dab725fe.json
+++ b/change/@fluentui-react-select-2bda5a8d-90e7-4700-93ae-4336dab725fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-select",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-148ddd64-8526-4045-90f7-d80bae3cdbbb.json
+++ b/change/@fluentui-react-spinbutton-148ddd64-8526-4045-90f7-d80bae3cdbbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-370dac0d-c029-49f6-9183-2d2bcbc04711.json
+++ b/change/@fluentui-react-switch-370dac0d-c029-49f6-9183-2d2bcbc04711.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-switch",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-aa97da2a-9b3c-4892-82ef-c918b7d78fe1.json
+++ b/change/@fluentui-react-table-aa97da2a-9b3c-4892-82ef-c918b7d78fe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-table",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-91098fb1-af1a-453b-9869-4db857003668.json
+++ b/change/@fluentui-react-tree-91098fb1-af1a-453b-9869-4db857003668.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: update @fluentui/react-icons to 2.0.203",
+  "packageName": "@fluentui/react-tree",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@ctrl/tinycolor": "3.3.4",
     "@cypress/react": "5.12.4",
     "@cypress/webpack-dev-server": "1.8.3",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@griffel/babel-preset": "1.4.13",
     "@griffel/eslint-plugin": "^1.2.0",
     "@griffel/jest-serializer": "1.1.9",

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.3.22",
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluentui/react-avatar": "^9.5.5",
     "@fluentui/react-button": "^9.3.16",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-tabster": "^9.7.5",
     "@fluentui/react-theme": "^9.1.8",
     "@fluentui/react-utilities": "^9.9.2",

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluentui/react-badge": "^9.1.15",
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-popover": "^9.6.0",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -33,7 +33,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-theme": "^9.1.8",

--- a/packages/react-components/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
@@ -13,9 +13,9 @@ exports[`PresenceBadge renders a default state 1`] = `
       aria-hidden={true}
       className=""
       fill="currentColor"
-      height={16}
+      height="16"
       viewBox="0 0 16 16"
-      width={16}
+      width="16"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/react-components/react-breadcrumb/package.json
+++ b/packages/react-components/react-breadcrumb/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluentui/react-button": "^9.3.16",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-link": "^9.0.42",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.3",
     "@fluentui/react-aria": "^9.3.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-label": "^9.1.15",
     "@fluentui/react-shared-contexts": "^9.5.0",

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -36,7 +36,7 @@
     "@fluentui/keyboard-keys": "^9.0.3",
     "@fluentui/react-context-selector": "^9.1.22",
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-portal": "^9.2.12",
     "@fluentui/react-positioning": "^9.6.0",

--- a/packages/react-components/react-datepicker-compat/package.json
+++ b/packages/react-components/react-datepicker-compat/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.3",
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-input": "^9.4.16",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-popover": "^9.6.0",

--- a/packages/react-components/react-dialog/package.json
+++ b/packages/react-components/react-dialog/package.json
@@ -42,7 +42,7 @@
     "@fluentui/react-context-selector": "^9.1.22",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-aria": "^9.3.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-tabster": "^9.7.5",
     "@fluentui/react-theme": "^9.1.8",
     "@fluentui/react-portal": "^9.2.12",

--- a/packages/react-components/react-field/package.json
+++ b/packages/react-components/react-field/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-label": "^9.1.15",
     "@fluentui/react-theme": "^9.1.8",

--- a/packages/react-components/react-infobutton/package.json
+++ b/packages/react-components/react-infobutton/package.json
@@ -33,7 +33,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-label": "^9.1.15",
     "@fluentui/react-popover": "^9.6.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -39,7 +39,7 @@
     "@fluentui/keyboard-keys": "^9.0.3",
     "@fluentui/react-aria": "^9.3.22",
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-portal": "^9.2.12",
     "@fluentui/react-positioning": "^9.6.0",
     "@fluentui/react-shared-contexts": "^9.5.0",

--- a/packages/react-components/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-components/react-menu/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -19,9 +19,9 @@ exports[`MenuItemCheckbox conformance renders a default state 1`] = `
       aria-hidden={true}
       className=""
       fill="currentColor"
-      height={16}
+      height="16"
       viewBox="0 0 16 16"
-      width={16}
+      width="16"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/react-components/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-components/react-menu/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -19,9 +19,9 @@ exports[`MenuItemRadio renders a default state 1`] = `
       aria-hidden={true}
       className=""
       fill="currentColor"
-      height={16}
+      height="16"
       viewBox="0 0 16 16"
-      width={16}
+      width="16"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/react-components/react-migration-v0-v9/package.json
+++ b/packages/react-components/react-migration-v0-v9/package.json
@@ -33,7 +33,7 @@
     "@fluentui/scripts-storybook": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-theme": "^9.1.8",
     "@fluentui/react-utilities": "^9.9.2",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",

--- a/packages/react-components/react-migration-v8-v9/package.json
+++ b/packages/react-components/react-migration-v8-v9/package.json
@@ -35,7 +35,7 @@
     "@fluentui/fluent2-theme": "^8.107.21",
     "@fluentui/react": "^8.110.2",
     "@fluentui/react-components": "^9.21.0",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-theme": "^9.1.8",
     "@fluentui/react-utilities": "^9.9.2",
     "@griffel/react": "^1.5.7",

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-label": "^9.1.15",
     "@fluentui/react-shared-contexts": "^9.5.0",

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-theme": "^9.1.8",

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.3",
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-theme": "^9.1.8",

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.6",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-label": "^9.1.15",
     "@fluentui/react-shared-contexts": "^9.5.0",

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-avatar": "^9.5.5",
     "@fluentui/react-checkbox": "^9.1.17",
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-radio": "^9.1.17",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/react-tags/package.json
+++ b/packages/react-components/react-tags/package.json
@@ -37,7 +37,7 @@
     "@fluentui/keyboard-keys": "^9.0.3",
     "@fluentui/react-aria": "^9.3.22",
     "@fluentui/react-avatar": "^9.5.5",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-tabster": "^9.7.5",
     "@fluentui/react-theme": "^9.1.8",

--- a/packages/react-components/react-toast/package.json
+++ b/packages/react-components/react-toast/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "react-transition-group": "^4.4.1",
     "@fluentui/react-aria": "^9.3.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-jsx-runtime": "9.0.0-alpha.6",
     "@fluentui/react-portal": "^9.2.12",
     "@fluentui/react-shared-contexts": "^9.5.0",

--- a/packages/react-components/react-tree/package.json
+++ b/packages/react-components/react-tree/package.json
@@ -41,7 +41,7 @@
     "@fluentui/react-avatar": "^9.5.5",
     "@fluentui/react-button": "^9.3.16",
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-portal": "^9.2.12",
     "@fluentui/react-shared-contexts": "^9.5.0",
     "@fluentui/react-tabster": "^9.7.5",

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-alert": "9.0.0-beta.51",
     "@fluentui/react-components": "^9.21.0",
     "@fluentui/react-context-selector": "^9.1.22",
-    "@fluentui/react-icons": "^2.0.196",
+    "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-storybook-addon-codesandbox": "9.0.0-alpha.0",
     "@fluentui/react-theme": "^9.1.8",
     "@fluentui/react-utilities": "^9.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,10 +1649,10 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
-"@fluentui/react-icons@^2.0.196":
-  version "2.0.196"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.196.tgz#5d7184f29775b3600d0adf60779dab47b4c1fc5b"
-  integrity sha512-FqhU9uKLE0iTHpk0POuGWjz/iDWHwPIK0LERtD2muErUKTiq1gIFIJglplVdz7//rqLxo3CvUQP/leya1tEA+Q==
+"@fluentui/react-icons@^2.0.203":
+  version "2.0.203"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.203.tgz#51dab997eec2db7bbcd429c3939490f868c2ab4e"
+  integrity sha512-eOV9GnCFzEIgllHEYenfkVB2MYChMRj2B8Vlr4qqdL0Kts7gRMfBIb+0+ADr5a3KIN0GtdAvG7KtsJ99O6gNmw==
   dependencies:
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"


### PR DESCRIPTION
This PR is to update the version of `@fluentui/react-icons` in our repo to the latest. This picks up `IconDirectionContext` as well as some performance optimizations, as well as newly added icons.

Fixes #27923 