### PR TITLE
Fix overlapping axis labels on smaller viewports

### DIFF
--- a/change/@fluentui-react-charting-1f77b865-250d-4cb3-bb5a-93fbdbf94a7c.json
+++ b/change/@fluentui-react-charting-1f77b865-250d-4cb3-bb5a-93fbdbf94a7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix overlapping axis labels on smaller viewports",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`AreaChart - mouse events Should render callout correctly on mouseover 1
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone6"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -565,6 +568,9 @@ exports[`AreaChart - mouse events Should render customized callout on mouseover 
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone6"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1000,6 +1006,9 @@ exports[`AreaChart - mouse events Should render customized callout per stack on 
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone6"
     onFocus={[Function]}
@@ -1437,6 +1446,9 @@ exports[`AreaChart snapShot testing Should not render circles when optimizeLarge
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone77"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1750,6 +1762,9 @@ exports[`AreaChart snapShot testing Should render with default colors when line 
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone69"
     onFocus={[Function]}
@@ -2102,6 +2117,9 @@ exports[`AreaChart snapShot testing renders Areachart correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone6"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2453,6 +2471,9 @@ exports[`AreaChart snapShot testing renders Areachart with single point correctl
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone61"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2791,6 +2812,9 @@ exports[`AreaChart snapShot testing renders enabledLegendsWrapLines correctly 1`
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone29"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3122,6 +3146,9 @@ exports[`AreaChart snapShot testing renders hideLegend hhh correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone14"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3312,6 +3339,9 @@ exports[`AreaChart snapShot testing renders hideTooltip correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone21"
     onFocus={[Function]}
@@ -3664,6 +3694,9 @@ exports[`AreaChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone37"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -4015,6 +4048,9 @@ exports[`AreaChart snapShot testing renders wrapXAxisLables correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone45"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -4365,6 +4401,9 @@ exports[`AreaChart snapShot testing renders yAxisTickFormat correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone53"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -662,7 +662,9 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       }
       if (this.props.parentRef || this.chartContainer) {
         const container = this.props.parentRef ? this.props.parentRef : this.chartContainer;
-        const currentContainerWidth = Math.max(container.getBoundingClientRect().width, this._calculateChartMinWidth());
+        const currentContainerWidth = this.props.enableReflow
+          ? Math.max(container.getBoundingClientRect().width, this._calculateChartMinWidth())
+          : container.getBoundingClientRect().width;
         const currentContainerHeight =
           container.getBoundingClientRect().height > legendContainerHeight
             ? container.getBoundingClientRect().height
@@ -699,7 +701,8 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
   };
 
   private _calculateChartMinWidth = (): number => {
-    let labelWidth = 10; // label padding
+    let labelWidth = 10; // Total padding on the left and right sides of the label
+
     // Case: rotated labels
     if (
       !this.props.wrapXAxisLables &&

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.styles.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.styles.ts
@@ -19,6 +19,9 @@ export const getStyles = (props: ICartesianChartStyleProps): ICartesianChartStyl
       },
       className,
     ],
+    chartWrapper: {
+      overflow: 'auto',
+    },
     xAxis: {
       selectors: {
         text: [

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -374,6 +374,12 @@ export interface ICartesianChartProps {
    * props for the svg; use this to include aria-* or other attributes on the tag
    */
   svgProps?: React.SVGProps<SVGSVGElement>;
+
+  /**
+   * Prop to disable shrinking of the chart beyond a certain limit and enable scrolling when the chart overflows
+   * @default True for LineChart but False for other charts
+   */
+  enableReflow?: boolean;
 }
 
 export interface IYValueHover {

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -146,6 +146,11 @@ export interface ICartesianChartStyles {
    * styles for the shape object in the callout
    */
   shapeStyles?: IStyle;
+
+  /**
+   * Styles for the chart wrapper div
+   */
+  chartWrapper?: IStyle;
 }
 
 export interface ICartesianChartProps {

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -775,6 +778,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1444,6 +1450,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2025,6 +2034,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone17"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2586,6 +2598,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone8"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2826,6 +2841,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone12"
     onFocus={[Function]}
@@ -3408,6 +3426,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone22"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3989,6 +4010,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone27"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -4569,6 +4593,9 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone32"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`HeatMapChart - mouse events Should render callout correctly on mouseove
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -580,6 +583,9 @@ exports[`HeatMapChart snapShot testing renders HeatMapChart correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -915,6 +921,9 @@ exports[`HeatMapChart snapShot testing renders corretly even when data is not pr
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone4"
     onFocus={[Function]}
@@ -1342,6 +1351,9 @@ exports[`HeatMapChart snapShot testing renders hideLegend correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone7"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1517,6 +1529,9 @@ exports[`HeatMapChart snapShot testing renders hideTooltip correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone9"
     onFocus={[Function]}
@@ -1853,6 +1868,9 @@ exports[`HeatMapChart snapShot testing renders yAxisTickFormat correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone12"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           "display": "block",
         }
       }
-      width={140}
+      width={0}
     >
       <g
         className=
@@ -118,7 +118,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={40}
+          width={-30}
           x={40}
           y={4}
         />
@@ -139,7 +139,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={50}
+          width={-37.5}
           x={40}
           y={106}
         />
@@ -160,7 +160,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={80}
+          width={-40}
           x={40}
           y={192.7}
         />
@@ -181,7 +181,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={20}
+          width={-15}
           x={40}
           y={233.5}
         />

--- a/packages/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -38,7 +41,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           "display": "block",
         }
       }
-      width={0}
+      width={140}
     >
       <g
         className=
@@ -115,7 +118,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={-30}
+          width={40}
           x={40}
           y={4}
         />
@@ -136,7 +139,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={-37.5}
+          width={50}
           x={40}
           y={106}
         />
@@ -157,7 +160,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={-40}
+          width={80}
           x={40}
           y={192.7}
         />
@@ -178,7 +181,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
-          width={-15}
+          width={20}
           x={40}
           y={233.5}
         />
@@ -1205,6 +1208,9 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1765,6 +1771,9 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders hideLegend correctl
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone8"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1894,6 +1903,9 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders showToolTipForYAxis
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone12"
     onFocus={[Function]}
@@ -2442,6 +2454,9 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders showYAxisLables cor
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone17"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -143,6 +143,10 @@ export interface ILineChartState extends IBasestate {
 }
 
 export class LineChartBase extends React.Component<ILineChartProps, ILineChartState> {
+  public static defaultProps: Partial<ILineChartProps> = {
+    enableReflow: true,
+  };
+
   private _points: LineChartDataWithIndex[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _calloutPoints: any[];

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`LineChart - mouse events Should render callout correctly on mouseover 1
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone9"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -547,6 +550,9 @@ exports[`LineChart - mouse events Should render customized callout on mouseover 
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone9"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -965,6 +971,9 @@ exports[`LineChart - mouse events Should render customized callout per stack on 
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone9"
     onFocus={[Function]}
@@ -1385,6 +1394,9 @@ exports[`LineChart snapShot testing Should render with default colors when line 
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone85"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1718,6 +1730,9 @@ exports[`LineChart snapShot testing renders LineChart correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone9"
     onFocus={[Function]}
@@ -2053,6 +2068,9 @@ exports[`LineChart snapShot testing renders enabledLegendsWrapLines correctly 1`
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone41"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2367,6 +2385,9 @@ exports[`LineChart snapShot testing renders hideLegend correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone20"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2540,6 +2561,9 @@ exports[`LineChart snapShot testing renders hideTooltip correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone30"
     onFocus={[Function]}
@@ -2875,6 +2899,9 @@ exports[`LineChart snapShot testing renders showXAxisLablesTooltip correctly 1`]
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone52"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3209,6 +3236,9 @@ exports[`LineChart snapShot testing renders wrapXAxisLables correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone63"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3542,6 +3572,9 @@ exports[`LineChart snapShot testing renders yAxisTickFormat correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone74"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           "display": "block",
         }
       }
-      width={150}
+      width={126}
     >
       <g
         className=
@@ -158,7 +158,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={70.30769230769232}
+            x={61.07692307692308}
             y={20}
           />
           <text
@@ -171,7 +171,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={78.30769230769232}
+            x={69.07692307692308}
             y={14}
           >
             50.0k
@@ -196,7 +196,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={103.76923076923076}
+            x={80.6923076923077}
             y={122}
           />
           <text
@@ -209,7 +209,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={111.76923076923076}
+            x={88.6923076923077}
             y={116}
           >
             30.0k
@@ -748,7 +748,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           "display": "block",
         }
       }
-      width={150}
+      width={126}
     >
       <g
         className=
@@ -865,7 +865,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={70.30769230769232}
+            x={61.07692307692308}
             y={20}
           />
           <text
@@ -878,7 +878,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={78.30769230769232}
+            x={69.07692307692308}
             y={14}
           >
             50.0k
@@ -903,7 +903,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={103.76923076923076}
+            x={80.6923076923077}
             y={122}
           />
           <text
@@ -916,7 +916,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={111.76923076923076}
+            x={88.6923076923077}
             y={116}
           >
             30.0k

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           "display": "block",
         }
       }
-      width={126}
+      width={0}
     >
       <g
         className=
@@ -158,7 +158,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={61.07692307692308}
+            x={12.615384615384617}
             y={20}
           />
           <text
@@ -171,7 +171,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={69.07692307692308}
+            x={20.615384615384617}
             y={14}
           >
             50.0k
@@ -196,7 +196,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={80.6923076923077}
+            x={-40.46153846153846}
             y={122}
           />
           <text
@@ -209,7 +209,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={88.6923076923077}
+            x={-32.46153846153846}
             y={116}
           >
             30.0k
@@ -748,7 +748,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           "display": "block",
         }
       }
-      width={126}
+      width={0}
     >
       <g
         className=
@@ -865,7 +865,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={61.07692307692308}
+            x={12.615384615384617}
             y={20}
           />
           <text
@@ -878,7 +878,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={69.07692307692308}
+            x={20.615384615384617}
             y={14}
           >
             50.0k
@@ -903,7 +903,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={80.6923076923077}
+            x={-40.46153846153846}
             y={122}
           />
           <text
@@ -916,7 +916,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={88.6923076923077}
+            x={-32.46153846153846}
             y={116}
           >
             30.0k

--- a/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -38,7 +41,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           "display": "block",
         }
       }
