### PR TITLE
fix(tokens): change colorPaletteRedForeground1 to hcCanvas in TeamsHC theme

### DIFF
--- a/change/@fluentui-tokens-d60ecbe8-f77e-4874-9394-462749c5b06a.json
+++ b/change/@fluentui-tokens-d60ecbe8-f77e-4874-9394-462749c5b06a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "change colorPaletteRedForeground1 to hcCanvas in TeamsHC theme",
+  "packageName": "@fluentui/tokens",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tokens/src/alias/highContrastColorPalette.ts
+++ b/packages/tokens/src/alias/highContrastColorPalette.ts
@@ -20,6 +20,7 @@ const statusColorPaletteTokens = statusSharedColorNames.reduce((acc, sharedColor
 }, {} as StatusColorPaletteTokens);
 
 // one-off patches
+statusColorPaletteTokens.colorPaletteRedForeground1 = hcCanvas;
 statusColorPaletteTokens.colorPaletteRedForegroundInverted = hcCanvasText;
 statusColorPaletteTokens.colorPaletteGreenForegroundInverted = hcCanvasText;
 statusColorPaletteTokens.colorPaletteYellowForegroundInverted = hcCanvasText;


### PR DESCRIPTION
## Previous Behavior

`colorPaletteRedForeground1` was `hcCanvasText` (white) in Teams HC theme, partners have been overriding it to black

## New Behavior

`colorPaletteRedForeground1` is `hcCanvas` (black) in Teams HC theme which matches partner expectations

## Related Issue(s)

- Fixes #27952
