### PR TITLE
chore: migrate jest configs from using deprecated globals to `transform` property/pattern

### DIFF
--- a/apps/react-18-tests-v9/jest.config.js
+++ b/apps/react-18-tests-v9/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-18-tests-v9',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/apps/ssr-tests-v9/jest.config.js
+++ b/apps/ssr-tests-v9/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'ssr-tests-v9',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   testEnvironment: 'node',
   coverageDirectory: './coverage',

--- a/apps/stress-test/jest.config.js
+++ b/apps/stress-test/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'ssr-tests-v9',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   testEnvironment: 'node',
   coverageDirectory: './coverage',

--- a/apps/vr-tests-react-components/jest.config.js
+++ b/apps/vr-tests-react-components/jest.config.js
@@ -6,13 +6,13 @@
 module.exports = {
   displayName: 'vr-tests-react-components',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.json',
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/packages/react-components/babel-preset-global-context/jest.config.js
+++ b/packages/react-components/babel-preset-global-context/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'babel-preset-global-context',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/babel-preset-storybook-full-source/jest.config.js
+++ b/packages/react-components/babel-preset-storybook-full-source/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'babel-preset-storybook-full-source',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/global-context/jest.config.js
+++ b/packages/react-components/global-context/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'global-context',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/keyboard-keys/jest.config.js
+++ b/packages/react-components/keyboard-keys/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'keyboard-keys',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/priority-overflow/jest.config.js
+++ b/packages/react-components/priority-overflow/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'priority-overflow',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-accordion/jest.config.js
+++ b/packages/react-components/react-accordion/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-accordion',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-alert/jest.config.js
+++ b/packages/react-components/react-alert/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-alert',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-aria/jest.config.js
+++ b/packages/react-components/react-aria/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-aria',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-avatar/jest.config.js
+++ b/packages/react-components/react-avatar/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-avatar',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-badge/jest.config.js
+++ b/packages/react-components/react-badge/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-badge',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-breadcrumb/jest.config.js
+++ b/packages/react-components/react-breadcrumb/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-breadcrumb',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-button/jest.config.js
+++ b/packages/react-components/react-button/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-button',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-card/jest.config.js
+++ b/packages/react-components/react-card/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-card',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-checkbox/jest.config.js
+++ b/packages/react-components/react-checkbox/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-checkbox',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-colorpicker-compat/jest.config.js
+++ b/packages/react-components/react-colorpicker-compat/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-colorpicker-compat',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-combobox/jest.config.js
+++ b/packages/react-components/react-combobox/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-combobox',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-components/jest.config.js
+++ b/packages/react-components/react-components/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-components',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-conformance-griffel/jest.config.js
+++ b/packages/react-components/react-conformance-griffel/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-conformance-griffel',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-context-selector/jest.config.js
+++ b/packages/react-components/react-context-selector/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-context-selector',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-data-grid-react-window/jest.config.js
+++ b/packages/react-components/react-data-grid-react-window/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-data-grid-react-window',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-datepicker-compat/jest.config.js
+++ b/packages/react-components/react-datepicker-compat/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-datepicker-compat',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-dialog/jest.config.js
+++ b/packages/react-components/react-dialog/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-dialog',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-divider/jest.config.js
+++ b/packages/react-components/react-divider/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-divider',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-drawer/jest.config.js
+++ b/packages/react-components/react-drawer/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-drawer',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-field/jest.config.js
+++ b/packages/react-components/react-field/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-field',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-image/jest.config.js
+++ b/packages/react-components/react-image/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-image',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-infobutton/jest.config.js
+++ b/packages/react-components/react-infobutton/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-infobutton',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-input/jest.config.js
+++ b/packages/react-components/react-input/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-input',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-jsx-runtime/jest.config.js
+++ b/packages/react-components/react-jsx-runtime/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-jsx-runtime',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-label/jest.config.js
+++ b/packages/react-components/react-label/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-label',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-link/jest.config.js
+++ b/packages/react-components/react-link/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-link',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-menu/jest.config.js
+++ b/packages/react-components/react-menu/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-menu',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-migration-v0-v9/jest.config.js
+++ b/packages/react-components/react-migration-v0-v9/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-migration-v0-v9',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-migration-v8-v9/jest.config.js
+++ b/packages/react-components/react-migration-v8-v9/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-migration-v8-v9',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-overflow/jest.config.js
+++ b/packages/react-components/react-overflow/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-overflow',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-persona/jest.config.js
+++ b/packages/react-components/react-persona/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-persona',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-popover/jest.config.js
+++ b/packages/react-components/react-popover/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-popover',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-portal-compat-context/jest.config.js
+++ b/packages/react-components/react-portal-compat-context/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-portal-compat-context',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-portal-compat/jest.config.js
+++ b/packages/react-components/react-portal-compat/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-portal-compat',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-portal/jest.config.js
+++ b/packages/react-components/react-portal/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-portal',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-positioning/jest.config.js
+++ b/packages/react-components/react-positioning/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-positioning',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-progress/jest.config.js
+++ b/packages/react-components/react-progress/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-progress',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-provider/jest.config.js
+++ b/packages/react-components/react-provider/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-provider',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-radio/jest.config.js
+++ b/packages/react-components/react-radio/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-radio',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-search/jest.config.js
+++ b/packages/react-components/react-search/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-search',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-select/jest.config.js
+++ b/packages/react-components/react-select/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-select',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-shared-contexts/jest.config.js
+++ b/packages/react-components/react-shared-contexts/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-shared-contexts',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-skeleton/jest.config.js
+++ b/packages/react-components/react-skeleton/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-skeleton',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-slider/jest.config.js
+++ b/packages/react-components/react-slider/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-slider',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-spinbutton/jest.config.js
+++ b/packages/react-components/react-spinbutton/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-spinbutton',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-spinner/jest.config.js
+++ b/packages/react-components/react-spinner/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-spinner',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-storybook-addon-codesandbox/jest.config.js
+++ b/packages/react-components/react-storybook-addon-codesandbox/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-storybook-addon-codesandbox',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-storybook-addon/jest.config.js
+++ b/packages/react-components/react-storybook-addon/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-storybook-addon',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-switch/jest.config.js
+++ b/packages/react-components/react-switch/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-switch',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-table/jest.config.js
+++ b/packages/react-components/react-table/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-table',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-tabs/jest.config.js
+++ b/packages/react-components/react-tabs/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-tabs',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-tabster/jest.config.js
+++ b/packages/react-components/react-tabster/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-tabster',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-tags/jest.config.js
+++ b/packages/react-components/react-tags/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-tags',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-text/jest.config.js
+++ b/packages/react-components/react-text/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-text',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-textarea/jest.config.js
+++ b/packages/react-components/react-textarea/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-textarea',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-theme-sass/jest.config.js
+++ b/packages/react-components/react-theme-sass/jest.config.js
@@ -6,15 +6,15 @@
 module.exports = {
   displayName: 'react-theme-sass',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   testEnvironment: 'jest-environment-node-single-context',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-theme/jest.config.js
+++ b/packages/react-components/react-theme/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-theme',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-toast/jest.config.js
+++ b/packages/react-components/react-toast/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-toast',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-toolbar/jest.config.js
+++ b/packages/react-components/react-toolbar/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-toolbar',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-tooltip/jest.config.js
+++ b/packages/react-components/react-tooltip/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-tooltip',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-tree/jest.config.js
+++ b/packages/react-components/react-tree/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-tree',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-utilities/jest.config.js
+++ b/packages/react-components/react-utilities/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-utilities',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/react-virtualizer/jest.config.js
+++ b/packages/react-components/react-virtualizer/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-virtualizer',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-components/theme-designer/jest.config.js
+++ b/packages/react-components/theme-designer/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'theme-designer',
   preset: '../../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/react-conformance/jest.config.js
+++ b/packages/react-conformance/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'react-conformance',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/packages/tokens/jest.config.js
+++ b/packages/tokens/jest.config.js
@@ -6,14 +6,14 @@
 module.exports = {
   displayName: 'tokens',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],

--- a/scripts/api-extractor/jest.config.js
+++ b/scripts/api-extractor/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-api-extractor',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/babel/jest.config.js
+++ b/scripts/babel/jest.config.js
@@ -7,13 +7,13 @@ module.exports = {
   displayName: 'scripts-babel',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      isolatedModules: true,
-    },
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/beachball/jest.config.js
+++ b/scripts/beachball/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-beachball',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/bundle-size-auditor/jest.config.js
+++ b/scripts/bundle-size-auditor/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
         isolatedModules: true,
       },
     ],

