### PR TITLE
feat: Deprecate @fluentui/react-data-grid-react-window

### DIFF
--- a/change/@fluentui-react-data-grid-react-window-ea106fe9-63cf-4abb-9d28-d20283720fb5.json
+++ b/change/@fluentui-react-data-grid-react-window-ea106fe9-63cf-4abb-9d28-d20283720fb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Deprecates package in favour of @fluentui-contrib/react-data-grid-react-window",
+  "packageName": "@fluentui/react-data-grid-react-window",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-data-grid-react-window/README.md
+++ b/packages/react-components/react-data-grid-react-window/README.md
@@ -1,5 +1,3 @@
 # @fluentui/react-data-grid-react-window
 
-**React Data Grid React Window components for [Fluent UI React](https://react.fluentui.dev/)**
-
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+**This package is deprecated - please use [@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/@fluentui-contrib/react-data-grid-react-window) instead**

--- a/packages/react-components/react-data-grid-react-window/etc/react-data-grid-react-window.api.md
+++ b/packages/react-components/react-data-grid-react-window/etc/react-data-grid-react-window.api.md
@@ -27,7 +27,7 @@ export const DataGrid: ForwardRefComponent<DataGridProps>;
 // @public @deprecated (undocumented)
 export const DataGridBody: ForwardRefComponent<DataGridBodyProps> & (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element);
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export type DataGridBodyProps<TItem = unknown> = Omit<DataGridBodyProps_2, 'children'> & {
     itemSize: number;
     height: number;
@@ -59,7 +59,7 @@ export { DataGridSelectionCell }
 
 export { DataGridSelectionCellProps }
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export type RowRenderer<TItem = unknown> = (row: TableRowData<TItem>, style: React_2.CSSProperties) => React_2.ReactNode;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-components/react-data-grid-react-window/etc/react-data-grid-react-window.api.md
+++ b/packages/react-components/react-data-grid-react-window/etc/react-data-grid-react-window.api.md
@@ -21,13 +21,13 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { TableRowData } from '@fluentui/react-table';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const DataGrid: ForwardRefComponent<DataGridProps>;
 
-// @public
+// @public @deprecated (undocumented)
 export const DataGridBody: ForwardRefComponent<DataGridBodyProps> & (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element);
 
-// @public
+// @public @deprecated (undocumented)
 export type DataGridBodyProps<TItem = unknown> = Omit<DataGridBodyProps_2, 'children'> & {
     itemSize: number;
     height: number;
@@ -50,7 +50,7 @@ export { DataGridHeaderProps }
 
 export { DataGridProps }
 
-// @public
+// @public @deprecated (undocumented)
 export const DataGridRow: ForwardRefComponent<DataGridRowProps> & (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element);
 
 export { DataGridRowProps }
@@ -59,7 +59,7 @@ export { DataGridSelectionCell }
 
 export { DataGridSelectionCellProps }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type RowRenderer<TItem = unknown> = (row: TableRowData<TItem>, style: React_2.CSSProperties) => React_2.ReactNode;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGrid/DataGrid.tsx
@@ -8,6 +8,9 @@ import {
 import type { DataGridProps } from '@fluentui/react-table';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
+/**
+ * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
+ */
 export const DataGrid: ForwardRefComponent<DataGridProps> = React.forwardRef((props, ref) => {
   const state = useDataGrid_unstable(props, ref);
 

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGrid/DataGrid.tsx
@@ -18,4 +18,5 @@ export const DataGrid: ForwardRefComponent<DataGridProps> = React.forwardRef((pr
   return renderDataGrid_unstable(state, useDataGridContextValues_unstable(state));
 });
 
+// eslint-disable-next-line deprecation/deprecation
 DataGrid.displayName = 'DataGrid';

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.tsx
@@ -16,4 +16,5 @@ export const DataGridBody: ForwardRefComponent<DataGridBodyProps> &
   return renderDataGridBody_unstable(state);
 }) as ForwardRefComponent<DataGridBodyProps> & (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element);
 
+// eslint-disable-next-line deprecation/deprecation
 DataGridBody.displayName = 'DataGridBody';

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.tsx
@@ -6,7 +6,7 @@ import { renderDataGridBody_unstable } from './renderDataGridBody';
 import type { DataGridBodyProps } from './DataGridBody.types';
 
 /**
- * DataGridBody component
+ * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
  */
 export const DataGridBody: ForwardRefComponent<DataGridBodyProps> &
   (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element) = React.forwardRef((props, ref) => {

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
@@ -9,10 +9,13 @@ import { ListChildComponentProps } from 'react-window';
 
 export type DataGridBodySlots = DataGridBodySlotsBase;
 
+/**
+ * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
+ */
 export type RowRenderer<TItem = unknown> = (row: TableRowData<TItem>, style: React.CSSProperties) => React.ReactNode;
 
 /**
- * DataGridBody Props
+ * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
  */
 export type DataGridBodyProps<TItem = unknown> = Omit<DataGridBodyPropsBase, 'children'> & {
   /**

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridBody/DataGridBody.types.ts
@@ -9,14 +9,8 @@ import { ListChildComponentProps } from 'react-window';
 
 export type DataGridBodySlots = DataGridBodySlotsBase;
 
-/**
- * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
- */
 export type RowRenderer<TItem = unknown> = (row: TableRowData<TItem>, style: React.CSSProperties) => React.ReactNode;
 
-/**
- * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
- */
 export type DataGridBodyProps<TItem = unknown> = Omit<DataGridBodyPropsBase, 'children'> & {
   /**
    * The size of each row

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridRow/DataGridRow.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridRow/DataGridRow.tsx
@@ -5,7 +5,7 @@ import type { DataGridRowProps } from '@fluentui/react-table';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
 /**
- * DataGridRow component
+ * @deprecated - please use [\@fluentui-contrib/react-data-grid-react-window](https://www.npmjs.com/package/\@fluentui-contrib/react-data-grid-react-window) instead
  */
 export const DataGridRow: ForwardRefComponent<DataGridRowProps> &
   (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element) = React.forwardRef((props, ref) => {

--- a/packages/react-components/react-data-grid-react-window/src/components/DataGridRow/DataGridRow.tsx
+++ b/packages/react-components/react-data-grid-react-window/src/components/DataGridRow/DataGridRow.tsx
@@ -15,4 +15,5 @@ export const DataGridRow: ForwardRefComponent<DataGridRowProps> &
   return renderDataGridRow_unstable(state);
 }) as ForwardRefComponent<DataGridRowProps> & (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element);
 
+// eslint-disable-next-line deprecation/deprecation
 DataGridRow.displayName = 'DataGridRow';

--- a/packages/react-components/react-data-grid-react-window/src/index.ts
+++ b/packages/react-components/react-data-grid-react-window/src/index.ts
@@ -1,5 +1,8 @@
+// eslint-disable-next-line deprecation/deprecation
 export { DataGridBody } from './DataGridBody';
+// eslint-disable-next-line deprecation/deprecation
 export { DataGrid } from './DataGrid';
+// eslint-disable-next-line deprecation/deprecation
 export { DataGridRow } from './DataGridRow';
 
 export { DataGridCell, DataGridHeader, DataGridHeaderCell, DataGridSelectionCell } from '@fluentui/react-table';

--- a/packages/react-components/react-table/stories/DataGrid/Virtualization.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Virtualization.stories.tsx
@@ -1,204 +1,10 @@
 import * as React from 'react';
-import {
-  FolderRegular,
-  EditRegular,
-  OpenRegular,
-  DocumentRegular,
-  PeopleRegular,
-  DocumentPdfRegular,
-  VideoRegular,
-  MoreHorizontalRegular,
-} from '@fluentui/react-icons';
-import {
-  TableColumnDefinition,
-  createTableColumn,
-  TableCellLayout,
-  PresenceBadgeStatus,
-  Avatar,
-  useScrollbarWidth,
-  useFluent,
-  TableCellActions,
-  Menu,
-  MenuTrigger,
-  MenuItem,
-  MenuList,
-  MenuPopover,
-  Button,
-} from '@fluentui/react-components';
-import {
-  DataGridBody,
-  DataGrid,
-  DataGridRow,
-  DataGridHeader,
-  DataGridCell,
-  DataGridHeaderCell,
-  RowRenderer,
-} from '@fluentui/react-data-grid-react-window';
-
-type FileCell = {
-  label: string;
-  icon: JSX.Element;
-};
-
-type LastUpdatedCell = {
-  label: string;
-  timestamp: number;
-};
-
-type LastUpdateCell = {
-  label: string;
-  icon: JSX.Element;
-};
-
-type AuthorCell = {
-  label: string;
-  status: PresenceBadgeStatus;
-};
-
-type Item = {
-  index: number;
-  file: FileCell;
-  author: AuthorCell;
-  lastUpdated: LastUpdatedCell;
-  lastUpdate: LastUpdateCell;
-};
-
-const baseItems = [
-  {
-    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
-    author: { label: 'Max Mustermann', status: 'available' },
-    lastUpdated: { label: '7h ago', timestamp: 1 },
-    lastUpdate: {
-      label: 'You edited this',
-      icon: <EditRegular />,
-    },
-  },
-  {
-    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
-    author: { label: 'Erika Mustermann', status: 'busy' },
-    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
-    lastUpdate: {
-      label: 'You recently opened this',
-      icon: <OpenRegular />,
-    },
-  },
-  {
-    file: { label: 'Training recording', icon: <VideoRegular /> },
-    author: { label: 'John Doe', status: 'away' },
-    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
-    lastUpdate: {
-      label: 'You recently opened this',
-      icon: <OpenRegular />,
-    },
-  },
-  {
-    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
-    author: { label: 'Jane Doe', status: 'offline' },
-    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
-    lastUpdate: {
-      label: 'You shared this in a Teams chat',
-      icon: <PeopleRegular />,
-    },
-  },
-];
-
-const items = new Array(1500).fill(0).map((_, i) => ({ ...baseItems[i % baseItems.length], index: i }));
-
-const columns: TableColumnDefinition<Item>[] = [
-  createTableColumn<Item>({
-    columnId: 'file',
-    compare: (a, b) => {
-      return a.file.label.localeCompare(b.file.label);
-    },
-    renderHeaderCell: () => {
-      return 'File';
-    },
-    renderCell: item => {
-      return (
-        <TableCellLayout media={item.file.icon}>
-          <strong>[{item.index}] </strong>
-          {item.file.label}
-          <TableCellActions>
-            <Menu>
-              <MenuTrigger>
-                <Button appearance="subtle" aria-label="more" icon={<MoreHorizontalRegular />} />
-              </MenuTrigger>
-
-              <MenuPopover>
-                <MenuList>
-                  <MenuItem>Item</MenuItem>
-                  <MenuItem>Item</MenuItem>
-                  <MenuItem>Item</MenuItem>
-                </MenuList>
-              </MenuPopover>
-            </Menu>
-          </TableCellActions>
-        </TableCellLayout>
-      );
-    },
-  }),
-  createTableColumn<Item>({
-    columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
-    renderHeaderCell: () => {
-      return 'Author';
-    },
-    renderCell: item => {
-      return (
-        <TableCellLayout media={<Avatar badge={{ status: item.author.status }} />}>{item.author.label}</TableCellLayout>
-      );
-    },
-  }),
-  createTableColumn<Item>({
-    columnId: 'lastUpdated',
-    compare: (a, b) => {
-      return a.lastUpdated.timestamp - b.lastUpdated.timestamp;
-    },
-    renderHeaderCell: () => {
-      return 'Last updated';
-    },
-
-    renderCell: item => {
-      return item.lastUpdated.label;
-    },
-  }),
-  createTableColumn<Item>({
-    columnId: 'lastUpdate',
-    compare: (a, b) => {
-      return a.lastUpdate.label.localeCompare(b.lastUpdate.label);
-    },
-    renderHeaderCell: () => {
-      return 'Last update';
-    },
-    renderCell: item => {
-      return <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>;
-    },
-  }),
-];
-
-const renderRow: RowRenderer<Item> = ({ item, rowId }, style) => (
-  <DataGridRow<Item> key={rowId} style={style}>
-    {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
-  </DataGridRow>
-);
-
 export const Virtualization = () => {
-  const { targetDocument } = useFluent();
-  const scrollbarWidth = useScrollbarWidth({ targetDocument });
-
   return (
-    <DataGrid items={items} columns={columns} focusMode="cell" sortable selectionMode="multiselect">
-      <DataGridHeader style={{ paddingRight: scrollbarWidth }}>
-        <DataGridRow>
-          {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
-        </DataGridRow>
-      </DataGridHeader>
-      <DataGridBody<Item> itemSize={50} height={400}>
-        {renderRow}
-      </DataGridBody>
-    </DataGrid>
+    <iframe
+      style={{ width: '100%', height: 500, border: 'none' }}
+      src="https://microsoft.github.io/fluentui-contrib/react-data-grid-react-window/iframe.html?id=datagrid--virtualized-data-grid&viewMode=story"
+    />
   );
 };
 
@@ -207,11 +13,16 @@ Virtualization.parameters = {
     description: {
       story: [
         'Virtualizating the DataGrid component involves recomposing components to use a virtualized container.',
-        'This is already done in the extension package `@fluentui/react-data-grid-react-window` which provides',
+        'This is already done in the extension package `@fluentui-contrib/react-data-grid-react-window` which provides',
         'extended DataGrid components that are powered',
         'by [react-window](https://react-window.vercel.app/#/examples/list/fixed-size).',
         '',
         'The example below shows how to use this extension package to virtualize the DataGrid component.',
+        '',
+        'Here some useful links for the package:',
+        '- [Storybook documentation](https://microsoft.github.io/fluentui-contrib/react-data-grid-react-window/?path=/story/datagrid--virtualized-data-grid)',
+        '- [NPM page](https://www.npmjs.com/package/@fluentui-contrib/react-data-grid-react-window)',
+        '- [README](https://github.com/microsoft/fluentui-contrib/blob/main/packages/react-data-grid-react-window/README.md)',
         '',
         '> ⚠️ Make sure to memoize the row render function to avoid excessive unmouting/mounting of components.',
         'react-window will [create components based on this renderer](https://react-window.vercel.app/#/api/FixedSizeList)',


### PR DESCRIPTION
Deprecates this package in favour of
`@fluentui-contrib/react-data-grid-react-window` and updates documtation and README
