### PR TITLE
fix: update chalk usage in a generator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ jobs:
         displayName: yarn (install packages)
 
       - script: |
-          yarn nx workspace-lint
           yarn nx run @fluentui/workspace-plugin:check-graph
           yarn nx g @fluentui/workspace-plugin:tsconfig-base-all --verify
           yarn nx g @fluentui/workspace-plugin:normalize-package-dependencies --verify

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -1,5 +1,5 @@
 import { Tree, updateJson, generateFiles, joinPathFragments } from '@nx/devkit';
-import * as path from 'path';
+import path from 'path';
 
 import { PackageJson, TsConfig } from '../../../types';
 import { getProjectConfig } from '../../../utils';

--- a/tools/workspace-plugin/src/generators/dependency-mismatch/index.ts
+++ b/tools/workspace-plugin/src/generators/dependency-mismatch/index.ts
@@ -1,4 +1,4 @@
-import * as semver from 'semver';
+import semver from 'semver';
 import { Tree, formatFiles, updateJson, readJson, ProjectConfiguration, getProjects } from '@nrwl/devkit';
 
 import { getProjectPaths, isPackageVersionPrerelease } from '../../utils';

--- a/tools/workspace-plugin/src/generators/generate-change-file.spec.ts
+++ b/tools/workspace-plugin/src/generators/generate-change-file.spec.ts
@@ -1,5 +1,5 @@
 import { logger } from '@nx/devkit';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 import { disableChalk, formatMockedCalls } from '../utils-testing';
 import { generateChangeFilesHelp } from './generate-change-files';

--- a/tools/workspace-plugin/src/generators/generate-change-files.ts
+++ b/tools/workspace-plugin/src/generators/generate-change-files.ts
@@ -1,7 +1,7 @@
 import { Tree, logger } from '@nx/devkit';
-import * as path from 'path';
-import * as childProcess from 'child_process';
-import * as chalk from 'chalk';
+import path from 'path';
+import childProcess from 'child_process';
+import chalk from 'chalk';
 
 import type { CliOptions } from 'beachball/lib/types/BeachballOptions';
 

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -1,7 +1,7 @@
-import * as Enquirer from 'enquirer';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as chalk from 'chalk';
+import Enquirer from 'enquirer';
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   Tree,

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.ts
@@ -16,9 +16,9 @@ import {
   ChangeType,
   readNxJson,
 } from '@nx/devkit';
-import * as path from 'path';
-import * as os from 'os';
-import * as ts from 'typescript';
+import path from 'path';
+import os from 'os';
+import ts from 'typescript';
 
 import { getTemplate, uniqueArray } from './lib/utils';
 import setupCypressComponentTesting from '../cypress-component-configuration';

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/lib/utils.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/lib/utils.ts
@@ -1,6 +1,6 @@
 import { logger } from '@nx/devkit';
