### PR TITLE
bugfix: adds grid-template-columns to DialogBody styles to ensure grid template layout

### DIFF
--- a/change/@fluentui-react-dialog-46140418-eae5-48fe-beea-485764cb1dfa.json
+++ b/change/@fluentui-react-dialog-46140418-eae5-48fe-beea-485764cb1dfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: adds grid-template-columns to DialogBody styles to ensure grid template layout",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.styles.ts
@@ -21,6 +21,7 @@ const useStyles = makeStyles({
     ...shorthands.overflow('unset'),
     ...shorthands.gap(DIALOG_GAP),
     gridTemplateRows: 'auto 1fr',
+    gridTemplateColumns: '1fr 1fr auto',
     [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
       maxWidth: '100vw',
       gridTemplateRows: 'auto 1fr auto',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

![image](https://github.com/microsoft/fluentui/assets/5483269/a48d2205-cb29-469b-92e0-9b7dd076cc8f)

due to missing `grid-template-columns` the `DialogBody` doesn't properly expand it's whole size when the body is complex

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

![image](https://github.com/microsoft/fluentui/assets/5483269/57c4c8b5-c7c9-4ff3-9727-e60fc2e9d1be)

1. adds `grid-tempalte-columns` to it's old value

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
