### PR TITLE
feat: Inverted appearance

### DIFF
--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -17,7 +17,7 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
 
 // @public
-export const renderToast_unstable: (state: ToastState) => JSX.Element;
+export const renderToast_unstable: (state: ToastState, contexts: ToastContextValues) => JSX.Element;
 
 // @public
 export const renderToastBody_unstable: (state: ToastBodyState) => JSX.Element;
@@ -50,7 +50,7 @@ export type ToastBodySlots = {
 };
 
 // @public
-export type ToastBodyState = ComponentState<ToastBodySlots>;
+export type ToastBodyState = ComponentState<ToastBodySlots> & Pick<ToastContextValue, 'appearance'>;
 
 // @public (undocumented)
 export const toastClassNames: SlotClassNames<ToastSlots>;
@@ -111,7 +111,7 @@ export type ToastPoliteness = 'assertive' | 'polite';
 export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start';
 
 // @public
-export type ToastProps = ComponentProps<ToastSlots> & {};
+export type ToastProps = ComponentProps<ToastSlots> & Pick<ToastContextValue, 'appearance'>;
 
 // @public (undocumented)
 export type ToastSlots = {
@@ -119,7 +119,7 @@ export type ToastSlots = {
 };
 
 // @public
-export type ToastState = ComponentState<ToastSlots>;
+export type ToastState = ComponentState<ToastSlots> & Pick<ToastProps, 'appearance'>;
 
 // @public (undocumented)
 export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
@@ -141,7 +141,7 @@ export type ToastTitleSlots = {
 };
 
 // @public
-export type ToastTitleState = ComponentState<ToastTitleSlots> & Pick<ToastContextValue, 'intent'>;
+export type ToastTitleState = ComponentState<ToastTitleSlots> & Pick<ToastContainerContextValue, 'intent'> & Pick<ToastContextValue, 'appearance'>;
 
 // @public
 export const ToastTrigger: React_2.FC<ToastTriggerProps>;

--- a/packages/react-components/react-toast/src/components/Toast/Toast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast/Toast.tsx
@@ -4,6 +4,7 @@ import { renderToast_unstable } from './renderToast';
 import { useToastStyles_unstable } from './useToastStyles.styles';
 import type { ToastProps } from './Toast.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useToastContextValues_unstable } from './useToastContextValues';
 
 /**
  * Toast component
@@ -12,7 +13,7 @@ export const Toast: ForwardRefComponent<ToastProps> = React.forwardRef((props, r
   const state = useToast_unstable(props, ref);
 
   useToastStyles_unstable(state);
-  return renderToast_unstable(state);
+  return renderToast_unstable(state, useToastContextValues_unstable(state));
 });
 
 Toast.displayName = 'Toast';

--- a/packages/react-components/react-toast/src/components/Toast/Toast.types.ts
+++ b/packages/react-components/react-toast/src/components/Toast/Toast.types.ts
@@ -1,15 +1,20 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ToastContextValue } from '../../contexts/toastContext';
 
 export type ToastSlots = {
   root: Slot<'div'>;
 };
 
+export type ToastContextValues = {
+  toast: ToastContextValue;
+};
+
 /**
  * Toast Props
  */
-export type ToastProps = ComponentProps<ToastSlots> & {};
+export type ToastProps = ComponentProps<ToastSlots> & Pick<ToastContextValue, 'appearance'>;
 
 /**
  * State used in rendering Toast
  */
-export type ToastState = ComponentState<ToastSlots>;
+export type ToastState = ComponentState<ToastSlots> & Pick<ToastProps, 'appearance'>;

--- a/packages/react-components/react-toast/src/components/Toast/renderToast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast/renderToast.tsx
@@ -3,13 +3,18 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 import { getSlotsNext } from '@fluentui/react-utilities';
-import type { ToastState, ToastSlots } from './Toast.types';
+import type { ToastState, ToastSlots, ToastContextValues } from './Toast.types';
+import { ToastContextProvider } from '../../contexts/toastContext';
 
 /**
  * Render the final JSX of Toast
  */
-export const renderToast_unstable = (state: ToastState) => {
+export const renderToast_unstable = (state: ToastState, contexts: ToastContextValues) => {
   const { slots, slotProps } = getSlotsNext<ToastSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return (
+    <ToastContextProvider value={contexts.toast}>
+      <slots.root {...slotProps.root} />
+    </ToastContextProvider>
+  );
 };

--- a/packages/react-components/react-toast/src/components/Toast/useToast.ts
+++ b/packages/react-components/react-toast/src/components/Toast/useToast.ts
@@ -20,5 +20,6 @@ export const useToast_unstable = (props: ToastProps, ref: React.Ref<HTMLElement>
       ref,
       ...props,
     }),
+    appearance: props.appearance,
   };
 };

