### PR TITLE
chore(wc): allow the CI to be triggered manually

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - web-components-v3
     paths:
-      - packages/web-components/*
+      - packages/web-components/**
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Previous Behavior

- WC storybook deployment was triggered only by change directly in `packages/web-components`

## New Behavior

- the deployment is triggered by a change anywhere in the `packages/web-components` subtree
- it is possible to trigger the workflow manually