### PR TITLE
fix(react-search): stories tweak

### DIFF
--- a/packages/react-components/react-search-preview/stories/SearchBox/SearchBoxAppearance.stories.tsx
+++ b/packages/react-components/react-search-preview/stories/SearchBox/SearchBoxAppearance.stories.tsx
@@ -8,16 +8,16 @@ const useStyles = makeStyles({
     flexDirection: 'column',
   },
   filledLighter: {
-    backgroundColor: tokens.colorNeutralBackgroundInverted,
+    // backgroundColor: tokens.colorNeutralBackgroundInverted,
   },
   filledLighterLabel: {
-    color: tokens.colorNeutralForegroundInverted2,
+    // color: tokens.colorNeutralForegroundInverted2,
   },
   filledDarker: {
-    backgroundColor: tokens.colorNeutralBackgroundInverted,
+    // backgroundColor: tokens.colorNeutralBackgroundInverted,
   },
   filledDarkerLabel: {
-    color: tokens.colorNeutralForegroundInverted2,
+    // color: tokens.colorNeutralForegroundInverted2,
   },
   fieldWrapper: {
     ...shorthands.padding(tokens.spacingVerticalMNudge, tokens.spacingHorizontalMNudge),

--- a/packages/react-components/react-search-preview/stories/SearchBox/SearchBoxAppearance.stories.tsx
+++ b/packages/react-components/react-search-preview/stories/SearchBox/SearchBoxAppearance.stories.tsx
@@ -1,23 +1,11 @@
 import * as React from 'react';
 import { SearchBox } from '@fluentui/react-search-preview';
-import { Field, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
+import { Field, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   base: {
     display: 'flex',
     flexDirection: 'column',
-  },
-  filledLighter: {
-    // backgroundColor: tokens.colorNeutralBackgroundInverted,
-  },
-  filledLighterLabel: {
-    // color: tokens.colorNeutralForegroundInverted2,
-  },
-  filledDarker: {
-    // backgroundColor: tokens.colorNeutralBackgroundInverted,
-  },
-  filledDarkerLabel: {
-    // color: tokens.colorNeutralForegroundInverted2,
   },
   fieldWrapper: {
     ...shorthands.padding(tokens.spacingVerticalMNudge, tokens.spacingHorizontalMNudge),
@@ -36,17 +24,11 @@ export const Appearance = () => {
         <SearchBox appearance="underline" />
       </Field>
 
-      <Field
-        className={mergeClasses(styles.fieldWrapper, styles.filledLighter)}
-        label={{ children: 'Filled lighter appearance', className: styles.filledLighterLabel }}
-      >
+      <Field className={styles.fieldWrapper} label="Filled lighter appearance">
         <SearchBox appearance="filled-lighter" />
       </Field>
 
-      <Field
-        className={mergeClasses(styles.fieldWrapper, styles.filledDarker)}
-        label={{ children: 'Filled darker appearance', className: styles.filledDarkerLabel }}
-      >
+      <Field className={styles.fieldWrapper} label="Filled darker appearance">
         <SearchBox appearance="filled-darker" />
       </Field>
     </div>

--- a/packages/react-components/react-search-preview/stories/SearchBox/SearchBoxContentBeforeAfter.stories.tsx
+++ b/packages/react-components/react-search-preview/stories/SearchBox/SearchBoxContentBeforeAfter.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SearchBox } from '@fluentui/react-search-preview';
 import { Button, ButtonProps, Field, makeStyles, shorthands, Text, tokens } from '@fluentui/react-components';
-import { PersonRegular, MicRegular } from '@fluentui/react-icons';
+import { MicRegular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
@@ -23,18 +23,6 @@ export const ContentBeforeAfter = () => {
     <div className={styles.root}>
       <Field
         className={styles.fieldWrapper}
-        label="Search by name"
-        hint={
-          <>
-            A SearchBox with a custom icon in the <code>contentBefore</code> slot.
-          </>
-        }
-      >
-        <SearchBox contentBefore={<PersonRegular />} />
-      </Field>
-
-      <Field
-        className={styles.fieldWrapper}
         label="Search by voice"
         hint={
           <>
@@ -50,12 +38,11 @@ export const ContentBeforeAfter = () => {
         label="Search with filter"
         hint={
           <>
-            A SearchBox with a presentational value in the <code>contentBefore</code> slot and another presentational
-            value in the <code>contentAfter</code> slot.
+            A SearchBox with a presentational value in the <code>contentAfter</code> slot.
           </>
         }
       >
-        <SearchBox contentBefore={<Text size={400}>Search:</Text>} contentAfter={<Text size={400}>Filter</Text>} />
+        <SearchBox contentAfter={<Text size={400}>Filter</Text>} />
       </Field>
     </div>
   );


### PR DESCRIPTION
Fixes tokens for appearance:
<img width="395" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/c3d20e7d-d365-45be-b6e0-a02c58d3a79f">

Removes stories that do not fit proper use case:
<img width="385" alt="image" src="https://github.com/microsoft/fluentui/assets/31319479/11d9cf00-5a4c-4d27-a5c0-8e3807adb148">
