### PR TITLE
ci: use ubuntu pool for size-auditor merge job

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -130,8 +130,7 @@ jobs:
       - template: .devops/templates/cleanup.yml
 
   - job: merge
-    pool:
-      vmImage: 'windows-2019'
+    pool: '1ES-Host-Ubuntu'
     dependsOn:
       - build_northstar
       - build_react
@@ -150,10 +149,10 @@ jobs:
           artifactName: 'bundlesize-northstar'
           targetPath: '$(Build.ArtifactStagingDirectory)/react-northstar'
 
-      - script: 'chocolatey install jq'
+      - script: 'sudo apt-get install jq'
         displayName: 'Install jq'
 
-      - script: jq -c -s "reduce .[] as $item ({}; . * $item)" $(Build.ArtifactStagingDirectory)/react-northstar/bundlesize.json $(Build.ArtifactStagingDirectory)/react/bundlesize.json > $(Build.ArtifactStagingDirectory)/bundlesizes.json
+      - script: jq -c -s 'reduce .[] as $item ({}; . * $item)' $(Build.ArtifactStagingDirectory)/react-northstar/bundlesize.json $(Build.ArtifactStagingDirectory)/react/bundlesize.json > $(Build.ArtifactStagingDirectory)/bundlesizes.json
         displayName: 'Merge @fluentui/react, @fluentui/react-components & @fluentui/react-northstar to bundlesizes.json'
 
       - task: PublishBuildArtifacts@1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

[windows-2019 is not supported since 2021](https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/#windows) and suddenly started causing issues when installing jq via chocolatey. this started blocking all of our PR's

## New Behavior

`merge` job migrated to our Ubuntu hosted pool which unifies our CI with rest of our jobs - also making this not fail randomly.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


