### PR TITLE
react-dialog(bugfix): Ensures dialog actions stretches on breakpoints

### DIFF
--- a/change/@fluentui-react-dialog-1d49c035-4bba-4e6d-9df2-5ed5fe7cad97.json
+++ b/change/@fluentui-react-dialog-1d49c035-4bba-4e6d-9df2-5ed5fe7cad97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Ensures dialog actions stretches on breakpoints",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.styles.ts
@@ -24,11 +24,17 @@ const useStyles = makeStyles({
     justifySelf: 'end',
     gridColumnStart: 2,
     gridColumnEnd: 4,
+    [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
+      gridColumnStart: 1,
+    },
   },
   gridPositionStart: {
     justifySelf: 'start',
     gridColumnStart: 1,
     gridColumnEnd: 2,
+    [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
+      gridColumnEnd: 4,
+    },
   },
   fluidStart: {
     gridColumnEnd: 4,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://github.com/microsoft/fluentui/assets/5483269/18a23fcf-e892-4eb3-bbe1-9dba034e2153)


## New Behavior

![image](https://github.com/microsoft/fluentui/assets/5483269/744be11e-ee6a-44fc-bd74-3d3e9ebfb68b)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27991
