### PR TITLE
X bars showing incorrect data when the values are large- bug 8380

### DIFF
--- a/change/@fluentui-react-charting-23ac9e54-88e2-456f-abde-468868ed7d1a.json
+++ b/change/@fluentui-react-charting-23ac9e54-88e2-456f-abde-468868ed7d1a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix for bug 8380",
+  "comment": "X bars showing incorrect data when the values are large- bug 8380",
   "packageName": "@fluentui/react-charting",
   "email": "ankityadav@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-charting-23ac9e54-88e2-456f-abde-468868ed7d1a.json
+++ b/change/@fluentui-react-charting-23ac9e54-88e2-456f-abde-468868ed7d1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for bug 8380",
+  "packageName": "@fluentui/react-charting",
+  "email": "ankityadav@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
@@ -396,6 +396,7 @@ export class HorizontalBarChartWithAxisBase extends React.Component<
 
       const xBarScale = d3ScaleLinear()
         .domain(this._isRtl ? [xMax, 0] : [0, xMax])
+        .nice()
         .range([this.margins.left!, containerWidth - this.margins.right!]);
       return { xBarScale, yBarScale };
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x ] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Data for the chart:
{
        y: 'String j',
        x: 81000,
        color: DefaultPalette.blue,
      },
      {
        y: 'String k',
        x: 19000,
        color: DefaultPalette.blue,
      },

![hbcwa-before](https://github.com/microsoft/fluentui/assets/103660888/c1b1d0b0-ff08-4226-93ce-5657d7f838d7)

<!-- This is the behavior we have today -->

## New Behavior
![hbcwa-after](https://github.com/microsoft/fluentui/assets/103660888/ceaa8c93-a388-4f1d-b0b8-33988e80a838)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
