### PR TITLE
chore: migrate to new slot API

### DIFF
--- a/change/@fluentui-react-accordion-50abb1df-4059-4514-974f-16421f838fc7.json
+++ b/change/@fluentui-react-accordion-50abb1df-4059-4514-974f-16421f838fc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-ca95c187-e056-4aab-899d-1990e3f84001.json
+++ b/change/@fluentui-react-alert-ca95c187-e056-4aab-899d-1990e3f84001.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-alert",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-1a6e1b8f-34a1-4578-a243-51c8dcf98502.json
+++ b/change/@fluentui-react-aria-1a6e1b8f-34a1-4578-a243-51c8dcf98502.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-96e05123-e95b-4df4-a6ac-164821127d0a.json
+++ b/change/@fluentui-react-avatar-96e05123-e95b-4df4-a6ac-164821127d0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-avatar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-77204d32-d1cb-46c5-8926-1ffdc7b0ef9c.json
+++ b/change/@fluentui-react-badge-77204d32-d1cb-46c5-8926-1ffdc7b0ef9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-badge",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-preview-ab49a59c-cc27-44c0-a545-803698e1700e.json
+++ b/change/@fluentui-react-breadcrumb-preview-ab49a59c-cc27-44c0-a545-803698e1700e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-69ffce56-b740-4982-b019-19cbd0e9cd7f.json
+++ b/change/@fluentui-react-button-69ffce56-b740-4982-b019-19cbd0e9cd7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-button",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-c12def4b-23c1-4da0-a666-b144c25a3753.json
+++ b/change/@fluentui-react-card-c12def4b-23c1-4da0-a666-b144c25a3753.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-card",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-3493874d-99df-496e-b20f-91b1396f6a22.json
+++ b/change/@fluentui-react-checkbox-3493874d-99df-496e-b20f-91b1396f6a22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-f0f26f9e-f038-444f-bd7e-e2dc2491963f.json
+++ b/change/@fluentui-react-combobox-f0f26f9e-f038-444f-bd7e-e2dc2491963f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-5ce3d20a-9f1a-4edd-954f-897a47006a52.json
+++ b/change/@fluentui-react-datepicker-compat-5ce3d20a-9f1a-4edd-954f-897a47006a52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-0c3b5edb-7395-4366-8400-30027a4d6af7.json
+++ b/change/@fluentui-react-dialog-0c3b5edb-7395-4366-8400-30027a4d6af7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-c910ec1f-060f-4681-b756-c4f363c292b3.json
+++ b/change/@fluentui-react-divider-c910ec1f-060f-4681-b756-c4f363c292b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-divider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-3c5fd291-b460-4ff3-8541-38c597f3f12d.json
+++ b/change/@fluentui-react-drawer-3c5fd291-b460-4ff3-8541-38c597f3f12d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-drawer",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-e724a61a-c7a7-4df1-8ce9-9fa32eb366ea.json
+++ b/change/@fluentui-react-field-e724a61a-c7a7-4df1-8ce9-9fa32eb366ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-field",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-461e34dc-e7d8-4f98-af4a-532e416b2ace.json
+++ b/change/@fluentui-react-image-461e34dc-e7d8-4f98-af4a-532e416b2ace.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-image",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infobutton-f280111c-01bb-4975-aa08-244ba08b6c8a.json
+++ b/change/@fluentui-react-infobutton-f280111c-01bb-4975-aa08-244ba08b6c8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-1d70c6a3-aecc-4ef9-b8fb-9f1e710b4f05.json
+++ b/change/@fluentui-react-input-1d70c6a3-aecc-4ef9-b8fb-9f1e710b4f05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-input",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-02be68fb-294a-4eb0-a5bf-248a102b2d2d.json
+++ b/change/@fluentui-react-label-02be68fb-294a-4eb0-a5bf-248a102b2d2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-label",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-1ce7ebbc-c41e-4bf9-95b3-0aa0ec100efe.json
+++ b/change/@fluentui-react-link-1ce7ebbc-c41e-4bf9-95b3-0aa0ec100efe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-link",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-3b670c4e-6636-45ef-af2c-cab25cb240cd.json
+++ b/change/@fluentui-react-menu-3b670c4e-6636-45ef-af2c-cab25cb240cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-a1bb6dea-e825-4789-9adb-492078fcb2f0.json
+++ b/change/@fluentui-react-persona-a1bb6dea-e825-4789-9adb-492078fcb2f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-persona",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-5716f820-95dc-4bce-a720-66f5866c7413.json
+++ b/change/@fluentui-react-popover-5716f820-95dc-4bce-a720-66f5866c7413.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-b4292ec0-c547-48f5-b90f-ad6c0b019525.json
+++ b/change/@fluentui-react-progress-b4292ec0-c547-48f5-b90f-ad6c0b019525.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-progress",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-2067b81c-c98e-49ea-b79e-8e8291c9cfe1.json
+++ b/change/@fluentui-react-provider-2067b81c-c98e-49ea-b79e-8e8291c9cfe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-provider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-d39ba987-e0b1-4176-999c-bd325671e55e.json
+++ b/change/@fluentui-react-radio-d39ba987-e0b1-4176-999c-bd325671e55e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-radio",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-d753b20d-8324-491e-9490-336b183e0121.json
+++ b/change/@fluentui-react-select-d753b20d-8324-491e-9490-336b183e0121.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-select",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-e3c15142-8f70-473d-8efa-ac667891562d.json
+++ b/change/@fluentui-react-skeleton-e3c15142-8f70-473d-8efa-ac667891562d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-f18b6242-32c8-4cfd-b199-54c0f53cfccb.json
+++ b/change/@fluentui-react-slider-f18b6242-32c8-4cfd-b199-54c0f53cfccb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-slider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-b73e76a8-2014-471f-b9a0-85bd04014a23.json
+++ b/change/@fluentui-react-spinbutton-b73e76a8-2014-471f-b9a0-85bd04014a23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-e43817c0-1513-498d-828f-36eb84a35e23.json
+++ b/change/@fluentui-react-spinner-e43817c0-1513-498d-828f-36eb84a35e23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-spinner",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-91433ea3-6918-4d06-b248-cac05efaa2f4.json
+++ b/change/@fluentui-react-switch-91433ea3-6918-4d06-b248-cac05efaa2f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-switch",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-f7f3ca89-93bc-4930-881f-cb83166cfdea.json
+++ b/change/@fluentui-react-table-f7f3ca89-93bc-4930-881f-cb83166cfdea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-table",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-preview-04ad5d05-9cae-4f68-b2d6-02e74c92c987.json
+++ b/change/@fluentui-react-tags-preview-04ad5d05-9cae-4f68-b2d6-02e74c92c987.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-37e8f2aa-e6f2-4025-bf68-b70c856b047b.json
+++ b/change/@fluentui-react-text-37e8f2aa-e6f2-4025-bf68-b70c856b047b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-text",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-321a9a95-b8a2-43b8-b31a-c4ad0bb6428f.json
+++ b/change/@fluentui-react-textarea-321a9a95-b8a2-43b8-b31a-c4ad0bb6428f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-textarea",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-2a03fd69-d63d-4973-954c-6213b17292bb.json
+++ b/change/@fluentui-react-toast-2a03fd69-d63d-4973-954c-6213b17292bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-toast",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-1bb0eef6-97fa-41e4-8796-a3ae7b3a897c.json
+++ b/change/@fluentui-react-toolbar-1bb0eef6-97fa-41e4-8796-a3ae7b3a897c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-d9c3df6c-14f5-42da-aea8-d301174cbc16.json
+++ b/change/@fluentui-react-tooltip-d9c3df6c-14f5-42da-aea8-d301174cbc16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-f924d50a-e604-4b82-8416-840290b1e5bb.json
+++ b/change/@fluentui-react-tree-f924d50a-e604-4b82-8416-840290b1e5bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-da6af28c-41de-41ae-a11c-40b62fb07c6b.json
+++ b/change/@fluentui-react-virtualizer-da6af28c-41de-41ae-a11c-40b62fb07c6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: migrate to new slot API",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/src/components/Accordion/renderAccordion.tsx
+++ b/packages/react-components/react-accordion/src/components/Accordion/renderAccordion.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 
 import type { AccordionState, AccordionSlots, AccordionContextValues } from './Accordion.types';
 import { AccordionProvider } from '../../contexts/accordion';
@@ -12,11 +12,11 @@ import { AccordionProvider } from '../../contexts/accordion';
  * Function that renders the final JSX of the component
  */
 export const renderAccordion_unstable = (state: AccordionState, contextValues: AccordionContextValues) => {
-  const { slots, slotProps } = getSlotsNext<AccordionSlots>(state);
+  assertSlots<AccordionSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <AccordionProvider value={contextValues.accordion}>{slotProps.root.children}</AccordionProvider>
-    </slots.root>
+    <state.root>
+      <AccordionProvider value={contextValues.accordion}>{state.root.children}</AccordionProvider>
+    </state.root>
   );
 };

--- a/packages/react-components/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-components/react-accordion/src/components/Accordion/useAccordion.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useControllableState, useEventCallback } from '@fluentui/react-utilities';
+import { getNativeElementProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { AccordionProps, AccordionState } from './Accordion.types';
 import type { AccordionItemValue } from '../AccordionItem/AccordionItem.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
@@ -48,11 +48,14 @@ export const useAccordion_unstable = <Value = AccordionItemValue>(
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ...props,
-      ...(navigation ? arrowNavigationProps : undefined),
-      ref,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ...props,
+        ...(navigation ? arrowNavigationProps : undefined),
+        ref,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };
 

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/renderAccordionHeader.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { AccordionHeaderState, AccordionHeaderSlots, AccordionHeaderContextValues } from './AccordionHeader.types';
 import { AccordionHeaderProvider } from '../../contexts/accordionHeader';
 
@@ -14,18 +14,18 @@ export const renderAccordionHeader_unstable = (
   state: AccordionHeaderState,
   contextValues: AccordionHeaderContextValues,
 ) => {
-  const { slots, slotProps } = getSlotsNext<AccordionHeaderSlots>(state);
+  assertSlots<AccordionHeaderSlots>(state);
 
   return (
     <AccordionHeaderProvider value={contextValues.accordionHeader}>
-      <slots.root {...slotProps.root}>
-        <slots.button {...slotProps.button}>
-          {state.expandIconPosition === 'start' && slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-          {slots.icon && <slots.icon {...slotProps.icon} />}
-          {slotProps.root.children}
-          {state.expandIconPosition === 'end' && slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-        </slots.button>
-      </slots.root>
+      <state.root>
+        <state.button>
+          {state.expandIconPosition === 'start' && state.expandIcon && <state.expandIcon />}
+          {state.icon && <state.icon />}
+          {state.root.children}
+          {state.expandIconPosition === 'end' && state.expandIcon && <state.expandIcon />}
+        </state.button>
+      </state.root>
     </AccordionHeaderProvider>
   );
 };

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeader.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  getNativeElementProps,
-  isResolvedShorthand,
-  resolveShorthand,
-  useEventCallback,
-} from '@fluentui/react-utilities';
+import { getNativeElementProps, isResolvedShorthand, useEventCallback, slot } from '@fluentui/react-utilities';
 import { ARIAButtonSlotProps, useARIAButtonShorthand } from '@fluentui/react-aria';
 import type { AccordionHeaderProps, AccordionHeaderState } from './AccordionHeader.types';
 import { useAccordionContext_unstable } from '../../contexts/accordion';
@@ -55,19 +50,23 @@ export const useAccordionHeader_unstable = (
       expandIcon: 'span',
       icon: 'div',
     },
-    root: getNativeElementProps(as || 'div', {
-      ref,
-      ...props,
-    }),
-    icon: resolveShorthand(icon),
-    expandIcon: resolveShorthand(expandIcon, {
-      required: true,
+    root: slot.always(
+      getNativeElementProps(as || 'div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    icon: slot.optional(icon, { elementType: 'div' }),
+    expandIcon: slot.optional(expandIcon, {
+      renderByDefault: true,
       defaultProps: {
         children: <ChevronRightRegular style={{ transform: `rotate(${expandIconRotation}deg)` }} />,
         'aria-hidden': true,
       },
+      elementType: 'span',
     }),
-    button: resolveShorthand<ARIAButtonSlotProps<'a'>>(
+    button: slot.always<ARIAButtonSlotProps<'a'>>(
       {
         ...useARIAButtonShorthand(button, {
           required: true,
@@ -87,7 +86,7 @@ export const useAccordionHeader_unstable = (
           }
         }),
       },
-      { required: true },
+      { elementType: 'button' },
     ),
   };
 };

--- a/packages/react-components/react-accordion/src/components/AccordionItem/renderAccordionItem.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionItem/renderAccordionItem.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { AccordionItemState, AccordionItemSlots, AccordionItemContextValues } from './AccordionItem.types';
 import { AccordionItemProvider } from '../../contexts/accordionItem';
 
@@ -11,11 +11,11 @@ import { AccordionItemProvider } from '../../contexts/accordionItem';
  * Function that renders the final JSX of the component
  */
 export const renderAccordionItem_unstable = (state: AccordionItemState, contextValues: AccordionItemContextValues) => {
-  const { slots, slotProps } = getSlotsNext<AccordionItemSlots>(state);
+  assertSlots<AccordionItemSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <AccordionItemProvider value={contextValues.accordionItem}>{slotProps.root.children}</AccordionItemProvider>
-    </slots.root>
+    <state.root>
+      <AccordionItemProvider value={contextValues.accordionItem}>{state.root.children}</AccordionItemProvider>
+    </state.root>
   );
 };

--- a/packages/react-components/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useAccordionContext_unstable } from '../../contexts/accordion';
 import type { AccordionItemProps, AccordionItemState } from './AccordionItem.types';
 
@@ -23,6 +23,6 @@ export const useAccordionItem_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', { ref, ...props }),
+    root: slot.always(getNativeElementProps('div', { ref, ...props }), { elementType: 'div' }),
   };
 };

--- a/packages/react-components/react-accordion/src/components/AccordionPanel/renderAccordionPanel.tsx
+++ b/packages/react-components/react-accordion/src/components/AccordionPanel/renderAccordionPanel.tsx
@@ -3,13 +3,13 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { AccordionPanelState, AccordionPanelSlots } from './AccordionPanel.types';
 
 /**
  * Function that renders the final JSX of the component
  */
 export const renderAccordionPanel_unstable = (state: AccordionPanelState) => {
-  const { slots, slotProps } = getSlotsNext<AccordionPanelSlots>(state);
-  return state.open ? <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root> : null;
+  assertSlots<AccordionPanelSlots>(state);
+  return state.open ? <state.root>{state.root.children}</state.root> : null;
 };

--- a/packages/react-components/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useTabsterAttributes } from '@fluentui/react-tabster';
 import { useAccordionContext_unstable } from '../../contexts/accordion';
 import type { AccordionPanelProps, AccordionPanelState } from './AccordionPanel.types';
@@ -23,10 +23,13 @@ export const useAccordionPanel_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-      ...(navigation && focusableProps),
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+        ...(navigation && focusableProps),
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-alert/src/components/Alert/renderAlert.tsx
+++ b/packages/react-components/react-alert/src/components/Alert/renderAlert.tsx
@@ -2,19 +2,19 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 
 import type { AlertState, AlertSlots } from './Alert.types';
 
 export const renderAlert_unstable = (state: AlertState) => {
-  const { slots, slotProps } = getSlotsNext<AlertSlots>(state);
+  assertSlots<AlertSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.avatar && <slots.avatar {...slotProps.avatar} />}
-      {slotProps.root.children}
-      {slots.action && <slots.action {...slotProps.action} />}
-    </slots.root>
+    <state.root>
+      {state.icon && <state.icon />}
+      {state.avatar && <state.avatar />}
+      {state.root.children}
+      {state.action && <state.action />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-alert/src/components/Alert/useAlert.tsx
+++ b/packages/react-components/react-alert/src/components/Alert/useAlert.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Avatar } from '@fluentui/react-avatar';
 import { Button } from '@fluentui/react-button';
 import { CheckmarkCircleFilled, DismissCircleFilled, InfoFilled, WarningFilled } from '@fluentui/react-icons';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 
 import type { AlertProps, AlertState } from './Alert.types';
 
@@ -39,36 +39,31 @@ export const useAlert_unstable = (props: AlertProps, ref: React.Ref<HTMLElement>
       break;
   }
 
-  const action = resolveShorthand(props.action, { defaultProps: { appearance: 'transparent' } });
-  const avatar = resolveShorthand(props.avatar);
+  const action = slot.optional(props.action, { defaultProps: { appearance: 'transparent' }, elementType: Button });
+  const avatar = slot.optional(props.avatar, { elementType: Avatar });
   let icon;
