### PR TITLE
feature(react-utilities): implements new slot methods (`slot` and `assertSlots`)

### DIFF
--- a/change/@fluentui-react-jsx-runtime-d2a505fc-6ffc-4679-aa63-5b29dcc83f7b.json
+++ b/change/@fluentui-react-jsx-runtime-d2a505fc-6ffc-4679-aa63-5b29dcc83f7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: updates createElement accordingly to new slot methods",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-jsx-runtime-d2a505fc-6ffc-4679-aa63-5b29dcc83f7b.json
+++ b/change/@fluentui-react-jsx-runtime-d2a505fc-6ffc-4679-aa63-5b29dcc83f7b.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "chore: updates createElement accordingly to new slot methods",
+  "comment": "chore: update createElement to support new slot methods",
   "packageName": "@fluentui/react-jsx-runtime",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-utilities-18c147c2-15a4-428f-89a7-049632ab27fe.json
+++ b/change/@fluentui-react-utilities-18c147c2-15a4-428f-89a7-049632ab27fe.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feature: implements new slot methods (slot and assertSlots)",
+  "comment": "feat: implement new slot methods (slot and assertSlots)",
   "packageName": "@fluentui/react-utilities",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-utilities-18c147c2-15a4-428f-89a7-049632ab27fe.json
+++ b/change/@fluentui-react-utilities-18c147c2-15a4-428f-89a7-049632ab27fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: implements new slot methods (slot and assertSlots)",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
@@ -1,14 +1,20 @@
-/* eslint-disable jsdoc/check-tag-names */
 /** @jsxRuntime classic */
 /** @jsxFrag Fragment */
 /** @jsx createElement */
-/* eslint-enable jsdoc/check-tag-names */
 
 import { render } from '@testing-library/react';
-import { ComponentProps, ComponentState, Slot, getSlotsNext, resolveShorthand } from '@fluentui/react-utilities';
+import {
+  ComponentProps,
+  ComponentState,
+  Slot,
+  assertSlots,
+  getSlotsNext,
+  resolveShorthand,
+  slot,
+} from '@fluentui/react-utilities';
 import { createElement } from './createElement';
 
