### PR TITLE
bugfix: removes default prevention verification on selection

### DIFF
--- a/change/@fluentui-react-utilities-881a428e-b3dc-4761-8ecf-c874364e95c5.json
+++ b/change/@fluentui-react-utilities-881a428e-b3dc-4761-8ecf-c874364e95c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: removes default prevention verification on selection",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/testing/mockSyntheticEvent.ts
+++ b/packages/react-components/react-table/src/testing/mockSyntheticEvent.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-const isDefaultPrevented = () => false;
 export function mockSyntheticEvent() {
-  return { isDefaultPrevented } as unknown as React.SyntheticEvent;
+  return {} as unknown as React.SyntheticEvent;
 }

--- a/packages/react-components/react-utilities/src/testing/mockSyntheticEvent.ts
+++ b/packages/react-components/react-utilities/src/testing/mockSyntheticEvent.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-const isDefaultPrevented = () => false;
 export function mockSyntheticEvent() {
-  return { isDefaultPrevented } as unknown as React.SyntheticEvent;
+  return {} as unknown as React.SyntheticEvent;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`useSelection` event handling mechanisn stops selection state change whenever an even was prevented.

This might be problematic as we want to use spacebar keydown events for selection, and spacebar events should be prevented as they would trigger scrolling by default.

## New Behavior

1. `useSelection` event handling mechanism doesn't stop selection state change anmore.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