-  /** Avatar prop takes precedence over the icon or intent prop */
-  if (!avatar) {
-    icon = resolveShorthand(props.icon, {
-      defaultProps: {
-        children: defaultIcon,
-      },
-      required: !!props.intent,
+  /** Avatar prop takes precedence over the icon or intent prop */ if (!avatar) {
+    icon = slot.optional(props.icon, {
+      defaultProps: { children: defaultIcon },
+      renderByDefault: !!props.intent,
+      elementType: 'span',
     });
   }
-
   return {
     action,
     appearance,
     avatar,
-    components: {
-      root: 'div',
-      icon: 'span',
-      action: Button,
-      avatar: Avatar,
-    },
+    components: { root: 'div', icon: 'span', action: Button, avatar: Avatar },
     icon,
     intent,
-    root: getNativeElementProps('div', {
-      ref,
-      role: defaultRole,
-      children: props.children,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        role: defaultRole,
+        children: props.children,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-aria/src/button/useARIAButtonShorthand.ts
+++ b/packages/react-components/react-aria/src/button/useARIAButtonShorthand.ts
@@ -12,8 +12,8 @@ import type { ARIAButtonProps, ARIAButtonSlotProps, ARIAButtonType } from './typ
  * for multiple scenarios of shorthand properties. Ensuring 1st rule of ARIA for cases
  * where no attribute addition is required.
  */
-export const useARIAButtonShorthand: ResolveShorthandFunction<ARIAButtonSlotProps> = (slot, options) => {
-  const shorthand = resolveShorthand(slot, options);
+export const useARIAButtonShorthand: ResolveShorthandFunction<ARIAButtonSlotProps> = (value, options) => {
+  const shorthand = resolveShorthand(value, options);
   const shorthandARIAButton = useARIAButtonProps<ARIAButtonType, ARIAButtonProps>(shorthand?.as ?? 'button', shorthand);
   return shorthand && shorthandARIAButton;
 };

--- a/packages/react-components/react-avatar/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/renderAvatar.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { AvatarSlots, AvatarState } from './Avatar.types';
 
 export const renderAvatar_unstable = (state: AvatarState) => {
-  const { slots, slotProps } = getSlotsNext<AvatarSlots>(state);
+  assertSlots<AvatarSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.initials && <slots.initials {...slotProps.initials} />}
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.image && <slots.image {...slotProps.image} />}
-      {slots.badge && <slots.badge {...slotProps.badge} />}
+    <state.root>
+      {state.initials && <state.initials />}
+      {state.icon && <state.icon />}
+      {state.image && <state.image />}
+      {state.badge && <state.badge />}
       {state.activeAriaLabelElement}
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/src/components/Avatar/useAvatar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, mergeCallbacks, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, mergeCallbacks, useId, slot } from '@fluentui/react-utilities';
 import { getInitials } from '../../utils/index';
 import type { AvatarNamedColor, AvatarProps, AvatarState } from './Avatar.types';
 import { PersonRegular } from '@fluentui/react-icons';
@@ -32,89 +32,66 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
 
   const baseId = useId('avatar-');
 
-  const root: AvatarState['root'] = getNativeElementProps(
-    'span',
-    {
-      role: 'img',
-      id: baseId,
-      // aria-label and/or aria-labelledby are resolved below
-      ...props,
-      ref,
-    },
-    /* excludedPropNames: */ ['name'],
+  const root: AvatarState['root'] = slot.always(
+    getNativeElementProps(
+      'span',
+      {
+        role: 'img',
+        id: baseId,
+        // aria-label and/or aria-labelledby are resolved below
+        ...props,
+        ref,
+      },
+      /* excludedPropNames: */ ['name'],
+    ),
+    { elementType: 'span' },
   );
-
   const [imageHidden, setImageHidden] = React.useState<true | undefined>(undefined);
-  let image: AvatarState['image'] = resolveShorthand(props.image, {
-    defaultProps: {
-      alt: '',
-      role: 'presentation',
-      'aria-hidden': true,
-      hidden: imageHidden,
-    },
-  });
-
-  // Image shouldn't be rendered if its src is not set
+  let image: AvatarState['image'] = slot.optional(props.image, {
+    defaultProps: { alt: '', role: 'presentation', 'aria-hidden': true, hidden: imageHidden },
+    elementType: 'img',
+  }); // Image shouldn't be rendered if its src is not set
   if (!image?.src) {
     image = undefined;
-  }
-
-  // Hide the image if it fails to load and restore it on a successful load
+  } // Hide the image if it fails to load and restore it on a successful load
   if (image) {
     image.onError = mergeCallbacks(image.onError, () => setImageHidden(true));
     image.onLoad = mergeCallbacks(image.onLoad, () => setImageHidden(undefined));
-  }
-
-  // Resolve the initials slot, defaulted to getInitials.
-  let initials: AvatarState['initials'] = resolveShorthand(props.initials, {
-    required: true,
+  } // Resolve the initials slot, defaulted to getInitials.
+  let initials: AvatarState['initials'] = slot.optional(props.initials, {
+    renderByDefault: true,
     defaultProps: {
       children: getInitials(name, dir === 'rtl', { firstInitialOnly: size <= 16 }),
       id: baseId + '__initials',
     },
-  });
-
-  // Don't render the initials slot if it's empty
+    elementType: 'span',
+  }); // Don't render the initials slot if it's empty
   if (!initials?.children) {
     initials = undefined;
-  }
-
-  // Render the icon slot *only if* there aren't any initials or image to display
+  } // Render the icon slot *only if* there aren't any initials or image to display
   let icon: AvatarState['icon'] = undefined;
   if (!initials && (!image || imageHidden)) {
-    icon = resolveShorthand(props.icon, {
-      required: true,
-      defaultProps: {
-        children: <PersonRegular />,
-        'aria-hidden': true,
-      },
+    icon = slot.optional(props.icon, {
+      renderByDefault: true,
+      defaultProps: { children: <PersonRegular />, 'aria-hidden': true },
+      elementType: 'span',
     });
   }
-
-  const badge: AvatarState['badge'] = resolveShorthand(props.badge, {
-    defaultProps: {
-      size: getBadgeSize(size),
-      id: baseId + '__badge',
-    },
+  const badge: AvatarState['badge'] = slot.optional(props.badge, {
+    defaultProps: { size: getBadgeSize(size), id: baseId + '__badge' },
+    elementType: PresenceBadge,
   });
-
-  let activeAriaLabelElement: AvatarState['activeAriaLabelElement'];
-
-  // Resolve aria-label and/or aria-labelledby if not provided by the user
+  let activeAriaLabelElement: AvatarState['activeAriaLabelElement']; // Resolve aria-label and/or aria-labelledby if not provided by the user
   if (!root['aria-label'] && !root['aria-labelledby']) {
     if (name) {
-      root['aria-label'] = name;
-
-      // Include the badge in labelledby if it exists
+      root['aria-label'] = name; // Include the badge in labelledby if it exists
       if (badge) {
         root['aria-labelledby'] = root.id + ' ' + badge.id;
       }
     } else if (initials) {
       // root's aria-label should be the name, but fall back to being labelledby the initials if name is missing
       root['aria-labelledby'] = initials.id + (badge ? ' ' + badge.id : '');
-    }
-
-    // Add the active state to the aria label
+    } // Add the active state to the aria label
     if (active === 'active' || active === 'inactive') {
       const activeText = DEFAULT_STRINGS[active];
       if (root['aria-labelledby']) {
@@ -132,7 +109,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
       }
     }
   }
-
   return {
     size,
     shape,
@@ -140,15 +116,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     activeAppearance,
     activeAriaLabelElement,
     color,
-
-    components: {
-      root: 'span',
-      initials: 'span',
-      icon: 'span',
-      image: 'img',
-      badge: PresenceBadge,
-    },
-
+    components: { root: 'span', initials: 'span', icon: 'span', image: 'img', badge: PresenceBadge },
     root,
     initials,
     icon,
@@ -156,7 +124,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
     badge,
   };
 };
-
 const getBadgeSize = (size: AvatarState['size']) => {
   if (size >= 96) {
     return 'extra-large';

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/renderAvatarGroup.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { AvatarGroupProvider } from '../../contexts/AvatarGroupContext';
 import type { AvatarGroupState, AvatarGroupSlots, AvatarGroupContextValues } from './AvatarGroup.types';
 
@@ -11,11 +11,11 @@ import type { AvatarGroupState, AvatarGroupSlots, AvatarGroupContextValues } fro
  * Render the final JSX of AvatarGroup
  */
 export const renderAvatarGroup_unstable = (state: AvatarGroupState, contextValues: AvatarGroupContextValues) => {
-  const { slots, slotProps } = getSlotsNext<AvatarGroupSlots>(state);
+  assertSlots<AvatarGroupSlots>(state);
 
   return (
     <AvatarGroupProvider value={contextValues.avatarGroup}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </AvatarGroupProvider>
   );
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroup/useAvatarGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { AvatarGroupProps, AvatarGroupState } from './AvatarGroup.types';
 
 /**
@@ -14,24 +14,19 @@ import type { AvatarGroupProps, AvatarGroupState } from './AvatarGroup.types';
 export const useAvatarGroup_unstable = (props: AvatarGroupProps, ref: React.Ref<HTMLElement>): AvatarGroupState => {
   const { layout = 'spread', size = defaultAvatarGroupSize } = props;
 
-  const root = getNativeElementProps(
-    'div',
-    {
-      role: 'group',
-      ...props,
-      ref,
-    },
-    ['size'],
+  const root = slot.always(
+    getNativeElementProps(
+      'div',
+      {
+        role: 'group',
+        ...props,
+        ref,
+      },
+      ['size'],
+    ),
+    { elementType: 'div' },
   );
-
-  return {
-    layout,
-    size,
-    components: {
-      root: 'div',
-    },
-    root,
-  };
+  return { layout, size, components: { root: 'div' }, root };
 };
 
 export const defaultAvatarGroupSize = 32;

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/renderAvatarGroupItem.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/renderAvatarGroupItem.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { AvatarGroupItemState, AvatarGroupItemSlots } from './AvatarGroupItem.types';
 
 /**
  * Render the final JSX of AvatarGroupItem
  */
 export const renderAvatarGroupItem_unstable = (state: AvatarGroupItemState) => {
-  const { slots, slotProps } = getSlotsNext<AvatarGroupItemSlots>(state);
+  assertSlots<AvatarGroupItemSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.avatar {...slotProps.avatar} />
-      {state.isOverflowItem && <slots.overflowLabel {...slotProps.overflowLabel} />}
-    </slots.root>
+    <state.root>
+      <state.avatar />
+      {state.isOverflowItem && <state.overflowLabel />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupItem/useAvatarGroupItem.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Avatar } from '../Avatar/Avatar';
 import { AvatarGroupContext, useAvatarGroupContext_unstable } from '../../contexts/AvatarGroupContext';
 import { defaultAvatarGroupSize } from '../AvatarGroup/useAvatarGroup';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import type { AvatarGroupItemProps, AvatarGroupItemState } from './AvatarGroupItem.types';
 
@@ -41,29 +41,29 @@ export const useAvatarGroupItem_unstable = (
       avatar: Avatar,
       overflowLabel: 'span',
     },
-    root: resolveShorthand(props.root, {
-      required: true,
+    root: slot.always(props.root, {
       defaultProps: {
         style,
         className,
       },
+      elementType: groupIsOverflow ? 'li' : 'div',
     }),
-    avatar: resolveShorthand(props.avatar, {
-      required: true,
+    avatar: slot.always(props.avatar, {
       defaultProps: {
         ref,
         size,
         color: 'colorful',
         ...avatarSlotProps,
       },
+      elementType: Avatar,
     }),
-    overflowLabel: resolveShorthand(props.overflowLabel, {
-      required: true,
+    overflowLabel: slot.always(props.overflowLabel, {
       defaultProps: {
         // Avatar already has its aria-label set to the name, this will prevent the name to be read twice.
         'aria-hidden': true,
         children: props.name,
       },
+      elementType: 'span',
     }),
   };
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/renderAvatarGroupPopover.tsx
@@ -5,9 +5,8 @@ import { createElement } from '@fluentui/react-jsx-runtime';
 import { AvatarGroupProvider } from '../../contexts/AvatarGroupContext';
 import { AvatarGroupContextValues } from '../AvatarGroup/AvatarGroup.types';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
-import { PopoverProps, PopoverTrigger } from '@fluentui/react-popover';
-import { TooltipProps } from '@fluentui/react-tooltip';
+import { assertSlots } from '@fluentui/react-utilities';
+import { PopoverTrigger } from '@fluentui/react-popover';
 import type { AvatarGroupPopoverState, AvatarGroupPopoverSlots } from './AvatarGroupPopover.types';
 
 /**
@@ -17,20 +16,20 @@ export const renderAvatarGroupPopover_unstable = (
   state: AvatarGroupPopoverState,
   contextValues: AvatarGroupContextValues,
 ) => {
-  const { slots, slotProps } = getSlotsNext<AvatarGroupPopoverSlots>(state);
+  assertSlots<AvatarGroupPopoverSlots>(state);
 
   return (
-    <slots.root {...(slotProps.root as PopoverProps)}>
+    <state.root>
       <PopoverTrigger disableButtonEnhancement>
-        <slots.tooltip {...(slotProps.tooltip as TooltipProps)}>
-          <slots.triggerButton {...slotProps.triggerButton} />
-        </slots.tooltip>
+        <state.tooltip>
+          <state.triggerButton />
+        </state.tooltip>
       </PopoverTrigger>
-      <slots.popoverSurface {...slotProps.popoverSurface}>
+      <state.popoverSurface>
         <AvatarGroupProvider value={contextValues.avatarGroup}>
-          <slots.content {...slotProps.content} />
+          <state.content />
         </AvatarGroupProvider>
-      </slots.popoverSurface>
-    </slots.root>
+      </state.popoverSurface>
+    </state.root>
   );
 };

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopover.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useAvatarGroupContext_unstable } from '../../contexts/AvatarGroupContext';
 import { defaultAvatarGroupSize } from '../AvatarGroup/useAvatarGroup';
-import { resolveShorthand, useControllableState } from '@fluentui/react-utilities';
+import { useControllableState, slot } from '@fluentui/react-utilities';
 import { MoreHorizontalRegular } from '@fluentui/react-icons';
 import { OnOpenChangeData, OpenPopoverEvents, Popover, PopoverSurface } from '@fluentui/react-popover';
 import type { AvatarGroupPopoverProps, AvatarGroupPopoverState } from './AvatarGroupPopover.types';
@@ -59,42 +59,45 @@ export const useAvatarGroupPopover_unstable = (props: AvatarGroupPopoverProps): 
       popoverSurface: PopoverSurface,
       tooltip: Tooltip,
     },
-    root: {
-      // Popover expects a child for its children. The children are added in the renderAvatarGroupPopover.
-      children: <></>,
-      size: 'small',
-      trapFocus: true,
-      ...restOfProps,
-      open: popoverOpen,
-      onOpenChange: handleOnPopoverChange,
-    },
-    triggerButton: resolveShorthand(props.triggerButton, {
-      required: true,
+    root: slot.always(
+      {
+        // Popover expects a child for its children. The children are added in the renderAvatarGroupPopover.
+        children: <></>,
+        size: 'small',
+        trapFocus: true,
+        ...restOfProps,
+        open: popoverOpen,
+        onOpenChange: handleOnPopoverChange,
+      },
+      { elementType: Popover },
+    ),
+    triggerButton: slot.always(props.triggerButton, {
       defaultProps: {
         children: triggerButtonChildren,
         type: 'button',
       },
+      elementType: 'button',
     }),
-    content: resolveShorthand(props.content, {
-      required: true,
+    content: slot.always(props.content, {
       defaultProps: {
         children,
         role: 'list',
       },
+      elementType: 'ul',
     }),
-    popoverSurface: resolveShorthand(props.popoverSurface, {
-      required: true,
+    popoverSurface: slot.always(props.popoverSurface, {
       defaultProps: {
         'aria-label': 'Overflow',
         tabIndex: 0,
       },
+      elementType: PopoverSurface,
     }),
-    tooltip: resolveShorthand(props.tooltip, {
-      required: true,
+    tooltip: slot.always(props.tooltip, {
       defaultProps: {
         content: 'View more people.',
         relationship: 'label',
       },
+      elementType: Tooltip,
     }),
   };
 };

--- a/packages/react-components/react-badge/src/components/Badge/renderBadge.tsx
+++ b/packages/react-components/react-badge/src/components/Badge/renderBadge.tsx
@@ -3,17 +3,17 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { BadgeState, BadgeSlots } from './Badge.types';
 
 export const renderBadge_unstable = (state: BadgeState) => {
-  const { slots, slotProps } = getSlotsNext<BadgeSlots>(state);
+  assertSlots<BadgeSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {state.iconPosition === 'before' && slots.icon && <slots.icon {...slotProps.icon} />}
+    <state.root>
+      {state.iconPosition === 'before' && state.icon && <state.icon />}
       {state.root.children}
-      {state.iconPosition === 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
-    </slots.root>
+      {state.iconPosition === 'after' && state.icon && <state.icon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-badge/src/components/Badge/useBadge.ts
+++ b/packages/react-components/react-badge/src/components/Badge/useBadge.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { BadgeProps, BadgeState } from './Badge.types';
 
 /**
@@ -24,11 +24,14 @@ export const useBadge_unstable = (props: BadgeProps, ref: React.Ref<HTMLElement>
       root: 'div',
       icon: 'span',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
-    icon: resolveShorthand(props.icon),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    icon: slot.optional(props.icon, { elementType: 'span' }),
   };
 
   return state;

--- a/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
+++ b/packages/react-components/react-badge/src/components/PresenceBadge/usePresenceBadge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import {
   presenceAvailableFilled,
   presenceAvailableRegular,
@@ -69,11 +69,12 @@ export const usePresenceBadge_unstable = (
         role: 'img',
         ...props,
         size,
-        icon: resolveShorthand(props.icon, {
+        icon: slot.optional(props.icon, {
           defaultProps: {
             children: IconElement ? <IconElement /> : null,
           },
-          required: true,
+          renderByDefault: true,
+          elementType: 'span',
         }),
       },
       ref,

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/renderBreadcrumb.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/renderBreadcrumb.tsx
@@ -3,20 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { BreadcrumbProvider } from './BreadcrumbContext';
 import type { BreadcrumbState, BreadcrumbSlots, BreadcrumbContextValues } from './Breadcrumb.types';
 /**
  * Render the final JSX of Breadcrumb
  */
 export const renderBreadcrumb_unstable = (state: BreadcrumbState, contextValues: BreadcrumbContextValues) => {
-  const { slots, slotProps } = getSlotsNext<BreadcrumbSlots>(state);
-  const { root, list } = slotProps;
+  assertSlots<BreadcrumbSlots>(state);
   return (
-    <slots.root {...root}>
+    <state.root>
       <BreadcrumbProvider value={contextValues.breadcrumb}>
-        {slots.list && <slots.list {...list}>{root.children}</slots.list>}
+        {state.list && <state.list>{state.root.children}</state.list>}
       </BreadcrumbProvider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/useBreadcrumb.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/useBreadcrumb.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { BreadcrumbProps, BreadcrumbState } from './Breadcrumb.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 
@@ -34,13 +34,16 @@ export const useBreadcrumb_unstable = (props: BreadcrumbProps, ref: React.Ref<HT
       root: 'nav',
       list: 'ol',
     },
-    root: getNativeElementProps('nav', {
-      ref,
-      'aria-label': props['aria-label'] ?? 'breadcrumb',
-      ...(focusMode === 'arrow' ? focusAttributes : {}),
-      ...rest,
-    }),
-    list: resolveShorthand(list, { required: true, defaultProps: { role: 'list' } }),
+    root: slot.always(
+      getNativeElementProps('nav', {
+        ref,
+        'aria-label': props['aria-label'] ?? 'breadcrumb',
+        ...(focusMode === 'arrow' ? focusAttributes : {}),
+        ...rest,
+      }),
+      { elementType: 'nav' },
+    ),
+    list: slot.optional(list, { renderByDefault: true, defaultProps: { role: 'list' }, elementType: 'ol' }),
     appearance,
     dividerType,
     iconPosition,

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbDivider/renderBreadcrumbDivider.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbDivider/renderBreadcrumbDivider.tsx
@@ -3,14 +3,14 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { BreadcrumbDividerState, BreadcrumbDividerSlots } from './BreadcrumbDivider.types';
 
 /**
  * Render the final JSX of BreadcrumbDivider
  */
 export const renderBreadcrumbDivider_unstable = (state: BreadcrumbDividerState) => {
-  const { slots, slotProps } = getSlotsNext<BreadcrumbDividerSlots>(state);
+  assertSlots<BreadcrumbDividerSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbDivider/useBreadcrumbDivider.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbDivider/useBreadcrumbDivider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { BreadcrumbDividerProps, BreadcrumbDividerState } from './BreadcrumbDivider.types';
 import {
   ChevronRight20Regular,
@@ -34,12 +34,15 @@ export const useBreadcrumbDivider_unstable = (
     components: {
       root: 'li',
     },
-    root: getNativeElementProps('li', {
-      ref,
-      'aria-hidden': true,
-      children: icon,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('li', {
+        ref,
+        'aria-hidden': true,
+        children: icon,
+        ...props,
+      }),
+      { elementType: 'li' },
+    ),
   };
 };
 

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/renderBreadcrumbItem.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/renderBreadcrumbItem.tsx
@@ -3,21 +3,21 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { BreadcrumbItemState, BreadcrumbItemSlots } from './BreadcrumbItem.types';
 
 /**
  * Render the final JSX of BreadcrumbItem
  */
 export const renderBreadcrumbItem_unstable = (state: BreadcrumbItemState) => {
-  const { slots, slotProps } = getSlotsNext<BreadcrumbItemSlots>(state);
+  assertSlots<BreadcrumbItemSlots>(state);
   const { iconOnly, iconPosition } = state;
 
   return (
-    <slots.root {...slotProps.root}>
-      {iconPosition !== 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
+    <state.root>
+      {iconPosition !== 'after' && state.icon && <state.icon />}
       {!iconOnly && state.root.children}
-      {iconPosition === 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
-    </slots.root>
+      {iconPosition === 'after' && state.icon && <state.icon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { BreadcrumbItemProps, BreadcrumbItemState } from './BreadcrumbItem.types';
 import { useBreadcrumbContext_unstable } from '../Breadcrumb/BreadcrumbContext';
 
@@ -19,21 +19,20 @@ export const useBreadcrumbItem_unstable = (
   const { size, iconPosition } = useBreadcrumbContext_unstable();
   const { current = false, icon } = props;
 
-  const iconShorthand = resolveShorthand(icon);
-
+  const iconSlot = slot.optional(icon, { elementType: 'span' });
   return {
-    components: {
-      root: 'li',
-      icon: 'span',
-    },
-    root: getNativeElementProps('li', {
-      ref,
-      ...props,
-    }),
+    components: { root: 'li', icon: 'span' },
+    root: slot.always(
+      getNativeElementProps('li', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'li' },
+    ),
     size,
     current,
-    icon: iconShorthand,
-    iconOnly: Boolean(iconShorthand?.children && !props.children),
+    icon: iconSlot,
+    iconOnly: Boolean(iconSlot?.children && !props.children),
     iconPosition: props.iconPosition || iconPosition,
   };
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/renderBreadcrumbLink.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/renderBreadcrumbLink.tsx
@@ -3,20 +3,20 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { BreadcrumbLinkState, BreadcrumbLinkSlots } from './BreadcrumbLink.types';
 
 /**
  * Render the final JSX of BreadcrumbLink
  */
 export const renderBreadcrumbLink_unstable = (state: BreadcrumbLinkState) => {
-  const { slots, slotProps } = getSlotsNext<BreadcrumbLinkSlots>(state);
+  assertSlots<BreadcrumbLinkSlots>(state);
   const { iconOnly, iconPosition } = state;
   return (
-    <slots.root {...slotProps.root}>
-      {iconPosition !== 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
+    <state.root>
+      {iconPosition !== 'after' && state.icon && <state.icon />}
       {!iconOnly && state.root.children}
-      {iconPosition === 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
-    </slots.root>
+      {iconPosition === 'after' && state.icon && <state.icon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { BreadcrumbLinkProps, BreadcrumbLinkState } from './BreadcrumbLink.types';
 import { Link } from '@fluentui/react-link';
 import { useBreadcrumbContext_unstable } from '../Breadcrumb/BreadcrumbContext';
@@ -20,18 +20,17 @@ export const useBreadcrumbLink_unstable = (
   const { current = false, disabled = false, icon, overflow = false, ...rest } = props;
 
   const linkAppearance = props.appearance || appearance;
-  const iconShorthand = resolveShorthand(icon);
-
+  const iconShorthand = slot.optional(icon, { elementType: 'span' });
   return {
-    components: {
-      root: Link,
-      icon: 'span',
-    },
-    root: getNativeElementProps('a', {
-      'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
-      ref,
-      ...rest,
-    }),
+    components: { root: Link, icon: 'span' },
+    root: slot.always(
+      getNativeElementProps('a', {
+        'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
+        ref,
+        ...rest,
+      }),
+      { elementType: Link },
+    ),
     appearance: linkAppearance === 'subtle' ? 'subtle' : 'default',
     current,
     disabled,

--- a/packages/react-components/react-button/src/components/Button/renderButton.tsx
+++ b/packages/react-components/react-button/src/components/Button/renderButton.tsx
@@ -3,21 +3,21 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ButtonSlots, ButtonState } from './Button.types';
 
 /**
  * Renders a Button component by passing the state defined props to the appropriate slots.
  */
 export const renderButton_unstable = (state: ButtonState) => {
-  const { slots, slotProps } = getSlotsNext<ButtonSlots>(state);
+  assertSlots<ButtonSlots>(state);
   const { iconOnly, iconPosition } = state;
 
   return (
-    <slots.root {...slotProps.root}>
-      {iconPosition !== 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
+    <state.root>
+      {iconPosition !== 'after' && state.icon && <state.icon />}
       {!iconOnly && state.root.children}
-      {iconPosition === 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
-    </slots.root>
+      {iconPosition === 'after' && state.icon && <state.icon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-button/src/components/Button/useButton.ts
+++ b/packages/react-components/react-button/src/components/Button/useButton.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ARIAButtonSlotProps, useARIAButtonShorthand } from '@fluentui/react-aria';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useButtonContext } from '../../contexts/ButtonContext';
 import type { ButtonProps, ButtonState } from './Button.types';
 
@@ -24,8 +24,7 @@ export const useButton_unstable = (
     shape = 'rounded',
     size = contextSize ?? 'medium',
   } = props;
-  const iconShorthand = resolveShorthand(icon);
-
+  const iconShorthand = slot.optional(icon, { elementType: 'span' });
   return {
     // Props passed at the top-level
     appearance,
@@ -33,26 +32,21 @@ export const useButton_unstable = (
     disabledFocusable,
     iconPosition,
     shape,
-    size,
-
-    // State calculated from a set of props
-    iconOnly: Boolean(iconShorthand?.children && !props.children),
-
-    // Slots definition
-    components: {
-      root: 'button',
-      icon: 'span',
-    },
-
-    root: getNativeElementProps(
-      as,
-      useARIAButtonShorthand<ARIAButtonSlotProps<'a'>>(props, {
-        required: true,
-        defaultProps: {
-          ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
-          type: 'button',
-        },
-      }),
+    size, // State calculated from a set of props
+    iconOnly: Boolean(iconShorthand?.children && !props.children), // Slots definition
+    components: { root: 'button', icon: 'span' },
+    root: slot.always(
+      getNativeElementProps(
+        as,
+        useARIAButtonShorthand<ARIAButtonSlotProps<'a'>>(props, {
+          required: true,
+          defaultProps: {
+            ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+            type: 'button',
+          },
+        }),
+      ),
+      { elementType: 'button' },
     ),
     icon: iconShorthand,
   };

--- a/packages/react-components/react-button/src/components/CompoundButton/renderCompoundButton.tsx
+++ b/packages/react-components/react-button/src/components/CompoundButton/renderCompoundButton.tsx
@@ -3,26 +3,27 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { CompoundButtonSlots, CompoundButtonState } from './CompoundButton.types';
 
 /**
  * Renders a CompoundButton component by passing the state defined props to the appropriate slots.
  */
 export const renderCompoundButton_unstable = (state: CompoundButtonState) => {
-  const { slots, slotProps } = getSlotsNext<CompoundButtonSlots>(state);
+  assertSlots<CompoundButtonSlots>(state);
   const { iconOnly, iconPosition } = state;
 
   return (
-    <slots.root {...slotProps.root}>
-      {iconPosition !== 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
+    <state.root>
+      {iconPosition !== 'after' && state.icon && <state.icon />}
       {!iconOnly && (
-        <slots.contentContainer {...slotProps.contentContainer}>
-          {slotProps.root.children}
-          {slots.secondaryContent && <slots.secondaryContent {...slotProps.secondaryContent} />}
-        </slots.contentContainer>
+        <state.contentContainer>
+          {state.root.children}
+          {state.secondaryContent && <state.secondaryContent />}
+        </state.contentContainer>
       )}
-      {iconPosition === 'after' && slots.icon && <slots.icon {...slotProps.icon} />}
-    </slots.root>
+
+      {iconPosition === 'after' && state.icon && <state.icon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-button/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-components/react-button/src/components/CompoundButton/useCompoundButton.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { useButton_unstable } from '../Button/index';
 import type { CompoundButtonProps, CompoundButtonState } from './CompoundButton.types';
 
@@ -23,8 +23,8 @@ export const useCompoundButton_unstable = (
       contentContainer: 'span',
       secondaryContent: 'span',
     },
-    contentContainer: resolveShorthand(contentContainer, { required: true }),
-    secondaryContent: resolveShorthand(secondaryContent),
+    contentContainer: slot.always(contentContainer, { elementType: 'span' }),
+    secondaryContent: slot.optional(secondaryContent, { elementType: 'span' }),
   };
 
   // Recalculate iconOnly to take into account secondaryContent.

--- a/packages/react-components/react-button/src/components/MenuButton/renderMenuButton.tsx
+++ b/packages/react-components/react-button/src/components/MenuButton/renderMenuButton.tsx
@@ -3,21 +3,21 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { MenuButtonSlots, MenuButtonState } from './MenuButton.types';
 
 /**
  * Renders a MenuButton component by passing the state defined props to the appropriate slots.
  */
 export const renderMenuButton_unstable = (state: MenuButtonState) => {
-  const { slots, slotProps } = getSlotsNext<MenuButtonSlots>(state);
+  assertSlots<MenuButtonSlots>(state);
   const { icon, iconOnly } = state;
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {!iconOnly && slotProps.root.children}
-      {(!iconOnly || !icon?.children) && slots.menuIcon && <slots.menuIcon {...slotProps.menuIcon} />}
-    </slots.root>
+    <state.root>
+      {state.icon && <state.icon />}
+      {!iconOnly && state.root.children}
+      {(!iconOnly || !icon?.children) && state.menuIcon && <state.menuIcon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-button/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-components/react-button/src/components/MenuButton/useMenuButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ChevronDownRegular } from '@fluentui/react-icons';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { useButton_unstable } from '../Button/index';
 import type { MenuButtonProps, MenuButtonState } from './MenuButton.types';
 
@@ -28,11 +28,12 @@ export const useMenuButton_unstable = (
       menuIcon: 'span',
     },
 
-    menuIcon: resolveShorthand(menuIcon, {
+    menuIcon: slot.optional(menuIcon, {
       defaultProps: {
         children: <ChevronDownRegular />,
       },
-      required: true,
+      renderByDefault: true,
+      elementType: 'span',
     }),
   };
 };

--- a/packages/react-components/react-button/src/components/SplitButton/renderSplitButton.tsx
+++ b/packages/react-components/react-button/src/components/SplitButton/renderSplitButton.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SplitButtonSlots, SplitButtonState } from './SplitButton.types';
 
 /**
  * Renders a SplitButton component by passing the state defined props to the appropriate slots.
  */
 export const renderSplitButton_unstable = (state: SplitButtonState) => {
-  const { slots, slotProps } = getSlotsNext<SplitButtonSlots>(state);
+  assertSlots<SplitButtonSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.primaryActionButton && <slots.primaryActionButton {...slotProps.primaryActionButton} />}
-      {slots.menuButton && <slots.menuButton {...slotProps.menuButton} />}
-    </slots.root>
+    <state.root>
+      {state.primaryActionButton && <state.primaryActionButton />}
+      {state.menuButton && <state.menuButton />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-button/src/components/SplitButton/useSplitButton.ts
+++ b/packages/react-components/react-button/src/components/SplitButton/useSplitButton.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, slot } from '@fluentui/react-utilities';
 import { Button } from '../Button/Button';
 import { MenuButton } from '../MenuButton/MenuButton';
 import type { SplitButtonProps, SplitButtonState } from './SplitButton.types';
@@ -29,7 +29,7 @@ export const useSplitButton_unstable = (
 
   const baseId = useId('splitButton-');
 
-  const menuButtonShorthand = resolveShorthand(menuButton, {
+  const menuButtonShorthand = slot.optional(menuButton, {
     defaultProps: {
       appearance,
       disabled,
@@ -38,10 +38,10 @@ export const useSplitButton_unstable = (
       shape,
       size,
     },
-    required: true,
+    renderByDefault: true,
+    elementType: MenuButton,
   });
-
-  const primaryActionButtonShorthand = resolveShorthand(primaryActionButton, {
+  const primaryActionButtonShorthand = slot.optional(primaryActionButton, {
     defaultProps: {
       appearance,
       children,
@@ -53,10 +53,9 @@ export const useSplitButton_unstable = (
       shape,
       size,
     },
-    required: true,
-  });
-
-  // Resolve menu button's aria-labelledby to be labelled by the primary action button if not a label was not provided
+    renderByDefault: true,
+    elementType: Button,
+  }); // Resolve menu button's aria-labelledby to be labelled by the primary action button if not a label was not provided
   // by the user.
   if (
     menuButtonShorthand &&
@@ -66,7 +65,6 @@ export const useSplitButton_unstable = (
   ) {
     menuButtonShorthand['aria-labelledby'] = primaryActionButtonShorthand.id;
   }
-
   return {
     // Props passed at the top-level
     appearance,
@@ -74,16 +72,9 @@ export const useSplitButton_unstable = (
     disabledFocusable,
     iconPosition,
     shape,
-    size,
-
-    // Slots definition
-    components: {
-      root: 'div',
-      menuButton: MenuButton,
-      primaryActionButton: Button,
-    },
-
-    root: getNativeElementProps('div', { ref, ...props }),
+    size, // Slots definition
+    components: { root: 'div', menuButton: MenuButton, primaryActionButton: Button },
+    root: slot.always(getNativeElementProps('div', { ref, ...props }), { elementType: 'div' }),
     menuButton: menuButtonShorthand,
     primaryActionButton: primaryActionButtonShorthand,
   };

--- a/packages/react-components/react-card/src/components/Card/renderCard.tsx
+++ b/packages/react-components/react-card/src/components/Card/renderCard.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { CardContextValue, CardSlots, CardState } from './Card.types';
 import { CardProvider } from './CardContext';
 
@@ -11,15 +11,15 @@ import { CardProvider } from './CardContext';
  * Render the final JSX of Card.
  */
 export const renderCard_unstable = (state: CardState, cardContextValue: CardContextValue) => {
-  const { slots, slotProps } = getSlotsNext<CardSlots>(state);
+  assertSlots<CardSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       <CardProvider value={cardContextValue}>
-        {slots.checkbox ? <slots.checkbox {...slotProps.checkbox} /> : null}
-        {slots.floatingAction ? <slots.floatingAction {...slotProps.floatingAction} /> : null}
-        {slotProps.root.children}
+        {state.checkbox ? <state.checkbox /> : null}
+        {state.floatingAction ? <state.floatingAction /> : null}
+        {state.root.children}
       </CardProvider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useFocusableGroup, useFocusWithin } from '@fluentui/react-tabster';
 
 import type { CardProps, CardState } from './Card.types';
@@ -96,13 +96,16 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLDivElement
       checkbox: 'input',
     },
 
-    root: getNativeElementProps('div', {
-      ref: cardRef,
-      role: 'group',
-      ...focusAttributes,
-      ...props,
-      ...selectableCardProps,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: cardRef,
+        role: 'group',
+        ...focusAttributes,
+        ...props,
+        ...selectableCardProps,
+      }),
+      { elementType: 'div' },
+    ),
 
     floatingAction: floatingActionSlot,
     checkbox: checkboxSlot,

--- a/packages/react-components/react-card/src/components/Card/useCardSelectable.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardSelectable.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mergeCallbacks, resolveShorthand } from '@fluentui/react-utilities';
+import { mergeCallbacks, slot } from '@fluentui/react-utilities';
 import { Enter } from '@fluentui/keyboard-keys';
 import { useFocusFinders } from '@fluentui/react-tabster';
 
@@ -89,7 +89,7 @@ export const useCardSelectable = (
       selectableCheckboxProps['aria-label'] = referenceLabel;
     }
 
-    return resolveShorthand(checkbox, {
+    return slot.optional(checkbox, {
       defaultProps: {
         ref: checkboxRef,
         type: 'checkbox',
@@ -99,6 +99,7 @@ export const useCardSelectable = (
         onBlur: () => setIsSelectFocused(false),
         ...selectableCheckboxProps,
       },
+      elementType: 'input',
     });
   }, [checkbox, floatingAction, isCardSelected, isSelectable, onChangeHandler, referenceId, referenceLabel]);
 
@@ -107,10 +108,11 @@ export const useCardSelectable = (
       return;
     }
 
-    return resolveShorthand(floatingAction, {
+    return slot.optional(floatingAction, {
       defaultProps: {
         ref: checkboxRef,
       },
+      elementType: 'div',
     });
   }, [floatingAction]);
 

--- a/packages/react-components/react-card/src/components/CardFooter/renderCardFooter.tsx
+++ b/packages/react-components/react-card/src/components/CardFooter/renderCardFooter.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { CardFooterSlots, CardFooterState } from './CardFooter.types';
 
 /**
  * Render the final JSX of CardFooter.
  */
 export const renderCardFooter_unstable = (state: CardFooterState) => {
-  const { slots, slotProps } = getSlotsNext<CardFooterSlots>(state);
+  assertSlots<CardFooterSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slotProps.root.children}
-      {slots.action && <slots.action {...slotProps.action} />}
-    </slots.root>
+    <state.root>
+      {state.root.children}
+      {state.action && <state.action />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-card/src/components/CardFooter/useCardFooter.ts
+++ b/packages/react-components/react-card/src/components/CardFooter/useCardFooter.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { CardFooterProps, CardFooterState } from './CardFooter.types';
 
 /**
@@ -20,10 +20,13 @@ export const useCardFooter_unstable = (props: CardFooterProps, ref: React.Ref<HT
       action: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
-    action: resolveShorthand(action),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    action: slot.optional(action, { elementType: 'div' }),
   };
 };

--- a/packages/react-components/react-card/src/components/CardHeader/renderCardHeader.tsx
+++ b/packages/react-components/react-card/src/components/CardHeader/renderCardHeader.tsx
@@ -3,21 +3,21 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { CardHeaderSlots, CardHeaderState } from './CardHeader.types';
 
 /**
  * Render the final JSX of CardHeader.
  */
 export const renderCardHeader_unstable = (state: CardHeaderState) => {
-  const { slots, slotProps } = getSlotsNext<CardHeaderSlots>(state);
+  assertSlots<CardHeaderSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.image && <slots.image {...slotProps.image} />}
-      <slots.header {...slotProps.header} />
-      {slots.description && <slots.description {...slotProps.description} />}
-      {slots.action && <slots.action {...slotProps.action} />}
-    </slots.root>
+    <state.root>
+      {state.image && <state.image />}
+      <state.header />
+      {state.description && <state.description />}
+      {state.action && <state.action />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeader.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, slot } from '@fluentui/react-utilities';
 import type { CardHeaderProps, CardHeaderState } from './CardHeader.types';
 import { useCardContext_unstable } from '../Card/CardContext';
 import { cardHeaderClassNames } from './useCardHeaderStyles.styles';
@@ -62,39 +62,33 @@ export const useCardHeader_unstable = (props: CardHeaderProps, ref: React.Ref<HT
   const hasChildId = React.useRef(false);
   const generatedId = useId(cardHeaderClassNames.header, referenceId);
 
-  const headerSlot = resolveShorthand(header, {
-    required: true,
+  const headerSlot = slot.optional(header, {
+    renderByDefault: true,
     defaultProps: {
       ref: headerRef,
       id: !hasChildId.current ? referenceId : undefined,
     },
+    elementType: 'div',
   });
-
   React.useEffect(() => {
     const headerId = !hasChildId.current ? headerRef.current?.id : undefined;
     const childWithId = getChildWithId(headerSlot?.children);
-
     hasChildId.current = Boolean(childWithId);
-
     setReferenceId(getReferenceId(headerId, childWithId, generatedId));
   }, [generatedId, header, headerSlot, setReferenceId]);
-
   return {
-    components: {
-      root: 'div',
-      image: 'div',
-      header: 'div',
-      description: 'div',
-      action: 'div',
-    },
+    components: { root: 'div', image: 'div', header: 'div', description: 'div', action: 'div' },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
-    image: resolveShorthand(image),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    image: slot.optional(image, { elementType: 'div' }),
     header: headerSlot,
-    description: resolveShorthand(description),
-    action: resolveShorthand(action),
+    description: slot.optional(description, { elementType: 'div' }),
+    action: slot.optional(action, { elementType: 'div' }),
   };
 };

--- a/packages/react-components/react-card/src/components/CardPreview/renderCardPreview.tsx
+++ b/packages/react-components/react-card/src/components/CardPreview/renderCardPreview.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { CardPreviewSlots, CardPreviewState } from './CardPreview.types';
 
 /**
  * Render the final JSX of CardPreview.
  */
 export const renderCardPreview_unstable = (state: CardPreviewState) => {
-  const { slots, slotProps } = getSlotsNext<CardPreviewSlots>(state);
+  assertSlots<CardPreviewSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slotProps.root.children}
-      {slots.logo && <slots.logo {...slotProps.logo} />}
-    </slots.root>
+    <state.root>
+      {state.root.children}
+      {state.logo && <state.logo />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-card/src/components/CardPreview/useCardPreview.ts
+++ b/packages/react-components/react-card/src/components/CardPreview/useCardPreview.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import type { CardPreviewProps, CardPreviewState } from './CardPreview.types';
 import { useCardContext_unstable } from '../Card/CardContext';
 import { cardPreviewClassNames } from './useCardPreviewStyles.styles';
@@ -50,10 +50,13 @@ export const useCardPreview_unstable = (props: CardPreviewProps, ref: React.Ref<
       logo: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ref: previewRef,
-      ...props,
-    }),
-    logo: resolveShorthand(logo),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: previewRef,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    logo: slot.optional(logo, { elementType: 'div' }),
   };
 };

--- a/packages/react-components/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/renderCheckbox.tsx
@@ -3,18 +3,18 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { CheckboxState, CheckboxSlots } from './Checkbox.types';
 
 export const renderCheckbox_unstable = (state: CheckboxState) => {
-  const { slots, slotProps } = getSlotsNext<CheckboxSlots>(state);
+  assertSlots<CheckboxSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.input {...slotProps.input} />
-      {state.labelPosition === 'before' && slots.label && <slots.label {...slotProps.label} />}
-      <slots.indicator {...slotProps.indicator} />
-      {state.labelPosition === 'after' && slots.label && <slots.label {...slotProps.label} />}
-    </slots.root>
+    <state.root>
+      <state.input />
+      {state.labelPosition === 'before' && state.label && <state.label />}
+      <state.indicator />
+      {state.labelPosition === 'after' && state.label && <state.label />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-checkbox/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-components/react-checkbox/src/components/Checkbox/useCheckbox.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import {
   getPartitionedNativeProps,
-  resolveShorthand,
   useControllableState,
   useEventCallback,
   useId,
   useIsomorphicLayoutEffect,
   useMergedRefs,
+  slot,
 } from '@fluentui/react-utilities';
 import { CheckboxProps, CheckboxState } from './Checkbox.types';
 import {
@@ -73,15 +73,14 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
       indicator: 'div',
       label: Label,
     },
-    root: resolveShorthand(props.root, {
-      required: true,
+    root: slot.always(props.root, {
       defaultProps: {
         ref: useFocusWithin<HTMLSpanElement>(),
         ...nativeProps.root,
       },
+      elementType: 'span',
     }),
-    input: resolveShorthand(props.input, {
-      required: true,
+    input: slot.always(props.input, {
       defaultProps: {
         type: 'checkbox',
         id,
@@ -89,22 +88,24 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
         checked: checked === true,
         ...nativeProps.primary,
       },
+      elementType: 'input',
     }),
-    label: resolveShorthand(props.label, {
-      required: false,
+    label: slot.optional(props.label, {
       defaultProps: {
         htmlFor: id,
         disabled,
         required,
         size: 'medium', // Even if the checkbox itself is large
       },
+      elementType: Label,
     }),
-    indicator: resolveShorthand(props.indicator, {
-      required: true,
+    indicator: slot.optional(props.indicator, {
+      renderByDefault: true,
       defaultProps: {
         'aria-hidden': true,
         children: checkmarkIcon,
       },
+      elementType: 'div',
     }),
   };
 

--- a/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
@@ -4,7 +4,7 @@ import { Portal } from '@fluentui/react-portal';
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { ComboboxContext } from '../../contexts/ComboboxContext';
 import type { ComboboxContextValues, ComboboxState, ComboboxSlots } from './Combobox.types';
 
@@ -12,22 +12,22 @@ import type { ComboboxContextValues, ComboboxState, ComboboxSlots } from './Comb
  * Render the final JSX of Combobox
  */
 export const renderCombobox_unstable = (state: ComboboxState, contextValues: ComboboxContextValues) => {
-  const { slots, slotProps } = getSlotsNext<ComboboxSlots>(state);
+  assertSlots<ComboboxSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       <ComboboxContext.Provider value={contextValues.combobox}>
-        <slots.input {...slotProps.input} />
-        {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-        {slots.listbox &&
+        <state.input />
+        {state.expandIcon && <state.expandIcon />}
+        {state.listbox &&
           (state.inlinePopup ? (
-            <slots.listbox {...slotProps.listbox} />
+            <state.listbox />
           ) : (
             <Portal mountNode={state.mountNode}>
-              <slots.listbox {...slotProps.listbox} />
+              <state.listbox />
             </Portal>
           ))}
       </ComboboxContext.Provider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -4,11 +4,11 @@ import { ArrowLeft, ArrowRight } from '@fluentui/keyboard-keys';
 import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
 import {
   getPartitionedNativeProps,
-  resolveShorthand,
   mergeCallbacks,
   useEventCallback,
   useId,
   useMergedRefs,
+  slot,
 } from '@fluentui/react-utilities';
 import { getDropdownActionFromKey } from '../../utils/dropdownKeyActions';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
@@ -158,62 +158,50 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   let triggerSlot: Slot<'input'>;
   let listboxSlot: Slot<typeof Listbox> | undefined;
 
-  triggerSlot = resolveShorthand(props.input, {
-    required: true,
+  triggerSlot = slot.always(props.input, {
     defaultProps: {
       ref: useMergedRefs(props.input?.ref, triggerRef),
       type: 'text',
       value: value ?? '',
       ...triggerNativeProps,
     },
+    elementType: 'input',
   });
-
   const resolvedPropsOnKeyDown = triggerSlot.onKeyDown;
   triggerSlot.onChange = mergeCallbacks(triggerSlot.onChange, onTriggerChange);
-  triggerSlot.onBlur = mergeCallbacks(triggerSlot.onBlur, onTriggerBlur);
-
-  // only resolve listbox slot if needed
+  triggerSlot.onBlur = mergeCallbacks(triggerSlot.onBlur, onTriggerBlur); // only resolve listbox slot if needed
   listboxSlot =
     open || hasFocus
-      ? resolveShorthand(props.listbox, {
-          required: true,
-          defaultProps: {
-            children: props.children,
-            style: popupDimensions,
-          },
+      ? slot.optional(props.listbox, {
+          renderByDefault: true,
+          defaultProps: { children: props.children, style: popupDimensions },
+          elementType: Listbox,
         })
       : undefined;
-
   [triggerSlot, listboxSlot] = useComboboxPopup(props, triggerSlot, listboxSlot);
   [triggerSlot, listboxSlot] = useTriggerListboxSlots(props, baseState, ref, triggerSlot, listboxSlot);
-
   if (hideActiveDescendant) {
     triggerSlot['aria-activedescendant'] = undefined;
   }
-
   const state: ComboboxState = {
-    components: {
-      root: 'div',
-      input: 'input',
-      expandIcon: 'span',
-      listbox: Listbox,
-    },
-    root: resolveShorthand(props.root, {
-      required: true,
+    components: { root: 'div', input: 'input', expandIcon: 'span', listbox: Listbox },
+    root: slot.always(props.root, {
       defaultProps: {
         'aria-owns': !inlinePopup ? listboxSlot?.id : undefined,
         ...rootNativeProps,
       },
+      elementType: 'div',
     }),
     input: triggerSlot,
     listbox: listboxSlot,
-    expandIcon: resolveShorthand(props.expandIcon, {
-      required: true,
+    expandIcon: slot.optional(props.expandIcon, {
+      renderByDefault: true,
       defaultProps: {
         'aria-expanded': open,
         children: <ChevronDownIcon />,
         role: 'button',
       },
+      elementType: 'span',
     }),
     ...baseState,
   };

--- a/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
@@ -5,7 +5,7 @@ import { Portal } from '@fluentui/react-portal';
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { ComboboxContext } from '../../contexts/ComboboxContext';
 import type { DropdownContextValues, DropdownState, DropdownSlots } from './Dropdown.types';
 
@@ -13,24 +13,24 @@ import type { DropdownContextValues, DropdownState, DropdownSlots } from './Drop
  * Render the final JSX of Dropdown
  */
 export const renderDropdown_unstable = (state: DropdownState, contextValues: DropdownContextValues) => {
-  const { slots, slotProps } = getSlotsNext<DropdownSlots>(state);
+  assertSlots<DropdownSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       <ComboboxContext.Provider value={contextValues.combobox}>
-        <slots.button {...slotProps.button}>
-          {slotProps.button.children}
-          {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-        </slots.button>
-        {slots.listbox &&
+        <state.button>
+          {state.button.children}
+          {state.expandIcon && <state.expandIcon />}
+        </state.button>
+        {state.listbox &&
           (state.inlinePopup ? (
-            <slots.listbox {...slotProps.listbox} />
+            <state.listbox />
           ) : (
             <Portal mountNode={state.mountNode}>
-              <slots.listbox {...slotProps.listbox} />
+              <state.listbox />
             </Portal>
           ))}
       </ComboboxContext.Provider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
-import { getPartitionedNativeProps, mergeCallbacks, resolveShorthand, useTimeout } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, mergeCallbacks, useMergedRefs, useTimeout, slot } from '@fluentui/react-utilities';
 import { getDropdownActionFromKey } from '../../utils/dropdownKeyActions';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
 import { useComboboxPopup } from '../../utils/useComboboxPopup';
@@ -10,7 +10,6 @@ import { Listbox } from '../Listbox/Listbox';
 import type { Slot } from '@fluentui/react-utilities';
 import type { OptionValue } from '../../utils/OptionCollection.types';
 import type { DropdownProps, DropdownState } from './Dropdown.types';
-import { useMergedRefs } from '@fluentui/react-utilities';
 
 /**
  * Create the state required to render Dropdown.
@@ -108,53 +107,43 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   let triggerSlot: Slot<'button'>;
   let listboxSlot: Slot<typeof Listbox> | undefined;
 
-  triggerSlot = resolveShorthand(props.button, {
-    required: true,
+  triggerSlot = slot.always(props.button, {
     defaultProps: {
       type: 'button',
       children: baseState.value || props.placeholder,
       ...triggerNativeProps,
     },
+    elementType: 'button',
   });
-
   triggerSlot.onKeyDown = mergeCallbacks(onTriggerKeyDown, triggerSlot.onKeyDown);
-
   listboxSlot =
     baseState.open || baseState.hasFocus
-      ? resolveShorthand(props.listbox, {
-          required: true,
-          defaultProps: {
-            children: props.children,
-            style: { width: popupWidth },
-          },
+      ? slot.optional(props.listbox, {
+          renderByDefault: true,
+          defaultProps: { children: props.children, style: { width: popupWidth } },
+          elementType: Listbox,
         })
       : undefined;
-
   [triggerSlot, listboxSlot] = useComboboxPopup(props, triggerSlot, listboxSlot);
   [triggerSlot, listboxSlot] = useTriggerListboxSlots(props, baseState, ref, triggerSlot, listboxSlot);
-
   const state: DropdownState = {
-    components: {
-      root: 'div',
-      button: 'button',
-      expandIcon: 'span',
-      listbox: Listbox,
-    },
-    root: resolveShorthand(props.root, {
-      required: true,
+    components: { root: 'div', button: 'button', expandIcon: 'span', listbox: Listbox },
+    root: slot.always(props.root, {
       defaultProps: {
         'aria-owns': !props.inlinePopup ? listboxSlot?.id : undefined,
         children: props.children,
         ...rootNativeProps,
       },
+      elementType: 'div',
     }),
     button: triggerSlot,
     listbox: listboxSlot,
-    expandIcon: resolveShorthand(props.expandIcon, {
-      required: true,
+    expandIcon: slot.optional(props.expandIcon, {
+      renderByDefault: true,
       defaultProps: {
         children: <ChevronDownIcon />,
       },
+      elementType: 'span',
     }),
     placeholderVisible: !baseState.value && !!props.placeholder,
     ...baseState,

--- a/packages/react-components/react-combobox/src/components/Listbox/renderListbox.tsx
+++ b/packages/react-components/react-combobox/src/components/Listbox/renderListbox.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ListboxContextValues, ListboxState, ListboxSlots } from './Listbox.types';
 import { ListboxContext } from '../../contexts/ListboxContext';
 
@@ -11,11 +11,11 @@ import { ListboxContext } from '../../contexts/ListboxContext';
  * Render the final JSX of Listbox
  */
 export const renderListbox_unstable = (state: ListboxState, contextValues: ListboxContextValues) => {
-  const { slots, slotProps } = getSlotsNext<ListboxSlots>(state);
+  assertSlots<ListboxSlots>(state);
 
   return (
     <ListboxContext.Provider value={contextValues.listbox}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </ListboxContext.Provider>
   );
 };

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { getNativeElementProps, mergeCallbacks, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
+import {
+  getNativeElementProps,
+  mergeCallbacks,
+  useEventCallback,
+  useMergedRefs,
+  slot,
+} from '@fluentui/react-utilities';
 import { useContextSelector, useHasParentContext } from '@fluentui/react-context-selector';
 import { getDropdownActionFromKey, getIndexFromAction } from '../../utils/dropdownKeyActions';
 import type { OptionValue } from '../../utils/OptionCollection.types';
@@ -87,14 +93,17 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      role: multiselect ? 'menu' : 'listbox',
-      'aria-activedescendant': hasComboboxContext ? undefined : activeOption?.id,
-      'aria-multiselectable': multiselect,
-      tabIndex: 0,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        role: multiselect ? 'menu' : 'listbox',
+        'aria-activedescendant': hasComboboxContext ? undefined : activeOption?.id,
+        'aria-multiselectable': multiselect,
+        tabIndex: 0,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     multiselect,
     clearSelection,
     ...optionCollection,

--- a/packages/react-components/react-combobox/src/components/Option/renderOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/renderOption.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { OptionState, OptionSlots } from './Option.types';
 
 /**
  * Render the final JSX of Option
  */
 export const renderOption_unstable = (state: OptionState) => {
-  const { slots, slotProps } = getSlotsNext<OptionSlots>(state);
+  assertSlots<OptionSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.checkIcon && <slots.checkIcon {...slotProps.checkIcon} />}
-      {slotProps.root.children}
-    </slots.root>
+    <state.root>
+      {state.checkIcon && <state.checkIcon />}
+      {state.root.children}
+    </state.root>
   );
 };

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useId, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useContextSelector } from '@fluentui/react-context-selector';
 import { CheckmarkFilled, Checkmark12Filled } from '@fluentui/react-icons';
 import { ComboboxContext } from '../../contexts/ComboboxContext';
@@ -115,20 +115,24 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
       root: 'div',
       checkIcon: 'span',
     },
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, optionRef),
-      'aria-disabled': disabled ? 'true' : undefined,
-      id,
-      ...semanticProps,
-      ...props,
-      onClick,
-    }),
-    checkIcon: resolveShorthand(props.checkIcon, {
-      required: true,
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, optionRef),
+        'aria-disabled': disabled ? 'true' : undefined,
+        id,
+        ...semanticProps,
+        ...props,
+        onClick,
+      }),
+      { elementType: 'div' },
+    ),
+    checkIcon: slot.optional(props.checkIcon, {
+      renderByDefault: true,
       defaultProps: {
         'aria-hidden': 'true',
         children: CheckIcon,
       },
+      elementType: 'span',
     }),
     active,
     disabled,

--- a/packages/react-components/react-combobox/src/components/OptionGroup/renderOptionGroup.tsx
+++ b/packages/react-components/react-combobox/src/components/OptionGroup/renderOptionGroup.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { OptionGroupState, OptionGroupSlots } from './OptionGroup.types';
 
 /**
  * Render the final JSX of OptionGroup
  */
 export const renderOptionGroup_unstable = (state: OptionGroupState) => {
-  const { slots, slotProps } = getSlotsNext<OptionGroupSlots>(state);
+  assertSlots<OptionGroupSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.label && <slots.label {...slotProps.label}>{slotProps.label.children}</slots.label>}
-      {slotProps.root.children}
-    </slots.root>
+    <state.root>
+      {state.label && <state.label>{state.label.children}</state.label>}
+      {state.root.children}
+    </state.root>
   );
 };

--- a/packages/react-components/react-combobox/src/components/OptionGroup/useOptionGroup.ts
+++ b/packages/react-components/react-combobox/src/components/OptionGroup/useOptionGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, slot } from '@fluentui/react-utilities';
 import type { OptionGroupProps, OptionGroupState } from './OptionGroup.types';
 
 /**
@@ -20,17 +20,21 @@ export const useOptionGroup_unstable = (props: OptionGroupProps, ref: React.Ref<
       root: 'div',
       label: 'span',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      role: 'group',
-      'aria-labelledby': label ? labelId : undefined,
-      ...props,
-    }),
-    label: resolveShorthand(label, {
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        role: 'group',
+        'aria-labelledby': label ? labelId : undefined,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    label: slot.optional(label, {
       defaultProps: {
         id: labelId,
         role: 'presentation',
       },
+      elementType: 'span',
     }),
   };
 };

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/renderDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/renderDatePicker.tsx
@@ -5,30 +5,29 @@
 import * as React from 'react';
 import { createElement } from '@fluentui/react-jsx-runtime';
 import { Portal } from '@fluentui/react-portal';
-import { getSlotsNext } from '@fluentui/react-utilities';
-import type { CalendarProps } from '../Calendar/Calendar.types';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DatePickerSlots, DatePickerState } from './DatePicker.types';
 
 /**
  * Render the final JSX of DatePicker
  */
 export const renderDatePicker_unstable = (state: DatePickerState) => {
-  const { slots, slotProps } = getSlotsNext<DatePickerSlots>(state);
+  assertSlots<DatePickerSlots>(state);
   const { inlinePopup } = state;
 
   return (
     <>
-      <slots.root {...slotProps.root} />
-      {slots.popupSurface &&
+      <state.root />
+      {state.popupSurface &&
         (inlinePopup ? (
-          <slots.popupSurface {...slotProps.popupSurface}>
-            <slots.calendar {...(slotProps.calendar as CalendarProps)} />
-          </slots.popupSurface>
+          <state.popupSurface>
+            <state.calendar />
+          </state.popupSurface>
         ) : (
           <Portal>
-            <slots.popupSurface {...slotProps.popupSurface}>
-              <slots.calendar {...(slotProps.calendar as CalendarProps)} />
-            </slots.popupSurface>
+            <state.popupSurface>
+              <state.calendar />
+            </state.popupSurface>
           </Portal>
         ))}
     </>

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -7,13 +7,13 @@ import { defaultDatePickerStrings } from './defaults';
 import { Input } from '@fluentui/react-input';
 import {
   mergeCallbacks,
-  resolveShorthand,
   useControllableState,
   useEventCallback,
   useId,
   useMergedRefs,
   useOnClickOutside,
   useOnScrollOutside,
+  slot,
 } from '@fluentui/react-utilities';
 import { useFieldContext_unstable as useFieldContext } from '@fluentui/react-field';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
@@ -353,8 +353,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     : 'outline';
 
   const [triggerWrapperRef, popupRef] = usePopupPositioning(props);
-  const root = resolveShorthand(restOfProps, {
-    required: true,
+  const root = slot.always(restOfProps, {
     defaultProps: {
       appearance: inputAppearance,
       'aria-controls': open ? popupSurfaceId : undefined,
@@ -364,32 +363,32 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
       readOnly: !allowTextInput,
       role: 'combobox',
     },
+    elementType: Input,
   });
 
-  const inputRoot = resolveShorthand(props.root, {
-    required: true,
+  const inputRoot = slot.always(props.root, {
     defaultProps: {
       'aria-owns': open ? popupSurfaceId : undefined,
       ref: triggerWrapperRef,
     },
+    elementType: 'span',
   });
   inputRoot.ref = useMergedRefs(inputRoot.ref, triggerWrapperRef);
   root.root = inputRoot;
-
-  const inputShorthand = resolveShorthand(props.input, { required: true });
+  const inputShorthand = slot.always(props.input, {
+    elementType: 'input',
+  });
   inputShorthand.ref = useMergedRefs(inputShorthand.ref, ref, rootRef);
   root.input = inputShorthand;
-
   root.onChange = useEventCallback(mergeCallbacks(root.onChange, onInputChange));
   root.onBlur = useEventCallback(mergeCallbacks(root.onBlur, onInputBlur));
   root.onKeyDown = useEventCallback(mergeCallbacks(root.onKeyDown, onInputKeyDown));
   root.onFocus = useEventCallback(mergeCallbacks(root.onFocus, onInputFocus));
   root.onClick = useEventCallback(mergeCallbacks(root.onClick, onInputClick));
-
   const { modalAttributes } = useModalAttributes({ trapFocus: true, alwaysFocusable: true, legacyTrapFocus: false });
   const popupSurface = open
-    ? resolveShorthand(props.popupSurface, {
-        required: true,
+    ? slot.optional(props.popupSurface, {
+        renderByDefault: true,
         defaultProps: {
           'aria-label': 'Calendar',
           'aria-modal': true,
@@ -398,9 +397,9 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
           ref: popupRef,
           ...modalAttributes,
         },
+        elementType: 'div',
       })
     : undefined;
-
   const { targetDocument } = useFluent();
   useOnClickOutside({
     element: targetDocument,
@@ -408,15 +407,12 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     refs: [triggerWrapperRef, popupRef],
     disabled: !open,
   });
-
   useOnScrollOutside({
     element: targetDocument,
     callback: ev => dismissDatePickerPopup(),
     refs: [triggerWrapperRef, popupRef],
     disabled: !open,
-  });
-
-  // When the popup is opened, focus should go to the calendar.
+  }); // When the popup is opened, focus should go to the calendar.
   // In v8 this was done by focusing after the callout was positioned, but in v9 this can be simulated by using a
   // useEffect hook.
   React.useEffect(() => {
@@ -424,9 +420,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
       calendar.current.focus();
     }
   }, [disableAutoFocus, open, props.disabled]);
-
-  const calendarShorthand = resolveShorthand(props.calendar, {
-    required: true,
+  const calendarShorthand = slot.always(props.calendar, {
     defaultProps: {
       allFocusable,
       componentRef: calendar,
@@ -446,21 +440,14 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
       today,
       value: selectedDate || initialPickerDate,
     },
+    elementType: Calendar,
   });
-
   calendarShorthand.onDismiss = useEventCallback(mergeCallbacks(calendarShorthand.onDismiss, calendarDismissed));
   calendarShorthand.onSelectDate = useEventCallback(mergeCallbacks(calendarShorthand.onSelectDate, calendarDismissed));
-
   const state: DatePickerState = {
     disabled: !!props.disabled,
     inlinePopup,
-
-    components: {
-      root: Input,
-      calendar: Calendar as React.FC<Partial<CalendarProps>>,
-      popupSurface: 'div',
-    },
-
+    components: { root: Input, calendar: Calendar as React.FC<Partial<CalendarProps>>, popupSurface: 'div' },
     calendar: calendarShorthand,
     root,
     popupSurface,

--- a/packages/react-components/react-dialog/src/components/DialogActions/renderDialogActions.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogActions/renderDialogActions.tsx
@@ -3,15 +3,15 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogActionsState, DialogActionsSlots } from './DialogActions.types';
 
 /**
  * Render the final JSX of DialogActions
  */
 export const renderDialogActions_unstable = (state: DialogActionsState) => {
-  const { slots, slotProps } = getSlotsNext<DialogActionsSlots>(state);
+  assertSlots<DialogActionsSlots>(state);
 
   // TODO Add additional slots in the appropriate place
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActions.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActions.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DialogActionsProps, DialogActionsState } from './DialogActions.types';
 
 /**
@@ -20,10 +20,13 @@ export const useDialogActions_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     position,
     fluid,
   };

--- a/packages/react-components/react-dialog/src/components/DialogBody/renderDialogBody.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogBody/renderDialogBody.tsx
@@ -3,15 +3,15 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogBodyState, DialogBodySlots } from './DialogBody.types';
 
 /**
  * Render the final JSX of DialogBody
  */
 export const renderDialogBody_unstable = (state: DialogBodyState) => {
-  const { slots, slotProps } = getSlotsNext<DialogBodySlots>(state);
+  assertSlots<DialogBodySlots>(state);
 
   // TODO Add additional slots in the appropriate place
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-dialog/src/components/DialogBody/useDialogBody.ts
+++ b/packages/react-components/react-dialog/src/components/DialogBody/useDialogBody.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DialogBodyProps, DialogBodyState } from './DialogBody.types';
 
 /**
@@ -16,9 +16,12 @@ export const useDialogBody_unstable = (props: DialogBodyProps, ref: React.Ref<HT
     components: {
       root: 'div',
     },
-    root: getNativeElementProps(props.as ?? 'div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(props.as ?? 'div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-dialog/src/components/DialogContent/renderDialogContent.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogContent/renderDialogContent.tsx
@@ -3,14 +3,14 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogContentState, DialogContentSlots } from './DialogContent.types';
 
 /**
  * Render the final JSX of DialogContent
  */
 export const renderDialogContent_unstable = (state: DialogContentState) => {
-  const { slots, slotProps } = getSlotsNext<DialogContentSlots>(state);
+  assertSlots<DialogContentSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContent.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContent.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { DialogContentProps, DialogContentState } from './DialogContent.types';
 
 /**
@@ -19,9 +19,12 @@ export const useDialogContent_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps(props.as ?? 'div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(props.as ?? 'div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-dialog/src/components/DialogSurface/renderDialogSurface.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/renderDialogSurface.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogSurfaceState, DialogSurfaceSlots, DialogSurfaceContextValues } from './DialogSurface.types';
 import { DialogSurfaceProvider } from '../../contexts';
 import { Portal } from '@fluentui/react-portal';
@@ -12,13 +12,13 @@ import { Portal } from '@fluentui/react-portal';
  * Render the final JSX of DialogSurface
  */
 export const renderDialogSurface_unstable = (state: DialogSurfaceState, contextValues: DialogSurfaceContextValues) => {
-  const { slots, slotProps } = getSlotsNext<DialogSurfaceSlots>(state);
+  assertSlots<DialogSurfaceSlots>(state);
 
   return (
     <Portal>
-      {slots.backdrop && <slots.backdrop {...slotProps.backdrop} />}
+      {state.backdrop && <state.backdrop />}
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
-        <slots.root {...slotProps.root} />
+        <state.root />
       </DialogSurfaceProvider>
     </Portal>
   );

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {
   getNativeElementProps,
-  resolveShorthand,
   useEventCallback,
   useMergedRefs,
   isResolvedShorthand,
+  slot,
 } from '@fluentui/react-utilities';
 import type { DialogSurfaceElement, DialogSurfaceProps, DialogSurfaceState } from './DialogSurface.types';
 import { useDialogContext_unstable } from '../../contexts';
@@ -58,32 +58,31 @@ export const useDialogSurface_unstable = (
     }
   });
 
-  const backdrop = resolveShorthand(props.backdrop, {
-    required: open && modalType !== 'non-modal',
+  const backdrop = slot.optional(props.backdrop, {
+    renderByDefault: open && modalType !== 'non-modal',
     defaultProps: {
       'aria-hidden': 'true',
     },
+    elementType: 'div',
   });
-
   if (backdrop) {
     backdrop.onClick = handledBackdropClick;
   }
-
   return {
-    components: {
-      backdrop: 'div',
-      root: 'div',
-    },
+    components: { backdrop: 'div', root: 'div' },
     backdrop,
-    root: getNativeElementProps(props.as ?? 'div', {
-      tabIndex: -1, // https://github.com/microsoft/fluentui/issues/25150
-      'aria-modal': modalType !== 'non-modal',
-      role: modalType === 'alert' ? 'alertdialog' : 'dialog',
-      'aria-labelledby': props['aria-label'] ? undefined : dialogTitleID,
-      ...props,
-      ...modalAttributes,
-      onKeyDown: handleKeyDown,
-      ref: useMergedRefs(ref, dialogRef),
-    }),
+    root: slot.always(
+      getNativeElementProps(props.as ?? 'div', {
+        tabIndex: -1, // https://github.com/microsoft/fluentui/issues/25150
+        'aria-modal': modalType !== 'non-modal',
+        role: modalType === 'alert' ? 'alertdialog' : 'dialog',
+        'aria-labelledby': props['aria-label'] ? undefined : dialogTitleID,
+        ...props,
+        ...modalAttributes,
+        onKeyDown: handleKeyDown,
+        ref: useMergedRefs(ref, dialogRef),
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-dialog/src/components/DialogTitle/renderDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/renderDialogTitle.tsx
@@ -4,19 +4,19 @@
 
 import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogTitleState, DialogTitleSlots } from './DialogTitle.types';
 
 /**
  * Render the final JSX of DialogTitle
  */
 export const renderDialogTitle_unstable = (state: DialogTitleState) => {
-  const { slots, slotProps } = getSlotsNext<DialogTitleSlots>(state);
+  assertSlots<DialogTitleSlots>(state);
 
   return (
     <>
-      <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>
-      {slots.action && <slots.action {...slotProps.action} />}
+      <state.root>{state.root.children}</state.root>
+      {state.action && <state.action />}
     </>
   );
 };

--- a/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/useDialogTitle.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DialogTitleProps, DialogTitleState } from './DialogTitle.types';
 import { useDialogContext_unstable } from '../../contexts/dialogContext';
 import { Dismiss20Regular } from '@fluentui/react-icons';
-import { resolveShorthand } from '@fluentui/react-utilities';
 import { DialogTrigger } from '../DialogTrigger/DialogTrigger';
 import { useDialogTitleInternalStyles } from './useDialogTitleStyles.styles';
 
@@ -26,13 +25,16 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
       root: 'h2',
       action: 'div',
     },
-    root: getNativeElementProps(as ?? 'h2', {
-      ref,
-      id: useDialogContext_unstable(ctx => ctx.dialogTitleId),
-      ...props,
-    }),
-    action: resolveShorthand(action, {
-      required: modalType === 'non-modal',
+    root: slot.always(
+      getNativeElementProps(as ?? 'h2', {
+        ref,
+        id: useDialogContext_unstable(ctx => ctx.dialogTitleId),
+        ...props,
+      }),
+      { elementType: 'h2' },
+    ),
+    action: slot.optional(action, {
+      renderByDefault: modalType === 'non-modal',
       defaultProps: {
         children: (
           <DialogTrigger disableButtonEnhancement action="close">
@@ -47,6 +49,7 @@ export const useDialogTitle_unstable = (props: DialogTitleProps, ref: React.Ref<
           </DialogTrigger>
         ),
       },
+      elementType: 'div',
     }),
   };
 };

--- a/packages/react-components/react-divider/src/components/Divider/renderDivider.tsx
+++ b/packages/react-components/react-divider/src/components/Divider/renderDivider.tsx
@@ -3,19 +3,15 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { DividerSlots, DividerState } from './Divider.types';
 
 /**
  * Renders a Divider component by passing the slot props (defined in `state`) to the appropriate slots.
  */
 export const renderDivider_unstable = (state: DividerState) => {
-  const { slots, slotProps } = getSlotsNext<DividerSlots>(state);
+  assertSlots<DividerSlots>(state);
   return (
-    <slots.root {...slotProps.root}>
-      {slotProps.root.children !== undefined && (
-        <slots.wrapper {...slotProps.wrapper}>{slotProps.root.children}</slots.wrapper>
-      )}
-    </slots.root>
+    <state.root>{state.root.children !== undefined && <state.wrapper>{state.root.children}</state.wrapper>}</state.root>
   );
 };

--- a/packages/react-components/react-divider/src/components/Divider/useDivider.ts
+++ b/packages/react-components/react-divider/src/components/Divider/useDivider.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, slot } from '@fluentui/react-utilities';
 import type { DividerProps, DividerState } from './Divider.types';
 
 /**
@@ -24,19 +24,22 @@ export const useDivider_unstable = (props: DividerProps, ref: React.Ref<HTMLElem
       wrapper: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      role: 'separator',
-      'aria-orientation': vertical ? 'vertical' : 'horizontal',
-      'aria-labelledby': props.children ? dividerId : undefined,
-      ...props,
-      ref,
-    }),
-    wrapper: resolveShorthand(wrapper, {
-      required: true,
+    root: slot.always(
+      getNativeElementProps('div', {
+        role: 'separator',
+        'aria-orientation': vertical ? 'vertical' : 'horizontal',
+        'aria-labelledby': props.children ? dividerId : undefined,
+        ...props,
+        ref,
+      }),
+      { elementType: 'div' },
+    ),
+    wrapper: slot.always(wrapper, {
       defaultProps: {
         id: dividerId,
         children: props.children,
       },
+      elementType: 'div',
     }),
   };
 };

--- a/packages/react-components/react-drawer/src/components/Drawer/renderDrawer.tsx
+++ b/packages/react-components/react-drawer/src/components/Drawer/renderDrawer.tsx
@@ -3,14 +3,14 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerState, DrawerSlots } from './Drawer.types';
 
 /**
  * Render the final JSX of Drawer
  */
 export const renderDrawer_unstable = (state: DrawerState) => {
-  const { slots, slotProps } = getSlotsNext<DrawerSlots>(state);
+  assertSlots<DrawerSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-drawer/src/components/Drawer/useDrawer.ts
+++ b/packages/react-components/react-drawer/src/components/Drawer/useDrawer.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 
 import type { DrawerProps, DrawerState } from './Drawer.types';
 import { DrawerOverlay } from '../DrawerOverlay/DrawerOverlay';
@@ -22,11 +22,11 @@ export const useDrawer_unstable = (props: DrawerProps, ref: React.Ref<HTMLElemen
       root: type === 'overlay' ? DrawerOverlay : DrawerInline,
     },
 
-    root: resolveShorthand(props, {
-      required: true,
+    root: slot.always(props, {
       defaultProps: {
         ref,
       } as DrawerProps,
+      elementType: type === 'overlay' ? DrawerOverlay : DrawerInline,
     }),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerBody/renderDrawerBody.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerBody/renderDrawerBody.tsx
@@ -1,12 +1,15 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerBodyState, DrawerBodySlots } from './DrawerBody.types';
 
 /**
  * Render the final JSX of DrawerBody
  */
 export const renderDrawerBody_unstable = (state: DrawerBodyState) => {
-  const { slots, slotProps } = getSlots<DrawerBodySlots>(state);
+  assertSlots<DrawerBodySlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-drawer/src/components/DrawerBody/useDrawerBody.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerBody/useDrawerBody.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerBodyProps, DrawerBodyState } from './DrawerBody.types';
 
 /**
@@ -17,9 +17,12 @@ export const useDrawerBody_unstable = (props: DrawerBodyProps, ref: React.Ref<HT
       root: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerFooter/renderDrawerFooter.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerFooter/renderDrawerFooter.tsx
@@ -1,12 +1,15 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerFooterState, DrawerFooterSlots } from './DrawerFooter.types';
 
 /**
  * Render the final JSX of DrawerFooter
  */
 export const renderDrawerFooter_unstable = (state: DrawerFooterState) => {
-  const { slots, slotProps } = getSlots<DrawerFooterSlots>(state);
+  assertSlots<DrawerFooterSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-drawer/src/components/DrawerFooter/useDrawerFooter.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerFooter/useDrawerFooter.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerFooterProps, DrawerFooterState } from './DrawerFooter.types';
 
 /**
@@ -17,9 +17,12 @@ export const useDrawerFooter_unstable = (props: DrawerFooterProps, ref: React.Re
       root: 'footer',
     },
 
-    root: getNativeElementProps('footer', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('footer', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'footer' },
+    ),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeader/renderDrawerHeader.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerHeader/renderDrawerHeader.tsx
@@ -1,12 +1,15 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerHeaderState, DrawerHeaderSlots } from './DrawerHeader.types';
 
 /**
  * Render the final JSX of DrawerHeader
  */
 export const renderDrawerHeader_unstable = (state: DrawerHeaderState) => {
-  const { slots, slotProps } = getSlots<DrawerHeaderSlots>(state);
+  assertSlots<DrawerHeaderSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeader/useDrawerHeader.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeader/useDrawerHeader.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerHeaderProps, DrawerHeaderState } from './DrawerHeader.types';
 
 /**
@@ -17,9 +17,12 @@ export const useDrawerHeader_unstable = (props: DrawerHeaderProps, ref: React.Re
       root: 'header',
     },
 
-    root: getNativeElementProps('header', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('header', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'header' },
+    ),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderNavigation/renderDrawerHeaderNavigation.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderNavigation/renderDrawerHeaderNavigation.tsx
@@ -1,12 +1,15 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerHeaderNavigationState, DrawerHeaderNavigationSlots } from './DrawerHeaderNavigation.types';
 
 /**
  * Render the final JSX of DrawerHeaderNavigation
  */
 export const renderDrawerHeaderNavigation_unstable = (state: DrawerHeaderNavigationState) => {
-  const { slots, slotProps } = getSlots<DrawerHeaderNavigationSlots>(state);
+  assertSlots<DrawerHeaderNavigationSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderNavigation/useDrawerHeaderNavigation.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderNavigation/useDrawerHeaderNavigation.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerHeaderNavigationProps, DrawerHeaderNavigationState } from './DrawerHeaderNavigation.types';
 
 /**
@@ -20,9 +20,12 @@ export const useDrawerHeaderNavigation_unstable = (
       root: 'nav',
     },
 
-    root: getNativeElementProps('nav', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('nav', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'nav' },
+    ),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/renderDrawerHeaderTitle.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/renderDrawerHeaderTitle.tsx
@@ -1,17 +1,20 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerHeaderTitleState, DrawerHeaderTitleSlots } from './DrawerHeaderTitle.types';
 
 /**
  * Render the final JSX of DrawerHeaderTitle
  */
 export const renderDrawerHeaderTitle_unstable = (state: DrawerHeaderTitleState) => {
-  const { slots, slotProps } = getSlots<DrawerHeaderTitleSlots>(state);
+  assertSlots<DrawerHeaderTitleSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.heading && <slots.heading {...slotProps.heading} />}
-      {slots.action && <slots.action {...slotProps.action} />}
-    </slots.root>
+    <state.root>
+      {state.heading && <state.heading />}
+      {state.action && <state.action />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
 import { useDialogTitle_unstable } from '@fluentui/react-dialog';
 
@@ -25,19 +25,24 @@ export const useDrawerHeaderTitle_unstable = (
       action: titleComponents.action,
     },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
-    heading: resolveShorthand(props.heading, {
-      required: true,
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+    heading: slot.optional(props.heading, {
+      renderByDefault: true,
       defaultProps: {
         ...heading,
         className: undefined, // remove className from heading
       },
+      elementType: titleComponents.root,
     }),
-    action: resolveShorthand(props.action, {
+    action: slot.optional(props.action, {
       defaultProps: action,
+      elementType: titleComponents.action,
     }),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerInline/renderDrawerInline.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/renderDrawerInline.tsx
@@ -1,16 +1,18 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerInlineState, DrawerInlineSlots } from './DrawerInline.types';
 
 /**
  * Render the final JSX of DrawerInline
  */
 export const renderDrawerInline_unstable = (state: DrawerInlineState) => {
-  const { slots, slotProps } = getSlots<DrawerInlineSlots>(state);
+  assertSlots<DrawerInlineSlots>(state);
 
   if (!state.open) {
     return null;
   }
-
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-drawer/src/components/DrawerInline/useDrawerInline.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/useDrawerInline.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useControllableState } from '@fluentui/react-utilities';
+import { getNativeElementProps, useControllableState, slot } from '@fluentui/react-utilities';
 import type { DrawerInlineProps, DrawerInlineState } from './DrawerInline.types';
 import { getDefaultDrawerProps } from '../../util/getDefaultDrawerProps';
 
@@ -27,10 +27,13 @@ export const useDrawerInline_unstable = (props: DrawerInlineProps, ref: React.Re
       root: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
 
     size,
     position,

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/renderDrawerOverlay.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/renderDrawerOverlay.tsx
@@ -1,5 +1,8 @@
-import * as React from 'react';
-import { getSlots } from '@fluentui/react-utilities';
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
+import { createElement } from '@fluentui/react-jsx-runtime';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DrawerOverlayState, DrawerOverlaySlots } from './DrawerOverlay.types';
 import { Dialog } from '@fluentui/react-dialog';
 
@@ -7,11 +10,11 @@ import { Dialog } from '@fluentui/react-dialog';
  * Render the final JSX of DrawerOverlay
  */
 export const renderDrawerOverlay_unstable = (state: DrawerOverlayState) => {
-  const { slots, slotProps } = getSlots<DrawerOverlaySlots>(state);
+  assertSlots<DrawerOverlaySlots>(state);
 
   return (
     <Dialog {...state.dialog}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </Dialog>
   );
 };

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerOverlayProps, DrawerOverlayState } from './DrawerOverlay.types';
 import { DialogProps, DialogSurface } from '@fluentui/react-dialog';
 import { getDefaultDrawerProps } from '../../util/getDefaultDrawerProps';
@@ -26,10 +26,13 @@ export const useDrawerOverlay_unstable = (
       backdrop: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: DialogSurface },
+    ),
     dialog: {
       open,
       defaultOpen,

--- a/packages/react-components/react-field/src/components/Field/renderField.tsx
+++ b/packages/react-components/react-field/src/components/Field/renderField.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { FieldContextProvider, getFieldControlProps } from '../../contexts/index';
 import type { FieldContextValues, FieldSlots, FieldState } from './Field.types';
 
@@ -11,7 +11,7 @@ import type { FieldContextValues, FieldSlots, FieldState } from './Field.types';
  * Render the final JSX of Field
  */
 export const renderField_unstable = (state: FieldState, contextValues: FieldContextValues) => {
-  const { slots, slotProps } = getSlotsNext<FieldSlots>(state);
+  assertSlots<FieldSlots>(state);
 
   let { children } = state;
   if (typeof children === 'function') {
@@ -20,17 +20,18 @@ export const renderField_unstable = (state: FieldState, contextValues: FieldCont
 
   return (
     <FieldContextProvider value={contextValues?.field}>
-      <slots.root {...slotProps.root}>
-        {slots.label && <slots.label {...slotProps.label} />}
+      <state.root>
+        {state.label && <state.label />}
         {children}
-        {slots.validationMessage && (
-          <slots.validationMessage {...slotProps.validationMessage}>
-            {slots.validationMessageIcon && <slots.validationMessageIcon {...slotProps.validationMessageIcon} />}
-            {slotProps.validationMessage.children}
-          </slots.validationMessage>
+        {state.validationMessage && (
+          <state.validationMessage>
+            {state.validationMessageIcon && <state.validationMessageIcon />}
+            {state.validationMessage.children}
+          </state.validationMessage>
         )}
-        {slots.hint && <slots.hint {...slotProps.hint} />}
-      </slots.root>
+
+        {state.hint && <state.hint />}
+      </state.root>
     </FieldContextProvider>
   );
 };

--- a/packages/react-components/react-field/src/components/Field/useField.tsx
+++ b/packages/react-components/react-field/src/components/Field/useField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { CheckmarkCircle12Filled, ErrorCircle12Filled, Warning12Filled } from '@fluentui/react-icons';
 import { Label } from '@fluentui/react-label';
-import { getNativeElementProps, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, slot } from '@fluentui/react-utilities';
 import type { FieldProps, FieldState } from './Field.types';
 
 const validationMessageIcons = {
@@ -33,38 +33,24 @@ export const useField_unstable = (props: FieldProps, ref: React.Ref<HTMLDivEleme
   const baseId = useId('field-');
   const generatedControlId = baseId + '__control';
 
-  const root = getNativeElementProps('div', { ...props, ref }, /*excludedPropNames:*/ ['children']);
-
-  const label = resolveShorthand(props.label, {
-    defaultProps: {
-      htmlFor: generatedControlId,
-      id: baseId + '__label',
-      required,
-      size,
-    },
+  const root = slot.always(getNativeElementProps('div', { ...props, ref }, /*excludedPropNames:*/ ['children']), {
+    elementType: 'div',
   });
-
-  const validationMessage = resolveShorthand(props.validationMessage, {
-    defaultProps: {
-      id: baseId + '__validationMessage',
-      role: validationState === 'error' ? 'alert' : undefined,
-    },
+  const label = slot.optional(props.label, {
+    defaultProps: { htmlFor: generatedControlId, id: baseId + '__label', required, size },
+    elementType: Label,
   });
-
-  const hint = resolveShorthand(props.hint, {
-    defaultProps: {
-      id: baseId + '__hint',
-    },
+  const validationMessage = slot.optional(props.validationMessage, {
+    defaultProps: { id: baseId + '__validationMessage', role: validationState === 'error' ? 'alert' : undefined },
+    elementType: 'div',
   });
-
+  const hint = slot.optional(props.hint, { defaultProps: { id: baseId + '__hint' }, elementType: 'div' });
   const defaultIcon = validationMessageIcons[validationState];
-  const validationMessageIcon = resolveShorthand(props.validationMessageIcon, {
-    required: !!defaultIcon,
-    defaultProps: {
-      children: defaultIcon,
-    },
+  const validationMessageIcon = slot.optional(props.validationMessageIcon, {
+    renderByDefault: !!defaultIcon,
+    defaultProps: { children: defaultIcon },
+    elementType: 'span',
   });
-
   return {
     children,
     generatedControlId,
@@ -72,13 +58,7 @@ export const useField_unstable = (props: FieldProps, ref: React.Ref<HTMLDivEleme
     required,
     size,
     validationState,
-    components: {
-      root: 'div',
-      label: Label,
-      validationMessage: 'div',
-      validationMessageIcon: 'span',
-      hint: 'div',
-    },
+    components: { root: 'div', label: Label, validationMessage: 'div', validationMessageIcon: 'span', hint: 'div' },
     root,
     label,
     validationMessageIcon,

--- a/packages/react-components/react-image/src/components/Image/renderImage.tsx
+++ b/packages/react-components/react-image/src/components/Image/renderImage.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { ImageSlots, ImageState } from './Image.types';
 
 /**
@@ -11,7 +11,7 @@ import { ImageSlots, ImageState } from './Image.types';
  * Given the state of an image, renders it.
  */
 export const renderImage_unstable = (state: ImageState) => {
-  const { slots, slotProps } = getSlotsNext<ImageSlots>(state);
+  assertSlots<ImageSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-image/src/components/Image/useImage.ts
+++ b/packages/react-components/react-image/src/components/Image/useImage.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { ImageProps, ImageState } from './Image.types';
 
 /**
@@ -17,10 +17,13 @@ export const useImage_unstable = (props: ImageProps, ref: React.Ref<HTMLImageEle
     components: {
       root: 'img',
     },
-    root: getNativeElementProps('img', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps<ImageProps>('img', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'img' },
+    ),
   };
 
   return state;

--- a/packages/react-components/react-infobutton/src/components/InfoButton/renderInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/renderInfoButton.tsx
@@ -3,23 +3,22 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { PopoverTrigger } from '@fluentui/react-popover';
-import type { PopoverProps } from '@fluentui/react-popover';
 import type { InfoButtonState, InfoButtonSlots } from './InfoButton.types';
 
 /**
  * Render the final JSX of InfoButton
  */
 export const renderInfoButton_unstable = (state: InfoButtonState) => {
-  const { slots, slotProps } = getSlotsNext<InfoButtonSlots>(state);
+  assertSlots<InfoButtonSlots>(state);
 
   return (
-    <slots.popover {...(slotProps.popover as PopoverProps)}>
+    <state.popover>
       <PopoverTrigger>
-        <slots.root {...slotProps.root} />
+        <state.root />
       </PopoverTrigger>
-      <slots.info {...slotProps.info} />
-    </slots.popover>
+      <state.info />
+    </state.popover>
   );
 };

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButton.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { DefaultInfoButtonIcon12, DefaultInfoButtonIcon16, DefaultInfoButtonIcon20 } from './DefaultInfoButtonIcons';
-import { getNativeElementProps, mergeCallbacks, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, mergeCallbacks, useControllableState, slot } from '@fluentui/react-utilities';
 import { Popover, PopoverSurface } from '@fluentui/react-popover';
-import { useControllableState } from '@fluentui/react-utilities';
 import type { InfoButtonProps, InfoButtonState } from './InfoButton.types';
 import type { PopoverProps } from '@fluentui/react-popover';
 
@@ -39,27 +38,30 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
       info: PopoverSurface,
     },
 
-    root: getNativeElementProps('button', {
-      children: infoButtonIconMap[size],
-      type: 'button',
-      'aria-label': 'information',
-      ...props,
-      ref,
-    }),
-    popover: resolveShorthand(props.popover, {
-      required: true,
+    root: slot.always(
+      getNativeElementProps('button', {
+        children: infoButtonIconMap[size],
+        type: 'button',
+        'aria-label': 'information',
+        ...props,
+        ref,
+      }),
+      { elementType: 'button' },
+    ),
+    popover: slot.always(props.popover, {
       defaultProps: {
         positioning: 'above-start',
         size: popoverSizeMap[size],
         withArrow: true,
       },
+      elementType: Popover as React.FC<Partial<PopoverProps>>,
     }),
-    info: resolveShorthand(props.info, {
-      required: true,
+    info: slot.always(props.info, {
       defaultProps: {
         role: 'note',
         tabIndex: -1,
       },
+      elementType: PopoverSurface,
     }),
   };
 

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/renderInfoLabel.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/renderInfoLabel.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { InfoLabelSlots, InfoLabelState } from './InfoLabel.types';
 
 /**
  * Render the final JSX of InfoLabel
  */
 export const renderInfoLabel_unstable = (state: InfoLabelState) => {
-  const { slots, slotProps } = getSlotsNext<InfoLabelSlots>(state);
+  assertSlots<InfoLabelSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.label {...slotProps.label} />
-      {slots.infoButton && <slots.infoButton {...slotProps.infoButton} />}
-    </slots.root>
+    <state.root>
+      <state.label />
+      {state.infoButton && <state.infoButton />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/useInfoLabel.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/useInfoLabel.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Label } from '@fluentui/react-label';
-import { mergeCallbacks, resolveShorthand, useEventCallback, useId } from '@fluentui/react-utilities';
+import { mergeCallbacks, useEventCallback, useId, slot } from '@fluentui/react-utilities';
 import { InfoButton } from '../InfoButton/InfoButton';
 import type { InfoLabelProps, InfoLabelState } from './InfoLabel.types';
 
@@ -28,34 +28,37 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
   const baseId = useId('infolabel-');
   const [open, setOpen] = React.useState(false);
 
-  const root = resolveShorthand(rootShorthand, {
-    required: true,
+  const root = slot.always(rootShorthand, {
     defaultProps: {
       className,
       style,
     },
+    elementType: 'span',
   });
 
-  const label = resolveShorthand(labelShorthand, {
-    required: true,
+  const label = slot.always(labelShorthand, {
     defaultProps: {
       id: baseId + '__label',
       ref,
       size,
       ...labelProps,
     },
+    elementType: Label,
   });
 
-  const infoButton = resolveShorthand(infoButtonShorthand, {
-    required: !!info,
+  const infoButton = slot.optional(infoButtonShorthand, {
+    renderByDefault: !!info,
     defaultProps: {
       id: baseId + '__infoButton',
       size,
       info,
     },
+    elementType: InfoButton,
   });
 
-  const infoButtonPopover = resolveShorthand(infoButton?.popover, { required: true });
+  const infoButtonPopover = slot.always(infoButton?.popover, {
+    elementType: 'div',
+  });
   infoButtonPopover.onOpenChange = useEventCallback(
     mergeCallbacks(infoButtonPopover.onOpenChange, (e, data) => {
       setOpen(data.open);
@@ -64,10 +67,11 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
 
   if (infoButton) {
     infoButton.popover = infoButtonPopover;
-    infoButton.info = resolveShorthand(infoButton?.info, {
+    infoButton.info = slot.optional(infoButton?.info, {
       defaultProps: {
         id: baseId + '__info',
       },
+      elementType: 'div',
     });
 
     infoButton['aria-labelledby'] ??= `${label.id} ${infoButton.id}`;

--- a/packages/react-components/react-input/src/components/Input/renderInput.tsx
+++ b/packages/react-components/react-input/src/components/Input/renderInput.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { InputSlots, InputState } from './Input.types';
 
 /**
  * Render the final JSX of Input
  */
 export const renderInput_unstable = (state: InputState) => {
-  const { slots, slotProps } = getSlotsNext<InputSlots>(state);
+  assertSlots<InputSlots>(state);
   return (
-    <slots.root {...slotProps.root}>
-      {slots.contentBefore && <slots.contentBefore {...slotProps.contentBefore} />}
-      <slots.input {...slotProps.input} />
-      {slots.contentAfter && <slots.contentAfter {...slotProps.contentAfter} />}
-    </slots.root>
+    <state.root>
+      {state.contentBefore && <state.contentBefore />}
+      <state.input />
+      {state.contentAfter && <state.contentAfter />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-input/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/src/components/Input/useInput.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import {
-  getPartitionedNativeProps,
-  resolveShorthand,
-  useControllableState,
-  useEventCallback,
-} from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { InputProps, InputState } from './Input.types';
 import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-contexts';
 
@@ -57,19 +52,19 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
       contentBefore: 'span',
       contentAfter: 'span',
     },
-    input: resolveShorthand(props.input, {
-      required: true,
+    input: slot.always(props.input, {
       defaultProps: {
         type: 'text',
         ref,
         ...nativeProps.primary,
       },
+      elementType: 'input',
     }),
-    contentAfter: resolveShorthand(props.contentAfter),
-    contentBefore: resolveShorthand(props.contentBefore),
-    root: resolveShorthand(props.root, {
-      required: true,
+    contentAfter: slot.optional(props.contentAfter, { elementType: 'span' }),
+    contentBefore: slot.optional(props.contentBefore, { elementType: 'span' }),
+    root: slot.always(props.root, {
       defaultProps: nativeProps.root,
+      elementType: 'span',
     }),
   };
 

--- a/packages/react-components/react-label/src/components/Label/renderLabel.tsx
+++ b/packages/react-components/react-label/src/components/Label/renderLabel.tsx
@@ -3,19 +3,19 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { LabelState, LabelSlots } from './Label.types';
 
 /**
  * Render the final JSX of Label
  */
 export const renderLabel_unstable = (state: LabelState) => {
-  const { slots, slotProps } = getSlotsNext<LabelSlots>(state);
+  assertSlots<LabelSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       {state.root.children}
-      {slots.required && <slots.required {...slotProps.required} />}
-    </slots.root>
+      {state.required && <state.required />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-label/src/components/Label/useLabel.tsx
+++ b/packages/react-components/react-label/src/components/Label/useLabel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { LabelProps, LabelState } from './Label.types';
-import { resolveShorthand } from '@fluentui/react-utilities';
 
 /**
  * Create the state required to render Label.
@@ -16,12 +15,13 @@ export const useLabel_unstable = (props: LabelProps, ref: React.Ref<HTMLElement>
   const { disabled = false, required = false, weight = 'regular', size = 'medium' } = props;
   return {
     disabled,
-    required: resolveShorthand(required === true ? '*' : required || undefined, {
+    required: slot.optional(required === true ? '*' : required || undefined, {
       defaultProps: { 'aria-hidden': 'true' },
+      elementType: 'span',
     }),
     weight,
     size,
     components: { root: 'label', required: 'span' },
-    root: getNativeElementProps('label', { ref, ...props }),
+    root: slot.always(getNativeElementProps('label', { ref, ...props }), { elementType: 'label' }),
   };
 };

--- a/packages/react-components/react-link/src/components/Link/renderLink.tsx
+++ b/packages/react-components/react-link/src/components/Link/renderLink.tsx
@@ -3,14 +3,14 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { LinkSlots, LinkState } from './Link.types';
 
 /**
  * Renders a Link component by passing the state defined props to the appropriate slots.
  */
 export const renderLink_unstable = (state: LinkState) => {
-  const { slots, slotProps } = getSlotsNext<LinkSlots>(state);
+  assertSlots<LinkSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-link/src/components/Link/useLink.ts
+++ b/packages/react-components/react-link/src/components/Link/useLink.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useBackgroundAppearance } from '@fluentui/react-shared-contexts';
 import { useLinkState_unstable } from './useLinkState';
 import type { LinkProps, LinkState } from './Link.types';
@@ -30,12 +30,15 @@ export const useLink_unstable = (
       root: 'a',
     },
 
-    root: getNativeElementProps(as, {
-      ref,
-      type,
-      ...props,
-      as,
-    }),
+    root: slot.always(
+      getNativeElementProps(as, {
+        ref,
+        type,
+        ...props,
+        as,
+      }),
+      { elementType: 'a' },
+    ),
     backgroundAppearance,
   };
 

--- a/packages/react-components/react-menu/src/components/MenuDivider/renderMenuDivider.tsx
+++ b/packages/react-components/react-menu/src/components/MenuDivider/renderMenuDivider.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { MenuDividerSlots, MenuDividerState } from './MenuDivider.types';
 
 /**
@@ -10,7 +10,7 @@ import { MenuDividerSlots, MenuDividerState } from './MenuDivider.types';
  * slots to children.
  */
 export const renderMenuDivider_unstable = (state: MenuDividerState) => {
-  const { slots, slotProps } = getSlotsNext<MenuDividerSlots>(state);
+  assertSlots<MenuDividerSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-menu/src/components/MenuDivider/useMenuDivider.ts
+++ b/packages/react-components/react-menu/src/components/MenuDivider/useMenuDivider.ts
@@ -1,4 +1,4 @@
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 import type { MenuDividerProps, MenuDividerState } from './MenuDivider.types';
 
@@ -10,11 +10,14 @@ export const useMenuDivider_unstable = (props: MenuDividerProps, ref: React.Ref<
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      role: 'presentation',
-      'aria-hidden': true,
-      ...props,
-      ref,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        role: 'presentation',
+        'aria-hidden': true,
+        ...props,
+        ref,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-menu/src/components/MenuGroup/renderMenuGroup.tsx
+++ b/packages/react-components/react-menu/src/components/MenuGroup/renderMenuGroup.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { MenuGroupContextValues, MenuGroupSlots, MenuGroupState } from './MenuGroup.types';
 import { MenuGroupContextProvider } from '../../contexts/menuGroupContext';
 
@@ -11,11 +11,11 @@ import { MenuGroupContextProvider } from '../../contexts/menuGroupContext';
  * slots to children.
  */
 export const renderMenuGroup_unstable = (state: MenuGroupState, contextValues: MenuGroupContextValues) => {
-  const { slots, slotProps } = getSlotsNext<MenuGroupSlots>(state);
+  assertSlots<MenuGroupSlots>(state);
 
   return (
     <MenuGroupContextProvider value={contextValues.menuGroup}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </MenuGroupContextProvider>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuGroup/useMenuGroup.ts
+++ b/packages/react-components/react-menu/src/components/MenuGroup/useMenuGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, slot } from '@fluentui/react-utilities';
 import { MenuGroupProps, MenuGroupState } from './MenuGroup.types';
 
 /**
@@ -12,12 +12,15 @@ export function useMenuGroup_unstable(props: MenuGroupProps, ref: React.Ref<HTML
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      'aria-labelledby': headerId,
-      role: 'group',
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        'aria-labelledby': headerId,
+        role: 'group',
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     headerId,
   };
 }

--- a/packages/react-components/react-menu/src/components/MenuGroupHeader/renderMenuGroupHeader.tsx
+++ b/packages/react-components/react-menu/src/components/MenuGroupHeader/renderMenuGroupHeader.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { MenuGroupHeaderSlots, MenuGroupHeaderState } from './MenuGroupHeader.types';
 
 /**
@@ -10,7 +10,7 @@ import { MenuGroupHeaderSlots, MenuGroupHeaderState } from './MenuGroupHeader.ty
  * slots to children.
  */
 export const renderMenuGroupHeader_unstable = (state: MenuGroupHeaderState) => {
-  const { slots, slotProps } = getSlotsNext<MenuGroupHeaderSlots>(state);
+  assertSlots<MenuGroupHeaderSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-menu/src/components/MenuGroupHeader/useMenuGroupHeader.ts
+++ b/packages/react-components/react-menu/src/components/MenuGroupHeader/useMenuGroupHeader.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMenuGroupContext_unstable } from '../../contexts/menuGroupContext';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { MenuGroupHeaderProps, MenuGroupHeaderState } from './MenuGroupHeader.types';
 
 /**
@@ -16,10 +16,13 @@ export function useMenuGroupHeader_unstable(
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      id,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        id,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 }

--- a/packages/react-components/react-menu/src/components/MenuItem/renderMenuItem.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItem/renderMenuItem.tsx
@@ -2,22 +2,22 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { MenuItemSlots, MenuItemState } from './MenuItem.types';
 
 /**
  * Function that renders the final JSX of the component
  */
 export const renderMenuItem_unstable = (state: MenuItemState) => {
-  const { slots, slotProps } = getSlotsNext<MenuItemSlots>(state);
+  assertSlots<MenuItemSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.checkmark && <slots.checkmark {...slotProps.checkmark} />}
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.content && <slots.content {...slotProps.content} />}
-      {slots.secondaryContent && <slots.secondaryContent {...slotProps.secondaryContent} />}
-      {slots.submenuIndicator && <slots.submenuIndicator {...slotProps.submenuIndicator} />}
-    </slots.root>
+    <state.root>
+      {state.checkmark && <state.checkmark />}
+      {state.icon && <state.icon />}
+      {state.content && <state.content />}
+      {state.secondaryContent && <state.secondaryContent />}
+      {state.submenuIndicator && <state.submenuIndicator />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEventCallback, resolveShorthand, useMergedRefs, getNativeElementProps } from '@fluentui/react-utilities';
+import { useEventCallback, useMergedRefs, getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useCharacterSearch } from './useCharacterSearch';
 import { useMenuTriggerContext_unstable } from '../../contexts/menuTriggerContext';
@@ -46,54 +46,59 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
       content: 'span',
       secondaryContent: 'span',
     },
-    root: getNativeElementProps(
-      as,
-      useARIAButtonProps(as, {
-        role: 'menuitem',
-        ...props,
-        disabled: false,
-        disabledFocusable: disabled,
-        ref: useMergedRefs(ref, innerRef) as React.Ref<ARIAButtonElementIntersection<'div'>>,
-        onKeyDown: useEventCallback(event => {
-          props.onKeyDown?.(event);
-          if (!event.isDefaultPrevented() && (event.key === Space || event.key === Enter)) {
-            dismissedWithKeyboardRef.current = true;
-          }
-        }),
-        onMouseEnter: useEventCallback(event => {
-          innerRef.current?.focus();
+    root: slot.always(
+      getNativeElementProps(
+        as,
+        useARIAButtonProps(as, {
+          role: 'menuitem',
+          ...props,
+          disabled: false,
+          disabledFocusable: disabled,
+          ref: useMergedRefs(ref, innerRef) as React.Ref<ARIAButtonElementIntersection<'div'>>,
+          onKeyDown: useEventCallback(event => {
+            props.onKeyDown?.(event);
+            if (!event.isDefaultPrevented() && (event.key === Space || event.key === Enter)) {
+              dismissedWithKeyboardRef.current = true;
+            }
+          }),
+          onMouseEnter: useEventCallback(event => {
+            innerRef.current?.focus();
 
-          props.onMouseEnter?.(event);
-        }),
-        onClick: useEventCallback(event => {
-          if (!hasSubmenu && !persistOnClick) {
-            setOpen(event, {
-              open: false,
-              keyboard: dismissedWithKeyboardRef.current,
-              bubble: true,
-              type: 'menuItemClick',
-              event,
-            });
-            dismissedWithKeyboardRef.current = false;
-          }
+            props.onMouseEnter?.(event);
+          }),
+          onClick: useEventCallback(event => {
+            if (!hasSubmenu && !persistOnClick) {
+              setOpen(event, {
+                open: false,
+                keyboard: dismissedWithKeyboardRef.current,
+                bubble: true,
+                type: 'menuItemClick',
+                event,
+              });
+              dismissedWithKeyboardRef.current = false;
+            }
 
-          props.onClick?.(event);
+            props.onClick?.(event);
+          }),
         }),
-      }),
+      ),
+      { elementType: 'div' },
     ),
-    icon: resolveShorthand(props.icon, { required: hasIcons }),
-    checkmark: resolveShorthand(props.checkmark, { required: hasCheckmarks }),
-    submenuIndicator: resolveShorthand(props.submenuIndicator, {
-      required: hasSubmenu,
+    icon: slot.optional(props.icon, { renderByDefault: hasIcons, elementType: 'span' }),
+    checkmark: slot.optional(props.checkmark, { renderByDefault: hasCheckmarks, elementType: 'span' }),
+    submenuIndicator: slot.optional(props.submenuIndicator, {
+      renderByDefault: hasSubmenu,
       defaultProps: {
         children: dir === 'ltr' ? <ChevronRightIcon /> : <ChevronLeftIcon />,
       },
+      elementType: 'span',
     }),
-    content: resolveShorthand(props.content, {
-      required: !!props.children,
+    content: slot.optional(props.content, {
+      renderByDefault: !!props.children,
       defaultProps: { children: props.children },
+      elementType: 'span',
     }),
-    secondaryContent: resolveShorthand(props.secondaryContent),
+    secondaryContent: slot.optional(props.secondaryContent, { elementType: 'span' }),
   };
   useCharacterSearch(state, innerRef);
   return state;

--- a/packages/react-components/react-menu/src/components/MenuItemCheckbox/renderMenuItemCheckbox.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItemCheckbox/renderMenuItemCheckbox.tsx
@@ -2,20 +2,20 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { MenuItemCheckboxState } from './MenuItemCheckbox.types';
 import type { MenuItemSlots } from '../MenuItem/MenuItem.types';
 
 /** Function that renders the final JSX of the component  */
 export const renderMenuItemCheckbox_unstable = (state: MenuItemCheckboxState) => {
-  const { slots, slotProps } = getSlotsNext<MenuItemSlots>(state);
+  assertSlots<MenuItemSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.checkmark && <slots.checkmark {...slotProps.checkmark} />}
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.content && <slots.content {...slotProps.content} />}
-      {slots.secondaryContent && <slots.secondaryContent {...slotProps.secondaryContent} />}
-    </slots.root>
+    <state.root>
+      {state.checkmark && <state.checkmark />}
+      {state.icon && <state.icon />}
+      {state.content && <state.content />}
+      {state.secondaryContent && <state.secondaryContent />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { Checkmark16Filled } from '@fluentui/react-icons';
 import { useMenuListContext_unstable } from '../../contexts/menuListContext';
 import { useMenuItem_unstable } from '../MenuItem/useMenuItem';
@@ -26,9 +26,10 @@ export const useMenuItemCheckbox_unstable = (
         persistOnClick: true,
         ...props,
         'aria-checked': checked,
-        checkmark: resolveShorthand(props.checkmark, {
+        checkmark: slot.optional(props.checkmark, {
           defaultProps: { children: <Checkmark16Filled /> },
-          required: true,
+          renderByDefault: true,
+          elementType: 'span',
         }),
         onClick: (e: React.MouseEvent<ARIAButtonElementIntersection<'div'>>) => {
           toggleCheckbox?.(e, name, value, checked);

--- a/packages/react-components/react-menu/src/components/MenuItemLink/renderMenuItemLink.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItemLink/renderMenuItemLink.tsx
@@ -2,22 +2,22 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { MenuItemLinkState, MenuItemLinkSlots } from './MenuItemLink.types';
 
 /**
  * Render the final JSX of MenuItemLink
  */
 export const renderMenuItemLink_unstable = (state: MenuItemLinkState) => {
-  const { slots, slotProps } = getSlotsNext<MenuItemLinkSlots>(state);
+  assertSlots<MenuItemLinkSlots>(state);
 
   // TODO Add additional slots in the appropriate place
   return (
-    <slots.root {...slotProps.root}>
-      {slots.checkmark && <slots.checkmark {...slotProps.checkmark} />}
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.content && <slots.content {...slotProps.content} />}
-      {slots.secondaryContent && <slots.secondaryContent {...slotProps.secondaryContent} />}
-    </slots.root>
+    <state.root>
+      {state.checkmark && <state.checkmark />}
+      {state.icon && <state.icon />}
+      {state.content && <state.content />}
+      {state.secondaryContent && <state.secondaryContent />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuItemLink/useMenuItemLink.ts
+++ b/packages/react-components/react-menu/src/components/MenuItemLink/useMenuItemLink.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { MenuItemLinkProps, MenuItemLinkState } from './MenuItemLink.types';
 import { useMenuItem_unstable } from '../MenuItem/useMenuItem';
 import { MenuItemProps } from '../MenuItem/MenuItem.types';
@@ -25,10 +25,13 @@ export const useMenuItemLink_unstable = (
       ...baseState.components,
       root: 'a',
     },
-    root: getNativeElementProps('a', {
-      ref,
-      role: 'menuitem',
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('a', {
+        ref,
+        role: 'menuitem',
+        ...props,
+      }),
+      { elementType: 'a' },
+    ),
   };
 };

--- a/packages/react-components/react-menu/src/components/MenuItemRadio/renderMenuItemRadio.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItemRadio/renderMenuItemRadio.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { MenuItemRadioState } from './MenuItemRadio.types';
 import type { MenuItemSlots } from '../MenuItem/MenuItem.types';
 
@@ -11,14 +11,14 @@ import type { MenuItemSlots } from '../MenuItem/MenuItem.types';
  * slots to children.
  */
 export const renderMenuItemRadio_unstable = (state: MenuItemRadioState) => {
-  const { slots, slotProps } = getSlotsNext<MenuItemSlots>(state);
+  assertSlots<MenuItemSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.checkmark && <slots.checkmark {...slotProps.checkmark} />}
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.content && <slots.content {...slotProps.content} />}
-      {slots.secondaryContent && <slots.secondaryContent {...slotProps.secondaryContent} />}
-    </slots.root>
+    <state.root>
+      {state.checkmark && <state.checkmark />}
+      {state.icon && <state.icon />}
+      {state.content && <state.content />}
+      {state.secondaryContent && <state.secondaryContent />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuItemRadio/useMenuItemRadio.tsx
+++ b/packages/react-components/react-menu/src/components/MenuItemRadio/useMenuItemRadio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { Checkmark16Filled } from '@fluentui/react-icons';
 import { useMenuListContext_unstable } from '../../contexts/menuListContext';
 import { useMenuItem_unstable } from '../MenuItem/useMenuItem';
@@ -28,9 +28,10 @@ export const useMenuItemRadio_unstable = (
         ...props,
         role: 'menuitemradio',
         'aria-checked': checked,
-        checkmark: resolveShorthand(props.checkmark, {
+        checkmark: slot.optional(props.checkmark, {
           defaultProps: { children: <Checkmark16Filled /> },
-          required: true,
+          renderByDefault: true,
+          elementType: 'span',
         }),
         onClick: (e: React.MouseEvent<ARIAButtonElementIntersection<'div'>>) => {
           selectRadio?.(e, name, value, checked);

--- a/packages/react-components/react-menu/src/components/MenuList/renderMenuList.tsx
+++ b/packages/react-components/react-menu/src/components/MenuList/renderMenuList.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { MenuListContextValues, MenuListSlots, MenuListState } from './MenuList.types';
 import { MenuListProvider } from '../../contexts/menuListContext';
 
@@ -10,11 +10,11 @@ import { MenuListProvider } from '../../contexts/menuListContext';
  * Function that renders the final JSX of the component
  */
 export const renderMenuList_unstable = (state: MenuListState, contextValues: MenuListContextValues) => {
-  const { slots, slotProps } = getSlotsNext<MenuListSlots>(state);
+  assertSlots<MenuListSlots>(state);
 
   return (
     <MenuListProvider value={contextValues.menuList}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </MenuListProvider>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/src/components/MenuList/useMenuList.ts
@@ -4,6 +4,7 @@ import {
   useEventCallback,
   useControllableState,
   getNativeElementProps,
+  slot,
 } from '@fluentui/react-utilities';
 import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabster';
 import { useHasParentContext } from '@fluentui/react-context-selector';
@@ -108,13 +109,16 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, innerRef),
-      role: 'menu',
-      'aria-labelledby': menuContext.triggerId,
-      ...focusAttributes,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, innerRef),
+        role: 'menu',
+        'aria-labelledby': menuContext.triggerId,
+        ...focusAttributes,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     hasIcons: menuContext.hasIcons || false,
     hasCheckmarks: menuContext.hasCheckmarks || false,
     checkedValues,

--- a/packages/react-components/react-menu/src/components/MenuPopover/renderMenuPopover.tsx
+++ b/packages/react-components/react-menu/src/components/MenuPopover/renderMenuPopover.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { MenuPopoverSlots, MenuPopoverState } from './MenuPopover.types';
 import { Portal } from '@fluentui/react-portal';
 
@@ -10,15 +10,15 @@ import { Portal } from '@fluentui/react-portal';
  * Render the final JSX of MenuPopover
  */
 export const renderMenuPopover_unstable = (state: MenuPopoverState) => {
-  const { slots, slotProps } = getSlotsNext<MenuPopoverSlots>(state);
+  assertSlots<MenuPopoverSlots>(state);
 
   if (state.inline) {
-    return <slots.root {...slotProps.root} />;
+    return <state.root />;
   }
 
   return (
     <Portal mountNode={state.mountNode}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </Portal>
   );
 };

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ArrowLeft, Tab, ArrowRight, Escape } from '@fluentui/keyboard-keys';
-import { getNativeElementProps, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useEventCallback, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
 import { dispatchMenuEnterEvent } from '../../utils/index';
@@ -60,51 +60,38 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
   const inline = useMenuContext_unstable(context => context.inline) ?? false;
   const mountNode = useMenuContext_unstable(context => context.mountNode);
 
-  const rootProps = getNativeElementProps('div', {
-    role: 'presentation',
-    ...restoreFocusSourceAttributes,
-    ...props,
-    ref: useMergedRefs(ref, popoverRef, mouseOverListenerCallbackRef),
-  });
-
+  const rootProps = slot.always(
+    getNativeElementProps('div', {
+      role: 'presentation',
+      ...restoreFocusSourceAttributes,
+      ...props,
+      ref: useMergedRefs(ref, popoverRef, mouseOverListenerCallbackRef),
+    }),
+    { elementType: 'div' },
+  );
   const { onMouseEnter: onMouseEnterOriginal, onKeyDown: onKeyDownOriginal } = rootProps;
-
   rootProps.onMouseEnter = useEventCallback((event: React.MouseEvent<HTMLElement>) => {
     if (openOnHover) {
       setOpen(event, { open: true, keyboard: false, type: 'menuPopoverMouseEnter', event });
     }
-
     onMouseEnterOriginal?.(event);
   });
-
   rootProps.onKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLElement>) => {
     const key = event.key;
-
     if (key === Escape || (isSubmenu && key === CloseArrowKey)) {
       if (open && popoverRef.current?.contains(event.target as HTMLElement)) {
-        setOpen(event, { open: false, keyboard: true, type: 'menuPopoverKeyDown', event });
-        // stop propagation to avoid conflicting with other elements that listen for `Escape`
+        setOpen(event, { open: false, keyboard: true, type: 'menuPopoverKeyDown', event }); // stop propagation to avoid conflicting with other elements that listen for `Escape`
         // e,g: Dialog, Popover and Tooltip
         event.stopPropagation();
       }
     }
-
     if (key === Tab) {
       setOpen(event, { open: false, keyboard: true, type: 'menuPopoverKeyDown', event });
       if (!isSubmenu) {
         triggerRef.current?.focus();
       }
     }
-
     onKeyDownOriginal?.(event);
   });
-
-  return {
-    inline,
-    mountNode,
-    components: {
-      root: 'div',
-    },
-    root: rootProps,
-  };
+  return { inline, mountNode, components: { root: 'div' }, root: rootProps };
 };

--- a/packages/react-components/react-menu/src/components/MenuSplitGroup/renderMenuSplitGroup.tsx
+++ b/packages/react-components/react-menu/src/components/MenuSplitGroup/renderMenuSplitGroup.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { MenuSplitGroupState, MenuSplitGroupSlots } from './MenuSplitGroup.types';
 
 /**
  * Render the final JSX of MenuSplitGroup
  */
 export const renderMenuSplitGroup_unstable = (state: MenuSplitGroupState) => {
-  const { slots, slotProps } = getSlotsNext<MenuSplitGroupSlots>(state);
+  assertSlots<MenuSplitGroupSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroup.ts
+++ b/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, getRTLSafeKey, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, getRTLSafeKey, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useFocusFinders } from '@fluentui/react-tabster';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import type { MenuSplitGroupProps, MenuSplitGroupState } from './MenuSplitGroup.types';
@@ -54,11 +54,14 @@ export const useMenuSplitGroup_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      role: 'group',
-      ref: useMergedRefs(ref, innerRef),
-      onKeyDown,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        role: 'group',
+        ref: useMergedRefs(ref, innerRef),
+        onKeyDown,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-persona/src/components/Persona/renderPersona.tsx
+++ b/packages/react-components/react-persona/src/components/Persona/renderPersona.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { PersonaState, PersonaSlots } from './Persona.types';
 
 /**
@@ -11,20 +11,18 @@ import type { PersonaState, PersonaSlots } from './Persona.types';
  */
 export const renderPersona_unstable = (state: PersonaState) => {
   const { presenceOnly, textPosition } = state;
-  const { slots, slotProps } = getSlotsNext<PersonaSlots>(state);
+  assertSlots<PersonaSlots>(state);
 
-  const coin = presenceOnly
-    ? slots.presence && <slots.presence {...slotProps.presence} />
-    : slots.avatar && <slots.avatar {...slotProps.avatar} />;
+  const coin = presenceOnly ? state.presence && <state.presence /> : state.avatar && <state.avatar />;
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       {(textPosition === 'after' || textPosition === 'below') && coin}
-      {slots.primaryText && <slots.primaryText {...slotProps.primaryText} />}
-      {slots.secondaryText && <slots.secondaryText {...slotProps.secondaryText} />}
-      {slots.tertiaryText && <slots.tertiaryText {...slotProps.tertiaryText} />}
-      {slots.quaternaryText && <slots.quaternaryText {...slotProps.quaternaryText} />}
+      {state.primaryText && <state.primaryText />}
+      {state.secondaryText && <state.secondaryText />}
+      {state.tertiaryText && <state.tertiaryText />}
+      {state.quaternaryText && <state.quaternaryText />}
       {textPosition === 'before' && coin}
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-persona/src/components/Persona/usePersona.ts
+++ b/packages/react-components/react-persona/src/components/Persona/usePersona.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Avatar } from '@fluentui/react-avatar';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { PresenceBadge } from '@fluentui/react-badge';
 import type { PersonaProps, PersonaState } from './Persona.types';
 
@@ -16,25 +16,23 @@ import type { PersonaProps, PersonaState } from './Persona.types';
 export const usePersona_unstable = (props: PersonaProps, ref: React.Ref<HTMLElement>): PersonaState => {
   const { name, presenceOnly = false, size = 'medium', textAlignment = 'start', textPosition = 'after' } = props;
 
-  const primaryText = resolveShorthand(props.primaryText, {
-    required: true,
+  const primaryText = slot.optional(props.primaryText, {
+    renderByDefault: true,
     defaultProps: {
       children: name,
     },
+    elementType: 'span',
   });
-  const secondaryText = resolveShorthand(props.secondaryText);
-  const tertiaryText = resolveShorthand(props.tertiaryText);
-  const quaternaryText = resolveShorthand(props.quaternaryText);
-
+  const secondaryText = slot.optional(props.secondaryText, { elementType: 'span' });
+  const tertiaryText = slot.optional(props.tertiaryText, { elementType: 'span' });
+  const quaternaryText = slot.optional(props.quaternaryText, { elementType: 'span' });
   const numTextLines = [primaryText, secondaryText, tertiaryText, quaternaryText].filter(Boolean).length;
-
   return {
     numTextLines,
     presenceOnly,
     size,
     textAlignment,
     textPosition,
-
     components: {
       root: 'div',
       avatar: Avatar,
@@ -45,29 +43,34 @@ export const usePersona_unstable = (props: PersonaProps, ref: React.Ref<HTMLElem
       quaternaryText: 'span',
     },
 
-    root: getNativeElementProps(
-      'div',
-      {
-        ...props,
-        ref,
-      },
-      /* excludedPropNames */ ['name'],
+    root: slot.always(
+      getNativeElementProps(
+        'div',
+        {
+          ...props,
+          ref,
+        },
+        /* excludedPropNames */ ['name'],
+      ),
+      { elementType: 'div' },
     ),
     avatar: !presenceOnly
-      ? resolveShorthand(props.avatar, {
-          required: true,
+      ? slot.optional(props.avatar, {
+          renderByDefault: true,
           defaultProps: {
             name,
             badge: props.presence,
             size: avatarSizes[size],
           },
+          elementType: Avatar,
         })
       : undefined,
     presence: presenceOnly
-      ? resolveShorthand(props.presence, {
+      ? slot.optional(props.presence, {
           defaultProps: {
             size: presenceSizes[size],
           },
+          elementType: PresenceBadge,
         })
       : undefined,
     primaryText,

--- a/packages/react-components/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/renderPopoverSurface.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { Portal } from '@fluentui/react-portal';
 import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.types';
 
@@ -10,13 +10,13 @@ import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.
  * Render the final JSX of PopoverSurface
  */
 export const renderPopoverSurface_unstable = (state: PopoverSurfaceState) => {
-  const { slots, slotProps } = getSlotsNext<PopoverSurfaceSlots>(state);
+  assertSlots<PopoverSurfaceSlots>(state);
 
   const surface = (
-    <slots.root {...slotProps.root}>
+    <state.root>
       {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
-      {slotProps.root.children}
-    </slots.root>
+      {state.root.children}
+    </state.root>
   );
 
   if (state.inline) {

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
@@ -44,13 +44,16 @@ export const usePopoverSurface_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, contentRef),
-      role: trapFocus ? 'dialog' : 'group',
-      'aria-modal': trapFocus ? true : undefined,
-      ...modalAttributes,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, contentRef),
+        role: trapFocus ? 'dialog' : 'group',
+        'aria-modal': trapFocus ? true : undefined,
+        ...modalAttributes,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 
   const {

--- a/packages/react-components/react-progress/src/components/ProgressBar/renderProgressBar.tsx
+++ b/packages/react-components/react-progress/src/components/ProgressBar/renderProgressBar.tsx
@@ -3,13 +3,13 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ProgressBarState, ProgressBarSlots } from './ProgressBar.types';
 
 /**
  * Render the final JSX of ProgressBar
  */
 export const renderProgressBar_unstable = (state: ProgressBarState) => {
-  const { slots, slotProps } = getSlotsNext<ProgressBarSlots>(state);
-  return <slots.root {...slotProps.root}>{slots.bar && <slots.bar {...slotProps.bar} />}</slots.root>;
+  assertSlots<ProgressBarSlots>(state);
+  return <state.root>{state.bar && <state.bar />}</state.root>;
 };

--- a/packages/react-components/react-progress/src/components/ProgressBar/useProgressBar.tsx
+++ b/packages/react-components/react-progress/src/components/ProgressBar/useProgressBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFieldContext_unstable } from '@fluentui/react-field';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { clampValue, clampMax } from '../../utils/index';
 import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
 
@@ -25,37 +25,32 @@ export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<
   const max = clampMax(props.max ?? 1);
   const value = clampValue(props.value, max);
 
-  const root = getNativeElementProps('div', {
-    ref,
-    role: 'progressbar',
-    'aria-valuemin': value !== undefined ? 0 : undefined,
-    'aria-valuemax': value !== undefined ? max : undefined,
-    'aria-valuenow': value,
-    'aria-labelledby': field?.labelId,
-    ...props,
-  });
-
+  const root = slot.always(
+    getNativeElementProps('div', {
+      ref,
+      role: 'progressbar',
+      'aria-valuemin': value !== undefined ? 0 : undefined,
+      'aria-valuemax': value !== undefined ? max : undefined,
+      'aria-valuenow': value,
+      'aria-labelledby': field?.labelId,
+      ...props,
+    }),
+    { elementType: 'div' },
+  );
   if (field && (field.validationMessageId || field.hintId)) {
     // Prepend the field's validation message and/or hint to the user's aria-describedby
     root['aria-describedby'] = [field?.validationMessageId, field?.hintId, root['aria-describedby']]
       .filter(Boolean)
       .join(' ');
   }
-
-  const bar = resolveShorthand(props.bar, {
-    required: true,
-  });
-
+  const bar = slot.always(props.bar, { elementType: 'div' });
   const state: ProgressBarState = {
     color,
     max,
     shape,
     thickness,
     value,
-    components: {
-      root: 'div',
-      bar: 'div',
-    },
+    components: { root: 'div', bar: 'div' },
     root,
     bar,
   };

--- a/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { canUseDOM, getSlotsNext } from '@fluentui/react-utilities';
+import { canUseDOM, assertSlots } from '@fluentui/react-utilities';
 import { TextDirectionProvider } from '@griffel/react';
 import {
   OverridesProvider_unstable as OverridesProvider,
@@ -22,7 +22,7 @@ export const renderFluentProvider_unstable = (
   state: FluentProviderState,
   contextValues: FluentProviderContextValues,
 ) => {
-  const { slots, slotProps } = getSlotsNext<FluentProviderSlots>(state);
+  assertSlots<FluentProviderSlots>(state);
 
   // Typescript (vscode) incorrectly references the FluentProviderProps.customStyleHooks_unstable
   // instead of FluentProviderContextValues.customStyleHooks_unstable and thinks it is
@@ -38,7 +38,7 @@ export const renderFluentProvider_unstable = (
             <TooltipVisibilityProvider value={contextValues.tooltip}>
               <TextDirectionProvider dir={contextValues.textDirection}>
                 <OverridesProvider value={contextValues.overrides_unstable}>
-                  <slots.root {...slotProps.root}>
+                  <state.root>
                     {canUseDOM() ? null : (
                       <style
                         // Using dangerous HTML because react can escape characters
@@ -48,8 +48,9 @@ export const renderFluentProvider_unstable = (
                         {...state.serverStyleProps.attributes}
                       />
                     )}
-                    {slotProps.root.children}
-                  </slots.root>
+
+                    {state.root.children}
+                  </state.root>
                 </OverridesProvider>
               </TextDirectionProvider>
             </TooltipVisibilityProvider>

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -10,7 +10,7 @@ import type {
   CustomStyleHooksContextValue_unstable as CustomStyleHooksContextValue,
   ThemeContextValue_unstable as ThemeContextValue,
 } from '@fluentui/react-shared-contexts';
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { useFluentProviderThemeStyleTag } from './useFluentProviderThemeStyleTag';
@@ -95,11 +95,14 @@ export const useFluentProvider_unstable = (
       root: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ...props,
-      dir,
-      ref: useMergedRefs(ref, useFocusVisible<HTMLDivElement>({ targetDocument })),
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ...props,
+        dir,
+        ref: useMergedRefs(ref, useFocusVisible<HTMLDivElement>({ targetDocument })),
+      }),
+      { elementType: 'div' },
+    ),
 
     serverStyleProps: {
       cssRule: rule,

--- a/packages/react-components/react-radio/src/components/Radio/renderRadio.tsx
+++ b/packages/react-components/react-radio/src/components/Radio/renderRadio.tsx
@@ -3,20 +3,20 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { RadioSlots, RadioState } from './Radio.types';
 
 /**
  * Render the final JSX of Radio
  */
 export const renderRadio_unstable = (state: RadioState) => {
-  const { slots, slotProps } = getSlotsNext<RadioSlots>(state);
+  assertSlots<RadioSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.input {...slotProps.input} />
-      <slots.indicator {...slotProps.indicator} />
-      {slots.label && <slots.label {...slotProps.label} />}
-    </slots.root>
+    <state.root>
+      <state.input />
+      <state.indicator />
+      {state.label && <state.label />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-radio/src/components/Radio/useRadio.tsx
+++ b/packages/react-components/react-radio/src/components/Radio/useRadio.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CircleFilled } from '@fluentui/react-icons';
 import { Label } from '@fluentui/react-label';
-import { getPartitionedNativeProps, mergeCallbacks, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, mergeCallbacks, useId, slot } from '@fluentui/react-utilities';
 import { useRadioGroupContextValue_unstable } from '../../contexts/RadioGroupContext';
 import { useFocusWithin } from '@fluentui/react-tabster';
 import type { RadioProps, RadioState } from './Radio.types';
@@ -35,16 +35,14 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
     excludedPropNames: ['checked', 'defaultChecked', 'onChange'],
   });
 
-  const root = resolveShorthand(props.root, {
-    required: true,
+  const root = slot.always(props.root, {
     defaultProps: {
       ref: useFocusWithin<HTMLSpanElement>(),
       ...nativeProps.root,
     },
+    elementType: 'span',
   });
-
-  const input = resolveShorthand(props.input, {
-    required: true,
+  const input = slot.always(props.input, {
     defaultProps: {
       ref,
       type: 'radio',
@@ -57,33 +55,20 @@ export const useRadio_unstable = (props: RadioProps, ref: React.Ref<HTMLInputEle
       'aria-describedby': ariaDescribedBy,
       ...nativeProps.primary,
     },
+    elementType: 'input',
   });
-
   input.onChange = mergeCallbacks(input.onChange, ev => onChange?.(ev, { value: ev.currentTarget.value }));
-
-  const label = resolveShorthand(props.label, {
-    defaultProps: {
-      htmlFor: input.id,
-      disabled: input.disabled,
-    },
+  const label = slot.optional(props.label, {
+    defaultProps: { htmlFor: input.id, disabled: input.disabled },
+    elementType: Label,
   });
-
-  const indicator = resolveShorthand(props.indicator, {
-    required: true,
-    defaultProps: {
-      'aria-hidden': true,
-      children: <CircleFilled />,
-    },
+  const indicator = slot.always(props.indicator, {
+    defaultProps: { 'aria-hidden': true, children: <CircleFilled /> },
+    elementType: 'div',
   });
-
   return {
     labelPosition,
-    components: {
-      root: 'span',
-      input: 'input',
-      label: Label,
-      indicator: 'div',
-    },
+    components: { root: 'span', input: 'input', label: Label, indicator: 'div' },
     root,
     input,
     label,

--- a/packages/react-components/react-radio/src/components/RadioGroup/renderRadioGroup.tsx
+++ b/packages/react-components/react-radio/src/components/RadioGroup/renderRadioGroup.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { RadioGroupContext } from '../../contexts/RadioGroupContext';
 import { RadioGroupContextValues, RadioGroupSlots, RadioGroupState } from './RadioGroup.types';
 
@@ -11,11 +11,11 @@ import { RadioGroupContextValues, RadioGroupSlots, RadioGroupState } from './Rad
  * Render the final JSX of RadioGroup
  */
 export const renderRadioGroup_unstable = (state: RadioGroupState, contextValues: RadioGroupContextValues) => {
-  const { slots, slotProps } = getSlotsNext<RadioGroupSlots>(state);
+  assertSlots<RadioGroupSlots>(state);
 
   return (
     <RadioGroupContext.Provider value={contextValues.radioGroup}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </RadioGroupContext.Provider>
   );
 };

--- a/packages/react-components/react-radio/src/components/RadioGroup/useRadioGroup.ts
+++ b/packages/react-components/react-radio/src/components/RadioGroup/useRadioGroup.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import { getNativeElementProps, isHTMLElement, useEventCallback, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, isHTMLElement, useEventCallback, useId, slot } from '@fluentui/react-utilities';
 import { RadioGroupProps, RadioGroupState } from './RadioGroup.types';
 
 /**
@@ -33,7 +33,9 @@ export const useRadioGroup_unstable = (props: RadioGroupProps, ref: React.Ref<HT
     root: {
       ref,
       role: 'radiogroup',
-      ...getNativeElementProps('div', props, /*excludedPropNames:*/ ['onChange', 'name']),
+      ...slot.always(getNativeElementProps('div', props, /*excludedPropNames:*/ ['onChange', 'name']), {
+        elementType: 'div',
+      }),
       onChange: useEventCallback(ev => {
         if (
           onChange &&

--- a/packages/react-components/react-select/src/components/Select/renderSelect.tsx
+++ b/packages/react-components/react-select/src/components/Select/renderSelect.tsx
@@ -3,18 +3,18 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SelectSlots, SelectState } from './Select.types';
 
 /**
  * Render the final JSX of Select
  */
 export const renderSelect_unstable = (state: SelectState) => {
-  const { slots, slotProps } = getSlotsNext<SelectSlots>(state);
+  assertSlots<SelectSlots>(state);
   return (
-    <slots.root {...slotProps.root}>
-      <slots.select {...slotProps.select}>{slotProps.select.children}</slots.select>
-      <slots.icon {...slotProps.icon} />
-    </slots.root>
+    <state.root>
+      <state.select>{state.select.children}</state.select>
+      <state.icon />
+    </state.root>
   );
 };

--- a/packages/react-components/react-select/src/components/Select/useSelect.tsx
+++ b/packages/react-components/react-select/src/components/Select/useSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import { getPartitionedNativeProps, resolveShorthand, useEventCallback } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, useEventCallback, slot } from '@fluentui/react-utilities';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import type { SelectProps, SelectState } from './Select.types';
 import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-contexts';
@@ -46,22 +46,23 @@ export const useSelect_unstable = (props: SelectProps, ref: React.Ref<HTMLSelect
       select: 'select',
       icon: 'span',
     },
-    select: resolveShorthand(select, {
-      required: true,
+    select: slot.always(select, {
       defaultProps: {
         defaultValue,
         value,
         ref,
         ...nativeProps.primary,
       },
+      elementType: 'select',
     }),
-    icon: resolveShorthand(icon, {
-      required: true,
+    icon: slot.optional(icon, {
+      renderByDefault: true,
       defaultProps: { children: <ChevronDownRegular /> },
+      elementType: 'span',
     }),
-    root: resolveShorthand(root, {
-      required: true,
+    root: slot.always(root, {
       defaultProps: nativeProps.root,
+      elementType: 'span',
     }),
   };
 

--- a/packages/react-components/react-skeleton/src/components/Skeleton/renderSkeleton.tsx
+++ b/packages/react-components/react-skeleton/src/components/Skeleton/renderSkeleton.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { SkeletonContextProvider } from '../../contexts/SkeletonContext';
 import type { SkeletonContextValues, SkeletonSlots, SkeletonState } from './Skeleton.types';
 
@@ -11,11 +11,11 @@ import type { SkeletonContextValues, SkeletonSlots, SkeletonState } from './Skel
  * Render the final JSX of Skeleton
  */
 export const renderSkeleton_unstable = (state: SkeletonState, contextValues: SkeletonContextValues) => {
-  const { slots, slotProps } = getSlotsNext<SkeletonSlots>(state);
+  assertSlots<SkeletonSlots>(state);
 
   return (
     <SkeletonContextProvider value={contextValues.skeletonGroup}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </SkeletonContextProvider>
   );
 };

--- a/packages/react-components/react-skeleton/src/components/Skeleton/useSkeleton.ts
+++ b/packages/react-components/react-skeleton/src/components/Skeleton/useSkeleton.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { SkeletonProps, SkeletonState } from './Skeleton.types';
 import { useSkeletonContext } from '../../contexts/SkeletonContext';
 
@@ -16,20 +16,15 @@ export const useSkeleton_unstable = (props: SkeletonProps, ref: React.Ref<HTMLEl
   const { animation: contextAnimation, appearance: contextAppearance } = useSkeletonContext();
   const { animation = contextAnimation ?? 'wave', appearance = contextAppearance ?? 'opaque' } = props;
 
-  const root = getNativeElementProps('div', {
-    ref,
-    role: 'progressbar',
-    'aria-busy': true,
-    'aria-label': 'Loading Content',
-    ...props,
-  });
-
-  return {
-    animation,
-    appearance,
-    components: {
-      root: 'div',
-    },
-    root,
-  };
+  const root = slot.always(
+    getNativeElementProps('div', {
+      ref,
+      role: 'progressbar',
+      'aria-busy': true,
+      'aria-label': 'Loading Content',
+      ...props,
+    }),
+    { elementType: 'div' },
+  );
+  return { animation, appearance, components: { root: 'div' }, root };
 };

--- a/packages/react-components/react-skeleton/src/components/SkeletonItem/renderSkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/src/components/SkeletonItem/renderSkeletonItem.tsx
@@ -3,14 +3,14 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SkeletonItemState, SkeletonItemSlots } from './SkeletonItem.types';
 
 /**
  * Render the final JSX of SkeletonItem
  */
 export const renderSkeletonItem_unstable = (state: SkeletonItemState) => {
-  const { slots, slotProps } = getSlotsNext<SkeletonItemSlots>(state);
+  assertSlots<SkeletonItemSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-skeleton/src/components/SkeletonItem/useSkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/src/components/SkeletonItem/useSkeletonItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useSkeletonContext } from '../../contexts/SkeletonContext';
 import type { SkeletonItemProps, SkeletonItemState } from './SkeletonItem.types';
 
@@ -21,19 +21,12 @@ export const useSkeletonItem_unstable = (props: SkeletonItemProps, ref: React.Re
     shape = 'rectangle',
   } = props;
 
-  const root = getNativeElementProps('div', {
-    ref,
-    ...props,
-  });
-
-  return {
-    appearance,
-    animation,
-    size,
-    shape,
-    components: {
-      root: 'div',
-    },
-    root,
-  };
+  const root = slot.always(
+    getNativeElementProps('div', {
+      ref,
+      ...props,
+    }),
+    { elementType: 'div' },
+  );
+  return { appearance, animation, size, shape, components: { root: 'div' }, root };
 };

--- a/packages/react-components/react-slider/src/components/Slider/renderSlider.tsx
+++ b/packages/react-components/react-slider/src/components/Slider/renderSlider.tsx
@@ -3,20 +3,20 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SliderState, SliderSlots } from './Slider.types';
 
 /**
  * Render the final JSX of Slider
  */
 export const renderSlider_unstable = (state: SliderState) => {
-  const { slots, slotProps } = getSlotsNext<SliderSlots>(state);
+  assertSlots<SliderSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.input {...slotProps.input} />
-      <slots.rail {...slotProps.rail} />
-      <slots.thumb {...slotProps.thumb} />
-    </slots.root>
+    <state.root>
+      <state.input />
+      <state.rail />
+      <state.thumb />
+    </state.root>
   );
 };

--- a/packages/react-components/react-slider/src/components/Slider/useSlider.ts
+++ b/packages/react-components/react-slider/src/components/Slider/useSlider.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import { getPartitionedNativeProps, resolveShorthand, useId, useMergedRefs } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, useId, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useSliderState_unstable } from './useSliderState';
 import { SliderProps, SliderState } from './Slider.types';
 import { useFocusWithin } from '@fluentui/react-tabster';
@@ -36,12 +36,11 @@ export const useSlider_unstable = (props: SliderProps, ref: React.Ref<HTMLInputE
       root: 'div',
       thumb: 'div',
     },
-    root: resolveShorthand(root, {
-      required: true,
+    root: slot.always(root, {
       defaultProps: nativeProps.root,
+      elementType: 'div',
     }),
-    input: resolveShorthand(input, {
-      required: true,
+    input: slot.always(input, {
       defaultProps: {
         id: useId('slider-', props.id),
         ref,
@@ -49,9 +48,10 @@ export const useSlider_unstable = (props: SliderProps, ref: React.Ref<HTMLInputE
         type: 'range',
         orient: vertical ? 'vertical' : undefined,
       },
+      elementType: 'input',
     }),
-    rail: resolveShorthand(rail, { required: true }),
-    thumb: resolveShorthand(thumb, { required: true }),
+    rail: slot.always(rail, { elementType: 'div' }),
+    thumb: slot.always(thumb, { elementType: 'div' }),
   };
 
   state.root.ref = useMergedRefs(state.root.ref, useFocusWithin<HTMLDivElement>());

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/renderSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/renderSpinButton.tsx
@@ -3,20 +3,20 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SpinButtonState, SpinButtonSlots } from './SpinButton.types';
 
 /**
  * Render the final JSX of SpinButton
  */
 export const renderSpinButton_unstable = (state: SpinButtonState) => {
-  const { slots, slotProps } = getSlotsNext<SpinButtonSlots>(state);
+  assertSlots<SpinButtonSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.input {...slotProps.input} />
-      <slots.incrementButton {...slotProps.incrementButton} />
-      <slots.decrementButton {...slotProps.decrementButton} />
-    </slots.root>
+    <state.root>
+      <state.input />
+      <state.incrementButton />
+      <state.decrementButton />
+    </state.root>
   );
 };

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -3,9 +3,9 @@ import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import {
   getPartitionedNativeProps,
   mergeCallbacks,
-  resolveShorthand,
   useControllableState,
   useTimeout,
+  slot,
 } from '@fluentui/react-utilities';
 import { ArrowUp, ArrowDown, End, Enter, Escape, Home, PageDown, PageUp } from '@fluentui/keyboard-keys';
 import {
@@ -257,12 +257,11 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
       incrementButton: 'button',
       decrementButton: 'button',
     },
-    root: resolveShorthand(root, {
-      required: true,
+    root: slot.always(root, {
       defaultProps: nativeProps.root,
+      elementType: 'span',
     }),
-    input: resolveShorthand(input, {
-      required: true,
+    input: slot.always(input, {
       defaultProps: {
         ref,
         autoComplete: 'off',
@@ -271,9 +270,9 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         type: 'text',
         ...nativeProps.primary,
       },
+      elementType: 'input',
     }),
-    incrementButton: resolveShorthand(incrementButton, {
-      required: true,
+    incrementButton: slot.always(incrementButton, {
       defaultProps: {
         tabIndex: -1,
         children: <ChevronUp16Regular />,
@@ -281,9 +280,9 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         'aria-label': 'Increment value',
         type: 'button',
       },
+      elementType: 'button',
     }),
-    decrementButton: resolveShorthand(decrementButton, {
-      required: true,
+    decrementButton: slot.always(decrementButton, {
       defaultProps: {
         tabIndex: -1,
         children: <ChevronDown16Regular />,
@@ -291,6 +290,7 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
         'aria-label': 'Decrement value',
         type: 'button',
       },
+      elementType: 'button',
     }),
   };
 

--- a/packages/react-components/react-spinner/src/components/Spinner/renderSpinner.tsx
+++ b/packages/react-components/react-spinner/src/components/Spinner/renderSpinner.tsx
@@ -3,24 +3,25 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SpinnerState, SpinnerSlots } from './Spinner.types';
 
 /**
  * Render the final JSX of Spinner
  */
 export const renderSpinner_unstable = (state: SpinnerState) => {
-  const { slots, slotProps } = getSlotsNext<SpinnerSlots>(state);
+  assertSlots<SpinnerSlots>(state);
   const { labelPosition, shouldRenderSpinner } = state;
   return (
-    <slots.root {...slotProps.root}>
-      {slots.label && shouldRenderSpinner && (labelPosition === 'above' || labelPosition === 'before') && (
-        <slots.label {...slotProps.label} />
+    <state.root>
+      {state.label && shouldRenderSpinner && (labelPosition === 'above' || labelPosition === 'before') && (
+        <state.label />
       )}
-      {slots.spinner && shouldRenderSpinner && <slots.spinner {...slotProps.spinner} />}
-      {slots.label && shouldRenderSpinner && (labelPosition === 'below' || labelPosition === 'after') && (
-        <slots.label {...slotProps.label} />
+
+      {state.spinner && shouldRenderSpinner && <state.spinner />}
+      {state.label && shouldRenderSpinner && (labelPosition === 'below' || labelPosition === 'after') && (
+        <state.label />
       )}
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinner.tsx
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinner.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useId, useTimeout } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, useTimeout, slot } from '@fluentui/react-utilities';
 import type { SpinnerProps, SpinnerState } from './Spinner.types';
 import { Label } from '@fluentui/react-label';
 import { DefaultSvg } from './DefaultSvg';
@@ -21,12 +21,11 @@ export const useSpinner_unstable = (props: SpinnerProps, ref: React.Ref<HTMLElem
   const baseId = useId('spinner');
 
   const { role = 'progressbar', tabIndex, ...rest } = props;
-  const nativeRoot = getNativeElementProps('div', { ref, role, ...rest }, ['size']);
-
+  const nativeRoot = slot.always(getNativeElementProps('div', { ref, role, ...rest }, ['size']), {
+    elementType: 'div',
+  });
   const [isVisible, setIsVisible] = React.useState(true);
-
   const [setDelayTimeout, clearDelayTimeout] = useTimeout();
-
   React.useEffect(() => {
     if (delay <= 0) {
       return;
@@ -35,42 +34,30 @@ export const useSpinner_unstable = (props: SpinnerProps, ref: React.Ref<HTMLElem
     setDelayTimeout(() => {
       setIsVisible(true);
     }, delay);
-
     return () => {
       clearDelayTimeout();
     };
   }, [setDelayTimeout, clearDelayTimeout, delay]);
-
-  const labelShorthand = resolveShorthand(props.label, {
-    defaultProps: {
-      id: baseId,
-    },
-    required: false,
+  const labelShorthand = slot.optional(props.label, {
+    defaultProps: { id: baseId },
+    renderByDefault: false,
+    elementType: Label,
   });
-
-  const spinnerShortHand = resolveShorthand(props.spinner, {
-    required: true,
-    defaultProps: {
-      children: <DefaultSvg />,
-      tabIndex,
-    },
+  const spinnerShortHand = slot.optional(props.spinner, {
+    renderByDefault: true,
+    defaultProps: { children: <DefaultSvg />, tabIndex },
+    elementType: 'span',
   });
-
   if (labelShorthand && nativeRoot && !nativeRoot['aria-labelledby']) {
     nativeRoot['aria-labelledby'] = labelShorthand.id;
   }
-
   const state: SpinnerState = {
     appearance,
     delay,
     labelPosition,
     size,
     shouldRenderSpinner: isVisible,
-    components: {
-      root: 'div',
-      spinner: 'span',
-      label: Label,
-    },
+    components: { root: 'div', spinner: 'span', label: Label },
     root: nativeRoot,
     spinner: spinnerShortHand,
     label: labelShorthand,

--- a/packages/react-components/react-switch/src/components/Switch/renderSwitch.tsx
+++ b/packages/react-components/react-switch/src/components/Switch/renderSwitch.tsx
@@ -3,22 +3,22 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SwitchState, SwitchSlots } from './Switch.types';
 
 /**
  * Render a Switch component by passing the state defined props to the appropriate slots.
  */
 export const renderSwitch_unstable = (state: SwitchState) => {
-  const { slots, slotProps } = getSlotsNext<SwitchSlots>(state);
+  assertSlots<SwitchSlots>(state);
   const { labelPosition } = state;
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.input {...slotProps.input} />
-      {labelPosition !== 'after' && slots.label && <slots.label {...slotProps.label} />}
-      <slots.indicator {...slotProps.indicator} />
-      {labelPosition === 'after' && slots.label && <slots.label {...slotProps.label} />}
-    </slots.root>
+    <state.root>
+      <state.input />
+      {labelPosition !== 'after' && state.label && <state.label />}
+      <state.indicator />
+      {labelPosition === 'after' && state.label && <state.label />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-switch/src/components/Switch/useSwitch.tsx
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitch.tsx
@@ -3,7 +3,7 @@ import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { CircleFilled } from '@fluentui/react-icons';
 import { Label } from '@fluentui/react-label';
 import { useFocusWithin } from '@fluentui/react-tabster';
-import { getPartitionedNativeProps, mergeCallbacks, resolveShorthand, useId } from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, mergeCallbacks, useId, slot } from '@fluentui/react-utilities';
 import type { SwitchProps, SwitchState } from './Switch.types';
 
 /**
@@ -29,52 +29,26 @@ export const useSwitch_unstable = (props: SwitchProps, ref: React.Ref<HTMLInputE
 
   const id = useId('switch-', nativeProps.primary.id);
 
-  const root = resolveShorthand(props.root, {
+  const root = slot.always(props.root, {
     defaultProps: { ref: useFocusWithin<HTMLDivElement>(), ...nativeProps.root },
-    required: true,
+    elementType: 'div',
   });
-
-  const indicator = resolveShorthand(props.indicator, {
-    defaultProps: {
-      'aria-hidden': true,
-      children: <CircleFilled />,
-    },
-    required: true,
+  const indicator = slot.always(props.indicator, {
+    defaultProps: { 'aria-hidden': true, children: <CircleFilled /> },
+    elementType: 'div',
   });
-
-  const input = resolveShorthand(props.input, {
-    defaultProps: {
-      checked,
-      defaultChecked,
-      id,
-      ref,
-      role: 'switch',
-      type: 'checkbox',
-      ...nativeProps.primary,
-    },
-    required: true,
+  const input = slot.always(props.input, {
+    defaultProps: { checked, defaultChecked, id, ref, role: 'switch', type: 'checkbox', ...nativeProps.primary },
+    elementType: 'input',
   });
   input.onChange = mergeCallbacks(input.onChange, ev => onChange?.(ev, { checked: ev.currentTarget.checked }));
-
-  const label = resolveShorthand(props.label, {
-    defaultProps: {
-      disabled,
-      htmlFor: id,
-      required,
-      size: 'medium',
-    },
+  const label = slot.optional(props.label, {
+    defaultProps: { disabled, htmlFor: id, required, size: 'medium' },
+    elementType: Label,
   });
-
   return {
-    labelPosition,
-
-    //Slots definition
-    components: {
-      root: 'div',
-      indicator: 'div',
-      input: 'input',
-      label: Label,
-    },
+    labelPosition, //Slots definition
+    components: { root: 'div', indicator: 'div', input: 'input', label: Label },
 
     root,
     indicator,

--- a/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
+++ b/packages/react-components/react-table/src/components/DataGridBody/renderDataGridBody.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DataGridBodyState, DataGridBodySlots } from './DataGridBody.types';
 import { TableRowIdContextProvider } from '../../contexts/rowIdContext';
 
@@ -10,15 +10,15 @@ import { TableRowIdContextProvider } from '../../contexts/rowIdContext';
  * Render the final JSX of DataGridBody
  */
 export const renderDataGridBody_unstable = (state: DataGridBodyState) => {
-  const { slots, slotProps } = getSlotsNext<DataGridBodySlots>(state);
+  assertSlots<DataGridBodySlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       {state.rows.map(row => (
         <TableRowIdContextProvider key={row.rowId} value={row.rowId}>
           {state.renderRow(row)}
         </TableRowIdContextProvider>
       ))}
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-table/src/components/DataGridRow/renderDataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/renderDataGridRow.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { DataGridRowState, DataGridRowSlots } from './DataGridRow.types';
 import { ColumnIdContextProvider } from '../../contexts/columnIdContext';
 
@@ -10,16 +10,16 @@ import { ColumnIdContextProvider } from '../../contexts/columnIdContext';
  * Render the final JSX of DataGridRow
  */
 export const renderDataGridRow_unstable = (state: DataGridRowState) => {
-  const { slots, slotProps } = getSlotsNext<DataGridRowSlots>(state);
+  assertSlots<DataGridRowSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.selectionCell && <slots.selectionCell {...slotProps.selectionCell} />}
+    <state.root>
+      {state.selectionCell && <state.selectionCell />}
       {state.columnDefs.map(columnDef => (
         <ColumnIdContextProvider value={columnDef.columnId} key={columnDef.columnId}>
           {state.renderCell(columnDef, state.dataGridContextValue)}
         </ColumnIdContextProvider>
       ))}
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/src/components/DataGridRow/useDataGridRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isInteractiveHTMLElement, useEventCallback, resolveShorthand } from '@fluentui/react-utilities';
+import { isInteractiveHTMLElement, useEventCallback, slot } from '@fluentui/react-utilities';
 import { Space } from '@fluentui/keyboard-keys';
 import type { DataGridRowProps, DataGridRowState } from './DataGridRow.types';
 import { useTableRow_unstable } from '../TableRow/useTableRow';
@@ -75,7 +75,10 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
       ...baseState.components,
       selectionCell: DataGridSelectionCell,
     },
-    selectionCell: resolveShorthand(props.selectionCell, { required: selectable }),
+    selectionCell: slot.optional(props.selectionCell, {
+      renderByDefault: selectable,
+      elementType: DataGridSelectionCell,
+    }),
     renderCell: props.children,
     columnDefs,
     dataGridContextValue,

--- a/packages/react-components/react-table/src/components/Table/renderTable.tsx
+++ b/packages/react-components/react-table/src/components/Table/renderTable.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableState, TableSlots, TableContextValues } from './Table.types';
 import { TableContextProvider } from '../../contexts/tableContext';
 
@@ -10,11 +10,11 @@ import { TableContextProvider } from '../../contexts/tableContext';
  * Render the final JSX of Table
  */
 export const renderTable_unstable = (state: TableState, contextValues: TableContextValues) => {
-  const { slots, slotProps } = getSlotsNext<TableSlots>(state);
+  assertSlots<TableSlots>(state);
 
   return (
     <TableContextProvider value={contextValues.table}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </TableContextProvider>
   );
 };

--- a/packages/react-components/react-table/src/components/Table/useTable.ts
+++ b/packages/react-components/react-table/src/components/Table/useTable.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TableProps, TableState } from './Table.types';
 
 /**
@@ -18,11 +18,14 @@ export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>
     components: {
       root: rootComponent,
     },
-    root: getNativeElementProps(rootComponent, {
-      ref,
-      role: rootComponent === 'div' ? 'table' : undefined,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(rootComponent, {
+        ref,
+        role: rootComponent === 'div' ? 'table' : undefined,
+        ...props,
+      }),
+      { elementType: rootComponent },
+    ),
     size: props.size ?? 'medium',
     noNativeElements: props.noNativeElements ?? false,
     sortable: props.sortable ?? false,

--- a/packages/react-components/react-table/src/components/TableBody/renderTableBody.tsx
+++ b/packages/react-components/react-table/src/components/TableBody/renderTableBody.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableBodyState, TableBodySlots } from './TableBody.types';
 
 /**
  * Render the final JSX of TableBody
  */
 export const renderTableBody_unstable = (state: TableBodyState) => {
-  const { slots, slotProps } = getSlotsNext<TableBodySlots>(state);
+  assertSlots<TableBodySlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
+++ b/packages/react-components/react-table/src/components/TableBody/useTableBody.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TableBodyProps, TableBodyState } from './TableBody.types';
 import { useTableContext } from '../../contexts/tableContext';
 
@@ -20,11 +20,14 @@ export const useTableBody_unstable = (props: TableBodyProps, ref: React.Ref<HTML
     components: {
       root: rootComponent,
     },
-    root: getNativeElementProps(rootComponent, {
-      ref,
-      role: rootComponent === 'div' ? 'rowgroup' : undefined,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(rootComponent, {
+        ref,
+        role: rootComponent === 'div' ? 'rowgroup' : undefined,
+        ...props,
+      }),
+      { elementType: rootComponent },
+    ),
     noNativeElements,
   };
 };

--- a/packages/react-components/react-table/src/components/TableCell/renderTableCell.tsx
+++ b/packages/react-components/react-table/src/components/TableCell/renderTableCell.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableCellState, TableCellSlots } from './TableCell.types';
 
 /**
  * Render the final JSX of TableCell
  */
 export const renderTableCell_unstable = (state: TableCellState) => {
-  const { slots, slotProps } = getSlotsNext<TableCellSlots>(state);
+  assertSlots<TableCellSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
+++ b/packages/react-components/react-table/src/components/TableCell/useTableCell.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TableCellProps, TableCellState } from './TableCell.types';
 import { useTableContext } from '../../contexts/tableContext';
 
@@ -21,11 +21,14 @@ export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTML
     components: {
       root: rootComponent,
     },
-    root: getNativeElementProps(rootComponent, {
-      ref,
-      role: rootComponent === 'div' ? 'cell' : undefined,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(rootComponent, {
+        ref,
+        role: rootComponent === 'div' ? 'cell' : undefined,
+        ...props,
+      }),
+      { elementType: rootComponent },
+    ),
     noNativeElements,
     size,
   };

--- a/packages/react-components/react-table/src/components/TableCellActions/renderTableCellActions.tsx
+++ b/packages/react-components/react-table/src/components/TableCellActions/renderTableCellActions.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableCellActionsState, TableCellActionsSlots } from './TableCellActions.types';
 
 /**
  * Render the final JSX of TableCellActions
  */
 export const renderTableCellActions_unstable = (state: TableCellActionsState) => {
-  const { slots, slotProps } = getSlotsNext<TableCellActionsSlots>(state);
+  assertSlots<TableCellActionsSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-table/src/components/TableCellActions/useTableCellActions.ts
+++ b/packages/react-components/react-table/src/components/TableCellActions/useTableCellActions.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TableCellActionsProps, TableCellActionsState } from './TableCellActions.types';
 
 /**
@@ -19,10 +19,13 @@ export const useTableCellActions_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     visible: props.visible ?? false,
   };
 };

--- a/packages/react-components/react-table/src/components/TableCellLayout/renderTableCellLayout.tsx
+++ b/packages/react-components/react-table/src/components/TableCellLayout/renderTableCellLayout.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { AvatarContextProvider } from '@fluentui/react-avatar';
 import type { TableCellLayoutState, TableCellLayoutSlots, TableCellLayoutContextValues } from './TableCellLayout.types';
 
@@ -13,21 +13,22 @@ export const renderTableCellLayout_unstable = (
   state: TableCellLayoutState,
   contextValues: TableCellLayoutContextValues,
 ) => {
-  const { slots, slotProps } = getSlotsNext<TableCellLayoutSlots>(state);
+  assertSlots<TableCellLayoutSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.media && (
+    <state.root>
+      {state.media && (
         <AvatarContextProvider value={contextValues.avatar}>
-          <slots.media {...slotProps.media} />
+          <state.media />
         </AvatarContextProvider>
       )}
-      {slots.content && (
-        <slots.content {...slotProps.content}>
-          {slots.main && <slots.main {...slotProps.main}>{slotProps.root.children}</slots.main>}
-          {slots.description && <slots.description {...slotProps.description} />}
-        </slots.content>
+
+      {state.content && (
+        <state.content>
+          {state.main && <state.main>{state.root.children}</state.main>}
+          {state.description && <state.description />}
+        </state.content>
       )}
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/useTableCellLayout.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TableCellLayoutProps, TableCellLayoutState } from './TableCellLayout.types';
 import { useTableContext } from '../../contexts/tableContext';
 
@@ -32,13 +32,16 @@ export const useTableCellLayout_unstable = (
       content: 'div',
       media: 'span',
     },
-    root: getNativeElementProps('div', { ref, ...props }),
+    root: slot.always(getNativeElementProps('div', { ref, ...props }), { elementType: 'div' }),
     appearance: props.appearance,
     truncate: props.truncate,
-    main: resolveShorthand(props.main, { required: true }),
-    media: resolveShorthand(props.media),
-    description: resolveShorthand(props.description),
-    content: resolveShorthand(props.content, { required: !!props.description || !!props.children }),
+    main: slot.optional(props.main, { renderByDefault: true, elementType: 'span' }),
+    media: slot.optional(props.media, { elementType: 'span' }),
+    description: slot.optional(props.description, { elementType: 'span' }),
+    content: slot.optional(props.content, {
+      renderByDefault: !!props.description || !!props.children,
+      elementType: 'div',
+    }),
     avatarSize: tableAvatarSizeMap[size],
     size,
   };

--- a/packages/react-components/react-table/src/components/TableHeader/renderTableHeader.tsx
+++ b/packages/react-components/react-table/src/components/TableHeader/renderTableHeader.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { TableHeaderContextProvider } from '../../contexts/tableHeaderContext';
 import type { TableHeaderState, TableHeaderSlots } from './TableHeader.types';
 
@@ -10,11 +10,11 @@ import type { TableHeaderState, TableHeaderSlots } from './TableHeader.types';
  * Render the final JSX of TableHeader
  */
 export const renderTableHeader_unstable = (state: TableHeaderState) => {
-  const { slots, slotProps } = getSlotsNext<TableHeaderSlots>(state);
+  assertSlots<TableHeaderSlots>(state);
 
   return (
     <TableHeaderContextProvider value="">
-      <slots.root {...slotProps.root} />
+      <state.root />
     </TableHeaderContextProvider>
   );
 };

--- a/packages/react-components/react-table/src/components/TableHeader/useTableHeader.ts
+++ b/packages/react-components/react-table/src/components/TableHeader/useTableHeader.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TableHeaderProps, TableHeaderState } from './TableHeader.types';
 import { useTableContext } from '../../contexts/tableContext';
 
@@ -20,11 +20,14 @@ export const useTableHeader_unstable = (props: TableHeaderProps, ref: React.Ref<
     components: {
       root: rootComponent,
     },
-    root: getNativeElementProps(rootComponent, {
-      ref,
-      role: rootComponent === 'div' ? 'rowgroup' : undefined,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(rootComponent, {
+        ref,
+        role: rootComponent === 'div' ? 'rowgroup' : undefined,
+        ...props,
+      }),
+      { elementType: rootComponent },
+    ),
     noNativeElements,
   };
 };

--- a/packages/react-components/react-table/src/components/TableHeaderCell/renderTableHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/renderTableHeaderCell.tsx
@@ -2,22 +2,22 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableHeaderCellState, TableHeaderCellSlots } from './TableHeaderCell.types';
 
 /**
  * Render the final JSX of TableHeaderCell
  */
 export const renderTableHeaderCell_unstable = (state: TableHeaderCellState) => {
-  const { slots, slotProps } = getSlotsNext<TableHeaderCellSlots>(state);
+  assertSlots<TableHeaderCellSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.button {...slotProps.button}>
-        {slotProps.root.children}
-        {slots.sortIcon && <slots.sortIcon {...slotProps.sortIcon} />}
-      </slots.button>
-      {slots.aside && <slots.aside {...slotProps.aside} />}
-    </slots.root>
+    <state.root>
+      <state.button>
+        {state.root.children}
+        {state.sortIcon && <state.sortIcon />}
+      </state.button>
+      {state.aside && <state.aside />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
+++ b/packages/react-components/react-table/src/components/TableHeaderCell/useTableHeaderCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useFocusWithin } from '@fluentui/react-tabster';
 import { ArrowUpRegular, ArrowDownRegular } from '@fluentui/react-icons';
 import { useARIAButtonShorthand } from '@fluentui/react-aria';
@@ -35,27 +35,34 @@ export const useTableHeaderCell_unstable = (
       sortIcon: 'span',
       aside: 'span',
     },
-    root: getNativeElementProps(rootComponent, {
-      ref: useMergedRefs(ref, useFocusWithin()),
-      role: rootComponent === 'div' ? 'columnheader' : undefined,
-      'aria-sort': sortable ? props.sortDirection ?? 'none' : undefined,
-      ...props,
-    }),
-    aside: resolveShorthand(props.aside),
-    sortIcon: resolveShorthand(props.sortIcon, {
-      required: !!props.sortDirection,
+    root: slot.always(
+      getNativeElementProps(rootComponent, {
+        ref: useMergedRefs(ref, useFocusWithin()),
+        role: rootComponent === 'div' ? 'columnheader' : undefined,
+        'aria-sort': sortable ? props.sortDirection ?? 'none' : undefined,
+        ...props,
+      }),
+      { elementType: rootComponent },
+    ),
+    aside: slot.optional(props.aside, { elementType: 'span' }),
+    sortIcon: slot.optional(props.sortIcon, {
+      renderByDefault: !!props.sortDirection,
       defaultProps: { children: props.sortDirection ? sortIcons[props.sortDirection] : undefined },
+      elementType: 'span',
     }),
-    button: useARIAButtonShorthand(props.button, {
-      required: true,
-      defaultProps: {
-        as: 'div',
-        ...(!sortable && {
-          role: 'presentation',
-          tabIndex: undefined,
-        }),
-      },
-    }),
+    button: slot.always(
+      useARIAButtonShorthand(props.button, {
+        required: true,
+        defaultProps: {
+          as: 'div',
+          ...(!sortable && {
+            role: 'presentation',
+            tabIndex: undefined,
+          }),
+        },
+      }),
+      { elementType: 'div' },
+    ),
     sortable,
     noNativeElements,
   };

--- a/packages/react-components/react-table/src/components/TableResizeHandle/renderTableResizeHandle.tsx
+++ b/packages/react-components/react-table/src/components/TableResizeHandle/renderTableResizeHandle.tsx
@@ -2,13 +2,13 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableResizeHandleState, TableResizeHandleSlots } from './TableResizeHandle.types';
 
 /**
  * Render the final JSX of TableResizeHandle
  */
 export const renderTableResizeHandle_unstable = (state: TableResizeHandleState) => {
-  const { slots, slotProps } = getSlotsNext<TableResizeHandleSlots>(state);
-  return <slots.root {...slotProps.root} />;
+  assertSlots<TableResizeHandleSlots>(state);
+  return <state.root />;
 };

--- a/packages/react-components/react-table/src/components/TableResizeHandle/useTableResizeHandle.ts
+++ b/packages/react-components/react-table/src/components/TableResizeHandle/useTableResizeHandle.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useEventCallback } from '@fluentui/react-utilities';
+import { getNativeElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { TableResizeHandleProps, TableResizeHandleState } from './TableResizeHandle.types';
 
 /**
@@ -23,10 +23,13 @@ export const useTableResizeHandle_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-      onClick,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+        onClick,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-table/src/components/TableRow/renderTableRow.tsx
+++ b/packages/react-components/react-table/src/components/TableRow/renderTableRow.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableRowState, TableRowSlots } from './TableRow.types';
 
 /**
  * Render the final JSX of TableRow
  */
 export const renderTableRow_unstable = (state: TableRowState) => {
-  const { slots, slotProps } = getSlotsNext<TableRowSlots>(state);
+  assertSlots<TableRowSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-table/src/components/TableRow/useTableRow.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRow.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useFocusVisible, useFocusWithin } from '@fluentui/react-tabster';
 import type { TableRowProps, TableRowState } from './TableRow.types';
 import { useTableContext } from '../../contexts/tableContext';
@@ -25,11 +25,14 @@ export const useTableRow_unstable = (props: TableRowProps, ref: React.Ref<HTMLEl
     components: {
       root: rootComponent,
     },
-    root: getNativeElementProps(rootComponent, {
-      ref: useMergedRefs(ref, focusVisibleRef, focusWithinRef),
-      role: rootComponent === 'div' ? 'row' : undefined,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps(rootComponent, {
+        ref: useMergedRefs(ref, focusVisibleRef, focusWithinRef),
+        role: rootComponent === 'div' ? 'row' : undefined,
+        ...props,
+      }),
+      { elementType: rootComponent },
+    ),
     size,
     noNativeElements,
     appearance: props.appearance ?? 'none',

--- a/packages/react-components/react-table/src/components/TableSelectionCell/renderTableSelectionCell.tsx
+++ b/packages/react-components/react-table/src/components/TableSelectionCell/renderTableSelectionCell.tsx
@@ -2,21 +2,20 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TableSelectionCellState, TableSelectionCellSlots } from './TableSelectionCell.types';
 
 /**
  * Render the final JSX of TableSelectionCell
  */
 export const renderTableSelectionCell_unstable = (state: TableSelectionCellState) => {
-  const { slots, slotProps } = getSlotsNext<TableSelectionCellSlots>(state);
+  assertSlots<TableSelectionCellSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {state.type === 'checkbox' && slots.checkboxIndicator && (
-        <slots.checkboxIndicator {...slotProps.checkboxIndicator} />
-      )}
-      {state.type === 'radio' && slots.radioIndicator && <slots.radioIndicator {...slotProps.radioIndicator} />}
-    </slots.root>
+    <state.root>
+      {state.type === 'checkbox' && state.checkboxIndicator && <state.checkboxIndicator />}
+
+      {state.type === 'radio' && state.radioIndicator && <state.radioIndicator />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-table/src/components/TableSelectionCell/useTableSelectionCell.tsx
+++ b/packages/react-components/react-table/src/components/TableSelectionCell/useTableSelectionCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand, useId } from '@fluentui/react-utilities';
+import { useId, slot } from '@fluentui/react-utilities';
 import { Checkbox } from '@fluentui/react-checkbox';
 import { Radio } from '@fluentui/react-radio';
 import type { TableSelectionCellProps, TableSelectionCellState } from './TableSelectionCell.types';
@@ -30,13 +30,15 @@ export const useTableSelectionCell_unstable = (
       checkboxIndicator: Checkbox,
       radioIndicator: Radio,
     },
-    checkboxIndicator: resolveShorthand(props.checkboxIndicator, {
-      required: type === 'checkbox',
+    checkboxIndicator: slot.optional(props.checkboxIndicator, {
+      renderByDefault: type === 'checkbox',
       defaultProps: { checked: props.checked },
+      elementType: Checkbox,
     }),
-    radioIndicator: resolveShorthand(props.radioIndicator, {
-      required: type === 'radio',
+    radioIndicator: slot.optional(props.radioIndicator, {
+      renderByDefault: type === 'radio',
       defaultProps: { checked: !!checked, input: { name: useId('table-selection-radio') } },
+      elementType: Radio,
     }),
     type,
     checked,

--- a/packages/react-components/react-tags-preview/src/components/InteractionTag/renderInteractionTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTag/renderInteractionTag.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { InteractionTagState, InteractionTagSlots, InteractionTagContextValues } from './InteractionTag.types';
 import { AvatarContextProvider } from '@fluentui/react-avatar';
 
@@ -14,25 +14,26 @@ export const renderInteractionTag_unstable = (
   state: InteractionTagState,
   contextValues: InteractionTagContextValues,
 ) => {
-  const { slots, slotProps } = getSlotsNext<InteractionTagSlots>(state);
+  assertSlots<InteractionTagSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.content && (
-        <slots.content {...slotProps.content}>
-          {slots.media && (
+    <state.root>
+      {state.content && (
+        <state.content>
+          {state.media && (
             <AvatarContextProvider value={contextValues.avatar}>
-              <slots.media {...slotProps.media} />
+              <state.media />
             </AvatarContextProvider>
           )}
-          {slots.icon && <slots.icon {...slotProps.icon} />}
-          {slots.primaryText && (
-            <slots.primaryText {...slotProps.primaryText}>{slotProps.root.children}</slots.primaryText>
-          )}
-          {slots.secondaryText && <slots.secondaryText {...slotProps.secondaryText} />}
-        </slots.content>
+
+          {state.icon && <state.icon />}
+          {state.primaryText && <state.primaryText>{state.root.children}</state.primaryText>}
+
+          {state.secondaryText && <state.secondaryText />}
+        </state.content>
       )}
-      {slots.dismissButton && state.dismissible && <slots.dismissButton {...slotProps.dismissButton} />}
-    </slots.root>
+
+      {state.dismissButton && state.dismissible && <state.dismissButton />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-tags-preview/src/components/InteractionTag/useInteractionTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTag/useInteractionTag.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useEventCallback, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useEventCallback, useId, slot } from '@fluentui/react-utilities';
 import { DismissRegular, bundleIcon, DismissFilled } from '@fluentui/react-icons';
 import type { InteractionTagProps, InteractionTagState } from './InteractionTag.types';
 import { Delete, Backspace } from '@fluentui/keyboard-keys';
@@ -58,15 +58,15 @@ export const useInteractionTag_unstable = (
     }
   });
 
-  const dismissButtonShorthand = resolveShorthand(props.dismissButton, {
-    required: dismissible,
+  const dismissButtonShorthand = slot.optional(props.dismissButton, {
+    renderByDefault: dismissible,
     defaultProps: {
       disabled,
       type: 'button',
       children: <DismissIcon />,
     },
+    elementType: 'button',
   });
-
   return {
     appearance,
     avatarShape: interactionTagAvatarShapeMap[shape],
@@ -75,7 +75,6 @@ export const useInteractionTag_unstable = (
     dismissible,
     shape,
     size,
-
     components: {
       root: 'div',
       content: 'button',
@@ -86,28 +85,34 @@ export const useInteractionTag_unstable = (
       dismissButton: 'button',
     },
 
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-      id,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+        id,
+      }),
+      { elementType: 'div' },
+    ),
 
-    content: resolveShorthand(props.content, {
-      required: true,
+    content: slot.always(props.content, {
       defaultProps: {
         disabled,
         type: 'button',
       },
+      elementType: 'button',
     }),
-    media: resolveShorthand(props.media),
-    icon: resolveShorthand(props.icon),
-    primaryText: resolveShorthand(props.primaryText, { required: true }),
-    secondaryText: resolveShorthand(props.secondaryText),
+    media: slot.optional(props.media, { elementType: 'span' }),
+    icon: slot.optional(props.icon, { elementType: 'span' }),
+    primaryText: slot.optional(props.primaryText, { renderByDefault: true, elementType: 'span' }),
+    secondaryText: slot.optional(props.secondaryText, { elementType: 'span' }),
 
-    dismissButton: {
-      ...dismissButtonShorthand,
-      onClick: onDismissButtonClick,
-      onKeyDown: onDismissButtonKeyDown,
-    },
+    dismissButton: slot.always(
+      {
+        ...dismissButtonShorthand,
+        onClick: onDismissButtonClick,
+        onKeyDown: onDismissButtonKeyDown,
+      },
+      { elementType: 'button' },
+    ),
   };
 };

--- a/packages/react-components/react-tags-preview/src/components/Tag/renderTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/renderTag.tsx
@@ -3,7 +3,7 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TagState, TagSlots, TagContextValues } from './Tag.types';
 import { AvatarContextProvider } from '@fluentui/react-avatar';
 
@@ -11,19 +11,20 @@ import { AvatarContextProvider } from '@fluentui/react-avatar';
  * Render the final JSX of Tag
  */
 export const renderTag_unstable = (state: TagState, contextValues: TagContextValues) => {
-  const { slots, slotProps } = getSlotsNext<TagSlots>(state);
+  assertSlots<TagSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.media && (
+    <state.root>
+      {state.media && (
         <AvatarContextProvider value={contextValues.avatar}>
-          <slots.media {...slotProps.media} />
+          <state.media />
         </AvatarContextProvider>
       )}
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {slots.primaryText && <slots.primaryText {...slotProps.primaryText} />}
-      {slots.secondaryText && <slots.secondaryText {...slotProps.secondaryText} />}
-      {slots.dismissIcon && state.dismissible && <slots.dismissIcon {...slotProps.dismissIcon} />}
-    </slots.root>
+
+      {state.icon && <state.icon />}
+      {state.primaryText && <state.primaryText />}
+      {state.secondaryText && <state.secondaryText />}
+      {state.dismissIcon && state.dismissible && <state.dismissIcon />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand, useEventCallback, useId } from '@fluentui/react-utilities';
+import { getNativeElementProps, useEventCallback, useId, slot } from '@fluentui/react-utilities';
 import { DismissRegular, bundleIcon, DismissFilled } from '@fluentui/react-icons';
 import type { TagProps, TagState } from './Tag.types';
 import { Delete, Backspace } from '@fluentui/keyboard-keys';
@@ -73,28 +73,33 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
       dismissIcon: 'span',
     },
 
-    root: getNativeElementProps('button', {
-      ref,
-      ...props,
-      id,
-      onClick: handleClick,
-      onKeyDown: handleKeyDown,
-    }),
+    root: slot.always(
+      getNativeElementProps('button', {
+        ref,
+        ...props,
+        id,
+        onClick: handleClick,
+        onKeyDown: handleKeyDown,
+      }),
+      { elementType: dismissible ? 'button' : 'span' },
+    ),
 
-    media: resolveShorthand(props.media),
-    icon: resolveShorthand(props.icon),
-    primaryText: resolveShorthand(props.primaryText, {
-      required: true,
+    media: slot.optional(props.media, { elementType: 'span' }),
+    icon: slot.optional(props.icon, { elementType: 'span' }),
+    primaryText: slot.optional(props.primaryText, {
+      renderByDefault: true,
       defaultProps: {
         children: props.children,
       },
+      elementType: 'span',
     }),
-    secondaryText: resolveShorthand(props.secondaryText),
-    dismissIcon: resolveShorthand(props.dismissIcon, {
-      required: dismissible,
+    secondaryText: slot.optional(props.secondaryText, { elementType: 'span' }),
+    dismissIcon: slot.optional(props.dismissIcon, {
+      renderByDefault: dismissible,
       defaultProps: {
         children: <DismissIcon />,
       },
+      elementType: 'span',
     }),
   };
 };

--- a/packages/react-components/react-tags-preview/src/components/TagGroup/renderTagGroup.tsx
+++ b/packages/react-components/react-tags-preview/src/components/TagGroup/renderTagGroup.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx createElement */
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TagGroupState, TagGroupSlots, TagGroupContextValues } from './TagGroup.types';
 import { TagGroupContextProvider } from '../../contexts/TagGroupContext';
 
@@ -9,11 +9,11 @@ import { TagGroupContextProvider } from '../../contexts/TagGroupContext';
  * Render the final JSX of TagGroup
  */
 export const renderTagGroup_unstable = (state: TagGroupState, contextValue: TagGroupContextValues) => {
-  const { slots, slotProps } = getSlotsNext<TagGroupSlots>(state);
+  assertSlots<TagGroupSlots>(state);
 
   return (
     <TagGroupContextProvider value={contextValue.tagGroup}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </TagGroupContextProvider>
   );
 };

--- a/packages/react-components/react-tags-preview/src/components/TagGroup/useTagGroup.ts
+++ b/packages/react-components/react-tags-preview/src/components/TagGroup/useTagGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useEventCallback, useMergedRefs, slot } from '@fluentui/react-utilities';
 import type { TagGroupProps, TagGroupState } from './TagGroup.types';
 import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabster';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
@@ -59,11 +59,14 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLEl
       root: 'div',
     },
 
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, innerRef),
-      role: 'toolbar',
-      ...arrowNavigationProps,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, innerRef),
+        role: 'toolbar',
+        ...arrowNavigationProps,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-text/src/components/Text/renderText.tsx
+++ b/packages/react-components/react-text/src/components/Text/renderText.tsx
@@ -3,14 +3,14 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TextSlots, TextState } from './Text.types';
 
 /**
  * Render the final JSX of Text
  */
 export const renderText_unstable = (state: TextState) => {
-  const { slots, slotProps } = getSlotsNext<TextSlots>(state);
+  assertSlots<TextSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-text/src/components/Text/useText.ts
+++ b/packages/react-components/react-text/src/components/Text/useText.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { TextProps, TextState } from './Text.types';
 
 /**
@@ -29,11 +29,14 @@ export const useText_unstable = (props: TextProps, ref: React.Ref<HTMLElement>):
 
     components: { root: 'span' },
 
-    root: getNativeElementProps(as, {
-      ref,
-      ...props,
-      as,
-    }),
+    root: slot.always(
+      getNativeElementProps(as, {
+        ref,
+        ...props,
+        as,
+      }),
+      { elementType: 'span' },
+    ),
   };
 
   return state;

--- a/packages/react-components/react-textarea/src/components/Textarea/renderTextarea.tsx
+++ b/packages/react-components/react-textarea/src/components/Textarea/renderTextarea.tsx
@@ -3,18 +3,18 @@
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TextareaState, TextareaSlots } from './Textarea.types';
 
 /**
  * Render the final JSX of Textarea
  */
 export const renderTextarea_unstable = (state: TextareaState) => {
-  const { slots, slotProps } = getSlotsNext<TextareaSlots>(state);
+  assertSlots<TextareaSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <slots.textarea {...slotProps.textarea} />
-    </slots.root>
+    <state.root>
+      <state.textarea />
+    </state.root>
   );
 };

--- a/packages/react-components/react-textarea/src/components/Textarea/useTextarea.ts
+++ b/packages/react-components/react-textarea/src/components/Textarea/useTextarea.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import {
-  getPartitionedNativeProps,
-  resolveShorthand,
-  useControllableState,
-  useEventCallback,
-} from '@fluentui/react-utilities';
+import { getPartitionedNativeProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { TextareaProps, TextareaState } from './Textarea.types';
 import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-contexts';
 
@@ -62,16 +57,16 @@ export const useTextarea_unstable = (props: TextareaProps, ref: React.Ref<HTMLTe
       root: 'span',
       textarea: 'textarea',
     },
-    textarea: resolveShorthand(props.textarea, {
-      required: true,
+    textarea: slot.always(props.textarea, {
       defaultProps: {
         ref,
         ...nativeProps.primary,
       },
+      elementType: 'textarea',
     }),
-    root: resolveShorthand(props.root, {
-      required: true,
+    root: slot.always(props.root, {
       defaultProps: nativeProps.root,
+      elementType: 'span',
     }),
   };
 

--- a/packages/react-components/react-toast/src/components/AriaLive/renderAriaLive.tsx
+++ b/packages/react-components/react-toast/src/components/AriaLive/renderAriaLive.tsx
@@ -3,19 +3,19 @@
 /** @jsx createElement */
 
 import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { AriaLiveState, AriaLiveSlots } from './AriaLive.types';
 
 /**
  * Render the final JSX of AriaLive
  */
 export const renderAriaLive_unstable = (state: AriaLiveState) => {
-  const { slots, slotProps } = getSlotsNext<AriaLiveSlots>(state);
+  assertSlots<AriaLiveSlots>(state);
 
   return (
     <>
-      <slots.assertive {...slotProps.assertive} />
-      <slots.polite {...slotProps.polite} />
+      <state.assertive />
+      <state.polite />
     </>
   );
 };

--- a/packages/react-components/react-toast/src/components/AriaLive/useAriaLive.ts
+++ b/packages/react-components/react-toast/src/components/AriaLive/useAriaLive.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand, createPriorityQueue, useEventCallback } from '@fluentui/react-utilities';
+import { createPriorityQueue, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { AnnounceOptions, AriaLiveProps, AriaLiveState, LiveMessage } from './AriaLive.types';
 
 /** The duration the message needs to be in present in DOM for screen readers to register a change and announce */
@@ -69,13 +69,13 @@ export const useAriaLive_unstable = (props: AriaLiveProps): AriaLiveState => {
       polite: 'div',
     },
 
-    assertive: resolveShorthand(props.assertive, {
-      required: true,
+    assertive: slot.always(props.assertive, {
       defaultProps: { 'aria-live': 'assertive', children: assertiveMessage },
+      elementType: 'div',
     }),
-    polite: resolveShorthand(props.polite, {
-      required: true,
+    polite: slot.always(props.polite, {
       defaultProps: { 'aria-live': 'polite', children: politeMessage },
+      elementType: 'div',
     }),
   };
 };

--- a/packages/react-components/react-toast/src/components/Toast/renderToast.tsx
+++ b/packages/react-components/react-toast/src/components/Toast/renderToast.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { BackgroundAppearanceProvider } from '@fluentui/react-shared-contexts';
 import type { ToastState, ToastSlots, ToastContextValues } from './Toast.types';
 
@@ -10,11 +10,11 @@ import type { ToastState, ToastSlots, ToastContextValues } from './Toast.types';
  * Render the final JSX of Toast
  */
 export const renderToast_unstable = (state: ToastState, contextValues: ToastContextValues) => {
-  const { slots, slotProps } = getSlotsNext<ToastSlots>(state);
+  assertSlots<ToastSlots>(state);
 
   return (
     <BackgroundAppearanceProvider value={contextValues.backgroundAppearance}>
-      <slots.root {...slotProps.root} />
+      <state.root />
     </BackgroundAppearanceProvider>
   );
 };

--- a/packages/react-components/react-toast/src/components/Toast/useToast.ts
+++ b/packages/react-components/react-toast/src/components/Toast/useToast.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { ToastProps, ToastState } from './Toast.types';
 
 /**
@@ -16,10 +16,13 @@ export const useToast_unstable = (props: ToastProps, ref: React.Ref<HTMLElement>
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     backgroundAppearance: props.appearance,
   };
 };

--- a/packages/react-components/react-toast/src/components/ToastBody/renderToastBody.tsx
+++ b/packages/react-components/react-toast/src/components/ToastBody/renderToastBody.tsx
@@ -3,19 +3,19 @@
 /** @jsx createElement */
 
 import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ToastBodyState, ToastBodySlots } from './ToastBody.types';
 
 /**
  * Render the final JSX of ToastBody
  */
 export const renderToastBody_unstable = (state: ToastBodyState) => {
-  const { slots, slotProps } = getSlotsNext<ToastBodySlots>(state);
+  assertSlots<ToastBodySlots>(state);
 
   return (
     <>
-      <slots.root {...slotProps.root} />
-      {slots.subtitle ? <slots.subtitle {...slotProps.subtitle} /> : null}
+      <state.root />
+      {state.subtitle ? <state.subtitle /> : null}
     </>
   );
 };

--- a/packages/react-components/react-toast/src/components/ToastBody/useToastBody.ts
+++ b/packages/react-components/react-toast/src/components/ToastBody/useToastBody.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { ToastBodyProps, ToastBodyState } from './ToastBody.types';
 import { useToastContainerContext } from '../../contexts/toastContainerContext';
 import { useBackgroundAppearance } from '@fluentui/react-shared-contexts';
@@ -21,12 +21,15 @@ export const useToastBody_unstable = (props: ToastBodyProps, ref: React.Ref<HTML
       root: 'div',
       subtitle: 'div',
     },
-    subtitle: resolveShorthand(props.subtitle),
-    root: getNativeElementProps('div', {
-      ref,
-      id: bodyId,
-      ...props,
-    }),
+    subtitle: slot.optional(props.subtitle, { elementType: 'div' }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        id: bodyId,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     backgroundAppearance,
   };
 };

--- a/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
+++ b/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { Transition } from 'react-transition-group';
 import type { ToastContainerState, ToastContainerSlots, ToastContainerContextValues } from './ToastContainer.types';
 import { ToastContainerContextProvider } from '../../contexts/toastContainerContext';
@@ -15,7 +15,7 @@ export const renderToastContainer_unstable = (
   contextValues: ToastContainerContextValues,
 ) => {
   const { onTransitionEntering, visible, transitionTimeout, remove, nodeRef } = state;
-  const { slots, slotProps } = getSlotsNext<ToastContainerSlots>(state);
+  assertSlots<ToastContainerSlots>(state);
 
   return (
     <Transition
@@ -28,8 +28,8 @@ export const renderToastContainer_unstable = (
       nodeRef={nodeRef}
     >
       <ToastContainerContextProvider value={contextValues.toast}>
-        <slots.root {...slotProps.root} />
-        <slots.timer {...slotProps.timer} />
+        <state.root />
+        <state.timer />
       </ToastContainerContextProvider>
     </Transition>
   );

--- a/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
@@ -5,8 +5,8 @@ import {
   ExtractSlotProps,
   Slot,
   useEventCallback,
-  resolveShorthand,
   useId,
+  slot,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { Delete, Tab } from '@fluentui/keyboard-keys';
@@ -214,24 +214,27 @@ export const useToastContainer_unstable = (
       timer: Timer,
       root: 'div',
     },
-    timer: resolveShorthand<TimerProps>(
+    timer: slot.always<TimerProps>(
       { key: updateId, onTimeout: close, running, timeout: timerTimeout ?? -1 },
-      { required: true },
+      { elementType: Timer },
     ),
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, toastRef, toastAnimationRef),
-      children,
-      tabIndex: 0,
-      role: 'listitem',
-      'aria-labelledby': titleId,
-      'aria-describedby': bodyId,
-      ...rest,
-      ...userRootSlot,
-      ...focusableGroupAttribute,
-      onMouseEnter,
-      onMouseLeave,
-      onKeyDown,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, toastRef, toastAnimationRef),
+        children,
+        tabIndex: 0,
+        role: 'listitem',
+        'aria-labelledby': titleId,
+        'aria-describedby': bodyId,
+        ...rest,
+        ...userRootSlot,
+        ...focusableGroupAttribute,
+        onMouseEnter,
+        onMouseLeave,
+        onKeyDown,
+      }),
+      { elementType: 'div' },
+    ),
     timerTimeout,
     transitionTimeout: 500,
     running,

--- a/packages/react-components/react-toast/src/components/ToastFooter/renderToastFooter.tsx
+++ b/packages/react-components/react-toast/src/components/ToastFooter/renderToastFooter.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ToastFooterState, ToastFooterSlots } from './ToastFooter.types';
 
 /**
  * Render the final JSX of ToastFooter
  */
 export const renderToastFooter_unstable = (state: ToastFooterState) => {
-  const { slots, slotProps } = getSlotsNext<ToastFooterSlots>(state);
+  assertSlots<ToastFooterSlots>(state);
 
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-toast/src/components/ToastFooter/useToastFooter.ts
+++ b/packages/react-components/react-toast/src/components/ToastFooter/useToastFooter.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { ToastFooterProps, ToastFooterState } from './ToastFooter.types';
 
 /**
@@ -16,9 +16,12 @@ export const useToastFooter_unstable = (props: ToastFooterProps, ref: React.Ref<
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-toast/src/components/ToastTitle/renderToastTitle.tsx
+++ b/packages/react-components/react-toast/src/components/ToastTitle/renderToastTitle.tsx
@@ -3,20 +3,20 @@
 /** @jsx createElement */
 
 import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ToastTitleState, ToastTitleSlots } from './ToastTitle.types';
 
 /**
  * Render the final JSX of ToastTitle
  */
 export const renderToastTitle_unstable = (state: ToastTitleState) => {
-  const { slots, slotProps } = getSlotsNext<ToastTitleSlots>(state);
+  assertSlots<ToastTitleSlots>(state);
 
   return (
     <>
-      {slots.media ? <slots.media {...slotProps.media} /> : null}
-      <slots.root {...slotProps.root} />
-      {slots.action ? <slots.action {...slotProps.action} /> : null}
+      {state.media ? <state.media /> : null}
+      <state.root />
+      {state.action ? <state.action /> : null}
     </>
   );
 };

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { CheckmarkCircleFilled, DismissCircleFilled, InfoFilled, WarningFilled } from '@fluentui/react-icons';
-import { getNativeElementProps, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import { useBackgroundAppearance } from '@fluentui/react-shared-contexts';
 
 import type { ToastTitleProps, ToastTitleState } from './ToastTitle.types';
@@ -38,19 +38,22 @@ export const useToastTitle_unstable = (props: ToastTitleProps, ref: React.Ref<HT
   }
 
   return {
-    action: resolveShorthand(props.action),
-    components: {
-      root: 'div',
-      media: 'div',
-      action: 'div',
-    },
-    media: resolveShorthand(props.media, { required: !!intent, defaultProps: { children: defaultIcon } }),
-    root: getNativeElementProps('div', {
-      ref,
-      children: props.children,
-      id: titleId,
-      ...props,
+    action: slot.optional(props.action, { elementType: 'div' }),
+    components: { root: 'div', media: 'div', action: 'div' },
+    media: slot.optional(props.media, {
+      renderByDefault: !!intent,
+      defaultProps: { children: defaultIcon },
+      elementType: 'div',
     }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        children: props.children,
+        id: titleId,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     intent,
     backgroundAppearance,
   };

--- a/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
@@ -3,7 +3,7 @@
 /** @jsx createElement */
 
 import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { Portal } from '@fluentui/react-portal';
 import type { ToasterState, ToasterSlotsInternal } from './Toaster.types';
 import { AriaLive } from '../AriaLive';
@@ -13,19 +13,19 @@ import { AriaLive } from '../AriaLive';
  */
 export const renderToaster_unstable = (state: ToasterState) => {
   const { announceRef, renderAriaLive } = state;
-  const { slots, slotProps } = getSlotsNext<ToasterSlotsInternal>(state);
+  assertSlots<ToasterSlotsInternal>(state);
 
-  const hasToasts = !!slots.bottomStart || !!slots.bottomEnd || !!slots.topStart || !!slots.topEnd;
+  const hasToasts = !!state.bottomStart || !!state.bottomEnd || !!state.topStart || !!state.topEnd;
 
   return (
     <>
       {renderAriaLive ? <AriaLive announceRef={announceRef} /> : null}
       {hasToasts ? (
         <Portal>
-          {slots.bottomStart ? <slots.bottomStart {...slotProps.bottomStart} /> : null}
-          {slots.bottomEnd ? <slots.bottomEnd {...slotProps.bottomEnd} /> : null}
-          {slots.topStart ? <slots.topStart {...slotProps.topStart} /> : null}
-          {slots.topEnd ? <slots.topEnd {...slotProps.topEnd} /> : null}
+          {state.bottomStart ? <state.bottomStart /> : null}
+          {state.bottomEnd ? <state.bottomEnd /> : null}
+          {state.topStart ? <state.topStart /> : null}
+          {state.topEnd ? <state.topEnd /> : null}
         </Portal>
       ) : null}
     </>

--- a/packages/react-components/react-toast/src/components/Toaster/useToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/useToaster.tsx
@@ -3,9 +3,9 @@ import {
   ExtractSlotProps,
   Slot,
   getNativeElementProps,
-  resolveShorthand,
   useEventCallback,
   useMergedRefs,
+  slot,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useFocusableGroup } from '@fluentui/react-tabster';
@@ -30,25 +30,22 @@ export const useToaster_unstable = (props: ToasterProps): ToasterState => {
   const announce = React.useCallback<Announce>((message, options) => announceRef.current(message, options), []);
   const { dir } = useFluent();
 
-  const rootProps = getNativeElementProps('div', rest);
+  const rootProps = slot.always(getNativeElementProps('div', rest), { elementType: 'div' });
   const focusableGroupAttr = useFocusableGroup({
     tabBehavior: 'limited-trap-focus',
     ignoreDefaultKeydown: { Escape: true },
   });
-
   const onKeyDown = useEventCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === Escape) {
       e.preventDefault();
       closeAllToasts();
     }
-
     props.onKeyDown?.(e);
   });
-
   const usePositionSlot = (toastPosition: ToastPosition) => {
     const focusManagementRef = useToasterFocusManagement_unstable(pauseAllToasts, playAllToasts);
     const { announceToast, toasterRef } = useToastAnnounce(announceProp ?? announce);
-    return resolveShorthand(toastsToRender.has(toastPosition) ? rootProps : null, {
+    return slot.optional(toastsToRender.has(toastPosition) ? rootProps : null, {
       defaultProps: {
         ref: useMergedRefs(focusManagementRef, toasterRef),
         children: toastsToRender.get(toastPosition)?.map(toast => (
@@ -66,22 +63,15 @@ export const useToaster_unstable = (props: ToasterProps): ToasterState => {
         onKeyDown,
         ...focusableGroupAttr,
         'data-toaster-position': toastPosition,
-        role: 'list',
-        // Explicitly casting because our slot types can't handle data attributes
+        role: 'list', // Explicitly casting because our slot types can't handle data attributes
       } as ExtractSlotProps<Slot<'div'>>,
+      elementType: 'div',
     });
   };
-
   return {
     dir,
-    components: {
-      root: 'div',
-      bottomStart: 'div',
-      bottomEnd: 'div',
-      topStart: 'div',
-      topEnd: 'div',
-    },
-    root: resolveShorthand(rootProps, { required: true }),
+    components: { root: 'div', bottomStart: 'div', bottomEnd: 'div', topStart: 'div', topEnd: 'div' },
+    root: slot.always(rootProps, { elementType: 'div' }),
     bottomStart: usePositionSlot(TOAST_POSITIONS.bottomStart),
     bottomEnd: usePositionSlot(TOAST_POSITIONS.bottomEnd),
     topStart: usePositionSlot(TOAST_POSITIONS.topStart),

--- a/packages/react-components/react-toolbar/src/components/Toolbar/renderToolbar.tsx
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/renderToolbar.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ToolbarState, ToolbarSlots, ToolbarContextValues } from './Toolbar.types';
 import { ToolbarContext } from './ToolbarContext';
 
@@ -10,11 +10,11 @@ import { ToolbarContext } from './ToolbarContext';
  * Render the final JSX of Toolbar
  */
 export const renderToolbar_unstable = (state: ToolbarState, contextValues: ToolbarContextValues) => {
-  const { slots, slotProps } = getSlotsNext<ToolbarSlots>(state);
+  assertSlots<ToolbarSlots>(state);
 
   return (
     <ToolbarContext.Provider value={contextValues.toolbar}>
-      <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>
+      <state.root>{state.root.children}</state.root>
     </ToolbarContext.Provider>
   );
 };

--- a/packages/react-components/react-toolbar/src/components/Toolbar/useToolbar.ts
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/useToolbar.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { useEventCallback, useControllableState } from '@fluentui/react-utilities';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { useEventCallback, useControllableState, getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { ToggableHandler, ToolbarProps, ToolbarState, UninitializedToolbarState } from './Toolbar.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 
@@ -31,13 +30,16 @@ export const useToolbar_unstable = (props: ToolbarProps, ref: React.Ref<HTMLElem
     },
     // TODO add appropriate slots, for example:
     // mySlot: resolveShorthand(props.mySlot),
-    root: getNativeElementProps('div', {
-      role: 'toolbar',
-      ref,
-      ...(vertical && { 'aria-orientation': 'vertical' }),
-      ...arrowNavigationProps,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        role: 'toolbar',
+        ref,
+        ...(vertical && { 'aria-orientation': 'vertical' }),
+        ...arrowNavigationProps,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 
   const [checkedValues, onCheckedValueChange] = useToolbarSelectableState({

--- a/packages/react-components/react-toolbar/src/components/ToolbarGroup/renderToolbarGroup.tsx
+++ b/packages/react-components/react-toolbar/src/components/ToolbarGroup/renderToolbarGroup.tsx
@@ -2,14 +2,14 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { ToolbarGroupState, ToolbarGroupSlots } from './ToolbarGroup.types';
 
 /**
  * Render the final JSX of ToolbarGroup
  */
 export const renderToolbarGroup_unstable = (state: ToolbarGroupState) => {
-  const { slots, slotProps } = getSlotsNext<ToolbarGroupSlots>(state);
+  assertSlots<ToolbarGroupSlots>(state);
 
-  return <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>;
+  return <state.root>{state.root.children}</state.root>;
 };

--- a/packages/react-components/react-toolbar/src/components/ToolbarGroup/useToolbarGroup.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarGroup/useToolbarGroup.ts
@@ -1,4 +1,4 @@
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types';
 
@@ -15,10 +15,13 @@ export const useToolbarGroup_unstable = (
     components: {
       root: 'div',
     },
-    root: getNativeElementProps<React.HTMLAttributes<HTMLDivElement>>('div', {
-      ref,
-      role: 'presentation',
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps<React.HTMLAttributes<HTMLDivElement>>('div', {
+        ref,
+        role: 'presentation',
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-tooltip/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/renderTooltip.tsx
@@ -7,24 +7,24 @@ import { Portal } from '@fluentui/react-portal';
 
 import { createElement } from '@fluentui/react-jsx-runtime';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TooltipSlots, TooltipState } from './Tooltip.types';
 
 /**
  * Render the final JSX of Tooltip
  */
 export const renderTooltip_unstable = (state: TooltipState) => {
-  const { slots, slotProps } = getSlotsNext<TooltipSlots>(state);
+  assertSlots<TooltipSlots>(state);
 
   return (
     <>
       {state.children}
       {state.shouldRenderTooltip && (
         <Portal mountNode={state.mountNode}>
-          <slots.content {...slotProps.content}>
+          <state.content>
             {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
             {state.content.children}
-          </slots.content>
+          </state.content>
         </Portal>
       )}
     </>

--- a/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -6,7 +6,6 @@ import {
 } from '@fluentui/react-shared-contexts';
 import {
   applyTriggerPropsToChildren,
-  resolveShorthand,
   useControllableState,
   useId,
   useIsomorphicLayoutEffect,
@@ -16,6 +15,7 @@ import {
   getTriggerChild,
   mergeCallbacks,
   useEventCallback,
+  slot,
 } from '@fluentui/react-utilities';
 import type { TooltipProps, TooltipState, TooltipChildProps } from './Tooltip.types';
 import { arrowHeight, tooltipBorderRadius } from './private/constants';
@@ -76,11 +76,11 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     components: {
       content: 'div',
     },
-    content: resolveShorthand(content, {
+    content: slot.always(content, {
       defaultProps: {
         role: 'tooltip',
       },
-      required: true,
+      elementType: 'div',
     }),
   };
 

--- a/packages/react-components/react-tree/src/components/Tree/renderTree.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/renderTree.tsx
@@ -2,15 +2,15 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { TreeProvider } from '../../contexts';
 import type { TreeContextValues, TreeSlots, TreeState } from '../Tree/Tree.types';
 
 export const renderTree_unstable = (state: TreeState, contextValues: TreeContextValues) => {
-  const { slots, slotProps } = getSlotsNext<TreeSlots>(state);
+  assertSlots<TreeSlots>(state);
   return (
     <TreeProvider value={contextValues.tree}>
-      {state.open && <slots.root {...slotProps.root}>{slotProps.root.children}</slots.root>}
+      {state.open && <state.root>{state.root.children}</state.root>}
     </TreeProvider>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItem/renderTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/renderTreeItem.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TreeItemState, TreeItemContextValues, TreeItemSlots } from './TreeItem.types';
 import { TreeItemProvider } from '../../contexts';
 
@@ -10,11 +10,11 @@ import { TreeItemProvider } from '../../contexts';
  * Render the final JSX of TreeItem
  */
 export const renderTreeItem_unstable = (state: TreeItemState, contextValues: TreeItemContextValues) => {
-  const { slots, slotProps } = getSlotsNext<TreeItemSlots>(state);
+  assertSlots<TreeItemSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      <TreeItemProvider value={contextValues.treeItem}>{slotProps.root.children}</TreeItemProvider>
-    </slots.root>
+    <state.root>
+      <TreeItemProvider value={contextValues.treeItem}>{state.root.children}</TreeItemProvider>
+    </state.root>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, useId, useMergedRefs } from '@fluentui/react-utilities';
-import { useEventCallback } from '@fluentui/react-utilities';
+import { getNativeElementProps, useId, useMergedRefs, useEventCallback, slot } from '@fluentui/react-utilities';
 import { elementContains } from '@fluentui/react-portal';
 import type { TreeItemProps, TreeItemState } from './TreeItem.types';
 import { useTreeContext_unstable } from '../../contexts/index';
@@ -160,24 +159,27 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
     },
     isAsideVisible,
     isActionsVisible,
-    root: getNativeElementProps(as, {
-      tabIndex: -1,
-      ...rest,
-      ref,
-      role: 'treeitem',
-      'aria-level': level,
-      [dataTreeItemValueAttrName]: value,
-      'aria-checked':
-        selectionMode === 'multiselect' ? (checked === 'mixed' ? undefined : checked ?? false) : undefined,
-      'aria-selected': selectionMode === 'single' ? checked : undefined,
-      'aria-expanded': isBranch ? open : undefined,
-      onClick: handleClick,
-      onKeyDown: handleKeyDown,
-      onMouseOver: handleActionsVisible,
-      onFocus: handleActionsVisible,
-      onMouseOut: handleActionsInvisible,
-      onBlur: handleActionsInvisible,
-      onChange: handleChange,
-    }),
+    root: slot.always(
+      getNativeElementProps(as, {
+        tabIndex: -1,
+        ...rest,
+        ref,
+        role: 'treeitem',
+        'aria-level': level,
+        [dataTreeItemValueAttrName]: value,
+        'aria-checked':
+          selectionMode === 'multiselect' ? (checked === 'mixed' ? undefined : checked ?? false) : undefined,
+        'aria-selected': selectionMode === 'single' ? checked : undefined,
+        'aria-expanded': isBranch ? open : undefined,
+        onClick: handleClick,
+        onKeyDown: handleKeyDown,
+        onMouseOver: handleActionsVisible,
+        onFocus: handleActionsVisible,
+        onMouseOut: handleActionsInvisible,
+        onBlur: handleActionsInvisible,
+        onChange: handleChange,
+      }),
+      { elementType: 'div' },
+    ),
   };
 }

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/renderTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/renderTreeItemLayout.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TreeItemLayoutState, TreeItemLayoutSlots } from './TreeItemLayout.types';
 import { ButtonContextProvider } from '@fluentui/react-button';
 
@@ -10,19 +10,19 @@ import { ButtonContextProvider } from '@fluentui/react-button';
  * Render the final JSX of TreeItemLayout
  */
 export const renderTreeItemLayout_unstable = (state: TreeItemLayoutState) => {
-  const { slots, slotProps } = getSlotsNext<TreeItemLayoutSlots>(state);
+  assertSlots<TreeItemLayoutSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-      {slots.selector && <slots.selector {...slotProps.selector} />}
-      {slots.iconBefore && <slots.iconBefore {...slotProps.iconBefore} />}
-      <slots.main {...slotProps.main}>{slotProps.root.children}</slots.main>
-      {slots.iconAfter && <slots.iconAfter {...slotProps.iconAfter} />}
+    <state.root>
+      {state.expandIcon && <state.expandIcon />}
+      {state.selector && <state.selector />}
+      {state.iconBefore && <state.iconBefore />}
+      <state.main>{state.root.children}</state.main>
+      {state.iconAfter && <state.iconAfter />}
       <ButtonContextProvider value={state.buttonContextValue}>
-        {slots.actions && <slots.actions {...slotProps.actions} />}
-        {slots.aside && <slots.aside {...slotProps.aside} />}
+        {state.actions && <state.actions />}
+        {state.aside && <state.aside />}
       </ButtonContextProvider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/renderTreeItemPersonaLayout.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/renderTreeItemPersonaLayout.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type {
   TreeItemPersonaLayoutState,
   TreeItemPersonaLayoutContextValues,
@@ -18,21 +18,21 @@ export const renderTreeItemPersonaLayout_unstable = (
   state: TreeItemPersonaLayoutState,
   contextValues: TreeItemPersonaLayoutContextValues,
 ) => {
-  const { slots, slotProps } = getSlotsNext<TreeItemPersonaLayoutSlots>(state);
+  assertSlots<TreeItemPersonaLayoutSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.expandIcon && <slots.expandIcon {...slotProps.expandIcon} />}
-      {slots.selector && <slots.selector {...slotProps.selector} />}
+    <state.root>
+      {state.expandIcon && <state.expandIcon />}
+      {state.selector && <state.selector />}
       <AvatarContextProvider value={contextValues.avatar}>
-        <slots.media {...slotProps.media} />
+        <state.media />
       </AvatarContextProvider>
-      <slots.main {...slotProps.main} />
-      {slots.description && <slots.description {...slotProps.description} />}
+      <state.main />
+      {state.description && <state.description />}
       <ButtonContextProvider value={state.buttonContextValue}>
-        {slots.actions && <slots.actions {...slotProps.actions} />}
-        {slots.aside && <slots.aside {...slotProps.aside} />}
+        {state.actions && <state.actions />}
+        {state.aside && <state.aside />}
       </ButtonContextProvider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayout.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayout.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { TreeItemPersonaLayoutProps, TreeItemPersonaLayoutState } from './TreeItemPersonaLayout.types';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { useTreeContext_unstable } from '../../contexts';
 import { treeAvatarSize } from '../../utils/tokens';
 import { useTreeItemLayout_unstable } from '../TreeItemLayout/useTreeItemLayout';
@@ -48,8 +48,8 @@ export const useTreeItemPersonaLayout_unstable = (
       selector: (selectionMode === 'multiselect' ? Checkbox : Radio) as React.ElementType<CheckboxProps | RadioProps>,
     },
     avatarSize: treeAvatarSize[size],
-    main: resolveShorthand(main, { required: true, defaultProps: { children } }),
-    media: resolveShorthand(media, { required: true }),
-    description: resolveShorthand(description),
+    main: slot.always(main, { defaultProps: { children }, elementType: 'div' }),
+    media: slot.always(media, { elementType: 'div' }),
+    description: slot.optional(description, { elementType: 'div' }),
   };
 };

--- a/packages/react-components/react-tree/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/src/hooks/useRootTree.ts
@@ -1,4 +1,4 @@
-import { SelectionMode, getNativeElementProps, useEventCallback } from '@fluentui/react-utilities';
+import { SelectionMode, getNativeElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
 import type {
   TreeCheckedChangeData,
   TreeNavigationData_unstable,
@@ -33,6 +33,7 @@ export function useRootTree(
     | 'aria-label'
     | 'aria-labelledby'
   >,
+
   ref: React.Ref<HTMLElement>,
 ): TreeState {
   warnIfNoProperPropsRootTree(props);
@@ -126,12 +127,15 @@ export function useRootTree(
     openItems,
     checkedItems,
     requestTreeResponse,
-    root: getNativeElementProps('div', {
-      ref,
-      role: 'tree',
-      'aria-multiselectable': selectionMode === 'multiselect' ? true : undefined,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        role: 'tree',
+        'aria-multiselectable': selectionMode === 'multiselect' ? true : undefined,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 }
 

--- a/packages/react-components/react-tree/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/src/hooks/useSubtree.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TreeProps, TreeState } from '../Tree';
 import { useTreeContext_unstable, useTreeItemContext_unstable } from '../contexts/index';
-import { getNativeElementProps, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 
 /**
  * Create the state required to render a sub-level tree.
@@ -34,11 +34,14 @@ export function useSubtree(props: Pick<TreeProps, 'appearance' | 'size'>, ref: R
     size,
     selectionMode,
     level: parentLevel + 1,
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, subtreeRef),
-      role: 'group',
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, subtreeRef),
+        role: 'group',
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     openItems,
     checkedItems,
     requestTreeResponse,

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/renderVirtualizer.tsx
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/renderVirtualizer.tsx
@@ -6,23 +6,23 @@ import type { VirtualizerSlots, VirtualizerState } from './Virtualizer.types';
 import type { ReactNode } from 'react';
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 
 export const renderVirtualizer_unstable = (state: VirtualizerState) => {
-  const { slots, slotProps } = getSlotsNext<VirtualizerSlots>(state);
+  assertSlots<VirtualizerSlots>(state);
 
   return (
     <React.Fragment>
       {/* The 'before' bookend to hold items in place and detect scroll previous */}
-      <slots.beforeContainer {...slotProps.beforeContainer}>
-        <slots.before {...slotProps.before} />
-      </slots.beforeContainer>
+      <state.beforeContainer>
+        <state.before />
+      </state.beforeContainer>
       {/* The reduced list of non-virtualized children to be rendered */}
       {state.virtualizedChildren}
       {/* The 'after' bookend to hold items in place and detect scroll next */}
-      <slots.afterContainer {...slotProps.afterContainer}>
-        <slots.after {...slotProps.after} />
-      </slots.afterContainer>
+      <state.afterContainer>
+        <state.after />
+      </state.afterContainer>
     </React.Fragment>
   );
 };

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -3,7 +3,7 @@ import type { VirtualizerProps, VirtualizerState } from './Virtualizer.types';
 
 import { useEffect, useRef, useCallback, useReducer, useImperativeHandle, useState } from 'react';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
-import { resolveShorthand } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { flushSync } from 'react-dom';
 import { useVirtualizerContextState_unstable } from '../../Utilities';
 import { renderVirtualizerChildPlaceholder } from './renderVirtualizer';
@@ -488,31 +488,31 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
       afterContainer: 'div',
     },
     virtualizedChildren: childArray.current,
-    before: resolveShorthand(props.before, {
-      required: true,
+    before: slot.always(props.before, {
       defaultProps: {
         ref: setBeforeRef,
         role: 'none',
       },
+      elementType: 'div',
     }),
-    after: resolveShorthand(props.after, {
-      required: true,
+    after: slot.always(props.after, {
       defaultProps: {
         ref: setAfterRef,
         role: 'none',
       },
+      elementType: 'div',
     }),
-    beforeContainer: resolveShorthand(props.beforeContainer, {
-      required: true,
+    beforeContainer: slot.always(props.beforeContainer, {
       defaultProps: {
         role: 'none',
       },
+      elementType: 'div',
     }),
-    afterContainer: resolveShorthand(props.afterContainer, {
-      required: true,
+    afterContainer: slot.always(props.afterContainer, {
       defaultProps: {
         role: 'none',
       },
+      elementType: 'div',
     }),
     beforeBufferHeight: isFullyInitialized ? calculateBefore() : 0,
     afterBufferHeight: isFullyInitialized ? calculateAfter() : 0,

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
@@ -5,11 +5,11 @@ import { createElement } from '@fluentui/react-jsx-runtime';
 
 import type { VirtualizerScrollViewSlots, VirtualizerScrollViewState } from './VirtualizerScrollView.types';
 
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
 export const renderVirtualizerScrollView_unstable = (state: VirtualizerScrollViewState) => {
-  const { slots, slotProps } = getSlotsNext<VirtualizerScrollViewSlots>(state);
+  assertSlots<VirtualizerScrollViewSlots>(state);
 
-  return <slots.container {...slotProps.container}>{renderVirtualizer_unstable(state)}</slots.container>;
+  return <state.container>{renderVirtualizer_unstable(state)}</state.container>;
 };

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
+import { useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useVirtualizer_unstable } from '../Virtualizer/useVirtualizer';
 import type { VirtualizerScrollViewProps, VirtualizerScrollViewState } from './VirtualizerScrollView.types';
 import { useStaticVirtualizerMeasure } from '../../Hooks';
@@ -69,11 +69,11 @@ export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewPr
       ...virtualizerState.components,
       container: 'div',
     },
-    container: resolveShorthand(props.container, {
-      required: true,
+    container: slot.always(props.container, {
       defaultProps: {
         ref: scrollViewRef as React.RefObject<HTMLDivElement>,
       },
+      elementType: 'div',
     }),
   };
 }

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/renderVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/renderVirtualizerScrollViewDynamic.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import {
   VirtualizerScrollViewDynamicSlots,
   VirtualizerScrollViewDynamicState,
@@ -10,6 +10,6 @@ import {
 import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
 export const renderVirtualizerScrollViewDynamic_unstable = (state: VirtualizerScrollViewDynamicState) => {
-  const { slots, slotProps } = getSlotsNext<VirtualizerScrollViewDynamicSlots>(state);
-  return <slots.container {...slotProps.container}>{renderVirtualizer_unstable(state)}</slots.container>;
+  assertSlots<VirtualizerScrollViewDynamicSlots>(state);
+  return <state.container>{renderVirtualizer_unstable(state)}</state.container>;
 };

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { resolveShorthand, useMergedRefs } from '@fluentui/react-utilities';
+import { useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useVirtualizer_unstable } from '../Virtualizer/useVirtualizer';
 import type {
   VirtualizerScrollViewDynamicProps,
@@ -89,11 +89,11 @@ export function useVirtualizerScrollViewDynamic_unstable(
       ...virtualizerState.components,
       container: 'div',
     },
-    container: resolveShorthand(props.container, {
-      required: true,
+    container: slot.always(props.container, {
       defaultProps: {
         ref: scrollViewRef,
       },
+      elementType: 'div',
     }),
   };
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Migrates all v9 libraries to the new slot API

Three v9 libraries not included in this PR:

1. react-migration-v0-v9 (reason: ???)
2. react-tabs (reason: logic in `renderTab` method)
3. react-search-preview (reason: ???)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28740