-describe('createElement', () => {
+describe('createElement with getSlotsNext', () => {
   describe('general behavior tests', () => {
     it('handles a string', () => {
       const result = render(<div>Hello world</div>);
@@ -164,5 +170,188 @@ describe('createElement', () => {
         </div>
       `);
     });
+  });
+});
+
+describe('createElement with assertSlots', () => {
+  describe('general behavior tests', () => {
+    it('handles a string', () => {
+      const result = render(<div>Hello world</div>);
+
+      expect(result.container.firstChild).toMatchInlineSnapshot(`
+        <div>
+          Hello world
+        </div>
+      `);
+    });
+
+    it('handles an array', () => {
+      const result = render(
+        <div>
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i}>{i}</div>
+          ))}
+        </div>,
+      );
+
+      expect(result.container.firstChild).toMatchInlineSnapshot(`
+        <div>
+          <div>
+            0
+          </div>
+          <div>
+            1
+          </div>
+          <div>
+            2
+          </div>
+        </div>
+      `);
+    });
+
+    it('handles an array of children', () => {
+      const result = render(
+        <div>
+          <div>1</div>
+          <div>2</div>
+        </div>,
+      );
+
+      expect(result.container.firstChild).toMatchInlineSnapshot(`
+        <div>
+          <div>
+            1
+          </div>
+          <div>
+            2
+          </div>
+        </div>
+      `);
+    });
+  });
+
+  describe('custom behavior tests', () => {
+    it('keeps children from "defaultProps" in a render callback', () => {
+      type TestComponentSlots = {
+        someSlot: NonNullable<Slot<'div'>>;
+      };
+      type TestComponentProps = ComponentProps<Partial<TestComponentSlots>>;
+      type TestComponentState = ComponentState<TestComponentSlots>;
+
+      const TestComponent = (props: TestComponentProps) => {
+        const state: TestComponentState = {
+          components: { someSlot: 'div' },
+          someSlot: slot(props.someSlot, {
+            required: true,
+            elementType: 'div',
+            defaultProps: { children: 'Default Children', id: 'slot' },
+          }),
+        };
+        assertSlots<TestComponentSlots>(state);
+        return <state.someSlot />;
+      };
+
+      const children = jest.fn().mockImplementation((Component, props) => (
+        <div id="render-fn">
+          <Component {...props} />
+        </div>
+      ));
+      const result = render(<TestComponent someSlot={{ children }} />);
+
+      expect(children).toHaveBeenCalledTimes(1);
+      expect(children).toHaveBeenCalledWith('div', { children: 'Default Children', id: 'slot' });
+
+      expect(result.container.firstChild).toMatchInlineSnapshot(`
+        <div
+          id="render-fn"
+        >
+          <div
+            id="slot"
+          >
+            Default Children
+          </div>
+        </div>
+      `);
+    });
+
+    it('keeps children from a render template in a render callback', () => {
+      type TestComponentSlots = { outer: NonNullable<Slot<'div'>>; inner: NonNullable<Slot<'div'>> };
+      type TestComponentState = ComponentState<TestComponentSlots>;
+      type TestComponentProps = ComponentProps<Partial<TestComponentSlots>>;
+
+      const TestComponent = (props: TestComponentProps) => {
+        const state: TestComponentState = {
+          components: { outer: 'div', inner: 'div' },
+          inner: slot(props.inner, { required: true, defaultProps: { id: 'inner' }, elementType: 'div' }),
+          outer: slot(props.outer, { required: true, defaultProps: { id: 'outer' }, elementType: 'div' }),
+        };
+        assertSlots<TestComponentSlots>(state);
+        return (
+          <state.outer>
+            <state.inner />
+          </state.outer>
+        );
+      };
+
+      const children = jest.fn().mockImplementation((Component, props) => (
+        <div id="render-fn">
+          <Component {...props} />
+        </div>
+      ));
+      const result = render(<TestComponent outer={{ children }} inner={{ children: 'Inner children' }} />);
+
+      expect(children).toHaveBeenCalledTimes(1);
+      expect(children.mock.calls[0][0]).toBe('div');
+      expect(children.mock.calls[0][1].id).toBe('outer');
+      expect(children.mock.calls[0][1].children).toMatchInlineSnapshot(`
+        <React.Fragment>
+          <div
+            id="inner"
+          >
+            Inner children
+          </div>
+        </React.Fragment>
+      `);
+
+      expect(result.container.firstChild).toMatchInlineSnapshot(`
+        <div
+          id="render-fn"
+        >
+          <div
+            id="outer"
+          >
+            <div
+              id="inner"
+            >
+              Inner children
+            </div>
+          </div>
+        </div>
+      `);
+    });
+
+    it("should support 'as' property to opt-out of base element type", () => {
+      type TestComponentSlots = { slot: NonNullable<Slot<'div', 'span'>> };
+      type TestComponentState = ComponentState<TestComponentSlots>;
+      type TestComponentProps = ComponentProps<Partial<TestComponentSlots>>;
+
+      const TestComponent = (props: TestComponentProps) => {
+        const state: TestComponentState = {
+          components: { slot: 'div' },
+          slot: slot(props.slot, {
+            required: true,
+            elementType: 'div',
+          }),
+        };
+        assertSlots<TestComponentSlots>(state);
+        return <state.slot />;
+      };
+
+      const result = render(<TestComponent slot={{ as: 'span' }} />);
+
+      expect(result.container.firstChild).toMatchInlineSnapshot(`<span />`);
+    });
+
+    it.todo("should pass 'as' property to base element that aren't html element");
   });
 });

--- a/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
@@ -242,7 +242,7 @@ describe('createElement with assertSlots', () => {
         const state: TestComponentState = {
           components: { someSlot: 'div' },
           someSlot: slot(props.someSlot, {
-            required: true,
+            renderByDefault: true,
             elementType: 'div',
             defaultProps: { children: 'Default Children', id: 'slot' },
           }),
@@ -282,8 +282,8 @@ describe('createElement with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { outer: 'div', inner: 'div' },
-          inner: slot(props.inner, { required: true, defaultProps: { id: 'inner' }, elementType: 'div' }),
-          outer: slot(props.outer, { required: true, defaultProps: { id: 'outer' }, elementType: 'div' }),
+          inner: slot(props.inner, { renderByDefault: true, defaultProps: { id: 'inner' }, elementType: 'div' }),
+          outer: slot(props.outer, { renderByDefault: true, defaultProps: { id: 'outer' }, elementType: 'div' }),
         };
         assertSlots<TestComponentSlots>(state);
         return (
@@ -339,7 +339,7 @@ describe('createElement with assertSlots', () => {
         const state: TestComponentState = {
           components: { slot: 'div' },
           slot: slot(props.slot, {
-            required: true,
+            renderByDefault: true,
             elementType: 'div',
           }),
         };

--- a/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
@@ -241,8 +241,7 @@ describe('createElement with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { someSlot: 'div' },
-          someSlot: slot(props.someSlot, {
-            renderByDefault: true,
+          someSlot: slot.always(props.someSlot, {
             elementType: 'div',
             defaultProps: { children: 'Default Children', id: 'slot' },
           }),
@@ -282,8 +281,8 @@ describe('createElement with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { outer: 'div', inner: 'div' },
-          inner: slot(props.inner, { renderByDefault: true, defaultProps: { id: 'inner' }, elementType: 'div' }),
-          outer: slot(props.outer, { renderByDefault: true, defaultProps: { id: 'outer' }, elementType: 'div' }),
+          inner: slot.always(props.inner, { defaultProps: { id: 'inner' }, elementType: 'div' }),
+          outer: slot.always(props.outer, { defaultProps: { id: 'outer' }, elementType: 'div' }),
         };
         assertSlots<TestComponentSlots>(state);
         return (
@@ -338,10 +337,7 @@ describe('createElement with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { slot: 'div' },
-          slot: slot(props.slot, {
-            renderByDefault: true,
-            elementType: 'div',
-          }),
+          slot: slot.always(props.slot, { elementType: 'div' }),
         };
         assertSlots<TestComponentSlots>(state);
         return <state.slot />;

--- a/packages/react-components/react-jsx-runtime/src/createElement.ts
+++ b/packages/react-components/react-jsx-runtime/src/createElement.ts
@@ -1,38 +1,60 @@
 import * as React from 'react';
-import { SlotRenderFunction, UnknownSlotProps, SLOT_RENDER_FUNCTION_SYMBOL } from '@fluentui/react-utilities';
-
-type WithMetadata<Props extends {}> = Props & {
-  [SLOT_RENDER_FUNCTION_SYMBOL]: SlotRenderFunction<Props>;
-};
+import {
+  UnknownSlotProps,
+  isSlot,
+  SlotComponent,
+  SLOT_COMPONENT_METADATA_SYMBOL,
+  slot,
+} from '@fluentui/react-utilities';
 
 export function createElement<P extends {}>(
   type: React.ElementType<P>,
   props?: P | null,
   ...children: React.ReactNode[]
 ): React.ReactElement<P> | null {
-  return hasRenderFunction(props)
-    ? createElementFromRenderFunction(type, props, children)
-    : React.createElement(type, props, ...children);
+  // TODO:
+  // this is for backwards compatibility with getSlotsNext
+  // it should be removed once getSlotsNext is obsolete
+  if (isSlot<P>(props)) {
+    return createElementFromSlotComponent(
+      slot(props, { required: true, elementType: type as React.ComponentType<P> }),
+      children,
+    );
+  }
+  if (isSlot<P>(type)) {
+    return createElementFromSlotComponent(type, children);
+  }
+  return React.createElement(type, props, ...children);
 }
 
-function createElementFromRenderFunction<P extends UnknownSlotProps>(
-  type: React.ElementType<P>,
-  props: WithMetadata<P>,
+function createElementFromSlotComponent<Props extends UnknownSlotProps>(
+  slotComponent: SlotComponent<Props>,
   overrideChildren: React.ReactNode[],
-): React.ReactElement<P> | null {
-  const { [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction, ...renderProps } = props;
+): React.ReactElement<Props> | null {
+  const { [SLOT_COMPONENT_METADATA_SYMBOL]: metadata, as, ...propsWithoutMetadata } = slotComponent;
+  const props = propsWithoutMetadata as UnknownSlotProps as Props;
+  const { elementType: baseElementType, renderFunction } = metadata;
 
-  if (overrideChildren.length > 0) {
-    renderProps.children = React.createElement(React.Fragment, {}, ...overrideChildren);
+  const elementType =
+    baseElementType === undefined || typeof baseElementType === 'string'
+      ? as ?? baseElementType ?? 'div'
+      : baseElementType;
+
+  if (typeof elementType !== 'string' && as) {
+    props.as = as;
   }
 
-  return React.createElement(
-    React.Fragment,
-    {},
-    renderFunction(type, renderProps as UnknownSlotProps as P),
-  ) as React.ReactElement<P>;
-}
+  if (renderFunction) {
+    if (overrideChildren.length > 0) {
+      props.children = React.createElement(React.Fragment, {}, ...overrideChildren);
+    }
 
-export function hasRenderFunction<Props extends {}>(props?: Props | null): props is WithMetadata<Props> {
-  return Boolean(props?.hasOwnProperty(SLOT_RENDER_FUNCTION_SYMBOL));
+    return React.createElement(
+      React.Fragment,
+      {},
+      renderFunction(elementType as React.ElementType<Props>, props),
+    ) as React.ReactElement<Props>;
+  }
+
+  return React.createElement(elementType, props, ...overrideChildren);
 }

--- a/packages/react-components/react-jsx-runtime/src/createElement.ts
+++ b/packages/react-components/react-jsx-runtime/src/createElement.ts
@@ -2,10 +2,9 @@ import * as React from 'react';
 import {
   UnknownSlotProps,
   isSlot,
-  SlotComponent,
+  SlotComponentType,
   SLOT_ELEMENT_TYPE_SYMBOL,
   SLOT_RENDER_FUNCTION_SYMBOL,
-  slot,
 } from '@fluentui/react-utilities';
 
 export function createElement<P extends {}>(
@@ -18,7 +17,7 @@ export function createElement<P extends {}>(
   // it should be removed once getSlotsNext is obsolete
   if (isSlot<P>(props)) {
     return createElementFromSlotComponent(
-      slot(props, { required: true, elementType: type as React.ComponentType<P> }),
+      { ...props, [SLOT_ELEMENT_TYPE_SYMBOL]: type } as SlotComponentType<P>,
       children,
     );
   }
@@ -29,7 +28,7 @@ export function createElement<P extends {}>(
 }
 
 function createElementFromSlotComponent<Props extends UnknownSlotProps>(
-  slotComponent: SlotComponent<Props>,
+  type: SlotComponentType<Props>,
   overrideChildren: React.ReactNode[],
 ): React.ReactElement<Props> | null {
   const {
@@ -37,7 +36,7 @@ function createElementFromSlotComponent<Props extends UnknownSlotProps>(
     [SLOT_ELEMENT_TYPE_SYMBOL]: baseElementType,
     [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
     ...propsWithoutMetadata
-  } = slotComponent;
+  } = type;
   const props = propsWithoutMetadata as UnknownSlotProps as Props;
 
   const elementType = typeof baseElementType === 'string' ? as ?? baseElementType : baseElementType;

--- a/packages/react-components/react-jsx-runtime/src/createElement.ts
+++ b/packages/react-components/react-jsx-runtime/src/createElement.ts
@@ -3,7 +3,8 @@ import {
   UnknownSlotProps,
   isSlot,
   SlotComponent,
-  SLOT_COMPONENT_METADATA_SYMBOL,
+  SLOT_ELEMENT_TYPE_SYMBOL,
+  SLOT_RENDER_FUNCTION_SYMBOL,
   slot,
 } from '@fluentui/react-utilities';
 
@@ -31,14 +32,15 @@ function createElementFromSlotComponent<Props extends UnknownSlotProps>(
   slotComponent: SlotComponent<Props>,
   overrideChildren: React.ReactNode[],
 ): React.ReactElement<Props> | null {
-  const { [SLOT_COMPONENT_METADATA_SYMBOL]: metadata, as, ...propsWithoutMetadata } = slotComponent;
+  const {
+    as,
+    [SLOT_ELEMENT_TYPE_SYMBOL]: baseElementType,
+    [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
+    ...propsWithoutMetadata
+  } = slotComponent;
   const props = propsWithoutMetadata as UnknownSlotProps as Props;
-  const { elementType: baseElementType, renderFunction } = metadata;
 
-  const elementType =
-    baseElementType === undefined || typeof baseElementType === 'string'
-      ? as ?? baseElementType ?? 'div'
-      : baseElementType;
+  const elementType = typeof baseElementType === 'string' ? as ?? baseElementType : baseElementType;
 
   if (typeof elementType !== 'string' && as) {
     props.as = as;

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -10,6 +10,9 @@ import * as React_2 from 'react';
 // @internal
 export function applyTriggerPropsToChildren<TriggerChildProps>(children: TriggerProps<TriggerChildProps>['children'], triggerChildProps: TriggerChildProps): React_2.ReactElement | null;
 
+// @internal
+export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asserts state is SlotComponents<Slots>;
+
 // @public
 export function canUseDOM(): boolean;
 
@@ -105,6 +108,9 @@ export function isMouseEvent(event: TouchOrMouseEvent): event is MouseEvent | Re
 export function isResolvedShorthand<Shorthand extends Slot<UnknownSlotProps>>(shorthand?: Shorthand): shorthand is ExtractSlotProps<Shorthand>;
 
 // @public
+export function isSlot<Props extends {}>(element: unknown): element is SlotComponent<Props>;
+
+// @public
 export function isTouchEvent(event: TouchOrMouseEvent): event is TouchEvent | React_2.TouchEvent;
 
 // @internal
@@ -154,7 +160,7 @@ export type RefObjectFunction<T> = React_2.RefObject<T> & ((value: T) => void);
 export function resetIdsForTests(): void;
 
 // @public
-export const resolveShorthand: ResolveShorthandFunction;
+export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps>;
 
 // @public (undocumented)
 export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlotProps> = {
@@ -211,12 +217,45 @@ export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentTyp
     } & WithSlotRenderFunction<IntrinsicElementProps<As>>;
 }[AlternateAs] | null : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
+// @public
+export function slot<Props extends UnknownSlotProps>(value: Props | SlotComponent<Props> | SlotShorthandValue | undefined, options: {
+    required: true;
+} & SlotOptions<Props>): SlotComponent<Props>;
+
+// @public (undocumented)
+export function slot<Props extends UnknownSlotProps>(value: Props | SlotComponent<Props> | SlotShorthandValue | undefined | null, options: {
+    required?: boolean;
+} & SlotOptions<Props>): SlotComponent<Props> | undefined;
+
+// @public (undocumented)
+export function slot<Props extends UnknownSlotProps>(value: SlotComponent<Props>, options?: {
+    required: true;
+} & Partial<SlotOptions<Props>>): SlotComponent<Props>;
+
 // @internal
-export const SLOT_RENDER_FUNCTION_SYMBOL: unique symbol;
+export const SLOT_COMPONENT_METADATA_SYMBOL: unique symbol;
 
 // @public
 export type SlotClassNames<Slots> = {
     [SlotName in keyof Slots]-?: string;
+};
+
+// @public
+export type SlotComponent<Props extends UnknownSlotProps> = Props & {
+    (props: React_2.PropsWithChildren<{}>): React_2.ReactElement | null;
+    [SLOT_COMPONENT_METADATA_SYMBOL]: Readonly<SlotComponentMetadata<Props>>;
+};
+
+// @public
+export type SlotComponentMetadata<Props extends UnknownSlotProps> = {
+    renderFunction?: SlotRenderFunction<Props>;
+    elementType: React_2.ComponentType<Props> | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+};
+
+// @public (undocumented)
+export type SlotOptions<Props extends UnknownSlotProps> = {
+    elementType: React_2.ComponentType<Props> | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+    defaultProps?: Partial<Props>;
 };
 
 // @public

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -233,9 +233,9 @@ export function slot<Props extends UnknownSlotProps>(value: SlotComponent<Props>
 } & Partial<SlotOptions<Props>>): SlotComponent<Props>;
 
 // @internal
-export const SLOT_COMPONENT_METADATA_SYMBOL: unique symbol;
+export const SLOT_ELEMENT_TYPE_SYMBOL: unique symbol;
 
-// @internal @deprecated
+// @internal
 export const SLOT_RENDER_FUNCTION_SYMBOL: unique symbol;
 
 // @public
@@ -246,13 +246,8 @@ export type SlotClassNames<Slots> = {
 // @public
 export type SlotComponent<Props extends UnknownSlotProps> = Props & {
     (props: React_2.PropsWithChildren<{}>): React_2.ReactElement | null;
-    [SLOT_COMPONENT_METADATA_SYMBOL]: Readonly<SlotComponentMetadata<Props>>;
-};
-
-// @public
-export type SlotComponentMetadata<Props extends UnknownSlotProps> = {
-    renderFunction?: SlotRenderFunction<Props>;
-    elementType: React_2.ComponentType<Props> | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+    [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<Props>;
+    [SLOT_ELEMENT_TYPE_SYMBOL]: React_2.ComponentType<Props> | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -219,12 +219,12 @@ export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentTyp
 
 // @public
 export function slot<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined, options: {
-    required: true;
+    renderByDefault: true;
 } & SlotOptions<Props>): SlotComponentType<Props>;
 
 // @public (undocumented)
 export function slot<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined | null, options: {
-    required?: boolean;
+    renderByDefault?: boolean;
 } & SlotOptions<Props>): SlotComponentType<Props> | undefined;
 
 // @internal

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -7,6 +7,9 @@
 import { DispatchWithoutAction } from 'react';
 import * as React_2 from 'react';
 
+// @public
+function always<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined, options: SlotOptions<Props>): SlotComponentType<Props>;
+
 // @internal
 export function applyTriggerPropsToChildren<TriggerChildProps>(children: TriggerProps<TriggerChildProps>['children'], triggerChildProps: TriggerChildProps): React_2.ReactElement | null;
 
@@ -130,6 +133,11 @@ export type OnSelectionChangeData = {
     selectedItems: Set<SelectionItemId>;
 };
 
+// @public
+function optional<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined | null, options: {
+    renderByDefault?: boolean;
+} & SlotOptions<Props>): SlotComponentType<Props> | undefined;
+
 // @internal (undocumented)
 export interface PriorityQueue<T> {
     // (undocumented)
@@ -161,6 +169,9 @@ export function resetIdsForTests(): void;
 
 // @public
 export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps>;
+
+// @public
+function resolveShorthand_2<Props extends UnknownSlotProps | null | undefined>(value: Props | SlotShorthandValue): Props;
 
 // @public (undocumented)
 export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlotProps> = {
@@ -217,15 +228,15 @@ export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentTyp
     } & WithSlotRenderFunction<IntrinsicElementProps<As>>;
 }[AlternateAs] | null : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
-// @public
-export function slot<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined, options: {
-    renderByDefault: true;
-} & SlotOptions<Props>): SlotComponentType<Props>;
-
-// @public (undocumented)
-export function slot<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined | null, options: {
-    renderByDefault?: boolean;
-} & SlotOptions<Props>): SlotComponentType<Props> | undefined;
+declare namespace slot {
+    export {
+        always,
+        optional,
+        resolveShorthand_2 as resolveShorthand,
+        SlotOptions
+    }
+}
+export { slot }
 
 // @internal
 export const SLOT_ELEMENT_TYPE_SYMBOL: unique symbol;

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -235,6 +235,9 @@ export function slot<Props extends UnknownSlotProps>(value: SlotComponent<Props>
 // @internal
 export const SLOT_COMPONENT_METADATA_SYMBOL: unique symbol;
 
+// @internal @deprecated
+export const SLOT_RENDER_FUNCTION_SYMBOL: unique symbol;
+
 // @public
 export type SlotClassNames<Slots> = {
     [SlotName in keyof Slots]-?: string;

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -108,7 +108,7 @@ export function isMouseEvent(event: TouchOrMouseEvent): event is MouseEvent | Re
 export function isResolvedShorthand<Shorthand extends Slot<UnknownSlotProps>>(shorthand?: Shorthand): shorthand is ExtractSlotProps<Shorthand>;
 
 // @public
-export function isSlot<Props extends {}>(element: unknown): element is SlotComponent<Props>;
+export function isSlot<Props extends {}>(element: unknown): element is SlotComponentType<Props>;
 
 // @public
 export function isTouchEvent(event: TouchOrMouseEvent): event is TouchEvent | React_2.TouchEvent;
@@ -218,19 +218,14 @@ export type Slot<Type extends keyof JSX.IntrinsicElements | React_2.ComponentTyp
 }[AlternateAs] | null : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
 // @public
-export function slot<Props extends UnknownSlotProps>(value: Props | SlotComponent<Props> | SlotShorthandValue | undefined, options: {
+export function slot<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined, options: {
     required: true;
-} & SlotOptions<Props>): SlotComponent<Props>;
+} & SlotOptions<Props>): SlotComponentType<Props>;
 
 // @public (undocumented)
-export function slot<Props extends UnknownSlotProps>(value: Props | SlotComponent<Props> | SlotShorthandValue | undefined | null, options: {
+export function slot<Props extends UnknownSlotProps>(value: Props | SlotShorthandValue | undefined | null, options: {
     required?: boolean;
-} & SlotOptions<Props>): SlotComponent<Props> | undefined;
-
-// @public (undocumented)
-export function slot<Props extends UnknownSlotProps>(value: SlotComponent<Props>, options?: {
-    required: true;
-} & Partial<SlotOptions<Props>>): SlotComponent<Props>;
+} & SlotOptions<Props>): SlotComponentType<Props> | undefined;
 
 // @internal
 export const SLOT_ELEMENT_TYPE_SYMBOL: unique symbol;
@@ -244,7 +239,7 @@ export type SlotClassNames<Slots> = {
 };
 
 // @public
-export type SlotComponent<Props extends UnknownSlotProps> = Props & {
+export type SlotComponentType<Props extends UnknownSlotProps> = Props & {
     (props: React_2.PropsWithChildren<{}>): React_2.ReactElement | null;
     [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<Props>;
     [SLOT_ELEMENT_TYPE_SYMBOL]: React_2.ComponentType<Props> | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);

--- a/packages/react-components/react-utilities/src/compose/assertSlots.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.test.tsx
@@ -1,0 +1,53 @@
+import { assertSlots } from './assertSlots';
+import { slot } from './slot';
+import { ComponentProps, ComponentState, Slot } from './types';
+
+type TestSlots = {
+  slotA?: Slot<'div', 'a'>;
+  slotB?: Slot<'div'>;
+  slotC?: Slot<'div'>;
+};
+
+type TestProps = ComponentProps<TestSlots> & {
+  notASlot?: string;
+  alsoNotASlot?: number;
+};
+type TestState = ComponentState<TestSlots>;
+
+describe('assertSlots', () => {
+  it('should not throw if all slots are properly declared', () => {
+    const props: TestProps = { slotA: 'hello' };
+    const state: TestState = {
+      components: {
+        slotA: 'div',
+        slotB: 'div',
+        slotC: 'div',
+      },
+      slotA: slot(props.slotA, { elementType: 'div' }),
+    };
+    expect(() => assertSlots<TestSlots>(state)).not.toThrow();
+  });
+  it('should throw if a slot is not declared with the `slot` function', () => {
+    const state: TestState = {
+      components: {
+        slotA: 'div',
+        slotB: 'div',
+        slotC: 'div',
+      },
+      slotA: {},
+    };
+    expect(() => assertSlots<TestSlots>(state)).toThrow();
+  });
+  it('should throw if a state.components.SLOT_NAME is not equivalent to the slot elementType', () => {
+    const props: TestProps = { slotA: 'hello' };
+    const state: TestState = {
+      components: {
+        slotA: 'a',
+        slotB: 'div',
+        slotC: 'div',
+      },
+      slotA: slot(props.slotA, { elementType: 'div' }),
+    };
+    expect(() => assertSlots<TestSlots>(state)).toThrow();
+  });
+});

--- a/packages/react-components/react-utilities/src/compose/assertSlots.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.test.tsx
@@ -1,5 +1,5 @@
 import { assertSlots } from './assertSlots';
-import { slot } from './slot';
+import * as slot from './slot';
 import { ComponentProps, ComponentState, Slot } from './types';
 
 type TestSlots = {
@@ -23,7 +23,7 @@ describe('assertSlots', () => {
         slotB: 'div',
         slotC: 'div',
       },
-      slotA: slot(props.slotA, { elementType: 'div' }),
+      slotA: slot.optional(props.slotA, { elementType: 'div' }),
     };
     expect(() => assertSlots<TestSlots>(state)).not.toThrow();
   });
@@ -46,7 +46,7 @@ describe('assertSlots', () => {
         slotB: 'div',
         slotC: 'div',
       },
-      slotA: slot(props.slotA, { elementType: 'div' }),
+      slotA: slot.optional(props.slotA, { elementType: 'div' }),
     };
     expect(() => assertSlots<TestSlots>(state)).toThrow();
   });

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -1,4 +1,4 @@
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 import { isSlot } from './isSlot';
 import { slot } from './slot';
 import { ComponentState, ExtractSlotProps, SlotComponent, SlotPropsRecord } from './types';
@@ -44,10 +44,10 @@ export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asse
             `Be sure to create slots properly by using ${slot.name}`,
         );
       } else {
-        const metadata = slotElement[SLOT_COMPONENT_METADATA_SYMBOL];
-        if (metadata.elementType !== typedState.components[slotName]) {
+        const { [SLOT_ELEMENT_TYPE_SYMBOL]: elementType } = slotElement;
+        if (elementType !== typedState.components[slotName]) {
           throw new TypeError(
-            `${assertSlots.name} error: state.${slotName} element type differs from state.components.${slotName}, ${metadata.elementType} !== ${typedState.components[slotName]}. \n` +
+            `${assertSlots.name} error: state.${slotName} element type differs from state.components.${slotName}, ${elementType} !== ${typedState.components[slotName]}. \n` +
               `Be sure to create slots properly by using ${slot.name} with the correct elementType`,
           );
         }

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -1,6 +1,5 @@
 import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 import { isSlot } from './isSlot';
-import { slot } from './slot';
 import { ComponentState, ExtractSlotProps, SlotComponentType, SlotPropsRecord } from './types';
 
 type SlotComponents<Slots extends SlotPropsRecord> = {
@@ -41,14 +40,14 @@ export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asse
       if (!isSlot(slotElement)) {
         throw new Error(
           `${assertSlots.name} error: state.${slotName} is not a slot.\n` +
-            `Be sure to create slots properly by using ${slot.name}`,
+            `Be sure to create slots properly by using 'slot.always' or 'slot.optional'.`,
         );
       } else {
         const { [SLOT_ELEMENT_TYPE_SYMBOL]: elementType } = slotElement;
         if (elementType !== typedState.components[slotName]) {
           throw new TypeError(
             `${assertSlots.name} error: state.${slotName} element type differs from state.components.${slotName}, ${elementType} !== ${typedState.components[slotName]}. \n` +
-              `Be sure to create slots properly by using ${slot.name} with the correct elementType`,
+              `Be sure to create slots properly by using 'slot.always' or 'slot.optional' with the correct elementType`,
           );
         }
       }

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -1,0 +1,57 @@
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { isSlot } from './isSlot';
+import { slot } from './slot';
+import { ComponentState, ExtractSlotProps, SlotComponent, SlotPropsRecord } from './types';
+
+type SlotComponents<Slots extends SlotPropsRecord> = {
+  [K in keyof Slots]: SlotComponent<ExtractSlotProps<Slots[K]>>;
+};
+
+/**
+ * @internal
+ * Assertion method to ensure state slots properties are properly declared.
+ * A properly declared slot must be declared by using the `slot` method.
+ *
+ * @example
+ * ```tsx
+ * export const renderInput_unstable = (state: InputState) => {
+    assertSlots<InputSlots>(state);
+    return (
+      <state.root>
+        {state.contentBefore && <state.contentBefore />}
+        <state.input />
+        {state.contentAfter && <state.contentAfter />}
+      </state.root>
+    );
+  };
+ * ```
+ */
+export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asserts state is SlotComponents<Slots> {
+  /**
+   * This verification is not necessary in production
+   * as we're verifying static properties that will not change between environments
+   */
+  if (process.env.NODE_ENV !== 'production') {
+    const typedState = state as ComponentState<Slots>;
+    for (const slotName of Object.keys(typedState.components)) {
+      const slotElement = typedState[slotName];
+      if (slotElement === undefined) {
+        continue;
+      }
+      if (!isSlot(slotElement)) {
+        throw new Error(
+          `${assertSlots.name} error: state.${slotName} is not a slot.\n` +
+            `Be sure to create slots properly by using ${slot.name}`,
+        );
+      } else {
+        const metadata = slotElement[SLOT_COMPONENT_METADATA_SYMBOL];
+        if (metadata.elementType !== typedState.components[slotName]) {
+          throw new TypeError(
+            `${assertSlots.name} error: state.${slotName} element type differs from state.components.${slotName}, ${metadata.elementType} !== ${typedState.components[slotName]}. \n` +
+              `Be sure to create slots properly by using ${slot.name} with the correct elementType`,
+          );
+        }
+      }
+    }
+  }
+}

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -1,10 +1,10 @@
 import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 import { isSlot } from './isSlot';
 import { slot } from './slot';
-import { ComponentState, ExtractSlotProps, SlotComponent, SlotPropsRecord } from './types';
+import { ComponentState, ExtractSlotProps, SlotComponentType, SlotPropsRecord } from './types';
 
 type SlotComponents<Slots extends SlotPropsRecord> = {
-  [K in keyof Slots]: SlotComponent<ExtractSlotProps<Slots[K]>>;
+  [K in keyof Slots]: SlotComponentType<ExtractSlotProps<Slots[K]>>;
 };
 
 /**

--- a/packages/react-components/react-utilities/src/compose/constants.ts
+++ b/packages/react-components/react-utilities/src/compose/constants.ts
@@ -4,3 +4,10 @@
  * It is used to hold internal metadata about the slot component
  */
 export const SLOT_COMPONENT_METADATA_SYMBOL = Symbol('fui.slotComponentMetadata');
+
+/**
+ * @internal
+ * Internal reference for the render function
+ * @deprecated `SLOT_COMPONENT_METADATA_SYMBOL` is used instead
+ */
+export const SLOT_RENDER_FUNCTION_SYMBOL = Symbol('fui.slotRenderFunction');

--- a/packages/react-components/react-utilities/src/compose/constants.ts
+++ b/packages/react-components/react-utilities/src/compose/constants.ts
@@ -1,13 +1,10 @@
 /**
  * @internal
- * Internal value that indicates a given component is a slot component
- * It is used to hold internal metadata about the slot component
+ * Internal reference for the render function
  */
-export const SLOT_COMPONENT_METADATA_SYMBOL = Symbol('fui.slotComponentMetadata');
-
+export const SLOT_RENDER_FUNCTION_SYMBOL = Symbol('fui.slotRenderFunction');
 /**
  * @internal
  * Internal reference for the render function
- * @deprecated `SLOT_COMPONENT_METADATA_SYMBOL` is used instead
  */
-export const SLOT_RENDER_FUNCTION_SYMBOL = Symbol('fui.slotRenderFunction');
+export const SLOT_ELEMENT_TYPE_SYMBOL = Symbol('fui.slotElementType');

--- a/packages/react-components/react-utilities/src/compose/constants.ts
+++ b/packages/react-components/react-utilities/src/compose/constants.ts
@@ -1,5 +1,6 @@
 /**
  * @internal
- * Internal reference for the render function
+ * Internal value that indicates a given component is a slot component
+ * It is used to hold internal metadata about the slot component
  */
-export const SLOT_RENDER_FUNCTION_SYMBOL = Symbol('fui.slotRenderFunction');
+export const SLOT_COMPONENT_METADATA_SYMBOL = Symbol('fui.slotComponentMetadata');

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { omit } from '../utils/omit';
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
 import type {
   AsIntrinsicElement,
   ComponentState,
@@ -11,6 +10,7 @@ import type {
   UnknownSlotProps,
 } from './types';
 import { isSlot } from './isSlot';
+import { SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
 export type Slots<S extends SlotPropsRecord> = {
   [K in keyof S]: ExtractSlotProps<S[K]> extends AsIntrinsicElement<infer As>
@@ -80,7 +80,7 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
   // TS Error: Property 'as' does not exist on type 'UnknownSlotProps | undefined'.ts(2339)
   const { as: asProp, children, ...rest } = props as NonUndefined<typeof props>;
 
-  const metadata = isSlot(props) ? props[SLOT_COMPONENT_METADATA_SYMBOL] : undefined;
+  const renderFunction = isSlot(props) ? props[SLOT_RENDER_FUNCTION_SYMBOL] : undefined;
 
   const slot = (
     state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
@@ -88,8 +88,8 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
       : state.components[slotName]
   ) as React.ElementType<R[K]>;
 
-  if (metadata?.renderFunction || typeof children === 'function') {
-    const render = (metadata?.renderFunction || children) as SlotRenderFunction<R[K]>;
+  if (renderFunction || typeof children === 'function') {
+    const render = (renderFunction || children) as SlotRenderFunction<R[K]>;
     return [
       React.Fragment,
       {

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -10,7 +10,7 @@ import type {
   UnionToIntersection,
   UnknownSlotProps,
 } from './types';
-import { isSlot } from './slot';
+import { isSlot } from './isSlot';
 
 export type Slots<S extends SlotPropsRecord> = {
   [K in keyof S]: ExtractSlotProps<S[K]> extends AsIntrinsicElement<infer As>

--- a/packages/react-components/react-utilities/src/compose/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/getSlots.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
-
 import { omit } from '../utils/omit';
-import { SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
 import type {
   AsIntrinsicElement,
   ComponentState,
@@ -11,6 +10,7 @@ import type {
   UnionToIntersection,
   UnknownSlotProps,
 } from './types';
+import { isSlot } from './slot';
 
 export type Slots<S extends SlotPropsRecord> = {
   [K in keyof S]: ExtractSlotProps<S[K]> extends AsIntrinsicElement<infer As>
@@ -76,12 +76,11 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
     return [null, undefined as R[K]];
   }
 
-  const {
-    children,
-    as: asProp,
-    [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
-    ...rest
-  } = props as typeof props & { [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<R[K]> };
+  type NonUndefined<T> = T extends undefined ? never : T;
+  // TS Error: Property 'as' does not exist on type 'UnknownSlotProps | undefined'.ts(2339)
+  const { as: asProp, children, ...rest } = props as NonUndefined<typeof props>;
+
+  const metadata = isSlot(props) ? props[SLOT_COMPONENT_METADATA_SYMBOL] : undefined;
 
   const slot = (
     state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
@@ -89,8 +88,8 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
       : state.components[slotName]
   ) as React.ElementType<R[K]>;
 
-  if (renderFunction || typeof children === 'function') {
-    const render = renderFunction || (children as SlotRenderFunction<R[K]>);
+  if (metadata?.renderFunction || typeof children === 'function') {
+    const render = (metadata?.renderFunction || children) as SlotRenderFunction<R[K]>;
     return [
       React.Fragment,
       {

--- a/packages/react-components/react-utilities/src/compose/getSlotsNext.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/getSlotsNext.test.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { getSlotsNext } from './getSlotsNext';
 import type { ExtractSlotProps, Slot, SlotComponent, UnknownSlotProps } from './types';
 import { resolveShorthand } from './resolveShorthand';
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
 const resolveShorthandMock = <Props extends UnknownSlotProps>(props: Props): SlotComponent<Props> => {
   // casting is required here as SlotComponent is a callable
-  return { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' }, ...props } as SlotComponent<Props>;
+  return { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div', ...props } as SlotComponent<Props>;
 };
 
 describe('getSlotsNext', () => {
@@ -22,7 +22,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'div' },
-      slotProps: { root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
+      slotProps: { root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
     });
   });
 
@@ -35,7 +35,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'span' },
-      slotProps: { root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
+      slotProps: { root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
     });
   });
 
@@ -49,7 +49,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'button' },
-      slotProps: { root: { id: 'id', href: 'href', [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
+      slotProps: { root: { id: 'id', href: 'href', [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
     });
   });
 
@@ -62,7 +62,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'a' },
-      slotProps: { root: { id: 'id', href: 'href', [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
+      slotProps: { root: { id: 'id', href: 'href', [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
     });
   });
 
@@ -80,8 +80,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
-        icon: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        icon: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
       },
     });
   });
@@ -100,8 +100,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'span', icon: 'button' },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
-        icon: { id: 'id', children: 'children', [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        icon: { id: 'id', children: 'children', [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
       },
     });
   });
@@ -120,12 +120,12 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: 'a' },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
         icon: {
           id: 'id',
           href: 'href',
           children: 'children',
-          [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+          [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
         },
       },
     });
@@ -145,12 +145,12 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
         icon: {
           id: 'id',
           href: 'href',
           children: 'children',
-          [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+          [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
         },
       },
     });
@@ -171,8 +171,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
-        icon: { id: 'bar', children: renderIcon, [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        icon: { id: 'bar', children: renderIcon, [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
       },
     });
   });
@@ -192,11 +192,12 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
         icon: {
           children: undefined,
           id: 'bar',
-          [SLOT_COMPONENT_METADATA_SYMBOL]: { renderFunction, elementType: 'div' },
+          [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
+          [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
         },
       },
     });
@@ -218,8 +219,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', input: 'input', icon: null },
       slotProps: {
-        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
-        input: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        input: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
         icon: undefined,
       },
     });

--- a/packages/react-components/react-utilities/src/compose/getSlotsNext.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/getSlotsNext.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { getSlotsNext } from './getSlotsNext';
-import type { ExtractSlotProps, Slot, SlotComponent, UnknownSlotProps } from './types';
+import type { ExtractSlotProps, Slot, SlotComponentType, UnknownSlotProps } from './types';
 import { resolveShorthand } from './resolveShorthand';
-import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
+import { SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
-const resolveShorthandMock = <Props extends UnknownSlotProps>(props: Props): SlotComponent<Props> => {
+const resolveShorthandMock = <Props extends UnknownSlotProps>(props: Props): SlotComponentType<Props> => {
   // casting is required here as SlotComponent is a callable
-  return { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div', ...props } as SlotComponent<Props>;
+  return { ...props } as SlotComponentType<Props>;
 };
 
 describe('getSlotsNext', () => {
@@ -22,7 +22,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'div' },
-      slotProps: { root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
+      slotProps: { root: {} },
     });
   });
 
@@ -35,7 +35,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'span' },
-      slotProps: { root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
+      slotProps: { root: {} },
     });
   });
 
@@ -49,7 +49,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'button' },
-      slotProps: { root: { id: 'id', href: 'href', [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
+      slotProps: { root: { id: 'id', href: 'href' } },
     });
   });
 
@@ -62,7 +62,7 @@ describe('getSlotsNext', () => {
       }),
     ).toEqual({
       slots: { root: 'a' },
-      slotProps: { root: { id: 'id', href: 'href', [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' } },
+      slotProps: { root: { id: 'id', href: 'href' } },
     });
   });
 
@@ -80,8 +80,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
-        icon: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
+        icon: {},
       },
     });
   });
@@ -100,8 +100,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'span', icon: 'button' },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
-        icon: { id: 'id', children: 'children', [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
+        icon: { id: 'id', children: 'children' },
       },
     });
   });
@@ -120,12 +120,11 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: 'a' },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
         icon: {
           id: 'id',
           href: 'href',
           children: 'children',
-          [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
         },
       },
     });
@@ -145,12 +144,11 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
         icon: {
           id: 'id',
           href: 'href',
           children: 'children',
-          [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
         },
       },
     });
@@ -171,8 +169,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
-        icon: { id: 'bar', children: renderIcon, [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
+        icon: { id: 'bar', children: renderIcon },
       },
     });
   });
@@ -192,12 +190,11 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', icon: Foo },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
         icon: {
           children: undefined,
           id: 'bar',
           [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
-          [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
         },
       },
     });
@@ -219,8 +216,8 @@ describe('getSlotsNext', () => {
     ).toEqual({
       slots: { root: 'div', input: 'input', icon: null },
       slotProps: {
-        root: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
-        input: { [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' },
+        root: {},
+        input: {},
         icon: undefined,
       },
     });

--- a/packages/react-components/react-utilities/src/compose/getSlotsNext.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/getSlotsNext.test.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import { getSlotsNext } from './getSlotsNext';
-import type { Slot } from './types';
+import type { ExtractSlotProps, Slot, SlotComponent, UnknownSlotProps } from './types';
 import { resolveShorthand } from './resolveShorthand';
-import { SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+
+const resolveShorthandMock = <Props extends UnknownSlotProps>(props: Props): SlotComponent<Props> => {
+  // casting is required here as SlotComponent is a callable
+  return { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' }, ...props } as SlotComponent<Props>;
+};
 
 describe('getSlotsNext', () => {
   type FooProps = { id?: string; children?: React.ReactNode };
@@ -10,17 +15,27 @@ describe('getSlotsNext', () => {
 
   it('returns provided component type for root if the as prop is not provided', () => {
     type Slots = { root: Slot<'div'> };
-    expect(getSlotsNext<Slots>({ root: {}, components: { root: 'div' } })).toEqual({
+    expect(
+      getSlotsNext<Slots>({
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({}),
+        components: { root: 'div' },
+      }),
+    ).toEqual({
       slots: { root: 'div' },
-      slotProps: { root: {} },
+      slotProps: { root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
     });
   });
 
   it('returns root slot as a span with no props', () => {
     type Slots = { root: Slot<'div', 'span'> };
-    expect(getSlotsNext<Slots>({ root: { as: 'span' }, components: { root: 'div' } })).toEqual({
+    expect(
+      getSlotsNext<Slots>({
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'span' }),
+        components: { root: 'div' },
+      }),
+    ).toEqual({
       slots: { root: 'span' },
-      slotProps: { root: {} },
+      slotProps: { root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
     });
   });
 
@@ -28,18 +43,26 @@ describe('getSlotsNext', () => {
     type Slots = { root: Slot<'button'> };
     const invalidProp = { href: 'href' } as React.ButtonHTMLAttributes<HTMLButtonElement>;
     expect(
-      getSlotsNext<Slots>({ root: { as: 'button', id: 'id', ...invalidProp }, components: { root: 'button' } }),
+      getSlotsNext<Slots>({
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'button', id: 'id', ...invalidProp }),
+        components: { root: 'button' },
+      }),
     ).toEqual({
       slots: { root: 'button' },
-      slotProps: { root: { id: 'id', href: 'href' } },
+      slotProps: { root: { id: 'id', href: 'href', [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
     });
   });
 
   it('returns root slot as an anchor, leaving the href intact', () => {
     type Slots = { root: Slot<'a'> };
-    expect(getSlotsNext<Slots>({ root: { as: 'a', id: 'id', href: 'href' }, components: { root: 'a' } })).toEqual({
+    expect(
+      getSlotsNext<Slots>({
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'a', id: 'id', href: 'href' }),
+        components: { root: 'a' },
+      }),
+    ).toEqual({
       slots: { root: 'a' },
-      slotProps: { root: { id: 'id', href: 'href' } },
+      slotProps: { root: { id: 'id', href: 'href', [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } } },
     });
   });
 
@@ -50,13 +73,16 @@ describe('getSlotsNext', () => {
     };
     expect(
       getSlotsNext<Slots>({
-        icon: {},
+        icon: resolveShorthandMock<ExtractSlotProps<Slots['icon']>>({}),
         components: { root: 'div', icon: Foo },
-        root: { as: 'div' },
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
       }),
     ).toEqual({
       slots: { root: 'div', icon: Foo },
-      slotProps: { root: {}, icon: {} },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+      },
     });
   });
 
@@ -68,12 +94,15 @@ describe('getSlotsNext', () => {
     expect(
       getSlotsNext<Slots>({
         components: { icon: 'button', root: 'div' },
-        root: { as: 'span' },
-        icon: { id: 'id', children: 'children' },
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'span' }),
+        icon: resolveShorthandMock<ExtractSlotProps<Slots['icon']>>({ id: 'id', children: 'children' }),
       }),
     ).toEqual({
       slots: { root: 'span', icon: 'button' },
-      slotProps: { root: {}, icon: { id: 'id', children: 'children' } },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: { id: 'id', children: 'children', [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+      },
     });
   });
 
@@ -84,13 +113,21 @@ describe('getSlotsNext', () => {
     };
     expect(
       getSlotsNext<Slots>({
-        root: { as: 'div' },
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
         components: { root: 'div', icon: 'a' },
-        icon: { id: 'id', href: 'href', children: 'children' },
+        icon: resolveShorthandMock<ExtractSlotProps<Slots['icon']>>({ id: 'id', href: 'href', children: 'children' }),
       }),
     ).toEqual({
       slots: { root: 'div', icon: 'a' },
-      slotProps: { root: {}, icon: { id: 'id', href: 'href', children: 'children' } },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: {
+          id: 'id',
+          href: 'href',
+          children: 'children',
+          [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+        },
+      },
     });
   });
 
@@ -102,12 +139,20 @@ describe('getSlotsNext', () => {
     expect(
       getSlotsNext<Slots>({
         components: { root: 'div', icon: Foo },
-        root: { as: 'div' },
-        icon: { id: 'id', href: 'href', children: 'children' },
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
+        icon: resolveShorthandMock<ExtractSlotProps<Slots['icon']>>({ id: 'id', href: 'href', children: 'children' }),
       }),
     ).toEqual({
       slots: { root: 'div', icon: Foo },
-      slotProps: { root: {}, icon: { id: 'id', href: 'href', children: 'children' } },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: {
+          id: 'id',
+          href: 'href',
+          children: 'children',
+          [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+        },
+      },
     });
   });
 
@@ -120,30 +165,40 @@ describe('getSlotsNext', () => {
     expect(
       getSlotsNext<Slots>({
         components: { root: 'div', icon: Foo },
-        root: { as: 'div' },
-        icon: { id: 'bar', children: renderIcon },
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
+        icon: resolveShorthandMock<ExtractSlotProps<Slots['icon']>>({ id: 'bar', children: renderIcon }),
       }),
     ).toEqual({
       slots: { root: 'div', icon: Foo },
-      slotProps: { root: {}, icon: { id: 'bar', children: renderIcon } },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: { id: 'bar', children: renderIcon, [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+      },
     });
   });
 
   it('can use slot children functions from resolveShorthand to replace default slot rendering', () => {
     type Slots = {
       root: Slot<'div'>;
-      icon: Slot<'a'>;
+      icon?: Slot<'a'>;
     };
     const renderFunction = (C: React.ElementType, p: {}) => <C {...p} />;
     expect(
       getSlotsNext<Slots>({
         components: { root: 'div', icon: Foo },
-        root: resolveShorthand({ as: 'div' }, { required: true }),
-        icon: resolveShorthand({ id: 'bar', children: renderFunction }),
+        root: resolveShorthand<ExtractSlotProps<Slots['root']>>({ as: 'div' }, { required: true }),
+        icon: resolveShorthand<ExtractSlotProps<Slots['icon']>>({ id: 'bar', children: renderFunction }),
       }),
     ).toEqual({
       slots: { root: 'div', icon: Foo },
-      slotProps: { root: {}, icon: { children: undefined, id: 'bar', [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction } },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: {
+          children: undefined,
+          id: 'bar',
+          [SLOT_COMPONENT_METADATA_SYMBOL]: { renderFunction, elementType: 'div' },
+        },
+      },
     });
   });
 
@@ -155,14 +210,18 @@ describe('getSlotsNext', () => {
     };
     expect(
       getSlotsNext<Slots>({
-        root: { as: 'div' },
+        root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
         components: { root: 'div', input: 'input', icon: 'a' },
-        input: {},
+        input: resolveShorthandMock<ExtractSlotProps<Slots['input']>>({}),
         icon: undefined,
       }),
     ).toEqual({
       slots: { root: 'div', input: 'input', icon: null },
-      slotProps: { root: {}, input: {}, icon: undefined },
+      slotProps: {
+        root: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        input: { [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } },
+        icon: undefined,
+      },
     });
   });
 });

--- a/packages/react-components/react-utilities/src/compose/index.ts
+++ b/packages/react-components/react-utilities/src/compose/index.ts
@@ -5,3 +5,5 @@ export * from './isResolvedShorthand';
 export * from './constants';
 export * from './getSlotsNext';
 export * from './slot';
+export * from './isSlot';
+export * from './assertSlots';

--- a/packages/react-components/react-utilities/src/compose/index.ts
+++ b/packages/react-components/react-utilities/src/compose/index.ts
@@ -1,9 +1,13 @@
+import * as slot from './slot';
+
 export * from './getSlots';
 export * from './resolveShorthand';
 export * from './types';
 export * from './isResolvedShorthand';
 export * from './constants';
 export * from './getSlotsNext';
-export * from './slot';
 export * from './isSlot';
 export * from './assertSlots';
+
+export { slot };
+export type { SlotOptions } from './slot';

--- a/packages/react-components/react-utilities/src/compose/index.ts
+++ b/packages/react-components/react-utilities/src/compose/index.ts
@@ -4,3 +4,4 @@ export * from './types';
 export * from './isResolvedShorthand';
 export * from './constants';
 export * from './getSlotsNext';
+export * from './slot';

--- a/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
@@ -1,31 +1,37 @@
 import * as React from 'react';
-import { isResolvedShorthand } from './isResolvedShorthand';
+import { isSlot } from './isSlot';
+import { slot } from './slot';
 
-describe('isResolvedShorthand', () => {
+describe('isSlot', () => {
   it('resolves a string', () => {
-    expect(isResolvedShorthand('hello')).toEqual(false);
+    expect(isSlot('hello')).toEqual(false);
   });
 
   it('resolves a JSX element', () => {
-    expect(isResolvedShorthand(<div>hello</div>)).toEqual(false);
+    expect(isSlot(<div>hello</div>)).toEqual(false);
   });
 
   it('resolves a number', () => {
-    expect(isResolvedShorthand(42)).toEqual(false);
+    expect(isSlot(42)).toEqual(false);
   });
 
   it('resolves null', () => {
-    expect(isResolvedShorthand(null)).toEqual(false);
+    expect(isSlot(null)).toEqual(false);
   });
 
   it('resolves undefined', () => {
-    expect(isResolvedShorthand(undefined)).toEqual(false);
+    expect(isSlot(undefined)).toEqual(false);
   });
 
   it('resolves object', () => {
-    expect(isResolvedShorthand({})).toEqual(true);
+    expect(isSlot({})).toEqual(false);
   });
+
   it('resolves array', () => {
-    expect(isResolvedShorthand(['1', 2])).toEqual(false);
+    expect(isSlot(['1', 2])).toEqual(false);
+  });
+
+  it('resolves actual slot', () => {
+    expect(isSlot(slot({}, { elementType: 'div' }))).toEqual(true);
   });
 });

--- a/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { isSlot } from './isSlot';
-import { slot } from './slot';
+import * as slot from './slot';
 
 describe('isSlot', () => {
   it('handles a string', () => {
@@ -32,6 +32,6 @@ describe('isSlot', () => {
   });
 
   it('handles actual slot', () => {
-    expect(isSlot(slot({}, { elementType: 'div' }))).toEqual(true);
+    expect(isSlot(slot.optional({}, { elementType: 'div' }))).toEqual(true);
   });
 });

--- a/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
@@ -3,35 +3,35 @@ import { isSlot } from './isSlot';
 import { slot } from './slot';
 
 describe('isSlot', () => {
-  it('resolves a string', () => {
+  it('handles a string', () => {
     expect(isSlot('hello')).toEqual(false);
   });
 
-  it('resolves a JSX element', () => {
+  it('handles a JSX element', () => {
     expect(isSlot(<div>hello</div>)).toEqual(false);
   });
 
-  it('resolves a number', () => {
+  it('handles a number', () => {
     expect(isSlot(42)).toEqual(false);
   });
 
-  it('resolves null', () => {
+  it('handles null', () => {
     expect(isSlot(null)).toEqual(false);
   });
 
-  it('resolves undefined', () => {
+  it('handles undefined', () => {
     expect(isSlot(undefined)).toEqual(false);
   });
 
-  it('resolves object', () => {
+  it('handles object', () => {
     expect(isSlot({})).toEqual(false);
   });
 
-  it('resolves array', () => {
+  it('handles array', () => {
     expect(isSlot(['1', 2])).toEqual(false);
   });
 
-  it('resolves actual slot', () => {
+  it('handles actual slot', () => {
     expect(isSlot(slot({}, { elementType: 'div' }))).toEqual(true);
   });
 });

--- a/packages/react-components/react-utilities/src/compose/isSlot.ts
+++ b/packages/react-components/react-utilities/src/compose/isSlot.ts
@@ -1,4 +1,4 @@
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 import { SlotComponent } from './types';
 
 /**
@@ -6,5 +6,5 @@ import { SlotComponent } from './types';
  * This is mainly used internally to ensure a slot is being used as a component.
  */
 export function isSlot<Props extends {}>(element: unknown): element is SlotComponent<Props> {
-  return Boolean((element as {} | undefined)?.hasOwnProperty(SLOT_COMPONENT_METADATA_SYMBOL));
+  return Boolean((element as {} | undefined)?.hasOwnProperty(SLOT_ELEMENT_TYPE_SYMBOL));
 }

--- a/packages/react-components/react-utilities/src/compose/isSlot.ts
+++ b/packages/react-components/react-utilities/src/compose/isSlot.ts
@@ -1,10 +1,10 @@
 import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
-import { SlotComponent } from './types';
+import { SlotComponentType } from './types';
 
 /**
  * Guard method to ensure a given element is a slot.
  * This is mainly used internally to ensure a slot is being used as a component.
  */
-export function isSlot<Props extends {}>(element: unknown): element is SlotComponent<Props> {
+export function isSlot<Props extends {}>(element: unknown): element is SlotComponentType<Props> {
   return Boolean((element as {} | undefined)?.hasOwnProperty(SLOT_ELEMENT_TYPE_SYMBOL));
 }

--- a/packages/react-components/react-utilities/src/compose/isSlot.ts
+++ b/packages/react-components/react-utilities/src/compose/isSlot.ts
@@ -1,0 +1,10 @@
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SlotComponent } from './types';
+
+/**
+ * Guard method to ensure a given element is a slot.
+ * This is mainly used internally to ensure a slot is being used as a component.
+ */
+export function isSlot<Props extends {}>(element: unknown): element is SlotComponent<Props> {
+  return Boolean((element as {} | undefined)?.hasOwnProperty(SLOT_COMPONENT_METADATA_SYMBOL));
+}

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { resolveShorthand } from './resolveShorthand';
 import type { Slot } from './types';
-import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 
 type TestProps = {
   slotA?: Slot<'div'>;
@@ -18,7 +17,6 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: 'hello',
-      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -28,7 +26,6 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: <div>hello</div>,
-      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -38,7 +35,6 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: 42,
-      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -47,7 +43,7 @@ describe('resolveShorthand', () => {
     const props: TestProps = { slotA };
     const resolvedProps = resolveShorthand(props.slotA);
 
-    expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
+    expect(resolvedProps).toEqual({});
     expect(resolvedProps).not.toBe(slotA);
   });
 
@@ -69,6 +65,6 @@ describe('resolveShorthand', () => {
     const props: TestProps = { slotA: undefined };
     const resolvedProps = resolveShorthand(props.slotA, { required: true });
 
-    expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
+    expect(resolvedProps).toEqual({});
   });
 });

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { resolveShorthand } from './resolveShorthand';
 import type { Slot } from './types';
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
 
 type TestProps = {
   slotA?: Slot<'div'>;
@@ -17,6 +18,7 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: 'hello',
+      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
     });
   });
 
@@ -26,6 +28,7 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: <div>hello</div>,
+      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
     });
   });
 
@@ -35,6 +38,7 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: 42,
+      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
     });
   });
 
@@ -43,7 +47,7 @@ describe('resolveShorthand', () => {
     const props: TestProps = { slotA };
     const resolvedProps = resolveShorthand(props.slotA);
 
-    expect(resolvedProps).toEqual(slotA);
+    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
     expect(resolvedProps).not.toBe(slotA);
   });
 
@@ -65,6 +69,6 @@ describe('resolveShorthand', () => {
     const props: TestProps = { slotA: undefined };
     const resolvedProps = resolveShorthand(props.slotA, { required: true });
 
-    expect(resolvedProps).toEqual({});
+    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
   });
 });

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { resolveShorthand } from './resolveShorthand';
 import type { Slot } from './types';
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 
 type TestProps = {
   slotA?: Slot<'div'>;
@@ -18,7 +18,7 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: 'hello',
-      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -28,7 +28,7 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: <div>hello</div>,
-      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -38,7 +38,7 @@ describe('resolveShorthand', () => {
 
     expect(resolvedProps).toEqual({
       children: 42,
-      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -47,7 +47,7 @@ describe('resolveShorthand', () => {
     const props: TestProps = { slotA };
     const resolvedProps = resolveShorthand(props.slotA);
 
-    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
+    expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
     expect(resolvedProps).not.toBe(slotA);
   });
 
@@ -69,6 +69,6 @@ describe('resolveShorthand', () => {
     const props: TestProps = { slotA: undefined };
     const resolvedProps = resolveShorthand(props.slotA, { required: true });
 
-    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
+    expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
   });
 });

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
@@ -1,4 +1,4 @@
-import { slot } from './slot';
+import * as slot from './slot';
 import type { SlotShorthandValue, UnknownSlotProps } from './types';
 
 export type ResolveShorthandOptions<Props, Required extends boolean = false> = Required extends true
@@ -19,7 +19,7 @@ export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlo
  * @param options - options to resolve shorthand props
  */
 export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (value, options) =>
-  slot<UnknownSlotProps>(value, {
+  slot.optional<UnknownSlotProps>(value, {
     ...options,
     renderByDefault: options?.required,
     // elementType as undefined is the way to identify between a slot and a resolveShorthand call

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
@@ -1,6 +1,5 @@
-import { isValidElement } from 'react';
-import type { SlotRenderFunction, SlotShorthandValue, UnknownSlotProps } from './types';
-import { SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
+import { slot } from './slot';
+import type { SlotShorthandValue, UnknownSlotProps } from './types';
 
 export type ResolveShorthandOptions<Props, Required extends boolean = false> = Required extends true
   ? { required: true; defaultProps?: Props }
@@ -19,32 +18,9 @@ export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlo
  * @param value - the base shorthand props
  * @param options - options to resolve shorthand props
  */
-export const resolveShorthand: ResolveShorthandFunction = (value, options) => {
-  const { required = false, defaultProps } = options || {};
-  if (value === null || (value === undefined && !required)) {
-    return undefined;
-  }
-
-  let resolvedShorthand: UnknownSlotProps & {
-    [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<UnknownSlotProps>;
-  } = {};
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof value === 'string' || typeof value === 'number' || Array.isArray(value) || isValidElement<any>(value)) {
-    resolvedShorthand.children = value;
-  } else if (typeof value === 'object') {
-    resolvedShorthand = value;
-  }
-
-  resolvedShorthand = {
-    ...defaultProps,
-    ...resolvedShorthand,
-  };
-
-  if (typeof resolvedShorthand.children === 'function') {
-    resolvedShorthand[SLOT_RENDER_FUNCTION_SYMBOL] = resolvedShorthand.children as SlotRenderFunction<UnknownSlotProps>;
-    resolvedShorthand.children = defaultProps?.children;
-  }
-
-  return resolvedShorthand;
-};
+export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (value, options) =>
+  slot<UnknownSlotProps>(value, {
+    ...options,
+    // elementType is required here although it'll be ignored by getSlotsNext
+    elementType: 'div',
+  });

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
@@ -21,6 +21,7 @@ export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlo
 export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (value, options) =>
   slot<UnknownSlotProps>(value, {
     ...options,
-    // elementType is required here although it'll be ignored by getSlotsNext
-    elementType: 'div',
+    // elementType as undefined is the way to identify between a slot and a resolveShorthand call
+    // in the case elementType is undefined assertSlots will fail, ensuring it'll only work with slot method.
+    elementType: undefined!,
   });

--- a/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/resolveShorthand.ts
@@ -21,6 +21,7 @@ export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlo
 export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (value, options) =>
   slot<UnknownSlotProps>(value, {
     ...options,
+    renderByDefault: options?.required,
     // elementType as undefined is the way to identify between a slot and a resolveShorthand call
     // in the case elementType is undefined assertSlots will fail, ensuring it'll only work with slot method.
     elementType: undefined!,

--- a/packages/react-components/react-utilities/src/compose/slot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/slot.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { slot } from './slot';
+import type { ComponentProps, Slot } from './types';
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+
+type TestSlots = {
+  slotA?: Slot<'div'>;
+  slotB?: Slot<'div'>;
+  slotC?: Slot<'div'>;
+};
+
+type TestProps = ComponentProps<TestSlots> & {
+  notASlot?: string;
+  alsoNotASlot?: number;
+};
+
+describe('slot', () => {
+  it('resolves a string', () => {
+    const props: TestProps = { slotA: 'hello' };
+    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+
+    expect(resolvedProps).toEqual({
+      children: 'hello',
+      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+    });
+  });
+
+  it('resolves a JSX element', () => {
+    const props: TestProps = { slotA: <div>hello</div> };
+    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+
+    expect(resolvedProps).toEqual({
+      children: <div>hello</div>,
+      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+    });
+  });
+
+  it('resolves a number', () => {
+    const props: TestProps = { slotA: 42 };
+    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+
+    expect(resolvedProps).toEqual({
+      children: 42,
+      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+    });
+  });
+
+  it('resolves an object as its copy', () => {
+    const slotA = {};
+    const props: TestProps = { slotA };
+    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+
+    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
+    expect(resolvedProps).not.toBe(slotA);
+  });
+
+  it('resolves "null" without creating a child element', () => {
+    const props: TestProps = { slotA: null, slotB: null };
+
+    expect(slot(props.slotA, { elementType: 'div' })).toEqual(undefined);
+    expect(slot(null, { required: true, elementType: 'div' })).toEqual(undefined);
+  });
+
+  it('resolves undefined without creating a child element', () => {
+    const props: TestProps = { slotA: undefined };
+    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+
+    expect(resolvedProps).toEqual(undefined);
+  });
+
+  it('resolves to empty object creating a child element', () => {
+    const props: TestProps = { slotA: undefined };
+    const resolvedProps = slot(props.slotA, { required: true, elementType: 'div' });
+
+    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
+  });
+});

--- a/packages/react-components/react-utilities/src/compose/slot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/slot.test.tsx
@@ -58,7 +58,7 @@ describe('slot', () => {
     const props: TestProps = { slotA: null, slotB: null };
 
     expect(slot(props.slotA, { elementType: 'div' })).toEqual(undefined);
-    expect(slot(null, { required: true, elementType: 'div' })).toEqual(undefined);
+    expect(slot(null, { renderByDefault: true, elementType: 'div' })).toEqual(undefined);
   });
 
   it('resolves undefined without creating a child element', () => {
@@ -70,7 +70,7 @@ describe('slot', () => {
 
   it('resolves to empty object creating a child element', () => {
     const props: TestProps = { slotA: undefined };
-    const resolvedProps = slot(props.slotA, { required: true, elementType: 'div' });
+    const resolvedProps = slot(props.slotA, { renderByDefault: true, elementType: 'div' });
 
     expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
   });

--- a/packages/react-components/react-utilities/src/compose/slot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/slot.test.tsx
@@ -74,4 +74,16 @@ describe('slot', () => {
 
     expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
   });
+
+  it('handles render functions', () => {
+    const props: TestProps = { slotA: { children: () => null } };
+    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+
+    expect(resolvedProps).toEqual({
+      [SLOT_COMPONENT_METADATA_SYMBOL]: {
+        elementType: 'div',
+        renderFunction: expect.any(Function),
+      },
+    });
+  });
 });

--- a/packages/react-components/react-utilities/src/compose/slot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/slot.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { slot } from './slot';
 import type { ComponentProps, Slot } from './types';
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
 type TestSlots = {
   slotA?: Slot<'div'>;
@@ -21,7 +21,7 @@ describe('slot', () => {
 
     expect(resolvedProps).toEqual({
       children: 'hello',
-      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -31,7 +31,7 @@ describe('slot', () => {
 
     expect(resolvedProps).toEqual({
       children: <div>hello</div>,
-      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -41,7 +41,7 @@ describe('slot', () => {
 
     expect(resolvedProps).toEqual({
       children: 42,
-      [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
     });
   });
 
@@ -50,7 +50,7 @@ describe('slot', () => {
     const props: TestProps = { slotA };
     const resolvedProps = slot(props.slotA, { elementType: 'div' });
 
-    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
+    expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
     expect(resolvedProps).not.toBe(slotA);
   });
 
@@ -72,7 +72,7 @@ describe('slot', () => {
     const props: TestProps = { slotA: undefined };
     const resolvedProps = slot(props.slotA, { required: true, elementType: 'div' });
 
-    expect(resolvedProps).toEqual({ [SLOT_COMPONENT_METADATA_SYMBOL]: { elementType: 'div' } });
+    expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
   });
 
   it('handles render functions', () => {
@@ -80,10 +80,8 @@ describe('slot', () => {
     const resolvedProps = slot(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual({
-      [SLOT_COMPONENT_METADATA_SYMBOL]: {
-        elementType: 'div',
-        renderFunction: expect.any(Function),
-      },
+      [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
+      [SLOT_RENDER_FUNCTION_SYMBOL]: expect.any(Function),
     });
   });
 });

--- a/packages/react-components/react-utilities/src/compose/slot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/slot.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { slot } from './slot';
+import * as slot from './slot';
 import type { ComponentProps, Slot } from './types';
 import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
@@ -17,7 +17,7 @@ type TestProps = ComponentProps<TestSlots> & {
 describe('slot', () => {
   it('resolves a string', () => {
     const props: TestProps = { slotA: 'hello' };
-    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual({
       children: 'hello',
@@ -27,7 +27,7 @@ describe('slot', () => {
 
   it('resolves a JSX element', () => {
     const props: TestProps = { slotA: <div>hello</div> };
-    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual({
       children: <div>hello</div>,
@@ -37,7 +37,7 @@ describe('slot', () => {
 
   it('resolves a number', () => {
     const props: TestProps = { slotA: 42 };
-    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual({
       children: 42,
@@ -48,7 +48,7 @@ describe('slot', () => {
   it('resolves an object as its copy', () => {
     const slotA = {};
     const props: TestProps = { slotA };
-    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
     expect(resolvedProps).not.toBe(slotA);
@@ -57,27 +57,27 @@ describe('slot', () => {
   it('resolves "null" without creating a child element', () => {
     const props: TestProps = { slotA: null, slotB: null };
 
-    expect(slot(props.slotA, { elementType: 'div' })).toEqual(undefined);
-    expect(slot(null, { renderByDefault: true, elementType: 'div' })).toEqual(undefined);
+    expect(slot.optional(props.slotA, { elementType: 'div' })).toEqual(undefined);
+    expect(slot.optional(null, { renderByDefault: true, elementType: 'div' })).toEqual(undefined);
   });
 
   it('resolves undefined without creating a child element', () => {
     const props: TestProps = { slotA: undefined };
-    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual(undefined);
   });
 
   it('resolves to empty object creating a child element', () => {
     const props: TestProps = { slotA: undefined };
-    const resolvedProps = slot(props.slotA, { renderByDefault: true, elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { renderByDefault: true, elementType: 'div' });
 
     expect(resolvedProps).toEqual({ [SLOT_ELEMENT_TYPE_SYMBOL]: 'div' });
   });
 
   it('handles render functions', () => {
     const props: TestProps = { slotA: { children: () => null } };
-    const resolvedProps = slot(props.slotA, { elementType: 'div' });
+    const resolvedProps = slot.optional(props.slotA, { elementType: 'div' });
 
     expect(resolvedProps).toEqual({
       [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',

--- a/packages/react-components/react-utilities/src/compose/slot.ts
+++ b/packages/react-components/react-utilities/src/compose/slot.ts
@@ -1,0 +1,172 @@
+import { isValidElement } from 'react';
+import type {
+  AsIntrinsicElement,
+  ComponentState,
+  ExtractSlotProps,
+  SlotComponent,
+  SlotComponentMetadata,
+  SlotPropsRecord,
+  SlotRenderFunction,
+  SlotShorthandValue,
+  UnknownSlotProps,
+} from './types';
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import * as React from 'react';
+
+export type SlotOptions<Props extends UnknownSlotProps> = {
+  elementType:
+    | React.ComponentType<Props>
+    | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+  defaultProps?: Partial<Props>;
+};
+
+/**
+ * Creates a slot from a slot shorthand or properties (`props.SLOT_NAME` or `props` itself)
+ *
+ * @param options - optional values you can pass to alter the signature of a slot, those values are:
+ *
+ * * `elementType` - the base element type of a slot, defaults to `'div'`
+ * * `defaultProps` - similar to a React component declaration, you can provide a slot default properties to be merged with the shorthand/properties provided
+ * * `required` - a boolean that indicates if a slot will be rendered even if it's base value is `undefined`.
+ * By default if `props.SLOT_NAME` is `undefined` then `state.SLOT_NAME` becomes `undefined`
+ * and nothing will be rendered, but if `required = true` then `state.SLOT_NAME` becomes an object
+ * with the values provided by `options.defaultProps` (or `{}`). This is useful for cases such as providing a default content
+ * in case no shorthand is provided, like the case of the `expandIcon` slot for the `AccordionHeader`
+ *
+ * @example of a required nullable slot
+ * ```tsx
+ * // AccordionHeader.types.ts
+ * type AccordionHeaderSlots = {
+ *    expandIcon?: Slot<'span'>
+ * }
+ * // useAccordionHeader.ts
+ * const state = {
+ *  expandIcon: slot(expandIconShorthand, {
+ *    required: true,
+ *    elementType: 'span',
+ *    defaultProps: { children: <ChevronRight/>, 'aria-hidden': true}
+ *  })
+ * }
+ * // renderAccordionHeader
+ * state.expandIcon && <state.expandIcon/>
+ * ```
+ */
+export function slot<Props extends UnknownSlotProps>(
+  value: Props | SlotComponent<Props> | SlotShorthandValue | undefined,
+  options: { required: true } & SlotOptions<Props>,
+): SlotComponent<Props>;
+export function slot<Props extends UnknownSlotProps>(
+  value: Props | SlotComponent<Props> | SlotShorthandValue | undefined | null,
+  options: { required?: boolean } & SlotOptions<Props>,
+): SlotComponent<Props> | undefined;
+export function slot<Props extends UnknownSlotProps>(
+  value: SlotComponent<Props>,
+  options?: { required: true } & Partial<SlotOptions<Props>>,
+): SlotComponent<Props>;
+export function slot<Props extends UnknownSlotProps>(
+  value: Props | SlotComponent<Props> | SlotShorthandValue | undefined | null,
+  options: { required?: boolean } & Partial<SlotOptions<Props>> = {},
+): SlotComponent<Props> | undefined {
+  const { required = false, defaultProps, elementType } = options;
+
+  if (value === null || (value === undefined && !required)) {
+    return undefined;
+  }
+
+  let metadata: SlotComponentMetadata<Props>;
+  if (isSlot<Props>(value)) {
+    metadata = value[SLOT_COMPONENT_METADATA_SYMBOL];
+    if (elementType !== undefined) {
+      metadata.elementType = elementType;
+    }
+  } else if (elementType !== undefined) {
+    metadata = { elementType };
+  } else {
+    throw new Error("[react-utilities]: slot options.elementType is required when value isn't a slot itself");
+  }
+
+  /**
+   * Casting is required here as SlotComponent is a function, not an object.
+   * Although SlotComponent has a function signature, it is still just an object.
+   * This is required to make a slot callable (JSX compatible), this is the exact same approach
+   * that is used on `@types/react` components
+   */
+  const propsWithMetadata = {
+    ...defaultProps,
+    [SLOT_COMPONENT_METADATA_SYMBOL]: metadata,
+  } as SlotComponent<Props>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof value === 'string' || typeof value === 'number' || Array.isArray(value) || isValidElement<any>(value)) {
+    propsWithMetadata.children = value;
+  } else if (typeof value === 'object') {
+    Object.assign(propsWithMetadata, value);
+    if (typeof value.children === 'function') {
+      metadata.renderFunction = value.children as SlotRenderFunction<Props>;
+      propsWithMetadata.children = defaultProps?.children;
+    }
+  }
+
+  return propsWithMetadata;
+}
+
+/**
+ * Guard method to ensure a given element is a slot.
+ * This is mainly used internally to ensure a slot is being used as a component.
+ */
+export function isSlot<Props extends {}>(element: unknown): element is SlotComponent<Props> {
+  return Boolean((element as {} | undefined)?.hasOwnProperty(SLOT_COMPONENT_METADATA_SYMBOL));
+}
+
+type SlotComponents<Slots extends SlotPropsRecord> = {
+  [K in keyof Slots]: SlotComponent<ExtractSlotProps<Slots[K]>>;
+};
+
+/**
+ * @internal
+ * Assertion method to ensure state slots properties are properly declared.
+ * A properly declared slot must be declared by using the `slot` method.
+ *
+ * @example
+ * ```tsx
+ * export const renderInput_unstable = (state: InputState) => {
+    assertSlots<InputSlots>(state);
+    return (
+      <state.root>
+        {state.contentBefore && <state.contentBefore />}
+        <state.input />
+        {state.contentAfter && <state.contentAfter />}
+      </state.root>
+    );
+  };
+ * ```
+ */
+export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asserts state is SlotComponents<Slots> {
+  /**
+   * This verification is not necessary in production
+   * as we're verifying static properties that will not change between environments
+   */
+  if (process.env.NODE_ENV !== 'production') {
+    const typedState = state as ComponentState<Slots>;
+    for (const slotName of Object.keys(typedState.components)) {
+      const slotElement = typedState[slotName];
+      if (slotElement === undefined) {
+        continue;
+      }
+      if (!isSlot(slotElement)) {
+        throw new Error(
+          `${assertSlots.name} error: state.${slotName} is not a slot.\n` +
+            `Be sure to create slots properly by using ${slot.name}`,
+        );
+      } else {
+        const metadata = slotElement[SLOT_COMPONENT_METADATA_SYMBOL];
+        if (metadata.elementType !== typedState.components[slotName]) {
+          throw new TypeError(
+            `${assertSlots.name} error: state.${slotName} element type differs from state.components.${slotName}, ${metadata.elementType} !== ${typedState.components[slotName]}. \n` +
+              `Be sure to create slots properly by using ${slot.name} with the correct elementType`,
+          );
+        }
+      }
+    }
+  }
+}

--- a/packages/react-components/react-utilities/src/compose/slot.ts
+++ b/packages/react-components/react-utilities/src/compose/slot.ts
@@ -78,8 +78,10 @@ export function slot<Props extends UnknownSlotProps>(
     }
   } else if (elementType !== undefined) {
     metadata = { elementType };
-  } else {
+  } else if (process.env.NODE_ENV !== 'production') {
     throw new Error("[react-utilities]: slot options.elementType is required when value isn't a slot itself");
+  } else {
+    metadata = { elementType: 'div' as React.ElementType<Props> as React.ComponentType<Props> };
   }
 
   /**

--- a/packages/react-components/react-utilities/src/compose/slot.ts
+++ b/packages/react-components/react-utilities/src/compose/slot.ts
@@ -1,12 +1,11 @@
 import type {
   AsIntrinsicElement,
-  SlotComponent,
+  SlotComponentType,
   SlotRenderFunction,
   SlotShorthandValue,
   UnknownSlotProps,
 } from './types';
 import * as React from 'react';
-import { isSlot } from './isSlot';
 import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
 export type SlotOptions<Props extends UnknownSlotProps> = {
@@ -48,55 +47,32 @@ export type SlotOptions<Props extends UnknownSlotProps> = {
  * ```
  */
 export function slot<Props extends UnknownSlotProps>(
-  value: Props | SlotComponent<Props> | SlotShorthandValue | undefined,
+  value: Props | SlotShorthandValue | undefined,
   options: { required: true } & SlotOptions<Props>,
-): SlotComponent<Props>;
+): SlotComponentType<Props>;
 export function slot<Props extends UnknownSlotProps>(
-  value: Props | SlotComponent<Props> | SlotShorthandValue | undefined | null,
+  value: Props | SlotShorthandValue | undefined | null,
   options: { required?: boolean } & SlotOptions<Props>,
-): SlotComponent<Props> | undefined;
+): SlotComponentType<Props> | undefined;
 export function slot<Props extends UnknownSlotProps>(
-  value: SlotComponent<Props>,
-  options?: { required: true } & Partial<SlotOptions<Props>>,
-): SlotComponent<Props>;
-export function slot<Props extends UnknownSlotProps>(
-  value: Props | SlotComponent<Props> | SlotShorthandValue | undefined | null,
-  options: { required?: boolean } & Partial<SlotOptions<Props>> = {},
-): SlotComponent<Props> | undefined {
-  const { required = false, defaultProps } = options;
+  value: Props | SlotShorthandValue | undefined | null,
+  options: { required?: boolean } & SlotOptions<Props>,
+): SlotComponentType<Props> | undefined {
+  const { required = false, defaultProps, elementType } = options;
 
   if (value === null || (value === undefined && !required)) {
     return undefined;
   }
 
   let renderFunction: SlotRenderFunction<Props> | undefined;
-  let elementType:
-    | React.ComponentType<Props>
-    | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
-
-  if (isSlot<Props>(value)) {
-    renderFunction = value[SLOT_RENDER_FUNCTION_SYMBOL];
-    elementType = value[SLOT_ELEMENT_TYPE_SYMBOL];
-    if (options.elementType !== undefined) {
-      elementType = options.elementType;
-    }
-  } else if (options.elementType !== undefined) {
-    elementType = options.elementType;
-  } else if (process.env.NODE_ENV !== 'production') {
-    throw new Error("[react-utilities]: slot options.elementType is required when value isn't a slot itself");
-  }
-  // in case of production, don't throw an error, just fallback to a div
-  else {
-    elementType = 'div' as React.ElementType<Props> as React.ComponentType<Props>;
-  }
 
   /**
-   * Casting is required here as SlotComponent is a function, not an object.
-   * Although SlotComponent has a function signature, it is still just an object.
+   * Casting is required here as SlotComponentType is a function, not an object.
+   * Although SlotComponentType has a function signature, it is still just an object.
    * This is required to make a slot callable (JSX compatible), this is the exact same approach
    * that is used on `@types/react` components
    */
-  const propsWithMetadata = { ...defaultProps } as SlotComponent<Props>;
+  const propsWithMetadata = { ...defaultProps } as SlotComponentType<Props>;
 
   if (
     typeof value === 'string' ||

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -239,7 +239,7 @@ export type SlotClassNames<Slots> = {
  * A definition of a slot, as a component, very similar to how a React component is declared,
  * but with some additional metadata that is used to determine how to render the slot.
  */
-export type SlotComponent<Props extends UnknownSlotProps> = Props & {
+export type SlotComponentType<Props extends UnknownSlotProps> = Props & {
   /**
    * **NOTE**: Slot components are not callable.
    */

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
 
 export type SlotRenderFunction<Props> = (
   Component: React.ElementType<Props>,
@@ -232,4 +233,30 @@ export type ForwardRefComponent<Props> = ObscureEventName extends keyof Props
  */
 export type SlotClassNames<Slots> = {
   [SlotName in keyof Slots]-?: string;
+};
+
+/**
+ * A definition of a slot, as a component, very similar to how a React component is declared,
+ * but with some additional metadata that is used to determine how to render the slot.
+ */
+export type SlotComponent<Props extends UnknownSlotProps> = Props & {
+  /**
+   * **NOTE**: Slot components are not callable.
+   */
+  (props: React.PropsWithChildren<{}>): React.ReactElement | null;
+  /**
+   * @internal
+   */
+  [SLOT_COMPONENT_METADATA_SYMBOL]: Readonly<SlotComponentMetadata<Props>>;
+};
+
+/**
+ * Metadata stored on a slot component to describe its behavior.
+ * This is used to determine how to render the slot.
+ */
+export type SlotComponentMetadata<Props extends UnknownSlotProps> = {
+  renderFunction?: SlotRenderFunction<Props>;
+  elementType:
+    | React.ComponentType<Props>
+    | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
 };

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SLOT_COMPONENT_METADATA_SYMBOL } from './constants';
+import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 
 export type SlotRenderFunction<Props> = (
   Component: React.ElementType<Props>,
@@ -247,16 +247,11 @@ export type SlotComponent<Props extends UnknownSlotProps> = Props & {
   /**
    * @internal
    */
-  [SLOT_COMPONENT_METADATA_SYMBOL]: Readonly<SlotComponentMetadata<Props>>;
-};
-
-/**
- * Metadata stored on a slot component to describe its behavior.
- * This is used to determine how to render the slot.
- */
-export type SlotComponentMetadata<Props extends UnknownSlotProps> = {
-  renderFunction?: SlotRenderFunction<Props>;
-  elementType:
+  [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<Props>;
+  /**
+   * @internal
+   */
+  [SLOT_ELEMENT_TYPE_SYMBOL]:
     | React.ComponentType<Props>
     | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
 };

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -7,6 +7,8 @@ export {
   resolveShorthand,
   isResolvedShorthand,
   SLOT_COMPONENT_METADATA_SYMBOL,
+  // eslint-disable-next-line deprecation/deprecation
+  SLOT_RENDER_FUNCTION_SYMBOL,
 } from './compose/index';
 export type {
   ExtractSlotProps,

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -23,7 +23,7 @@ export type {
   SlotRenderFunction,
   SlotShorthandValue,
   UnknownSlotProps,
-  SlotComponent,
+  SlotComponentType,
   SlotOptions,
 } from './compose/index';
 

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -6,8 +6,7 @@ export {
   assertSlots,
   resolveShorthand,
   isResolvedShorthand,
-  SLOT_COMPONENT_METADATA_SYMBOL,
-  // eslint-disable-next-line deprecation/deprecation
+  SLOT_ELEMENT_TYPE_SYMBOL,
   SLOT_RENDER_FUNCTION_SYMBOL,
 } from './compose/index';
 export type {
@@ -25,7 +24,6 @@ export type {
   SlotShorthandValue,
   UnknownSlotProps,
   SlotComponent,
-  SlotComponentMetadata,
   SlotOptions,
 } from './compose/index';
 

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -1,9 +1,12 @@
 export {
+  slot,
+  isSlot,
   getSlots,
   getSlotsNext,
+  assertSlots,
   resolveShorthand,
   isResolvedShorthand,
-  SLOT_RENDER_FUNCTION_SYMBOL,
+  SLOT_COMPONENT_METADATA_SYMBOL,
 } from './compose/index';
 export type {
   ExtractSlotProps,
@@ -19,6 +22,9 @@ export type {
   SlotRenderFunction,
   SlotShorthandValue,
   UnknownSlotProps,
+  SlotComponent,
+  SlotComponentMetadata,
+  SlotOptions,
 } from './compose/index';
 
 export {


### PR DESCRIPTION
This PR implements the next steps on slot API as discussed on previous RFC's and issues on this topic.

1. https://github.com/microsoft/fluentui/issues/27376
2. https://github.com/microsoft/fluentui/pull/27164

### Modifications

1. adds `slot` namespace that provides all methods to help create a slot
2. adds `assertSlots` method to ensure the state provided by a state hook is following proper new mechanisms
3. modifies `@fluentui/react-jsx-runtime` to properly support previous and new methods of slot creation accordingly
4. modifies `resolveShorthand` to do exactly the same thing as `slot` does

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27376
