### PR TITLE
Add loopworkspace extension to FileIconType

### DIFF
--- a/change/@fluentui-react-file-type-icons-bf50e101-ae17-4733-ac7b-1d0fec971473.json
+++ b/change/@fluentui-react-file-type-icons-bf50e101-ae17-4733-ac7b-1d0fec971473.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add loopworkspace to FileIconType enum\"",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-file-type-icons/src/FileIconType.ts
+++ b/packages/react-file-type-icons/src/FileIconType.ts
@@ -22,6 +22,7 @@ export enum FileIconType {
   form = 14,
   sway = 15,
   playlist = 16,
+  loopworkspace = 17,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17;

--- a/packages/react-file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/react-file-type-icons/src/getFileTypeIconProps.ts
@@ -20,6 +20,7 @@ const LINKED_FOLDER = 'linkedfolder';
 const FORM = 'form';
 const SWAY = 'sway';
 const PLAYLIST = 'playlist';
+const LOOP_WORKSPACE = 'loopworkspace';
 
 export const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
@@ -142,6 +143,9 @@ export function getFileTypeIconNameFromExtensionOrType(
         break;
       case FileIconType.playlist:
         iconBaseName = PLAYLIST;
+        break;
+      case FileIconType.loopworkspace:
+        iconBaseName = LOOP_WORKSPACE;
         break;
     }
   }


### PR DESCRIPTION
This PR is to unblock Loop to be able to use the loopworkspace file type icons, by adding this type to the `FileIconType` enum. Fixes #28554 