### PR TITLE
fix: v9 Option hover and pressed tokens

### DIFF
--- a/change/@fluentui-react-combobox-61c39a8b-d105-4eb8-bcd6-542e55ca5db5.json
+++ b/change/@fluentui-react-combobox-61c39a8b-d105-4eb8-bcd6-542e55ca5db5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add color tokens for option hover and pressed states",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
@@ -27,10 +27,12 @@ const useStyles = makeStyles({
 
     '&:hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
+      color: tokens.colorNeutralForeground1Hover,
     },
 
     '&:active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
+      color: tokens.colorNeutralForeground1Pressed,
     },
   },
 


### PR DESCRIPTION
Adds explicit tokens for react-combobox Option hover & pressed states. This does not change the Web light/dark theme, but does affect Teams high contrast, and potentially other themes that use separate hover/pressed foreground tokens.

Fixes #28225