### PR TITLE
docs(public-docsite): Add banner to controls page

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/ControlsPage/ControlsPage.tsx
+++ b/apps/public-docsite/src/pages/Overviews/ControlsPage/ControlsPage.tsx
@@ -13,6 +13,13 @@ import { getSubTitle } from '../../../utilities/index';
 import { ControlsPageProps } from './ControlsPage.doc';
 import { Platforms } from '../../../interfaces/Platforms';
 
+const webPlatformBanner = {
+  banner: {
+    title: 'Fluent UI v9',
+    message: 'Check out the all new [Fluent UI version 9](https://react.fluentui.dev)!',
+  },
+};
+
 const ControlsPageBase: React.FunctionComponent<IPageProps<Platforms>> = props => {
   const { platform } = props;
   return (
@@ -20,6 +27,7 @@ const ControlsPageBase: React.FunctionComponent<IPageProps<Platforms>> = props =
       {...props}
       title="Controls"
       platform={platform}
+      {...(props.platform === Platforms.web && webPlatformBanner)}
       subTitle={getSubTitle(platform!)}
       otherSections={_otherSections(platform!) as IPageSectionProps[]}
       showSideRail={false}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Website is missing the v9 banner when looking at the controls page and in the react section.

![image](https://github.com/microsoft/fluentui/assets/5953191/44b730fa-c015-4121-8fe6-8b5f8706be10)


## New Behavior

Website now has the v9 banner in all web platform pages.

![image](https://github.com/microsoft/fluentui/assets/5953191/777c6d3f-8001-4bd9-b2be-aeb44c385975)


