### PR TITLE
fix(Toolbar): remove `items` from `defaultProps`

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - `Datepicker`: add onCalendarOpenStateChange prop. @jurokapsiar ([#28136](https://github.com/microsoft/fluentui/pull/28136))
 - Outline color now respects OS force colors settings. @george-cz ([#28182](https://github.com/microsoft/fluentui/pull/28182))
+- Remove `items` from `defaultProps` in Toolbar to fix warnings @layershifter ([#28723](https://github.com/microsoft/fluentui/pull/28723))
 
 <!--------------------------------[ v0.66.4 ]------------------------------- -->
 ## [v0.66.4](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.66.4) (2023-03-10)

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -156,7 +156,7 @@ export const Toolbar = compose<'div', ToolbarProps, ToolbarStylesProps, {}, {}>(
       children,
       design,
       getOverflowItems,
-      items,
+      items = [],
       overflow,
       overflowItem,
       overflowOpen,
@@ -663,7 +663,6 @@ Toolbar.propTypes = {
 };
 Toolbar.defaultProps = {
   accessibility: toolbarBehavior,
-  items: [],
   overflowItem: {},
   overflowSentinel: {},
 };


### PR DESCRIPTION
## Previous Behavior

Warnings are triggered once `children` are defined:

```
Warning: Failed prop type: Prop `items` in `Toolbar` conflicts with props: `children`. They cannot be defined together, choose one or the other.
```

## New Behavior

No warnings on this usage.