### PR TITLE
feat: Hoist intent to imperative API

### DIFF
--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -102,9 +102,6 @@ export type ToastId = string;
 export type ToastIntent = 'info' | 'success' | 'error' | 'warning';
 
 // @public (undocumented)
-export type ToastLifecycleStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
-
-// @public (undocumented)
 export type ToastOffset = Partial<Record<ToastPosition, ToastOffsetObject>> | ToastOffsetObject;
 
 // @public (undocumented)
@@ -123,6 +120,9 @@ export type ToastSlots = {
 
 // @public
 export type ToastState = ComponentState<ToastSlots>;
+
+// @public (undocumented)
+export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
 
 // @public
 export const ToastTitle: ForwardRefComponent<ToastTitleProps>;

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -141,7 +141,7 @@ export type ToastTitleSlots = {
 };
 
 // @public
-export type ToastTitleState = ComponentState<ToastTitleSlots> & Required<Pick<ToastContextValue, 'intent'>>;
+export type ToastTitleState = ComponentState<ToastTitleSlots> & Pick<ToastContextValue, 'intent'>;
 
 // @public
 export const ToastTrigger: React_2.FC<ToastTriggerProps>;

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -6,15 +6,7 @@
 
 /// <reference types="react" />
 
-import { ARIAButtonResultProps } from '@fluentui/react-aria';
-import { ARIAButtonType } from '@fluentui/react-aria';
-import type { ComponentProps } from '@fluentui/react-utilities';
-import type { ComponentState } from '@fluentui/react-utilities';
-import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
-import type { Slot } from '@fluentui/react-utilities';
-import type { SlotClassNames } from '@fluentui/react-utilities';
-import type { TriggerProps } from '@fluentui/react-utilities';
 
 // @public
 export const renderToast_unstable: (state: ToastState) => JSX.Element;
@@ -99,6 +91,12 @@ export type ToastFooterState = ComponentState<ToastFooterSlots>;
 export type ToastId = string;
 
 // @public (undocumented)
+export type ToastIntent = 'info' | 'success' | 'error' | 'warning';
+
+// @public (undocumented)
+export type ToastLifecycleStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
+
+// @public (undocumented)
 export type ToastOffset = Partial<Record<ToastPosition, ToastOffsetObject>> | ToastOffsetObject;
 
 // @public (undocumented)
@@ -118,9 +116,6 @@ export type ToastSlots = {
 // @public
 export type ToastState = ComponentState<ToastSlots>;
 
-// @public (undocumented)
-export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
-
 // @public
 export const ToastTitle: ForwardRefComponent<ToastTitleProps>;
 
@@ -129,7 +124,7 @@ export const toastTitleClassNames: SlotClassNames<ToastTitleSlots>;
 
 // @public
 export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {
-    intent?: 'info' | 'success' | 'error' | 'warning';
+    intent?: ToastIntent;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -6,7 +6,15 @@
 
 /// <reference types="react" />
 
+import { ARIAButtonResultProps } from '@fluentui/react-aria';
+import { ARIAButtonType } from '@fluentui/react-aria';
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
+import type { Slot } from '@fluentui/react-utilities';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { TriggerProps } from '@fluentui/react-utilities';
 
 // @public
 export const renderToast_unstable: (state: ToastState) => JSX.Element;

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -131,9 +131,7 @@ export const ToastTitle: ForwardRefComponent<ToastTitleProps>;
 export const toastTitleClassNames: SlotClassNames<ToastTitleSlots>;
 
 // @public
-export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {
-    intent?: ToastIntent;
-};
+export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {};
 
 // @public (undocumented)
 export type ToastTitleSlots = {
@@ -143,7 +141,7 @@ export type ToastTitleSlots = {
 };
 
 // @public
-export type ToastTitleState = ComponentState<ToastTitleSlots> & Required<Pick<ToastTitleProps, 'intent'>>;
+export type ToastTitleState = ComponentState<ToastTitleSlots> & Required<Pick<ToastContextValue, 'intent'>>;
 
 // @public
 export const ToastTrigger: React_2.FC<ToastTriggerProps>;

--- a/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
@@ -20,7 +20,15 @@ export type ToastContainerSlots = {
 export type ToastContainerProps = ComponentProps<Partial<ToastContainerSlots>> &
   Pick<
     Toast,
-    'close' | 'remove' | 'updateId' | 'data' | 'timeout' | 'politeness' | 'pauseOnHover' | 'pauseOnWindowBlur'
+    | 'close'
+    | 'remove'
+    | 'updateId'
+    | 'data'
+    | 'timeout'
+    | 'politeness'
+    | 'pauseOnHover'
+    | 'pauseOnWindowBlur'
+    | 'intent'
   > & {
     visible: boolean;
     announce: Announce;

--- a/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
@@ -51,7 +51,7 @@ export const useToastContainer_unstable = (
       return;
     }
 
-    const politeness = desiredPoliteness ? desiredPoliteness : intentPolitenessMap[intent];
+    const politeness = desiredPoliteness ?? intentPolitenessMap[intent];
     announce(toastRef.current?.textContent ?? '', { politeness });
   }, [announce, desiredPoliteness, toastRef, visible, updateId, intent]);
 

--- a/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
@@ -11,6 +11,13 @@ import type { ToastContainerProps, ToastContainerState } from './ToastContainer.
 import { useToast } from '../../state';
 import { Timer, TimerProps } from '../Timer/Timer';
 
+const intentPolitenessMap = {
+  success: 'assertive',
+  warning: 'assertive',
+  error: 'assertive',
+  info: 'polite',
+} as const;
+
 /**
  * Create the state required to render ToastContainer.
  *
@@ -33,16 +40,20 @@ export const useToastContainer_unstable = (
     announce,
     data,
     timeout: timerTimeout,
-    politeness,
+    politeness: desiredPoliteness,
+    intent = 'info',
     ...rest
   } = props;
   const { play, running, toastRef } = useToast<HTMLDivElement>({ ...props });
 
   React.useEffect(() => {
-    if (visible) {
-      announce(toastRef.current?.textContent ?? '', { politeness });
+    if (!visible) {
+      return;
     }
-  }, [announce, politeness, toastRef, visible, updateId]);
+
+    const politeness = desiredPoliteness ? desiredPoliteness : intentPolitenessMap[intent];
+    announce(toastRef.current?.textContent ?? '', { politeness });
+  }, [announce, desiredPoliteness, toastRef, visible, updateId, intent]);
 
   // It's impossible to animate to height: auto in CSS, the actual pixel value must be known
   // Get the height of the toast before animation styles have been applied and set a CSS

--- a/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
@@ -17,4 +17,4 @@ export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {};
 /**
  * State used in rendering ToastTitle
  */
-export type ToastTitleState = ComponentState<ToastTitleSlots> & Required<Pick<ToastContextValue, 'intent'>>;
+export type ToastTitleState = ComponentState<ToastTitleSlots> & Pick<ToastContextValue, 'intent'>;

--- a/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ToastContextValue } from '../../contexts/toastContext';
 
 export type ToastTitleSlots = {
   root: NonNullable<Slot<'div'>>;
@@ -11,15 +12,9 @@ export type ToastIntent = 'info' | 'success' | 'error' | 'warning';
 /**
  * ToastTitle Props
  */
-export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {
-  /**
-   * The intent prop, if present, determines the icon to be rendered in the icon slot. The icon prop
-   * overrides the intent prop
-   */
-  intent?: ToastIntent;
-};
+export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {};
 
 /**
  * State used in rendering ToastTitle
  */
-export type ToastTitleState = ComponentState<ToastTitleSlots> & Required<Pick<ToastTitleProps, 'intent'>>;
+export type ToastTitleState = ComponentState<ToastTitleSlots> & Required<Pick<ToastContextValue, 'intent'>>;

--- a/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
@@ -6,6 +6,8 @@ export type ToastTitleSlots = {
   action?: Slot<'div'>;
 };
 
+export type ToastIntent = 'info' | 'success' | 'error' | 'warning';
+
 /**
  * ToastTitle Props
  */
@@ -14,7 +16,7 @@ export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {
    * The intent prop, if present, determines the icon to be rendered in the icon slot. The icon prop
    * overrides the intent prop
    */
-  intent?: 'info' | 'success' | 'error' | 'warning';
+  intent?: ToastIntent;
 };
 
 /**

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
@@ -4,6 +4,7 @@ import { CheckmarkCircleFilled, DismissCircleFilled, InfoFilled, WarningFilled }
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 
 import type { ToastTitleProps, ToastTitleState } from './ToastTitle.types';
+import { useToastContext } from '../../contexts/toastContext';
 
 /**
  * Create the state required to render ToastTitle.
@@ -15,7 +16,7 @@ import type { ToastTitleProps, ToastTitleState } from './ToastTitle.types';
  * @param ref - reference to root HTMLElement of ToastTitle
  */
 export const useToastTitle_unstable = (props: ToastTitleProps, ref: React.Ref<HTMLElement>): ToastTitleState => {
-  const { intent = 'info' } = props;
+  const { intent = 'info' } = useToastContext();
 
   /** Determine the role and media to render based on the intent */
   let defaultIcon;
@@ -41,7 +42,7 @@ export const useToastTitle_unstable = (props: ToastTitleProps, ref: React.Ref<HT
       media: 'div',
       action: 'div',
     },
-    media: resolveShorthand(props.media, { required: !!props.intent, defaultProps: { children: defaultIcon } }),
+    media: resolveShorthand(props.media, { required: !!intent, defaultProps: { children: defaultIcon } }),
     intent,
     root: getNativeElementProps('div', {
       ref,

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
@@ -16,7 +16,7 @@ import { useToastContext } from '../../contexts/toastContext';
  * @param ref - reference to root HTMLElement of ToastTitle
  */
 export const useToastTitle_unstable = (props: ToastTitleProps, ref: React.Ref<HTMLElement>): ToastTitleState => {
-  const { intent = 'info' } = useToastContext();
+  const { intent } = useToastContext();
 
   /** Determine the role and media to render based on the intent */
   let defaultIcon;

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -71,7 +71,7 @@ export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitle
       toastTitleClassNames.media,
       styles.media,
       state.media.className,
-      intentIconStyles[intent],
+      intent && intentIconStyles[intent],
     );
   }
 

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -36,15 +36,64 @@ const useStyles = makeStyles({
   },
 });
 
+const useIntentIconStyles = makeStyles({
+  success: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteGreenForeground3,
+  },
+  error: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteCranberryForeground2,
+  },
+  warning: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteDarkOrangeForeground1,
+  },
+  info: {
+    color: tokens.colorNeutralForeground2,
+  },
+  progress: {
+    color: tokens.colorNeutralForegroundInverted2,
+  },
+});
+
+const useIntentIconStylesInverted = makeStyles({
+  success: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteGreenForeground3,
+  },
+  error: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteRedForegroundInverted,
+  },
+  warning: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteYellowForegroundInverted,
+  },
+  info: {
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
 /**
  * Apply styling to the ToastTitle slots based on the state
  */
 export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitleState => {
   const styles = useStyles();
+  const intentIconStyles = useIntentIconStyles();
+  const intentIconStylesInverted = useIntentIconStylesInverted();
+  const { intent } = state;
+  const inverted = false;
   state.root.className = mergeClasses(toastTitleClassNames.root, styles.root, state.root.className);
 
   if (state.media) {
-    state.media.className = mergeClasses(toastTitleClassNames.media, styles.media, state.media.className);
+    state.media.className = mergeClasses(
+      toastTitleClassNames.media,
+      styles.media,
+      state.media.className,
+      intentIconStyles[intent],
+      inverted && intentIconStylesInverted[intent],
+    );
   }
 
   if (state.action) {

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -57,33 +57,13 @@ const useIntentIconStyles = makeStyles({
   },
 });
 
-const useIntentIconStylesInverted = makeStyles({
-  success: {
-    // FIXME https://github.com/microsoft/fluentui/issues/28219
-    color: tokens.colorPaletteGreenForeground3,
-  },
-  error: {
-    // FIXME https://github.com/microsoft/fluentui/issues/28219
-    color: tokens.colorPaletteRedForegroundInverted,
-  },
-  warning: {
-    // FIXME https://github.com/microsoft/fluentui/issues/28219
-    color: tokens.colorPaletteYellowForegroundInverted,
-  },
-  info: {
-    color: tokens.colorNeutralForeground2,
-  },
-});
-
 /**
  * Apply styling to the ToastTitle slots based on the state
  */
 export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitleState => {
   const styles = useStyles();
   const intentIconStyles = useIntentIconStyles();
-  const intentIconStylesInverted = useIntentIconStylesInverted();
   const { intent } = state;
-  const inverted = false;
   state.root.className = mergeClasses(toastTitleClassNames.root, styles.root, state.root.className);
 
   if (state.media) {
@@ -92,7 +72,6 @@ export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitle
       styles.media,
       state.media.className,
       intentIconStyles[intent],
-      inverted && intentIconStylesInverted[intent],
     );
   }
 

--- a/packages/react-components/react-toast/src/contexts/toastContext.tsx
+++ b/packages/react-components/react-toast/src/contexts/toastContext.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { ToastOptions } from '../state/types';
 
 export type ToastContextValue = {
   close: () => void;
-};
+} & Pick<ToastOptions, 'intent'>;
 
 const toastContextDefaultValue: ToastContextValue = {
   close: () => null,

--- a/packages/react-components/react-toast/src/index.ts
+++ b/packages/react-components/react-toast/src/index.ts
@@ -1,5 +1,5 @@
 export { useToastController } from './state';
-export type { ToastPosition, ToastId, ToastOffset, ToastPoliteness, ToastStatus } from './state';
+export type { ToastPosition, ToastId, ToastOffset, ToastPoliteness, ToastLifecycleStatus } from './state';
 
 export { ToastTrigger } from './ToastTrigger';
 export type { ToastTriggerChildProps, ToastTriggerProps, ToastTriggerState } from './ToastTrigger';
@@ -21,7 +21,7 @@ export {
   renderToastTitle_unstable,
   toastTitleClassNames,
 } from './ToastTitle';
-export type { ToastTitleProps, ToastTitleState, ToastTitleSlots } from './ToastTitle';
+export type { ToastTitleProps, ToastTitleState, ToastTitleSlots, ToastIntent } from './ToastTitle';
 
 export {
   ToastBody,

--- a/packages/react-components/react-toast/src/index.ts
+++ b/packages/react-components/react-toast/src/index.ts
@@ -1,5 +1,5 @@
 export { useToastController } from './state';
-export type { ToastPosition, ToastId, ToastOffset, ToastPoliteness, ToastLifecycleStatus } from './state';
+export type { ToastPosition, ToastId, ToastOffset, ToastPoliteness, ToastStatus } from './state';
 
 export { ToastTrigger } from './ToastTrigger';
 export type { ToastTriggerChildProps, ToastTriggerProps, ToastTriggerState } from './ToastTrigger';

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -54,11 +54,12 @@ export interface ToastOptions<TData = object> {
    * Used to determine [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) narration
    * This will override the intent prop
    */
-  politeness: ToastPoliteness;
+  politeness?: ToastPoliteness;
 
   /**
    * Default toast types that determine the urgency or [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) narration
    * The UI layer may use these intents to apply specific styling.
+   * @default info
    */
   intent?: ToastIntent;
   /**

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -6,11 +6,11 @@ export type ToasterId = string;
 
 export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start';
 export type ToastPoliteness = 'assertive' | 'polite';
-export type ToastLifecycleStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
+export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
 export type ToastChangeHandler = (event: null, data: ToastChangeData) => void;
 
 export interface ToastChangeData extends ToastOptions, Pick<Toast, 'updateId'> {
-  status: ToastLifecycleStatus;
+  status: ToastStatus;
 }
 
 export interface ToastOptions<TData = object> {

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -6,11 +6,11 @@ export type ToasterId = string;
 
 export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start';
 export type ToastPoliteness = 'assertive' | 'polite';
-export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
+export type ToastLifecycleStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
 export type ToastChangeHandler = (event: null, data: ToastChangeData) => void;
 
 export interface ToastChangeData extends ToastOptions, Pick<Toast, 'updateId'> {
-  status: ToastStatus;
+  status: ToastLifecycleStatus;
 }
 
 export interface ToastOptions<TData = object> {

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -7,6 +7,7 @@ export type ToasterId = string;
 export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start';
 export type ToastPoliteness = 'assertive' | 'polite';
 export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
+export type ToastIntent = 'info' | 'success' | 'error' | 'warning';
 export type ToastChangeHandler = (event: null, data: ToastChangeData) => void;
 
 export interface ToastChangeData extends ToastOptions, Pick<Toast, 'updateId'> {
@@ -51,8 +52,15 @@ export interface ToastOptions<TData = object> {
   priority: number;
   /**
    * Used to determine [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) narration
+   * This will override the intent prop
    */
   politeness: ToastPoliteness;
+
+  /**
+   * Default toast types that determine the urgency or [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) narration
+   * The UI layer may use these intents to apply specific styling.
+   */
+  intent?: ToastIntent;
   /**
    * Additional data that needs to be passed to the toast
    */

--- a/packages/react-components/react-toast/src/state/vanilla/toaster.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/toaster.ts
@@ -45,7 +45,6 @@ export class Toaster {
     this.onUpdate = () => null;
     this.toastOptions = {
       onStatusChange: undefined,
-      politeness: 'polite',
       priority: 0,
       pauseOnHover: false,
       pauseOnWindowBlur: false,

--- a/packages/react-components/react-toast/stories/Toast/CustomAnnounce.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/CustomAnnounce.stories.tsx
@@ -26,11 +26,11 @@ export const CustomAnnounce = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success">
+        <ToastTitle>
           {politeness === 'polite' ? 'Polite' : 'Assertive'} toast {counter++}
         </ToastTitle>
       </Toast>,
-      { politeness },
+      { intent: 'success' },
     );
 
   const announce: ToasterProps['announce'] = (msg, options) => {

--- a/packages/react-components/react-toast/stories/Toast/CustomAnnounce.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/CustomAnnounce.stories.tsx
@@ -19,7 +19,7 @@ let counter = 0;
 export const CustomAnnounce = () => {
   const styles = useStyles();
   const [alert, setAlert] = React.useState('');
-  const [status, setStatus] = React.useState('');
+  const [intent, setIntent] = React.useState('');
   const [politeness, setPoliteness] = React.useState<ToastPoliteness>('polite');
   const toasterId = useId('toaster');
   const { dispatchToast } = useToastController(toasterId);
@@ -34,13 +34,13 @@ export const CustomAnnounce = () => {
     );
 
   const announce: ToasterProps['announce'] = (msg, options) => {
-    options.politeness === 'assertive' ? setAlert(msg) : setStatus(msg);
+    options.politeness === 'assertive' ? setAlert(msg) : setIntent(msg);
   };
 
   return (
     <>
-      <div role="status" className={styles.visuallyHidden}>
-        {status}
+      <div role="intent" className={styles.visuallyHidden}>
+        {intent}
       </div>
       <div role="alert" className={styles.visuallyHidden}>
         {alert}

--- a/packages/react-components/react-toast/stories/Toast/CustomAnnounce.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/CustomAnnounce.stories.tsx
@@ -19,7 +19,7 @@ let counter = 0;
 export const CustomAnnounce = () => {
   const styles = useStyles();
   const [alert, setAlert] = React.useState('');
-  const [intent, setIntent] = React.useState('');
+  const [status, setStatus] = React.useState('');
   const [politeness, setPoliteness] = React.useState<ToastPoliteness>('polite');
   const toasterId = useId('toaster');
   const { dispatchToast } = useToastController(toasterId);
@@ -34,13 +34,13 @@ export const CustomAnnounce = () => {
     );
 
   const announce: ToasterProps['announce'] = (msg, options) => {
-    options.politeness === 'assertive' ? setAlert(msg) : setIntent(msg);
+    options.politeness === 'assertive' ? setAlert(msg) : setStatus(msg);
   };
 
   return (
     <>
-      <div role="intent" className={styles.visuallyHidden}>
-        {intent}
+      <div role="status" className={styles.visuallyHidden}>
+        {status}
       </div>
       <div role="alert" className={styles.visuallyHidden}>
         {alert}

--- a/packages/react-components/react-toast/stories/Toast/CustomTimeout.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/CustomTimeout.stories.tsx
@@ -15,12 +15,11 @@ export const CustomTimeout = () => {
               <Link>Dismiss</Link>
             </ToastTrigger>
           }
-          intent="info"
         >
           {timeout >= 0 ? `Custom timeout ${timeout}ms` : `Dismiss manually`}
         </ToastTitle>
       </Toast>,
-      { timeout },
+      { timeout, intent: 'info' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/Default.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Default.stories.tsx
@@ -8,15 +8,14 @@ export const Default = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success" action={<Link>Undo</Link>}>
-          Email sent
-        </ToastTitle>
+        <ToastTitle action={<Link>Undo</Link>}>Email sent</ToastTitle>
         <ToastBody subtitle="Subtitle">This is a toast body</ToastBody>
         <ToastFooter>
           <Link>Action</Link>
           <Link>Action</Link>
         </ToastFooter>
       </Toast>,
+      { intent: 'success' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/DefaultToastOptions.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DefaultToastOptions.stories.tsx
@@ -8,8 +8,9 @@ export const DefaultToastOptions = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="info">Options configured in Toaster</ToastTitle>
+        <ToastTitle>Options configured in Toaster</ToastTitle>
       </Toast>,
+      { intent: 'info' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/DismissAll.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissAll.stories.tsx
@@ -8,8 +8,9 @@ export const DismissAll = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success">'This is a toast</ToastTitle>
+        <ToastTitle>'This is a toast</ToastTitle>
       </Toast>,
+      { intent: 'info' },
     );
   const dismissAll = () => dismissAllToasts();
 

--- a/packages/react-components/react-toast/stories/Toast/DismissToast.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissToast.stories.tsx
@@ -10,9 +10,9 @@ export const DismissToast = () => {
   const notify = () => {
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success">This is a toast</ToastTitle>
+        <ToastTitle>This is a toast</ToastTitle>
       </Toast>,
-      { toastId, onStatusChange: (e, { status }) => setUnmounted(status === 'unmounted') },
+      { toastId, intent: 'success', onStatusChange: (e, { status }) => setUnmounted(status === 'unmounted') },
     );
     setUnmounted(false);
   };

--- a/packages/react-components/react-toast/stories/Toast/DismissToastWithAction.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissToastWithAction.stories.tsx
@@ -9,7 +9,6 @@ export const DismissToastWithAction = () => {
     dispatchToast(
       <Toast>
         <ToastTitle
-          intent="success"
           action={
             <ToastTrigger>
               <Link>Dismiss</Link>
@@ -19,7 +18,7 @@ export const DismissToastWithAction = () => {
           Dismiss me
         </ToastTitle>
       </Toast>,
-      { timeout: -1 },
+      { timeout: -1, intent: 'success' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/Intent.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Intent.stories.tsx
@@ -13,7 +13,6 @@ export const Intent = () => {
           <Toast>
             <ToastTitle media={<Spinner size="tiny" />}>Progress toast</ToastTitle>
           </Toast>,
-          { timeout: -1 },
         );
         break;
       case 'avatar':
@@ -29,8 +28,9 @@ export const Intent = () => {
       case 'warning':
         dispatchToast(
           <Toast>
-            <ToastTitle intent={intent}>Toast intent: {intent}</ToastTitle>
+            <ToastTitle>Toast intent: {intent}</ToastTitle>
           </Toast>,
+          { intent },
         );
         break;
     }
@@ -67,8 +67,8 @@ Intent.parameters = {
         'Each intent affects the default icon in the title and its colour. These icon slots can be overriden',
         'to render other content such as progress spinners or avatars.',
         '',
-        '>⚠️ intent does **not** determine urgency of the screen reader aria-live narration,',
-        'use the `politeness` option when dispatching a toast',
+        '>intent determines the urgency of the screen reader aria-live narration.',
+        'To retain default intent styles, use the`politeness` option to override the urgency or aria-live narration.',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-toast/stories/Toast/Intent.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Intent.stories.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { Toaster, useToastController, ToastTitle, Toast, ToastIntent } from '@fluentui/react-toast';
+import { useId, Button, Field, RadioGroup, Radio, Spinner, Avatar } from '@fluentui/react-components';
+
+export const Intent = () => {
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController(toasterId);
+  const [intent, setIntent] = React.useState<ToastIntent | 'progress' | 'avatar'>('success');
+  const notify = () => {
+    switch (intent) {
+      case 'progress':
+        dispatchToast(
+          <Toast>
+            <ToastTitle media={<Spinner size="tiny" />}>Progress toast</ToastTitle>
+          </Toast>,
+          { timeout: -1 },
+        );
+        break;
+      case 'avatar':
+        dispatchToast(
+          <Toast>
+            <ToastTitle media={<Avatar name="Erika Mustermann" size={16} />}>Avatar toast</ToastTitle>
+          </Toast>,
+        );
+        break;
+      case 'error':
+      case 'info':
+      case 'success':
+      case 'warning':
+        dispatchToast(
+          <Toast>
+            <ToastTitle intent={intent}>Toast intent: {intent}</ToastTitle>
+          </Toast>,
+        );
+        break;
+    }
+  };
+
+  return (
+    <>
+      <Field label="Select a intent">
+        <RadioGroup value={intent} onChange={(e, data) => setIntent(data.value as ToastIntent)}>
+          <Radio label="success" value="success" />
+          <Radio label="info" value="info" />
+          <Radio label="warning" value="warning" />
+          <Radio label="error" value="error" />
+          <Radio label="progress (custom media slot)" value="progress" />
+          <Radio label="avatar (custom media slot)" value="avatar" />
+        </RadioGroup>
+      </Field>
+      <Toaster toasterId={toasterId} />
+      <Button onClick={() => notify()}>Make toast</Button>
+    </>
+  );
+};
+
+Intent.parameters = {
+  docs: {
+    description: {
+      story: [
+        'The toast comes by default with 4 different intents:',
+        '- success',
+        '- info',
+        '- warning',
+        '- error',
+        '',
+        'Each intent affects the default icon in the title and its colour. These icon slots can be overriden',
+        'to render other content such as progress spinners or avatars.',
+        '',
+        '>⚠️ intent does **not** determine urgency of the screen reader aria-live narration,',
+        'use the `politeness` option when dispatching a toast',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-toast/stories/Toast/MultipleToasters.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/MultipleToasters.stories.tsx
@@ -12,14 +12,16 @@ export const MultipleToasters = () => {
     if (toaster === first) {
       dispatchFirstToast(
         <Toast>
-          <ToastTitle intent="info">First toaster</ToastTitle>
+          <ToastTitle>First toaster</ToastTitle>
         </Toast>,
+        { intent: 'info' },
       );
     } else {
       dispatchSecondToast(
         <Toast>
-          <ToastTitle intent="info">Second toaster</ToastTitle>
+          <ToastTitle>Second toaster</ToastTitle>
         </Toast>,
+        { intent: 'info' },
       );
     }
   };

--- a/packages/react-components/react-toast/stories/Toast/Offset.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Offset.stories.tsx
@@ -37,11 +37,11 @@ export const Offset = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="info">
+        <ToastTitle>
           Offset: {horizontal}, {vertical}
         </ToastTitle>
       </Toast>,
-      { position },
+      { position, intent: 'info' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/PauseOnHover.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnHover.stories.tsx
@@ -8,9 +8,9 @@ export const PauseOnHover = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="info">Hover me!</ToastTitle>
+        <ToastTitle>Hover me!</ToastTitle>
       </Toast>,
-      { pauseOnHover: true },
+      { pauseOnHover: true, intent: 'info' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/PauseOnWindowBlur.stories.tsx
@@ -8,9 +8,9 @@ export const PauseOnWindowBlur = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="info">Click on another window!</ToastTitle>
+        <ToastTitle>Click on another window!</ToastTitle>
       </Toast>,
-      { pauseOnWindowBlur: true },
+      { pauseOnWindowBlur: true, intent: 'info' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/ToastDescription.md
+++ b/packages/react-components/react-toast/stories/Toast/ToastDescription.md
@@ -14,7 +14,7 @@
 A Toasts displays temporary content to the user. Toasts are rendered as a separate surface that can be dismissed by
 user action or a application timeout. Toasts are typically used in the following situations:
 
-- Update the user on the status of a task
+- Update the user on the intent of a task
 - Display the progress of a task
 - Notify the user to take an action
 - Notify the user of an application update

--- a/packages/react-components/react-toast/stories/Toast/ToastDescription.md
+++ b/packages/react-components/react-toast/stories/Toast/ToastDescription.md
@@ -14,7 +14,7 @@
 A Toasts displays temporary content to the user. Toasts are rendered as a separate surface that can be dismissed by
 user action or a application timeout. Toasts are typically used in the following situations:
 
-- Update the user on the intent of a task
+- Update the user on the status of a task
 - Display the progress of a task
 - Notify the user to take an action
 - Notify the user of an application update

--- a/packages/react-components/react-toast/stories/Toast/ToastLifecycle.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastLifecycle.stories.tsx
@@ -54,9 +54,7 @@ export const ToastLifecycle = () => {
   const notify = () => {
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success" action={<Link>Undo</Link>}>
-          Email sent
-        </ToastTitle>
+        <ToastTitle action={<Link>Undo</Link>}>Email sent</ToastTitle>
         <ToastBody subtitle="Subtitle">This is a toast body</ToastBody>
         <ToastFooter>
           <Link>Action</Link>
@@ -65,6 +63,7 @@ export const ToastLifecycle = () => {
       </Toast>,
       {
         timeout: 1000,
+        intent: 'success',
         onStatusChange: (e, { status: toastStatus }) => {
           setDismissed(toastStatus === 'unmounted');
           setStatusLog(prev => [[Date.now(), toastStatus], ...prev]);

--- a/packages/react-components/react-toast/stories/Toast/ToastLifecycle.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastLifecycle.stories.tsx
@@ -6,7 +6,7 @@ import {
   ToastTitle,
   ToastBody,
   ToastFooter,
-  ToastLifecycleStatus,
+  ToastStatus,
 } from '@fluentui/react-toast';
 import { useId, Link, Button, Text, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
@@ -49,7 +49,7 @@ export const ToastLifecycle = () => {
   const toasterId = useId('toaster');
   const labelId = useId();
   const { dispatchToast } = useToastController(toasterId);
-  const [intentLog, setLifecycleStatusLog] = React.useState<[number, ToastLifecycleStatus][]>([]);
+  const [statusLog, setStatusLog] = React.useState<[number, ToastStatus][]>([]);
   const [dismissed, setDismissed] = React.useState(true);
   const notify = () => {
     dispatchToast(
@@ -67,7 +67,7 @@ export const ToastLifecycle = () => {
         timeout: 1000,
         onStatusChange: (e, { status: toastStatus }) => {
           setDismissed(toastStatus === 'unmounted');
-          setLifecycleStatusLog(prev => [[Date.now(), toastStatus], ...prev]);
+          setStatusLog(prev => [[Date.now(), toastStatus], ...prev]);
         },
       },
     );
@@ -80,20 +80,20 @@ export const ToastLifecycle = () => {
           <Button className={styles.button} disabledFocusable={!dismissed} onClick={notify}>
             Make toast
           </Button>
-          <Button className={styles.button} onClick={() => setLifecycleStatusLog([])}>
+          <Button className={styles.button} onClick={() => setStatusLog([])}>
             Clear log
           </Button>
         </div>
         <div className={styles.logContainer}>
           <div className={styles.logLabel} id={labelId}>
-            LifecycleStatus log
+            Status log
           </div>
           <div role="log" aria-labelledby={labelId} className={styles.log}>
-            {intentLog.map(([time, toastLifecycleStatus]) => {
+            {statusLog.map(([time, toastStatus]) => {
               const date = new Date(time);
               return (
                 <div key={time}>
-                  {date.toLocaleTimeString()} <Text weight="bold">{toastLifecycleStatus}</Text>
+                  {date.toLocaleTimeString()} <Text weight="bold">{toastStatus}</Text>
                 </div>
               );
             })}
@@ -118,7 +118,7 @@ ToastLifecycle.parameters = {
         '- dismissed - The toast is visually invisible but still mounted',
         '- unounted - The toast has been completely unmounted and no longer exists',
         '',
-        'Use the `onLifecycleStatusChange` option when dispatching a toast to listen to lifecycle changes.',
+        'Use the `onStatusChange` option when dispatching a toast to listen to lifecycle changes.',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-toast/stories/Toast/ToastLifecycle.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastLifecycle.stories.tsx
@@ -6,7 +6,7 @@ import {
   ToastTitle,
   ToastBody,
   ToastFooter,
-  ToastStatus,
+  ToastLifecycleStatus,
 } from '@fluentui/react-toast';
 import { useId, Link, Button, Text, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
@@ -49,7 +49,7 @@ export const ToastLifecycle = () => {
   const toasterId = useId('toaster');
   const labelId = useId();
   const { dispatchToast } = useToastController(toasterId);
-  const [statusLog, setStatusLog] = React.useState<[number, ToastStatus][]>([]);
+  const [intentLog, setLifecycleStatusLog] = React.useState<[number, ToastLifecycleStatus][]>([]);
   const [dismissed, setDismissed] = React.useState(true);
   const notify = () => {
     dispatchToast(
@@ -67,7 +67,7 @@ export const ToastLifecycle = () => {
         timeout: 1000,
         onStatusChange: (e, { status: toastStatus }) => {
           setDismissed(toastStatus === 'unmounted');
-          setStatusLog(prev => [[Date.now(), toastStatus], ...prev]);
+          setLifecycleStatusLog(prev => [[Date.now(), toastStatus], ...prev]);
         },
       },
     );
@@ -80,20 +80,20 @@ export const ToastLifecycle = () => {
           <Button className={styles.button} disabledFocusable={!dismissed} onClick={notify}>
             Make toast
           </Button>
-          <Button className={styles.button} onClick={() => setStatusLog([])}>
+          <Button className={styles.button} onClick={() => setLifecycleStatusLog([])}>
             Clear log
           </Button>
         </div>
         <div className={styles.logContainer}>
           <div className={styles.logLabel} id={labelId}>
-            Status log
+            LifecycleStatus log
           </div>
           <div role="log" aria-labelledby={labelId} className={styles.log}>
-            {statusLog.map(([time, toastStatus]) => {
+            {intentLog.map(([time, toastLifecycleStatus]) => {
               const date = new Date(time);
               return (
                 <div key={time}>
-                  {date.toLocaleTimeString()} <Text weight="bold">{toastStatus}</Text>
+                  {date.toLocaleTimeString()} <Text weight="bold">{toastLifecycleStatus}</Text>
                 </div>
               );
             })}
@@ -118,7 +118,7 @@ ToastLifecycle.parameters = {
         '- dismissed - The toast is visually invisible but still mounted',
         '- unounted - The toast has been completely unmounted and no longer exists',
         '',
-        'Use the `onStatusChange` option when dispatching a toast to listen to lifecycle changes.',
+        'Use the `onLifecycleStatusChange` option when dispatching a toast to listen to lifecycle changes.',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
@@ -9,9 +9,9 @@ export const ToastPositions = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success">This toast is {position}</ToastTitle>
+        <ToastTitle>This toast is {position}</ToastTitle>
       </Toast>,
-      { position },
+      { position, intent: 'success' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/ToasterLimit.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToasterLimit.stories.tsx
@@ -9,8 +9,9 @@ export const ToasterLimit = () => {
   const notify = () =>
     dispatchToast(
       <Toast>
-        <ToastTitle intent="success">Limited to 3 toasts</ToastTitle>
+        <ToastTitle>Limited to 3 toasts</ToastTitle>
       </Toast>,
+      { intent: 'success' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/UpdateToast.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/UpdateToast.stories.tsx
@@ -11,9 +11,14 @@ export const UpdateToast = () => {
   const notify = () => {
     dispatchToast(
       <Toast>
-        <ToastTitle intent="warning">This toast never closes</ToastTitle>
+        <ToastTitle>This toast never closes</ToastTitle>
       </Toast>,
-      { toastId, timeout: -1, onStatusChange: (e, { status }) => setUnmounted(status === 'unmounted') },
+      {
+        toastId,
+        intent: 'warning',
+        timeout: -1,
+        onStatusChange: (e, { status }) => setUnmounted(status === 'unmounted'),
+      },
     );
     setUnmounted(false);
   };
@@ -21,9 +26,10 @@ export const UpdateToast = () => {
     updateToast({
       content: (
         <Toast>
-          <ToastTitle intent="success">This toast will close soon</ToastTitle>
+          <ToastTitle>This toast will close soon</ToastTitle>
         </Toast>
       ),
+      intent: 'success',
       toastId,
       timeout: 2000,
     });

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Toast, ToastTitle, ToastBody, ToastFooter, Toaster } from '@fluentui/react-toast';
 export { Default } from './Default.stories';
+export { Intent } from './Intent.stories';
 export { DefaultToastOptions } from './DefaultToastOptions.stories';
 export { CustomTimeout } from './CustomTimeout.stories';
 export { DismissToastWithAction } from './DismissToastWithAction.stories';


### PR DESCRIPTION
Hoists the `intent` prop used by the ToastTitle to the imperative API, so that default aria-live politeness can be set based on intent.

Also adds colors to the ToastTitle icon based on intent, unavailable tokens are labelled with FIXME

Addresses #26638 