-import * as ejs from 'ejs';
-import * as fs from 'fs';
+import ejs from 'ejs';
+import fs from 'fs';
 /**
  * Similar to @nx/devkit#generateFiles function but for getting content only
  *

--- a/tools/workspace-plugin/src/generators/migrate-v8-pkg/lib/utils.ts
+++ b/tools/workspace-plugin/src/generators/migrate-v8-pkg/lib/utils.ts
@@ -1,11 +1,8 @@
 import { stripIndents } from '@nx/devkit';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 /**
  * Should be used to get the tooling config object when JS configuration is used
- *
- * @param host
- * @param path
  */
 export function getCjsConfigObjectAst(fileContent: string): ts.ObjectLiteralExpression {
   const sourceFile = ts.createSourceFile('file-config.js', fileContent, ts.ScriptTarget.Latest, true);

--- a/tools/workspace-plugin/src/generators/normalize-package-dependencies/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/normalize-package-dependencies/index.spec.ts
@@ -10,7 +10,7 @@ import {
   readProjectConfiguration,
   updateJson,
 } from '@nx/devkit';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 import generator from './index';
 import { PackageJson } from '../../types';

--- a/tools/workspace-plugin/src/generators/normalize-package-dependencies/index.ts
+++ b/tools/workspace-plugin/src/generators/normalize-package-dependencies/index.ts
@@ -11,11 +11,11 @@ import {
   ProjectGraph,
   readProjectConfiguration,
 } from '@nx/devkit';
-import * as semver from 'semver';
+import chalk from 'chalk';
+import semver from 'semver';
 
 import { NormalizePackageDependenciesGeneratorSchema } from './schema';
 import { PackageJson } from '../../types';
-import * as chalk from 'chalk';
 
 type ProjectIssues = { [projectName: string]: { [depName: string]: string } };
 

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.spec.ts
@@ -11,7 +11,7 @@ import {
   workspaceRoot,
   installPackagesTask,
 } from '@nrwl/devkit';
-import * as childProcess from 'child_process';
+import childProcess from 'child_process';
 
 import generator from './index';
 import { PackageJson, TsConfig } from '../../types';

--- a/tools/workspace-plugin/src/generators/print-stats.spec.ts
+++ b/tools/workspace-plugin/src/generators/print-stats.spec.ts
@@ -1,6 +1,6 @@
 import { addProjectConfiguration, getProjects, logger, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import { disableChalk, formatMockedCalls } from '../utils-testing';
 
 import { printStats } from './print-stats';

--- a/tools/workspace-plugin/src/generators/print-stats.ts
+++ b/tools/workspace-plugin/src/generators/print-stats.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import { Tree, ProjectConfiguration, logger } from '@nx/devkit';
 
 interface Options<T extends ProjectConfiguration> {

--- a/tools/workspace-plugin/src/generators/rc-caret/index.ts
+++ b/tools/workspace-plugin/src/generators/rc-caret/index.ts
@@ -1,5 +1,5 @@
 import { Tree, updateJson, getProjects, formatFiles } from '@nx/devkit';
-import * as semver from 'semver';
+import semver from 'semver';
 import { VersionBumpGeneratorSchema } from './schema';
 import { getProjectConfig, isPackageVersionConverged, printUserLogs, UserLog } from '../../utils';
 import { PackageJson } from '../../types';

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 import { Tree, formatFiles, names, generateFiles, joinPathFragments, workspaceRoot } from '@nx/devkit';
 
 import { getProjectConfig, isPackageConverged } from '../../utils';

--- a/tools/workspace-plugin/src/generators/react-library/index.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 import {
   Tree,
   formatFiles,

--- a/tools/workspace-plugin/src/generators/recipe-generator/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/recipe-generator/index.spec.ts
@@ -1,6 +1,6 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { addProjectConfiguration, Tree, writeJson } from '@nx/devkit';
-import * as path from 'path';
+import path from 'path';
 
 import generator from './index';
 import { RecipeGeneratorGeneratorSchema } from './schema';

--- a/tools/workspace-plugin/src/generators/tsconfig-base-all/lib/utils.ts
+++ b/tools/workspace-plugin/src/generators/tsconfig-base-all/lib/utils.ts
@@ -1,5 +1,5 @@
 // use this module to define any kind of generic utilities that are used in more than 1 place within the generator implementation
-import * as path from 'path';
+import path from 'path';
 import { readJson, Tree } from '@nx/devkit';
 
 /**

--- a/tools/workspace-plugin/src/generators/version-bump/index.ts
+++ b/tools/workspace-plugin/src/generators/version-bump/index.ts
@@ -1,5 +1,5 @@
 import { Tree, updateJson, getProjects, formatFiles } from '@nx/devkit';
-import * as semver from 'semver';
+import semver from 'semver';
 import { VersionBumpGeneratorSchema } from './schema';
 import {
   getProjectConfig,

--- a/tools/workspace-plugin/src/generators/workspace-generator/index.ts
+++ b/tools/workspace-plugin/src/generators/workspace-generator/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 import { Tree, formatFiles, generateFiles, names, offsetFromRoot } from '@nx/devkit';
 
 import { WorkspaceGeneratorGeneratorSchema } from './schema';

--- a/tools/workspace-plugin/src/utils.ts
+++ b/tools/workspace-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import * as yargsParser from 'yargs-parser';
+import yargsParser from 'yargs-parser';
 import type * as Enquirer from 'enquirer';
 import {
   joinPathFragments,
@@ -11,7 +11,7 @@ import {
   readNxJson,
 } from '@nx/devkit';
 import { PackageJson, PackageJsonWithBeachball } from './types';
-import * as semver from 'semver';
+import semver from 'semver';
 
 /**
  * CLI prompts abstraction to trigger dynamic prompts within a generator

--- a/tools/workspace-plugin/tsconfig.json
+++ b/tools/workspace-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "esModuleInterop": true,
     "module": "commonjs"
   },
   "files": [],


### PR DESCRIPTION
Fixes #28736.
Fixes #28737.

`@fluentui/workspace-plugin` didn't have `esModuleInterop` enabled, this PR enables it. Imports were updated to follow this.

The main goal is to fix `chalk` usage as `import * as chalk` does not work in the configuration of `ts-node` provided by Nx.