### PR TITLE
Migrate react-search to preview

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.js
+++ b/apps/public-docsite-v9/.storybook/main.js
@@ -15,6 +15,7 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     '../../../packages/react-components/react-migration-v0-v9/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
     '../../../packages/react-components/react-migration-v8-v9/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
     '../../../packages/react-components/react-datepicker-compat/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
+    '../../../packages/react-components/react-search-preview/stories/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
   ],
   staticDirs: ['../public'],
   addons: [...rootMain.addons],

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -33,6 +33,7 @@
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-codesandbox": "*",
     "@fluentui/theme-designer": "*",
+    "@fluentui/react-search-preview": "*",
     "@griffel/react": "^1.5.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/change/@fluentui-react-search-preview-1b45c3f6-0791-45a6-9c07-9e02ad62d5d7.json
+++ b/change/@fluentui-react-search-preview-1b45c3f6-0791-45a6-9c07-9e02ad62d5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: release preview package",
+  "packageName": "@fluentui/react-search-preview",
+  "email": "eysjiang@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search-preview/package.json
+++ b/packages/react-components/react-search-preview/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-search-preview",
   "version": "0.0.0",
-  "private": true,
   "description": "Search input for Fluent UI v9",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -228,7 +228,7 @@ export const allComponents: {
     fluentTooltip: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, Tooltip>;
     fluentTreeView: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof TreeView>;
     fluentTreeItem: (overrideDefinition?: OverrideFoundationElementDefinition<TreeItemOptions> | undefined) => FoundationElementRegistry<TreeItemOptions, Constructable<FoundationElement>>;
-    register(container?: Container | undefined, ...rest: any[]): void;
+    register(container?: Container, ...rest: any[]): void;
 };
 
 // Warning: (ae-internal-missing-underscore) The name "ambientShadow" should be prefixed with an underscore because the declaration is marked as @internal

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -228,7 +228,7 @@ export const allComponents: {
     fluentTooltip: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, Tooltip>;
     fluentTreeView: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof TreeView>;
     fluentTreeItem: (overrideDefinition?: OverrideFoundationElementDefinition<TreeItemOptions> | undefined) => FoundationElementRegistry<TreeItemOptions, Constructable<FoundationElement>>;
-    register(container?: Container, ...rest: any[]): void;
+    register(container?: Container | undefined, ...rest: any[]): void;
 };
 
 // Warning: (ae-internal-missing-underscore) The name "ambientShadow" should be prefixed with an underscore because the declaration is marked as @internal

--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -168,6 +168,7 @@ function _createCodesandboxRule(allPackageInfo = getAllPackageInfo()) {
       '@fluentui/react-datepicker-compat',
       '@fluentui/react-migration-v8-v9',
       '@fluentui/react-migration-v0-v9',
+      '@fluentui/react-search-preview',
     ];
 
     const importMappings = Object.values(allPackageInfo).reduce((acc, cur) => {


### PR DESCRIPTION
This PR migrates SearchBox to preview, as part of #26648.