### PR TITLE
Accordion: export AccordionHeaderProvider

### DIFF
--- a/change/@fluentui-react-accordion-d347d71a-89ad-47dd-94e6-e739bbd01e34.json
+++ b/change/@fluentui-react-accordion-d347d71a-89ad-47dd-94e6-e739bbd01e34.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Accordion - export AccordionHeaderContextProvider",
+  "packageName": "@fluentui/react-accordion",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-components/react-accordion/etc/react-accordion.api.md
@@ -195,7 +195,7 @@ export function useAccordionContextValues_unstable(state: AccordionState): Accor
 export const useAccordionHeader_unstable: (props: AccordionHeaderProps, ref: React_2.Ref<HTMLElement>) => AccordionHeaderState;
 
 // @public (undocumented)
-export const useAccordionHeaderContext: () => {
+export const useAccordionHeaderContext_unstable: () => {
     open: boolean;
     disabled: boolean;
     size: string;

--- a/packages/react-components/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-components/react-accordion/etc/react-accordion.api.md
@@ -42,6 +42,9 @@ export const AccordionHeader: ForwardRefComponent<AccordionHeaderProps>;
 export const accordionHeaderClassNames: SlotClassNames<AccordionHeaderSlots>;
 
 // @public (undocumented)
+export const AccordionHeaderContextProvider: React_2.Provider<AccordionHeaderContextValue | undefined>;
+
+// @public (undocumented)
 export type AccordionHeaderContextValue = Required<Pick<AccordionHeaderProps, 'expandIconPosition' | 'size'>> & {
     disabled: boolean;
     open: boolean;
@@ -190,6 +193,14 @@ export function useAccordionContextValues_unstable(state: AccordionState): Accor
 
 // @public
 export const useAccordionHeader_unstable: (props: AccordionHeaderProps, ref: React_2.Ref<HTMLElement>) => AccordionHeaderState;
+
+// @public (undocumented)
+export const useAccordionHeaderContext: () => {
+    open: boolean;
+    disabled: boolean;
+    size: string;
+    expandIconPosition: string;
+};
 
 // @public (undocumented)
 export function useAccordionHeaderContextValues_unstable(state: AccordionHeaderState): AccordionHeaderContextValues;

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeaderContext.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/AccordionHeaderContext.ts
@@ -3,6 +3,8 @@ import type { AccordionHeaderContextValue } from './AccordionHeader.types';
 
 export const AccordionHeaderContext = React.createContext<AccordionHeaderContextValue | undefined>(undefined);
 
+export const AccordionHeaderContextProvider = AccordionHeaderContext.Provider;
+
 const accordionHeaderContextDefaultValue = {
   open: false,
   disabled: false,

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/index.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/index.ts
@@ -4,3 +4,4 @@ export * from './renderAccordionHeader';
 export * from './useAccordionHeader';
 export * from './useAccordionHeaderContextValues';
 export * from './useAccordionHeaderStyles.styles';
+export * from './AccordionHeaderContext';

--- a/packages/react-components/react-accordion/src/index.ts
+++ b/packages/react-components/react-accordion/src/index.ts
@@ -45,7 +45,7 @@ export {
   useAccordionHeaderContextValues_unstable,
   useAccordionHeaderStyles_unstable,
   useAccordionHeader_unstable,
-  useAccordionHeaderContext,
+  useAccordionHeaderContext as useAccordionHeaderContext_unstable,
 } from './AccordionHeader';
 export type {
   AccordionHeaderContextValue,

--- a/packages/react-components/react-accordion/src/index.ts
+++ b/packages/react-components/react-accordion/src/index.ts
@@ -40,10 +40,12 @@ export type {
 export {
   AccordionHeader,
   accordionHeaderClassNames,
+  AccordionHeaderContextProvider,
   renderAccordionHeader_unstable,
   useAccordionHeaderContextValues_unstable,
   useAccordionHeaderStyles_unstable,
   useAccordionHeader_unstable,
+  useAccordionHeaderContext,
 } from './AccordionHeader';
 export type {
   AccordionHeaderContextValue,


### PR DESCRIPTION
I'm working on extending the functionality of AccordionHeaderProvider in TMP and need to "override" the `renderAccordionHeader_unstable` function and add a slot. To do this, I need to render `AccordionHeaderContextProvider` as a wrapper, but currently its not exported from FluentUI.

## Previous Behavior

no export

## New Behavior

exported AccordionHeaderContextProvider

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
