### PR TITLE
Fix: flickering of items with large dividers in Overflow component

### DIFF
--- a/change/@fluentui-priority-overflow-a7aa4464-bf5d-40c9-9502-4936cb1f0c3f.json
+++ b/change/@fluentui-priority-overflow-a7aa4464-bf5d-40c9-9502-4936cb1f0c3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: flickering in Overflow",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-76164a9e-e55d-44b1-b7be-4f397c4cfa86.json
+++ b/change/@fluentui-react-overflow-76164a9e-e55d-44b1-b7be-4f397c4cfa86.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: flickering in Overflow",
+  "packageName": "@fluentui/react-overflow",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -555,6 +555,90 @@ describe('Overflow', () => {
     cy.get(`[${selectors.item}="2"]`).should('not.be.visible');
   });
 
+  it('should be no flickering', () => {
+    mount(
+      <Container>
+        <Item width="unset" id="0">
+          Item 0
+        </Item>
+        <Item width="unset" id="1">
+          Item 1
+        </Item>
+        <Item width="unset" id="2">
+          Super Long Item 2
+        </Item>
+        <Item width="unset" id="3">
+          3
+        </Item>
+        <Item id="4">Item 4</Item>
+        <Item id="5">Item 5</Item>
+        <Menu />
+      </Container>,
+    );
+
+    setContainerSize(355);
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    setContainerSize(354);
+    cy.get(`[${selectors.item}="3"]`).should('be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
+    setContainerSize(353);
+    cy.get(`[${selectors.item}="3"]`).should('be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
+    setContainerSize(352);
+    cy.get(`[${selectors.item}="3"]`).should('be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
+  });
+
+  it('should be no flickering with larger divider', () => {
+    mount(
+      <Container>
+        <Item id={'1'} groupId={'1'}>
+          1
+        </Item>
+        <CustomDivider groupId={'1'} data-divider="1" />
+        <Item id={'2'} groupId={'2'}>
+          2
+        </Item>
+        <CustomDivider groupId={'2'} data-divider="2" />
+        <Item id={'3'} groupId={'3'}>
+          3
+        </Item>
+        <Item id={'4'} groupId={'3'}>
+          4
+        </Item>
+        <CustomDivider groupId={'3'} data-divider="3" />
+        <Item id={'5'} groupId={'4'}>
+          5
+        </Item>
+        <Item id={'6'} groupId={'4'}>
+          6
+        </Item>
+        <CustomDivider groupId={'4'} data-divider="4" />
+        <Item id={'7'} groupId={'5'}>
+          7
+        </Item>
+        <Menu />
+      </Container>,
+    );
+
+    setContainerSize(470);
+    cy.get(`[${selectors.item}="7"]`).should('be.visible');
+    setContainerSize(469);
+    cy.get(`[${selectors.divider}="4"]`).should('exist');
+    cy.get(`[${selectors.item}="6"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('be.visible');
+    cy.get(`[${selectors.divider}]`).should('have.length', 4);
+    setContainerSize(419);
+    cy.get(`[${selectors.divider}="4"]`).should('not.exist');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    setContainerSize(418);
+    cy.get(`[${selectors.divider}="4"]`).should('not.exist');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    setContainerSize(417);
+  });
+
   it('should remove overflow menu if the last overflowed item can take its place', () => {
     const mapHelper = new Array(10).fill(0).map((_, i) => i);
     mount(

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -603,18 +603,20 @@ describe('Overflow', () => {
         <Item id={'3'} groupId={'3'}>
           3
         </Item>
-        <Item id={'4'} groupId={'3'}>
+        <CustomDivider groupId={'3'} data-divider="3" />
+        <Item id={'4'} groupId={'4'}>
           4
         </Item>
-        <CustomDivider groupId={'3'} data-divider="3" />
-        <Item id={'5'} groupId={'4'}>
+        <CustomDivider groupId={'4'} data-divider="4" />
+        <Item id={'5'} groupId={'5'}>
           5
         </Item>
-        <Item id={'6'} groupId={'4'}>
+        <CustomDivider groupId={'5'} data-divider="5" />
+        <Item id={'6'} groupId={'6'}>
           6
         </Item>
-        <CustomDivider groupId={'4'} data-divider="4" />
-        <Item id={'7'} groupId={'5'}>
+        <CustomDivider groupId={'6'} data-divider="6" />
+        <Item id={'7'} groupId={'7'}>
           7
         </Item>
         <Menu />
@@ -622,21 +624,24 @@ describe('Overflow', () => {
     );
 
     setContainerSize(470);
-    cy.get(`[${selectors.item}="7"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('be.visible');
     setContainerSize(469);
-    cy.get(`[${selectors.divider}="4"]`).should('exist');
+    cy.get(`[${selectors.divider}="5"]`).should('exist');
     cy.get(`[${selectors.item}="6"]`).should('not.be.visible');
     cy.get(`[${selectors.item}="5"]`).should('be.visible');
-    cy.get(`[${selectors.divider}]`).should('have.length', 4);
-    setContainerSize(419);
-    cy.get(`[${selectors.divider}="4"]`).should('not.exist');
+    cy.get(`[${selectors.divider}]`).should('have.length', 5);
+    setContainerSize(468);
+    cy.get(`[${selectors.item}="6"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('be.visible');
+    setContainerSize(467);
+    cy.get(`[${selectors.item}="6"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('be.visible');
+    setContainerSize(466);
+    cy.get(`[${selectors.item}="6"]`).should('not.be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('be.visible');
+    setContainerSize(449);
     cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
     cy.get(`[${selectors.item}="4"]`).should('be.visible');
-    setContainerSize(418);
-    cy.get(`[${selectors.divider}="4"]`).should('not.exist');
-    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
-    cy.get(`[${selectors.item}="4"]`).should('be.visible');
-    setContainerSize(417);
   });
 
   it('should remove overflow menu if the last overflowed item can take its place', () => {

--- a/packages/react-components/react-overflow/stories/Overflow/LargerDividers.stories.tsx
+++ b/packages/react-components/react-overflow/stories/Overflow/LargerDividers.stories.tsx
@@ -57,7 +57,7 @@ export const LargerDividers = () => {
   const styles = useStyles();
 
   return (
-    <Overflow padding={20}>
+    <Overflow>
       <div className={mergeClasses(styles.container, styles.resizableArea)}>
         <OverflowItem id={'1'} groupId={'1'}>
           <Button>Item 1</Button>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
![flickering](https://github.com/microsoft/fluentui/assets/11574680/2f2d8973-05f0-4214-bcca-fd2bafc7cf61)

## New Behavior
![flickering-fixed](https://github.com/microsoft/fluentui/assets/11574680/9dc23c74-654a-4024-b65e-763542677292)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28711
