### PR TITLE
Keytips: Align keytipData with visible instance for dupes

### DIFF
--- a/change/@fluentui-react-f5d92ca7-54dc-4233-b320-97e9faf3f3b1.json
+++ b/change/@fluentui-react-f5d92ca7-54dc-4233-b320-97e9faf3f3b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keytip: Make keytip data align with which instance is visible (for duplicate registrations)",
+  "packageName": "@fluentui/react",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -12,6 +12,7 @@ import {
   Async,
   initializeComponentRef,
   KeyCodes,
+  isElementVisibleAndNotHidden,
 } from '../../Utilities';
 import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { KeytipTree } from './KeytipTree';
@@ -375,7 +376,15 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
         // Account for overflow set sequences when checking for duplicates
         keytipId = sequencesToID(mergeOverflows(keytip.keySequences, keytip.overflowSetSequence));
       }
+      const targetSelector = ktpTargetFromSequences(keytip.keySequences);
+      const matchingElements = document.querySelectorAll(targetSelector);
       seenIds[keytipId] = seenIds[keytipId] ? seenIds[keytipId] + 1 : 1;
+
+      // If there are multiple elements for the keytip sequence, return true if the element instance
+      // that corresponds to the keytip instance is visible
+      if (matchingElements.length > 1 && seenIds[keytipId] <= matchingElements.length) {
+        return keytip.visible && isElementVisibleAndNotHidden(matchingElements[seenIds[keytipId] - 1] as HTMLElement);
+      }
       return keytip.visible && seenIds[keytipId] === 1;
     });
   }


### PR DESCRIPTION
## Previous Behavior
Currently, keytips have the ability to render only for visible instances of target elements, but if there are multiple of the same registration (e.g. keytipData), the first one is always used. This can result in the keytip not being positioned correctly for the instance that's visible. Note, this is related to responsive scaling where the same control can be rendered with the same keytip tree multiple times where only one instance is visible at a time

## New Behavior
With this change, the fetching of the keytipData will now return the instance that's associated with the corresponding visible element instance. This makes the keytipData that's used align with how keytips already choose where to be visible (e.g. which element is their target). This new code will only run if there are multiple keytips with the exact same registration (same keytip sequence (e.g. tree and element keytip)) which can happen for responsive scaling. 
