### PR TITLE
docs(react-tooltip): Add info icon + tooltip story to Tooltip stories

### DIFF
--- a/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
@@ -17,10 +17,10 @@ export const Icon = (props: Partial<TooltipProps>) => {
   const styles = useStyles();
   const iconId = useId('icon');
   const contentId = useId('content');
-  const [open, setOpen] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
 
   return (
-    <div aria-owns={open ? contentId : undefined} className={styles.root}>
+    <div aria-owns={visible ? contentId : undefined} className={styles.root}>
       <Label>This is an icon with a Tooltip to show extra information</Label>
       <Tooltip
         content={{
@@ -30,14 +30,14 @@ export const Icon = (props: Partial<TooltipProps>) => {
         positioning="above-start"
         withArrow
         relationship="label"
-        onVisibleChange={(e, { visible }) => setOpen(visible)}
+        onVisibleChange={(e, data) => setVisible(data.visible)}
         {...props}
       >
         <Info16Regular
           tabIndex={0}
           id={iconId}
           aria-labelledby={`${iconId} ${contentId}`}
-          className={mergeClasses(open && styles.visible)}
+          className={mergeClasses(visible && styles.visible)}
         />
       </Tooltip>
     </div>

--- a/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { Label, makeStyles, mergeClasses, tokens, Tooltip, useId } from '@fluentui/react-components';
 import { Info16Regular } from '@fluentui/react-icons';
 import type { TooltipProps } from '@fluentui/react-components';

--- a/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
@@ -17,10 +17,10 @@ export const Icon = (props: Partial<TooltipProps>) => {
   const styles = useStyles();
   const iconId = useId('icon');
   const contentId = useId('content');
-  const [visible, setVisible] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
 
   return (
-    <div aria-owns={visible ? contentId : undefined} className={styles.root}>
+    <div aria-owns={open ? contentId : undefined} className={styles.root}>
       <Label>This is an icon with a Tooltip to show extra information</Label>
       <Tooltip
         content={{
@@ -30,14 +30,14 @@ export const Icon = (props: Partial<TooltipProps>) => {
         positioning="above-start"
         withArrow
         relationship="label"
-        onVisibleChange={(e, { visible }) => setVisible(visible)}
+        onVisibleChange={(e, { visible }) => setOpen(visible)}
         {...props}
       >
         <Info16Regular
           tabIndex={0}
           id={iconId}
           aria-labelledby={`${iconId} ${contentId}`}
-          className={mergeClasses(visible && styles.visible)}
+          className={mergeClasses(open && styles.visible)}
         />
       </Tooltip>
     </div>

--- a/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { Label, makeStyles, mergeClasses, tokens, Tooltip, useId } from '@fluentui/react-components';
+import { Info16Regular } from '@fluentui/react-icons';
+import type { TooltipProps } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    columnGap: tokens.spacingVerticalS,
+  },
+  visible: {
+    color: tokens.colorNeutralForeground2BrandSelected,
+  },
+});
+
+export const Icon = (props: Partial<TooltipProps>) => {
+  const styles = useStyles();
+  const iconId = useId('icon');
+  const contentId = useId('content');
+  const [visible, setVisible] = React.useState(false);
+
+  return (
+    <div aria-owns={visible ? contentId : undefined} className={styles.root}>
+      <Label>This is an icon with a Tooltip to show extra information</Label>
+      <Tooltip
+        content={{
+          children: 'Content must never contain focusable elements.',
+          id: contentId,
+        }}
+        positioning="above-start"
+        withArrow
+        relationship="label"
+        onVisibleChange={(e, { visible }) => setVisible(visible)}
+        {...props}
+      >
+        <Info16Regular
+          tabIndex={0}
+          id={iconId}
+          aria-labelledby={`${iconId} ${contentId}`}
+          className={mergeClasses(visible && styles.visible)}
+        />
+      </Tooltip>
+    </div>
+  );
+};
+
+Icon.parameters = {
+  docs: {
+    description: {
+      story: `Tooltips can be attached to icons to create an info icon.`,
+    },
+  },
+};

--- a/packages/react-components/react-tooltip/stories/Tooltip/index.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/Tooltip/index.stories.tsx
@@ -12,6 +12,7 @@ export { CustomMount } from './TooltipCustomMount.stories';
 export { Controlled } from './TooltipControlled.stories';
 export { Positioning } from './TooltipPositioning.stories';
 export { Target } from './TooltipTarget.stories';
+export { Icon } from './TooltipIcon.stories';
 
 export default {
   title: 'Components/Tooltip',


### PR DESCRIPTION
This PR adds a story to tooltip that shows how to build an info icon with a tooltip following an InfoIcon pattern.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28602 