-      width={0}
+      width={150}
     >
       <g
         className=
@@ -155,7 +158,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={12.615384615384617}
+            x={70.30769230769232}
             y={20}
           />
           <text
@@ -168,7 +171,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={20.615384615384617}
+            x={78.30769230769232}
             y={14}
           >
             50.0k
@@ -193,7 +196,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={-40.46153846153846}
+            x={103.76923076923076}
             y={122}
           />
           <text
@@ -206,7 +209,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={-32.46153846153846}
+            x={111.76923076923076}
             y={116}
           >
             30.0k
@@ -730,6 +733,9 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -742,7 +748,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           "display": "block",
         }
       }
-      width={0}
+      width={150}
     >
       <g
         className=
@@ -859,7 +865,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={12.615384615384617}
+            x={70.30769230769232}
             y={20}
           />
           <text
@@ -872,7 +878,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={20.615384615384617}
+            x={78.30769230769232}
             y={14}
           >
             50.0k
@@ -897,7 +903,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             onMouseOver={[Function]}
             role="img"
             width={16}
-            x={-40.46153846153846}
+            x={103.76923076923076}
             y={122}
           />
           <text
@@ -910,7 +916,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
                   font-weight: 600;
                 }
             textAnchor="middle"
-            x={-32.46153846153846}
+            x={111.76923076923076}
             y={116}
           >
             30.0k
