### PR TITLE
bugfix: renames content slot to main

### DIFF
--- a/change/@fluentui-react-tree-7b6d4596-b8e2-46b5-a0d4-d3d4e921fce0.json
+++ b/change/@fluentui-react-tree-7b6d4596-b8e2-46b5-a0d4-d3d4e921fce0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: renames content slot to main",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -168,7 +168,7 @@ export type TreeItemLayoutProps = ComponentProps<Partial<TreeItemLayoutSlots>>;
 // @public (undocumented)
 export type TreeItemLayoutSlots = {
     root: Slot<'div'>;
-    content: NonNullable<Slot<'div'>>;
+    main: NonNullable<Slot<'div'>>;
     iconBefore?: Slot<'div'>;
     iconAfter?: Slot<'div'>;
     expandIcon?: Slot<'div'>;
@@ -200,7 +200,7 @@ export type TreeItemPersonaLayoutProps = ComponentProps<Partial<TreeItemPersonaL
 export type TreeItemPersonaLayoutSlots = Pick<TreeItemLayoutSlots, 'actions' | 'aside' | 'expandIcon' | 'selector'> & {
     root: NonNullable<Slot<'div'>>;
     media: NonNullable<Slot<'div'>>;
-    content: NonNullable<Slot<'div'>>;
+    main: NonNullable<Slot<'div'>>;
     description?: Slot<'div'>;
 };
 

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.types.ts
@@ -8,7 +8,7 @@ export type TreeItemLayoutSlots = {
   /**
    * Content. Children of the root slot are automatically rendered here
    */
-  content: NonNullable<Slot<'div'>>;
+  main: NonNullable<Slot<'div'>>;
   /**
    * Icon slot that renders right before main content
    */

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/__snapshots__/TreeItemLayout.test.tsx.snap
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/__snapshots__/TreeItemLayout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TreeItemLayout renders a default state 1`] = `
     class="fui-TreeItemLayout"
   >
     <div
-      class="fui-TreeItemLayout__content"
+      class="fui-TreeItemLayout__main"
     >
       Default TreeItemLayout
     </div>

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/renderTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/renderTreeItemLayout.tsx
@@ -17,7 +17,7 @@ export const renderTreeItemLayout_unstable = (state: TreeItemLayoutState) => {
       {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
       {slots.selector && <slots.selector {...slotProps.selector} />}
       {slots.iconBefore && <slots.iconBefore {...slotProps.iconBefore} />}
-      <slots.content {...slotProps.content}>{slotProps.root.children}</slots.content>
+      <slots.main {...slotProps.main}>{slotProps.root.children}</slots.main>
       {slots.iconAfter && <slots.iconAfter {...slotProps.iconAfter} />}
       <ButtonContextProvider value={state.buttonContextValue}>
         {slots.actions && <slots.actions {...slotProps.actions} />}

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -19,7 +19,7 @@ export const useTreeItemLayout_unstable = (
   props: TreeItemLayoutProps,
   ref: React.Ref<HTMLElement>,
 ): TreeItemLayoutState => {
-  const { content, iconAfter, iconBefore, as = 'span' } = props;
+  const { main, iconAfter, iconBefore, as = 'span' } = props;
 
   const layoutRef = useTreeItemContext_unstable(ctx => ctx.layoutRef);
   const selectionMode = useTreeContext_unstable(ctx => ctx.selectionMode);
@@ -63,7 +63,7 @@ export const useTreeItemLayout_unstable = (
       root: 'div',
       expandIcon: 'div',
       iconBefore: 'div',
-      content: 'div',
+      main: 'div',
       iconAfter: 'div',
       actions: 'div',
       aside: 'div',
@@ -73,7 +73,7 @@ export const useTreeItemLayout_unstable = (
     buttonContextValue: { size: 'small' },
     root: getNativeElementProps(as, { ...props, ref: useMergedRefs(ref, layoutRef) }),
     iconBefore: resolveShorthand(iconBefore, { defaultProps: { 'aria-hidden': true } }),
-    content: resolveShorthand(content, { required: true }),
+    main: resolveShorthand(main, { required: true }),
     iconAfter: resolveShorthand(iconAfter, { defaultProps: { 'aria-hidden': true } }),
     aside: isAsideVisible ? resolveShorthand(props.aside) : undefined,
     actions,

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -9,7 +9,7 @@ import { useTreeItemContext_unstable } from '../../contexts/treeItemContext';
 export const treeItemLayoutClassNames: SlotClassNames<TreeItemLayoutSlots> = {
   root: 'fui-TreeItemLayout',
   iconBefore: 'fui-TreeItemLayout__iconBefore',
-  content: 'fui-TreeItemLayout__content',
+  main: 'fui-TreeItemLayout__main',
   iconAfter: 'fui-TreeItemLayout__iconAfter',
   expandIcon: 'fui-TreeItemLayout__expandIcon',
   aside: 'fui-TreeItemLayout__aside',
@@ -126,7 +126,7 @@ const useExpandIconStyles = makeStyles({
 /**
  * Styles for the content slot
  */
-const useContentStyles = makeStyles({
+const useMainStyles = makeStyles({
   base: {
     ...shorthands.padding(0, tokens.spacingHorizontalXXS),
   },
@@ -167,12 +167,12 @@ const useIconAfterStyles = makeStyles({
  * Apply styling to the TreeItemLayout slots based on the state
  */
 export const useTreeItemLayoutStyles_unstable = (state: TreeItemLayoutState): TreeItemLayoutState => {
-  const { content, iconAfter, iconBefore, expandIcon, root, aside, actions, selector } = state;
+  const { main, iconAfter, iconBefore, expandIcon, root, aside, actions, selector } = state;
   const rootStyles = useRootStyles();
   const actionsStyles = useActionsStyles();
   const asideStyles = useAsideStyles();
 
-  const contentStyles = useContentStyles();
+  const mainStyles = useMainStyles();
 
   const expandIconStyles = useExpandIconStyles();
   const iconStyles = useIconStyles();
@@ -192,7 +192,7 @@ export const useTreeItemLayoutStyles_unstable = (state: TreeItemLayoutState): Tr
     root.className,
   );
 
-  content.className = mergeClasses(treeItemLayoutClassNames.content, contentStyles.base, content.className);
+  main.className = mergeClasses(treeItemLayoutClassNames.main, mainStyles.base, main.className);
 
   if (expandIcon) {
     expandIcon.className = mergeClasses(

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.types.ts
@@ -16,7 +16,7 @@ export type TreeItemPersonaLayoutSlots = Pick<TreeItemLayoutSlots, 'actions' | '
   /**
    * Content. Children of the root slot are automatically rendered here
    */
-  content: NonNullable<Slot<'div'>>;
+  main: NonNullable<Slot<'div'>>;
   /**
    * Secondary text that describes or complements the content
    */

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/__snapshots__/TreeItemPersonaLayout.test.tsx.snap
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/__snapshots__/TreeItemPersonaLayout.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TreeItemPersonaLayout renders a default state 1`] = `
       class="fui-TreeItemPersonaLayout__media"
     />
     <div
-      class="fui-TreeItemPersonaLayout__content"
+      class="fui-TreeItemPersonaLayout__main"
     >
       Default TreeItemPersonaLayout
     </div>

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/renderTreeItemPersonaLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/renderTreeItemPersonaLayout.tsx
@@ -27,7 +27,7 @@ export const renderTreeItemPersonaLayout_unstable = (
       <AvatarContextProvider value={contextValues.avatar}>
         <slots.media {...slotProps.media} />
       </AvatarContextProvider>
-      <slots.content {...slotProps.content} />
+      <slots.main {...slotProps.main} />
       {slots.description && <slots.description {...slotProps.description} />}
       <ButtonContextProvider value={state.buttonContextValue}>
         {slots.actions && <slots.actions {...slotProps.actions} />}

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayout.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayout.ts
@@ -20,7 +20,7 @@ export const useTreeItemPersonaLayout_unstable = (
   props: TreeItemPersonaLayoutProps,
   ref: React.Ref<HTMLSpanElement>,
 ): TreeItemPersonaLayoutState => {
-  const { media, children, content, description } = props;
+  const { media, children, main, description } = props;
 
   const treeItemLayoutState = useTreeItemLayout_unstable(
     {
@@ -38,7 +38,7 @@ export const useTreeItemPersonaLayout_unstable = (
     ...treeItemLayoutState,
     components: {
       expandIcon: 'div',
-      content: 'div',
+      main: 'div',
       description: 'div',
       root: 'div',
       media: 'div',
@@ -48,7 +48,7 @@ export const useTreeItemPersonaLayout_unstable = (
       selector: (selectionMode === 'multiselect' ? Checkbox : Radio) as React.ElementType<CheckboxProps | RadioProps>,
     },
     avatarSize: treeAvatarSize[size],
-    content: resolveShorthand(content, { required: true, defaultProps: { children } }),
+    main: resolveShorthand(main, { required: true, defaultProps: { children } }),
     media: resolveShorthand(media, { required: true }),
     description: resolveShorthand(description),
   };

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
@@ -9,7 +9,7 @@ export const treeItemPersonaLayoutClassNames: SlotClassNames<TreeItemPersonaLayo
   root: 'fui-TreeItemPersonaLayout',
   media: 'fui-TreeItemPersonaLayout__media',
   description: 'fui-TreeItemPersonaLayout__description',
-  content: 'fui-TreeItemPersonaLayout__content',
+  main: 'fui-TreeItemPersonaLayout__main',
   expandIcon: 'fui-TreeItemPersonaLayout__expandIcon',
   aside: 'fui-TreeItemPersonaLayout__aside',
   actions: 'fui-TreeItemPersonaLayout__actions',
@@ -25,7 +25,7 @@ const useRootStyles = makeStyles({
     gridTemplateRows: '1fr auto',
     gridTemplateColumns: 'auto auto 1fr auto',
     gridTemplateAreas: `
-      "expandIcon media content        aside"
+      "expandIcon media main        aside"
       "expandIcon media description aside"
     `,
     alignItems: 'center',
@@ -69,9 +69,9 @@ const useMediaStyles = makeStyles({
   },
 });
 
-const useContentStyles = makeStyles({
+const useMainStyles = makeStyles({
   base: {
-    ...shorthands.gridArea('content'),
+    ...shorthands.gridArea('main'),
     ...shorthands.padding(
       tokens.spacingVerticalMNudge,
       tokens.spacingHorizontalXS,
@@ -149,7 +149,7 @@ export const useTreeItemPersonaLayoutStyles_unstable = (
   const actionsStyles = useActionsStyles();
   const asideStyles = useAsideStyles();
   const expandIconStyles = useExpandIconStyles();
-  const contentStyles = useContentStyles();
+  const mainStyles = useMainStyles();
 
   const itemType = useTreeItemContext_unstable(ctx => ctx.itemType);
 
@@ -162,12 +162,12 @@ export const useTreeItemPersonaLayoutStyles_unstable = (
 
   state.media.className = mergeClasses(treeItemPersonaLayoutClassNames.media, mediaStyles.base, state.media.className);
 
-  if (state.content) {
-    state.content.className = mergeClasses(
-      treeItemPersonaLayoutClassNames.content,
-      contentStyles.base,
-      state.description && contentStyles.withDescription,
-      state.content.className,
+  if (state.main) {
+    state.main.className = mergeClasses(
+      treeItemPersonaLayoutClassNames.main,
+      mainStyles.base,
+      state.description && mainStyles.withDescription,
+      state.main.className,
     );
   }
   if (state.description) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`TreeItemLayout` and `TreeItemPersonaLayout` have a `content` slot. Seems like some collision issues are happening between the `content` slot and the props provided by root https://github.com/microsoft/fluentui/issues/28693#issuecomment-1659737176

## New Behavior

1. Renames `content` slot to `main` to avoid collision

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28693
