### PR TITLE
Use node16 in WC deploy workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.18.1
+          cache: 'yarn'
+
       - name: Build and Deploy Job
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
## Previous Behavior

WC storybook deploy pipeline is broken as it uses node 18: https://github.com/microsoft/fluentui/actions/runs/5590137140/job/15140616749

## New Behavior

The deploy pipeline uses node 16.

