### PR TITLE
fix: DetailsColumn tooltip shows on focus, is associated via aria-describedby

### DIFF
--- a/change/@fluentui-react-aea800d3-31d8-4c2c-a34f-9b91f4d2463d.json
+++ b/change/@fluentui-react-aea800d3-31d8-4c2c-a34f-9b91f4d2463d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DetailsColumn tooltip shows on focus, and is associated via aria-describedby",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -13,6 +13,7 @@ import type {
   IDetailsColumnRenderTooltipProps,
   IDetailsColumnFilterIconProps,
 } from './DetailsColumn.types';
+import { ITooltipHost } from '../Tooltip/TooltipHost.types';
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 
@@ -46,6 +47,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
   private _root = React.createRef<HTMLDivElement>();
   private _dragDropSubscription?: IDisposable;
   private _classNames: IProcessedStyleSet<IDetailsColumnStyles>;
+  private _tooltipRef = React.createRef<ITooltipHost>();
 
   constructor(props: IDetailsColumnProps) {
     super(props);
@@ -94,13 +96,14 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     const hasInnerButton =
       column.columnActionsMode !== ColumnActionsMode.disabled &&
       (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined);
+    // use aria-describedby to point to the tooltip if the tooltip is not using the ariaLabel string
+    const shouldAssociateTooltip =
+      (!this.props.onRenderColumnHeaderTooltip && this._hasAccessibleDescription()) ||
+      (this.props.onRenderColumnHeaderTooltip && !column.ariaLabel);
     const accNameDescription = {
       'aria-label': column.ariaLabel ? column.ariaLabel : column.isIconOnly ? column.name : undefined,
       'aria-labelledby': column.ariaLabel || column.isIconOnly ? undefined : `${parentId}-${column.key}-name`,
-      'aria-describedby':
-        !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleDescription()
-          ? `${parentId}-${column.key}-tooltip`
-          : undefined,
+      'aria-describedby': shouldAssociateTooltip ? `${parentId}-${column.key}-tooltip` : undefined,
     };
 
     return (
@@ -127,6 +130,8 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
           }}
           data-automationid={'ColumnsHeaderColumn'}
           data-item-key={column.key}