--- a/scripts/cypress/jest.config.js
+++ b/scripts/cypress/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-cypress',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/dangerjs/jest.config.js
+++ b/scripts/dangerjs/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-dangerjs',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/executors/jest.config.js
+++ b/scripts/executors/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-executors',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/fluentui-publish/jest.config.js
+++ b/scripts/fluentui-publish/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-fluentui-publish',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/generators/jest.config.js
+++ b/scripts/generators/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-generators',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/github/jest.config.js
+++ b/scripts/github/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-github',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/gulp/jest.config.js
+++ b/scripts/gulp/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-gulp',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/jest/jest.config.js
+++ b/scripts/jest/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-jest',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/lint-staged/jest.config.js
+++ b/scripts/lint-staged/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-lint-staged',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/monorepo/jest.config.js
+++ b/scripts/monorepo/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-monorepo',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/package-manager/jest.config.js
+++ b/scripts/package-manager/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-package-manager',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/perf-test-flamegrill/jest.config.js
+++ b/scripts/perf-test-flamegrill/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-perf-test-flamegrill',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/prettier/jest.config.js
+++ b/scripts/prettier/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-prettier',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/projects-test/jest.config.js
+++ b/scripts/projects-test/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-projects-test',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/puppeteer/jest.config.js
+++ b/scripts/puppeteer/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-puppeteer',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   moduleNameMapper: {
     '^puppeteer-core/internal/(.*)': '<rootDir>/../../node_modules/puppeteer-core/lib/cjs/puppeteer/$1',

