### PR TITLE
fix: made disabled BreadcrumbLink not focusable

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-ccc0bbee-fe68-4046-bec9-c215d548e0bf.json
+++ b/change/@fluentui-react-breadcrumb-preview-ccc0bbee-fe68-4046-bec9-c215d548e0bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: disabled BreadcrumbLink shouldn't be focusable",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
+++ b/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
@@ -91,6 +91,7 @@ export const breadcrumbLinkClassNames: SlotClassNames<BreadcrumbLinkSlots>;
 export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> & Pick<LinkProps, 'appearance' | 'disabled'> & {
     current?: boolean;
     iconPosition?: 'before' | 'after';
+    href?: string;
     overflow?: boolean;
     size?: 'small' | 'medium' | 'large';
 };

--- a/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
+++ b/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
@@ -12,7 +12,6 @@ import { ButtonState } from '@fluentui/react-button';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { Link } from '@fluentui/react-link';
 import { LinkProps } from '@fluentui/react-link';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
@@ -91,14 +90,13 @@ export const breadcrumbLinkClassNames: SlotClassNames<BreadcrumbLinkSlots>;
 export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> & Pick<LinkProps, 'appearance' | 'disabled'> & {
     current?: boolean;
     iconPosition?: 'before' | 'after';
-    href?: string;
     overflow?: boolean;
     size?: 'small' | 'medium' | 'large';
 };
 
 // @public (undocumented)
 export type BreadcrumbLinkSlots = {
-    root: Slot<typeof Link>;
+    root: LinkProps;
     icon?: Slot<'span'>;
 };
 
@@ -188,7 +186,7 @@ export const useBreadcrumbItem_unstable: (props: BreadcrumbItemProps, ref: React
 export const useBreadcrumbItemStyles_unstable: (state: BreadcrumbItemState) => BreadcrumbItemState;
 
 // @public
-export const useBreadcrumbLink_unstable: (props: BreadcrumbLinkProps, ref: React_2.Ref<HTMLElement>) => BreadcrumbLinkState;
+export const useBreadcrumbLink_unstable: (props: BreadcrumbLinkProps, ref: React_2.Ref<HTMLAnchorElement | HTMLButtonElement>) => BreadcrumbLinkState;
 
 // @public
 export const useBreadcrumbLinkStyles_unstable: (state: BreadcrumbLinkState) => BreadcrumbLinkState;

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.cy.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.cy.tsx
@@ -24,8 +24,13 @@ const BreadcrumbSampleWithButton = (props: BreadcrumbProps) => (
         <BreadcrumbButton id="breadcrumb-button-2">Item 2</BreadcrumbButton>
       </BreadcrumbItem>
       <BreadcrumbItem>
-        <BreadcrumbButton id="breadcrumb-button-3" current>
+        <BreadcrumbButton id="breadcrumb-button-3" disabled>
           Item 3
+        </BreadcrumbButton>
+      </BreadcrumbItem>
+      <BreadcrumbItem>
+        <BreadcrumbButton id="breadcrumb-button-4" current>
+          Item 4
         </BreadcrumbButton>
       </BreadcrumbItem>
     </Breadcrumb>
@@ -54,8 +59,13 @@ const BreadcrumbSampleWithLink = (props: BreadcrumbProps) => (
         </BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbItem>
-        <BreadcrumbLink href="#" id="breadcrumb-link-3" current>
+        <BreadcrumbLink href="#" id="breadcrumb-link-3" disabled>
           Item 3
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#" id="breadcrumb-link-4" current>
+          Item 4
         </BreadcrumbLink>
       </BreadcrumbItem>
     </Breadcrumb>
@@ -102,7 +112,8 @@ describe('Breadcrumb', () => {
         cy.realPress('Tab');
         cy.get('#breadcrumb-button-2').should('be.focused');
         cy.realPress('Tab');
-        cy.get('#breadcrumb-button-3').should('be.focused');
+        cy.get('#breadcrumb-button-3').should('not.be.focused');
+        cy.get('#breadcrumb-button-4').should('be.focused');
       });
     });
 
@@ -120,7 +131,8 @@ describe('Breadcrumb', () => {
         cy.realPress('ArrowRight');
         cy.get('#breadcrumb-button-2').should('be.focused');
         cy.realPress('ArrowRight');
-        cy.get('#breadcrumb-button-3').should('be.focused');
+        cy.get('#breadcrumb-button-3').should('not.be.focused');
+        cy.get('#breadcrumb-button-4').should('be.focused');
         cy.realPress('ArrowRight');
         cy.get('#breadcrumb-button-1').should('be.focused');
       });
@@ -141,7 +153,8 @@ describe('Breadcrumb', () => {
         cy.realPress('Tab');
         cy.get('#breadcrumb-link-2').should('be.focused');
         cy.realPress('Tab');
-        cy.get('#breadcrumb-link-3').should('be.focused');
+        cy.get('#breadcrumb-link-3').should('not.be.focused');
+        cy.get('#breadcrumb-link-4').should('be.focused');
       });
     });
 
