### PR TITLE
fix(EventListener): do not use `defaultProps`

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `Input`: Remove wrong recommendation - usage of role="search" #28168 @kolaps33 ([#28168](https://github.com/microsoft/fluentui/pull/28168))
 
 ### Fixes
+- Do not use `defaultProps` in `EventListener` to avoid deprecation warnings. @layershifter ([#28725](https://github.com/microsoft/fluentui/pull/28725))
 - `Datepicker`: add onCalendarOpenStateChange prop. @jurokapsiar ([#28136](https://github.com/microsoft/fluentui/pull/28136))
 - Outline color now respects OS force colors settings. @george-cz ([#28182](https://github.com/microsoft/fluentui/pull/28182))
 

--- a/packages/fluentui/react-component-event-listener/src/EventListener.ts
+++ b/packages/fluentui/react-component-event-listener/src/EventListener.ts
@@ -1,12 +1,14 @@
 import { useEventListener } from './useEventListener';
 import { EventListenerOptions, EventTypes } from './types';
 
-export function EventListener<T extends EventTypes>(props: EventListenerOptions<T>) {
-  useEventListener(props);
+export function EventListener<T extends EventTypes>({
+  listener,
+  type,
+  capture = false,
+  targetRef,
+  target,
+}: EventListenerOptions<T>) {
+  useEventListener({ listener, type, capture, targetRef, target });
 
   return null;
 }
-
-EventListener.defaultProps = {
-  capture: false,
-};


### PR DESCRIPTION
## New Behavior

No deprecation warnings with React 18 in `EventListener` component.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28024
