### PR TITLE
feat: Implement composite navigation for Table and DataGrid

### DIFF
--- a/change/@fluentui-react-components-da6942fb-51ea-4e2c-8151-edf05ce372b7.json
+++ b/change/@fluentui-react-components-da6942fb-51ea-4e2c-8151-edf05ce372b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Export useTableCompositeNavigation hook",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-0f76a6d8-c171-4ce2-b9d3-2b2e74b4fa1e.json
+++ b/change/@fluentui-react-table-0f76a6d8-c171-4ce2-b9d3-2b2e74b4fa1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Implement composite navigation for Table and DataGrid",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-77c7124a-1b60-4c25-997b-e503878c34ee.json
+++ b/change/@fluentui-react-tabster-77c7124a-1b60-4c25-997b-e503878c34ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Implmenent useMergeTabsterAttributes_unstable",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -978,6 +978,7 @@ import { useTableCellLayout_unstable } from '@fluentui/react-table';
 import { useTableCellLayoutStyles_unstable } from '@fluentui/react-table';
 import { useTableCellStyles_unstable } from '@fluentui/react-table';
 import { useTableColumnSizing_unstable } from '@fluentui/react-table';
+import { useTableCompositeNavigation } from '@fluentui/react-table';
 import { useTableContext } from '@fluentui/react-table';
 import { useTableFeatures } from '@fluentui/react-table';
 import { UseTableFeaturesOptions } from '@fluentui/react-table';
@@ -2974,6 +2975,8 @@ export { useTableCellLayoutStyles_unstable }
 export { useTableCellStyles_unstable }
 
 export { useTableColumnSizing_unstable }
+
+export { useTableCompositeNavigation }
 
 export { useTableContext }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -955,6 +955,7 @@ export {
   useTableFeatures,
   useTableSelection,
   useTableSort,
+  useTableCompositeNavigation,
   createTableColumn,
   DataGridCell,
   dataGridCellClassNames,

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -20,6 +20,7 @@ import { SelectionHookParams } from '@fluentui/react-utilities';
 import { SelectionMode as SelectionMode_2 } from '@fluentui/react-utilities';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { TabsterDOMAttribute } from '@fluentui/react-tabster';
 
 // @public (undocumented)
 export type CellRenderFunction<TItem = unknown> = (column: TableColumnDefinition<TItem>, dataGridContextValue: DataGridContextValue) => React_2.ReactNode;
@@ -88,6 +89,7 @@ export type DataGridContextValue = TableFeaturesState<any> & {
     subtleSelection: boolean;
     selectionAppearance: TableRowProps['appearance'];
     resizableColumns?: boolean;
+    compositeRowTabsterAttribute: TabsterDOMAttribute;
 };
 
 // @public (undocumented)
@@ -96,7 +98,7 @@ export type DataGridContextValues = TableContextValues & {
 };
 
 // @public (undocumented)
-export type DataGridFocusMode = 'none' | 'cell' | 'row_unstable';
+export type DataGridFocusMode = 'none' | 'cell' | 'row_unstable' | 'composite';
 
 // @public
 export const DataGridHeader: ForwardRefComponent<DataGridHeaderProps>;
@@ -185,7 +187,7 @@ export type DataGridSlots = TableSlots;
 // @public
 export type DataGridState = TableState & {
     tableState: TableFeaturesState<unknown>;
-} & Pick<DataGridContextValue, 'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance' | 'getRowId' | 'resizableColumns'>;
+} & Pick<DataGridContextValue, 'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance' | 'getRowId' | 'resizableColumns' | 'compositeRowTabsterAttribute'>;
 
 // @public
 export const renderDataGrid_unstable: (state: DataGridState, contextValues: DataGridContextValues) => JSX.Element;
@@ -620,6 +622,13 @@ export const useTableCellStyles_unstable: (state: TableCellState) => TableCellSt
 
 // @public (undocumented)
 export function useTableColumnSizing_unstable<TItem>(params?: UseTableColumnSizingParams): (tableState: TableFeaturesState<TItem>) => TableFeaturesState<TItem>;
+
+// @public (undocumented)
+export function useTableCompositeNavigation(): {
+    onTableKeyDown: React_2.KeyboardEventHandler;
+    tableTabsterAttribute: TabsterDOMAttribute;
+    tableRowTabsterAttribute: TabsterDOMAttribute;
+};
 
 // @public (undocumented)
 export const useTableContext: () => TableContextValue;

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.cy.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.cy.tsx
@@ -106,27 +106,26 @@ describe('DataGrid', () => {
     cy.focused().should('have.text', '7-3');
   });
 
