### PR TITLE
fix: ToastTitle inverted should be visible in teams high contrast

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Toast/Toast.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Toast/Toast.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from '@fluentui/react-toast';
 import { Link } from '@fluentui/react-link';
 import { Steps, StoryWright } from 'storywright';
+import { DARK_MODE, HIGH_CONTRAST, RTL, getStoryVariant } from '../../utilities/getStoryVariant';
 
 export default {
   title: 'Toast',
@@ -86,6 +87,10 @@ export const FullToast = () => {
   );
 };
 
+export const FullToastDarkMode = getStoryVariant(FullToast, DARK_MODE);
+export const FullToastHighContrastMode = getStoryVariant(FullToast, HIGH_CONTRAST);
+export const FullToastRTL = getStoryVariant(FullToast, RTL);
+
 export const WithoutSubtitle = () => {
   const { dispatchToast } = useToastController();
   const { toastRef, onStatusChange } = useToastScreenshotData();
@@ -114,6 +119,10 @@ export const WithoutSubtitle = () => {
   );
 };
 
+export const WithoutSubtitleDarkMode = getStoryVariant(WithoutSubtitle, DARK_MODE);
+export const WithoutSubtitleHighContrastMode = getStoryVariant(WithoutSubtitle, HIGH_CONTRAST);
+export const WithoutSubtitleRTL = getStoryVariant(WithoutSubtitle, RTL);
+
 export const TitleOnly = () => {
   const { dispatchToast } = useToastController();
   const { toastRef, onStatusChange } = useToastScreenshotData();
@@ -136,6 +145,10 @@ export const TitleOnly = () => {
     </>
   );
 };
+
+export const TitleOnlyDarkMode = getStoryVariant(TitleOnly, DARK_MODE);
+export const TitleOnlyHighContrastMode = getStoryVariant(TitleOnly, HIGH_CONTRAST);
+export const TitleOnlyRTL = getStoryVariant(TitleOnly, RTL);
 
 export const FullToastInverted = () => {
   const { dispatchToast } = useToastController();
@@ -169,6 +182,9 @@ export const FullToastInverted = () => {
   );
 };
 
+export const FullToastInvertedDarkMode = getStoryVariant(FullToastInverted, DARK_MODE);
+export const FullToastInvertedHighContrastMode = getStoryVariant(FullToastInverted, HIGH_CONTRAST);
+
 export const WithoutSubtitleInverted = () => {
   const { dispatchToast } = useToastController();
   const { toastRef, onStatusChange } = useToastScreenshotData();
@@ -197,6 +213,9 @@ export const WithoutSubtitleInverted = () => {
   );
 };
 
+export const WithoutSubtitleInvertedDarkMode = getStoryVariant(WithoutSubtitleInverted, DARK_MODE);
+export const WithoutSubtitleInvertedHighContrastMode = getStoryVariant(WithoutSubtitleInverted, HIGH_CONTRAST);
+
 export const TitleOnlyInverted = () => {
   const { dispatchToast } = useToastController();
   const { toastRef, onStatusChange } = useToastScreenshotData();
@@ -219,3 +238,6 @@ export const TitleOnlyInverted = () => {
     </>
   );
 };
+
+export const TitleOnlyInvertedDarkMode = getStoryVariant(TitleOnlyInverted, DARK_MODE);
+export const TitleOnlyInvertedHighContrastMode = getStoryVariant(TitleOnlyInverted, HIGH_CONTRAST);

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -35,7 +35,7 @@ const useActionBaseClassName = makeResetStyles({
 
 const useInvertedStyles = makeStyles({
   root: {
-    color: tokens.colorNeutralForegroundInverted,
+    color: tokens.colorNeutralForegroundInverted2,
   },
 
   action: {


### PR DESCRIPTION
Uses colorNeutralForegroundInverted2 for ToastTitle color.

Also adds Dark, HC, RTL tests for Toast

Before
![image](https://github.com/microsoft/fluentui/assets/20744592/e23df1c4-2bf5-4f78-98f1-92b4a360a5f6)


After
![image](https://github.com/microsoft/fluentui/assets/20744592/d7a24052-3476-4f48-a38f-27b3f8d72ad3)
