### PR TITLE
feat(react-utilities): add useMotionPresence hook

### DIFF
--- a/change/@fluentui-react-utilities-01c80b27-0a05-464e-abdf-bdddf86d72ac.json
+++ b/change/@fluentui-react-utilities-01c80b27-0a05-464e-abdf-bdddf86d72ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: new useMotionPresence hook - get the state for css animations/transitions",
+  "packageName": "@fluentui/react-utilities",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/index.ts
+++ b/packages/react-components/react-utilities/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useOnScrollOutside';
 export * from './usePrevious';
 export * from './useScrollbarWidth';
 export * from './useTimeout';
+export * from './useMotionPresence';

--- a/packages/react-components/react-utilities/src/hooks/useMotionPresence.test.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMotionPresence.test.ts
@@ -1,0 +1,247 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useMotionPresence, UseMotionPresenceOptions } from './useMotionPresence';
+
+const defaultDuration = 100;
+const renderHookWithRef = (
+  initialPresence: boolean,
+  initialOptions?: UseMotionPresenceOptions,
+  style: Record<string, string | undefined> = { 'transition-duration': `${defaultDuration}ms` },
+) => {
+  const refEl = document.createElement('div');
+  const hook = renderHook(({ presence, options }) => useMotionPresence(presence, options), {
+    initialProps: {
+      presence: initialPresence,
+      options: initialOptions,
+    } as {
+      presence: boolean;
+      options?: UseMotionPresenceOptions;
+    },
+  });
+
+  Object.entries(style).forEach(([key, value]) => value && refEl.style.setProperty(key, value));
+
+  act(() => hook.result.current.ref(refEl));
+
+  return hook;
+};
+
+describe('useMotionPresence', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('when presence is false by default', () => {
+    it('should return default values when presence is false', () => {
+      const { result } = renderHookWithRef(false);
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+      expect(result.current.visible).toBe(false);
+    });
+  });
+
+  describe('when presence is true by default', () => {
+    it('should return default values', () => {
+      const { result } = renderHookWithRef(true);
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('resting');
+      expect(result.current.shouldRender).toBe(true);
+      expect(result.current.visible).toBe(true);
+    });
+
+    it('should not change values after timeout ', () => {
+      const { result } = renderHookWithRef(true);
+
+      const assertSameValues = () => {
+        expect(typeof result.current.ref).toBe('function');
+        expect(result.current.motionState).toBe('resting');
+        expect(result.current.shouldRender).toBe(true);
+        expect(result.current.visible).toBe(true);
+      };
+
+      assertSameValues();
+      act(() => jest.advanceTimersToNextTimer());
+      act(() => jest.advanceTimersToNextTimer());
+      assertSameValues();
+    });
+
+    it('should change visible to true when animateOnFirstMount is true', () => {
+      const { result } = renderHookWithRef(true, { animateOnFirstMount: true });
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('resting');
+      expect(result.current.shouldRender).toBe(true);
+      expect(result.current.visible).toBe(false);
+
+      act(() => jest.advanceTimersToNextTimer());
+
+      expect(result.current.visible).toBe(true);
+    });
+  });
+
+  describe('when presence changes', () => {
+    it('should toggle values starting with false', () => {
+      const { result, rerender } = renderHookWithRef(false);
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+      expect(result.current.visible).toBe(false);
+
+      rerender({ presence: true });
+
+      expect(result.current.shouldRender).toBe(true);
+      expect(result.current.motionState).toBe('resting');
+
+      // double requestAnimationFrame
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.visible).toBe(true);
+
+      rerender({ presence: false });
+
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.motionState).toBe('exiting');
+      expect(result.current.visible).toBe(false);
+
+      act(() => {
+        // requestAnimationFrame
+        act(() => jest.advanceTimersToNextTimer());
+
+        // timeout
+        jest.advanceTimersByTime(defaultDuration + 1);
+      });
+
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('should toggle values starting with true', () => {
+      const { result, rerender } = renderHookWithRef(true);
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('resting');
+      expect(result.current.shouldRender).toBe(true);
+      expect(result.current.visible).toBe(true);
+
+      rerender({ presence: false });
+
+      // requestAnimationFrame
+      act(() => jest.advanceTimersToNextTimer());
+
+      expect(result.current.motionState).toBe('exiting');
+      expect(result.current.visible).toBe(false);
+
+      act(() => {
+        // requestAnimationFrame
+        jest.advanceTimersToNextTimer();
+
+        // timeout
+        jest.advanceTimersByTime(defaultDuration + 1);
+      });
+
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+      expect(result.current.visible).toBe(false);
+    });
+  });
+
+  describe.each([
+    { message: 'with transition', styles: { 'transition-duration': '100ms' } },
+    { message: 'with long transition', styles: { 'transition-duration': '1000ms' } },
+    { message: 'with animation', styles: { 'animation-duration': '100ms' } },
+    { message: 'with long animation', styles: { 'animation-duration': '1000ms' } },
+  ])('when presence changes - $message', ({ styles }) => {
+    it('should toggle values starting with false when animateOnFirstMount is true', () => {
+      const { result, rerender } = renderHookWithRef(
+        false,
+        {
+          animateOnFirstMount: true,
+        },
+        styles,
+      );
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+      expect(result.current.visible).toBe(false);
+
+      rerender({ presence: true });
+
+      expect(result.current.shouldRender).toBe(true);
+      expect(result.current.motionState).toBe('resting');
+      // requestAnimationFrame
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.visible).toBe(true);
+      expect(result.current.motionState).toBe('entering');
+      // timeout
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.motionState).toBe('resting');
+
+      rerender({ presence: false });
+
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.visible).toBe(false);
+      expect(result.current.motionState).toBe('exiting');
+
+      // requestAnimationFrame
+      act(() => jest.advanceTimersToNextTimer());
+      // timeout
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+    });
+  });
+
+  describe.each([
+    { message: 'with no transition', styles: { 'transition-duration': '0' } },
+    { message: 'with no animation', styles: { 'animation-duration': '0' } },
+  ])('when presence changes - $message', ({ styles }) => {
+    it('should toggle values when transition-duration is 0', () => {
+      const { result, rerender } = renderHookWithRef(
+        false,
+        {
+          animateOnFirstMount: true,
+        },
+        styles,
+      );
+
+      expect(typeof result.current.ref).toBe('function');
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+      expect(result.current.visible).toBe(false);
+
+      rerender({ presence: true });
+
+      expect(result.current.shouldRender).toBe(true);
+      expect(result.current.motionState).toBe('resting');
+      // requestAnimationFrame
+      act(() => jest.advanceTimersToNextTimer());
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.visible).toBe(true);
+      // timeout
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.motionState).toBe('resting');
+
+      rerender({ presence: false });
+
+      act(() => jest.advanceTimersToNextTimer());
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.visible).toBe(false);
+
+      // requestAnimationFrame
+      act(() => jest.advanceTimersToNextTimer());
+      // timeout
+      act(() => jest.advanceTimersToNextTimer());
+      expect(result.current.motionState).toBe('unmounted');
+      expect(result.current.shouldRender).toBe(false);
+    });
+  });
+});

