### PR TITLE
bugfix: moves handleBackdropClick from defaultProps to an override

### DIFF
--- a/change/@fluentui-react-dialog-b94a462e-5c88-4181-a8b8-3f1aa9068b92.json
+++ b/change/@fluentui-react-dialog-b94a462e-5c88-4181-a8b8-3f1aa9068b92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: moves handleBackdropClick from defaultProps to an override ",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -23,7 +23,6 @@ export const useDialogSurface_unstable = (
   props: DialogSurfaceProps,
   ref: React.Ref<DialogSurfaceElement>,
 ): DialogSurfaceState => {
-  const { backdrop, as } = props;
   const modalType = useDialogContext_unstable(ctx => ctx.modalType);
   const modalAttributes = useDialogContext_unstable(ctx => ctx.modalAttributes);
   const dialogRef = useDialogContext_unstable(ctx => ctx.dialogRef);
@@ -59,19 +58,24 @@ export const useDialogSurface_unstable = (
     }
   });
 
+  const backdrop = resolveShorthand(props.backdrop, {
+    required: open && modalType !== 'non-modal',
+    defaultProps: {
+      'aria-hidden': 'true',
+    },
+  });
+
+  if (backdrop) {
+    backdrop.onClick = handledBackdropClick;
+  }
+
   return {
     components: {
       backdrop: 'div',
       root: 'div',
     },
-    backdrop: resolveShorthand(backdrop, {
-      required: open && modalType !== 'non-modal',
-      defaultProps: {
-        'aria-hidden': 'true',
-        onClick: handledBackdropClick,
-      },
-    }),
-    root: getNativeElementProps(as ?? 'div', {
+    backdrop,
+    root: getNativeElementProps(props.as ?? 'div', {
       tabIndex: -1, // https://github.com/microsoft/fluentui/issues/25150
       'aria-modal': modalType !== 'non-modal',
       role: modalType === 'alert' ? 'alertdialog' : 'dialog',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Event listener that ensured `backdrop` functionality on click event was being added as a `defaultProp`, which could be overridden by external user by passing `backdrop={{onClick}}`, breaking backdrop behaviour

## New Behavior

1. Makes `handleBackdropClick` an override method instead of a `defaultProp`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
