### PR TITLE
bugfix: selector slot required when selection mode is defined

### DIFF
--- a/change/@fluentui-react-tree-3b5f955f-0166-4e3b-85dc-82dddef56b0c.json
+++ b/change/@fluentui-react-tree-3b5f955f-0166-4e3b-85dc-82dddef56b0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: makes selector slot required when selection mode is defined",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -80,6 +80,7 @@ export const useTreeItemLayout_unstable = (
     actions,
     expandIcon,
     selector: resolveShorthand(props.selector, {
+      required: selectionMode !== 'none',
       defaultProps: {
         checked,
         tabIndex: -1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. makes selector slot required whenever the selection mode is defined, to ensure slot creation

<img width="1126" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/84fee1fc-fcb4-47e7-8a82-a106e46e9fcf">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
