### PR TITLE
chore: add react-tags to docsite

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.js
+++ b/apps/public-docsite-v9/.storybook/main.js
@@ -15,6 +15,7 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     '../../../packages/react-components/react-migration-v0-v9/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
     '../../../packages/react-components/react-migration-v8-v9/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
     '../../../packages/react-components/react-datepicker-compat/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
+    '../../../packages/react-components/react-tags/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
   ],
   staticDirs: ['../public'],
   addons: [...rootMain.addons],


### PR DESCRIPTION
Add react-tags to docsite so it can be visible before it is ready to go unstable/stable