### PR TITLE
fix: do not dismiss editable comboboxes on scroll or resize immediately after opening

### DIFF
--- a/change/@fluentui-react-f1224d11-1ccf-4845-805f-fe84e7b89377.json
+++ b/change/@fluentui-react-f1224d11-1ccf-4845-805f-fe84e7b89377.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not dismiss editable comboboxes on scroll or resize immediately after opening",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -293,6 +293,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   private _async: Async;
   private _events: EventGroup;
 
+  // props to prevent dismiss on scroll/resize immediately after opening
+  private _overrideScrollDismiss = false;
+  private _overrideScrollDimissTimeout: number;
+
   constructor(props: IComboBoxInternalProps) {
     super(props);
 
@@ -403,8 +407,15 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     this._notifyPendingValueChanged(prevState);
 
-    if (isOpen && !prevState.isOpen && onMenuOpen) {
-      onMenuOpen();
+    if (isOpen && !prevState.isOpen) {
+      // handle dismiss buffer after suggestions are opened
+      this._overrideScrollDismiss = true;
+      this._async.clearTimeout(this._overrideScrollDimissTimeout);
+      this._overrideScrollDimissTimeout = this._async.setTimeout(() => {
+        this._overrideScrollDismiss = false;
+      }, 100);
+
+      onMenuOpen?.();
     }
 
     if (!isOpen && prevState.isOpen && onMenuDismissed) {
@@ -834,6 +845,20 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       ? this._processInputChangeWithFreeform(updatedValue)
       : this._processInputChangeWithoutFreeform(updatedValue);
   };
+
+  /**
+   * Do not dismiss if the window resizes or scrolls within 100ms of opening
+   * This prevents the Android issue where pickers immediately dismiss on open, because the keyboard appears
+   * @param ev - the event triggering the dismiss check
+   * @returns a boolean indicating whether the callout dismissal should be prevented
+   */
+  private _preventDismissOnScrollOrResize(ev: Event) {
+    if (this._overrideScrollDismiss && (ev.type === 'scroll' || ev.type === 'resize')) {
+      return true;
+    }
+
+    return false;
+  }
 
   /**
    * Process the new input's new value when the combo box allows freeform entry
@@ -1371,6 +1396,8 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         calloutMaxWidth={dropdownMaxWidth ? dropdownMaxWidth : comboBoxMenuWidth}
         hidden={persistMenu ? !isOpen : undefined}
         shouldRestoreFocus={shouldRestoreFocus}
+        // eslint-disable-next-line react/jsx-no-bind
+        preventDismissOnEvent={this._preventDismissOnScrollOrResize.bind(this)}
       >
         {onRenderUpperContent(this.props, this._onRenderUpperContent)}
         <div className={this._classNames.optionsContainerWrapper} ref={this._comboBoxMenu}>

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1397,7 +1397,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         hidden={persistMenu ? !isOpen : undefined}
         shouldRestoreFocus={shouldRestoreFocus}
         // eslint-disable-next-line react/jsx-no-bind
-        preventDismissOnEvent={this._preventDismissOnScrollOrResize.bind(this)}
+        preventDismissOnEvent={(ev: Event) => this._preventDismissOnScrollOrResize(ev)}
       >
         {onRenderUpperContent(this.props, this._onRenderUpperContent)}
         <div className={this._classNames.optionsContainerWrapper} ref={this._comboBoxMenu}>

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -368,7 +368,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
         directionalHint={DirectionalHint.bottomLeftEdge}
         directionalHintForRTL={DirectionalHint.bottomRightEdge}
         // eslint-disable-next-line react/jsx-no-bind
-        preventDismissOnEvent={this._preventDismissOnScrollOrResize.bind(this)}
+        preventDismissOnEvent={(ev: Event) => this._preventDismissOnScrollOrResize(ev)}
         {...this.props.pickerCalloutProps}
       >
         <StyledTypedSuggestions

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -111,6 +111,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
   private _styledSuggestions = getStyledSuggestions(this.SuggestionOfProperType);
   private _id: string;
   private _async: Async;
+  private _overrideScrollDismiss = false;
+  private _overrideScrollDimissTimeout: number;
 
   public static getDerivedStateFromProps(newProps: IBasePickerProps<any>) {
     if (newProps.selectedItems) {
@@ -174,6 +176,15 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
           this.resetFocus(this.state.items.length - 1);
         }
       }
+    }
+
+    // handle dismiss buffer after suggestions are opened
+    if (this.state.suggestionsVisible && !oldState.suggestionsVisible) {
+      this._overrideScrollDismiss = true;
+      this._async.clearTimeout(this._overrideScrollDimissTimeout);
+      this._overrideScrollDimissTimeout = this._async.setTimeout(() => {
+        this._overrideScrollDismiss = false;
+      }, 100);
     }
   }
 
@@ -356,6 +367,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
         onDismiss={this.dismissSuggestions}
         directionalHint={DirectionalHint.bottomLeftEdge}
         directionalHintForRTL={DirectionalHint.bottomRightEdge}
+        // eslint-disable-next-line react/jsx-no-bind
+        preventDismissOnEvent={this._preventDismissOnScrollOrResize.bind(this)}
         {...this.props.pickerCalloutProps}
       >
         <StyledTypedSuggestions
@@ -951,6 +964,16 @@ export class BasePicker<T, P extends IBasePickerProps<T>>
         {removedItemText}
       </div>
     );
+  }
+
+  // do not dismiss if the window resizes or scrolls within 100ms of opening
+  // this prevents the Android issue where pickers immediately dismiss on open, because the keyboard appears
+  private _preventDismissOnScrollOrResize(ev: Event) {
+    if (this._overrideScrollDismiss && (ev.type === 'scroll' || ev.type === 'resize')) {
+      return true;
+    }
+
+    return false;
   }
 
   /** If suggestions are still loading after a predefined amount of time, set state to show user alert */


### PR DESCRIPTION
This is primarily geared towards fixing the issue where Android resizes the window when the keyboard opens (vs. iOS, which overlays the keyboard over the window). This means that editable comboboxes and pickers always dismiss the list of options immediately after opening on focus, since the keyboard simultaneously pops up.

## Previous Behavior

Android users at best must open a combobox or picker popup twice to view options. At worst, they can never use the popup -- this happens in the case of Talkback users, since Talkback shows/hides the keychain toolbar above the keyboard every time the popup opens and closes. Also for any picker/combobox implementations that do not provide a way to re-open the listbox popup while focus remains in the input.

## New Behavior

If the Combobox or Picker's Callout detects a scroll or resize event within 100ms of opening, it does not dismiss. This is scoped to Combobox and Picker because those are the two components that get this keyboard + Callout interaction, and limited to events within 100ms of opening, which prevents the Android keyboard dismissal but is too short for intentional user events.

## Related Issue(s)

- Fixes [16064](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16064)
