### PR TITLE
fix: correcting focus behavior of react-search

### DIFF
--- a/packages/react-components/react-search/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-components/react-search/src/components/SearchBox/SearchBox.types.ts
@@ -22,4 +22,6 @@ export type SearchBoxProps = ComponentProps<SearchBoxSlots>;
  */
 export type SearchBoxState = ComponentState<SearchBoxSlots> &
   Required<Pick<InputState, 'size'>> &
-  Required<Pick<SearchBoxProps, 'disabled'>>;
+  Required<Pick<SearchBoxProps, 'disabled'>> & {
+    focused: boolean;
+  };

--- a/packages/react-components/react-search/src/components/SearchBox/renderSearchBox.tsx
+++ b/packages/react-components/react-search/src/components/SearchBox/renderSearchBox.tsx
@@ -15,15 +15,17 @@ export const renderSearchBox_unstable = (state: SearchBoxState) => {
 
   // TODO Add additional slots in the appropriate place
   const rootSlots = {
-    contentAfter: slots.contentAfter && {
-      ...slotProps.contentAfter,
-      children: (
-        <>
-          {slotProps.contentAfter.children}
-          {slots.dismiss && <slots.dismiss {...slotProps.dismiss} />}
-        </>
-      ),
-    },
+    contentAfter:
+      (slots.contentAfter && {
+        ...slotProps.contentAfter,
+        children: (
+          <>
+            {slotProps.contentAfter.children}
+            {slots.dismiss && <slots.dismiss {...slotProps.dismiss} />}
+          </>
+        ),
+      }) ||
+      (slots.dismiss && <slots.dismiss {...slotProps.dismiss} />),
   };
 
   return <slots.root {...slotProps.root} {...rootSlots} />;

--- a/packages/react-components/react-search/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/src/components/SearchBox/useSearchBox.tsx
@@ -55,6 +55,9 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
       ref: useMergedRefs(searchBoxRef, ref),
       type: 'search',
       input: {}, // defining here to have access in styles hook
+
+      disabled,
+      size,
       value,
 
       root: {
@@ -89,8 +92,8 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
     }),
     contentAfter: resolveShorthand(contentAfter, { required: true }),
 
-    focused,
     disabled,
+    focused,
     size,
   };
 

