### PR TITLE
fix(react-menu): revert menuitem focus ring back to border

### DIFF
--- a/change/@fluentui-react-menu-93b6b74a-3721-45f9-ab96-6f9be236abf9.json
+++ b/change/@fluentui-react-menu-93b6b74a-3721-45f9-ab96-6f9be236abf9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: revert menuItem focus ring back to border",
+  "packageName": "@fluentui/react-menu",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, makeStyles, shorthands } from '@griffel/react';
 import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
-import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
 import { useCheckmarkStyles_unstable } from '../../selectable/index';
 import type { MenuItemCheckboxState } from '../MenuItemCheckbox/index';
@@ -17,18 +17,7 @@ export const menuItemClassNames: SlotClassNames<MenuItemSlots> = {
 };
 
 const useStyles = makeStyles({
-  focusIndicator: {
-    ':focus': {
-      outlineStyle: 'none',
-    },
-    ':focus-visible': {
-      outlineStyle: 'none',
-    },
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusMedium),
-      ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
-    }),
-  },
+  focusIndicator: createFocusOutlineStyle(),
   // TODO: this should be extracted to another package
   root: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),


### PR DESCRIPTION
revert #28685 

Why outlined focus ring is not used in this specific case:
When Menu is default open, on page load it focuses on the first item, browser will render a default `:focus-visible` ring with css `outline` styles. If we don't want this, we need to do two things:
1. set default focus ring to none by  `':focus-visible': { outlineStyle: 'none' }`
2. update our focus ring selector from  `[&data-fui-focus-visible]: style` to `[&data-fui-focus-visible]:focus: style`, to be more specific and win over the style we added in step 1.
But this brings new issue - we have consumers overriding focus ring style by using just `:focus-visible`. If we update our own focus ring selector to be more specific, it breaks their overrides.

Since we don't want focus ring on default load (which will break all vr test), and we don't want to make focus ring selector more specific, we can only revert back to border focus ring.