--- a/packages/react-components/react-utilities/src/hooks/useMotionPresence.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMotionPresence.ts
@@ -1,0 +1,345 @@
+import * as React from 'react';
+import { useTimeout } from './useTimeout';
+
+/**
+ * CSS Typed Object Model
+ * @see https://drafts.css-houdini.org/css-typed-om-1/
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSUnitValue
+ */
+interface CSSUnitValue {
+  value: number;
+  readonly unit: string;
+}
+
+/**
+ * Style property map read only.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/StylePropertyMapReadOnly
+ */
+interface StylePropertyMapReadOnly {
+  [Symbol.iterator](): IterableIterator<[string, CSSUnitValue[]]>;
+
+  get(property: string): CSSUnitValue | undefined;
+  getAll(property: string): CSSUnitValue[];
+  has(property: string): boolean;
+  readonly size: number;
+}
+
+/**
+ * HTMLElement with styled map.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/computedStyleMap
+ */
+type HTMLElementWithStyledMap<TElement extends HTMLElement = HTMLElement> = TElement & {
+  computedStyleMap(): StylePropertyMapReadOnly;
+};
+
+interface CSSWithNumber {
+  number(value: number): {
+    value: number;
+    readonly unit: string;
+  };
+}
+
+/**
+ * State for useMotionPresence hook.
+ */
+export type UseMotionPresenceState<TElement extends HTMLElement> = {
+  /**
+   * Ref to the element.
+   */
+  ref: React.RefCallback<TElement>;
+
+  /**
+   * Whether the element should be rendered in the DOM.
+   * This should be used to conditionally render the element.
+   */
+  shouldRender: boolean;
+
+  /**
+   * Whether the element is currently visible in the DOM.
+   */
+  visible: boolean;
+
+  /**
+   * Current state of the element.
+   *
+   * - `entering` - The element is entering the DOM.
+   * - `exiting` - The element is exiting the DOM.
+   * - `resting` - The element is currently not animating. This is the final and initial state of the element.
+   * - `unmounted` - The element is not rendered in the DOM.
+   */
+  motionState: 'entering' | 'exiting' | 'resting' | 'unmounted';
+};
+
+/**
+ * Options for useMotionPresence hook.
+ */
+export type UseMotionPresenceOptions = {
+  /**
+   * Whether to animate the element on first mount.
+   *
+   * @default false
+   */
+  animateOnFirstMount?: boolean;
+};
+
+/**
+ * Returns CSS styles of the given node.
+ * @param node - DOM node.
+ * @returns - CSS styles.
+ */
+const getElementComputedStyle = (node: HTMLElement): CSSStyleDeclaration => {
+  const window = node.ownerDocument?.defaultView;
+
+  return window!.getComputedStyle(node, null);
+};
+
+/**
+ * Converts a CSS duration string to milliseconds.
+ *
+ * @param duration - CSS duration string
+ * @returns Duration in milliseconds
+ */
+function toMs(duration: string): number {
+  const trimmed = duration.trim();
+
+  if (trimmed.includes('auto')) {
+    return 0;
+  }
+
+  if (trimmed.includes('ms')) {
+    return parseFloat(trimmed);
+  }
+
+  return Number(trimmed.slice(0, -1).replace(',', '.')) * 1000;
+}
+
+/**
+ * Checks if the browser supports CSSOM.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/computedStyleMap
+ *
+ * @param node - DOM node
+ * @returns Whether the browser supports CSSOM
+ */
+const hasCSSOMSupport = (node: HTMLElementWithStyledMap) => {
+  /**
+   * As we are using the experimental CSSOM API, we need to check if the browser supports it.
+   * The typecast here is to allow the use of the `number` function that is not yet part of the CSSOM typings.
+   * @see https://www.npmjs.com/package/@types/w3c-css-typed-object-model-level-1
+   */
+  return Boolean(typeof CSS !== 'undefined' && (CSS as unknown as CSSWithNumber).number && node.computedStyleMap);
+};
+
+/**
+ *
+ * Gets the computed style of a given element.
+ * If the browser supports CSSOM, it will return a ComputedStyleMap object.
+ * Otherwise, it will return a CSSStyleDeclaration object.
+ */
+const getCSSStyle = (node: HTMLElementWithStyledMap): CSSStyleDeclaration | StylePropertyMapReadOnly => {
+  if (hasCSSOMSupport(node)) {
+    return node.computedStyleMap();
+  }
+
+  return getElementComputedStyle(node);
+};
+
+/**
+ * Gets the computed map property for a given element using the CSSOM API.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/computedStyleMap
+ *
+ * @param computedStyle - Computed style of the element
+ * @param prop - CSS property
+ * @returns Computed map property
+ */
+const getComputedMapProp = (computedStyle: StylePropertyMapReadOnly, prop: string): string[] => {
+  const props = computedStyle.getAll(prop);
+
+  if (props.length > 0) {
+    return props.map(({ value, unit }) => `${value}${unit}`);
+  }
+
+  return ['0'];
+};
+
+/**
+ * Gets the computed style property for a given element using the getComputedStyle API.
+ *
+ * @param computedStyle - Computed style of the element
+ * @param prop - CSS property
+ * @returns Computed style property
+ */
+const getComputedStyleProp = (computedStyle: CSSStyleDeclaration, prop: string): string[] => {
+  const propValue = computedStyle.getPropertyValue(prop);
+
+  return propValue ? propValue.split(',') : ['0'];
+};
+
+/**
+ * Gets the maximum duration from a list of CSS durations.
+ *
+ * @param durations - List of CSS durations
+ * @param delays - List of CSS delays
+ * @returns Maximum duration
+ */
+const getMaxCSSDuration = (durations: string[], delays: string[]): number => {
+  const totalDurations: number[] = [];
+
+  durations.forEach(duration => totalDurations.push(toMs(duration.trim())));
+
+  delays.forEach((delay, index) => {
+    const parsedDelay = toMs(delay.trim());
+
+    if (totalDurations[index]) {
+      totalDurations[index] = totalDurations[index] + parsedDelay;
+    } else {
+      totalDurations[index] = parsedDelay;
+    }
+  });
+
+  return Math.max(...totalDurations);
+};
+
+/**
+ * Gets the motion information for a given element.
+ *
+ * @param computedStyle - Computed style of the element
+ * @returns motion information
+ */
+const getMotionDuration = (node: HTMLElementWithStyledMap) => {
+  const hasModernCSSSupport = hasCSSOMSupport(node);
+  const computedStyle = getCSSStyle(node);
+
+  const getProp = (prop: string): string[] => {
+    return hasModernCSSSupport
+      ? getComputedMapProp(computedStyle as StylePropertyMapReadOnly, prop)
+      : getComputedStyleProp(computedStyle as CSSStyleDeclaration, prop);
+  };
+
+  const transitionDuration = getMaxCSSDuration(getProp('transition-duration'), getProp('transition-delay'));
+  const animationDuration = getMaxCSSDuration(getProp('animation-duration'), getProp('animation-delay'));
+
+  return Math.max(transitionDuration, animationDuration);
+};
+
+/**
+ * Hook to manage the presence of an element in the DOM based on its CSS transition/animation state.
+ *
+ * @param present - Whether the element should be present in the DOM
+ * @param events - Callbacks for when the element enters or exits the DOM
+ */
+export const useMotionPresence = <TElement extends HTMLElement>(
+  present: boolean,
+  options: UseMotionPresenceOptions = {},
+): UseMotionPresenceState<TElement> => {
+  const { animateOnFirstMount } = { animateOnFirstMount: false, ...options };
+
+  const [state, setState] = React.useState<Omit<UseMotionPresenceState<TElement>, 'ref'>>({
+    shouldRender: present,
+    motionState: present ? 'resting' : 'unmounted',
+    visible: false,
+  });
+
+  const [currentElement, setCurrentElement] = React.useState<HTMLElementWithStyledMap<TElement> | null>(null);
+  const [setAnimationTimeout, clearAnimationTimeout] = useTimeout();
+  const skipAnimationOnFirstRender = React.useRef(!animateOnFirstMount);
+
+  const processAnimation = React.useCallback(
+    (callback: () => void) => {
+      if (!currentElement) {
+        return;
+      }
+
+      clearAnimationTimeout();
+      const animationFrame = requestAnimationFrame(() => {
+        const duration = getMotionDuration(currentElement);
+
+        if (duration === 0) {
+          callback();
+          return;
+        }
+
+        /**
+         * Use CSS transition duration + 1ms to ensure the animation has finished on both enter and exit states.
+         * This is an alternative to using the `transitionend` event which can be unreliable as it fires multiple times
+         * if the transition has multiple properties.
+         */
+        setAnimationTimeout(() => callback(), duration + 1);
+      });
+
+      return () => {
+        clearAnimationTimeout();
+        cancelAnimationFrame(animationFrame);
+      };
+    },
+    [clearAnimationTimeout, currentElement, setAnimationTimeout],
+  );
+
+  const ref: React.RefCallback<HTMLElementWithStyledMap<TElement>> = React.useCallback(node => {
+    if (!node) {
+      return;
+    }
+
+    setCurrentElement(node);
+  }, []);
+
+  React.useEffect(() => {
+    if (present) {
+      setState({
+        shouldRender: true,
+        visible: skipAnimationOnFirstRender.current ? true : false,
+        motionState: 'resting',
+      });
+    }
+  }, [present]);
+
+  React.useEffect(() => {
+    if (!currentElement) {
+      return;
+    }
+
+    let animationFrame: number;
+    const skipAnimation = skipAnimationOnFirstRender.current;
+    const onDestroy = () => cancelAnimationFrame(animationFrame);
+
+    animationFrame = requestAnimationFrame(() => {
+      setState(prevState => {
+        let motionState = prevState.motionState;
+
+        if (skipAnimation) {
+          motionState = present ? 'resting' : 'unmounted';
+        } else {
+          motionState = present ? 'entering' : 'exiting';
+        }
+
+        return {
+          ...prevState,
+          motionState,
+          visible: present,
+        };
+      });
+    });
+
+    if (skipAnimation) {
+      return onDestroy;
+    }
+
+    processAnimation(() => {
+      setState(prevState => ({
+        ...prevState,
+        motionState: present ? 'resting' : 'unmounted',
+        shouldRender: present,
+      }));
+    });
+
+    return onDestroy;
+  }, [currentElement, present, processAnimation]);
+
+  React.useEffect(() => {
+    skipAnimationOnFirstRender.current = false;
+  }, []);
+
+  return {
+    ref,
+    ...state,
+  };
+};

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -36,8 +36,15 @@ export {
   usePrevious,
   useScrollbarWidth,
   useTimeout,
+  useMotionPresence,
 } from './hooks/index';
