### PR TITLE
fix(react-tags-preview): fix InteractionTag hover styles

### DIFF
--- a/packages/react-components/react-tags-preview/src/components/InteractionTag/useInteractionTagStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTag/useInteractionTagStyles.styles.ts
@@ -99,6 +99,7 @@ const useContentButtonStyles = makeStyles({
 
       [`& .${iconFilledClassName}`]: {
         display: 'inline',
+        color: tokens.colorNeutralForeground2BrandHover,
       },
       [`& .${iconRegularClassName}`]: {
         display: 'none',
@@ -110,6 +111,7 @@ const useContentButtonStyles = makeStyles({
 
       [`& .${iconFilledClassName}`]: {
         display: 'inline',
+        color: tokens.colorNeutralForeground2BrandPressed,
       },
       [`& .${iconRegularClassName}`]: {
         display: 'none',
@@ -118,15 +120,15 @@ const useContentButtonStyles = makeStyles({
   },
   brand: {
     backgroundColor: tokens.colorBrandBackground2,
-    color: tokens.colorBrandForeground2,
+    color: tokens.colorBrandForeground1,
     ':hover': {
       cursor: 'pointer',
       backgroundColor: tokens.colorBrandBackground2Hover,
-      color: tokens.colorBrandForeground2Hover,
+      color: tokens.colorCompoundBrandForeground1Hover,
     },
     ':hover:active': {
       backgroundColor: tokens.colorBrandBackground2Pressed,
-      color: tokens.colorBrandForeground2Pressed,
+      color: tokens.colorCompoundBrandForeground1Pressed,
     },
   },
 
@@ -256,16 +258,16 @@ const useDismissButtonStyles = makeStyles({
   },
   brand: {
     backgroundColor: tokens.colorBrandBackground2,
-    color: tokens.colorBrandForeground2,
+    color: tokens.colorBrandForeground1,
     borderLeftColor: tokens.colorBrandStroke2, // divider
     ':hover': {
       cursor: 'pointer',
       backgroundColor: tokens.colorBrandBackground2Hover,
-      color: tokens.colorBrandForeground2Hover,
+      color: tokens.colorCompoundBrandForeground1Hover,
     },
     ':hover:active': {
       backgroundColor: tokens.colorBrandBackground2Pressed,
-      color: tokens.colorBrandForeground2Pressed,
+      color: tokens.colorCompoundBrandForeground1Pressed,
     },
   },
 

--- a/packages/react-components/react-tags-preview/stories/TagGroup/TagGroupOverflow.stories.tsx
+++ b/packages/react-components/react-tags-preview/stories/TagGroup/TagGroupOverflow.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TagGroup, Tag, TagProps } from '@fluentui/react-tags-preview';
+import { TagGroup, Tag, TagProps, tagClassNames } from '@fluentui/react-tags-preview';
 import {
   makeStyles,
   shorthands,
@@ -50,7 +50,14 @@ type OverflowMenuItemProps = {
 };
 
 const useMenuItemStyles = makeStyles({
-  menuItem: shorthands.padding(tokens.spacingVerticalSNudge, tokens.spacingHorizontalXS),
+  menuItem: {
+    ...shorthands.padding(tokens.spacingVerticalSNudge, tokens.spacingHorizontalXS),
+    ':hover': {
+      [`& .${tagClassNames.root}`]: {
+        color: tokens.colorNeutralForeground2Hover,
+      },
+    },
+  },
   tag: {
     backgroundColor: 'transparent',
     ...shorthands.borderColor('transparent'),


### PR DESCRIPTION
Fix the left over issues on #28368 

1. InteractionTag brand variant had no style change on hover in contrast theme, now it changes text color: 
     <img width="323" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/d6eb6364-9708-43aa-983d-002c901dcc38">

2. InteractionTag outline variant fills icon on hover and changes icon to brand color
    <img width="401" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/2e30efac-ee92-4d02-b69d-3b8f5e7e9810">

3. Fix visual issue in Tag overflow story:
    | before | after | 
    | ------ | ------ |
    |<img width="181" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/fc23eeba-3cec-4f06-adf1-185c2c3d0fc9">| <img width="180" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/de8ebce2-4d40-45f6-9d98-50d430410ab1"> |

