### PR TITLE
fix: Toaster should play toasts on action dismiss

### DIFF
--- a/change/@fluentui-react-toast-32213210-a713-431e-96a7-befff4c5f4bb.json
+++ b/change/@fluentui-react-toast-32213210-a713-431e-96a7-befff4c5f4bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Toaster should play toasts on action dismiss",
+  "packageName": "@fluentui/react-toast",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toast/stories/Toast/DismissToastWithAction.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/DismissToastWithAction.stories.tsx
@@ -26,7 +26,7 @@ export const DismissToastWithAction = () => {
           Dismiss me
         </ToastTitle>
       </Toast>,
-      { timeout: -1, intent: 'success' },
+      { intent: 'success' },
     );
 
   return (

--- a/packages/react-components/react-toast/stories/Toast/ToastDescription.md
+++ b/packages/react-components/react-toast/stories/Toast/ToastDescription.md
@@ -1,16 +1,3 @@
-<!-- Don't allow prettier to collapse code block into single line -->
-<!-- prettier-ignore -->
-> **⚠️ Preview components are considered unstable:**
->
-> ```jsx
->
-> import { Toast } from '@fluentui/react-components/unstable';
->
-> ```
->
-> - Features and APIs may change before final release
-> - Please contact us if you intend to use this in your product
-
 A Toasts displays temporary content to the user. Toasts are rendered as a separate surface that can be dismissed by
 user action or a application timeout. Toasts are typically used in the following situations:
 


### PR DESCRIPTION
Due to facebook/react#25194, onBlur was never called when the toast was manually dismissed by focusing a trigger. Adds the `focusin` and `focusout` listeners to the HTMLElement to workaround this bug. Also adds a test to make sure that other toasts are resumed after dismiss.

Also removes the unstable warning for the component docs
