### PR TITLE
feat(tools): update/verify packages that changed versioning approach from pre-release to standard to accommodate proper dependency definitions

### DIFF
--- a/tools/generators/normalize-package-dependencies/index.ts
+++ b/tools/generators/normalize-package-dependencies/index.ts
@@ -9,6 +9,7 @@ import {
   logger,
   createProjectGraphAsync,
   ProjectGraph,
+  readProjectConfiguration,
 } from '@nrwl/devkit';
 import * as semver from 'semver';
 
@@ -17,6 +18,9 @@ import { PackageJson } from '../../types';
 import * as chalk from 'chalk';
 
 type ProjectIssues = { [projectName: string]: { [depName: string]: string } };
+
+const NORMALIZED_INNER_WORKSPACE_VERSION = '*';
+const NORMALIZED_PRERELEASE_RANGE_VERSION = '>=9.0.0-alpha';
 
 export default async function (tree: Tree, schema: NormalizePackageDependenciesGeneratorSchema) {
   const normalizedOptions = normalizeOptions(tree, schema);
@@ -69,7 +73,7 @@ function normalizePackageJsonDependencies(tree: Tree, projectConfig: ProjectConf
 
     for (const packageName in deps) {
       if (isProjectDependencyAnWorkspaceProject(graph, packageName, projectDependencies)) {
-        const { updated } = getVersion(deps, packageName);
+        const { updated } = getVersion(tree, deps, packageName);
         deps[packageName] = updated;
       }
     }
@@ -92,18 +96,37 @@ function reportPackageJsonDependenciesIssues(issues: ProjectIssues) {
     logger.log('');
   });
 
-  logger.info(`All these dependencies version should be specified as '*'`);
+  logger.info(
+    `All these dependencies version should be specified as '${NORMALIZED_INNER_WORKSPACE_VERSION}' or '${NORMALIZED_PRERELEASE_RANGE_VERSION}' `,
+  );
   logger.info(`Fix this by running 'nx workspace-generator normalize-package-dependencies'`);
 
   throw new Error('package dependency violations found');
 }
 
-function getVersion(deps: Record<string, string>, packageName: string) {
+function getVersion(tree: Tree, deps: Record<string, string>, packageName: string) {
   const current = deps[packageName];
-  const updated = semver.prerelease(current) ? '>=9.0.0-alpha' : '*';
+  const updated = getUpdatedVersion(current);
+
   const match = current === updated;
 
   return { updated, match };
+
+  function getUpdatedVersion(currentVersion: string) {
+    if (currentVersion === NORMALIZED_PRERELEASE_RANGE_VERSION) {
+      const prereleasePkg = readProjectConfiguration(tree, packageName);
+      const prereleasePkgJson = readJson<PackageJson>(tree, joinPathFragments(prereleasePkg.root, 'package.json'));
+      const isPrerelease = semver.prerelease(prereleasePkgJson.version) !== null;
+
+      return isPrerelease ? NORMALIZED_PRERELEASE_RANGE_VERSION : NORMALIZED_INNER_WORKSPACE_VERSION;
+    }
+
+    if (semver.prerelease(current)) {
+      return NORMALIZED_PRERELEASE_RANGE_VERSION;
+    }
+
+    return NORMALIZED_INNER_WORKSPACE_VERSION;
+  }
 }
 
 function getPackageJsonDependenciesIssues(
@@ -133,7 +156,7 @@ function getPackageJsonDependenciesIssues(
 
     // eslint-disable-next-line guard-for-in
     for (const packageName in deps) {
-      const { match } = getVersion(deps, packageName);
+      const { match } = getVersion(tree, deps, packageName);
 
       if (isProjectDependencyAnWorkspaceProject(graph, packageName, projectDependencies) && !match) {
         issues = issues ?? {};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

if version was set to `>=9.0.0-alpha` already and package migrated to standard versioning policy, we dont update deps nor trigger error in `verify` mode.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

as we will be migrating away from pre-releases we need to update our dependency versions as well. This change to the generator adds that feature.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/28430
- Implements partially https://github.com/microsoft/fluentui/issues/28461
