### PR TITLE
chore(react-tabs): migrate to new slot API

### DIFF
--- a/change/@fluentui-react-tabs-79da62f4-21a0-4398-a9dd-e850571f6a38.json
+++ b/change/@fluentui-react-tabs-79da62f4-21a0-4398-a9dd-e850571f6a38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(react-tabs): migrate to new slot API",
+  "packageName": "@fluentui/react-tabs",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/etc/react-tabs.api.md
+++ b/packages/react-components/react-tabs/etc/react-tabs.api.md
@@ -111,6 +111,7 @@ export type TabState = ComponentState<TabInternalSlots> & Pick<TabProps, 'value'
     appearance?: 'transparent' | 'subtle';
     iconOnly: boolean;
     selected: boolean;
+    contentReservedSpaceClassName?: string;
     size: 'small' | 'medium' | 'large';
     vertical: boolean;
 };

--- a/packages/react-components/react-tabs/etc/react-tabs.api.md
+++ b/packages/react-components/react-tabs/etc/react-tabs.api.md
@@ -107,11 +107,10 @@ export type TabSlots = {
 };
 
 // @public
-export type TabState = ComponentState<TabSlots> & Pick<TabProps, 'value'> & Required<Pick<TabProps, 'disabled'>> & {
+export type TabState = ComponentState<TabInternalSlots> & Pick<TabProps, 'value'> & Required<Pick<TabProps, 'disabled'>> & {
     appearance?: 'transparent' | 'subtle';
     iconOnly: boolean;
     selected: boolean;
-    contentReservedSpaceClassName?: string;
     size: 'small' | 'medium' | 'large';
     vertical: boolean;
 };

--- a/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
@@ -23,6 +23,10 @@ export type TabSlots = {
   content: NonNullable<Slot<'span'>>;
 };
 
+export type TabInternalSlots = TabSlots & {
+  contentReservedSpace?: Slot<'span'>;
+};
+
 /**
  * Tab Props
  */
@@ -41,7 +45,7 @@ export type TabProps = ComponentProps<Partial<TabSlots>> & {
 /**
  * State used in rendering Tab
  */
-export type TabState = ComponentState<TabSlots> &
+export type TabState = ComponentState<TabInternalSlots> &
   Pick<TabProps, 'value'> &
   Required<Pick<TabProps, 'disabled'>> & {
     /**
@@ -56,11 +60,6 @@ export type TabState = ComponentState<TabSlots> &
      * If this tab is selected
      */
     selected: boolean;
-    /**
-     * When defined, tab content with selected style is rendered hidden to reserve space.
-     * This keeps consistent content size between unselected and selected states.
-     */
-    contentReservedSpaceClassName?: string;
     /**
      * A tab can be either 'small', 'medium', or 'large' size.
      */

--- a/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
@@ -61,6 +61,13 @@ export type TabState = ComponentState<TabInternalSlots> &
      */
     selected: boolean;
     /**
+     * When defined, tab content with selected style is rendered hidden to reserve space.
+     * This keeps consistent content size between unselected and selected states.
+     *
+     * @deprecated - use `contentReservedSpace` internal slot instead.
+     */
+    contentReservedSpaceClassName?: string;
+    /**
      * A tab can be either 'small', 'medium', or 'large' size.
      */
     size: 'small' | 'medium' | 'large';

--- a/packages/react-components/react-tabs/src/components/Tab/renderTab.tsx
+++ b/packages/react-components/react-tabs/src/components/Tab/renderTab.tsx
@@ -2,22 +2,20 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
-import type { TabState, TabSlots } from './Tab.types';
+import { assertSlots } from '@fluentui/react-utilities';
+import type { TabState, TabInternalSlots } from './Tab.types';
 
 /**
  * Render the final JSX of Tab
  */
 export const renderTab_unstable = (state: TabState) => {
-  const { slots, slotProps } = getSlotsNext<TabSlots>(state);
+  assertSlots<TabInternalSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slots.icon && <slots.icon {...slotProps.icon} />}
-      {!state.iconOnly && <slots.content {...slotProps.content} />}
-      {!state.selected && !state.iconOnly && state.contentReservedSpaceClassName !== undefined && (
-        <slots.content {...slotProps.content} className={state.contentReservedSpaceClassName} />
-      )}
-    </slots.root>
+    <state.root>
+      {state.icon && <state.icon />}
+      {!state.iconOnly && <state.content />}
+      {state.contentReservedSpace && <state.contentReservedSpace />}
+    </state.root>
   );
 };

--- a/packages/react-components/react-tabs/src/components/Tab/useTab.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTab.ts
@@ -48,16 +48,11 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
   }, [onRegister, onUnregister, innerRef, value]);
 
   const iconSlot = slot.optional(icon, { elementType: 'span' });
