### PR TITLE
fix(react-search): Fix zoom reflow

### DIFF
--- a/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -15,21 +15,21 @@ export const searchBoxClassNames: SlotClassNames<SearchBoxSlots> = {
 const useRootStyles = makeStyles({
   small: {
     columnGap: 0,
-    width: '468px',
+    maxWidth: '468px',
 
     paddingLeft: tokens.spacingHorizontalSNudge,
     paddingRight: tokens.spacingHorizontalSNudge,
   },
   medium: {
     columnGap: 0,
-    width: '468px',
+    maxWidth: '468px',
 
     paddingLeft: tokens.spacingHorizontalS,
     paddingRight: tokens.spacingHorizontalS,
   },
   large: {
     columnGap: 0,
-    width: '468px',
+    maxWidth: '468px',
 
     paddingLeft: tokens.spacingHorizontalMNudge,
     paddingRight: tokens.spacingHorizontalMNudge,


### PR DESCRIPTION
This PR fixes the zoom reflow (when the screen gets squished smaller than the width of the component, the component shrinks) issue identified in #28324.