### PR TITLE
fix: Pivot overflow role uses tab

### DIFF
--- a/change/@fluentui-react-c502b5d8-9ae6-45d0-bf60-6e087207129c.json
+++ b/change/@fluentui-react-c502b5d8-9ae6-45d0-bf60-6e087207129c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use tab role for Pivot overflow button",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -47,7 +47,7 @@ const getLinkItems = (props: IPivotProps, pivotId: string): PivotLinkCollection 
       result.links.push({
         headerText: linkText,
         ...pivotItemProps,
-        itemKey: itemKey,
+        itemKey,
       });
       result.keyToIndexMapping[itemKey] = index;
       result.keyToTabIdMapping[itemKey] = getTabId(props, pivotId, itemKey, index);
@@ -298,6 +298,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
               menuProps={overflowMenuProps}
               menuIconProps={{ iconName: 'More', style: { color: 'inherit' } }}
               ariaLabel={overflowAriaLabel}
+              role="tab"
             />
           )}
         </FocusZone>

--- a/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -1851,6 +1851,7 @@ exports[`Pivot renders Pivot with overflow 1`] = `
       onKeyUp={[Function]}
       onMouseDown={[Function]}
       onMouseUp={[Function]}
+      role="tab"
       type="button"
     >
       <span


### PR DESCRIPTION
## Previous Behavior

We were exposing the overflow button as a menu button rather than a tab. The pros and cons of each approach are pretty even -- in functionality it's a menubutton, but it's more expected to encounter a tab within a tablist. The reason for this change is that a menubutton within a tablist triggers an automated error, and a tab does not, and also likely does not have meaningful known user-facing drawbacks. This will also match the semantics used in v9's TabList.

## New Behavior

The overflow button uses the tab role.

## Related Issue(s)

- Fixes [16426](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16426)
