### PR TITLE
[Documentation]: Add information about `aria-label` on the surface if there is no DialogTitle in the best practices.

### DIFF
--- a/packages/react-components/react-dialog/stories/Dialog/DialogBestPractices.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogBestPractices.md
@@ -9,6 +9,7 @@
 - Validate that people’s entries are acceptable before closing the dialog. Show an inline validation error near the field they must correct.
 - Modal dialogs should be used very sparingly—only when it’s critical that people make a choice or provide information before they can proceed. Thee dialogs are generally used for irreversible or potentially destructive tasks. They’re typically paired with an backdrop without a light dismiss.
 - Add a `aria-describedby` attribute on `DialogSurface` pointing to the dialog content on short confirmation like dialogs.
+- Add a `aria-label` or `aria-labelledby` attribute on `DialogSurface` if there is no `DialogTitle`
 
 ### Don't
 


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Adds to `Dialog` best practices the usage of `aria-label` or `aria-labelledby` if no `DialogTitle` is provided

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27900
