### PR TITLE
bugfix: disable menu opening if contextmenu event is prevented

### DIFF
--- a/change/@fluentui-react-menu-e3ad7a8c-1083-4535-90f9-b4dc318a6dce.json
+++ b/change/@fluentui-react-menu-e3ad7a8c-1083-4535-90f9-b4dc318a6dce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: disable menu opening if contextmenu event is prevented",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/Menu/Menu.cy.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.cy.tsx
@@ -1051,6 +1051,14 @@ describe('Context menu', () => {
     cy.get(menuTriggerSelector).rightclick().get(menuSelector).should('exist');
   });
 
+  it('should not open if event is prevented', () => {
+    mount(<ContextMenuExample />);
+    cy.get(menuTriggerSelector).then(([trigger]) => {
+      trigger.addEventListener('contextmenu', e => e.preventDefault(), { capture: true, once: true });
+    });
+    cy.get(menuTriggerSelector).rightclick().get(menuSelector).should('not.exist');
+  });
+
   it('should close when the trigger is clicked', () => {
     mount(<ContextMenuExample />);
 

--- a/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -50,7 +50,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   const child = getTriggerChild(children);
 
   const onContextMenu = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(event)) {
+    if (isTargetDisabled(event) || event.isDefaultPrevented()) {
       return;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`MenuTrigger` would open a menu regardless if the `contextmenu` event was prevent.

## New Behavior

1. `MenuTrigger` doesn't open the menu if `contextmenu` event has been prevented
2. adds test to ensure behavior

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