-export type { RefObjectFunction, UseControllableStateOptions, UseOnClickOrScrollOutsideOptions } from './hooks/index';
+export type {
+  RefObjectFunction,
+  UseControllableStateOptions,
+  UseOnClickOrScrollOutsideOptions,
+  UseMotionPresenceOptions,
+  UseMotionPresenceState,
+} from './hooks/index';
 
 export { canUseDOM, useIsSSR, SSRProvider } from './ssr/index';
 


### PR DESCRIPTION
This PR implements the `useMotionPresence` hook. This is part of the [Component CSS Transitions/Animations on mount/unmount RFC](https://github.com/microsoft/fluentui/pull/27328/files) efforts. A preview of the usage of this hook can be found in the [feat: implement motion for Drawer](https://github.com/microsoft/fluentui/pull/28133) PR.

## Context
Currently, there is a limitation in incorporating motion effects to components during their mounting or unmounting. This restricts the ability to apply CSS motion for components featuring an open/close behavior.
This hook effectively tracks CSS animations/transitions and returns the state of those animations/transitions.

## Example
```ts
const {
  /**
   * Ref used to track the target element that requires animation. It should
   * be passed to the element responsible for performing the animation.
   */
  ref,

  /**
   * Determines whether the component should be displayed on the screen.
   *
   * This property will evaluate to `true` when the provided presence value is true.
   * Once the provided value changes to false, the hook will monitor the transition/animation
   * completion and subsequently set this property to false.
   */
  shouldRender,

  /**
   * Indicates whether the component is currently rendered and visible.
   *
   * This flag will be set to `true` one frame after the shouldRender value becomes true.
   * It will be set to `false` when the specified presence value changes to false.
   */
  visible,

  /**
   * Current state of the tracked element
   *
   * Can return one of the following states:
   * - `entering` - The element is entering the DOM.
   * - `exiting` - The element is exiting the DOM.
   * - `resting` - The element is currently not animating, but rendered on screen.
   * - `unmounted` - The element is not rendered in the DOM.
   */
  motionState,
} = useMotionPresence(open);
```