@@ -1352,6 +1358,9 @@ exports[`VerticalBarChart snapShot testing Should not render bar labels 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone37"
     onFocus={[Function]}
@@ -1803,6 +1812,9 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2253,6 +2265,9 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone17"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2683,6 +2698,9 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone8"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2792,6 +2810,9 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone12"
     onFocus={[Function]}
@@ -3243,6 +3264,9 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone22"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3693,6 +3717,9 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone27"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -4142,6 +4169,9 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone32"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           "display": "block",
         }
       }
-      width={116}
+      width={0}
     >
       <g
         className=
@@ -201,7 +201,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={72}
+              x={-44}
               y={127.88461538461539}
             />
             <rect
@@ -225,7 +225,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={72}
+              x={-44}
               y={29.807692307692307}
             />
           </g>
@@ -241,7 +241,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={80}
+            x={-36}
             y={23.807692307692307}
           >
             50
@@ -690,7 +690,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           "display": "block",
         }
       }
-      width={116}
+      width={0}
     >
       <g
         className=
@@ -850,7 +850,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={72}
+              x={-44}
               y={127.88461538461539}
             />
             <rect
@@ -874,7 +874,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={72}
+              x={-44}
               y={29.807692307692307}
             />
           </g>
@@ -890,7 +890,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={80}
+            x={-36}
             y={23.807692307692307}
           >
             50
@@ -1257,7 +1257,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           "display": "block",
         }
       }
-      width={116}
+      width={0}
     >
       <g
         className=
@@ -1408,7 +1408,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               key="1"
               transform="translate(0, 0)"
               width={16}
-              x={72}
+              x={-44}
               y={127.88461538461539}
             />
             <rect
@@ -1423,7 +1423,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               key="2"
               transform="translate(0, 0)"
               width={16}
-              x={72}
+              x={-44}
               y={29.807692307692307}
             />
           </g>
@@ -1439,7 +1439,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={80}
+            x={-36}
             y={23.807692307692307}
           >
             50
@@ -1455,7 +1455,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           strokeWidth={3}
           transform="translate(0, 0)"
           x1={56}
-          x2={80}
+          x2={-36}
           y1={201.4423076923077}
           y2={127.88461538461539}
         />
@@ -1472,7 +1472,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           visibility="visibility"
         />
         <circle
-          cx={80}
+          cx={-36}
           cy={127.88461538461539}
           fill="#ffffff"
           key="0-1-dot"

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -26,6 +26,9 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -38,7 +41,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           "display": "block",
         }
       }
-      width={0}
+      width={140}
     >
       <g
         className=
@@ -198,7 +201,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={-44}
+              x={96}
               y={127.88461538461539}
             />
             <rect
@@ -222,7 +225,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={-44}
+              x={96}
               y={29.807692307692307}
             />
           </g>
@@ -238,7 +241,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={-36}
+            x={104}
             y={23.807692307692307}
           >
             50
@@ -672,6 +675,9 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -684,7 +690,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           "display": "block",
         }
       }
-      width={0}
+      width={140}
     >
       <g
         className=
@@ -844,7 +850,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={-44}
+              x={96}
               y={127.88461538461539}
             />
             <rect
@@ -868,7 +874,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={-44}
+              x={96}
               y={29.807692307692307}
             />
           </g>
@@ -884,7 +890,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={-36}
+            x={104}
             y={23.807692307692307}
           >
             50
@@ -1236,6 +1242,9 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1248,7 +1257,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           "display": "block",
         }
       }
-      width={0}
+      width={140}
     >
       <g
         className=
@@ -1399,7 +1408,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               key="1"
               transform="translate(0, 0)"
               width={16}
-              x={-44}
+              x={96}
               y={127.88461538461539}
             />
             <rect
@@ -1414,7 +1423,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               key="2"
               transform="translate(0, 0)"
               width={16}
-              x={-44}
+              x={96}
               y={29.807692307692307}
             />
           </g>
@@ -1430,7 +1439,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={-36}
+            x={104}
             y={23.807692307692307}
           >
             50
@@ -1446,7 +1455,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           strokeWidth={3}
           transform="translate(0, 0)"
           x1={56}
-          x2={-36}
+          x2={104}
           y1={201.4423076923077}
           y2={127.88461538461539}
         />
@@ -1463,7 +1472,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           visibility="visibility"
         />
         <circle
-          cx={-36}
+          cx={104}
           cy={127.88461538461539}
           fill="#ffffff"
           key="0-1-dot"
@@ -1931,6 +1940,9 @@ exports[`VerticalStackedBarChart snapShot testing Should not render bar labels 1
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone42"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2287,6 +2299,9 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone3"
     onFocus={[Function]}
@@ -2645,6 +2660,9 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone17"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2982,6 +3000,9 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone8"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3088,6 +3109,9 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone12"
     onFocus={[Function]}
@@ -3446,6 +3470,9 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone32"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -3802,6 +3829,9 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone22"
     onFocus={[Function]}
@@ -4160,6 +4190,9 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
         &:focus {
           outline: none;
         }
+        {
+          overflow: auto;
+        }
     data-focuszone-id="FocusZone27"
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -4516,6 +4549,9 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
         ms-FocusZone
         &:focus {
           outline: none;
+        }
+        {
+          overflow: auto;
         }
     data-focuszone-id="FocusZone37"
     onFocus={[Function]}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           "display": "block",
         }
       }
