### PR TITLE
build(wc): Enforce node 16

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.18.1
-          cache: 'yarn'
-
       - name: Build and Deploy Job
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "engines": {
-    "node": "^16.18.1 || ^18.0.0"
+    "node": "^16.18.1"
   },
   "scripts": {
     "build": "lage build --verbose",


### PR DESCRIPTION
## Previous Behavior

- Repo dependencies require node <= 16, otherwise fail to install:
![image](https://github.com/microsoft/fluentui/assets/9615899/73e19f99-c757-47d6-b924-b511747dc80e)
- Engines allow node 16 or node 18.

## New Behavior
Engines only allow node 16.

## Related Issue(s)

- Fixes CI
