### PR TITLE
Added icon to the BreadcrumbItem

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-5bdaf6e2-9260-4dfe-ace7-09993bd79c34.json
+++ b/change/@fluentui-react-breadcrumb-preview-5bdaf6e2-9260-4dfe-ace7-09993bd79c34.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Added an icon for BreadcrumbItem",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/docs/Spec.md
+++ b/packages/react-components/react-breadcrumb-preview/docs/Spec.md
@@ -120,8 +120,8 @@ Breadcrumb can be:
 
 ### Icon
 
-Non-clickable items can't have icon.
-Only BreadcrumButton and BreadcrumbLink can have an icon with text or just icon.
+Breadcrumb items can have icons. If you need an icon for an interactive item, use it inside BreadcrumButton or BreadcrumbLink.
+For non-interactive items use the icon inside BreadcrumbItem.
 
 ### Size
 
@@ -190,7 +190,7 @@ BreadcrumbItem can be:
 
 - Button - BreadcrumbButton component is used inside BreadcrumbItem.
 - Link - BreadcrumbLink is used inside BreadcrumbItem.
-- Non-clickable content
+- Non-clickable content (text and/or icon).
 - Dropdown Menu
 
 It can contain a tooltip.
@@ -257,6 +257,9 @@ Usage
 </BreadcrumbItem>
 <BreadcrumbItem>
   <BreadcrumbLink icon={<IconComponent />}>Item</BreadcrumbLink>