-  const NestedFocusableExample = () => (
-    <DataGrid items={testItems} columns={testColumns}>
-      <DataGridHeader>
-        <DataGridRow<Item>>{({ renderHeaderCell }) => <DataGridCell>{renderHeaderCell()}</DataGridCell>}</DataGridRow>
-      </DataGridHeader>
-      <DataGridBody<Item>>
-        {({ item }) => (
-          <DataGridRow<Item>>
-            {({ renderCell }) => (
-              <DataGridCell focusMode="group">
-                <button>{renderCell(item)}-1</button>
-                <button>{renderCell(item)}-2</button>
-              </DataGridCell>
-            )}
-          </DataGridRow>
-        )}
-      </DataGridBody>
-    </DataGrid>
-  );
-
   it('should use focusable group for cells', () => {
+    const NestedFocusableExample = () => (
+      <DataGrid items={testItems} columns={testColumns}>
+        <DataGridHeader>
+          <DataGridRow<Item>>{({ renderHeaderCell }) => <DataGridCell>{renderHeaderCell()}</DataGridCell>}</DataGridRow>
+        </DataGridHeader>
+        <DataGridBody<Item>>
+          {({ item }) => (
+            <DataGridRow<Item>>
+              {({ renderCell }) => (
+                <DataGridCell focusMode="group">
+                  <button>{renderCell(item)}-1</button>
+                  <button>{renderCell(item)}-2</button>
+                </DataGridCell>
+              )}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>
+    );
     mount(<NestedFocusableExample />);
 
     cy.contains('1-1-11-1-2').focus().realPress('Enter');
@@ -139,5 +138,39 @@ describe('DataGrid', () => {
     cy.focused().should('have.text', '1-1-1').realPress('Escape');
     cy.focused().should('have.text', '1-1-11-1-2').realPress('ArrowRight');
     cy.focused().should('have.text', '1-2-11-2-2');
+  });
+
+  it('should navigate in composite mode', () => {
+    const CompositeExample = () => (
+      <>
+        <button>Before</button>
+        <DataGrid items={testItems} focusMode="composite" columns={testColumns}>
+          <DataGridHeader>
+            <DataGridRow<Item>>
+              {({ renderHeaderCell }) => <DataGridCell>{renderHeaderCell()}</DataGridCell>}
+            </DataGridRow>
+          </DataGridHeader>
+          <DataGridBody<Item>>
+            {({ item }) => (
+              <DataGridRow<Item>>{({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}</DataGridRow>
+            )}
+          </DataGridBody>
+        </DataGrid>
+        <button>After</button>
+      </>
+    );
+    mount(<CompositeExample />);
+
+    cy.contains('header-1').focus().realPress('ArrowRight');
+    cy.focused().should('have.text', 'header-2').realPress('ArrowDown');
+    cy.focused().should('have.attr', 'role', 'row').realPress('ArrowRight');
+    cy.focused().should('have.text', '1-1').should('have.attr', 'role', 'gridcell').realPress('ArrowRight');
+    cy.focused().should('have.text', '1-2').should('have.attr', 'role', 'gridcell').realPress('ArrowDown');
+    cy.focused().should('have.attr', 'role', 'row').realPress('ArrowRight');
+    cy.focused().should('have.text', '2-1').should('have.attr', 'role', 'gridcell').realPress('Tab');
+    cy.focused().should('have.text', 'After').realPress(['Shift', 'Tab']);
+    cy.focused().should('have.attr', 'role', 'row').realPress('ArrowRight');
+    cy.focused().should('have.text', '7-1').should('have.attr', 'role', 'gridcell').realPress(['Shift', 'Tab']);
+    cy.focused().should('have.text', 'Before');
   });
 });

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.types.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { SelectionHookParams, SelectionMode } from '@fluentui/react-utilities';
+import { TabsterDOMAttribute } from '@fluentui/react-tabster';
 import type { TableContextValues, TableProps, TableSlots, TableState } from '../Table/Table.types';
 import type {
   SortState,
@@ -9,11 +11,10 @@ import type {
   TableColumnId,
 } from '../../hooks';
 import { TableRowProps } from '../TableRow/TableRow.types';
-import { SelectionHookParams, SelectionMode } from '@fluentui/react-utilities';
 
 export type DataGridSlots = TableSlots;
 
-export type DataGridFocusMode = 'none' | 'cell' | 'row_unstable';
+export type DataGridFocusMode = 'none' | 'cell' | 'row_unstable' | 'composite';
 
 export type DataGridContextValues = TableContextValues & {
   dataGrid: DataGridContextValue;
@@ -51,6 +52,8 @@ export type DataGridContextValue = TableFeaturesState<any> & {
    * Enables column resizing
    */
   resizableColumns?: boolean;
+
+  compositeRowTabsterAttribute: TabsterDOMAttribute;
 };
 
 /**
@@ -92,5 +95,11 @@ export type DataGridProps = TableProps &
  */
 export type DataGridState = TableState & { tableState: TableFeaturesState<unknown> } & Pick<
     DataGridContextValue,
-    'focusMode' | 'selectableRows' | 'subtleSelection' | 'selectionAppearance' | 'getRowId' | 'resizableColumns'
+    | 'focusMode'
+    | 'selectableRows'
+    | 'subtleSelection'
+    | 'selectionAppearance'
+    | 'getRowId'
+    | 'resizableColumns'
+    | 'compositeRowTabsterAttribute'
   >;

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGrid.ts
@@ -2,10 +2,16 @@ import * as React from 'react';
 import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabster';
 import type { DataGridProps, DataGridState } from './DataGrid.types';
 import { useTable_unstable } from '../Table/useTable';
-import { useTableFeatures, useTableSort, useTableSelection, useTableColumnSizing_unstable } from '../../hooks';
-import { CELL_WIDTH } from '../TableSelectionCell';
 import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { End, Home } from '@fluentui/keyboard-keys';
+import {
+  useTableFeatures,
+  useTableSort,
+  useTableSelection,
+  useTableColumnSizing_unstable,
+  useTableCompositeNavigation,
+} from '../../hooks';
+import { CELL_WIDTH } from '../TableSelectionCell';
 
 /**
  * Create the state required to render DataGrid.
@@ -39,10 +45,15 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
 
   const widthOffset = containerWidthOffset ?? (selectionMode ? -CELL_WIDTH : 0);
 
-  const navigable = focusMode !== 'none';
-  const keyboardNavAttr = useArrowNavigationGroup({
+  const gridTabsterAttribute = useArrowNavigationGroup({
     axis: 'grid',
   });
+
+  const {
+    onTableKeyDown: onCompositeKeyDown,
+    tableTabsterAttribute: compositeTabsterAttribute,
+    tableRowTabsterAttribute: compositeRowTabsterAttribute,
+  } = useTableCompositeNavigation();
 
   const tableState = useTableFeatures({ items, columns, getRowId }, [
     useTableSort({
@@ -69,6 +80,9 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
   const { findFirstFocusable, findLastFocusable } = useFocusFinders();
   const onKeyDown = useEventCallback((e: React.KeyboardEvent<HTMLTableElement>) => {
     props.onKeyDown?.(e);
+    focusMode === 'composite' && onCompositeKeyDown(e);
+
+    // handle ctrl+home and ctrl+end
     if (!innerRef.current || !e.ctrlKey || e.defaultPrevented) {
       return;
     }
@@ -94,7 +108,8 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
       role: 'grid',
       as: 'div',
       noNativeElements: true,
-      ...(navigable && keyboardNavAttr),
+      ...(focusMode === 'cell' && gridTabsterAttribute),
+      ...(focusMode === 'composite' && compositeTabsterAttribute),
       ...props,
       onKeyDown,
     },
@@ -109,5 +124,6 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     subtleSelection,
     selectionAppearance,
     resizableColumns,
+    compositeRowTabsterAttribute,
   };
 };

--- a/packages/react-components/react-table/src/components/DataGrid/useDataGridContextValues.ts
+++ b/packages/react-components/react-table/src/components/DataGrid/useDataGridContextValues.ts
@@ -3,15 +3,25 @@ import { DataGridContextValues, DataGridState } from './DataGrid.types';
 
 export function useDataGridContextValues_unstable(state: DataGridState): DataGridContextValues {
   const tableContextValues = useTableContextValues_unstable(state);
+  const {
+    tableState,
+    focusMode,
+    selectableRows,
+    subtleSelection,
+    selectionAppearance,
+    resizableColumns,
+    compositeRowTabsterAttribute,
+  } = state;
   return {
     ...tableContextValues,
     dataGrid: {
-      ...state.tableState,
-      focusMode: state.focusMode,
-      selectableRows: state.selectableRows,
-      subtleSelection: state.subtleSelection,
-      selectionAppearance: state.selectionAppearance,
-      resizableColumns: state.resizableColumns,
+      ...tableState,
+      focusMode,
+      selectableRows,
+      subtleSelection,
+      selectionAppearance,
+      resizableColumns,
+      compositeRowTabsterAttribute,
     },
   };
 }

--- a/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridCell/useDataGridCell.ts
@@ -17,7 +17,7 @@ import { useColumnIdContext } from '../../contexts/columnIdContext';
 export const useDataGridCell_unstable = (props: DataGridCellProps, ref: React.Ref<HTMLElement>): DataGridCellState => {
   const { focusMode } = props;
   const columnId = useColumnIdContext();
-  const tabbable = useDataGridContext_unstable(ctx => ctx.focusMode === 'cell');
+  const tabbable = useDataGridContext_unstable(ctx => ctx.focusMode === 'cell' || ctx.focusMode === 'composite');
   const resizableColumns = useDataGridContext_unstable(ctx => ctx.resizableColumns);
   const columnSizing = useDataGridContext_unstable(ctx => ctx.columnSizing_unstable);
   const focusableGroupAttr = useFocusableGroup({ tabBehavior: 'limited-trap-focus' });

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.tsx
@@ -23,7 +23,9 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
   const columnDefs = useDataGridContext_unstable(ctx => ctx.columns);
   const selectable = useDataGridContext_unstable(ctx => ctx.selectableRows);
   const selected = useDataGridContext_unstable(ctx => ctx.selection.isRowSelected(rowId));
-  const tabbable = useDataGridContext_unstable(ctx => ctx.focusMode === 'row_unstable');
+  const focusMode = useDataGridContext_unstable(ctx => ctx.focusMode);
+  const compositeRowTabsterAttribute = useDataGridContext_unstable(ctx => ctx.compositeRowTabsterAttribute);
+  const tabbable = focusMode === 'row_unstable' || focusMode === 'composite';
   const appearance = useDataGridContext_unstable(ctx => {
     if (!isHeader && selectable && ctx.selection.isRowSelected(rowId)) {
       return ctx.selectionAppearance;
@@ -56,12 +58,13 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
     {
       appearance,
       'aria-selected': selectable ? selected : undefined,
+      tabIndex: tabbable && !isHeader ? 0 : undefined,
+      ...(focusMode === 'composite' && !isHeader && compositeRowTabsterAttribute),
       ...props,
       onClick,
       onKeyDown,
       children: null,
       as: 'div',
-      tabIndex: tabbable && !isHeader ? 0 : undefined,
     },
     ref,
   );

--- a/packages/react-components/react-table/src/contexts/dataGridContext.ts
+++ b/packages/react-components/react-table/src/contexts/dataGridContext.ts
@@ -1,5 +1,6 @@
 import { createContext, useContextSelector } from '@fluentui/react-context-selector';
 import type { ContextSelector } from '@fluentui/react-context-selector';
+import { TabsterDOMAttribute } from '@fluentui/react-tabster';
 import { DataGridContextValue } from '../components/DataGrid/DataGrid.types';
 import { defaultTableState } from '../hooks';
 
@@ -11,6 +12,7 @@ const dataGridContextDefaultValue: DataGridContextValue = {
   selectableRows: false,
   selectionAppearance: 'brand',
   focusMode: 'none',
+  compositeRowTabsterAttribute: {} as TabsterDOMAttribute,
 };
 
 export const DataGridContextProvider = dataGridContext.Provider;

--- a/packages/react-components/react-table/src/hooks/index.ts
+++ b/packages/react-components/react-table/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useTableSort';
 export * from './useTableSelection';
 export * from './createColumn';
 export * from './useTableColumnSizing';
+export * from './useTableCompositeNavigation';

--- a/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
+++ b/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import { ArrowDown, ArrowRight, Escape, Enter, keyCodes, ArrowUp } from '@fluentui/keyboard-keys';
+import { ArrowDown, ArrowRight, Escape, keyCodes, ArrowUp } from '@fluentui/keyboard-keys';
 import {
   useArrowNavigationGroup,
   useFocusableGroup,

--- a/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
+++ b/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
@@ -6,6 +6,7 @@ import {
   useFocusableGroup,
   useMergedTabsterAttributes_unstable,
   TabsterDOMAttribute,
+  useFocusFinders,
 } from '@fluentui/react-tabster';
 import { isHTMLElement } from '@fluentui/react-utilities';
 
@@ -17,6 +18,7 @@ export function useTableCompositeNavigation(): {
   const horizontalAttr = useArrowNavigationGroup({ axis: 'horizontal' });
   const gridAttr = useArrowNavigationGroup({ axis: 'grid' });
   const groupperAttr = useFocusableGroup({ tabBehavior: 'limited-trap-focus' });
+  const { findFirstFocusable } = useFocusFinders();
   const { targetDocument } = useFluent();
 
   const rowAttr = useMergedTabsterAttributes_unstable(horizontalAttr, groupperAttr);
@@ -34,8 +36,8 @@ export function useTableCompositeNavigation(): {
       const activeElementRole = activeElement.getAttribute('role');
 
       // Enter groupper when in row focus mode to navigate cells
-      if (e.key === ArrowRight && activeElementRole === 'row') {
-        activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: Enter, keyCode: keyCodes.Enter }));
+      if (e.key === ArrowRight && activeElementRole === 'row' && isHTMLElement(activeElement)) {
+        findFirstFocusable(activeElement)?.focus();
       }
 
       if (activeElementRole === 'row') {
@@ -64,7 +66,7 @@ export function useTableCompositeNavigation(): {
         activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: e.key, keyCode: e.keyCode }));
       }
     },
-    [targetDocument],
+    [targetDocument, findFirstFocusable],
   );
 
   return {

--- a/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
+++ b/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { ArrowDown, ArrowRight, Escape, Enter, keyCodes, ArrowUp } from '@fluentui/keyboard-keys';
+import {
+  useArrowNavigationGroup,
+  useFocusableGroup,
+  useMergedTabsterAttributes_unstable,
+  TabsterDOMAttribute,
+} from '@fluentui/react-tabster';
+import { isHTMLElement } from '@fluentui/react-utilities';
+
+export function useTableCompositeNavigation(): {
+  onTableKeyDown: React.KeyboardEventHandler;
+  tableTabsterAttribute: TabsterDOMAttribute;
+  tableRowTabsterAttribute: TabsterDOMAttribute;
+} {
+  const horizontalAttr = useArrowNavigationGroup({ axis: 'horizontal' });
+  const gridAttr = useArrowNavigationGroup({ axis: 'grid' });
+  const groupperAttr = useFocusableGroup({ tabBehavior: 'limited-trap-focus' });
+  const { targetDocument } = useFluent();
+
+  const rowAttr = useMergedTabsterAttributes_unstable(horizontalAttr, groupperAttr);
+
+  const onKeyDown: React.KeyboardEventHandler = React.useCallback(
+    e => {
+      if (!targetDocument) {
+        return;
+      }
+
+      const activeElement = targetDocument.activeElement;
+      if (!activeElement || !e.currentTarget.contains(activeElement)) {
+        return;
+      }
+      const activeElementRole = activeElement.getAttribute('role');
+
+      // Enter groupper when in row focus mode to navigate cells
+      if (e.key === ArrowRight && activeElementRole === 'row') {
+        activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: Enter, keyCode: keyCodes.Enter }));
+      }
+
+      if (activeElementRole === 'row') {
+        return;
+      }
+
+      const isInCell = (() => {
+        let cur = isHTMLElement(activeElement) ? activeElement : null;
+        while (cur) {
+          const curRole = cur.getAttribute('role');
+          if (curRole === 'cell' || curRole === 'gridcell') {
+            return true;
+          }
+
+          cur = cur.parentElement;
+        }
+
+        return false;
+      })();
+
+      // Escape groupper focus trap before arrow down
+      if ((e.key === ArrowDown || e.key === ArrowUp) && isInCell) {
+        activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: Escape, keyCode: keyCodes.Escape }));
+        // Tabster uses keycodes
+        // eslint-disable-next-line deprecation/deprecation
+        activeElement.dispatchEvent(new KeyboardEvent('keydown', { key: e.key, keyCode: e.keyCode }));
+      }
+    },
+    [targetDocument],
+  );
+
+  return {
+    onTableKeyDown: onKeyDown,
+    tableTabsterAttribute: gridAttr,
+    tableRowTabsterAttribute: rowAttr,
+  };
+}

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -4,6 +4,7 @@ export {
   useTableSort,
   createTableColumn,
   useTableColumnSizing_unstable,
+  useTableCompositeNavigation,
 } from './hooks';
 
 export type {

--- a/packages/react-components/react-table/src/testing/mockDataGridContext.ts
+++ b/packages/react-components/react-table/src/testing/mockDataGridContext.ts
@@ -9,6 +9,7 @@ import {
   TableSortState,
   defaultColumnSizingState,
 } from '../hooks';
+import { TabsterDOMAttribute } from '@fluentui/react-tabster';
 
 interface Item {
   first: string;
@@ -45,6 +46,7 @@ export function mockDataGridContext(
     // eslint-disable-next-line @typescript-eslint/naming-convention
     columnSizing_unstable: defaultColumnSizingState,
     tableRef: React.createRef(),
+    compositeRowTabsterAttribute: {} as TabsterDOMAttribute,
     ...options,
   };
 

--- a/packages/react-components/react-table/stories/DataGrid/CompositeNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/CompositeNavigation.stories.tsx
@@ -91,9 +91,6 @@ const items: Item[] = [
 const columns: TableColumnDefinition<Item>[] = [
   createTableColumn<Item>({
     columnId: 'file',
-    compare: (a, b) => {
-      return a.file.label.localeCompare(b.file.label);
-    },
     renderHeaderCell: () => {
       return 'File';
     },
@@ -103,9 +100,6 @@ const columns: TableColumnDefinition<Item>[] = [
   }),
   createTableColumn<Item>({
     columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
     renderHeaderCell: () => {
       return 'Author';
     },
@@ -123,9 +117,6 @@ const columns: TableColumnDefinition<Item>[] = [
   }),
   createTableColumn<Item>({
     columnId: 'lastUpdated',
-    compare: (a, b) => {
-      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
-    },
     renderHeaderCell: () => {
       return 'Last updated';
     },
@@ -136,9 +127,6 @@ const columns: TableColumnDefinition<Item>[] = [
   }),
   createTableColumn<Item>({
     columnId: 'lastUpdate',
-    compare: (a, b) => {
-      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
-    },
     renderHeaderCell: () => {
       return 'Last update';
     },
@@ -148,9 +136,9 @@ const columns: TableColumnDefinition<Item>[] = [
   }),
 ];
 
-export const RowNavigation = () => {
+export const CompositeNavigation = () => {
   return (
-    <DataGrid items={items} columns={columns} focusMode="row_unstable">
+    <DataGrid items={items} columns={columns} focusMode="composite">
       <DataGridHeader>
         <DataGridRow>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
@@ -165,19 +153,4 @@ export const RowNavigation = () => {
       </DataGridBody>
     </DataGrid>
   );
-};
-
-RowNavigation.storyName = 'Row Navigation (unstable)';
-RowNavigation.parameters = {
-  docs: {
-    description: {
-      story: [
-        'Different keyboard navigation strategies are supported through  the `focusMode` prop.',
-        '',
-        "> ⚠️ The Fluent UI team doesn't currently know all the a11y specifics of row navigation yet to provide",
-        'accurate guidance for this scenario. Until then, if using the unstable mode of this keyboard navigation',
-        'strategy, the user is responsible for the accessibility of the component.',
-      ].join('\n'),
-    },
-  },
 };

--- a/packages/react-components/react-table/stories/DataGrid/CompositeNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/CompositeNavigation.stories.tsx
@@ -138,7 +138,7 @@ const columns: TableColumnDefinition<Item>[] = [
 
 export const CompositeNavigation = () => {
   return (
-    <DataGrid items={items} columns={columns} focusMode="composite">
+    <DataGrid selectionMode="multiselect" items={items} columns={columns} focusMode="composite">
       <DataGridHeader>
         <DataGridRow>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -157,6 +157,7 @@ export const Default = () => {
       selectionMode="multiselect"
       getRowId={item => item.file.label}
       onSelectionChange={(e, data) => console.log(data)}
+      focusMode="composite"
     >
       <DataGridHeader>
         <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>

--- a/packages/react-components/react-table/stories/DataGrid/index.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/index.stories.tsx
@@ -10,7 +10,7 @@ import {
 import descriptionMd from './DataGridDescription.md';
 
 export { Default } from './Default.stories';
-export { RowNavigation } from './RowNavigation.stories';
+export { CompositeNavigation } from './CompositeNavigation.stories';
 export { FocusableElementsInCells } from './FocusableElementsInCells.stories';
 export { Sort } from './Sort.stories';
 export { SortControlled } from './SortControlled.stories';

--- a/packages/react-components/react-table/stories/Table/CompositeNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/CompositeNavigation.stories.tsx
@@ -11,8 +11,6 @@ import {
 import {
   PresenceBadgeStatus,
   Avatar,
-  Button,
-  useArrowNavigationGroup,
   TableBody,
   TableCell,
   TableRow,
@@ -20,6 +18,7 @@ import {
   TableHeader,
   TableHeaderCell,
   TableCellLayout,
+  useTableCompositeNavigation,
 } from '@fluentui/react-components';
 
 const items = [
@@ -68,26 +67,33 @@ const columns = [
   { columnKey: 'lastUpdate', label: 'Last update' },
 ];
 
-export const RowNavigation = () => {
-  const keyboardNavAttr = useArrowNavigationGroup({ axis: 'grid' });
+export const CompositeNavigation = () => {
+  const { tableRowTabsterAttribute, tableTabsterAttribute, onTableKeyDown } = useTableCompositeNavigation();
 
   return (
-    <Table {...keyboardNavAttr} role="grid" aria-label="Table with grid keyboard navigation">
+    <Table
+      role="grid"
+      aria-label="Table with grid keyboard navigation"
+      noNativeElements
+      onKeyDown={onTableKeyDown}
+      {...tableTabsterAttribute}
+    >
       <TableHeader>
         <TableRow>
           {columns.map(column => (
-            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
+            <TableHeaderCell tabIndex={0} key={column.columnKey}>
+              {column.label}
+            </TableHeaderCell>
           ))}
-          <TableHeaderCell />
         </TableRow>
       </TableHeader>
       <TableBody>
         {items.map(item => (
-          <TableRow tabIndex={0} key={item.file.label}>
+          <TableRow tabIndex={0} key={item.file.label} {...tableRowTabsterAttribute}>
             <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
             </TableCell>
-            <TableCell role="gridcell">
+            <TableCell tabIndex={0} role="gridcell">
               <TableCellLayout
                 media={
                   <Avatar
@@ -100,14 +106,11 @@ export const RowNavigation = () => {
                 {item.author.label}
               </TableCellLayout>
             </TableCell>
-            <TableCell role="gridcell">{item.lastUpdated.label}</TableCell>
-            <TableCell role="gridcell">
-              <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
+            <TableCell tabIndex={0} role="gridcell">
+              {item.lastUpdated.label}
             </TableCell>
-            <TableCell role="gridcell">
-              <TableCellLayout>
-                <Button icon={<EditRegular />}>Edit</Button>
-              </TableCellLayout>
+            <TableCell tabIndex={0} role="gridcell">
+              <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
             </TableCell>
           </TableRow>
         ))}
@@ -115,17 +118,13 @@ export const RowNavigation = () => {
     </Table>
   );
 };
-
-RowNavigation.storyName = 'Row Navigation (unstable)';
-RowNavigation.parameters = {
+CompositeNavigation.parameters = {
   docs: {
     description: {
       story: [
         'Different keyboard navigation strategies are supported through  the `focusMode` prop.',
-        '',
-        "> ⚠️ The Fluent UI team doesn't currently know know all the a11y specifics of row navigation yet to provide",
-        'accurate guidance for this scenario. Until then, if using the unstable mode of this keyboard navigation',
-        'strategy, the user is responsible for the accessibility of the component.',
+        'Composite navigation combines row focus and cell focus. By default the user navigates the table',
+        'by row. When the user presses the right arrow key, focus mode switches to cells of the current row.',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-table/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/index.stories.tsx
@@ -18,7 +18,7 @@ export { CellActions } from './CellActions.stories';
 export { PrimaryCell } from './PrimaryCell.stories';
 export { CellNavigation } from './CellNavigation.stories';
 export { FocusableElementsInCells } from './FocusableElements.Cells.stories';
-export { RowNavigation } from './RowNavigation.stories';
+export { CompositeNavigation } from './CompositeNavigation.stories';
 
 export { Sort } from './Sort.stories';
 export { ResizableColumnsUncontrolled } from './ResizableColumnsUncontrolled.stories';

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -44,6 +44,9 @@ export type FocusOutlineStyleOptions = {
     outlineOffset?: string | FocusOutlineOffset;
 };
 
+// @public (undocumented)
+export type TabsterDOMAttribute = Types.TabsterDOMAttribute;
+
 // @public
 export const useArrowNavigationGroup: (options?: UseArrowNavigationGroupOptions) => Types.TabsterDOMAttribute;
 
@@ -85,6 +88,9 @@ export function useFocusWithin<TElement extends HTMLElement = HTMLElement>(): Re
 
 // @public
 export function useKeyboardNavAttribute<E extends HTMLElement>(): RefObject<E>;
+
+// @internal
+export const useMergedTabsterAttributes_unstable: (...attributes: Types.TabsterDOMAttribute[]) => Types.TabsterDOMAttribute;
 
 // @public
 export const useModalAttributes: (options?: UseModalAttributesOptions) => {

--- a/packages/react-components/react-tabster/src/hooks/index.ts
+++ b/packages/react-components/react-tabster/src/hooks/index.ts
@@ -7,4 +7,5 @@ export * from './useKeyboardNavAttribute';
 export * from './useModalAttributes';
 export * from './useTabsterAttributes';
 export * from './useObservedElement';
+export * from './useMergeTabsterAttributes';
 export * from './useFocusObserved';

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Types } from 'tabster';
+
+/**
+ * Merges a collection of tabster attributes. The attributes passed as arguments to this
+ * hook cannot change at runtime.
+ * @internal
+ * @param attributes
+ * @returns
+ */
+export const useMergedTabsterAttributes_unstable: (
+  ...attributes: Types.TabsterDOMAttribute[]
+) => Types.TabsterDOMAttribute = (...attributes) => {
+  const stringAttributes = attributes
+    .map(attribute => attribute[Types.TabsterAttributeName])
+    .filter(Boolean) as string[];
+
+  const mergedStrigAttribute = React.useMemo(() => {
+    let attribute = stringAttributes[0];
+    attributes.shift();
+
+    for (const attr of stringAttributes) {
+      attribute = mergeAttributes(attribute, attr);
+    }
+
+    return attribute;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, stringAttributes);
+
+  return { [Types.TabsterAttributeName]: mergedStrigAttribute };
+};
+
+function mergeAttributes(a: string, b?: string): string {
+  if (!b) {
+    return a;
+  }
+
+  let aParsed = {};
+  let bParsed = {};
+  if (a) {
+    try {
+      aParsed = JSON.parse(a);
+      // eslint-disable-next-line no-empty
+    } catch {}
+  }
+
+  if (b) {
+    try {
+      bParsed = JSON.parse(b);
+      // eslint-disable-next-line no-empty
+    } catch {}
+  }
+
+  return JSON.stringify({ ...aParsed, ...bParsed });
+}

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { Types } from 'tabster';
 
 /**
- * Merges a collection of tabster attributes. The attributes passed as arguments to this
- * hook cannot change at runtime.
+ * Merges a collection of tabster attributes.
+ *
+ * >⚠️The attributes passed as arguments to this  hook cannot change at runtime.
  * @internal
- * @param attributes
- * @returns
+ * @param attributes - collection of tabster attributes from other react-tabster hooks
+ * @returns single merged tabster attribute
  */
 export const useMergedTabsterAttributes_unstable: (
   ...attributes: Types.TabsterDOMAttribute[]

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -4,7 +4,7 @@ import { Types } from 'tabster';
 /**
  * Merges a collection of tabster attributes.
  *
- * >⚠️The attributes passed as arguments to this  hook cannot change at runtime.
+ * ⚠️The attributes passed as arguments to this  hook cannot change at runtime.
  * @internal
  * @param attributes - collection of tabster attributes from other react-tabster hooks
  * @returns single merged tabster attribute

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -9,6 +9,7 @@ export {
   useTabsterAttributes,
   useObservedElement,
   useFocusObserved,
+  useMergedTabsterAttributes_unstable,
 } from './hooks/index';
 export type {
   UseArrowNavigationGroupOptions,
@@ -26,3 +27,6 @@ export type {
 } from './focus/index';
 
 export { applyFocusVisiblePolyfill } from './focus/index';
+import { Types as TabsterTypes } from 'tabster';
+
+export type TabsterDOMAttribute = TabsterTypes.TabsterDOMAttribute;


### PR DESCRIPTION
Implents a new hook `useTableCompositeNavigation` that provides the same kind of hybrid row/cell navigation provided by the [v0 table](https://fluentsite.z22.web.core.windows.net/0.66.2/components/table/definition?showCode=false&showRtl=false&showTransparent=false&showVariables=false#usage-navigable).

This hook is reused in the DataGrid with the new `composite` focusMode option.