-      width={140}
+      width={116}
     >
       <g
         className=
@@ -201,7 +201,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={96}
+              x={72}
               y={127.88461538461539}
             />
             <rect
@@ -225,7 +225,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={96}
+              x={72}
               y={29.807692307692307}
             />
           </g>
@@ -241,7 +241,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={104}
+            x={80}
             y={23.807692307692307}
           >
             50
@@ -690,7 +690,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           "display": "block",
         }
       }
-      width={140}
+      width={116}
     >
       <g
         className=
@@ -850,7 +850,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={96}
+              x={72}
               y={127.88461538461539}
             />
             <rect
@@ -874,7 +874,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               role="img"
               transform="translate(0, 0)"
               width={16}
-              x={96}
+              x={72}
               y={29.807692307692307}
             />
           </g>
@@ -890,7 +890,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={104}
+            x={80}
             y={23.807692307692307}
           >
             50
@@ -1257,7 +1257,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           "display": "block",
         }
       }
-      width={140}
+      width={116}
     >
       <g
         className=
@@ -1408,7 +1408,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               key="1"
               transform="translate(0, 0)"
               width={16}
-              x={96}
+              x={72}
               y={127.88461538461539}
             />
             <rect
@@ -1423,7 +1423,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
               key="2"
               transform="translate(0, 0)"
               width={16}
