### PR TITLE
Export combobox selection types

### DIFF
--- a/change/@fluentui-react-components-65d7d4e7-165f-4208-927d-38b6bce56795.json
+++ b/change/@fluentui-react-components-65d7d4e7-165f-4208-927d-38b6bce56795.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Export combobox selection types",
+  "comment": "chore: Export combobox selection types.",
   "packageName": "@fluentui/react-components",
   "email": "tfaller1@gmx.de",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-components-65d7d4e7-165f-4208-927d-38b6bce56795.json
+++ b/change/@fluentui-react-components-65d7d4e7-165f-4208-927d-38b6bce56795.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export combobox selection types",
+  "packageName": "@fluentui/react-components",
+  "email": "tfaller1@gmx.de",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -542,6 +542,7 @@ import { optionGroupClassNames } from '@fluentui/react-combobox';
 import { OptionGroupProps } from '@fluentui/react-combobox';
 import { OptionGroupSlots } from '@fluentui/react-combobox';
 import { OptionGroupState } from '@fluentui/react-combobox';
+import { OptionOnSelectData } from '@fluentui/react-combobox';
 import { OptionProps } from '@fluentui/react-combobox';
 import { OptionSlots } from '@fluentui/react-combobox';
 import { OptionState } from '@fluentui/react-combobox';
@@ -765,6 +766,7 @@ import { SelectionHookParams } from '@fluentui/react-utilities';
 import { SelectionItemId } from '@fluentui/react-utilities';
 import { SelectionMethods } from '@fluentui/react-utilities';
 import { SelectionMode as SelectionMode_2 } from '@fluentui/react-utilities';
+import { SelectionEvents } from '@fluentui/react-combobox';
 import { SelectOnChangeData } from '@fluentui/react-select';
 import { SelectProps } from '@fluentui/react-select';
 import { SelectSlots } from '@fluentui/react-select';
@@ -2495,6 +2497,8 @@ export { OptionGroupSlots }
 
 export { OptionGroupState }
 
+export { OptionOnSelectData }
+
 export { OptionProps }
 
 export { OptionSlots }
@@ -2940,6 +2944,8 @@ export { SelectionItemId }
 export { SelectionMethods }
 
 export { SelectionMode_2 as SelectionMode }
+
+export { SelectionEvents }
 
 export { SelectOnChangeData }
 

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -762,11 +762,11 @@ import { ResolveShorthandOptions } from '@fluentui/react-utilities';
 import { Select } from '@fluentui/react-select';
 import { SelectableHandler } from '@fluentui/react-menu';
 import { selectClassNames } from '@fluentui/react-select';
+import { SelectionEvents } from '@fluentui/react-combobox';
 import { SelectionHookParams } from '@fluentui/react-utilities';
 import { SelectionItemId } from '@fluentui/react-utilities';
 import { SelectionMethods } from '@fluentui/react-utilities';
 import { SelectionMode as SelectionMode_2 } from '@fluentui/react-utilities';
-import { SelectionEvents } from '@fluentui/react-combobox';
 import { SelectOnChangeData } from '@fluentui/react-select';
 import { SelectProps } from '@fluentui/react-select';
 import { SelectSlots } from '@fluentui/react-select';
@@ -2937,6 +2937,8 @@ export { SelectableHandler }
 
 export { selectClassNames }
 
+export { SelectionEvents }
+
 export { SelectionHookParams }
 
 export { SelectionItemId }
@@ -2944,8 +2946,6 @@ export { SelectionItemId }
 export { SelectionMethods }
 
 export { SelectionMode_2 as SelectionMode }
-
-export { SelectionEvents }
 
 export { SelectOnChangeData }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -385,12 +385,14 @@ export type {
   ListboxProps,
   ListboxSlots,
   ListboxState,
+  OptionOnSelectData,
   OptionProps,
   OptionSlots,
   OptionState,
   OptionGroupProps,
   OptionGroupSlots,
   OptionGroupState,
+  SelectionEvents,
 } from '@fluentui/react-combobox';
 export {
   Divider,


### PR DESCRIPTION
## Previous Behavior

OptionOnSelectData and SelectionEvents are not exported by @fluentui/react-components.
Currently only @fluentui/react-combobox exports them.

## New Behavior

@fluentui/react-components also exports them, like the other combobox types.
Improves the developer experience.
