### PR TITLE
Fix rtl not being applied in HorizontalBarChart

### DIFF
--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -40,7 +40,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
   private _calloutId: string;
   private _refArray: IRefArrayData[];
   private _calloutAnchorPoint: IChartDataPoint | null;
-  private _isRTL: boolean = getRTL();
+  private _isRTL: boolean = getRTL(this.props.theme);
 
   constructor(props: IHorizontalBarChartProps) {
     super(props);


### PR DESCRIPTION
Bug captured in discussion here: https://github.com/microsoft/fluentui/discussions/28436

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Setting `rtl` on HorizontalBarChart did not flip its axis and labels.

![image](https://github.com/microsoft/fluentui/assets/6162428/cbb9c869-0b50-46fe-8bac-ba0d71ffc2fe)

## New Behavior

Setting `rtl` on HorizontalBaseChart flips bars as expected.

![image](https://github.com/microsoft/fluentui/assets/6162428/855301ad-46ff-422c-98e7-9e5c5360cef5)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes issue described in https://github.com/microsoft/fluentui/discussions/28436
