### PR TITLE
fix: Alert example missing aria-label for icon

### DIFF
--- a/packages/react-components/react-alert/stories/Alert/AlertAction.stories.tsx
+++ b/packages/react-components/react-alert/stories/Alert/AlertAction.stories.tsx
@@ -11,7 +11,8 @@ export const Action = () => (
     <Alert
       intent="error"
       action={{
-        icon: <DismissCircleRegular aria-label="dismiss message" />,
+        icon: <DismissCircleRegular />,
+        'aria-label': 'dismiss message',
       }}
     >
       Save failed

--- a/packages/react-components/react-alert/stories/Alert/AlertAvatar.stories.tsx
+++ b/packages/react-components/react-alert/stories/Alert/AlertAvatar.stories.tsx
@@ -11,6 +11,7 @@ export const Avatar = () => (
     <Alert
       action={{
         icon: <DismissCircleRegular />,
+        'aria-label': 'dismiss message',
       }}
       avatar={{ name: 'John Smith', size: 24, color: 'dark-green' }}
     >


### PR DESCRIPTION
small fix, just a missing `aria-label` on a dismiss icon button.

Also moved the accName of the other icon action up to the button node, which is mostly a preference, but it is slightly less verbose that way.