### PR TITLE
fix: Checking for the existence of addEventListener on element coming from context in useFocusRects

### DIFF
--- a/change/@fluentui-utilities-e9131211-ff24-4edd-96f2-f3a4a4a68fc7.json
+++ b/change/@fluentui-utilities-e9131211-ff24-4edd-96f2-f3a4a4a68fc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Checking for the existence of addEventListener on element coming from context in useFocusRects.",
+  "packageName": "@fluentui/utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -108,7 +108,10 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
     let onPointerDown: (ev: PointerEvent) => void;
     let onKeyDown: (ev: KeyboardEvent) => void;
     let onKeyUp: (ev: KeyboardEvent) => void;
-    if (context?.providerRef?.current) {
+    if (
+      context?.providerRef?.current &&
+      (context?.providerRef?.current as Partial<Pick<HTMLElement, 'addEventListener'>>)?.addEventListener
+    ) {
       el = context.providerRef.current;
       // The NOINLINE directive tells terser not to move the setCallbackMap implementation into the call site during
       // minification.


### PR DESCRIPTION
## Previous Behavior

Passing a non-html element to the `as` prop of `ThemeProvider` made the app using it crash because `useFocusRects` would try to call the non-existent `addEventListener` function from the `current` value of the `ref` to that non-html element.

## New Behavior

Passing a non-html element to the `as` prop of `ThemeProvider` no longer crashes the app using it. `useFocusRects` now checks for the existence of `addEventListener` in the `current` value of the `ref` and, if this doesn't exist, attaches the listeners to the window instead.

## Related Issue(s)

- Fixes #28016.
