### PR TITLE
feat(tools): remove configuration filters and apply workspace dependency rules automatically withn normalize-package-dependencies generator

### DIFF
--- a/tools/generators/normalize-package-dependencies/README.md
+++ b/tools/generators/normalize-package-dependencies/README.md
@@ -13,8 +13,6 @@ Workspace Generator for package.json dependencies normalization.
   - [Examples](#examples)
 - [Options](#options)
   - [`verify`](#verify)
-  - [`projectType`](#projecttype)
-  - [`tag`](#tag)
 
 <!-- tocstop -->
 
@@ -40,16 +38,4 @@ yarn nx workspace-generator normalize-package-dependencies
 
 #### `verify`
 
-Run generator in check(verification mode). Verify package.json dependencies for all projects or filtered projects (if filters are applied)
-
-#### `projectType`
-
-Type: `application | library | any`
-
-Filter flag. Use to apply generator execution only on projects that contain provided `projectType` within their `project.json#projectType`.
-
-#### `tag`
-
-Type: `string`
-
-Filter flag. Use to apply generator execution only on projects that contain provided tag within their `project.json#tags`.
+Run generator in check(verification mode). Verify package.json dependencies for all projects.

--- a/tools/generators/normalize-package-dependencies/index.ts
+++ b/tools/generators/normalize-package-dependencies/index.ts
@@ -103,7 +103,7 @@ function getVersion(deps: Record<string, string>, packageName: string) {
   const updated = semver.prerelease(current) ? '>=9.0.0-alpha' : '*';
   const match = current === updated;
 
-  return { current, updated, match };
+  return { updated, match };
 }
 
 function getPackageJsonDependenciesIssues(

--- a/tools/generators/normalize-package-dependencies/schema.json
+++ b/tools/generators/normalize-package-dependencies/schema.json
@@ -4,16 +4,6 @@
   "id": "normalize-package-dependencies",
   "type": "object",
   "properties": {
-    "projectType": {
-      "type": "string",
-      "description": "Filter flag. Use to apply generator execution only on projects that contain provided `projectType` within their `project.json#projectType`.",
-      "enum": ["application", "library", "any"],
-      "default": "any"
-    },
-    "tag": {
-      "type": "string",
-      "description": "Filter flag. Use to apply generator execution only on projects that contain provided tag within their `project.json#tags`."
-    },
     "verify": {
       "type": "boolean",
       "description": "Run generator in check(verification mode). Verify package.json dependencies for all projects or filtered projects (if filters are applied)"

--- a/tools/generators/normalize-package-dependencies/schema.ts
+++ b/tools/generators/normalize-package-dependencies/schema.ts
@@ -1,13 +1,5 @@
 export interface NormalizePackageDependenciesGeneratorSchema {
   /**
-   * Filter flag. Use to apply generator execution only on projects that contain provided `projectType` within their `project.json#projectType`.
-   */
-  projectType?: 'application' | 'library' | 'any';
-  /**
-   * Filter flag. Use to apply generator execution only on projects that contain provided tag within their `project.json#tags`.
-   */
-  tag?: string;
-  /**
    * Run generator in check(verification mode). Verify package.json dependencies for all projects or filtered projects (if filters are applied)
    */
   verify?: boolean;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

- based on feedback the generator was simplified to run only on set ruleset without configuration options (filters)
- updates all deps within `applications`/ devDeps only within `libraries` (https://github.com/microsoft/fluentui/pull/28382#discussion_r1251704490)
- packages that use prerelase version will not use `*` but instead `>=9.0.0-alpha`, this is only option to make `yarn` pass as expected

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/28382
- Partially implements https://github.com/microsoft/fluentui/issues/28461
