### PR TITLE
bugfix: headless tree should respect itemType

### DIFF
--- a/change/@fluentui-react-tree-d232366f-f4dc-4d83-ab71-0c1c341c1798.json
+++ b/change/@fluentui-react-tree-d232366f-f4dc-4d83-ab71-0c1c341c1798.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: headless tree should respect itemType",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
+++ b/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
@@ -126,7 +126,7 @@ export function createHeadlessTree<Props extends HeadlessTreeItemProps>(
           'aria-setsize': parentItem.childrenValues.length,
           itemType: item.itemType,
         }),
-        itemType: 'leaf',
+        itemType: propsWithoutParentValue.itemType ?? 'leaf',
         level: parentItem.level + 1,
         parentValue,
         childrenValues: [],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

1.  `createHeadlessTree`  ignored initial `itemType` value provided by the user on tree item creation

## New Behavior

1. `createHeadlessTree` now respects initial `itemType` value provided by the user on tree item creation

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28758
