### PR TITLE
feat(react-shared-contexts): add AnnounceContext

### DIFF
--- a/change/@fluentui-react-shared-contexts-6be5add1-ce81-4471-bd65-d79d627c1a96.json
+++ b/change/@fluentui-react-shared-contexts-6be5add1-ce81-4471-bd65-d79d627c1a96.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds Announce context",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "eysjiang@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-shared-contexts/etc/react-shared-contexts.api.md
+++ b/packages/react-components/react-shared-contexts/etc/react-shared-contexts.api.md
@@ -8,6 +8,14 @@ import * as React_2 from 'react';
 import type { Theme } from '@fluentui/react-theme';
 
 // @internal (undocumented)
+export type AnnounceContextValue_unstable = {
+    announce: (message: string, options?: AnnounceOptions) => void;
+};
+
+// @internal (undocumented)
+export const AnnounceProvider_unstable: React_2.Provider<AnnounceContextValue_unstable | undefined>;
+
+// @internal (undocumented)
 export type BackgroundAppearanceContextValue = 'inverted' | undefined;
 
 // @internal (undocumented)
@@ -333,6 +341,11 @@ export type TooltipVisibilityContextValue_unstable = {
 
 // @internal (undocumented)
 export const TooltipVisibilityProvider_unstable: React_2.Provider<TooltipVisibilityContextValue_unstable>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "useAnnounce" is marked as @public, but its signature references "AnnounceContextValue_unstable" which is marked as @internal
+//
+// @public (undocumented)
+export function useAnnounce_unstable(): AnnounceContextValue_unstable;
 
 // Warning: (ae-incompatible-release-tags) The symbol "useBackgroundAppearance" is marked as @public, but its signature references "BackgroundAppearanceContextValue" which is marked as @internal
 //

--- a/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
+++ b/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export type AnnounceOptions = {
+  alert?: boolean;
+  priority?: number;
+  batchId?: string;
+};
+
+/**
+ * @internal
+ */
+export type AnnounceContextValue = (message: string, options: AnnounceOptions) => void;
+
+/**
+ * @internal
+ */
+export const AnnounceContext = React.createContext<AnnounceContextValue | undefined>(undefined);
+
+/**
+ * @internal
+ */
+export const AnnounceProvider = AnnounceContext.Provider;
+
+export function useAnnounce(): AnnounceContextValue {
+  return React.useContext(AnnounceContext) ?? (() => null);
+}

--- a/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
+++ b/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
@@ -10,8 +10,8 @@ export type AnnounceOptions = {
 /**
  * @internal
  */
-export type AnnounceContextValue<T = AnnounceOptions> = {
-  announce?: (message: string, options?: T) => void;
+export type AnnounceContextValue = {
+  announce: (message: string, options?: AnnounceOptions) => void;
 };
 
 /**
@@ -25,5 +25,5 @@ const AnnounceContext = React.createContext<AnnounceContextValue | undefined>(un
 export const AnnounceProvider = AnnounceContext.Provider;
 
 export function useAnnounce(): AnnounceContextValue {
-  return React.useContext(AnnounceContext) ?? {};
+  return React.useContext(AnnounceContext) ?? { announce: () => undefined };
 }

--- a/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
+++ b/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
@@ -9,7 +9,7 @@ export type AnnounceOptions = {
 /**
  * @internal
  */
-export type AnnounceContextValue = (message: string, options: AnnounceOptions) => void;
+export type AnnounceContextValue<T = AnnounceOptions> = (message: string, options?: T) => void;
 
 /**
  * @internal

--- a/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
+++ b/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
@@ -2,14 +2,17 @@ import * as React from 'react';
 
 export type AnnounceOptions = {
   alert?: boolean;
-  priority?: number;
   batchId?: string;
+  polite?: boolean;
+  priority?: number;
 };
 
 /**
  * @internal
  */
-export type AnnounceContextValue<T = AnnounceOptions> = (message: string, options?: T) => void;
+export type AnnounceContextValue<T = AnnounceOptions> = {
+  announce?: (message: string, options?: T) => void;
+};
 
 /**
  * @internal
@@ -22,5 +25,5 @@ export const AnnounceContext = React.createContext<AnnounceContextValue | undefi
 export const AnnounceProvider = AnnounceContext.Provider;
 
 export function useAnnounce(): AnnounceContextValue {
-  return React.useContext(AnnounceContext) ?? (() => null);
+  return React.useContext(AnnounceContext) ?? {};
 }

--- a/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
+++ b/packages/react-components/react-shared-contexts/src/AnnounceContext/AnnounceContext.ts
@@ -17,7 +17,7 @@ export type AnnounceContextValue<T = AnnounceOptions> = {
 /**
  * @internal
  */
-export const AnnounceContext = React.createContext<AnnounceContextValue | undefined>(undefined);
+const AnnounceContext = React.createContext<AnnounceContextValue | undefined>(undefined);
 
 /**
  * @internal

--- a/packages/react-components/react-shared-contexts/src/AnnounceContext/index.ts
+++ b/packages/react-components/react-shared-contexts/src/AnnounceContext/index.ts
@@ -1,0 +1,1 @@
+export * from './AnnounceContext';

--- a/packages/react-components/react-shared-contexts/src/index.ts
+++ b/packages/react-components/react-shared-contexts/src/index.ts
@@ -33,3 +33,6 @@ export { BackgroundAppearanceProvider, useBackgroundAppearance } from './Backgro
 export type { BackgroundAppearanceContextValue } from './BackgroundAppearanceContext';
 
 export { PortalMountNodeProvider, usePortalMountNode } from './PortalMountNodeContext';
+
+export { AnnounceProvider as AnnounceProvider_unstable, useAnnounce as useAnnounce_unstable } from './AnnounceContext';
+export type { AnnounceContextValue as AnnounceContextValue_unstable } from './AnnounceContext';


### PR DESCRIPTION
This PR adds AnnounceContext for use in FAI.

This context is a top-level screen reader notification utility that can be consumed by any component and used to fire on-demand screen reader announcements.

With something as complex as chat, and especially with loading messages and uploading files, we need a way to manage and queue custom screen reader notifications. Chat messages especially need the ability to have the screen reader notification text differ from the visual text on screen, since the visual text of a message often contains more information than is necessary in a notification.

We are hosting it in FUI instead of FAI because we eventually want it in FUI, and having the context be imported from there means we won’t have to change the import every place it’s used.