### PR TITLE
react-tags: Add bundle size fixture for InteractionTag and TagGroup

### DIFF
--- a/packages/react-components/react-tags/bundle-size/InteractionTag.fixture.js
+++ b/packages/react-components/react-tags/bundle-size/InteractionTag.fixture.js
@@ -1,0 +1,7 @@
+import { InteractionTag } from '@fluentui/react-tags';
+
+console.log(InteractionTag);
+
+export default {
+  name: 'InteractionTag',
+};

--- a/packages/react-components/react-tags/bundle-size/TagGroup.fixture.js
+++ b/packages/react-components/react-tags/bundle-size/TagGroup.fixture.js
@@ -1,0 +1,7 @@
+import { TagGroup } from '@fluentui/react-tags';
+
+console.log(TagGroup);
+
+export default {
+  name: 'TagGroup',
+};


### PR DESCRIPTION
Add fixture for InteractionTag and TagGroup