### PR TITLE
fix: add accNames to buttons and inputs in v9 Table example code

### DIFF
--- a/packages/react-components/react-table/stories/Table/CellActions.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/CellActions.stories.tsx
@@ -91,8 +91,8 @@ export const CellActions = () => {
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
               <TableCellActions>
-                <Button icon={<EditIcon />} appearance="subtle" />
-                <Button icon={<MoreHorizontalIcon />} appearance="subtle" />
+                <Button icon={<EditIcon />} appearance="subtle" aria-label="Edit" />
+                <Button icon={<MoreHorizontalIcon />} appearance="subtle" aria-label="More actions" />
               </TableCellActions>
             </TableCell>
             <TableCell>

--- a/packages/react-components/react-table/stories/Table/PrimaryCell.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/PrimaryCell.stories.tsx
@@ -93,8 +93,8 @@ export const PrimaryCell = () => {
                 {item.file.label}
               </TableCellLayout>
               <TableCellActions>
-                <Button icon={<EditIcon />} appearance="subtle" />
-                <Button icon={<MoreHorizontalIcon />} appearance="subtle" />
+                <Button icon={<EditIcon />} appearance="subtle" aria-label="Edit" />
+                <Button icon={<MoreHorizontalIcon />} appearance="subtle" aria-label="More actions" />
               </TableCellActions>
             </TableCell>
 

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsControlled.stories.tsx
@@ -9,6 +9,7 @@ import {
   TableHeaderCell,
   TableRow,
   createTableColumn,
+  useId,
   useTableColumnSizing_unstable,
   useTableFeatures,
   useTableSort,
@@ -239,20 +240,24 @@ export const ResizableColumnsControlled = () => {
 
   const rows = sort(getRows());
 
+  const inputId = useId('first-column');
+
   return (
     <>
       <p>
-        <Label>First column width: </Label>
+        <Label htmlFor={`${inputId}-width`}>First column width: </Label>
         <Input
           type="number"
+          id={`${inputId}-width`}
           onChange={onWidthChange}
           value={columnSizingOptions.file.idealWidth ? columnSizingOptions.file.idealWidth.toString() : ''}
         />
       </p>
       <p>
-        <Label>First column minWidth: </Label>
+        <Label htmlFor={`${inputId}-minwidth`}>First column minWidth: </Label>
         <Input
           type="number"
+          id={`${inputId}-minwidth`}
           onChange={onMinWidthChange}
           value={columnSizingOptions.file.minWidth ? columnSizingOptions.file.minWidth?.toString() : ''}
         />

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsUncontrolled.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsUncontrolled.stories.tsx
@@ -15,6 +15,7 @@ import {
   PresenceBadgeStatus,
   Avatar,
   Input,
+  useId,
 } from '@fluentui/react-components';
 import {
   DocumentPdfRegular,
@@ -147,11 +148,13 @@ export const ResizableColumnsUncontrolled = () => {
   };
   const rows = getRows();
 
+  const inputId = useId('column-width');
+
   return (
     <>
       <p>
-        First column width:{' '}
-        <Input type="number" onChange={onWidthChange} value={inputValue ? inputValue.toString() : ''} />
+        <label htmlFor={inputId}>First column width: </label>
+        <Input type="number" id={inputId} onChange={onWidthChange} value={inputValue ? inputValue.toString() : ''} />
       </p>
       <Table sortable aria-label="Table with sort" ref={tableRef}>
         <TableHeader>

--- a/packages/react-components/react-table/stories/Table/SelectionWithCellActions.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/SelectionWithCellActions.stories.tsx
@@ -190,8 +190,8 @@ export const SelectionWithCellActions = () => {
             <TableCell>
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
               <TableCellActions onClick={onClickCellActions} onKeyDown={onKeyDownCellActions}>
-                <Button icon={<EditIcon />} appearance="subtle" />
-                <Button icon={<MoreHorizontalIcon />} appearance="subtle" />
+                <Button icon={<EditIcon />} appearance="subtle" aria-label="Edit" />
+                <Button icon={<MoreHorizontalIcon />} appearance="subtle" aria-label="More actions" />
               </TableCellActions>
             </TableCell>
             <TableCell>


### PR DESCRIPTION
Simple examples-only fix, adds `aria-label`s to buttons and label/input associations that were missing accNames in the story code.