### PR TITLE
feat: Export useEventCallback and mergeCallbacks

### DIFF
--- a/change/@fluentui-react-components-456dce87-c14b-482d-8f3a-cd2e4fe113b2.json
+++ b/change/@fluentui-react-components-456dce87-c14b-482d-8f3a-cd2e4fe113b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Export useEventCallback and mergeCallbacks",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -399,6 +399,7 @@ import { MenuTriggerChildProps } from '@fluentui/react-menu';
 import { MenuTriggerContextProvider } from '@fluentui/react-menu';
 import { MenuTriggerProps } from '@fluentui/react-menu';
 import { MenuTriggerState } from '@fluentui/react-menu';
+import { mergeCallbacks } from '@fluentui/react-utilities';
 import { mergeClasses } from '@griffel/react';
 import { OnOpenChangeData } from '@fluentui/react-popover';
 import { OnVisibleChangeData } from '@fluentui/react-tooltip';
@@ -906,6 +907,7 @@ import { useDivider_unstable } from '@fluentui/react-divider';
 import { useDividerStyles_unstable } from '@fluentui/react-divider';
 import { useDropdown_unstable } from '@fluentui/react-combobox';
 import { useDropdownStyles_unstable } from '@fluentui/react-combobox';
+import { useEventCallback } from '@fluentui/react-utilities';
 import { useField_unstable } from '@fluentui/react-field';
 import { useFieldContext_unstable } from '@fluentui/react-field';
 import { useFieldContextValues_unstable } from '@fluentui/react-field';
@@ -1880,6 +1882,8 @@ export { MenuTriggerContextProvider }
 export { MenuTriggerProps }
 
 export { MenuTriggerState }
+
+export { mergeCallbacks }
 
 export { mergeClasses }
 
@@ -2894,6 +2898,8 @@ export { useDividerStyles_unstable }
 export { useDropdown_unstable }
 
 export { useDropdownStyles_unstable }
+
+export { useEventCallback }
 
 export { useField_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -102,6 +102,8 @@ export {
   SSRProvider,
   useId,
   useIsomorphicLayoutEffect,
+  useEventCallback,
+  mergeCallbacks,
   useIsSSR,
   useMergedRefs,
   useScrollbarWidth,


### PR DESCRIPTION
Export these utilities so that they can be reused for the [react-chat component](https://github.com/microsoft/fluentui-contrib/tree/main/packages/react-chat)