--- a/packages/react-components/react-toast/src/components/Toast/useToastContextValues.ts
+++ b/packages/react-components/react-toast/src/components/Toast/useToastContextValues.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { ToastContextValues, ToastState } from './Toast.types';
+
+export function useToastContextValues_unstable(state: ToastState): ToastContextValues {
+  const { appearance } = state;
+
+  const toastContext = React.useMemo(
+    () => ({
+      appearance,
+    }),
+    [appearance],
+  );
+
+  return {
+    toast: toastContext,
+  };
+}

--- a/packages/react-components/react-toast/src/components/Toast/useToastStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/Toast/useToastStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { ToastSlots, ToastState } from './Toast.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -21,12 +21,25 @@ const useRootBaseClassName = makeResetStyles({
   backgroundColor: tokens.colorNeutralBackground1,
 });
 
+const useStyles = makeStyles({
+  inverted: {
+    color: tokens.colorNeutralForegroundInverted2,
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
+  },
+});
+
 /**
  * Apply styling to the Toast slots based on the state
  */
 export const useToastStyles_unstable = (state: ToastState): ToastState => {
   const rootBaseClassName = useRootBaseClassName();
-  state.root.className = mergeClasses(toastClassNames.root, rootBaseClassName, state.root.className);
+  const styles = useStyles();
+  state.root.className = mergeClasses(
+    toastClassNames.root,
+    rootBaseClassName,
+    state.appearance === 'inverted' && styles.inverted,
+    state.root.className,
+  );
 
   return state;
 };

