### PR TITLE
feat(tools): re-generate react-components.api.md when preparing 1st stable release

### DIFF
--- a/tools/generators/prepare-initial-release/index.spec.ts
+++ b/tools/generators/prepare-initial-release/index.spec.ts
@@ -8,6 +8,7 @@ import {
   readJson,
   updateJson,
   ProjectGraph,
+  workspaceRoot,
 } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import * as childProcess from 'child_process';
@@ -120,6 +121,10 @@ describe('prepare-initial-release generator', () => {
         expect(execSyncSpy.mock.calls.flat()).toMatchInlineSnapshot(`
           Array [
             "yarn change --message 'feat: release preview package' --type minor --package @proj/react-one-preview",
+            Object {
+              "cwd": "${workspaceRoot}",
+              "stdio": "inherit",
+            },
           ]
         `);
       });
@@ -285,7 +290,20 @@ describe('prepare-initial-release generator', () => {
         expect(execSyncSpy.mock.calls.flat()).toMatchInlineSnapshot(`
           Array [
             "yarn change --message 'feat: release stable' --type minor --package @proj/react-one",
+            Object {
+              "cwd": "${workspaceRoot}",
+              "stdio": "inherit",
+            },
             "yarn change --message 'feat: add @proj/react-one to suite' --type minor --package @proj/react-components",
+            Object {
+              "cwd": "${workspaceRoot}",
+              "stdio": "inherit",
+            },
+            "yarn lage generate-api --to @proj/react-components",
+            Object {
+              "cwd": "${workspaceRoot}",
+              "stdio": "inherit",
+            },
           ]
         `);
         expect(installPackagesTaskSpy).toHaveBeenCalled();

--- a/tools/generators/prepare-initial-release/index.ts
+++ b/tools/generators/prepare-initial-release/index.ts
@@ -11,6 +11,7 @@ import {
   installPackagesTask,
   readJson,
   stripIndents,
+  workspaceRoot,
 } from '@nrwl/devkit';
 
 import * as tsquery from '@phenomnomnominal/tsquery';
@@ -236,9 +237,10 @@ async function stableRelease(tree: Tree, options: NormalizedSchema) {
   tree.rename(options.projectConfig.root, newPackage.root);
 
   return (_tree: Tree) => {
+    installPackagesTask(tree, true);
     generateChangefileTask(tree, newPackage.name, { message: 'feat: release stable' });
     generateChangefileTask(tree, suitePackageName, { message: `feat: add ${newPackage.name} to suite` });
-    installPackagesTask(tree);
+    generateApiMarkdownTask(tree, suitePackageName);
   };
 }
 
@@ -280,7 +282,12 @@ async function getProjectThatNeedsToBeUpdated(tree: Tree, options: NormalizedSch
 
 function generateChangefileTask(tree: Tree, projectName: string, options: { message: string }) {
   const cmd = `yarn change --message '${options.message}' --type minor --package ${projectName}`;
-  return execSync(cmd);
+  return execSync(cmd, { cwd: workspaceRoot, stdio: 'inherit' });
+}
+
+function generateApiMarkdownTask(tree: Tree, projectName: string) {
+  const cmd = `yarn lage generate-api --to ${projectName}`;
+  return execSync(cmd, { cwd: workspaceRoot, stdio: 'inherit' });
 }
 
 function assertProject(tree: Tree, options: NormalizedSchema) {


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

re-generate `react-components.api.md` after `-preview` package is propagated to stable phase.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially fixes #28471 
