### PR TITLE
feat: allSelectedRows and someSelectedRows should be more reliable

### DIFF
--- a/change/@fluentui-react-table-9bafa4eb-c107-4426-b422-56d0113f018b.json
+++ b/change/@fluentui-react-table-9bafa4eb-c107-4426-b422-56d0113f018b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "28456",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/useTableSelection.test.ts
+++ b/packages/react-components/react-table/src/hooks/useTableSelection.test.ts
@@ -219,6 +219,36 @@ describe('useTableSelectionState', () => {
     });
 
     describe('allRowsSelected', () => {
+      it('should return true after items updated if all selectable rows are selected', () => {
+        const getRowId = (item: { value: string }) => item.value;
+        let tableState = mockTableState({ items, getRowId });
+        const { result, rerender } = renderHook(() =>
+          useTableSelectionState(tableState, { selectionMode: 'multiselect' }),
+        );
+
+        act(() => {
+          result.current.selection.toggleAllRows(mockSyntheticEvent());
+        });
+
+        act(() => {
+          result.current.selection.deselectRow(mockSyntheticEvent(), 'c');
+        });
+
+        expect(result.current.selection.allRowsSelected).toBe(false);
+
+        // remove the deselected item
+        const nextItems = [...items];
+        const indexToDelete = nextItems.findIndex(x => x.value === 'c');
+        nextItems.splice(indexToDelete, 1);
+        tableState = mockTableState({ items: nextItems, getRowId });
+
+        act(() => {
+          rerender();
+        });
+
+        expect(result.current.selection.allRowsSelected).toBe(true);
+      });
+
       it('should return true if all rows are selected', () => {
         const { result } = renderHook(() =>
           useTableSelectionState(mockTableState({ items }), { selectionMode: 'multiselect' }),
@@ -258,6 +288,32 @@ describe('useTableSelectionState', () => {
     });
 
     describe('someRowsSelected', () => {
+      it('should return false after selectedItems are removed', () => {
+        const getRowId = (item: { value: string }) => item.value;
+        let tableState = mockTableState({ items, getRowId });
+        const { result, rerender } = renderHook(() =>
+          useTableSelectionState(tableState, { selectionMode: 'multiselect' }),
+        );
+
+        act(() => {
+          result.current.selection.selectRow(mockSyntheticEvent(), 'a');
+        });
+
+        expect(result.current.selection.someRowsSelected).toBe(true);
+
+        // remove the deselected item
+        const nextItems = [...items];
+        const indexToDelete = nextItems.findIndex(x => x.value === 'a');
+        nextItems.splice(indexToDelete, 1);
+        tableState = mockTableState({ items: nextItems, getRowId });
+
+        act(() => {
+          rerender();
+        });
+
+        expect(result.current.selection.someRowsSelected).toBe(false);
+      });
+
       it('should return true if there is a selected row', () => {
         const { result } = renderHook(() =>
           useTableSelectionState(mockTableState({ items }), { selectionMode: 'multiselect' }),

--- a/packages/react-components/react-table/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useTableSelection.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { SelectionHookParams, useEventCallback, useSelection } from '@fluentui/react-utilities';
 import type { TableRowId, TableSelectionState, TableFeaturesState } from './types';
 
@@ -36,6 +37,50 @@ export function useTableSelectionState<TItem>(
     onSelectionChange,
   });
 
+  // Selection state can contain obselete items (i.e. rows that are removed)
+  const selectableRowIds = React.useMemo(() => {
+    const rowIds = new Set<TableRowId>();
+    for (let i = 0; i < items.length; i++) {
+      rowIds.add(getRowId?.(items[i]) ?? i);
+    }
+
+    return rowIds;
+  }, [items, getRowId]);
+
+  const allRowsSelected = React.useMemo(() => {
+    if (selectionMode === 'single') {
+      const selectedRow = Array.from(selected)[0];
+      return selectableRowIds.has(selectedRow);
+    }
+
+    // multiselect case
+    if (selected.size < selectableRowIds.size) {
+      return false;
+    }
+
+    for (const selectableRowId of selectableRowIds) {
+      if (!selected.has(selectableRowId)) {
+        return false;
+      }
+    }
+
+    return true;
+  }, [selectableRowIds, selected, selectionMode]);
+
+  const someRowsSelected = React.useMemo(() => {
+    if (selected.size <= 0) {
+      return false;
+    }
+
+    for (const selectableRowId of selectableRowIds) {
+      if (selected.has(selectableRowId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [selectableRowIds, selected]);
+
   const toggleAllRows: TableSelectionState['toggleAllRows'] = useEventCallback(e => {
     selectionMethods.toggleAllItems(
       e,
@@ -63,8 +108,8 @@ export function useTableSelectionState<TItem>(
     ...tableState,
     selection: {
       selectionMode,
-      someRowsSelected: selected.size > 0,
-      allRowsSelected: selectionMode === 'single' ? selected.size > 0 : selected.size === items.length,
+      someRowsSelected,
+      allRowsSelected,
       selectedRows: selected,
       toggleRow,
       toggleAllRows,

--- a/packages/react-components/react-table/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/src/hooks/useTableSelection.ts
@@ -58,13 +58,14 @@ export function useTableSelectionState<TItem>(
       return false;
     }
 
-    for (const selectableRowId of selectableRowIds) {
+    let res = true;
+    selectableRowIds.forEach(selectableRowId => {
       if (!selected.has(selectableRowId)) {
-        return false;
+        res = false;
       }
-    }
+    });
 
-    return true;
+    return res;
   }, [selectableRowIds, selected, selectionMode]);
 
   const someRowsSelected = React.useMemo(() => {
@@ -72,13 +73,14 @@ export function useTableSelectionState<TItem>(
       return false;
     }
 
-    for (const selectableRowId of selectableRowIds) {
+    let res = false;
+    selectableRowIds.forEach(selectableRowId => {
       if (selected.has(selectableRowId)) {
-        return true;
+        res = true;
       }
-    }
+    });
 
-    return false;
+    return res;
   }, [selectableRowIds, selected]);
 
   const toggleAllRows: TableSelectionState['toggleAllRows'] = useEventCallback(e => {

--- a/packages/react-components/react-table/stories/Table/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Default.stories.tsx
@@ -1,3 +1,20 @@
+import {
+  PresenceBadgeStatus,
+  Avatar,
+  TableBody,
+  TableCell,
+  TableRow,
+  Table,
+  TableHeader,
+  TableHeaderCell,
+  TableSelectionCell,
+  TableCellLayout,
+  useTableFeatures,
+  TableColumnDefinition,
+  useTableSelection,
+  createTableColumn,
+  Button,
+} from '@fluentui/react-components';
 import * as React from 'react';
 import {
   FolderRegular,
@@ -8,23 +25,39 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
-import {
-  TableBody,
-  TableCell,
-  TableRow,
-  Table,
-  TableHeader,
-  TableHeaderCell,
-  TableCellLayout,
-  PresenceBadgeStatus,
-  Avatar,
-} from '@fluentui/react-components';
 
-const items = [
+type FileCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type LastUpdatedCell = {
+  label: string;
+  timestamp: number;
+};
+
+type LastUpdateCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type AuthorCell = {
+  label: string;
+  status: PresenceBadgeStatus;
+};
+
+type Item = {
+  file: FileCell;
+  author: AuthorCell;
+  lastUpdated: LastUpdatedCell;
+  lastUpdate: LastUpdateCell;
+};
+
+let data: Item[] = [
   {
     file: { label: 'Meeting notes', icon: <DocumentRegular /> },
     author: { label: 'Max Mustermann', status: 'available' },
-    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdated: { label: '7h ago', timestamp: 3 },
     lastUpdate: {
       label: 'You edited this',
       icon: <EditRegular />,
@@ -51,7 +84,7 @@ const items = [
   {
     file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
     author: { label: 'Jane Doe', status: 'offline' },
-    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 1 },
     lastUpdate: {
       label: 'You shared this in a Teams chat',
       icon: <PeopleRegular />,
@@ -59,49 +92,119 @@ const items = [
   },
 ];
 
-const columns = [
-  { columnKey: 'file', label: 'File' },
-  { columnKey: 'author', label: 'Author' },
-  { columnKey: 'lastUpdated', label: 'Last updated' },
-  { columnKey: 'lastUpdate', label: 'Last update' },
+const columns: TableColumnDefinition<Item>[] = [
+  createTableColumn<Item>({
+    columnId: 'file',
+  }),
+  createTableColumn<Item>({
+    columnId: 'author',
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdated',
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdate',
+  }),
 ];
 
 export const Default = () => {
+  const [items, setItems] = React.useState<Item[]>(data);
+
+  const {
+    getRows,
+    selection: { allRowsSelected, someRowsSelected, toggleAllRows, toggleRow, isRowSelected },
+  } = useTableFeatures(
+    {
+      columns,
+      items,
+      getRowId: item => item.file.label,
+    },
+    [
+      useTableSelection({
+        selectionMode: 'multiselect',
+        defaultSelectedItems: new Set([0, 1]),
+      }),
+    ],
+  );
+
+  let rows = getRows(row => {
+    const selected = isRowSelected(row.rowId);
+    return {
+      ...row,
+      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === ' ') {
+          e.preventDefault();
+          toggleRow(e, row.rowId);
+        }
+      },
+      selected,
+      appearance: selected ? ('brand' as const) : ('none' as const),
+    };
+  });
+
+  const toggleAllKeydown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ') {
+        toggleAllRows(e);
+        e.preventDefault();
+      }
+    },
+    [toggleAllRows],
+  );
+
+  const onDelete = () => {
+    data = data.filter((x, index) => index !== 0);
+    setItems(data);
+  };
+
   return (
-    <Table arial-label="Default table">
-      <TableHeader>
-        <TableRow>
-          {columns.map(column => (
-            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
-          ))}
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {items.map(item => (
-          <TableRow key={item.file.label}>
-            <TableCell>
-              <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
-            </TableCell>
-            <TableCell>
-              <TableCellLayout
-                media={
-                  <Avatar
-                    aria-label={item.author.label}
-                    name={item.author.label}
-                    badge={{ status: item.author.status as PresenceBadgeStatus }}
-                  />
-                }
-              >
-                {item.author.label}
-              </TableCellLayout>
-            </TableCell>
-            <TableCell>{item.lastUpdated.label}</TableCell>
-            <TableCell>
-              <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
-            </TableCell>
+    <>
+      <Button onClick={onDelete}>deleted</Button>
+      <Table aria-label="Table with multiselect">
+        <TableHeader>
+          <TableRow>
+            <TableSelectionCell
+              checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
+              onClick={toggleAllRows}
+              onKeyDown={toggleAllKeydown}
+              checkboxIndicator={{ 'aria-label': 'Select all rows ' }}
+            />
+
+            <TableHeaderCell>File</TableHeaderCell>
+            <TableHeaderCell>Author</TableHeaderCell>
+            <TableHeaderCell>Last updated</TableHeaderCell>
+            <TableHeaderCell>Last update</TableHeaderCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
+            <TableRow
+              key={item.file.label}
+              onClick={onClick}
+              onKeyDown={onKeyDown}
+              aria-selected={selected}
+              appearance={appearance}
+            >
+              <TableSelectionCell checked={selected} checkboxIndicator={{ 'aria-label': 'Select row' }} />
+              <TableCell>
+                <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
+              </TableCell>
+              <TableCell>
+                <TableCellLayout
+                  media={<Avatar aria-label={item.author.label} badge={{ status: item.author.status }} />}
+                >
+                  {item.author.label}
+                </TableCellLayout>
+              </TableCell>
+              <TableCell>{item.lastUpdated.label}</TableCell>
+              <TableCell>
+                <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
   );
 };

--- a/packages/react-components/react-table/stories/Table/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/Default.stories.tsx
@@ -1,20 +1,3 @@
-import {
-  PresenceBadgeStatus,
-  Avatar,
-  TableBody,
-  TableCell,
-  TableRow,
-  Table,
-  TableHeader,
-  TableHeaderCell,
-  TableSelectionCell,
-  TableCellLayout,
-  useTableFeatures,
-  TableColumnDefinition,
-  useTableSelection,
-  createTableColumn,
-  Button,
-} from '@fluentui/react-components';
 import * as React from 'react';
 import {
   FolderRegular,
@@ -25,39 +8,23 @@ import {
   DocumentPdfRegular,
   VideoRegular,
 } from '@fluentui/react-icons';
+import {
+  TableBody,
+  TableCell,
+  TableRow,
+  Table,
+  TableHeader,
+  TableHeaderCell,
+  TableCellLayout,
+  PresenceBadgeStatus,
+  Avatar,
+} from '@fluentui/react-components';
 
-type FileCell = {
-  label: string;
-  icon: JSX.Element;
-};
-
-type LastUpdatedCell = {
-  label: string;
-  timestamp: number;
-};
-
-type LastUpdateCell = {
-  label: string;
-  icon: JSX.Element;
-};
-
-type AuthorCell = {
-  label: string;
-  status: PresenceBadgeStatus;
-};
-
-type Item = {
-  file: FileCell;
-  author: AuthorCell;
-  lastUpdated: LastUpdatedCell;
-  lastUpdate: LastUpdateCell;
-};
-
-let data: Item[] = [
+const items = [
   {
     file: { label: 'Meeting notes', icon: <DocumentRegular /> },
     author: { label: 'Max Mustermann', status: 'available' },
-    lastUpdated: { label: '7h ago', timestamp: 3 },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
     lastUpdate: {
       label: 'You edited this',
       icon: <EditRegular />,
@@ -84,7 +51,7 @@ let data: Item[] = [
   {
     file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
     author: { label: 'Jane Doe', status: 'offline' },
-    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 1 },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
     lastUpdate: {
       label: 'You shared this in a Teams chat',
       icon: <PeopleRegular />,
@@ -92,119 +59,49 @@ let data: Item[] = [
   },
 ];
 
-const columns: TableColumnDefinition<Item>[] = [
-  createTableColumn<Item>({
-    columnId: 'file',
-  }),
-  createTableColumn<Item>({
-    columnId: 'author',
-  }),
-  createTableColumn<Item>({
-    columnId: 'lastUpdated',
-  }),
-  createTableColumn<Item>({
-    columnId: 'lastUpdate',
-  }),
+const columns = [
+  { columnKey: 'file', label: 'File' },
+  { columnKey: 'author', label: 'Author' },
+  { columnKey: 'lastUpdated', label: 'Last updated' },
+  { columnKey: 'lastUpdate', label: 'Last update' },
 ];
 
 export const Default = () => {
-  const [items, setItems] = React.useState<Item[]>(data);
-
-  const {
-    getRows,
-    selection: { allRowsSelected, someRowsSelected, toggleAllRows, toggleRow, isRowSelected },
-  } = useTableFeatures(
-    {
-      columns,
-      items,
-      getRowId: item => item.file.label,
-    },
-    [
-      useTableSelection({
-        selectionMode: 'multiselect',
-        defaultSelectedItems: new Set([0, 1]),
-      }),
-    ],
-  );
-
-  let rows = getRows(row => {
-    const selected = isRowSelected(row.rowId);
-    return {
-      ...row,
-      onClick: (e: React.MouseEvent) => toggleRow(e, row.rowId),
-      onKeyDown: (e: React.KeyboardEvent) => {
-        if (e.key === ' ') {
-          e.preventDefault();
-          toggleRow(e, row.rowId);
-        }
-      },
-      selected,
-      appearance: selected ? ('brand' as const) : ('none' as const),
-    };
-  });
-
-  const toggleAllKeydown = React.useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === ' ') {
-        toggleAllRows(e);
-        e.preventDefault();
-      }
-    },
-    [toggleAllRows],
-  );
-
-  const onDelete = () => {
-    data = data.filter((x, index) => index !== 0);
-    setItems(data);
-  };
-
   return (
-    <>
-      <Button onClick={onDelete}>deleted</Button>
-      <Table aria-label="Table with multiselect">
-        <TableHeader>
-          <TableRow>
-            <TableSelectionCell
-              checked={allRowsSelected ? true : someRowsSelected ? 'mixed' : false}
-              onClick={toggleAllRows}
-              onKeyDown={toggleAllKeydown}
-              checkboxIndicator={{ 'aria-label': 'Select all rows ' }}
-            />
-
-            <TableHeaderCell>File</TableHeaderCell>
-            <TableHeaderCell>Author</TableHeaderCell>
-            <TableHeaderCell>Last updated</TableHeaderCell>
-            <TableHeaderCell>Last update</TableHeaderCell>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {rows.map(({ item, selected, onClick, onKeyDown, appearance }) => (
-            <TableRow
-              key={item.file.label}
-              onClick={onClick}
-              onKeyDown={onKeyDown}
-              aria-selected={selected}
-              appearance={appearance}
-            >
-              <TableSelectionCell checked={selected} checkboxIndicator={{ 'aria-label': 'Select row' }} />
-              <TableCell>
-                <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
-              </TableCell>
-              <TableCell>
-                <TableCellLayout
-                  media={<Avatar aria-label={item.author.label} badge={{ status: item.author.status }} />}
-                >
-                  {item.author.label}
-                </TableCellLayout>
-              </TableCell>
-              <TableCell>{item.lastUpdated.label}</TableCell>
-              <TableCell>
-                <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
-              </TableCell>
-            </TableRow>
+    <Table arial-label="Default table">
+      <TableHeader>
+        <TableRow>
+          {columns.map(column => (
+            <TableHeaderCell key={column.columnKey}>{column.label}</TableHeaderCell>
           ))}
-        </TableBody>
-      </Table>
-    </>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items.map(item => (
+          <TableRow key={item.file.label}>
+            <TableCell>
+              <TableCellLayout media={item.file.icon}>{item.file.label}</TableCellLayout>
+            </TableCell>
+            <TableCell>
+              <TableCellLayout
+                media={
+                  <Avatar
+                    aria-label={item.author.label}
+                    name={item.author.label}
+                    badge={{ status: item.author.status as PresenceBadgeStatus }}
+                  />
+                }
+              >
+                {item.author.label}
+              </TableCellLayout>
+            </TableCell>
+            <TableCell>{item.lastUpdated.label}</TableCell>
+            <TableCell>
+              <TableCellLayout media={item.lastUpdate.icon}>{item.lastUpdate.label}</TableCellLayout>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 };


### PR DESCRIPTION
We took the decision to decouple the selection state from the data. This means that the selection state does not always stay in sync with the data, but the resulting output should be correct.

In this case `allSeletedRows` and `someSelectedRows` were calculated based on the size of the selected rows which was wrong, because there can be outdated values in there. Updates the `useTableSelection` hook to make sure that those states reflect the what is in the data. This will cause extra computation (which is memoized) but there is no other way to maintain consistency.

It might be possible to update `useSelection` accept the set of selectable items, but the extra computation will still need to be there.

Fixes #28456