### PR TITLE
Fix contrast issues in V8 Fluent2 Dark Theme

### DIFF
--- a/change/@fluentui-fluent2-theme-ef95a929-6b64-477a-a5b8-9a5b59e53221.json
+++ b/change/@fluentui-fluent2-theme-ef95a929-6b64-477a-a5b8-9a5b59e53221.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure fluent2 dark theme isInverted:true, set primary fluent2darktheme button color to match light theme",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Button.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Button.styles.ts
@@ -88,6 +88,9 @@ export function getPrimaryButtonStyles(theme: ITheme): Partial<IButtonStyles> {
     description: {
       color: semanticColors.primaryButtonText,
     },
+    descriptionHovered: {
+      color: semanticColors.primaryButtonText,
+    },
   };
 
   return styles;

--- a/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
@@ -3,6 +3,7 @@ import { createTheme } from '@fluentui/react';
 import { IExtendedEffects, IExtendedSemanticColors } from './types';
 import { fluent2ComponentStyles } from './fluent2ComponentStyles';
 import { fluent2SharedColors } from './fluent2SharedColors';
+import { Fluent2WebLightTheme } from './fluent2WebLightTheme';
 
 const fluent2ForV8DarkEffects: IExtendedEffects = {
   elevation4: '0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
@@ -56,6 +57,9 @@ const p = fluent2ForV8DarkPalette;
 const grey36 = '#5C5C5C';
 
 const semanticColorMappingOverridesForDark: Partial<IExtendedSemanticColors> = {
+  // Primary button is unique, it's background color is shared across themes
+  primaryButtonBackground: Fluent2WebLightTheme.semanticColors.primaryButtonBackground,
+
   // This hex matches the v9 theme.
   link: p.themeDark,
 
@@ -104,4 +108,5 @@ export const Fluent2WebDarkTheme: ITheme = createTheme({
   semanticColors: semanticColorMappingOverridesForDark,
   components: fluent2ComponentStyles,
   effects: fluent2ForV8DarkEffects,
+  isInverted: true,
 });

--- a/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
@@ -59,6 +59,8 @@ const grey36 = '#5C5C5C';
 const semanticColorMappingOverridesForDark: Partial<IExtendedSemanticColors> = {
   // Primary button is unique, it's background color is shared across themes
   primaryButtonBackground: Fluent2WebLightTheme.semanticColors.primaryButtonBackground,
+  primaryButtonBackgroundHovered: Fluent2WebLightTheme.semanticColors.primaryButtonBackgroundHovered,
+  primaryButtonBackgroundPressed: Fluent2WebLightTheme.semanticColors.primaryButtonBackgroundPressed,
 
   // This hex matches the v9 theme.
   link: p.themeDark,

--- a/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
+++ b/packages/fluent2-theme/src/fluent2WebDarkTheme.ts
@@ -58,9 +58,9 @@ const grey36 = '#5C5C5C';
 
 const semanticColorMappingOverridesForDark: Partial<IExtendedSemanticColors> = {
   // Primary button is unique, it's background color is shared across themes
-  primaryButtonBackground: Fluent2WebLightTheme.semanticColors.primaryButtonBackground,
-  primaryButtonBackgroundHovered: Fluent2WebLightTheme.semanticColors.primaryButtonBackgroundHovered,
-  primaryButtonBackgroundPressed: Fluent2WebLightTheme.semanticColors.primaryButtonBackgroundPressed,
+  primaryButtonBackgroundHovered: Fluent2WebLightTheme.palette.themePrimary,
+  primaryButtonBackgroundPressed: Fluent2WebLightTheme.palette.themeDarker,
+  primaryButtonBackground: Fluent2WebLightTheme.palette.themeDarkAlt,
 
   // This hex matches the v9 theme.
   link: p.themeDark,


### PR DESCRIPTION
## Previous Behavior
Fluent2 Dark Theme for V8 did not respect 'isInverted' flag and used lightmode high-contrast colors for background in some scenarios (message bar warnings etc.)
Primary button color was a slightly lighter shade in dark theme.

## New Behavior
IsInverted: true set on Fluent 2 Dark Theme for v8, all background colors should now be appropriate lower-contrast colors.
Primary button color is the same on V8 Fluent 2 dark and light themes.

## Related Issue(s)
- Fixes #28455 
- Fixes #28454