@@ -159,7 +172,8 @@ describe('Breadcrumb', () => {
         cy.realPress('ArrowRight');
         cy.get('#breadcrumb-link-2').should('be.focused');
         cy.realPress('ArrowRight');
-        cy.get('#breadcrumb-link-3').should('be.focused');
+        cy.get('#breadcrumb-link-3').should('not.be.focused');
+        cy.get('#breadcrumb-link-4').should('be.focused');
         cy.realPress('ArrowRight');
         cy.get('#breadcrumb-link-1').should('be.focused');
       });

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -109,7 +109,7 @@ describe('Breadcrumb', () => {
               class="fui-BreadcrumbItem"
             >
               <button
-                class="fui-Link fui-Link fui-BreadcrumbLink"
+                class="fui-Link fui-BreadcrumbLink"
                 type="button"
               >
                 Link 1

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.test.tsx
@@ -29,7 +29,7 @@ describe('BreadcrumbLink', () => {
     expect(result.container).toMatchInlineSnapshot(`
       <div>
         <a
-          class="fui-Link fui-Link fui-BreadcrumbLink"
+          class="fui-Link fui-BreadcrumbLink"
           href="#"
           tabindex="0"
         >
@@ -48,7 +48,7 @@ describe('BreadcrumbLink', () => {
     expect(result.container).toMatchInlineSnapshot(`
       <div>
         <a
-          class="fui-Link fui-Link fui-BreadcrumbLink"
+          class="fui-Link fui-BreadcrumbLink"
           href="#"
           tabindex="0"
         >
@@ -85,7 +85,7 @@ describe('BreadcrumbLink', () => {
     expect(result.container).toMatchInlineSnapshot(`
       <div>
         <a
-          class="fui-Link fui-Link fui-BreadcrumbLink"
+          class="fui-Link fui-BreadcrumbLink"
           href="#"
           tabindex="0"
         >
@@ -118,7 +118,7 @@ describe('BreadcrumbLink', () => {
     expect(result.container).toMatchInlineSnapshot(`
       <div>
         <a
-          class="fui-Link fui-Link fui-BreadcrumbLink"
+          class="fui-Link fui-BreadcrumbLink"
           href="#"
           tabindex="0"
         >

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.types.ts
@@ -33,6 +33,10 @@ export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> &
     iconPosition?: 'before' | 'after';
 
     /**
+     * Internal prop for `href`
+     */
+    href?: string;
+    /**
      * Defines a sate when the Link is part of overflow menu.
      *
      * @default false

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.types.ts
@@ -1,11 +1,11 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { Link, LinkProps } from '@fluentui/react-link';
+import { LinkProps } from '@fluentui/react-link';
 
 export type BreadcrumbLinkSlots = {
   /**
    * Root element of the BreadcrumbLink.
    */
-  root: Slot<typeof Link>;
+  root: LinkProps;
 
   /**
    * Icon that renders either before or after the `children` as specified by the `iconPosition` prop.
@@ -32,10 +32,6 @@ export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> &
      */
     iconPosition?: 'before' | 'after';
 
-    /**
-     * Internal prop for `href`
-     */
-    href?: string;
     /**
      * Defines a sate when the Link is part of overflow menu.
      *

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
@@ -27,14 +27,14 @@ export const useBreadcrumbLink_unstable = (
   return {
     components: { root: Link, icon: 'span' },
     root: slot.always(
-      getNativeElementProps('a', {
+      getNativeElementProps(as, {
         'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
         ref,
         type,
         disabled,
         ...rest,
         href,
-        as
+        as,
       }),
       { elementType: Link },
     ),

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
@@ -18,6 +18,9 @@ export const useBreadcrumbLink_unstable = (
 ): BreadcrumbLinkState => {
   const { appearance, iconPosition, size } = useBreadcrumbContext_unstable();
   const { current = false, disabled = false, icon, overflow = false, ...rest } = props;
+  const href = disabled ? undefined : props.href;
+  const as = props.as || (href ? 'a' : 'button');
+  const type = as === 'button' ? 'button' : undefined;
 
   const linkAppearance = props.appearance || appearance;
   const iconShorthand = slot.optional(icon, { elementType: 'span' });
@@ -27,7 +30,11 @@ export const useBreadcrumbLink_unstable = (
       getNativeElementProps('a', {
         'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
         ref,
+        type,
+        disabled,
         ...rest,
+        href,
+        as
       }),
       { elementType: Link },
     ),

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { getNativeElementProps, slot } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import type { BreadcrumbLinkProps, BreadcrumbLinkState } from './BreadcrumbLink.types';
-import { Link } from '@fluentui/react-link';
+import { useLink_unstable } from '@fluentui/react-link';
 import { useBreadcrumbContext_unstable } from '../Breadcrumb/BreadcrumbContext';
 /**
  * Create the state required to render BreadcrumbLink.
@@ -14,30 +14,29 @@ import { useBreadcrumbContext_unstable } from '../Breadcrumb/BreadcrumbContext';
  */
 export const useBreadcrumbLink_unstable = (
   props: BreadcrumbLinkProps,
-  ref: React.Ref<HTMLElement>,
+  ref: React.Ref<HTMLAnchorElement | HTMLButtonElement>,
 ): BreadcrumbLinkState => {
   const { appearance, iconPosition, size } = useBreadcrumbContext_unstable();
-  const { current = false, disabled = false, icon, overflow = false, ...rest } = props;
-  const href = disabled ? undefined : props.href;
-  const as = props.as || (href ? 'a' : 'button');
-  const type = as === 'button' ? 'button' : undefined;
+  const { current = false, disabled = false, icon, overflow = false } = props;
+
+  const link = useLink_unstable(props, ref);
 
   const linkAppearance = props.appearance || appearance;
   const iconShorthand = slot.optional(icon, { elementType: 'span' });
+
   return {
-    components: { root: Link, icon: 'span' },
-    root: slot.always(
-      getNativeElementProps(as, {
+    components: {
+      root: link.components.root,
+      icon: 'span',
+    },
+
+    root: slot.always(link.root, {
+      defaultProps: {
         'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
-        ref,
-        type,
-        disabled,
-        ...rest,
-        href,
-        as,
-      }),
-      { elementType: Link },
-    ),
+      },
+      elementType: link.components.root,
+    }),
+
     appearance: linkAppearance === 'subtle' ? 'subtle' : 'default',
     current,
     disabled,

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLinkStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLinkStyles.styles.ts
@@ -29,6 +29,12 @@ const useStyles = makeStyles({
     alignItems: 'center',
     ...shorthands.padding(tokens.spacingHorizontalXS),
   },
+  iconOnly: {
+    '&:hover': {
+      ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid'),
+      ...shorthands.padding(tokens.spacingVerticalNone, tokens.spacingHorizontalXS),
+    },
+  },
   small: {
     height: '24px',
     ...typographyStyles.caption1,
@@ -112,7 +118,8 @@ export const useBreadcrumbLinkStyles_unstable = (state: BreadcrumbLinkState): Br
   );
 
   if (state.icon) {
-    state.icon.className = mergeClasses(iconStyles[state.size], styles.icon, state.icon.className);
+    const iconOnlyClass = state.iconOnly ? styles.iconOnly : '';
+    state.icon.className = mergeClasses(iconStyles[state.size], styles.icon, state.icon.className, iconOnlyClass);
   }
 
   useLinkStyles_unstable(state as LinkState);


### PR DESCRIPTION
## Previous Behavior
- It was possible to focus on the disabled BreadcrumbLink
- No styles for hover on a BreadcrumbLink with single icon
 
## New Behavior
- Disabled BreadcrumbLink is not focusable
- Added border-bottom on hover for a BreadcrumbLink with a single icon