--- a/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -40,12 +40,12 @@ const useRootStyles = makeStyles({
     paddingRight: 0,
 
     // dismiss + contentAfter appear on focus
-    // '& + span': {
-    //   display: 'none',
-    // },
-    // '&:focus + span': {
-    //   display: 'flex',
-    // },
+    '& + span': {
+      display: 'none',
+    },
+    '&:focus + span': {
+      display: 'flex',
+    },
 
     // removes the WebKit pseudoelement styling
     '::-webkit-search-decoration': {
@@ -99,7 +99,7 @@ const useDismissStyles = makeStyles({
  * Apply styling to the SearchBox slots based on the state
  */
 export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxState => {
-  const { focused, disabled, size } = state;
+  const { disabled, focused, size } = state;
 
   const rootStyles = useRootStyles();
   const contentAfterStyles = useContentAfterStyles();
@@ -123,8 +123,6 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
     state.contentAfter!.className = mergeClasses(
       searchBoxClassNames.contentAfter,
       contentAfterStyles.contentAfter,
-      focused && contentAfterStyles.focused,
-      !focused && contentAfterStyles.default,
       state.contentAfter.className,
     );
   } else if (state.dismiss) {

--- a/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -40,12 +40,12 @@ const useRootStyles = makeStyles({
     paddingRight: 0,
 
     // dismiss + contentAfter appear on focus
-    '& + span': {
-      display: 'none',
-    },
-    '&:focus + span': {
-      display: 'flex',
-    },
+    // '& + span': {
+    //   display: 'none',
+    // },
+    // '&:focus + span': {
+    //   display: 'flex',
+    // },
 
     // removes the WebKit pseudoelement styling
     '::-webkit-search-decoration': {
@@ -61,6 +61,12 @@ const useContentAfterStyles = makeStyles({
   contentAfter: {
     paddingLeft: tokens.spacingHorizontalM,
     columnGap: tokens.spacingHorizontalXS,
+  },
+  focused: {
+    display: 'flex',
+  },
+  default: {
+    display: 'none',
   },
 });
 
@@ -93,7 +99,7 @@ const useDismissStyles = makeStyles({
  * Apply styling to the SearchBox slots based on the state
  */
 export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxState => {
-  const { disabled, size } = state;
+  const { focused, disabled, size } = state;
 
   const rootStyles = useRootStyles();
   const contentAfterStyles = useContentAfterStyles();
@@ -117,6 +123,8 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
     state.contentAfter!.className = mergeClasses(
       searchBoxClassNames.contentAfter,
       contentAfterStyles.contentAfter,
+      focused && contentAfterStyles.focused,
+      !focused && contentAfterStyles.default,
       state.contentAfter.className,
     );
   } else if (state.dismiss) {

--- a/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -39,13 +39,13 @@ const useRootStyles = makeStyles({
     paddingLeft: tokens.spacingHorizontalSNudge,
     paddingRight: 0,
 
-    // dismiss + contentAfter appear on focus
-    '& + span': {
-      display: 'none',
-    },
-    '&:focus + span': {
-      display: 'flex',
-    },
+    // // dismiss + contentAfter appear on focus
+    // '& + span': {
+    //   display: 'none',
+    // },
+    // '&:focus + span': {
+    //   display: 'flex',
+    // },
 
     // removes the WebKit pseudoelement styling
     '::-webkit-search-decoration': {
@@ -115,14 +115,22 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
       dismissClassName,
       disabled && dismissStyles.disabled,
       dismissStyles[size],
+
+      focused && contentAfterStyles.focused,
+      !focused && contentAfterStyles.default,
+
       state.dismiss.className,
     );
   }
 
   if (state.contentAfter) {
-    state.contentAfter!.className = mergeClasses(
+    state.contentAfter.className = mergeClasses(
       searchBoxClassNames.contentAfter,
       contentAfterStyles.contentAfter,
+
+      focused && contentAfterStyles.focused,
+      !focused && contentAfterStyles.default,
+
       state.contentAfter.className,
     );
   } else if (state.dismiss) {

--- a/packages/react-components/react-search/stories/SearchBox/SearchBoxDefault.stories.tsx
+++ b/packages/react-components/react-search/stories/SearchBox/SearchBoxDefault.stories.tsx
@@ -3,4 +3,11 @@ import { SearchBox, SearchBoxProps } from '@fluentui/react-search';
 
 import { FilterRegular } from '@fluentui/react-icons';
 
-export const Default = (props: Partial<SearchBoxProps>) => <SearchBox {...props} contentAfter={<FilterRegular />} />;
+export const Default = (props: Partial<SearchBoxProps>) => (
+  <>
+    <SearchBox {...props} contentAfter={<FilterRegular />} size="small" />
+    <SearchBox {...props} contentAfter={<FilterRegular />} />
+    <SearchBox {...props} contentAfter={<FilterRegular />} size="large" />
+    <SearchBox {...props} contentAfter={null} />
+  </>
+);

--- a/packages/react-components/react-search/stories/SearchBox/SearchBoxDefault.stories.tsx
+++ b/packages/react-components/react-search/stories/SearchBox/SearchBoxDefault.stories.tsx
@@ -5,9 +5,9 @@ import { FilterRegular } from '@fluentui/react-icons';
 
 export const Default = (props: Partial<SearchBoxProps>) => (
   <>
-    <SearchBox {...props} contentAfter={<FilterRegular />} size="small" />
-    <SearchBox {...props} contentAfter={<FilterRegular />} />
-    <SearchBox {...props} contentAfter={<FilterRegular />} size="large" />
-    <SearchBox {...props} contentAfter={null} />
+    <SearchBox {...props} contentAfter={<FilterRegular />} size="small" placeholder="small" />
+    <SearchBox {...props} contentAfter={<FilterRegular />} size="medium" placeholder="medium" />
+    <SearchBox {...props} contentAfter={<FilterRegular />} size="large" placeholder="large" />
+    <SearchBox {...props} contentAfter={null} placeholder="no contentAfter" />
   </>
 );


### PR DESCRIPTION
- Polishes the appearances of react-search based on the selected size and appearance
- Add the appear-on-focus behavior to the contentAfter and dismiss icons
- Enables excluding contentAfter while still maintaining the dismiss button

<img width="824" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/f88f3455-ece1-4d51-9436-ec9ef67e622c">