--- a/packages/react-components/react-toast/src/components/ToastBody/ToastBody.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastBody/ToastBody.types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ToastContextValue } from '../../contexts/toastContext';
 
 export type ToastBodySlots = {
   root: Slot<'div'>;
@@ -13,4 +14,4 @@ export type ToastBodyProps = ComponentProps<ToastBodySlots> & {};
 /**
  * State used in rendering ToastBody
  */
-export type ToastBodyState = ComponentState<ToastBodySlots>;
+export type ToastBodyState = ComponentState<ToastBodySlots> & Pick<ToastContextValue, 'appearance'>;

--- a/packages/react-components/react-toast/src/components/ToastBody/useToastBody.ts
+++ b/packages/react-components/react-toast/src/components/ToastBody/useToastBody.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import type { ToastBodyProps, ToastBodyState } from './ToastBody.types';
+import { useToastContext } from '../../contexts/toastContext';
 
 /**
  * Create the state required to render ToastBody.
@@ -12,6 +13,7 @@ import type { ToastBodyProps, ToastBodyState } from './ToastBody.types';
  * @param ref - reference to root HTMLElement of ToastBody
  */
 export const useToastBody_unstable = (props: ToastBodyProps, ref: React.Ref<HTMLElement>): ToastBodyState => {
+  const { appearance } = useToastContext();
   return {
     components: {
       root: 'div',
@@ -22,5 +24,6 @@ export const useToastBody_unstable = (props: ToastBodyProps, ref: React.Ref<HTML
       ref,
       ...props,
     }),
+    appearance,
   };
 };

--- a/packages/react-components/react-toast/src/components/ToastBody/useToastBodyStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastBody/useToastBodyStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { ToastBodySlots, ToastBodyState } from './ToastBody.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -15,6 +15,7 @@ const useRootBaseClassName = makeResetStyles({
   fontSize: tokens.fontSizeBase300,
   lineHeight: tokens.fontSizeBase300,
   fontWeight: tokens.fontWeightRegular,
+  color: tokens.colorNeutralForeground1,
 });
 
 const useSubtitleBaseClassName = makeResetStyles({
@@ -27,18 +28,34 @@ const useSubtitleBaseClassName = makeResetStyles({
   color: tokens.colorNeutralForeground2,
 });
 
+const useInvertedStyles = makeStyles({
+  root: {
+    color: tokens.colorNeutralForegroundInverted2,
+  },
+  subtitle: {
+    color: tokens.colorNeutralForegroundInverted2,
+  },
+});
+
 /**
  * Apply styling to the ToastBody slots based on the state
  */
 export const useToastBodyStyles_unstable = (state: ToastBodyState): ToastBodyState => {
   const rootBaseClassName = useRootBaseClassName();
   const subtitleBaseClassName = useSubtitleBaseClassName();
-  state.root.className = mergeClasses(toastBodyClassNames.root, rootBaseClassName, state.root.className);
+  const invertedStyles = useInvertedStyles();
+  state.root.className = mergeClasses(
+    toastBodyClassNames.root,
+    rootBaseClassName,
+    state.appearance === 'inverted' && invertedStyles.root,
+    state.root.className,
+  );
 
   if (state.subtitle) {
     state.subtitle.className = mergeClasses(
       toastBodyClassNames.subtitle,
       subtitleBaseClassName,
+      state.appearance === 'inverted' && invertedStyles.subtitle,
       state.subtitle.className,
     );
   }

--- a/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { Announce } from '../AriaLive/AriaLive.types';
 import { Toast, ToastIntent } from '../../state';
-import { ToastContextValue } from '../../contexts/toastContext';
+import { ToastContainerContextValue } from '../../contexts/toastContainerContext';
 import { TimerProps } from '../Timer/Timer';
 
 export type ToastContainerContextValues = {
-  toast: ToastContextValue;
+  toast: ToastContainerContextValue;
 };
 
 export type ToastContainerSlots = {

--- a/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
+++ b/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
@@ -5,7 +5,7 @@ import { createElement } from '@fluentui/react-jsx-runtime';
 import { getSlotsNext } from '@fluentui/react-utilities';
 import { Transition } from 'react-transition-group';
 import type { ToastContainerState, ToastContainerSlots, ToastContainerContextValues } from './ToastContainer.types';
-import { ToastContextProvider } from '../../contexts/toastContext';
+import { ToastContainerContextProvider } from '../../contexts/toastContainerContext';
 
 /**
  * Render the final JSX of ToastContainer
@@ -27,10 +27,10 @@ export const renderToastContainer_unstable = (
       onEntering={onTransitionEntering}
       nodeRef={nodeRef}
     >
-      <ToastContextProvider value={contextValues.toast}>
+      <ToastContainerContextProvider value={contextValues.toast}>
         <slots.root {...slotProps.root} />
         <slots.timer {...slotProps.timer} />
-      </ToastContextProvider>
+      </ToastContainerContextProvider>
     </Transition>
   );
 };

--- a/packages/react-components/react-toast/src/components/ToastContainer/useToastContainerContextValues.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/useToastContainerContextValues.ts
@@ -4,7 +4,7 @@ import { ToastContainerContextValues, ToastContainerState } from './ToastContain
 export function useToastContainerContextValues_unstable(state: ToastContainerState): ToastContainerContextValues {
   const { close, intent } = state;
 
-  const toastContext = React.useMemo(
+  const toastContainerContext = React.useMemo(
     () => ({
       close,
       intent,
@@ -13,6 +13,6 @@ export function useToastContainerContextValues_unstable(state: ToastContainerSta
   );
 
   return {
-    toast: toastContext,
+    toast: toastContainerContext,
   };
 }

--- a/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/ToastTitle.types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ToastContainerContextValue } from '../../contexts/toastContainerContext';
 import { ToastContextValue } from '../../contexts/toastContext';
 
 export type ToastTitleSlots = {
@@ -15,4 +16,6 @@ export type ToastTitleProps = ComponentProps<ToastTitleSlots> & {};
 /**
  * State used in rendering ToastTitle
  */
-export type ToastTitleState = ComponentState<ToastTitleSlots> & Pick<ToastContextValue, 'intent'>;
+export type ToastTitleState = ComponentState<ToastTitleSlots> &
+  Pick<ToastContainerContextValue, 'intent'> &
+  Pick<ToastContextValue, 'appearance'>;

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
@@ -4,6 +4,7 @@ import { CheckmarkCircleFilled, DismissCircleFilled, InfoFilled, WarningFilled }
 import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 
 import type { ToastTitleProps, ToastTitleState } from './ToastTitle.types';
+import { useToastContainerContext } from '../../contexts/toastContainerContext';
 import { useToastContext } from '../../contexts/toastContext';
 
 /**
@@ -16,7 +17,8 @@ import { useToastContext } from '../../contexts/toastContext';
  * @param ref - reference to root HTMLElement of ToastTitle
  */
 export const useToastTitle_unstable = (props: ToastTitleProps, ref: React.Ref<HTMLElement>): ToastTitleState => {
-  const { intent } = useToastContext();
+  const { intent } = useToastContainerContext();
+  const { appearance } = useToastContext();
 
   /** Determine the role and media to render based on the intent */
   let defaultIcon;
@@ -43,11 +45,12 @@ export const useToastTitle_unstable = (props: ToastTitleProps, ref: React.Ref<HT
       action: 'div',
     },
     media: resolveShorthand(props.media, { required: !!intent, defaultProps: { children: defaultIcon } }),
-    intent,
     root: getNativeElementProps('div', {
       ref,
       children: props.children,
       ...props,
     }),
+    intent,
+    appearance,
   };
 };

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -13,6 +13,7 @@ const useRootBaseClassName = makeResetStyles({
   display: 'flex',
   alignItems: 'center',
   gridColumnEnd: 3,
+  color: tokens.colorNeutralForeground1,
 });
 
 const useMediaBaseClassName = makeResetStyles({
@@ -21,6 +22,7 @@ const useMediaBaseClassName = makeResetStyles({
   gridColumnEnd: 2,
   paddingRight: '8px',
   fontSize: '16px',
+  color: tokens.colorNeutralForeground1,
 });
 
 const useActionBaseClassName = makeResetStyles({
@@ -29,6 +31,20 @@ const useActionBaseClassName = makeResetStyles({
   paddingLeft: '12px',
   gridColumnEnd: -1,
   color: tokens.colorBrandForeground1,
+});
+
+const useInvertedStyles = makeStyles({
+  root: {
+    color: tokens.colorNeutralForegroundInverted,
+  },
+
+  action: {
+    color: tokens.colorBrandForegroundInverted,
+  },
+
+  media: {
+    color: tokens.colorNeutralForegroundInverted,
+  },
 });
 
 const useIntentIconStyles = makeStyles({
@@ -47,7 +63,22 @@ const useIntentIconStyles = makeStyles({
   info: {
     color: tokens.colorNeutralForeground2,
   },
-  progress: {
+});
+
+const useIntentIconStylesInverted = makeStyles({
+  success: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteGreenForegroundInverted,
+  },
+  error: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteRedForegroundInverted,
+  },
+  warning: {
+    // FIXME https://github.com/microsoft/fluentui/issues/28219
+    color: tokens.colorPaletteYellowForegroundInverted,
+  },
+  info: {
     color: tokens.colorNeutralForegroundInverted2,
   },
 });
@@ -60,20 +91,34 @@ export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitle
   const actionBaseClassName = useActionBaseClassName();
   const mediaBaseClassName = useMediaBaseClassName();
   const intentIconStyles = useIntentIconStyles();
+  const intentIconStylesInverted = useIntentIconStylesInverted();
   const { intent } = state;
-  state.root.className = mergeClasses(toastTitleClassNames.root, rootBaseClassName, state.root.className);
+  const invertedStyles = useInvertedStyles();
+  state.root.className = mergeClasses(
+    toastTitleClassNames.root,
+    rootBaseClassName,
+    state.appearance === 'inverted' && invertedStyles.root,
+    state.root.className,
+  );
 
   if (state.media) {
     state.media.className = mergeClasses(
       toastTitleClassNames.media,
       mediaBaseClassName,
+      state.appearance === 'inverted' && invertedStyles.media,
       state.media.className,
       intent && intentIconStyles[intent],
+      intent && state.appearance === 'inverted' && intentIconStylesInverted[intent],
     );
   }
 
   if (state.action) {
-    state.action.className = mergeClasses(toastTitleClassNames.action, actionBaseClassName, state.action.className);
+    state.action.className = mergeClasses(
+      toastTitleClassNames.action,
+      actionBaseClassName,
+      state.appearance === 'inverted' && invertedStyles.action,
+      state.action.className,
+    );
   }
 
   return state;

--- a/packages/react-components/react-toast/src/components/ToastTrigger/useToastTrigger.ts
+++ b/packages/react-components/react-toast/src/components/ToastTrigger/useToastTrigger.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { applyTriggerPropsToChildren, getTriggerChild, useEventCallback } from '@fluentui/react-utilities';
 import { useARIAButtonProps } from '@fluentui/react-aria';
 import type { ToastTriggerProps, ToastTriggerState } from './ToastTrigger.types';
-import { useToastContext } from '../../contexts/toastContext';
+import { useToastContainerContext } from '../../contexts/toastContainerContext';
 
 /**
  * A non-visual component that wraps its child
@@ -15,7 +15,7 @@ import { useToastContext } from '../../contexts/toastContext';
  */
 export const useToastTrigger_unstable = (props: ToastTriggerProps): ToastTriggerState => {
   const { children, disableButtonEnhancement = false } = props;
-  const { close } = useToastContext();
+  const { close } = useToastContainerContext();
 
   const child = getTriggerChild(children);
 

--- a/packages/react-components/react-toast/src/contexts/toastContainerContext.tsx
+++ b/packages/react-components/react-toast/src/contexts/toastContainerContext.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { ToastIntent } from '../state/types';
+
+export type ToastContainerContextValue = {
+  close: () => void;
+  intent: ToastIntent | undefined;
+};
+
+const toastContainerContextDefaultValue: ToastContainerContextValue = {
+  close: () => null,
+  intent: undefined,
+};
+
+const toastContainerContext = React.createContext<ToastContainerContextValue | undefined>(undefined);
+
+export const ToastContainerContextProvider = toastContainerContext.Provider;
+export const useToastContainerContext = () =>
+  React.useContext(toastContainerContext) ?? toastContainerContextDefaultValue;

--- a/packages/react-components/react-toast/src/contexts/toastContext.tsx
+++ b/packages/react-components/react-toast/src/contexts/toastContext.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
-import { ToastIntent } from '../state/types';
 
 export type ToastContextValue = {
-  close: () => void;
-  intent: ToastIntent | undefined;
+  appearance?: 'inverted';
 };
 
 const toastContextDefaultValue: ToastContextValue = {
-  close: () => null,
-  intent: undefined,
+  appearance: undefined,
 };
 
 const toastContext = React.createContext<ToastContextValue | undefined>(undefined);

--- a/packages/react-components/react-toast/stories/Toast/InvertedAppearance.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/InvertedAppearance.stories.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Toaster, useToastController, Toast, ToastTitle, ToastBody, ToastFooter } from '@fluentui/react-toast';
+import { useId, Link, Button } from '@fluentui/react-components';
+
+export const InvertedAppearance = () => {
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController(toasterId);
+  const notify = () =>
+    dispatchToast(
+      <Toast appearance="inverted">
+        <ToastTitle action={<Link>Undo</Link>}>Email sent</ToastTitle>
+        <ToastBody subtitle="Subtitle">This is a toast body</ToastBody>
+        <ToastFooter>
+          <Link>Action</Link>
+          <Link>Action</Link>
+        </ToastFooter>
+      </Toast>,
+      { intent: 'success' },
+    );
+
+  return (
+    <>
+      <Toaster toasterId={toasterId} />
+      <Button onClick={notify}>Make toast</Button>
+    </>
+  );
+};

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Toast, ToastTitle, ToastBody, ToastFooter, Toaster } from '@fluentui/react-toast';
 export { Default } from './Default.stories';
 export { Intent } from './Intent.stories';
+export { InvertedAppearance } from './InvertedAppearance.stories';
 export { DefaultToastOptions } from './DefaultToastOptions.stories';
 export { CustomTimeout } from './CustomTimeout.stories';
 export { DismissToastWithAction } from './DismissToastWithAction.stories';


### PR DESCRIPTION
Adds the `appearance` prop to `Toast` and adds inverted styles to all Toast components.

Renames the ToastContext to ToastContainerContext to avoid the clash with the context that is actually being used by the Toast (i.e. ToastContext) that holds the appearance value for the component.

