### PR TITLE
fix(scripts-beachball): dont override */9.0-alpha versions specified within apps during release

### DIFF
--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -22,7 +22,7 @@
     "@fluentui/react-avatar": "*",
     "@fluentui/react-button": "*",
     "@fluentui/react-field": "*",
-    "@fluentui/react-infobutton": "9.0.0-beta.42",
+    "@fluentui/react-infobutton": ">=9.0.0-alpha",
     "@fluentui/react-persona": "*",
     "@fluentui/react-provider": "*",
     "@fluentui/react-spinbutton": "*",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -34,7 +34,7 @@
     "@fluentui/react-field": "*",
     "@fluentui/react-icons": "^2.0.203",
     "@fluentui/react-image": "*",
-    "@fluentui/react-infobutton": "9.0.0-beta.42",
+    "@fluentui/react-infobutton": ">=9.0.0-alpha",
     "@fluentui/react-input": "*",
     "@fluentui/react-label": "*",
     "@fluentui/react-link": "*",

--- a/scripts/beachball/shared.config.ts
+++ b/scripts/beachball/shared.config.ts
@@ -22,10 +22,10 @@ export const config: typeof baseConfig & Required<Pick<BeachballConfig, 'changel
     precommit: () => {
       try {
         const generators = [
-          // Fixes unwanted pre-release dependency bumps caused by beachball
-          'normalize-package-dependencies',
           // Fixes any dependency mismatches caused by beachball scoping
           'dependency-mismatch',
+          // Fixes unwanted pre-release dependency bumps caused by beachball - This needs to run last otherwise deps within apps will contain exact versions ( which dependency-mismatch generator update - TODO we need to fix it)
+          'normalize-package-dependencies',
         ];
 
         generators.forEach(generator => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

every release that bumps inner workspace dependency used within applications will put master in invalid state

<img width="997" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/a859b694-0229-4ffc-bd84-f0ddd291eab8">


## New Behavior

- Fixed invalid deps
- fixed order of generators invocations on beachball release so this wont happen again

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
