### PR TITLE
feat(react-positioning): simplify maxSize options

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -568,9 +568,12 @@ const AutoSizeUpdatePosition = () => {
       <button ref={targetRef} style={{ width: 'fit-content', marginLeft: 100, marginTop: 10 }}>
         Target
       </button>
-      <Box ref={containerRef} style={{ overflow: 'auto', border: '3px solid green' }}>
+      <Box
+        ref={containerRef}
+        style={{ border: '3px solid green', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
+      >
         {isLoaded ? (
-          <div id="full-content" style={{ backgroundColor: 'cornflowerblue', width: 200, height: 100 }} />
+          <>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</>
         ) : (
           <button id="load-content" onClick={onLoaded}>
             load content
@@ -1132,9 +1135,9 @@ storiesOf('Positioning', module)
     <StoryWright
       steps={new Steps()
         .click('#load-content')
-        .wait('#full-content')
+        .waitForNotFound('#load-content')
         .wait(250) // let updatePosition finish
-        .snapshot('floating element is fully visible')
+        .snapshot('floating element width fills boundary and has text ellipsis')
         .end()}
     >
       <AutoSizeUpdatePosition />

--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -1125,7 +1125,7 @@ storiesOf('Positioning', module)
     <StoryWright
       steps={new Steps()
         .click('#load-content')
-        .waitForNotFound('#load-content')
+        .wait('#full-content')
         .wait(250) // let updatePosition finish
         .snapshot('floating element width fills boundary and overflows 10px because of overflow:clip')
         .end()}

--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -487,11 +487,7 @@ const AutoSizeAsyncContent = () => {
   });
 
   const [isLoaded, setLoaded] = React.useState(false);
-  React.useEffect(() => {
-    setTimeout(() => {
-      setLoaded(true);
-    }, 500);
-  });
+  const onLoaded = () => setLoaded(true);
 
   return (
     <div
@@ -511,21 +507,12 @@ const AutoSizeAsyncContent = () => {
           <span id="full-content">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. In fermentum et sollicitudin ac orci phasellus egestas. Facilisi cras fermentum odio eu
-            feugiat pretium nibh ipsum consequat. Praesent semper feugiat nibh sed pulvinar proin gravida hendrerit
-            lectus. Porta nibh venenatis cras sed felis eget. Enim sed faucibus turpis in. Non blandit massa enim nec
-            dui nunc mattis. Ut eu sem integer vitae justo. Lacus vestibulum sed arcu non. Vivamus arcu felis bibendum
-            ut. Sagittis vitae et leo duis ut diam quam nulla porttitor. Amet est placerat in egestas erat imperdiet.
-            Dapibus ultrices in iaculis nunc sed augue. Risus sed vulputate odio ut enim blandit volutpat maecenas. Orci
-            dapibus ultrices in iaculis nunc sed augue lacus. Quam elementum pulvinar etiam non quam. Tempor commodo
-            ullamcorper a lacus vestibulum sed arcu. Nunc non blandit massa enim nec. Venenatis a condimentum vitae
-            sapien. Sodales ut eu sem integer vitae justo eget magna. In aliquam sem fringilla ut morbi tincidunt augue.
-            Diam volutpat commodo sed egestas egestas fringilla phasellus faucibus scelerisque. Semper eget duis at
-            tellus. Diam donec adipiscing tristique risus nec feugiat in fermentum posuere. Amet volutpat consequat
-            mauris nunc congue nisi vitae. Hendrerit gravida rutrum quisque non tellus. Aliquet eget sit amet tellus.
-            Libero id faucibus nisl tincidunt. Amet nulla facilisi morbi tempus iaculis urna id.
+            feugiat pretium nibh ipsum consequat.
           </span>
         ) : (
-          <span>Loading...</span>
+          <button id="load-content" onClick={onLoaded}>
+            load
+          </button>
         )}
       </Box>
     </div>
@@ -568,15 +555,12 @@ const AutoSizeUpdatePosition = () => {
       <button ref={targetRef} style={{ width: 'fit-content', marginLeft: 100, marginTop: 10 }}>
         Target
       </button>
-      <Box
-        ref={containerRef}
-        style={{ border: '3px solid green', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
-      >
+      <Box ref={containerRef} style={{ overflow: 'clip', overflowClipMargin: 10, border: '3px solid green' }}>
         {isLoaded ? (
-          <>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</>
+          <div id="full-content" style={{ backgroundColor: 'cornflowerblue', width: 300, height: 100 }} />
         ) : (
           <button id="load-content" onClick={onLoaded}>
-            load content
+            load + update position
           </button>
         )}
       </Box>
@@ -1127,7 +1111,13 @@ storiesOf('Positioning', module)
   .addStory('pinned', () => <Pinned />)
   .addStory('auto size', () => <AutoSize />)
   .addStory('auto size with async content', () => (
-    <StoryWright steps={new Steps().wait('#full-content').snapshot('floating element is within the boundary').end()}>
+    <StoryWright
+      steps={new Steps()
+        .click('#load-content')
+        .wait('#full-content')
+        .snapshot('floating element is within the boundary')
+        .end()}
+    >
       <AutoSizeAsyncContent />
     </StoryWright>
   ))
@@ -1137,7 +1127,7 @@ storiesOf('Positioning', module)
         .click('#load-content')
         .waitForNotFound('#load-content')
         .wait(250) // let updatePosition finish
-        .snapshot('floating element width fills boundary and has text ellipsis')
+        .snapshot('floating element width fills boundary and overflows 10px because of overflow:clip')
         .end()}
     >
       <AutoSizeUpdatePosition />

--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -477,6 +477,110 @@ const AutoSize = () => {
   );
 };
 
+const AutoSizeAsyncContent = () => {
+  const styles = useStyles();
+  const [overflowBoundary, setOverflowBoundary] = React.useState<HTMLDivElement | null>(null);
+  const { containerRef, targetRef } = usePositioning({
+    position: 'below',
+    autoSize: true,
+    overflowBoundary,
+  });
+
+  const [isLoaded, setLoaded] = React.useState(false);
+  React.useEffect(() => {
+    setTimeout(() => {
+      setLoaded(true);
+    }, 500);
+  });
+
+  return (
+    <div
+      ref={setOverflowBoundary}
+      className={styles.boundary}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 200,
+        padding: '10px 50px',
+        position: 'relative',
+      }}
+    >
+      <button ref={targetRef}>Target</button>
+      <Box ref={containerRef} style={{ overflow: 'auto', border: '3px solid green' }}>
+        {isLoaded ? (
+          <span id="full-content">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. In fermentum et sollicitudin ac orci phasellus egestas. Facilisi cras fermentum odio eu
+            feugiat pretium nibh ipsum consequat. Praesent semper feugiat nibh sed pulvinar proin gravida hendrerit
+            lectus. Porta nibh venenatis cras sed felis eget. Enim sed faucibus turpis in. Non blandit massa enim nec
+            dui nunc mattis. Ut eu sem integer vitae justo. Lacus vestibulum sed arcu non. Vivamus arcu felis bibendum
+            ut. Sagittis vitae et leo duis ut diam quam nulla porttitor. Amet est placerat in egestas erat imperdiet.
+            Dapibus ultrices in iaculis nunc sed augue. Risus sed vulputate odio ut enim blandit volutpat maecenas. Orci
+            dapibus ultrices in iaculis nunc sed augue lacus. Quam elementum pulvinar etiam non quam. Tempor commodo
+            ullamcorper a lacus vestibulum sed arcu. Nunc non blandit massa enim nec. Venenatis a condimentum vitae
+            sapien. Sodales ut eu sem integer vitae justo eget magna. In aliquam sem fringilla ut morbi tincidunt augue.
+            Diam volutpat commodo sed egestas egestas fringilla phasellus faucibus scelerisque. Semper eget duis at
+            tellus. Diam donec adipiscing tristique risus nec feugiat in fermentum posuere. Amet volutpat consequat
+            mauris nunc congue nisi vitae. Hendrerit gravida rutrum quisque non tellus. Aliquet eget sit amet tellus.
+            Libero id faucibus nisl tincidunt. Amet nulla facilisi morbi tempus iaculis urna id.
+          </span>
+        ) : (
+          <span>Loading...</span>
+        )}
+      </Box>
+    </div>
+  );
+};
+
+const AutoSizeUpdatePosition = () => {
+  const styles = useStyles();
+  const [overflowBoundary, setOverflowBoundary] = React.useState<HTMLDivElement | null>(null);
+  const positioningRef = React.useRef<PositioningImperativeRef>(null);
+  const { containerRef, targetRef } = usePositioning({
+    position: 'below',
+    align: 'start',
+    autoSize: true,
+    overflowBoundary,
+    positioningRef,
+  });
+
+  const [isLoaded, setLoaded] = React.useState(false);
+  const onLoaded = () => setLoaded(true);
+
+  React.useEffect(() => {
+    if (isLoaded) {
+      positioningRef.current?.updatePosition();
+    }
+  }, [isLoaded]);
+
+  return (
+    <div
+      ref={setOverflowBoundary}
+      className={styles.boundary}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 200,
+        width: 250,
+        position: 'relative',
+      }}
+    >
+      <button ref={targetRef} style={{ width: 'fit-content', marginLeft: 100, marginTop: 10 }}>
+        Target
+      </button>
+      <Box ref={containerRef} style={{ overflow: 'auto', border: '3px solid green' }}>
+        {isLoaded ? (
+          <div id="full-content" style={{ backgroundColor: 'cornflowerblue', width: 200, height: 100 }} />
+        ) : (
+          <button id="load-content" onClick={onLoaded}>
+            load content
+          </button>
+        )}
+      </Box>
+    </div>
+  );
+};
+
 const DisableTether = () => {
   const styles = useStyles();
   const { containerRef, targetRef } = usePositioning({
@@ -1019,6 +1123,23 @@ storiesOf('Positioning', module)
   .addStory('horizontal overflow', () => <HorizontalOverflow />, { includeRtl: true })
   .addStory('pinned', () => <Pinned />)
   .addStory('auto size', () => <AutoSize />)
+  .addStory('auto size with async content', () => (
+    <StoryWright steps={new Steps().wait('#full-content').snapshot('floating element is within the boundary').end()}>
+      <AutoSizeAsyncContent />
+    </StoryWright>
+  ))
+  .addStory('auto size with async content reset styles on updatePosition', () => (
+    <StoryWright
+      steps={new Steps()
+        .click('#load-content')
+        .wait('#full-content')
+        .wait(250) // let updatePosition finish
+        .snapshot('floating element is fully visible')
+        .end()}
+    >
+      <AutoSizeUpdatePosition />
+    </StoryWright>
+  ))
   .addStory('disable tether', () => <DisableTether />)
   .addStory('position fixed', () => <PositionAndAlignProps positionFixed />, { includeRtl: true })
   .addStory('virtual element', () => <VirtualElement />)

--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -486,9 +486,6 @@ const AutoSizeAsyncContent = () => {
     overflowBoundary,
   });
 
-  const [isLoaded, setLoaded] = React.useState(false);
-  const onLoaded = () => setLoaded(true);
-
   return (
     <div
       ref={setOverflowBoundary}
@@ -503,19 +500,24 @@ const AutoSizeAsyncContent = () => {
     >
       <button ref={targetRef}>Target</button>
       <Box ref={containerRef} style={{ overflow: 'auto', border: '3px solid green' }}>
-        {isLoaded ? (
-          <span id="full-content">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-            dolore magna aliqua. In fermentum et sollicitudin ac orci phasellus egestas. Facilisi cras fermentum odio eu
-            feugiat pretium nibh ipsum consequat.
-          </span>
-        ) : (
-          <button id="load-content" onClick={onLoaded}>
-            load
-          </button>
-        )}
+        <AsyncFloatingContent />
       </Box>
     </div>
+  );
+};
+const AsyncFloatingContent = () => {
+  const [isLoaded, setLoaded] = React.useState(false);
+  const onLoaded = () => setLoaded(true);
+  return isLoaded ? (
+    <span id="full-content">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua. In fermentum et sollicitudin ac orci phasellus egestas. Facilisi cras fermentum odio eu feugiat
+      pretium nibh ipsum consequat.
+    </span>
+  ) : (
+    <button id="load-content" onClick={onLoaded}>
+      load
+    </button>
   );
 };
 

--- a/change/@fluentui-react-positioning-bc570315-c0a5-4a0f-a762-5fb18e58b4e8.json
+++ b/change/@fluentui-react-positioning-bc570315-c0a5-4a0f-a762-5fb18e58b4e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: simplify autoSize options to make 'always'/'height-always'/'width-always' equivalent to true/'height'/'width'.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -3,6 +3,7 @@ import type { Middleware, Placement, Strategy } from '@floating-ui/dom';
 import type { PositionManager, TargetElement } from './types';
 import { debounce, writeArrowUpdates, writeContainerUpdates, getScrollParent } from './utils';
 import { isHTMLElement } from '@fluentui/react-utilities';
+import { resetMaxSizeStyles } from './middleware/maxSize';
 
 interface PositionManagerOptions {
   /**
@@ -79,6 +80,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
       isFirstUpdate = false;
     }
 
+    resetMaxSizeStyles(container.style);
     Object.assign(container.style, { position: strategy });
     computePosition(target, container, { placement, middleware, strategy })
       .then(({ x, y, middlewareData, placement: computedPlacement }) => {

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -3,7 +3,6 @@ import type { Middleware, Placement, Strategy } from '@floating-ui/dom';
 import type { PositionManager, TargetElement } from './types';
 import { debounce, writeArrowUpdates, writeContainerUpdates, getScrollParent } from './utils';
 import { isHTMLElement } from '@fluentui/react-utilities';
-import { resetMaxSizeStyles } from './middleware/maxSize';
 
 interface PositionManagerOptions {
   /**
@@ -80,7 +79,6 @@ export function createPositionManager(options: PositionManagerOptions): Position
       isFirstUpdate = false;
     }
 
-    resetMaxSizeStyles(container.style);
     Object.assign(container.style, { position: strategy });
     computePosition(target, container, { placement, middleware, strategy })
       .then(({ x, y, middlewareData, placement: computedPlacement }) => {

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -29,31 +29,28 @@ const CSS_VAR_OVERFLOW_Y = '--maxsize-overflow-y';
 
 export const resetMaxSizeStyles = (floatingElementStyle: CSSStyleDeclaration) => {
   if (floatingElementStyle.boxSizing === `var(${CSS_VAR_BOX_SIZING})`) {
-    floatingElementStyle.removeProperty(CSS_VAR_BOX_SIZING);
     floatingElementStyle.removeProperty('box-sizing');
-  }
 
-  if (floatingElementStyle.maxWidth === `var(${CSS_VAR_AVAILABLE_WIDTH})`) {
-    floatingElementStyle.removeProperty('max-width');
-    floatingElementStyle.removeProperty(CSS_VAR_AVAILABLE_WIDTH);
+    if (floatingElementStyle.maxWidth === `var(${CSS_VAR_AVAILABLE_WIDTH})`) {
+      floatingElementStyle.removeProperty('max-width');
+    }
     if (floatingElementStyle.width === `var(${CSS_VAR_AVAILABLE_WIDTH})`) {
       floatingElementStyle.removeProperty('width');
     }
-  }
 
-  if (floatingElementStyle.maxHeight === `var(${CSS_VAR_AVAILABLE_HEIGHT})`) {
-    floatingElementStyle.removeProperty('max-height');
-    floatingElementStyle.removeProperty(CSS_VAR_AVAILABLE_HEIGHT);
+    if (floatingElementStyle.maxHeight === `var(${CSS_VAR_AVAILABLE_HEIGHT})`) {
+      floatingElementStyle.removeProperty('max-height');
+    }
     if (floatingElementStyle.height === `var(${CSS_VAR_AVAILABLE_HEIGHT})`) {
       floatingElementStyle.removeProperty('height');
     }
-  }
 
-  if (floatingElementStyle.overflowX === `var(${CSS_VAR_OVERFLOW_X})`) {
-    floatingElementStyle.removeProperty('overflow-x');
-  }
-  if (floatingElementStyle.overflowY === `var(${CSS_VAR_OVERFLOW_Y})`) {
-    floatingElementStyle.removeProperty('overflow-y');
+    if (floatingElementStyle.overflowX === `var(${CSS_VAR_OVERFLOW_X})`) {
+      floatingElementStyle.removeProperty('overflow-x');
+    }
+    if (floatingElementStyle.overflowY === `var(${CSS_VAR_OVERFLOW_Y})`) {
+      floatingElementStyle.removeProperty('overflow-y');
+    }
   }
 };
 
@@ -79,8 +76,10 @@ export function maxSize(autoSize: PositioningOptions['autoSize'], options: MaxSi
         elements.floating.style.setProperty('max-width', `var(${CSS_VAR_AVAILABLE_WIDTH})`);
         if (widthOverflow) {
           elements.floating.style.setProperty('width', `var(${CSS_VAR_AVAILABLE_WIDTH})`);
-          elements.floating.style.setProperty(CSS_VAR_OVERFLOW_X, 'auto');
-          elements.floating.style.setProperty('overflow-x', `var(${CSS_VAR_OVERFLOW_X})`);
+          if (!elements.floating.style.overflowX) {
+            elements.floating.style.setProperty(CSS_VAR_OVERFLOW_X, 'auto');
+            elements.floating.style.setProperty('overflow-x', `var(${CSS_VAR_OVERFLOW_X})`);
+          }
         }
       }
 
@@ -89,8 +88,10 @@ export function maxSize(autoSize: PositioningOptions['autoSize'], options: MaxSi
         elements.floating.style.setProperty('max-height', `var(${CSS_VAR_AVAILABLE_HEIGHT})`);
         if (heightOverflow) {
           elements.floating.style.setProperty('height', `var(${CSS_VAR_AVAILABLE_HEIGHT})`);
-          elements.floating.style.setProperty(CSS_VAR_OVERFLOW_Y, 'auto');
-          elements.floating.style.setProperty('overflow-y', `var(${CSS_VAR_OVERFLOW_Y})`);
+          if (!elements.floating.style.overflowY) {
+            elements.floating.style.setProperty(CSS_VAR_OVERFLOW_Y, 'auto');
+            elements.floating.style.setProperty('overflow-y', `var(${CSS_VAR_OVERFLOW_Y})`);
+          }
         }
       }
     },

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -1,62 +1,24 @@
 import { size } from '@floating-ui/dom';
 import type { Middleware } from '@floating-ui/dom';
-import type { PositioningOptions } from '../types';
+import type { NormalizedAutoSize, PositioningOptions } from '../types';
 import { getBoundary } from '../utils/getBoundary';
 export interface MaxSizeMiddlewareOptions extends Pick<PositioningOptions, 'overflowBoundary'> {
   container: HTMLElement | null;
 }
 
 /**
- * AutoSizes contains many options from historic implementation.
- * Now options 'always'/'height-always'/'width-always' are obsolete.
- * This function maps them to true/'height'/'width'
- */
-const normalizeAutoSize = (
-  autoSize?: PositioningOptions['autoSize'],
-): { applyMaxWidth: boolean; applyMaxHeight: boolean } => {
-  switch (autoSize) {
-    case 'always':
-    case true:
-      return {
-        applyMaxWidth: true,
-        applyMaxHeight: true,
-      };
-
-    case 'width-always':
-    case 'width':
-      return {
-        applyMaxWidth: true,
-        applyMaxHeight: false,
-      };
-
-    case 'height-always':
-    case 'height':
-      return {
-        applyMaxWidth: false,
-        applyMaxHeight: true,
-      };
-
-    default:
-      return {
-        applyMaxWidth: false,
-        applyMaxHeight: false,
-      };
-  }
-};
-
-/**
  * floating-ui `size` middleware uses floating element's height/width to calculate available height/width.
  * This middleware only runs once per lifecycle, resetting styles applied by maxSize from previous lifecycle.
  * Then floating element's original size is restored and `size` middleware can calculate available height/width correctly.
  */
-export const resetMaxSize = (autoSize: PositioningOptions['autoSize']): Middleware => ({
+export const resetMaxSize = (normalizedAutoSize: NormalizedAutoSize): Middleware => ({
   name: 'resetMaxSize',
   fn({ middlewareData: { maxSizeAlreadyReset }, elements }) {
     if (maxSizeAlreadyReset) {
       return {};
     }
 
-    const { applyMaxWidth, applyMaxHeight } = normalizeAutoSize(autoSize);
+    const { applyMaxWidth, applyMaxHeight } = normalizedAutoSize;
     if (applyMaxWidth) {
       elements.floating.style.removeProperty('box-sizing');
       elements.floating.style.removeProperty('max-width');
@@ -75,20 +37,17 @@ export const resetMaxSize = (autoSize: PositioningOptions['autoSize']): Middlewa
   },
 });
 
-export function maxSize(autoSize: PositioningOptions['autoSize'], options: MaxSizeMiddlewareOptions): Middleware {
+export function maxSize(normalizedAutoSize: NormalizedAutoSize, options: MaxSizeMiddlewareOptions): Middleware {
   const { container, overflowBoundary } = options;
   return size({
     ...(overflowBoundary && { altBoundary: true, boundary: getBoundary(container, overflowBoundary) }),
     apply({ availableHeight, availableWidth, elements, rects }) {
-      const { applyMaxWidth, applyMaxHeight } = normalizeAutoSize(autoSize);
-
-      const widthOverflow = rects.floating.width > availableWidth;
-      const heightOverflow = rects.floating.height > availableHeight;
+      const { applyMaxWidth, applyMaxHeight } = normalizedAutoSize;
 
       if (applyMaxWidth) {
         elements.floating.style.setProperty('box-sizing', 'border-box');
         elements.floating.style.setProperty('max-width', `${availableWidth}px`);
-        if (widthOverflow) {
+        if (rects.floating.width > availableWidth) {
           elements.floating.style.setProperty('width', `${availableWidth}px`);
           if (!elements.floating.style.overflowX) {
             elements.floating.style.setProperty('overflow-x', 'auto');
@@ -99,7 +58,7 @@ export function maxSize(autoSize: PositioningOptions['autoSize'], options: MaxSi
       if (applyMaxHeight) {
         elements.floating.style.setProperty('box-sizing', 'border-box');
         elements.floating.style.setProperty('max-height', `${availableHeight}px`);
-        if (heightOverflow) {
+        if (rects.floating.height > availableHeight) {
           elements.floating.style.setProperty('height', `${availableHeight}px`);
           if (!elements.floating.style.overflowY) {
             elements.floating.style.setProperty('overflow-y', 'auto');

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -44,6 +44,11 @@ const normalizeAutoSize = (
   }
 };
 
+/**
+ * floating-ui `size` middleware uses floating element's height/width to calculate available height/width.
+ * This middleware only runs once per lifecycle, resetting styles applied by maxSize from previous lifecycle.
+ * Then floating element's original size is restored and `size` middleware can calculate available height/width correctly.
+ */
 export const resetMaxSize = (autoSize: PositioningOptions['autoSize']): Middleware => ({
   name: 'resetMaxSize',
   fn({ middlewareData: { maxSizeAlreadyReset }, elements }) {

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -46,8 +46,8 @@ const normalizeAutoSize = (
 
 export const resetMaxSize = (autoSize: PositioningOptions['autoSize']): Middleware => ({
   name: 'resetMaxSize',
-  fn({ middlewareData, elements }) {
-    if (middlewareData.maxSizeReset) {
+  fn({ middlewareData: { maxSizeAlreadyReset }, elements }) {
+    if (maxSizeAlreadyReset) {
       return {};
     }
 
@@ -64,7 +64,7 @@ export const resetMaxSize = (autoSize: PositioningOptions['autoSize']): Middlewa
     }
 
     return {
-      data: { maxSizeReset: true },
+      data: { maxSizeAlreadyReset: true },
       reset: { rects: true },
     };
   },

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -6,35 +6,92 @@ export interface MaxSizeMiddlewareOptions extends Pick<PositioningOptions, 'over
   container: HTMLElement | null;
 }
 
+type SimplifiedAutoSize = boolean | 'height' | 'width';
+/**
+ * AutoSizes contains many options from historic implementation.
+ * Now options 'always'/'height-always'/'width-always' are obsolete.
+ * This function maps them to true/'height'/'width'
+ */
+const getSimplifiedAutoSize = (autoSize?: PositioningOptions['autoSize']): SimplifiedAutoSize | undefined =>
+  autoSize === 'always'
+    ? true
+    : autoSize === 'height-always'
+    ? 'height'
+    : autoSize === 'width-always'
+    ? 'width'
+    : autoSize;
+
+const CSS_VAR_BOX_SIZING = '--maxsize-box-sizing';
+const CSS_VAR_AVAILABLE_WIDTH = '--maxsize-available-width';
+const CSS_VAR_AVAILABLE_HEIGHT = '--maxsize-available-height';
+const CSS_VAR_OVERFLOW_X = '--maxsize-overflow-x';
+const CSS_VAR_OVERFLOW_Y = '--maxsize-overflow-y';
+
+export const resetMaxSizeStyles = (floatingElementStyle: CSSStyleDeclaration) => {
+  if (floatingElementStyle.boxSizing === `var(${CSS_VAR_BOX_SIZING})`) {
+    floatingElementStyle.removeProperty(CSS_VAR_BOX_SIZING);
+    floatingElementStyle.removeProperty('box-sizing');
+  }
+
+  if (floatingElementStyle.maxWidth === `var(${CSS_VAR_AVAILABLE_WIDTH})`) {
+    floatingElementStyle.removeProperty('max-width');
+    floatingElementStyle.removeProperty(CSS_VAR_AVAILABLE_WIDTH);
+    if (floatingElementStyle.width === `var(${CSS_VAR_AVAILABLE_WIDTH})`) {
+      floatingElementStyle.removeProperty('width');
+    }
+  }
+
+  if (floatingElementStyle.maxHeight === `var(${CSS_VAR_AVAILABLE_HEIGHT})`) {
+    floatingElementStyle.removeProperty('max-height');
+    floatingElementStyle.removeProperty(CSS_VAR_AVAILABLE_HEIGHT);
+    if (floatingElementStyle.height === `var(${CSS_VAR_AVAILABLE_HEIGHT})`) {
+      floatingElementStyle.removeProperty('height');
+    }
+  }
+
+  if (floatingElementStyle.overflowX === `var(${CSS_VAR_OVERFLOW_X})`) {
+    floatingElementStyle.removeProperty('overflow-x');
+  }
+  if (floatingElementStyle.overflowY === `var(${CSS_VAR_OVERFLOW_Y})`) {
+    floatingElementStyle.removeProperty('overflow-y');
+  }
+};
+
 export function maxSize(autoSize: PositioningOptions['autoSize'], options: MaxSizeMiddlewareOptions): Middleware {
   const { container, overflowBoundary } = options;
   return size({
     ...(overflowBoundary && { altBoundary: true, boundary: getBoundary(container, overflowBoundary) }),
     apply({ availableHeight, availableWidth, elements, rects }) {
-      if (autoSize) {
-        elements.floating.style.setProperty('box-sizing', 'border-box');
+      const simplifiedAutoSize = getSimplifiedAutoSize(autoSize);
+      if (simplifiedAutoSize) {
+        elements.floating.style.setProperty(CSS_VAR_BOX_SIZING, 'border-box');
+        elements.floating.style.setProperty('box-sizing', `var(${CSS_VAR_BOX_SIZING})`);
       }
 
-      const applyMaxWidth = autoSize === 'always' || autoSize === 'width-always';
-      const widthOverflow = rects.floating.width > availableWidth && (autoSize === true || autoSize === 'width');
+      const applyMaxWidth = simplifiedAutoSize === true || simplifiedAutoSize === 'width';
+      const widthOverflow = rects.floating.width > availableWidth;
 
-      const applyMaxHeight = autoSize === 'always' || autoSize === 'height-always';
-      const heightOverflow = rects.floating.height > availableHeight && (autoSize === true || autoSize === 'height');
+      const applyMaxHeight = simplifiedAutoSize === true || simplifiedAutoSize === 'height';
+      const heightOverflow = rects.floating.height > availableHeight;
 
-      if (applyMaxHeight || heightOverflow) {
-        elements.floating.style.setProperty('max-height', `${availableHeight}px`);
-      }
-      if (heightOverflow) {
-        elements.floating.style.setProperty('height', `${availableHeight}px`);
-        elements.floating.style.setProperty('overflow-y', 'auto');
+      if (applyMaxWidth) {
+        elements.floating.style.setProperty(CSS_VAR_AVAILABLE_WIDTH, `${availableWidth}px`);
+        elements.floating.style.setProperty('max-width', `var(${CSS_VAR_AVAILABLE_WIDTH})`);
+        if (widthOverflow) {
+          elements.floating.style.setProperty('width', `var(${CSS_VAR_AVAILABLE_WIDTH})`);
+          elements.floating.style.setProperty(CSS_VAR_OVERFLOW_X, 'auto');
+          elements.floating.style.setProperty('overflow-x', `var(${CSS_VAR_OVERFLOW_X})`);
+        }
       }
 
-      if (applyMaxWidth || widthOverflow) {
-        elements.floating.style.setProperty('max-width', `${availableWidth}px`);
-      }
-      if (widthOverflow) {
-        elements.floating.style.setProperty('width', `${availableWidth}px`);
-        elements.floating.style.setProperty('overflow-x', 'auto');
+      if (applyMaxHeight) {
+        elements.floating.style.setProperty(CSS_VAR_AVAILABLE_HEIGHT, `${availableHeight}px`);
+        elements.floating.style.setProperty('max-height', `var(${CSS_VAR_AVAILABLE_HEIGHT})`);
+        if (heightOverflow) {
+          elements.floating.style.setProperty('height', `var(${CSS_VAR_AVAILABLE_HEIGHT})`);
+          elements.floating.style.setProperty(CSS_VAR_OVERFLOW_Y, 'auto');
+          elements.floating.style.setProperty('overflow-y', `var(${CSS_VAR_OVERFLOW_Y})`);
+        }
       }
     },
   });

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -11,14 +11,14 @@ export interface MaxSizeMiddlewareOptions extends Pick<PositioningOptions, 'over
  * This middleware only runs once per lifecycle, resetting styles applied by maxSize from previous lifecycle.
  * Then floating element's original size is restored and `size` middleware can calculate available height/width correctly.
  */
-export const resetMaxSize = (normalizedAutoSize: NormalizedAutoSize): Middleware => ({
+export const resetMaxSize = (autoSize: NormalizedAutoSize): Middleware => ({
   name: 'resetMaxSize',
   fn({ middlewareData: { maxSizeAlreadyReset }, elements }) {
     if (maxSizeAlreadyReset) {
       return {};
     }
 
-    const { applyMaxWidth, applyMaxHeight } = normalizedAutoSize;
+    const { applyMaxWidth, applyMaxHeight } = autoSize;
     if (applyMaxWidth) {
       elements.floating.style.removeProperty('box-sizing');
       elements.floating.style.removeProperty('max-width');
@@ -37,12 +37,12 @@ export const resetMaxSize = (normalizedAutoSize: NormalizedAutoSize): Middleware
   },
 });
 
-export function maxSize(normalizedAutoSize: NormalizedAutoSize, options: MaxSizeMiddlewareOptions): Middleware {
+export function maxSize(autoSize: NormalizedAutoSize, options: MaxSizeMiddlewareOptions): Middleware {
   const { container, overflowBoundary } = options;
   return size({
     ...(overflowBoundary && { altBoundary: true, boundary: getBoundary(container, overflowBoundary) }),
     apply({ availableHeight, availableWidth, elements, rects }) {
-      const { applyMaxWidth, applyMaxHeight } = normalizedAutoSize;
+      const { applyMaxWidth, applyMaxHeight } = autoSize;
 
       if (applyMaxWidth) {
         elements.floating.style.setProperty('box-sizing', 'border-box');

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -42,29 +42,27 @@ export function maxSize(autoSize: NormalizedAutoSize, options: MaxSizeMiddleware
   return size({
     ...(overflowBoundary && { altBoundary: true, boundary: getBoundary(container, overflowBoundary) }),
     apply({ availableHeight, availableWidth, elements, rects }) {
+      const applyMaxSizeStyles = (apply: boolean, dimension: 'width' | 'height', availableSize: number) => {
+        if (!apply) {
+          return;
+        }
+
+        elements.floating.style.setProperty('box-sizing', 'border-box');
+        elements.floating.style.setProperty(`max-${dimension}`, `${availableSize}px`);
+
+        if (rects.floating[dimension] > availableSize) {
+          elements.floating.style.setProperty(dimension, `${availableSize}px`);
+
+          const axis = dimension === 'width' ? 'x' : 'y';
+          if (!elements.floating.style.getPropertyValue(`overflow-${axis}`)) {
+            elements.floating.style.setProperty(`overflow-${axis}`, 'auto');
+          }
+        }
+      };
+
       const { applyMaxWidth, applyMaxHeight } = autoSize;
-
-      if (applyMaxWidth) {
-        elements.floating.style.setProperty('box-sizing', 'border-box');
-        elements.floating.style.setProperty('max-width', `${availableWidth}px`);
-        if (rects.floating.width > availableWidth) {
-          elements.floating.style.setProperty('width', `${availableWidth}px`);
-          if (!elements.floating.style.overflowX) {
-            elements.floating.style.setProperty('overflow-x', 'auto');
-          }
-        }
-      }
-
-      if (applyMaxHeight) {
-        elements.floating.style.setProperty('box-sizing', 'border-box');
-        elements.floating.style.setProperty('max-height', `${availableHeight}px`);
-        if (rects.floating.height > availableHeight) {
-          elements.floating.style.setProperty('height', `${availableHeight}px`);
-          if (!elements.floating.style.overflowY) {
-            elements.floating.style.setProperty('overflow-y', 'auto');
-          }
-        }
-      }
+      applyMaxSizeStyles(applyMaxWidth, 'width', availableWidth);
+      applyMaxSizeStyles(applyMaxHeight, 'height', availableHeight);
     },
   });
 }

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -136,11 +136,11 @@ export interface PositioningOptions {
   arrowPadding?: number;
 
   /**
-   * Applies max-height and max-width on the positioned element to fit it within the available space in viewport.
-   * true enables this for both width and height when overflow happens.
-   * 'always' applies `max-height`/`max-width` regardless of overflow.
-   * 'height' applies `max-height` when overflow happens, and 'width' for `max-width`
-   * `height-always` applies `max-height` regardless of overflow, and 'width-always' for always applying `max-width`
+   * Applies styles on the positioned element to fit it within the available space in viewport.
+   * - true: set styles for max height/width.
+   * - 'height': set styles for max height.
+   * - 'width'': set styles for max width.
+   * Note that options 'always'/'height-always'/'width-always' are now obsolete, and equivalent to true/'height'/'width'.
    */
   autoSize?: AutoSize;
 

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -49,6 +49,7 @@ export type Position = 'above' | 'below' | 'before' | 'after';
 export type Alignment = 'top' | 'bottom' | 'start' | 'end' | 'center';
 
 export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | 'always' | boolean;
+export type NormalizedAutoSize = { applyMaxWidth: boolean; applyMaxHeight: boolean };
 
 export type Boundary = HTMLElement | Array<HTMLElement> | 'clippingParents' | 'scrollParent' | 'window';
 

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -155,7 +155,7 @@ function usePositioningOptions(options: PositioningOptions) {
   const {
     align,
     arrowPadding,
-    autoSize,
+    autoSize: rawAutoSize,
     coverTarget,
     flipBoundary,
     offset,
@@ -174,14 +174,14 @@ function usePositioningOptions(options: PositioningOptions) {
   const { dir } = useFluent();
   const isRtl = dir === 'rtl';
   const positionStrategy: Strategy = strategy ?? positionFixed ? 'fixed' : 'absolute';
-  const normalizedAutoSize = normalizeAutoSize(autoSize);
+  const autoSize = normalizeAutoSize(rawAutoSize);
 
   return React.useCallback(
     (container: HTMLElement | null, arrow: HTMLElement | null) => {
       const hasScrollableElement = hasScrollParent(container);
 
       const middleware = [
-        normalizedAutoSize && resetMaxSizeMiddleware(normalizedAutoSize),
+        autoSize && resetMaxSizeMiddleware(autoSize),
         offset && offsetMiddleware(offset),
         coverTarget && coverTargetMiddleware(),
         !pinned && flipMiddleware({ container, flipBoundary, hasScrollableElement, isRtl, fallbackPositions }),
@@ -193,7 +193,7 @@ function usePositioningOptions(options: PositioningOptions) {
           overflowBoundaryPadding,
           isRtl,
         }),
-        normalizedAutoSize && maxSizeMiddleware(normalizedAutoSize, { container, overflowBoundary }),
+        autoSize && maxSizeMiddleware(autoSize, { container, overflowBoundary }),
         intersectingMiddleware(),
         arrow && arrowMiddleware({ element: arrow, padding: arrowPadding }),
         hideMiddleware({ strategy: 'referenceHidden' }),
@@ -212,7 +212,7 @@ function usePositioningOptions(options: PositioningOptions) {
     [
       align,
       arrowPadding,
-      normalizedAutoSize,
+      autoSize,
       coverTarget,
       disableTether,
       flipBoundary,

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -10,7 +10,7 @@ import type {
   TargetElement,
   UsePositioningReturn,
 } from './types';
-import { useCallbackRef, toFloatingUIPlacement, hasAutofocusFilter, hasScrollParent } from './utils';
+import { useCallbackRef, toFloatingUIPlacement, hasAutofocusFilter, hasScrollParent, normalizeAutoSize } from './utils';
 import {
   shift as shiftMiddleware,
   flip as flipMiddleware,
@@ -174,13 +174,14 @@ function usePositioningOptions(options: PositioningOptions) {
   const { dir } = useFluent();
   const isRtl = dir === 'rtl';
   const positionStrategy: Strategy = strategy ?? positionFixed ? 'fixed' : 'absolute';
+  const normalizedAutoSize = normalizeAutoSize(autoSize);
 
   return React.useCallback(
     (container: HTMLElement | null, arrow: HTMLElement | null) => {
       const hasScrollableElement = hasScrollParent(container);
 
       const middleware = [
-        autoSize && resetMaxSizeMiddleware(autoSize),
+        normalizedAutoSize && resetMaxSizeMiddleware(normalizedAutoSize),
         offset && offsetMiddleware(offset),
         coverTarget && coverTargetMiddleware(),
         !pinned && flipMiddleware({ container, flipBoundary, hasScrollableElement, isRtl, fallbackPositions }),
@@ -192,7 +193,7 @@ function usePositioningOptions(options: PositioningOptions) {
           overflowBoundaryPadding,
           isRtl,
         }),
-        autoSize && maxSizeMiddleware(autoSize, { container, overflowBoundary }),
+        normalizedAutoSize && maxSizeMiddleware(normalizedAutoSize, { container, overflowBoundary }),
         intersectingMiddleware(),
         arrow && arrowMiddleware({ element: arrow, padding: arrowPadding }),
         hideMiddleware({ strategy: 'referenceHidden' }),
@@ -211,7 +212,7 @@ function usePositioningOptions(options: PositioningOptions) {
     [
       align,
       arrowPadding,
-      autoSize,
+      normalizedAutoSize,
       coverTarget,
       disableTether,
       flipBoundary,

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -16,6 +16,7 @@ import {
   flip as flipMiddleware,
   coverTarget as coverTargetMiddleware,
   maxSize as maxSizeMiddleware,
+  resetMaxSize as resetMaxSizeMiddleware,
   offset as offsetMiddleware,
   intersecting as intersectingMiddleware,
 } from './middleware';
@@ -179,6 +180,7 @@ function usePositioningOptions(options: PositioningOptions) {
       const hasScrollableElement = hasScrollParent(container);
 
       const middleware = [
+        autoSize && resetMaxSizeMiddleware(autoSize),
         offset && offsetMiddleware(offset),
         coverTarget && coverTargetMiddleware(),
         !pinned && flipMiddleware({ container, flipBoundary, hasScrollableElement, isRtl, fallbackPositions }),

--- a/packages/react-components/react-positioning/src/utils/index.ts
+++ b/packages/react-components/react-positioning/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from './toggleScrollListener';
 export * from './hasAutoFocusFilter';
 export * from './writeArrowUpdates';
 export * from './writeContainerupdates';
+export * from './normalizeAutoSize';

--- a/packages/react-components/react-positioning/src/utils/normalizeAutoSize.test.ts
+++ b/packages/react-components/react-positioning/src/utils/normalizeAutoSize.test.ts
@@ -1,0 +1,53 @@
+import { normalizeAutoSize } from './normalizeAutoSize';
+
+describe('normalizeAutoSize', () => {
+  const cases = [
+    [
+      'always',
+      {
+        applyMaxWidth: true,
+        applyMaxHeight: true,
+      },
+    ],
+    [
+      true,
+      {
+        applyMaxWidth: true,
+        applyMaxHeight: true,
+      },
+    ],
+    [
+      'width-always',
+      {
+        applyMaxWidth: true,
+        applyMaxHeight: false,
+      },
+    ],
+    [
+      'width',
+      {
+        applyMaxWidth: true,
+        applyMaxHeight: false,
+      },
+    ],
+    [
+      'height-always',
+      {
+        applyMaxWidth: false,
+        applyMaxHeight: true,
+      },
+    ],
+    [
+      'height',
+      {
+        applyMaxWidth: false,
+        applyMaxHeight: true,
+      },
+    ],
+    [false, false],
+  ] as const;
+
+  it.each(cases)('should normalize autoSize', (rawAutoSize, normalizedAutoSize) => {
+    expect(normalizeAutoSize(rawAutoSize)).toEqual(normalizedAutoSize);
+  });
+});

--- a/packages/react-components/react-positioning/src/utils/normalizeAutoSize.ts
+++ b/packages/react-components/react-positioning/src/utils/normalizeAutoSize.ts
@@ -1,0 +1,34 @@
+import type { NormalizedAutoSize, PositioningOptions } from '../types';
+
+/**
+ * AutoSizes contains many options from historic implementation.
+ * Now options 'always'/'height-always'/'width-always' are obsolete.
+ * This function maps them to true/'height'/'width'
+ */
+export const normalizeAutoSize = (autoSize?: PositioningOptions['autoSize']): NormalizedAutoSize | false => {
+  switch (autoSize) {
+    case 'always':
+    case true:
+      return {
+        applyMaxWidth: true,
+        applyMaxHeight: true,
+      };
+
+    case 'width-always':
+    case 'width':
+      return {
+        applyMaxWidth: true,
+        applyMaxHeight: false,
+      };
+
+    case 'height-always':
+    case 'height':
+      return {
+        applyMaxWidth: false,
+        applyMaxHeight: true,
+      };
+
+    default:
+      return false;
+  }
+};


### PR DESCRIPTION
Fix item 2 in #28623

## Previous Behavior
AutoSize has several options:
```tsx
export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | 'always' | boolean;

export interface PositioningOptions {
  autoSize?: AutoSize;
}
```
`'height'` - apply max-height only when floating element overflows boundary.
`'height-always'` - apply max-height regardless of overflow.
The same goes with `true`/`'always'` and `'width'`/`'width-always'`.

There are two examples in [issue 28623 _2. Consolidate 'height'/'height-always' option_](https://github.com/microsoft/fluentui/issues/28623), explaining why we need both set of options.

## New Behavior
Options `'always'/'height-always'/'width-always'` are now obsolete, and equivalent to `true/'height'/'width'`.

This is achieved by always applying max-height/max-width, but remove them when `updatePosition` is called.
The size of the content affects the max-height/max-width style we're applying, because the availableWidth/availableHeight from floating ui `size` middleware is calculated as below:
<img width="700" alt="Screenshot 2023-07-26 at 12 25 12" src="https://github.com/microsoft/fluentui/assets/28751745/64e7b37e-a202-47b3-bffd-bd0354bddde7"> 

Test cases are added for both case A and case B mentioned in the above issue.

Additionally, this PR fixes 1.b in #28623 by applying overflow style only when overflow styles aren't present. Therefore user can use inline overflow style to override overflow-x/overflow-y added by maxSize. 