### PR TITLE
V8 Fluent2 Theme: Spinner sizes

### DIFF
--- a/change/@fluentui-fluent2-theme-0e6007c6-6d99-4aaf-afc1-a22793e47026.json
+++ b/change/@fluentui-fluent2-theme-0e6007c6-6d99-4aaf-afc1-a22793e47026.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add all spinner sizes for fluent2 theme in v8",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Spinner.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Spinner.styles.ts
@@ -21,6 +21,14 @@ export function getSpinnerStyles(
         height: 32,
         width: 32,
       },
+      size === SpinnerSize.small && {
+        height: 28,
+        width: 28,
+      },
+      size === SpinnerSize.xSmall && {
+        height: 24,
+        width: 24,
+      },
     ],
   };
 


### PR DESCRIPTION
## Previous Behavior
Only two sizes (32/34px) of spinners no matter the settings:
![image](https://github.com/microsoft/fluentui/assets/99835933/18803097-d365-46f0-b93c-11cf604beeea)


## New Behavior
Spinners have a v9 equivalent for the v8 available sizes.
V9 has more options for sizing, we have imitated the sizing's for the v8 size settings available.
<img width="223" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/2fe4d755-013f-4bbc-a8eb-164955284954">


## Related Issue(s)
- Fixes #26785
