### PR TITLE
fix: Calendar uses month-only selection string when only month picker is used

### DIFF
--- a/change/@fluentui-react-datepicker-compat-6564eb05-a29c-443b-bede-9013941919fc.json
+++ b/change/@fluentui-react-datepicker-compat-6564eb05-a29c-443b-bede-9013941919fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Calendar uses month-only selection string when only month picker is used",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-e6a59ed9-7ac7-4d6d-a675-8815b201c9f5.json
+++ b/change/@fluentui-react-e6a59ed9-7ac7-4d6d-a675-8815b201c9f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Calendar uses month-only selection string when only month picker is used",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/Calendar/Calendar.tsx
@@ -317,9 +317,12 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       );
     }
     if (dateTimeFormatter && strings!.selectedDateFormatString) {
+      const dateStringFormatter = monthPickerOnly
+        ? dateTimeFormatter.formatMonthYear
+        : dateTimeFormatter.formatMonthDayYear;
       selectedDateString = strings!.selectedDateFormatString.replace(
         '{0}',
-        dateTimeFormatter.formatMonthDayYear(selectedDate, strings!),
+        dateStringFormatter(selectedDate, strings!),
       );
     }
     const selectionAndTodayString = selectedDateString + ', ' + todayDateString;

--- a/packages/react/src/components/Calendar/Calendar.base.tsx
+++ b/packages/react/src/components/Calendar/Calendar.base.tsx
@@ -301,14 +301,14 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
     const classes = getClassNames(styles, {
       theme: theme!,
       className,
-      isMonthPickerVisible: isMonthPickerVisible,
-      isDayPickerVisible: isDayPickerVisible,
-      monthPickerOnly: monthPickerOnly,
-      showMonthPickerAsOverlay: showMonthPickerAsOverlay,
-      overlaidWithButton: overlaidWithButton,
+      isMonthPickerVisible,
+      isDayPickerVisible,
+      monthPickerOnly,
+      showMonthPickerAsOverlay,
+      overlaidWithButton,
       overlayedWithButton: overlaidWithButton,
-      showGoToToday: showGoToToday,
-      showWeekNumbers: showWeekNumbers,
+      showGoToToday,
+      showWeekNumbers,
     });
 
     let todayDateString: string = '';
@@ -317,10 +317,10 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
       todayDateString = format(strings!.todayDateFormatString, dateTimeFormatter.formatMonthDayYear(today, strings!));
     }
     if (dateTimeFormatter && strings!.selectedDateFormatString) {
-      selectedDateString = format(
-        strings!.selectedDateFormatString,
-        dateTimeFormatter.formatMonthDayYear(selectedDate, strings!),
-      );
+      const dateStringFormatter = monthPickerOnly
+        ? dateTimeFormatter.formatMonthYear
+        : dateTimeFormatter.formatMonthDayYear;
+      selectedDateString = format(strings!.selectedDateFormatString, dateStringFormatter(selectedDate, strings!));
     }
     const selectionAndTodayString = selectedDateString + ', ' + todayDateString;
 


### PR DESCRIPTION

## Previous Behavior

When Calendar or DatePicker is used in a month-only configuration (i.e. no date picking at all, only month and year) we still had the screen reader-only selected date string include the weekday and date information.

## New Behavior

The selected date string only includes the month and year for month-only Calendars/DatePickers in both v8 & v9 compat.

## Related Issue(s)

- Fixes [16425](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16425)
