### PR TITLE
fix: v8 Rating should update in response to keyboard events, not focus events

### DIFF
--- a/change/@fluentui-react-6c10b703-0791-4201-9290-ebec3fd9c545.json
+++ b/change/@fluentui-react-6c10b703-0791-4201-9290-ebec3fd9c545.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: change rating in response to keyboard events, not focus events",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Rating/Rating.base.tsx
+++ b/packages/react/src/components/Rating/Rating.base.tsx
@@ -168,8 +168,7 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
             break;
         }
 
-        const shouldSelectStar = newRating !== starNum || which === KeyCodes.enter || which === KeyCodes.space;
-        if (shouldSelectStar && (rating === undefined || Math.ceil(rating) !== newRating)) {
+        if (newRating !== starNum && (rating === undefined || Math.ceil(rating) !== newRating)) {
           setRating(newRating, event);
         }
       };

--- a/packages/react/src/components/Rating/Rating.base.tsx
+++ b/packages/react/src/components/Rating/Rating.base.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { classNamesFunction, css, format, divProperties, getNativeProps, useFocusRects } from '../../Utilities';
+import {
+  classNamesFunction,
+  css,
+  format,
+  divProperties,
+  getNativeProps,
+  KeyCodes,
+  useFocusRects,
+} from '../../Utilities';
 import { Icon } from '../../Icon';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { RatingSize } from './Rating.types';
@@ -137,6 +145,35 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
         }
       };
 
+      const onStarKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+        // eslint-disable-next-line deprecation/deprecation
+        const { which } = event;
+        let newRating = starNum;
+        switch (which) {
+          case KeyCodes.right:
+          case KeyCodes.down:
+            newRating = Math.min(max, newRating + 1);
+            break;
+          case KeyCodes.left:
+          case KeyCodes.up:
+            newRating = Math.max(1, newRating - 1);
+            break;
+          case KeyCodes.home:
+          case KeyCodes.pageUp:
+            newRating = 1;
+            break;
+          case KeyCodes.end:
+          case KeyCodes.pageDown:
+            newRating = max;
+            break;
+        }
+
+        const shouldSelectStar = newRating !== starNum || which === KeyCodes.enter || which === KeyCodes.space;
+        if (shouldSelectStar && (rating === undefined || Math.ceil(rating) !== newRating)) {
+          setRating(newRating, event);
+        }
+      };
+
       stars.push(
         <button
           className={css(
@@ -146,8 +183,8 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
           id={getStarId(id, starNum)}
           key={starNum}
           {...(starNum === Math.ceil(displayRating) && { 'data-is-current': true })}
-          onFocus={onSelectStar}
-          onClick={onSelectStar} // For Safari & Firefox on OSX
+          onKeyDown={onStarKeyDown}
+          onClick={onSelectStar}
           disabled={!!(disabled || readOnly)}
           role="radio"
           aria-hidden={readOnly ? 'true' : undefined}

--- a/packages/react/src/components/Rating/Rating.test.tsx
+++ b/packages/react/src/components/Rating/Rating.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { mount, ReactWrapper } from 'enzyme';
 import { Rating } from './Rating';
+import { KeyCodes } from '../../Utilities';
 import { isConformant } from '../../common/isConformant';
 import type { IRatingProps, IRating } from './Rating.types';
 
@@ -34,7 +35,7 @@ describe('Rating', () => {
     expect(ref.current?.rating).toBe(1);
     _checkState(rating, [100, 0, 0, 0, 0]);
 
-    rating.find('.ms-Rating-button').at(1).simulate('focus');
+    rating.find('.ms-Rating-button').at(0).simulate('keyDown', { which: KeyCodes.right });
 
     expect(ref.current?.rating).toBe(2);
     _checkState(rating, [100, 100, 0, 0, 0]);

--- a/packages/react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`Rating renders correctly 1`] = `
       disabled={false}
       id="Rating0-star-0"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -285,7 +285,7 @@ exports[`Rating renders correctly 1`] = `
       disabled={false}
       id="Rating0-star-1"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -442,7 +442,7 @@ exports[`Rating renders correctly 1`] = `
       disabled={false}
       id="Rating0-star-2"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -599,7 +599,7 @@ exports[`Rating renders correctly 1`] = `
       disabled={false}
       id="Rating0-star-3"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -756,7 +756,7 @@ exports[`Rating renders correctly 1`] = `
       disabled={false}
       id="Rating0-star-4"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -977,7 +977,7 @@ exports[`Rating renders correctly with half star 1`] = `
       disabled={false}
       id="Rating3-star-0"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -1134,7 +1134,7 @@ exports[`Rating renders correctly with half star 1`] = `
       disabled={false}
       id="Rating3-star-1"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -1292,7 +1292,7 @@ exports[`Rating renders correctly with half star 1`] = `
       disabled={false}
       id="Rating3-star-2"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -1449,7 +1449,7 @@ exports[`Rating renders correctly with half star 1`] = `
       disabled={false}
       id="Rating3-star-3"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >
@@ -1606,7 +1606,7 @@ exports[`Rating renders correctly with half star 1`] = `
       disabled={false}
       id="Rating3-star-4"
       onClick={[Function]}
-      onFocus={[Function]}
+      onKeyDown={[Function]}
       role="radio"
       type="button"
     >


### PR DESCRIPTION
## Previous Behavior

Rating stars/radios would select when they received focus, rather than in response to keyboard or mouse events. This created a bug with touchscreen screen readers where it was impossible to select a rating and then swipe past the control, since swiping through the control would continue selecting stars.

## New Behavior

Left/right/up/down/home/end/page up/page down all update the rating, as well as clicking on a specific star. This keeps the same behavior from the perspective of pointer and keyboard users, but touchscreen screen reader users can use the control in the same way as native radios.

## Related Issue(s)

- Fixes [16318](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16318)
- Fixes #27818 
