### PR TITLE
fix(web-components): add check in toggle button to ensure setAttribute is not called before connectedCallback

### DIFF
--- a/change/@fluentui-web-components-ce49d0a8-e88e-4b52-81ed-24d9badc8cab.json
+++ b/change/@fluentui-web-components-ce49d0a8-e88e-4b52-81ed-24d9badc8cab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(web-components): check if component is connected before calling setAttribute in attribute changed callback",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/toggle-button/toggle-button.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.ts
@@ -47,6 +47,10 @@ export class ToggleButton extends Button {
   @observable
   public checked: boolean = false;
   protected checkedChanged(prev: boolean | undefined, next: boolean): void {
+    if (!this.$fastController.isConnected) {
+      return;
+    }
+
     if (!this.dirtyChecked) {
       this.dirtyChecked = true;
     }


### PR DESCRIPTION
## Previous Behavior
The component could error out as setAttribute could be called incorrectly.

## New Behavior
No error as we check that the $fastController is called before we invoke setAttribute.

## Related Issue(s)
n/a