### PR TITLE
fix(react-conformance): add @swc/helpers to deps instead of tslib as we use swc for transpilation

### DIFF
--- a/change/@fluentui-react-conformance-f6f452eb-ff7e-4715-918a-4a62a51a7e40.json
+++ b/change/@fluentui-react-conformance-f6f452eb-ff7e-4715-918a-4a62a51a7e40.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add @swc/helpers to deps instead of tslib as we use swc for transpilation",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -29,7 +29,7 @@
     "chalk": "^2.4.2",
     "react-docgen-typescript": "^2.1.0",
     "react-is": "^17.0.2",
-    "tslib": "^2.1.0"
+    "@swc/helpers": "^0.4.14"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <19.0.0",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

During migration to v9 setup (including swc use for transpilation ) we forgot to replace tslib with swc helpers

## Related Issue(s)

Follows https://github.com/microsoft/fluentui/pull/28215