+</BreadcrumbItem>
+<BreadcrumbItem icon={<IconComponent />}>
+  Item
 </BreadcrumbItem>
 ```
 

--- a/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
+++ b/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
@@ -67,15 +67,19 @@ export const breadcrumbItemClassNames: SlotClassNames<BreadcrumbItemSlots>;
 // @public
 export type BreadcrumbItemProps = ComponentProps<BreadcrumbItemSlots> & Pick<BreadcrumbProps, 'size'> & {
     current?: boolean;
+    iconPosition?: 'before' | 'after';
 };
 
 // @public (undocumented)
 export type BreadcrumbItemSlots = {
     root: Slot<'li'>;
+    icon?: Slot<'span'>;
 };
 
 // @public
-export type BreadcrumbItemState = ComponentState<BreadcrumbItemSlots> & Required<Pick<BreadcrumbItemProps, 'size' | 'current'>>;
+export type BreadcrumbItemState = ComponentState<BreadcrumbItemSlots> & Required<Pick<BreadcrumbItemProps, 'size' | 'current' | 'iconPosition'>> & {
+    iconOnly: boolean;
+};
 
 // @public
 export const BreadcrumbLink: ForwardRefComponent<BreadcrumbLinkProps>;

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.test.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { BreadcrumbItem } from './BreadcrumbItem';
+import { BreadcrumbItemProps } from './BreadcrumbItem.types';
 import { isConformant } from '../../testing/isConformant';
+import { breadcrumbItemClassNames } from './useBreadcrumbItemStyles.styles';
 
 describe('BreadcrumbItem', () => {
   isConformant({
-    Component: BreadcrumbItem,
+    Component: BreadcrumbItem as React.FunctionComponent<BreadcrumbItemProps>,
     displayName: 'BreadcrumbItem',
+    testOptions: {
+      'has-static-classnames': [
+        {
+          props: {},
+          expectedClassNames: {
+            root: breadcrumbItemClassNames.root,
+          },
+        },
+      ],
+    },
   });
 
   // create visual regression tests in /apps/vr-tests

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.types.ts
@@ -3,6 +3,11 @@ import type { BreadcrumbProps } from '../Breadcrumb';
 
 export type BreadcrumbItemSlots = {
   root: Slot<'li'>;
+
+  /**
+   * Icon that renders either before or after the `children` as specified by the `iconPosition` prop.
+   */
+  icon?: Slot<'span'>;
 };
 
 /**
@@ -16,10 +21,24 @@ export type BreadcrumbItemProps = ComponentProps<BreadcrumbItemSlots> &
      * @default false
      */
     current?: boolean;
+
+    /**
+     * Icon position for BreadcrumbLink or BreadcrumbLink.
+     *
+     * @default 'before'
+     */
+    iconPosition?: 'before' | 'after';
   };
 
 /**
  * State used in rendering BreadcrumbItem
  */
 export type BreadcrumbItemState = ComponentState<BreadcrumbItemSlots> &
-  Required<Pick<BreadcrumbItemProps, 'size' | 'current'>>;
+  Required<Pick<BreadcrumbItemProps, 'size' | 'current' | 'iconPosition'>> & {
+    /**
+     * A BreadcrumbItem can contain only an icon.
+     *
+     * @default false
+     */
+    iconOnly: boolean;
+  };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/renderBreadcrumbItem.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/renderBreadcrumbItem.tsx
@@ -11,6 +11,13 @@ import type { BreadcrumbItemState, BreadcrumbItemSlots } from './BreadcrumbItem.
  */
 export const renderBreadcrumbItem_unstable = (state: BreadcrumbItemState) => {
   const { slots, slotProps } = getSlotsNext<BreadcrumbItemSlots>(state);
+  const { iconOnly, iconPosition } = state;
 
-  return <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>;
+  return (
+    <slots.root {...slotProps.root}>
+      {iconPosition !== 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
+      {!iconOnly && state.root.children}
+      {iconPosition === 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
+    </slots.root>
+  );
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
 import type { BreadcrumbItemProps, BreadcrumbItemState } from './BreadcrumbItem.types';
 import { useBreadcrumbContext_unstable } from '../Breadcrumb/BreadcrumbContext';
 
@@ -16,11 +16,16 @@ export const useBreadcrumbItem_unstable = (
   props: BreadcrumbItemProps,
   ref: React.Ref<HTMLElement>,
 ): BreadcrumbItemState => {
-  const { size } = useBreadcrumbContext_unstable();
-  const { current = false } = props;
+  const { size, iconPosition } = useBreadcrumbContext_unstable();
+  const { current = false, icon } = props;
+
+  // const isInteractive = typeof props.children !== 'string';
+  const iconShorthand = resolveShorthand(icon);
+
   return {
     components: {
       root: 'li',
+      icon: 'span',
     },
     root: getNativeElementProps('li', {
       ref,
@@ -28,5 +33,8 @@ export const useBreadcrumbItem_unstable = (
     }),
     size,
     current,
+    icon: iconShorthand,
+    iconOnly: Boolean(iconShorthand?.children && !props.children),
+    iconPosition: props.iconPosition || iconPosition,
   };
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
@@ -19,7 +19,6 @@ export const useBreadcrumbItem_unstable = (
   const { size, iconPosition } = useBreadcrumbContext_unstable();
   const { current = false, icon } = props;
 
-  // const isInteractive = typeof props.children !== 'string';
   const iconShorthand = resolveShorthand(icon);
 
   return {

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
@@ -5,6 +5,7 @@ import { tokens, typographyStyles } from '@fluentui/react-theme';
 
 export const breadcrumbItemClassNames: SlotClassNames<BreadcrumbItemSlots> = {
   root: 'fui-BreadcrumbItem',
+  icon: 'fui-BreadcrumbItem__icon',
 };
 
 /**
@@ -16,6 +17,11 @@ const useStyles = makeStyles({
     alignItems: 'center',
     color: tokens.colorNeutralForeground2,
     boxSizing: 'border-box',
+  },
+  icon: {
+    display: 'flex',
+    alignItems: 'center',
+    ...shorthands.padding(tokens.spacingHorizontalXS),
   },
   small: {
     height: '24px',
@@ -43,11 +49,33 @@ const useStyles = makeStyles({
   },
 });
 
+const useIconStyles = makeStyles({
+  small: {
+    fontSize: '12px',
+    height: '12px',
+    lineHeight: tokens.lineHeightBase200,
+    width: '12px',
+  },
+  medium: {
+    fontSize: '16px',
+    height: '16px',
+    lineHeight: tokens.lineHeightBase400,
+    width: '16px',
+  },
+  large: {
+    fontSize: '20px',
+    height: '20px',
+    lineHeight: tokens.lineHeightBase600,
+    width: '20px',
+  },
+});
+
 /**
  * Apply styling to the BreadcrumbItem slots based on the state
  */
 export const useBreadcrumbItemStyles_unstable = (state: BreadcrumbItemState): BreadcrumbItemState => {
   const styles = useStyles();
+  const iconStyles = useIconStyles();
   const size = state.size || 'medium';
   const currentSizeMap = {
     small: styles.currentSmall,
@@ -61,6 +89,10 @@ export const useBreadcrumbItemStyles_unstable = (state: BreadcrumbItemState): Br
     state.current && currentSizeMap[size],
     state.root.className,
   );
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(iconStyles[state.size], styles.icon, state.icon.className);
+  }
 
   return state;
 };

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbItem/BreadcrumbItemDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbItem/BreadcrumbItemDefault.stories.tsx
@@ -100,7 +100,6 @@ export const Default = () => {
         <BreadcrumbItem icon={<CalendarMonth />} iconPosition="after">
           Item with an icon
         </BreadcrumbItem>
-        <BreadcrumbItem icon={<CalendarMonth />}>Item with an icon</BreadcrumbItem>
       </Breadcrumb>
     </>
   );

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbItem/BreadcrumbItemDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbItem/BreadcrumbItemDefault.stories.tsx
@@ -10,9 +10,15 @@ import {
   isTruncatableBreadcrumbContent,
 } from '@fluentui/react-breadcrumb-preview';
 import type { PartitionBreadcrumbItems } from '@fluentui/react-breadcrumb-preview';
-import { MoreHorizontalRegular, MoreHorizontalFilled, bundleIcon } from '@fluentui/react-icons';
+import {
+  MoreHorizontalRegular,
+  MoreHorizontalFilled,
+  bundleIcon,
+  CalendarMonth20Filled,
+  CalendarMonth20Regular,
+} from '@fluentui/react-icons';
 import { Tooltip } from '@fluentui/react-components';
-
+const CalendarMonth = bundleIcon(CalendarMonth20Filled, CalendarMonth20Regular);
 const MoreHorizontal = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
 
 type Item = {
@@ -84,6 +90,17 @@ export const Default = () => {
           </BreadcrumbItem>
         )}
         {endDisplayedItems && endDisplayedItems.map(item => renderItem(item))}
+      </Breadcrumb>
+      <h2>BreadcrumbItem with icon</h2>
+      <Breadcrumb aria-label="breadcrumb-item-icon-example">
+        <BreadcrumbItem icon={<CalendarMonth />}>Item with an icon</BreadcrumbItem>
+        <BreadcrumbDivider />
+        <BreadcrumbItem icon={<CalendarMonth />} />
+        <BreadcrumbDivider />
+        <BreadcrumbItem icon={<CalendarMonth />} iconPosition="after">
+          Item with an icon
+        </BreadcrumbItem>
+        <BreadcrumbItem icon={<CalendarMonth />}>Item with an icon</BreadcrumbItem>
       </Breadcrumb>
     </>
   );


### PR DESCRIPTION
At the beginning we agreed not to have an icon for non-interactive items.
The designers asked to have icons in all the items for consistency. I, also, found a use case in Loop app that non-clickable items can have icons.

## Previous Behavior
It was not possible to have icons as part of BreadcrumbItem.

## New Behavior
Added possibility to have an icon for BreadcrumbItem
![image](https://github.com/microsoft/fluentui/assets/11574680/2e3b850b-e344-49f6-8245-4549cc4e126f)