### PR TITLE
fix: Overflow update should run show/hide steps twice

### DIFF
--- a/change/@fluentui-priority-overflow-c98cbac7-b421-4898-a6b9-cd0cf7dfb500.json
+++ b/change/@fluentui-priority-overflow-c98cbac7-b421-4898-a6b9-cd0cf7dfb500.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Overflow update should run show/hide steps twice",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-87d68562-a91a-45c0-bdd9-133e3a7d2616.json
+++ b/change/@fluentui-react-overflow-87d68562-a91a-45c0-bdd9-133e3a7d2616.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Overflow update should run show/hide steps twice",
+  "packageName": "@fluentui/react-overflow",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -641,34 +641,50 @@ describe('Overflow', () => {
     cy.contains('Update priority').click().get('#foo-visibility').should('have.text', 'visible');
   });
 
-  it('Should have correct initial visibility state', () => {
-    const mapHelper = new Array(10).fill(0).map((_, i) => i);
-    const Assert = () => {
-      const isVisible = mapHelper.map(i => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        return useIsOverflowItemVisible(i.toString());
-      });
-
-      if (isVisible.every(x => x)) {
-        return <span data-passed="true" />;
-      }
-
-      return null;
+  it('Should switch priorities and use all available space', () => {
+    const Example = () => {
+      const [selected, setSelelected] = React.useState(0);
+      return (
+        <>
+          <Container>
+            {mapHelper.map(i => (
+              <Item key={i} id={i.toString()} priority={selected === i ? 1000 : 0} width={i === 9 ? 100 : undefined}>
+                <span onClick={() => setSelelected(i)} style={{ color: selected === i ? 'red' : 'black' }}>
+                  {i}
+                </span>
+              </Item>
+            ))}
+            <Menu />
+          </Container>
+          <div>
+            <button id="select-9" onClick={() => setSelelected(9)}>
+              Select 9
+            </button>
+            <button id="select-0" onClick={() => setSelelected(0)}>
+              Select 0
+            </button>
+          </div>
+        </>
+      );
     };
 
-    mount(
-      <Container minimumVisible={5}>
-        {mapHelper.map(i => (
-          <Item key={i} id={i.toString()}>
-            {i}
-          </Item>
-        ))}
-        <Menu />
-        <Assert />
-      </Container>,
-    );
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+    mount(<Example />);
 
-    setContainerSize(500);
-    cy.get('[data-passed="true"]').should('exist');
+    cy.get(`[${selectors.item}="3"]`).click();
+    setContainerSize(250);
+    cy.get('#select-9').click();
+    cy.get(`[${selectors.item}="9"]`).should('be.visible');
+    cy.get(`[${selectors.item}="0"]`).should('be.visible');
+    cy.get(`[${selectors.item}="1"]`).should('be.visible');
+    cy.get(`[${selectors.item}="2"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="3"]`).should('not.be.visible');
+
+    cy.get('#select-0').click();
+    cy.get(`[${selectors.item}="9"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="0"]`).should('be.visible');
+    cy.get(`[${selectors.item}="1"]`).should('be.visible');
+    cy.get(`[${selectors.item}="2"]`).should('be.visible');
+    cy.get(`[${selectors.item}="3"]`).should('be.visible');
   });
 });

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -9,7 +9,6 @@ import {
   useIsOverflowGroupVisible,
   useOverflowMenu,
   useOverflowContext,
-  useIsOverflowItemVisible,
 } from '@fluentui/react-overflow';
 import { Portal } from '@fluentui/react-portal';
 

--- a/packages/react-components/react-overflow/stories/Overflow/Pinned.stories.tsx
+++ b/packages/react-components/react-overflow/stories/Overflow/Pinned.stories.tsx
@@ -85,11 +85,13 @@ const OverflowSelectionItem: React.FC<{
   return (
     <OverflowItem id={props.id} priority={props.selected ? 1000 : undefined}>
       <Button
+        style={{ flexWrap: 'nowrap', whiteSpace: 'nowrap', flexShrink: 0 }}
         aria-pressed={props.selected ? 'true' : 'false'}
         appearance={props.selected ? 'primary' : 'secondary'}
         onClick={onClick}
       >
         Item {props.id}
+        {props.id === '6' ? 'xxxxxxxxxxx' : ''}
       </Button>
     </OverflowItem>
   );

--- a/packages/react-components/react-overflow/stories/Overflow/Pinned.stories.tsx
+++ b/packages/react-components/react-overflow/stories/Overflow/Pinned.stories.tsx
@@ -85,13 +85,11 @@ const OverflowSelectionItem: React.FC<{
   return (
     <OverflowItem id={props.id} priority={props.selected ? 1000 : undefined}>
       <Button
-        style={{ flexWrap: 'nowrap', whiteSpace: 'nowrap', flexShrink: 0 }}
         aria-pressed={props.selected ? 'true' : 'false'}
         appearance={props.selected ? 'primary' : 'secondary'}
         onClick={onClick}
       >
         Item {props.id}
-        {props.id === '6' ? 'xxxxxxxxxxx' : ''}
       </Button>
     </OverflowItem>
   );


### PR DESCRIPTION
When new items are added to the overflow manager, they are always visible by default. This might not actually be the 'correct' state especially considering priorities.

Consider and item that is added whose priority is less than the top of the invisible item queue - it should actually not be visible. This can negatively affect the overflow calculation (which is batched)

In order to avoid these other solutions for their negative perf and complexity:
* Add more logic to addItem to account for an 'invalid' state
* Call `forceUpdate` every time an item is added

This PR simply changes the logic to run the hide/show step twice. Which will resolve any new items to their correct state first. In order to improve performance a cache for the offset size was added. This improves the performance even compared to the current version since `offsetWidth` and `offsetHeight` can be called multiple times for a single element in an overflow update.

Fixes #28624
