### PR TITLE
fix: remove margin from icon when ToolbarButton is vertical

### DIFF
--- a/change/@fluentui-react-toolbar-d17fdf5d-7561-468e-b616-f1bbe8f690d5.json
+++ b/change/@fluentui-react-toolbar-d17fdf5d-7561-468e-b616-f1bbe8f690d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove margin from Icon in ToolbarButton when vertical prop is passed",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "chassunc@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { useButtonStyles_unstable } from '@fluentui/react-button';
 import { ToolbarButtonState } from './ToolbarButton.types';
 
@@ -8,6 +8,7 @@ const useBaseStyles = makeStyles({
   },
   verticalIcon: {
     fontSize: '24px',
+    ...shorthands.margin('0'),
   },
 });
 


### PR DESCRIPTION
## Overview

Remove margin from icon inside ToolbarButton when vertical. 

Before: 

![Befor](https://github.com/microsoft/fluentui/assets/86579954/ebfa2e88-b1a9-44fb-83d1-362e96ef45f7)

After: 

![after](https://github.com/microsoft/fluentui/assets/86579954/c86967f4-5700-467f-b798-befd9fc199ec)

