### PR TITLE
fix(react-card): infer a11y id from immediate header element

### DIFF
--- a/change/@fluentui-react-card-e65cb71c-d483-449c-b1cb-b6b23d07f25b.json
+++ b/change/@fluentui-react-card-e65cb71c-d483-449c-b1cb-b6b23d07f25b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: infer a11y id from immediate header element",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/Card/Card.cy.tsx
+++ b/packages/react-components/react-card/src/components/Card/Card.cy.tsx
@@ -60,6 +60,29 @@ const CardSample = (props: CardProps) => (
   </>
 );
 
+const CardWithCustomHeader = ({
+  customHeaderId = 'custom-header-id',
+  ...props
+}: CardProps & { customHeaderId: string }) => (
+  <>
+    <p tabIndex={0} id="before">
+      Before
+    </p>
+
+    <Card id="card" {...props}>
+      <CardHeader
+        image={<img src={resolveAsset('powerpoint_logo.svg')} alt="Microsoft PowerPoint logo" />}
+        header={<b id={customHeaderId}>App Name</b>}
+        description={<span>Developer</span>}
+      />
+    </Card>
+
+    <p tabIndex={0} id="after">
+      After
+    </p>
+  </>
+);
+
 const CardWithPreview = (props: CardProps) => (
   <>
     <p tabIndex={0} id="before">
@@ -420,6 +443,17 @@ describe('Card', () => {
         cy.get(`.${cardClassNames.checkbox}`).then(slot => {
           expect(header.attr('id')).equals(slot.attr('aria-labelledby'));
         });
+      });
+    });
+
+    it('should sync selectable aria-labelledby with card header immediate child', () => {
+      const customHeaderId = 'custom-header';
+
+      mountFluent(<CardWithCustomHeader customHeaderId={customHeaderId} selected />);
+
+      cy.get(`.${cardHeaderClassNames.header}`).should('not.have.attr', 'id');
+      cy.get(`.${cardClassNames.checkbox}`).then(slot => {
+        cy.get(`#${customHeaderId}`).then(() => expect(customHeaderId).equals(slot.attr('aria-labelledby')));
       });
     });
 

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
@@ -20,7 +20,12 @@ function getReferenceId(
   if (refId) {
     return refId;
   }
-  return childWithId?.props.id ? childWithId.props.id : generatedId;
+
+  if (childWithId?.props.id) {
+    return childWithId?.props.id;
+  }
+
+  return generatedId;
 }
 
 /**

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
@@ -63,12 +63,12 @@ export const useCardHeader_unstable = (props: CardHeaderProps, ref: React.Ref<HT
   const generatedId = useId(cardHeaderClassNames.header, referenceId);
 
   React.useEffect(() => {
-    const refId = !hasChildId.current ? headerRef.current?.id : undefined;
+    const headerId = !hasChildId.current ? headerRef.current?.id : undefined;
     const childWithId = getChildWithId(header);
 
     hasChildId.current = Boolean(childWithId);
 
-    setReferenceId(getReferenceId(refId, childWithId, generatedId));
+    setReferenceId(getReferenceId(headerId, childWithId, generatedId));
   }, [generatedId, header, setReferenceId]);
 
   return {

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
@@ -4,6 +4,11 @@ import type { CardHeaderProps, CardHeaderState } from './CardHeader.types';
 import { useCardContext_unstable } from '../Card/CardContext';
 import { cardHeaderClassNames } from './useCardHeaderStyles.styles';
 
+/**
+ * Finds the first child of CardHeader with an id prop.
+ *
+ * @param header - the header prop of CardHeader
+ */
 function getChildWithId(header: CardHeaderProps['header']) {
   function isReactElementWithIdProp(element: React.ReactNode): element is React.ReactElement {
     return React.isValidElement(element) && Boolean(element.props.id);
@@ -12,13 +17,22 @@ function getChildWithId(header: CardHeaderProps['header']) {
   return React.Children.toArray(header).find(isReactElementWithIdProp);
 }
 
+/**
+ * Returns the id to use for the CardHeader root element.
+ *
+ * @param headerId - the id prop of the CardHeader component
+ * @param childWithId - the first child of the CardHeader component with an id prop
+ * @param generatedId - a generated id
+ *
+ * @returns the id to use for the CardHeader root element
+ */
 function getReferenceId(
-  refId: string | undefined,
+  headerId: string | undefined,
   childWithId: React.ReactElement | undefined,
   generatedId: string,
 ): string {
-  if (refId) {
-    return refId;
+  if (headerId) {
+    return headerId;
   }
 
   if (childWithId?.props.id) {

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
@@ -36,7 +36,7 @@ function getReferenceId(
   }
 
   if (childWithId?.props.id) {
-    return childWithId?.props.id;
+    return childWithId.props.id;
   }
 
   return generatedId;

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
@@ -21,15 +21,25 @@ export const useCardHeader_unstable = (props: CardHeaderProps, ref: React.Ref<HT
   } = useCardContext_unstable();
   const headerRef = React.useRef<HTMLDivElement>(null);
 
+  const hasChildId = React.useRef(false);
   const generatedId = useId(cardHeaderClassNames.header, referenceId);
 
   React.useEffect(() => {
-    if (header && headerRef.current) {
-      const { id } = headerRef.current;
+    const refId = !hasChildId.current && headerRef.current?.id;
+    const childWithId = React.Children.toArray(header).find(element => {
+      if (!React.isValidElement(element)) {
+        return false;
+      }
 
-      setReferenceId(id ? id : generatedId);
-    }
-  }, [header, setReferenceId, generatedId]);
+      const { id } = element.props;
+
+      return !!id;
+    }) as React.ReactElement | undefined;
+
+    hasChildId.current = !!childWithId;
+
+    setReferenceId(refId ? refId : childWithId?.props.id ? childWithId?.props.id : generatedId);
+  }, [generatedId, header, setReferenceId]);
 
   return {
     components: {
@@ -49,7 +59,7 @@ export const useCardHeader_unstable = (props: CardHeaderProps, ref: React.Ref<HT
       required: true,
       defaultProps: {
         ref: headerRef,
-        id: referenceId,
+        id: !hasChildId.current ? referenceId : undefined,
       },
     }),
     description: resolveShorthand(description),


### PR DESCRIPTION
## Previous Behavior

To enable narration of the correct element when a card is selectable, we would create a dynamic id for the CardHeader element and synchronise it with the internal checkbox aria-describedby attribute.

## New Behavior

We now infer the value from the children element from the CardHeader `header` property (if any). In case no element is found, it'll fallback to the previous behaviour. This will allow to a more precise target for the element we use to enable narration.