-  const contentShorthand = slot.always(content, {
+  const contentSlot = slot.always(content, {
     defaultProps: { children: props.children },
     elementType: 'span',
   });
-  const iconOnly = Boolean(iconSlot?.children && !contentShorthand.children);
-  const contentReservedSpaceSlot = slot.optional(content, {
-    renderByDefault: !selected && !iconOnly && reserveSelectedTabSpace,
-    defaultProps: { children: props.children },
-    elementType: 'span',
-  });
+  const iconOnly = Boolean(iconSlot?.children && !contentSlot.children);
   return {
     components: { root: 'button', icon: 'span', content: 'span', contentReservedSpace: 'span' },
     root: slot.always(
@@ -76,8 +71,12 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
     ),
     icon: iconSlot,
     iconOnly,
-    content: contentShorthand,
-    contentReservedSpace: contentReservedSpaceSlot,
+    content: contentSlot,
+    contentReservedSpace: slot.optional(content, {
+      renderByDefault: !selected && !iconOnly && reserveSelectedTabSpace,
+      defaultProps: { children: props.children },
+      elementType: 'span',
+    }),
     appearance,
     disabled,
     selected,

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.styles.ts
@@ -506,6 +506,10 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
       contentStyles.placeholder,
       state.content.className,
     );
+    // FIXME: this is a deprecated API
+    // should be removed in the next major version
+    // eslint-disable-next-line deprecation/deprecation
+    state.contentReservedSpaceClassName = state.contentReservedSpace.className;
   }
 
   state.content.className = mergeClasses(

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.styles.ts
@@ -497,8 +497,8 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
   }
 
   // This needs to be before state.content.className is updated
-  if (state.contentReservedSpaceClassName !== undefined) {
-    state.contentReservedSpaceClassName = mergeClasses(
+  if (state.contentReservedSpace) {
+    state.contentReservedSpace.className = mergeClasses(
       reservedSpaceClassNames.content,
       contentStyles.base,
       size === 'large' ? contentStyles.largeSelected : contentStyles.selected,

--- a/packages/react-components/react-tabs/src/components/TabList/renderTabList.tsx
+++ b/packages/react-components/react-tabs/src/components/TabList/renderTabList.tsx
@@ -2,7 +2,7 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { TabListState, TabListSlots, TabListContextValues } from './TabList.types';
 import { TabListProvider } from './TabListContext';
 
@@ -10,11 +10,11 @@ import { TabListProvider } from './TabListContext';
  * Render the final JSX of TabList
  */
 export const renderTabList_unstable = (state: TabListState, contextValues: TabListContextValues) => {
-  const { slots, slotProps } = getSlotsNext<TabListSlots>(state);
+  assertSlots<TabListSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
+    <state.root>
       <TabListProvider value={contextValues.tabList}>{state.root.children}</TabListProvider>
-    </slots.root>
+    </state.root>
   );
 };

--- a/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
+++ b/packages/react-components/react-tabs/src/components/TabList/useTabList.ts
@@ -5,6 +5,7 @@ import {
   useControllableState,
   useEventCallback,
   useMergedRefs,
+  slot,
 } from '@fluentui/react-utilities';
 import type { TabRegisterData, SelectTabData, SelectTabEvent, TabListProps, TabListState } from './TabList.types';
 import { TabValue } from '../Tab/Tab.types';
@@ -81,13 +82,16 @@ export const useTabList_unstable = (props: TabListProps, ref: React.Ref<HTMLElem
     components: {
       root: 'div',
     },
-    root: getNativeElementProps('div', {
-      ref: useMergedRefs(ref, innerRef),
-      role: 'tablist',
-      'aria-orientation': vertical ? 'vertical' : 'horizontal',
-      ...focusAttributes,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref: useMergedRefs(ref, innerRef),
+        role: 'tablist',
+        'aria-orientation': vertical ? 'vertical' : 'horizontal',
+        ...focusAttributes,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
     appearance,
     reserveSelectedTabSpace,
     disabled,


### PR DESCRIPTION
## New Behavior

1. Migrates `react-tabs`  package to new slot API
2. adds new internal slot to stop logic from spreading into render method