### PR TITLE
fix(scripts/generators): make sure to flush nx Tree outside nx context in order to write changes on physical file system

### DIFF
--- a/scripts/generators/create-package/index.ts
+++ b/scripts/generators/create-package/index.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'child_process';
 import * as path from 'path';
 
-import { PackageJson, findGitRoot, getProjectMetadata, tree } from '@fluentui/scripts-monorepo';
+import { PackageJson, findGitRoot, flushTreeChanges, getProjectMetadata, tree } from '@fluentui/scripts-monorepo';
 import { addProjectConfiguration } from '@nrwl/devkit';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
@@ -295,4 +295,6 @@ function updateNxProject(_answers: Answers, config: { projectName: string; proje
     projectType: 'library',
     implicitDependencies: [],
   });
+
+  flushTreeChanges();
 }

--- a/scripts/monorepo/src/index.d.ts
+++ b/scripts/monorepo/src/index.d.ts
@@ -10,4 +10,4 @@ export { getDefaultEnvironmentVars } from './getDefaultEnvironmentVars';
 export { getProjectMetadata, workspaceRoot, getUncommittedFiles, getUntrackedFiles } from './utils';
 export * as eslintConstants from './eslint-constants';
 export { getNthCommit } from './getNthCommit';
-export { tree } from './tree';
+export { tree, flushTreeChanges } from './tree';

--- a/scripts/monorepo/src/tree.js
+++ b/scripts/monorepo/src/tree.js
@@ -1,5 +1,7 @@
 const { workspaceRoot } = require('@nrwl/devkit');
-const { FsTree } = require('nx/src/generators/tree');
+const { FsTree, flushChanges } = require('nx/src/generators/tree');
+
 const tree = new FsTree(workspaceRoot, false);
 
+exports.flushTreeChanges = () => flushChanges(workspaceRoot, tree.listChanges());
 exports.tree = tree;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`yarn create-component` doesn't work after migration to nx 15.9 which introduced `project.json` per package instead global `workspace.json`. This change needed us to monkey patch how nx devkit is used outside nx environment, but we forgot to flush the virtual FS tree to real FS.

## New Behavior

`yarn create-component` does work

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #28032 
