### PR TITLE
chore: Exporting MENU_ENTER_EVENT and dispatchMenuEnterEvent utilities from @fluentui/react-menu

### DIFF
--- a/change/@fluentui-react-menu-f1d69af6-f08c-4798-9e3e-f6b558ea2553.json
+++ b/change/@fluentui-react-menu-f1d69af6-f08c-4798-9e3e-f6b558ea2553.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Exporting MENU_ENTER_EVENT and dispatchMenuEnterEvent utilities.",
+  "packageName": "@fluentui/react-menu",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -24,7 +24,13 @@ import type { TriggerProps } from '@fluentui/react-utilities';
 import type { UseOnClickOrScrollOutsideOptions } from '@fluentui/react-utilities';
 
 // @public
+export const dispatchMenuEnterEvent: (el: HTMLElement, nativeEvent: MouseEvent) => void;
+
+// @public
 export const Menu: React_2.FC<MenuProps>;
+
+// @public
+export const MENU_ENTER_EVENT = "fuimenuenter";
 
 // @public (undocumented)
 export type MenuCheckedValueChangeData = {

--- a/packages/react-components/react-menu/src/index.ts
+++ b/packages/react-components/react-menu/src/index.ts
@@ -117,4 +117,4 @@ export {
 } from './MenuItemLink';
 export type { MenuItemLinkProps, MenuItemLinkSlots, MenuItemLinkState } from './MenuItemLink';
 
-export { useOnMenuMouseEnter } from './utils';
+export { MENU_ENTER_EVENT, dispatchMenuEnterEvent, useOnMenuMouseEnter } from './utils';

--- a/packages/react-components/react-menu/src/utils/useOnMenuEnter.ts
+++ b/packages/react-components/react-menu/src/utils/useOnMenuEnter.ts
@@ -62,8 +62,8 @@ export const useOnMenuMouseEnter = (options: UseOnClickOrScrollOutsideOptions) =
 
 /**
  * Dispatches the custom MouseEvent enter event. Similar to calling `el.click()`
- * @param el element for the event target
- * @param nativeEvent the native mouse event this is mapped to
+ * @param el - element for the event target
+ * @param nativeEvent - the native mouse event this is mapped to
  */
 export const dispatchMenuEnterEvent = (el: HTMLElement, nativeEvent: MouseEvent) => {
   el.dispatchEvent(new CustomEvent(MENU_ENTER_EVENT, { bubbles: true, detail: { nativeEvent } }));


### PR DESCRIPTION
## PR Description

This PR exports the `MENU_ENTER_EVENT` and the `dispatchMenuEnterEvent` utilities from `@fluentui/react-menu`. These utilities are needed in order to be able to properly use `useOnMenuMouseEnter` in most circumstances.