### PR TITLE
Changes How Component Imports Button Options

### DIFF
--- a/change/@fluentui-web-components-c08984aa-b18a-4f04-8b96-346bfab7c1bd.json
+++ b/change/@fluentui-web-components-c08984aa-b18a-4f04-8b96-346bfab7c1bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Changes how toggleButton imports Button component options.",
+  "packageName": "@fluentui/web-components",
+  "email": "harankin@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/src/toggle-button/toggle-button.options.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.options.ts
@@ -1,5 +1,5 @@
 import { ButtonOptions, ValuesOf } from '@microsoft/fast-foundation';
-import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
+import { ButtonAppearance, ButtonShape, ButtonSize } from '@fluentui/web-components';
 
 /**
  * Toggle Button Appearance constants


### PR DESCRIPTION
Imports Button options from @fluentui/web-components instead of using relative path to Button.
This does NOT alter the functionality of ToggleButton.

When wrapping this component in React or Angular, the component does not successfully render a shadow DOM. This PR is an attempt to clean up implementation in the web component to fix the rendering issue.