--- a/scripts/storybook/jest.config.js
+++ b/scripts/storybook/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-storybook',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/tasks/jest.config.js
+++ b/scripts/tasks/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-tasks',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/test-ssr/jest.config.js
+++ b/scripts/test-ssr/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-test-ssr',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/triage-bot/jest.config.js
+++ b/scripts/triage-bot/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-triage-bot',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/ts-node/jest.config.js
+++ b/scripts/ts-node/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-ts-node',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/update-release-notes/jest.config.js
+++ b/scripts/update-release-notes/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-update-release-notes',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/utils/jest.config.js
+++ b/scripts/utils/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-utils',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/scripts/webpack/jest.config.js
+++ b/scripts/webpack/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   displayName: 'scripts-webpack',
   preset: '../../jest.preset.js',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   coverageDirectory: './coverage',
   testEnvironment: 'node',

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -438,21 +438,22 @@ describe('migrate-converged-pkg generator', () => {
          * @type {import('@jest/types').Config.InitialOptions}
          */
         module.exports = {
-        displayName: 'react-dummy',
-        preset: '../../../jest.preset.js',
-        transform: {
-        '^.+\\\\\\\\.tsx?$': [
-        'ts-jest',
-        {
-        tsconfig: '<rootDir>/tsconfig.spec.json',
-        isolatedModules: true,
-        }
-        ],
-        },
-        coverageDirectory: './coverage',
-        setupFilesAfterEnv: ['./config/tests.js'],
-        snapshotSerializers: ['@griffel/jest-serializer'],
-        };"
+          displayName: 'react-dummy',
+          preset: '../../../jest.preset.js',
+          transform: {
+            '^.+\\\\\\\\.tsx?$': [
+              'ts-jest',
+              {
+                tsconfig: '<rootDir>/tsconfig.spec.json',
+                isolatedModules: true,
+              },
+            ],
+          },
+          coverageDirectory: './coverage',
+          setupFilesAfterEnv: ['./config/tests.js'],
+          snapshotSerializers: ['@griffel/jest-serializer'],
+        };
+        "
       `);
     });
 

--- a/tools/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/generators/migrate-converged-pkg/index.spec.ts
@@ -438,22 +438,21 @@ describe('migrate-converged-pkg generator', () => {
          * @type {import('@jest/types').Config.InitialOptions}
          */
         module.exports = {
-          displayName: 'react-dummy',
-          preset: '../../../jest.preset.js',
-          globals: {
-            'ts-jest': {
-              tsconfig: '<rootDir>/tsconfig.spec.json',
-              isolatedModules: true,
-            },
-          },
-          transform: {
-            '^.+\\\\\\\\.tsx?$': 'ts-jest',
-          },
-          coverageDirectory: './coverage',
-          setupFilesAfterEnv: ['./config/tests.js'],
-          snapshotSerializers: ['@griffel/jest-serializer'],
-        };
-        "
+        displayName: 'react-dummy',
+        preset: '../../../jest.preset.js',
+        transform: {
+        '^.+\\\\\\\\.tsx?$': [
+        'ts-jest',
+        {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
+        }
+        ],
+        },
+        coverageDirectory: './coverage',
+        setupFilesAfterEnv: ['./config/tests.js'],
+        snapshotSerializers: ['@griffel/jest-serializer'],
+        };"
       `);
     });
 

--- a/tools/generators/migrate-converged-pkg/index.ts
+++ b/tools/generators/migrate-converged-pkg/index.ts
@@ -304,14 +304,14 @@ const templates = {
       module.exports = {
         displayName: '${options.pkgName}',
         preset: '../../../jest.preset.js',
-        globals: {
-          'ts-jest': {
-            tsconfig: '<rootDir>/tsconfig.spec.json',
-            isolatedModules: true,
-          },
-        },
         transform: {
-          '^.+\\.tsx?$': 'ts-jest',
+          '^.+\\.tsx?$': [
+            'ts-jest',
+            {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+              isolatedModules: true,
+            }
+          ],
         },
         coverageDirectory: './coverage',
         setupFilesAfterEnv: ['${options.testSetupFilePath}'],

--- a/tools/jest.config.ts
+++ b/tools/jest.config.ts
@@ -6,14 +6,14 @@
 export default {
   displayName: 'tools',
   preset: '../jest.preset.js',
-  globals: {},
   testPathIgnorePatterns: ['/node_modules/'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
         diagnostics: false,
-        tsconfig: '<rootDir>/tsconfig.json',
+        isolatedModules: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
       },
     ],
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

- jest deprecated `globals` configuration migrated to `transform`
  - migration done via nx generator 
- update jest configs within all `scripts/*` packages ( no type checking used for greater speed tests )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/27935