+          onBlur={this._onColumnBlur}
+          onFocus={this._onColumnFocus}
         >
           {isDraggable && (
             <IconComponent iconName="GripperBarVertical" className={classNames.gripperBarVerticalStyle} />
@@ -137,6 +142,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
               id: `${parentId}-${column.key}-tooltip`,
               setAriaDescribedBy: false,
               column,
+              componentRef: this._tooltipRef,
               content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
               children: (
                 <span
@@ -268,6 +274,14 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     if (onColumnClick) {
       onColumnClick(ev, column);
     }
+  };
+
+  private _onColumnBlur = () => {
+    this._tooltipRef.current && this._tooltipRef.current.dismiss();
+  };
+
+  private _onColumnFocus = () => {
+    this._tooltipRef.current && this._tooltipRef.current.show();
   };
 
   private _getColumnDragDropOptions(): IDragDropOptions {

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -97,9 +97,9 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       column.columnActionsMode !== ColumnActionsMode.disabled &&
       (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined);
     // use aria-describedby to point to the tooltip if the tooltip is not using the ariaLabel string
-    const shouldAssociateTooltip =
-      (!this.props.onRenderColumnHeaderTooltip && this._hasAccessibleDescription()) ||
-      (this.props.onRenderColumnHeaderTooltip && !column.ariaLabel);
+    const shouldAssociateTooltip = this.props.onRenderColumnHeaderTooltip
+      ? !column.ariaLabel
+      : this._hasAccessibleDescription();
     const accNameDescription = {
       'aria-label': column.ariaLabel ? column.ariaLabel : column.isIconOnly ? column.name : undefined,
       'aria-labelledby': column.ariaLabel || column.isIconOnly ? undefined : `${parentId}-${column.key}-name`,

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -186,7 +186,7 @@ describe('DetailsColumn', () => {
     expect(component.exists(`#${referenceId}`)).toBe(true);
   });
 
-  it('does render invalid aria-describedby pointing to a custom tooltip not using ariaLabel', () => {
+  it('renders valid aria-describedby pointing to a custom tooltip not set using ariaLabel', () => {
     const column: IColumn = { ...baseColumn, isFiltered: true, filterAriaLabel: 'Foo' };
     let component: any;
     const columns = [column];

--- a/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -4,6 +4,7 @@ import { ColumnActionsMode } from './DetailsList.types';
 import { mount } from 'enzyme';
 import { DetailsList } from './DetailsList';
 import { TooltipHost } from '../../Tooltip';
+import { resetIds } from '../../Utilities';
 import * as renderer from 'react-test-renderer';
 import type { IColumn, IDetailsHeaderProps } from './DetailsList.types';
 import type { IRenderFunction } from '../../Utilities';
@@ -14,6 +15,7 @@ let baseColumn: IColumn;
 
 describe('DetailsColumn', () => {
   beforeEach(() => {
+    resetIds();
     mockOnColumnClick = jest.fn();
     baseColumn = {
       key: '1',
@@ -184,8 +186,42 @@ describe('DetailsColumn', () => {
     expect(component.exists(`#${referenceId}`)).toBe(true);
   });
 
-  it('does not render invalid aria-describedby if custom DetailsHeader has onRenderColumnHeaderTooltip', () => {
+  it('does render invalid aria-describedby pointing to a custom tooltip not using ariaLabel', () => {
     const column: IColumn = { ...baseColumn, isFiltered: true, filterAriaLabel: 'Foo' };
+    let component: any;
+    const columns = [column];
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        onRenderDetailsHeader={(props: IDetailsHeaderProps, defaultRenderer?: IRenderFunction<IDetailsHeaderProps>) => {
+          return defaultRenderer!({
+            ...props,
+            onRenderColumnHeaderTooltip: (
+              tooltipProps: ITooltipHostProps,
+              tooltipRenderer?: IRenderFunction<ITooltipHostProps>,
+            ) => {
+              return <TooltipHost {...tooltipProps} content="foo" />;
+            },
+          });
+        }}
+        componentRef={ref => (component = ref)}
+        onShouldVirtualize={() => false}
+      />,
+    );
+
+    const ariaDescribedByEl = component.find('[aria-describedby]').first().getDOMNode();
+    const referenceId = ariaDescribedByEl.getAttribute('aria-describedby');
+
+    expect(component.exists(`#${referenceId}`)).toBe(true);
+  });
+
+  it('does not render invalid aria-describedby if custom DetailsHeader has onRenderColumnHeaderTooltip', () => {
+    const column: IColumn = { ...baseColumn, isFiltered: true, ariaLabel: 'Foo', filterAriaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                 display: block;
               }
           data-automationid="DetailsHeader"
-          data-focuszone-id="FocusZone44"
+          data-focuszone-id="FocusZone2"
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
@@ -86,7 +86,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
           role="row"
         >
           <div
-            aria-labelledby="header43-checkTooltip"
+            aria-labelledby="header1-checkTooltip"
             className=
                 ms-DetailsHeader-cell
                 ms-DetailsHeader-cellIsCheck
@@ -192,7 +192,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                 data-automationid="DetailsRowCheck"
                 data-is-focusable={true}
                 data-selection-toggle={true}
-                id="header43-check"
+                id="header1-check"
                 role="checkbox"
                 tabIndex={-1}
               >
@@ -388,6 +388,8 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
             data-is-draggable={false}
             data-item-key="1"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -408,8 +410,8 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                   }
             >
               <span
-                aria-describedby="header43-1-tooltip"
-                aria-labelledby="header43-1-name"
+                aria-describedby="header1-1-tooltip"
+                aria-labelledby="header1-1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -441,7 +443,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                       z-index: 1;
                     }
                 data-is-focusable="true"
-                id="header43-1"
+                id="header1-1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
                 role="button"
@@ -456,7 +458,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                         overflow: hidden;
                         text-overflow: ellipsis;
                       }
-                  id="header43-1-name"
+                  id="header1-1-name"
                 >
                   Foo
                 </span>
@@ -514,7 +516,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                   width: 1px;
                 }
             hidden={true}
-            id="header43-1-tooltip"
+            id="header1-1-tooltip"
           >
             Foo
           </label>
@@ -548,7 +550,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                   min-height: 1px;
                   min-width: 100%;
                 }
-            data-focuszone-id="FocusZone45"
+            data-focuszone-id="FocusZone3"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -348,6 +348,8 @@ exports[`DetailsHeader can render 1`] = `
     data-is-focusable="true"
     data-item-key="a"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -537,6 +539,8 @@ exports[`DetailsHeader can render 1`] = `
     data-is-focusable="true"
     data-item-key="b"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -756,6 +760,8 @@ exports[`DetailsHeader can render 1`] = `
     data-is-focusable="true"
     data-item-key="c"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -1130,6 +1136,8 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     data-is-focusable="true"
     data-item-key="a"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -1319,6 +1327,8 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     data-is-focusable="true"
     data-item-key="b"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -1538,6 +1548,8 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     data-is-focusable="true"
     data-item-key="c"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -2074,6 +2086,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     data-is-focusable="true"
     data-item-key="a"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -2264,6 +2278,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     data-is-focusable="true"
     data-item-key="b"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {
@@ -2509,6 +2525,8 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     data-is-focusable="true"
     data-item-key="c"
     draggable={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
     role="columnheader"
     style={
       Object {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -2232,6 +2232,8 @@ exports[`DetailsList renders List correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2420,6 +2422,8 @@ exports[`DetailsList renders List correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2608,6 +2612,8 @@ exports[`DetailsList renders List correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3215,6 +3221,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_0"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3347,6 +3355,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_1"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3479,6 +3489,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_2"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3611,6 +3623,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_3"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3743,6 +3757,8 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_4"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -4295,6 +4311,8 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -4483,6 +4501,8 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -4671,6 +4691,8 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -5279,6 +5301,8 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -5467,6 +5491,8 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -5655,6 +5681,8 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6262,6 +6290,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_0"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6397,6 +6427,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_1"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6532,6 +6564,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_2"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6667,6 +6701,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_3"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6802,6 +6838,8 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_4"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -7217,6 +7255,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -7405,6 +7445,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -7593,6 +7635,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
@@ -1704,6 +1704,8 @@ exports[`DetailsListV2 renders List correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -1892,6 +1894,8 @@ exports[`DetailsListV2 renders List correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2080,6 +2084,8 @@ exports[`DetailsListV2 renders List correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2687,6 +2693,8 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_0"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2819,6 +2827,8 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_1"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2951,6 +2961,8 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_2"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3083,6 +3095,8 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_3"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3215,6 +3229,8 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_4"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3767,6 +3783,8 @@ exports[`DetailsListV2 renders List in compact mode correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3955,6 +3973,8 @@ exports[`DetailsListV2 renders List in compact mode correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -4143,6 +4163,8 @@ exports[`DetailsListV2 renders List in compact mode correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -4751,6 +4773,8 @@ exports[`DetailsListV2 renders List in fixed constrained layout correctly 1`] = 
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -4939,6 +4963,8 @@ exports[`DetailsListV2 renders List in fixed constrained layout correctly 1`] = 
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -5127,6 +5153,8 @@ exports[`DetailsListV2 renders List in fixed constrained layout correctly 1`] = 
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -5734,6 +5762,8 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_0"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -5869,6 +5899,8 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_1"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6004,6 +6036,8 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_2"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6139,6 +6173,8 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_3"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6274,6 +6310,8 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
             data-is-focusable="true"
             data-item-key="column_key_4"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6689,6 +6727,8 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -6877,6 +6917,8 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -7065,6 +7107,8 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -390,6 +390,8 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -522,6 +524,8 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -654,6 +658,8 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -1225,6 +1231,8 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -1357,6 +1365,8 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -1489,6 +1499,8 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2557,6 +2569,8 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2689,6 +2703,8 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -2821,6 +2837,8 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3392,6 +3410,8 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             data-is-focusable="true"
             data-item-key="key"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3524,6 +3544,8 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             data-is-focusable="true"
             data-item-key="name"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {
@@ -3656,6 +3678,8 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             data-is-focusable="true"
             data-item-key="value"
             draggable={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
             role="columnheader"
             style={
               Object {


### PR DESCRIPTION
## Previous Behavior

We provided an out-of-the-box method to create a DetailsColumn tooltip, but that tooltip wasn't keyboard accessible or associated via `aria-describedby` (with the exception of icon columns using `column.ariaLabel`).

## New Behavior

Now, when using `onRenderColumnHeaderTooltip`, the tooltip shows/hides on column header focus and blur, and is associated via `aria-describedby` unless the tooltip is already using the `column.ariaLabel` text since we don't want the same text as both label & description.

The reason to add `onFocus` and `onBlur` events to the columnheader node + call `.show()` and `.dismiss()` was to avoid needing to rearrange the DOM to make the TooltipHost the parent of the focusable columnheader.

## Related Issue(s)

- Fixes [16455](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16455)
