### PR TITLE
fix(react-positioning): autoSize causing position update to reach maximum

### DIFF
--- a/change/@fluentui-react-positioning-86dcd6cd-76f3-4f49-b446-04e827493aa7.json
+++ b/change/@fluentui-react-positioning-86dcd6cd-76f3-4f49-b446-04e827493aa7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: autoSize causing maximum positioning update",
+  "packageName": "@fluentui/react-positioning",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/middleware/maxSize.test.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.test.ts
@@ -1,0 +1,30 @@
+import { Platform, computePosition } from '@floating-ui/dom';
+import { resetMaxSize } from './maxSize';
+
+const referenceRect = { x: 0, y: 0, width: 100, height: 100 };
+const floatingRect = { x: 0, y: 0, width: 50, height: 50 };
+const mockGetElementRects = jest.fn(() =>
+  Promise.resolve({
+    reference: referenceRect,
+    floating: floatingRect,
+  }),
+);
+const platform = {
+  getElementRects: mockGetElementRects,
+  getDimensions: () => Promise.resolve({ width: 10, height: 10 }),
+} as unknown as Platform;
+
+describe('maxSize', () => {
+  it('resetMaxSize reset once per life cycle', async () => {
+    const button = document.createElement('div');
+    const tooltip = document.createElement('div');
+    const autoSize = { applyMaxHeight: true, applyMaxWidth: true };
+
+    await computePosition(button, tooltip, {
+      placement: 'right',
+      middleware: [resetMaxSize(autoSize)],
+      platform,
+    });
+    expect(mockGetElementRects).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-components/react-positioning/src/middleware/maxSize.test.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.test.ts
@@ -1,8 +1,8 @@
 import { Platform, computePosition } from '@floating-ui/dom';
 import { resetMaxSize } from './maxSize';
 
-const referenceRect = { x: 0, y: 0, width: 100, height: 100 };
-const floatingRect = { x: 0, y: 0, width: 50, height: 50 };
+const referenceRect: Partial<DOMRect> = { x: 0, y: 0, width: 100, height: 100 };
+const floatingRect: Partial<DOMRect> = { x: 0, y: 0, width: 50, height: 50 };
 const mockGetElementRects = jest.fn(() =>
   Promise.resolve({
     reference: referenceRect,
@@ -11,10 +11,11 @@ const mockGetElementRects = jest.fn(() =>
 );
 const platform = {
   getElementRects: mockGetElementRects,
-} as unknown as Platform;
+} as Partial<Platform> as Platform;
 
 describe('maxSize', () => {
   it('resetMaxSize reset once per life cycle', async () => {
+    expect.hasAssertions();
     const button = document.createElement('div');
     const tooltip = document.createElement('div');
     const autoSize = { applyMaxHeight: true, applyMaxWidth: true };

--- a/packages/react-components/react-positioning/src/middleware/maxSize.test.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.test.ts
@@ -11,7 +11,6 @@ const mockGetElementRects = jest.fn(() =>
 );
 const platform = {
   getElementRects: mockGetElementRects,
-  getDimensions: () => Promise.resolve({ width: 10, height: 10 }),
 } as unknown as Platform;
 
 describe('maxSize', () => {

--- a/packages/react-components/react-positioning/src/middleware/maxSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/maxSize.ts
@@ -13,8 +13,8 @@ export interface MaxSizeMiddlewareOptions extends Pick<PositioningOptions, 'over
  */
 export const resetMaxSize = (autoSize: NormalizedAutoSize): Middleware => ({
   name: 'resetMaxSize',
-  fn({ middlewareData: { maxSizeAlreadyReset }, elements }) {
-    if (maxSizeAlreadyReset) {
+  fn({ middlewareData, elements }) {
+    if (middlewareData.resetMaxSize?.maxSizeAlreadyReset) {
       return {};
     }
 


### PR DESCRIPTION
#28649 introduced `resetMaxSize`  middleware - when `autoSize` is specified, `resetMaxSize` middleware is used to reset the styles from previous life cycle and set a flag to not reset again. But the flag didn't work because of a stupid mistake in the check. This PR corrects it. 