### PR TITLE
fix (react-data-grid-react-window): Added index in DataGridBody RowRenderFunction

### DIFF
--- a/change/@fluentui-react-data-grid-react-window-aa0947c1-4957-48e3-8149-d6f2885afc76.json
+++ b/change/@fluentui-react-data-grid-react-window-aa0947c1-4957-48e3-8149-d6f2885afc76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update DataGridBody RowRenderFunction props",
+  "packageName": "@fluentui/react-data-grid-react-window",
+  "email": "fengqi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
@@ -11,6 +11,10 @@ export type DataGridBodySlots = DataGridBodySlotsBase;
 export type RowRenderFunction<TItem = unknown> = (
   row: TableRowData<TItem>,
   style: React.CSSProperties,
+  /**
+   * The index of each row
+   */
+  index?: number,
 ) => React.ReactNode;
 
 /**

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/renderDataGridBody.tsx
@@ -27,7 +27,7 @@ export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
           const row: TableRowData<unknown> = data[index];
           return (
             <TableRowIndexContextProvider value={state.ariaRowIndexStart + index}>
-              <TableRowIdContextProvider value={row.rowId}>{state.renderRow(row, style)}</TableRowIdContextProvider>
+              <TableRowIdContextProvider value={row.rowId}>{state.renderRow(row, style, index)}</TableRowIdContextProvider>
             </TableRowIndexContextProvider>
           );
         }}


### PR DESCRIPTION
## Previous Behavior

The render function accept `({ item, rowId }, style) => React.ReactNode;`.
```
export type RowRenderFunction<TItem = unknown> = (
  row: TableRowData<TItem>,
  style: React.CSSProperties,
) => React.ReactNode;
```

## New Behavior
Adding another optional `index:number` for rendering index cell in each row as row header, which is in numerical order. ` ({ item, rowId}, style, index) => React.ReactNode;`.
```
export type RowRenderFunction<TItem = unknown> = (
  row: TableRowData<TItem>,
  style: React.CSSProperties,
  /**
   * The index of each row
   */
  index?: number,
) => React.ReactNode;
```
