### PR TITLE
Default pointer-events to 'none' for focus rectangles

### DIFF
--- a/change/@fluentui-react-8d5952ad-7979-4a9c-bae9-f37a22caf598.json
+++ b/change/@fluentui-react-8d5952ad-7979-4a9c-bae9-f37a22caf598.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass-through pointer events in Details Row focus rects",
+  "packageName": "@fluentui/react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/react/src/components/DetailsList/DetailsRow.styles.ts
@@ -113,6 +113,7 @@ export const getDetailsRowStyles = (props: IDetailsRowStyleProps): IDetailsRowSt
       borderColor: focusBorder,
       outlineColor: white,
       highContrastStyle: rowHighContrastFocus,
+      pointerEvents: 'none',
     }),
     classNames.isSelected,
     {


### PR DESCRIPTION
## Previous Behavior

In the `DetailsList`, if focus is on a row and focus rectangles are visible, a Link within a cell cannot be clicked, because the events are intercepted by the `:after` element on the row.

## New Behavior

The focus rectangles supplied by `:after` now have `pointer-events: none` so that the clicks are not intercepted.


This appears to have been a regression some time within the last several months.