-              x={96}
+              x={72}
               y={29.807692307692307}
             />
           </g>
@@ -1439,7 +1439,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             role="img"
             textAnchor="middle"
             transform="translate(0, 0)"
-            x={104}
+            x={80}
             y={23.807692307692307}
           >
             50
@@ -1455,7 +1455,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           strokeWidth={3}
           transform="translate(0, 0)"
           x1={56}
-          x2={104}
+          x2={80}
           y1={201.4423076923077}
           y2={127.88461538461539}
         />
@@ -1472,7 +1472,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           visibility="visibility"
         />
         <circle
-          cx={104}
+          cx={80}
           cy={127.88461538461539}
           fill="#ffffff"
           key="0-1-dot"

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -166,18 +166,20 @@ export function createNumericXAxis(xAxisParams: IXAxisParams, chartType: ChartTy
   if (xAxisElement) {
     d3Select(xAxisElement).call(xAxis).selectAll('text').attr('aria-hidden', 'true');
   }
-  return xAxisScale;
+  const tickValues = xAxisScale.ticks(xAxisCount).map(xAxis.tickFormat()!);
+  return { xScale: xAxisScale, tickValues };
 }
 
-function multiFormat(date: Date, locale: d3TimeFormat.TimeLocaleObject) {
-  const formatMillisecond = locale.format('.%L');
-  const formatSecond = locale.format(':%S');
-  const formatMinute = locale.format('%I:%M');
-  const formatHour = locale.format('%I %p');
-  const formatDay = locale.format('%a %d');
-  const formatWeek = locale.format('%b %d');
-  const formatMonth = locale.format('%B');
-  const formatYear = locale.format('%Y');
+function multiFormat(date: Date, locale?: d3TimeFormat.TimeLocaleObject) {
+  const timeFormat = locale ? locale.format : d3TimeFormat.timeFormat;
+  const formatMillisecond = timeFormat('.%L');
+  const formatSecond = timeFormat(':%S');
+  const formatMinute = timeFormat('%I:%M');
+  const formatHour = timeFormat('%I %p');
+  const formatDay = timeFormat('%a %d');
+  const formatWeek = timeFormat('%b %d');
+  const formatMonth = timeFormat('%B');
+  const formatYear = timeFormat('%Y');
 
   return (
     d3TimeSecond(date) < date
@@ -240,7 +242,11 @@ export function createDateXAxis(
   if (xAxisElement) {
     d3Select(xAxisElement).call(xAxis).selectAll('text').attr('aria-hidden', 'true');
   }
-  return xAxisScale;
+  const tickValues = (tickParams.tickValues ?? xAxisScale.ticks(xAxisCount)).map((val, idx) => {
+    const tickFormat = xAxis.tickFormat();
+    return tickFormat ? tickFormat(val, idx) : multiFormat(val as Date);
+  });
+  return { xScale: xAxisScale, tickValues };
 }
 
 /**
@@ -283,7 +289,8 @@ export function createStringXAxis(
   if (xAxisParams.xAxisElement) {
     d3Select(xAxisParams.xAxisElement).call(xAxis).selectAll('text').attr('aria-hidden', 'true');
   }
-  return xAxisScale;
+  const tickValues = dataset.map(xAxis.tickFormat()!);
+  return { xScale: xAxisScale, tickValues };
 }
 
 /**
@@ -724,28 +731,34 @@ export function createYAxisLabels(
     }
   });
 }
-/**
- * This function is calculating the length of longest Y axis label in px ,so that we are able to
- * create the cartesian chart by shifting that many points to the right/left.
- * @param points
- * @returns
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function calculateLongestYAxisLabel(
-  points: IHorizontalBarChartWithAxisDataPoint[],
-  yAxisElement: SVGElement,
-): number {
-  let maxLabelLength = 0;
-  points.forEach((point: IHorizontalBarChartWithAxisDataPoint) => {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d');
-    ctx!.font = window.getComputedStyle(yAxisElement, null).getPropertyValue('font-size');
-    const wordLengthInPixel = ctx!.measureText(point.y as string).width;
-    maxLabelLength = Math.max(wordLengthInPixel, maxLabelLength);
-  });
 
-  return maxLabelLength;
-}
+/**
+ * Calculates the width of the longest axis label in pixels
+ */
+export const calculateLongestLabelWidth = (labels: (string | number)[], query: string = 'none'): number => {
+  let maxLabelWidth = 0;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (ctx) {
+    const axisText = document.querySelector(query);
+    if (axisText) {
+      const styles = window.getComputedStyle(axisText, null);
+      const fontWeight = styles.getPropertyValue('font-weight');
+      const fontSize = styles.getPropertyValue('font-size');
+      const fontFamily = styles.getPropertyValue('font-family');
+      ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
+    } else {
+      ctx.font = 'bold 10px "Segoe UI"';
+    }
+
+    labels.forEach(label => {
+      maxLabelWidth = Math.max(ctx.measureText(label.toString()).width, maxLabelWidth);
+    });
+  }
+
+  return maxLabelWidth;
+};
 
 /**
  * This method displays a tooltip to the x axis lables(tick values)

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -749,7 +749,7 @@ export const calculateLongestLabelWidth = (labels: (string | number)[], query: s
       const fontFamily = styles.getPropertyValue('font-family');
       ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
     } else {
-      ctx.font = 'bold 10px "Segoe UI"';
+      ctx.font = '600 10px "Segoe UI"';
     }
 
     labels.forEach(label => {

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -244,6 +244,7 @@ export function createDateXAxis(
   }
   const tickValues = (tickParams.tickValues ?? xAxisScale.ticks(xAxisCount)).map((val, idx) => {
     const tickFormat = xAxis.tickFormat();
+    // val is a Date object. So when the tick format is not set, format val as a string to calculate its width
     return tickFormat ? tickFormat(val, idx) : multiFormat(val as Date);
   });
   return { xScale: xAxisScale, tickValues };


### PR DESCRIPTION
## Previous Behavior

X-axis labels start overlapping when the window is zoomed in, or the window size is reduced

## New Behavior

Scrollbar becomes visible when the viewport is smaller than the minimum width of the cartesian chart

- The minimum width is larger than it should be for some charts with string axis and 2:1 spacing
- Test cases to check if the cartesian charts are readable on smaller viewports:
  - Shrink the window and reload the chart when width and height props are not provided
  - Zoom in the window and reload the chart when width and height props are not provided
  - Decrease the width and height props passed to the chart