### PR TITLE
feat(react-tree): adds openItems and checkedItems to tree callback data

### DIFF
--- a/change/@fluentui-react-tree-b474b0cc-81a2-48d4-b63b-268445c11d76.json
+++ b/change/@fluentui-react-tree-b474b0cc-81a2-48d4-b63b-268445c11d76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: adds openItems and checkedItems to tree callback data",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -101,6 +101,7 @@ export const Tree: ForwardRefComponent<TreeProps>;
 // @public (undocumented)
 export type TreeCheckedChangeData = {
     value: TreeItemValue;
+    checkedItems: Map<TreeItemValue, TreeSelectionValue>;
     target: HTMLElement;
     event: React_2.ChangeEvent<HTMLElement>;
     type: 'Change';
@@ -152,6 +153,7 @@ export type TreeItemContextValue = {
     itemType: TreeItemType;
     value: TreeItemValue;
     open: boolean;
+    checked?: TreeSelectionValue;
 };
 
 // @public
@@ -269,6 +271,7 @@ export type TreeNavigationEvent_unstable = TreeNavigationData_unstable['event'];
 // @public (undocumented)
 export type TreeOpenChangeData = {
     open: boolean;
+    openItems: Set<TreeItemValue>;
     value: TreeItemValue;
     target: HTMLElement;
 } & ({

--- a/packages/react-components/react-tree/src/components/FlatTree/__snapshots__/FlatTree.test.tsx.snap
+++ b/packages/react-components/react-tree/src/components/FlatTree/__snapshots__/FlatTree.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`FlatTree renders a default state 1`] = `
 <div>
   <div
     class="fui-FlatTree"
-    role="baseTree"
+    role="tree"
   >
     Default FlatTree
   </div>

--- a/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
@@ -31,6 +31,7 @@ export type TreeNavigationEvent_unstable = TreeNavigationData_unstable['event'];
 
 export type TreeOpenChangeData = {
   open: boolean;
+  openItems: Set<TreeItemValue>;
   value: TreeItemValue;
   target: HTMLElement;
 } & (
@@ -45,6 +46,7 @@ export type TreeOpenChangeEvent = TreeOpenChangeData['event'];
 
 export type TreeCheckedChangeData = {
   value: TreeItemValue;
+  checkedItems: Map<TreeItemValue, TreeSelectionValue>;
   target: HTMLElement;
   event: React.ChangeEvent<HTMLElement>;
   type: 'Change';

--- a/packages/react-components/react-tree/src/components/Tree/__snapshots__/Tree.test.tsx.snap
+++ b/packages/react-components/react-tree/src/components/Tree/__snapshots__/Tree.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Tree renders a default state 1`] = `
 <div>
   <div
     class="fui-Tree"
-    role="baseTree"
+    role="tree"
   >
     Default Tree
   </div>

--- a/packages/react-components/react-tree/src/components/Tree/useTreeNavigation.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTreeNavigation.ts
@@ -1,20 +1,14 @@
-import { useMergedRefs } from '@fluentui/react-utilities';
 import { TreeNavigationData_unstable } from './Tree.types';
 import { nextTypeAheadElement } from '../../utils/nextTypeAheadElement';
 import { treeDataTypes } from '../../utils/tokens';
 import { treeItemFilter } from '../../utils/treeItemFilter';
 import { useRovingTabIndex } from '../../hooks/useRovingTabIndexes';
-import { HTMLElementWalker, useHTMLElementWalkerRef } from '../../hooks/useHTMLElementWalker';
+import { HTMLElementWalker } from '../../utils/createHTMLElementWalker';
 
 export function useTreeNavigation() {
-  const [{ rove }, rovingRootRef] = useRovingTabIndex(treeItemFilter);
-  const [walkerRef, rootRef] = useHTMLElementWalkerRef(treeItemFilter);
+  const { rove, initialize } = useRovingTabIndex(treeItemFilter);
 
-  const getNextElement = (data: TreeNavigationData_unstable) => {
-    if (!walkerRef.current) {
-      return;
-    }
-    const treeItemWalker = walkerRef.current;
+  const getNextElement = (data: TreeNavigationData_unstable, treeItemWalker: HTMLElementWalker) => {
     switch (data.type) {
       case treeDataTypes.Click:
         return data.target;
@@ -41,13 +35,13 @@ export function useTreeNavigation() {
         return treeItemWalker.previousElement();
     }
   };
-  function navigate(data: TreeNavigationData_unstable) {
-    const nextElement = getNextElement(data);
+  function navigate(data: TreeNavigationData_unstable, walker: HTMLElementWalker) {
+    const nextElement = getNextElement(data, walker);
     if (nextElement) {
       rove(nextElement);
     }
   }
-  return [navigate, useMergedRefs(rootRef, rovingRootRef)] as const;
+  return { navigate, initialize } as const;
 }
 
 function lastChildRecursive(walker: HTMLElementWalker) {

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -3,7 +3,7 @@ import { getNativeElementProps, useId, useMergedRefs } from '@fluentui/react-uti
 import { useEventCallback } from '@fluentui/react-utilities';
 import { elementContains } from '@fluentui/react-portal';
 import type { TreeItemProps, TreeItemState } from './TreeItem.types';
-import { useTreeContext_unstable } from '../../contexts/index';
+import { useTreeContext_unstable, useTreeItemContext_unstable } from '../../contexts/index';
 import { dataTreeItemValueAttrName } from '../../utils/getTreeItemValueFromElement';
 import { Space } from '@fluentui/keyboard-keys';
 import { treeDataTypes } from '../../utils/tokens';
@@ -42,8 +42,14 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
   const selectionRef = React.useRef<HTMLInputElement>(null);
 
   const open = useTreeContext_unstable(ctx => ctx.openItems.has(value));
-  const checked = useTreeContext_unstable(ctx => ctx.checkedItems.get(value) ?? false);
   const selectionMode = useTreeContext_unstable(ctx => ctx.selectionMode);
+  const parentChecked = useTreeItemContext_unstable(ctx => ctx.checked);
+  const checked = useTreeContext_unstable(ctx => {
+    if (selectionMode === 'multiselect' && typeof parentChecked === 'boolean') {
+      return parentChecked;
+    }
+    return ctx.checkedItems.get(value);
+  });
 
   const handleClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
     onClick?.(event);
@@ -133,13 +139,21 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
     if (isEventFromSubtree) {
       return;
     }
-    requestTreeResponse({ event, value, itemType, type: 'Change', target: event.currentTarget });
+    requestTreeResponse({
+      event,
+      value,
+      itemType,
+      type: 'Change',
+      target: event.currentTarget,
+      checked: checked === 'mixed' ? true : !checked,
+    });
   });
 
   const isBranch = itemType === 'branch';
   return {
     value,
     open,
+    checked,
     subtreeRef,
     layoutRef,
     selectionRef,
@@ -159,7 +173,8 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
       role: 'treeitem',
       'aria-level': level,
       [dataTreeItemValueAttrName]: value,
-      'aria-checked': selectionMode === 'multiselect' ? checked : undefined,
+      'aria-checked':
+        selectionMode === 'multiselect' ? (checked === 'mixed' ? undefined : checked ?? false) : undefined,
       'aria-selected': selectionMode === 'single' ? checked : undefined,
       'aria-expanded': isBranch ? open : undefined,
       onClick: handleClick,

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemContextValues.ts
@@ -13,6 +13,7 @@ export function useTreeItemContextValues_unstable(state: TreeItemState): TreeIte
     isActionsVisible,
     isAsideVisible,
     selectionRef,
+    checked,
   } = state;
 
   /**
@@ -21,6 +22,7 @@ export function useTreeItemContextValues_unstable(state: TreeItemState): TreeIte
    */
   const treeItem: TreeItemContextValue = {
     value,
+    checked,
     itemType,
     layoutRef,
     subtreeRef,

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -35,8 +35,7 @@ export const useTreeItemLayout_unstable = (
   const selectionRef = useTreeItemContext_unstable(ctx => ctx.selectionRef);
   const expandIconRef = useTreeItemContext_unstable(ctx => ctx.expandIconRef);
   const actionsRef = useTreeItemContext_unstable(ctx => ctx.actionsRef);
-  const value = useTreeItemContext_unstable(ctx => ctx.value);
-  const checked = useTreeContext_unstable(ctx => ctx.checkedItems.get(value) ?? false);
+  const checked = useTreeItemContext_unstable(ctx => ctx.checked ?? false);
   const isBranch = useTreeItemContext_unstable(ctx => ctx.itemType === 'branch');
 
   const expandIcon = resolveShorthand(props.expandIcon, {

--- a/packages/react-components/react-tree/src/contexts/treeContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeContext.ts
@@ -19,9 +19,9 @@ export type TreeContextValue = {
 };
 
 export type TreeItemRequest = { itemType: TreeItemType } & (
-  | OmitWithoutExpanding<TreeOpenChangeData, 'open'>
+  | OmitWithoutExpanding<TreeOpenChangeData, 'open' | 'openItems'>
   | TreeNavigationData_unstable
-  | OmitWithoutExpanding<TreeCheckedChangeData, 'checked' | 'selectionMode'>
+  | OmitWithoutExpanding<TreeCheckedChangeData, 'selectionMode' | 'checkedItems'>
 );
 
 // helper type that avoids the expansion of unions while inferring it, should work exactly the same as Omit

--- a/packages/react-components/react-tree/src/contexts/treeItemContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeItemContext.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Context, ContextSelector, createContext, useContextSelector } from '@fluentui/react-context-selector';
 import type { TreeItemType, TreeItemValue } from '../TreeItem';
-import { virtualTreeRootId } from '../utils/createHeadlessTree';
+import { headlessTreeRootId } from '../utils/createHeadlessTree';
+import { TreeSelectionValue } from '../Tree';
 
 export type TreeItemContextValue = {
   isActionsVisible: boolean;
@@ -14,10 +15,11 @@ export type TreeItemContextValue = {
   itemType: TreeItemType;
   value: TreeItemValue;
   open: boolean;
+  checked?: TreeSelectionValue;
 };
 
 const defaultContextValue: TreeItemContextValue = {
-  value: virtualTreeRootId,
+  value: headlessTreeRootId,
   selectionRef: React.createRef(),
   layoutRef: React.createRef(),
   subtreeRef: React.createRef(),
@@ -27,6 +29,7 @@ const defaultContextValue: TreeItemContextValue = {
   isAsideVisible: false,
   itemType: 'leaf',
   open: false,
+  checked: undefined,
 };
 
 export const TreeItemContext: Context<TreeItemContextValue | undefined> = createContext<

--- a/packages/react-components/react-tree/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/src/hooks/useRootTree.ts
@@ -14,10 +14,10 @@ import { createCheckedItems } from '../utils/createCheckedItems';
 import { treeDataTypes } from '../utils/tokens';
 
 /**
- * Create the state required to render the root level BaseTree.
+ * Create the state required to render the root level tree.
  *
- * @param props - props from this instance of BaseTree
- * @param ref - reference to root HTMLElement of BaseTree
+ * @param props - props from this instance of tree
+ * @param ref - reference to root HTMLElement of tree
  */
 export function useRootTree(
   props: Pick<
@@ -56,7 +56,11 @@ export function useRootTree(
       case treeDataTypes.Click:
       case treeDataTypes.ExpandIconClick: {
         return ReactDOM.unstable_batchedUpdates(() => {
-          requestOpenChange({ ...request, open: request.itemType === 'branch' && !openItems.has(request.value) });
+          requestOpenChange({
+            ...request,
+            open: request.itemType === 'branch' && !openItems.has(request.value),
+            openItems: openItems.dangerouslyGetInternalSet_unstable(),
+          });
           requestNavigation({ ...request, type: treeDataTypes.Click });
         });
       }
@@ -66,18 +70,31 @@ export function useRootTree(
         }
         const open = openItems.has(request.value);
         if (!open) {
-          return requestOpenChange({ ...request, open: true });
+          return requestOpenChange({
+            ...request,
+            open: true,
+            openItems: openItems.dangerouslyGetInternalSet_unstable(),
+          });
         }
         return requestNavigation(request);
       }
       case treeDataTypes.Enter: {
         const open = openItems.has(request.value);
-        return requestOpenChange({ ...request, open: request.itemType === 'branch' && !open });
+        return requestOpenChange({
+          ...request,
+          open: request.itemType === 'branch' && !open,
+          openItems: openItems.dangerouslyGetInternalSet_unstable(),
+        });
       }
       case treeDataTypes.ArrowLeft: {
         const open = openItems.has(request.value);
         if (open && request.itemType === 'branch') {
-          return requestOpenChange({ ...request, open: false, type: treeDataTypes.ArrowLeft });
+          return requestOpenChange({
+            ...request,
+            open: false,
+            type: treeDataTypes.ArrowLeft,
+            openItems: openItems.dangerouslyGetInternalSet_unstable(),
+          });
         }
         return requestNavigation({ ...request, type: treeDataTypes.ArrowLeft });
       }
@@ -88,12 +105,11 @@ export function useRootTree(
       case treeDataTypes.TypeAhead:
         return requestNavigation({ ...request, target: request.event.currentTarget });
       case treeDataTypes.Change: {
-        const previousCheckedValue = checkedItems.get(request.value);
         return requestCheckedChange({
           ...request,
           selectionMode: selectionMode as SelectionMode,
-          checked: previousCheckedValue === 'mixed' ? true : !previousCheckedValue,
-        });
+          checkedItems: checkedItems.dangerouslyGetInternalMap_unstable(),
+        } as TreeCheckedChangeData);
       }
     }
   });
@@ -112,7 +128,7 @@ export function useRootTree(
     requestTreeResponse,
     root: getNativeElementProps('div', {
       ref,
-      role: 'baseTree',
+      role: 'tree',
       'aria-multiselectable': selectionMode === 'multiselect' ? true : undefined,
       ...props,
     }),
@@ -123,7 +139,7 @@ function warnIfNoProperPropsRootTree(props: Pick<TreeProps, 'aria-label' | 'aria
   if (process.env.NODE_ENV === 'development') {
     if (!props['aria-label'] && !props['aria-labelledby']) {
       // eslint-disable-next-line no-console
-      console.warn('BaseTree must have either a `aria-label` or `aria-labelledby` property defined');
+      console.warn('Tree must have either a `aria-label` or `aria-labelledby` property defined');
     }
   }
 }

--- a/packages/react-components/react-tree/src/hooks/useRovingTabIndexes.ts
+++ b/packages/react-components/react-tree/src/hooks/useRovingTabIndexes.ts
@@ -1,26 +1,13 @@
-import { useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
-import { HTMLElementFilter, useHTMLElementWalkerRef } from './useHTMLElementWalker';
+import { HTMLElementFilter, HTMLElementWalker } from '../utils/createHTMLElementWalker';
 
 /**
  * https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex
  */
 export function useRovingTabIndex(filter?: HTMLElementFilter) {
   const currentElementRef = React.useRef<HTMLElement>();
-  const [walkerRef, rootRef] = useHTMLElementWalkerRef(filter);
 
-  const rootRefCallback = (element?: HTMLElement) => {
-    if (!element) {
-      return;
-    }
-    reset();
-  };
-
-  function reset() {
-    if (!walkerRef.current) {
-      return;
-    }
-    const walker = walkerRef.current;
+  const initialize = React.useCallback((walker: HTMLElementWalker) => {
     walker.currentElement = walker.root;
     let tabbableChild = walker.firstChild(element =>
       element.tabIndex === 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP,
@@ -36,8 +23,8 @@ export function useRovingTabIndex(filter?: HTMLElementFilter) {
     while ((nextElement = walker.nextElement()) && nextElement !== tabbableChild) {
       nextElement.tabIndex = -1;
     }
-  }
-  function rove(nextElement: HTMLElement) {
+  }, []);
+  const rove = React.useCallback((nextElement: HTMLElement) => {
     if (!currentElementRef.current) {
       return;
     }
@@ -45,13 +32,10 @@ export function useRovingTabIndex(filter?: HTMLElementFilter) {
     nextElement.tabIndex = 0;
     nextElement.focus();
     currentElementRef.current = nextElement;
-  }
+  }, []);
 
-  return [
-    {
-      rove,
-      reset,
-    },
-    useMergedRefs(rootRef, rootRefCallback) as React.Ref<HTMLElement>,
-  ] as const;
+  return {
+    rove,
+    initialize,
+  };
 }

--- a/packages/react-components/react-tree/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/src/hooks/useSubtree.ts
@@ -4,10 +4,10 @@ import { useTreeContext_unstable, useTreeItemContext_unstable } from '../context
 import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
 
 /**
- * Create the state required to render a sub-level BaseTree.
+ * Create the state required to render a sub-level tree.
  *
- * @param props - props from this instance of BaseTree
- * @param ref - reference to root HTMLElement of BaseTree
+ * @param props - props from this instance of tree
+ * @param ref - reference to root HTMLElement of tree
  */
 export function useSubtree(props: Pick<TreeProps, 'appearance' | 'size'>, ref: React.Ref<HTMLElement>): TreeState {
   const contextAppearance = useTreeContext_unstable(ctx => ctx.appearance);

--- a/packages/react-components/react-tree/src/utils/createHTMLElementWalker.ts
+++ b/packages/react-components/react-tree/src/utils/createHTMLElementWalker.ts
@@ -1,5 +1,4 @@
 import { isHTMLElement } from '@fluentui/react-utilities';
-import * as React from 'react';
 
 export interface HTMLElementWalker {
   readonly root: HTMLElement;
@@ -83,16 +82,3 @@ export function createHTMLElementWalker(
     },
   };
 }
-
-export const useHTMLElementWalkerRef = (filter?: HTMLElementFilter) => {
-  const walkerRef = React.useRef<HTMLElementWalker>();
-
-  const rootRefCallback = (element?: HTMLElement) => {
-    if (!element) {
-      walkerRef.current = undefined;
-      return;
-    }
-    walkerRef.current = createHTMLElementWalker(element, filter);
-  };
-  return [walkerRef as React.RefObject<HTMLElementWalker>, rootRefCallback as React.Ref<HTMLElement>] as const;
-};

--- a/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
+++ b/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
@@ -104,7 +104,7 @@ export function createHeadlessTree<Props extends HeadlessTreeItemProps>(
     get: key => itemsPerValue.get(key),
     has: key => itemsPerValue.has(key),
     add(props) {
-      const { parentValue = virtualTreeRootId, ...propsWithoutParentValue } = props;
+      const { parentValue = headlessTreeRootId, ...propsWithoutParentValue } = props;
       const parentItem = itemsPerValue.get(parentValue);
       if (!parentItem) {
         if (process.env.NODE_ENV === 'development') {
@@ -169,12 +169,12 @@ export function createHeadlessTree<Props extends HeadlessTreeItemProps>(
   return headlessTree as HeadlessTree<Props>;
 }
 
-export const virtualTreeRootId = '__fuiHeadlessTreeRoot';
+export const headlessTreeRootId = '__fuiHeadlessTreeRoot';
 
 function createHeadlessTreeRootItem(): HeadlessTreeItem<HeadlessTreeItemProps> {
   return {
     parentValue: undefined,
-    value: virtualTreeRootId,
+    value: headlessTreeRootId,
     itemType: 'branch',
     getTreeItemProps: () => {
       if (process.env.NODE_ENV !== 'production') {
@@ -182,8 +182,8 @@ function createHeadlessTreeRootItem(): HeadlessTreeItem<HeadlessTreeItemProps> {
         console.error('HeadlessTree: internal error, trying to access treeitem props from invalid root element');
       }
       return {
-        id: virtualTreeRootId,
-        value: virtualTreeRootId,
+        id: headlessTreeRootId,
+        value: headlessTreeRootId,
         'aria-setsize': -1,
         'aria-level': -1,
         'aria-posinset': -1,
@@ -223,11 +223,8 @@ function* HeadlessTreeSubtreeGenerator<Props extends HeadlessTreeItemProps>(
     return;
   }
   for (const childValue of item.childrenValues) {
-    const child = virtualTreeItems.get(childValue)!;
-    yield child;
-    if (child.childrenValues.length > 0) {
-      yield* HeadlessTreeSubtreeGenerator(childValue, virtualTreeItems);
-    }
+    yield virtualTreeItems.get(childValue)!;
+    yield* HeadlessTreeSubtreeGenerator(childValue, virtualTreeItems);
   }
 }
 

--- a/packages/react-components/react-tree/src/utils/nextTypeAheadElement.ts
+++ b/packages/react-components/react-tree/src/utils/nextTypeAheadElement.ts
@@ -1,4 +1,4 @@
-import { HTMLElementWalker } from '../hooks/useHTMLElementWalker';
+import { HTMLElementWalker } from './createHTMLElementWalker';
 
 export function nextTypeAheadElement(treeWalker: HTMLElementWalker, key: string) {
   const keyToLowerCase = key.toLowerCase();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior


1. reduces the amount of HTMLElementWalker instances being created
2. adds `openItems` and `checkedItems` to tree callback data
3. adds `checked` state to tree item context
4. fix role `baseTree` issue

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
