### PR TITLE
V9 Button Focus: Move border width increase to inset

### DIFF
--- a/change/@fluentui-react-button-200fdd74-ae66-410a-a525-daefec48abaa.json
+++ b/change/@fluentui-react-button-200fdd74-ae66-410a-a525-daefec48abaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: Button focus borders were extending past bounding box causing overlap, focus border is now inset",
+  "packageName": "@fluentui/react-button",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -95,12 +95,12 @@ const useRootBaseClassName = makeResetStyles({
   // Focus styles
 
   ...createCustomFocusIndicatorStyle({
-    borderColor: tokens.colorTransparentStroke,
+    borderColor: tokens.colorStrokeFocus2,
     borderRadius: tokens.borderRadiusMedium,
+    borderWidth: '1px',
     outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
-    boxShadow: `
-      ${tokens.shadow4},
-      0 0 0 2px ${tokens.colorStrokeFocus2}
+    boxShadow: `0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2}
+      inset
     `,
     zIndex: 1,
   }),
@@ -445,8 +445,12 @@ const useRootFocusStyles = makeStyles({
 
   // Primary styles
   primary: createCustomFocusIndicatorStyle({
-    ...shorthands.borderColor(tokens.colorNeutralForegroundOnBrand),
-    boxShadow: `${tokens.shadow2}, 0 0 0 2px ${tokens.colorStrokeFocus2}`,
+    ...shorthands.borderColor(tokens.colorStrokeFocus2),
+    boxShadow: `${tokens.shadow2}, 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
+    ':hover': {
+      boxShadow: `${tokens.shadow2}, 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2} inset`,
+      ...shorthands.borderColor(tokens.colorStrokeFocus2),
+    },
   }),
 
   // Size variations


### PR DESCRIPTION
## Previous Behavior
Our focus behavior on buttons causes an increase in the buttons borderWidth.
While this increase is intentional design, it overflows the bounding box and can cause overlap with other items (i.e. grids)
Should have the border width increase inset so that it ensures there is no pixels outside the components bounding box.

## New Behavior
Border width still increase on focus, however it now uses an inset shadow box to place additional width on internal side.

## Related Issue(s)

- Fixes #
