### PR TITLE
chore: Exporting CSS files in @fluentui/react package

### DIFF
--- a/change/@fluentui-react-b3b9e7bb-d031-4766-b6f1-595b8c3892b9.json
+++ b/change/@fluentui-react-b3b9e7bb-d031-4766-b6f1-595b8c3892b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Exporting CSS files in @fluentui/react package.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,6 +70,7 @@
     "react-dom": ">=16.8.0 <19.0.0"
   },
   "exports": {
+    "./dist/css/*": "./dist/css/*",
     "./dist/sass/*": "./dist/sass/*",
     "./lib/ActivityItem": {
       "types": "./lib/ActivityItem.d.ts",


### PR DESCRIPTION
## Previous Behavior

CSS files were not included in the list of exports of the `@fluentui/react` package.

## New Behavior

CSS files are now included in the list of exports of the `@fluentui/react` package.

## Related Issue(s)

- Fixes #27356
