### PR TITLE
chore: adds internal tag on jsdocs for getSlotsNext

### DIFF
--- a/change/@fluentui-react-utilities-f1dc6a83-6fd4-4d86-a5ef-b68f5420ea11.json
+++ b/change/@fluentui-react-utilities-f1dc6a83-6fd4-4d86-a5ef-b68f5420ea11.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: adds internal tag on jsdoce for getSlotsNext",
+  "comment": "chore: adds internal tag on jsdoc for getSlotsNext",
   "packageName": "@fluentui/react-utilities",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-utilities-f1dc6a83-6fd4-4d86-a5ef-b68f5420ea11.json
+++ b/change/@fluentui-react-utilities-f1dc6a83-6fd4-4d86-a5ef-b68f5420ea11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adds internal tag on jsdoce for getSlotsNext",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -73,7 +73,7 @@ export function getSlots<R extends SlotPropsRecord>(state: ComponentState<R>): {
     slotProps: ObjectSlotProps<R>;
 };
 
-// @public
+// @internal
 export function getSlotsNext<R extends SlotPropsRecord>(state: ComponentState<R>): {
     slots: Slots<R>;
     slotProps: ObjectSlotProps<R>;

--- a/packages/react-components/react-utilities/src/compose/getSlotsNext.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlotsNext.ts
@@ -4,6 +4,11 @@ import { ObjectSlotProps, Slots } from './getSlots';
 
 /**
  * Similar to `getSlots`, main difference is that it's compatible with new custom jsx pragma
+ *
+ * @internal
+ * This is an internal temporary method, this method will cease to exist eventually!
+ *
+ * * ❗️❗️ **DO NOT USE IT EXTERNALLY** ❗️❗️
  */
 export function getSlotsNext<R extends SlotPropsRecord>(
   state: ComponentState<R>,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. adds `internal` tag to jsdoc comments on `getSlotsNext`
2. add comments specifying that this method should not be used externally (just to be clear)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
