### PR TITLE
Breadcrumb UI adjustments

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-947a179a-446f-4171-b318-b4d9b224559c.json
+++ b/change/@fluentui-react-breadcrumb-preview-947a179a-446f-4171-b318-b4d9b224559c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: spacing in BreadcrumbButton and Link, added more examples to the stories",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
@@ -26,20 +26,19 @@ const defaultButtonStyles = {
   cursor: 'auto',
 };
 const useStyles = makeStyles({
-  root: {},
+  root: {
+    ...shorthands.padding(tokens.spacingHorizontalNone),
+  },
   small: {
     height: '24px',
-    ...shorthands.padding(tokens.spacingHorizontalSNudge),
     ...typographyStyles.caption1,
   },
   medium: {
     height: '32px',
-    ...shorthands.padding(tokens.spacingHorizontalSNudge),
     ...typographyStyles.body1,
   },
   large: {
     height: '40px',
-    ...shorthands.padding(tokens.spacingHorizontalS),
     ...typographyStyles.body2,
   },
   current: {

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
@@ -15,6 +15,7 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     color: tokens.colorNeutralForeground2,
+    boxSizing: 'border-box',
   },
   small: {
     height: '24px',

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLinkStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLinkStyles.styles.ts
@@ -22,6 +22,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     alignItems: 'center',
+    textWrap: 'nowrap',
   },
   icon: {
     display: 'flex',
@@ -30,17 +31,14 @@ const useStyles = makeStyles({
   },
   small: {
     height: '24px',
-    ...shorthands.padding(tokens.spacingHorizontalSNudge),
     ...typographyStyles.caption1,
   },
   medium: {
     height: '32px',
-    ...shorthands.padding(tokens.spacingHorizontalSNudge),
     ...typographyStyles.body1,
   },
   large: {
     height: '40px',
-    ...shorthands.padding(tokens.spacingHorizontalS),
     ...typographyStyles.body2,
   },
   overflow: {

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbItemWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbItemWithOverflow.stories.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { makeStyles, shorthands, Tooltip } from '@fluentui/react-components';
+import { MoreHorizontalRegular, MoreHorizontalFilled, bundleIcon } from '@fluentui/react-icons';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbButton,
+  BreadcrumbDivider,
+  partitionBreadcrumbItems,
+  truncateBreadcrumbLongName,
+  truncateBreadcrumLongTooltip,
+  isTruncatableBreadcrumbContent,
+} from '@fluentui/react-breadcrumb-preview';
+import type { PartitionBreadcrumbItems } from '@fluentui/react-breadcrumb-preview';
+
+const MoreHorizontal = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
+
+type Item = {
+  key: number;
+  item: string;
+};
+
+const items: Item[] = [
+  {
+    key: 0,
+    item: 'Item 1',
+  },
+  {
+    key: 1,
+    item: 'Item 2',
+  },
+  {
+    key: 2,
+    item: 'Item 3',
+  },
+  {
+    key: 3,
+    item: 'Item 4',
+  },
+  {
+    key: 4,
+    item: 'Item 5 which is longer than 30 characters',
+  },
+  {
+    key: 5,
+    item: "Item 6 is long even for tooltip. Don't think about what you want to be, but what you want to do.",
+  },
+];
+
+function renderItem(entry: Item, isLastItem: boolean) {
+  return (
+    <React.Fragment key={`item-${entry.key}`}>
+      {isTruncatableBreadcrumbContent(entry.item, 30) ? (
+        <Tooltip withArrow content={truncateBreadcrumLongTooltip(entry.item)} relationship="label">
+          <BreadcrumbItem current={isLastItem}>{truncateBreadcrumbLongName(entry.item)}</BreadcrumbItem>
+        </Tooltip>
+      ) : (
+        <BreadcrumbItem current={isLastItem}>{entry.item}</BreadcrumbItem>
+      )}
+
+      {!isLastItem && <BreadcrumbDivider />}
+    </React.Fragment>
+  );
+}
+
+const useStyles = makeStyles({
+  root: {
+    alignItems: 'flex-start',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    ...shorthands.overflow('auto'),
+    ...shorthands.padding('50px', '20px'),
+    rowGap: '20px',
+  },
+});
+
+const getTooltipContent = (breadcrumbItems: readonly Item[]) => {
+  return breadcrumbItems.reduce((acc, initialValue, idx, arr) => {
+    return (
+      <div style={{ display: 'flex' }}>
+        {acc}
+        {arr[0].item !== initialValue.item && <BreadcrumbDivider />}
+        {initialValue.item}
+      </div>
+    );
+  }, <div style={{ display: 'flex' }} />);
+};
+
+const BreadcrumbItemOverflowExample = () => {
+  const { startDisplayedItems, overflowItems, endDisplayedItems }: PartitionBreadcrumbItems<Item> =
+    partitionBreadcrumbItems({
+      items,
+      maxDisplayedItems: 3,
+    });
+  const lastIdx = items.length - 1;
+  return (
+    <Breadcrumb aria-label="breadcrumb-with-overflow">
+      {startDisplayedItems.map(item => renderItem(item, lastIdx === item.key))}
+      {overflowItems && (
+        <BreadcrumbItem>
+          <Tooltip withArrow content={getTooltipContent(overflowItems)} relationship="label">
+            <BreadcrumbButton icon={<MoreHorizontal />} aria-label={`more items`} />
+          </Tooltip>
+        </BreadcrumbItem>
+      )}
+      {endDisplayedItems && endDisplayedItems.map(item => renderItem(item, lastIdx === item.key))}
+    </Breadcrumb>
+  );
+};
+
+export const BreadcrumbItemWithOverflow = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <BreadcrumbItemOverflowExample />
+    </div>
+  );
+};
+
+BreadcrumbItemWithOverflow.parameters = {
+  docs: {
+    description: {
+      story: ['For non-interactive Breadcrumbs tooltips are used instead of overflow menu.'].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbLinkWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbLinkWithOverflow.stories.tsx
@@ -107,7 +107,7 @@ const linkItems: LinkItem[] = [
 
 function renderLink(el: LinkItem, isLastItem: boolean = false) {
   return (
-    <React.Fragment key={`start-items-${el.key}`}>
+    <React.Fragment key={`link-items-${el.key}`}>
       <OverflowItem id={el.key.toString()} priority={isLastItem ? el.key : undefined} groupId={el.key.toString()}>
         <BreadcrumbItem>
           <BreadcrumbLink
@@ -237,7 +237,7 @@ const BreadcrumbControlledOverflowExample = () => {
     <div className={mergeClasses(styles.example, styles.horizontal)}>
       <Overflow padding={40}>
         <Breadcrumb>
-          {startDisplayedItems.map((item: LinkItem) => renderLink(item, item.key === linkItems.length - 1))}
+          {startDisplayedItems.map((item: LinkItem) => renderLink(item, false))}
           <ControlledOverflowMenu
             overflowItems={overflowItems}
             startDisplayedItems={startDisplayedItems}

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbLinkWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbLinkWithOverflow.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  ButtonProps,
   makeStyles,
   mergeClasses,
   shorthands,
@@ -27,8 +26,9 @@ import {
 import {
   Breadcrumb,
   BreadcrumbItem,
-  BreadcrumbButton,
+  BreadcrumbLink,
   BreadcrumbDivider,
+  BreadcrumbLinkProps,
   partitionBreadcrumbItems,
 } from '@fluentui/react-breadcrumb-preview';
 import type { PartitionBreadcrumbItems } from '@fluentui/react-breadcrumb-preview';
@@ -36,79 +36,94 @@ import type { PartitionBreadcrumbItems } from '@fluentui/react-breadcrumb-previe
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 const MoreHorizontal = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
 
-type ButtonItem = {
+type LinkItem = {
   key: number;
   item?: string;
-  buttonProps?: {
-    onClick?: () => void;
-    icon?: ButtonProps['icon'];
+  linkProps: {
+    'aria-label'?: string;
+    href?: string;
+    icon?: BreadcrumbLinkProps['icon'];
     disabled?: boolean;
     iconPosition?: 'before' | 'after';
   };
 };
 
-const buttonItems: ButtonItem[] = [
+const linkItems: LinkItem[] = [
   {
     key: 0,
     item: 'Item 0',
-    buttonProps: {
-      onClick: () => console.log('item 0 was clicked'),
+    linkProps: {
+      href: 'https://developer.microsoft.com/',
     },
   },
   {
     key: 1,
     item: 'Item 1',
-    buttonProps: {
+    linkProps: {
+      href: 'https://developer.microsoft.com/',
       icon: <CalendarMonth />,
-      onClick: () => console.log('item 1 was clicked'),
     },
   },
   {
     key: 2,
     item: 'Item 2',
-    buttonProps: {
-      onClick: () => console.log('item 2 was clicked'),
+    linkProps: {
+      href: 'https://developer.microsoft.com/',
     },
   },
   {
     key: 3,
-    item: 'Item 3',
-    buttonProps: {
-      onClick: () => console.log('item 3 was clicked'),
+    linkProps: {
+      'aria-label': 'Item 3',
+      href: 'https://developer.microsoft.com/',
+      icon: <CalendarMonth />,
     },
   },
   {
     key: 4,
     item: 'Item 4',
-    buttonProps: {
-      onClick: () => console.log('item 4 was clicked'),
+    linkProps: {
+      href: 'https://developer.microsoft.com/',
+      icon: <CalendarMonthRegular />,
+      iconPosition: 'after',
     },
   },
   {
     key: 5,
     item: 'Item 5',
-    buttonProps: {
-      icon: <CalendarMonthRegular />,
-      iconPosition: 'after',
-      onClick: () => console.log('item 5 was clicked'),
+    linkProps: {
+      href: 'https://developer.microsoft.com/',
+      disabled: true,
     },
   },
   {
     key: 6,
     item: 'Item 6',
-    buttonProps: {
-      onClick: () => console.log('item 6 was clicked'),
-      disabled: true,
-    },
-  },
-  {
-    key: 7,
-    item: 'Item 7',
-    buttonProps: {
-      onClick: () => console.log('item 7 was clicked'),
+    linkProps: {
+      href: 'https://developer.microsoft.com/',
     },
   },
 ];
+
+function renderLink(el: LinkItem, isLastItem: boolean = false) {
+  return (
+    <React.Fragment key={`start-items-${el.key}`}>
+      <OverflowItem id={el.key.toString()} priority={isLastItem ? el.key : undefined} groupId={el.key.toString()}>
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            {...el.linkProps}
+            target="_blank"
+            current={isLastItem}
+            href={isLastItem ? undefined : el.linkProps?.href}
+          >
+            {el.item}
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+      </OverflowItem>
+      {!isLastItem && <OverflowGroupDivider groupId={el.key} />}
+    </React.Fragment>
+  );
+}
 
 const useOverflowMenuStyles = makeStyles({
   menu: {
@@ -146,7 +161,7 @@ const useStyles = makeStyles({
   },
 });
 
-const OverflowBreadcrumbButton: React.FC<{ id: string; item: ButtonItem }> = props => {
+const OverflowBreadcrumbButton: React.FC<{ id: string; item: LinkItem }> = props => {
   const { item, id } = props;
   const isVisible = useIsOverflowItemVisible(id);
 
@@ -154,7 +169,7 @@ const OverflowBreadcrumbButton: React.FC<{ id: string; item: ButtonItem }> = pro
     return null;
   }
 
-  return <MenuItem {...item.buttonProps}>{item.item}</MenuItem>;
+  return <MenuItem {...item.linkProps}>{item.item}</MenuItem>;
 };
 
 const OverflowGroupDivider: React.FC<{
@@ -167,7 +182,7 @@ const OverflowGroupDivider: React.FC<{
   );
 };
 
-const ControlledOverflowMenu = (props: PartitionBreadcrumbItems<ButtonItem>) => {
+const ControlledOverflowMenu = (props: PartitionBreadcrumbItems<LinkItem>) => {
   const { overflowItems, startDisplayedItems, endDisplayedItems } = props;
   const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
@@ -192,16 +207,16 @@ const ControlledOverflowMenu = (props: PartitionBreadcrumbItems<ButtonItem>) => 
       <MenuPopover>
         <MenuList className={styles.menu}>
           {isOverflowing &&
-            startDisplayedItems.map((item: ButtonItem) => (
+            startDisplayedItems.map((item: LinkItem) => (
               <OverflowBreadcrumbButton id={item.key.toString()} item={item} key={item.key} />
             ))}
           {overflowItems &&
-            overflowItems.map((item: ButtonItem) => (
+            overflowItems.map((item: LinkItem) => (
               <OverflowBreadcrumbButton id={item.key.toString()} item={item} key={item.key} />
             ))}
           {isOverflowing &&
             endDisplayedItems &&
-            endDisplayedItems.map((item: ButtonItem) => (
+            endDisplayedItems.map((item: LinkItem) => (
               <OverflowBreadcrumbButton id={item.key.toString()} item={item} key={item.key} />
             ))}
         </MenuList>
@@ -212,28 +227,17 @@ const ControlledOverflowMenu = (props: PartitionBreadcrumbItems<ButtonItem>) => 
 const BreadcrumbControlledOverflowExample = () => {
   const styles = useExampleStyles();
 
-  const { startDisplayedItems, overflowItems, endDisplayedItems }: PartitionBreadcrumbItems<ButtonItem> =
+  const { startDisplayedItems, overflowItems, endDisplayedItems }: PartitionBreadcrumbItems<LinkItem> =
     partitionBreadcrumbItems({
-      items: buttonItems,
+      items: linkItems,
       maxDisplayedItems: 4,
     });
 
   return (
     <div className={mergeClasses(styles.example, styles.horizontal)}>
-      <Overflow>
+      <Overflow padding={40}>
         <Breadcrumb>
-          {startDisplayedItems.map((item: ButtonItem) => {
-            return (
-              <React.Fragment key={`start-items-${item.key}`}>
-                <OverflowItem id={`${item.key}`} groupId={item.key.toString()}>
-                  <BreadcrumbItem>
-                    <BreadcrumbButton {...item.buttonProps}>{item.item}</BreadcrumbButton>
-                  </BreadcrumbItem>
-                </OverflowItem>
-                <OverflowGroupDivider groupId={item.key} />
-              </React.Fragment>
-            );
-          })}
+          {startDisplayedItems.map((item: LinkItem) => renderLink(item, item.key === linkItems.length - 1))}
           <ControlledOverflowMenu
             overflowItems={overflowItems}
             startDisplayedItems={startDisplayedItems}
@@ -241,25 +245,9 @@ const BreadcrumbControlledOverflowExample = () => {
           />
           <BreadcrumbDivider />
           {endDisplayedItems &&
-            endDisplayedItems.map((item: ButtonItem) => {
-              const isLastItem = item.key === buttonItems.length - 1;
-
-              return (
-                <React.Fragment key={`end-items-${item.key}`}>
-                  <OverflowItem
-                    id={item.key.toString()}
-                    priority={isLastItem ? item.key : undefined}
-                    groupId={item.key.toString()}
-                  >
-                    <BreadcrumbItem>
-                      <BreadcrumbButton {...item.buttonProps} current={isLastItem}>
-                        {item.item}
-                      </BreadcrumbButton>
-                    </BreadcrumbItem>
-                  </OverflowItem>
-                  {!isLastItem && <OverflowGroupDivider groupId={item.key} />}
-                </React.Fragment>
-              );
+            endDisplayedItems.map((item: LinkItem) => {
+              const isLastItem = item.key === linkItems.length - 1;
+              return renderLink(item, isLastItem);
             })}
         </Breadcrumb>
       </Overflow>
@@ -267,7 +255,7 @@ const BreadcrumbControlledOverflowExample = () => {
   );
 };
 
-export const BreadcrumbWithOverflow = () => {
+export const BreadcrumbLinkWithOverflow = () => {
   const styles = useStyles();
 
   return (
@@ -275,17 +263,4 @@ export const BreadcrumbWithOverflow = () => {
       <BreadcrumbControlledOverflowExample />
     </div>
   );
-};
-
-BreadcrumbWithOverflow.parameters = {
-  docs: {
-    description: {
-      story: [
-        'The maximum number of items in a breadcrumb can be customized. We recommend a maximum of 6 items or fewer.',
-        'When the maximum number is exceeded, items in the middle auto-collapse into an overflow menu.',
-        '\nThe first and last items should always appear  in the breadcrumb. Breadcrumbs should never wrap.',
-        'By default BreadcrumbButton is used.',
-      ].join('\n'),
-    },
-  },
 };

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithOverflow.stories.tsx
@@ -167,6 +167,21 @@ const OverflowGroupDivider: React.FC<{
   );
 };
 
+const renderButton = (el: ButtonItem, isLastItem: boolean = false) => {
+  return (
+    <React.Fragment key={`button-items-${el.key}`}>
+      <OverflowItem id={el.key.toString()} priority={isLastItem ? el.key : undefined} groupId={el.key.toString()}>
+        <BreadcrumbItem>
+          <BreadcrumbButton {...el.buttonProps} current={isLastItem}>
+            {el.item}
+          </BreadcrumbButton>
+        </BreadcrumbItem>
+      </OverflowItem>
+      {!isLastItem && <OverflowGroupDivider groupId={el.key} />}
+    </React.Fragment>
+  );
+};
+
 const ControlledOverflowMenu = (props: PartitionBreadcrumbItems<ButtonItem>) => {
   const { overflowItems, startDisplayedItems, endDisplayedItems } = props;
   const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
@@ -222,18 +237,7 @@ const BreadcrumbControlledOverflowExample = () => {
     <div className={mergeClasses(styles.example, styles.horizontal)}>
       <Overflow>
         <Breadcrumb>
-          {startDisplayedItems.map((item: ButtonItem) => {
-            return (
-              <React.Fragment key={`start-items-${item.key}`}>
-                <OverflowItem id={`${item.key}`} groupId={item.key.toString()}>
-                  <BreadcrumbItem>
-                    <BreadcrumbButton {...item.buttonProps}>{item.item}</BreadcrumbButton>
-                  </BreadcrumbItem>
-                </OverflowItem>
-                <OverflowGroupDivider groupId={item.key} />
-              </React.Fragment>
-            );
-          })}
+          {startDisplayedItems.map((item: ButtonItem) => renderButton(item, false))}
           <ControlledOverflowMenu
             overflowItems={overflowItems}
             startDisplayedItems={startDisplayedItems}
@@ -243,23 +247,7 @@ const BreadcrumbControlledOverflowExample = () => {
           {endDisplayedItems &&
             endDisplayedItems.map((item: ButtonItem) => {
               const isLastItem = item.key === buttonItems.length - 1;
-
-              return (
-                <React.Fragment key={`end-items-${item.key}`}>
-                  <OverflowItem
-                    id={item.key.toString()}
-                    priority={isLastItem ? item.key : undefined}
-                    groupId={item.key.toString()}
-                  >
-                    <BreadcrumbItem>
-                      <BreadcrumbButton {...item.buttonProps} current={isLastItem}>
-                        {item.item}
-                      </BreadcrumbButton>
-                    </BreadcrumbItem>
-                  </OverflowItem>
-                  {!isLastItem && <OverflowGroupDivider groupId={item.key} />}
-                </React.Fragment>
-              );
+              return renderButton(item, isLastItem);
             })}
         </Breadcrumb>
       </Overflow>

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/index.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/index.stories.tsx
@@ -6,6 +6,8 @@ import bestPracticesMd from './BreadcrumbBestPractices.md';
 export { Default } from './BreadcrumbDefault.stories';
 export { BreadcrumbSize } from './BreadcrumbSize.stories';
 export { BreadcrumbWithOverflow } from './BreadcrumbWithOverflow.stories';
+export { BreadcrumbLinkWithOverflow } from './BreadcrumbLinkWithOverflow.stories';
+export { BreadcrumbItemWithOverflow } from './BreadcrumbItemWithOverflow.stories';
 export { BreadcrumbFocusMode } from './BreadcrumbFocusMode';
 
 export default {

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbDivider/BreadcrumbDividerDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbDivider/BreadcrumbDividerDefault.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Breadcrumb, BreadcrumbItem, BreadcrumbDivider } from '@fluentui/react-breadcrumb-preview';
-import { ArrowRight16Filled } from '@fluentui/react-icons';
 
 export const Default = () => (
   <>
+    <h2>Slash divider which can be used only for small non-clickable items</h2>
     <Breadcrumb aria-label="Breadcrumb example with slash divider" size="small" dividerType="slash">
       <BreadcrumbItem>Item</BreadcrumbItem>
       <BreadcrumbDivider />
@@ -11,13 +11,12 @@ export const Default = () => (
       <BreadcrumbDivider />
       <BreadcrumbItem>Item</BreadcrumbItem>
     </Breadcrumb>
+    <h2>Default type of the divider</h2>
     <Breadcrumb aria-label="Breadcrumb example with the divider" size="large">
       <BreadcrumbItem>Item</BreadcrumbItem>
       <BreadcrumbDivider />
       <BreadcrumbItem>Item</BreadcrumbItem>
-      <BreadcrumbDivider>
-        <ArrowRight16Filled />
-      </BreadcrumbDivider>
+      <BreadcrumbDivider />
       <BreadcrumbItem>Item</BreadcrumbItem>
     </Breadcrumb>
   </>

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbLink/BreadcrumbLinkDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbLink/BreadcrumbLinkDefault.stories.tsx
@@ -82,7 +82,7 @@ const linkItems: Item[] = [
 
 function renderLink(el: Item, isLastItem: boolean = false) {
   return (
-    <React.Fragment key={`${el.key}-button`}>
+    <React.Fragment key={`${el.key}-link`}>
       <BreadcrumbItem>
         <BreadcrumbLink
           {...el.linkProps}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
- removed custom divider because it's not recommended to use these kinds of dividers: ![image](https://github.com/microsoft/fluentui/assets/11574680/97a07741-51c7-482e-be3d-7ef252a94cdb)
- removed paddings from BreadcrumbLink and BreadcrumbButton: 
![image](https://github.com/microsoft/fluentui/assets/11574680/efab3093-ab74-4a6b-9273-88e3e985cc50)

## New Behavior
- Divider:
![image](https://github.com/microsoft/fluentui/assets/11574680/6e76a3fa-4f05-40a7-a32e-f2ceb9bf271b)
- BreadcumbButton (looks almost the same, but there are no paddings)
![image](https://github.com/microsoft/fluentui/assets/11574680/fba532c0-d91f-43a0-983c-052a58781365)
