### PR TITLE
feat: supports new automatic JSX runtime

### DIFF
--- a/change/@fluentui-react-jsx-runtime-911c855a-9f72-4f62-8d13-d9f768887ada.json
+++ b/change/@fluentui-react-jsx-runtime-911c855a-9f72-4f62-8d13-d9f768887ada.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: supports new automatic JSX runtime",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-jsx-runtime/etc/react-jsx-runtime.api.md
+++ b/packages/react-components/react-jsx-runtime/etc/react-jsx-runtime.api.md
@@ -8,7 +8,7 @@ import { Fragment } from 'react';
 import * as React_2 from 'react';
 
 // @public (undocumented)
-export function createElement<P extends {}>(type: React_2.ElementType<P>, props?: P | null, ...children: React_2.ReactNode[]): React_2.ReactElement<P> | null;
+export function createElement<P extends {}>(type: React_2.ElementType<P>, props?: P | null, ...children: React_2.ReactNode[]): React_2.ReactElement<P>;
 
 export { Fragment }
 

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -51,6 +51,18 @@
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },
+    "./jsx-dev-runtime": {
+      "types": "./dist/jsx-dev-runtime.d.ts",
+      "node": "./lib-commonjs/jsx-dev-runtime.js",
+      "import": "./lib/jsx-dev-runtime.js",
+      "require": "./lib-commonjs/jsx-dev-runtime.js"
+    },
+    "./jsx-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
+      "node": "./lib-commonjs/jsx-runtime.js",
+      "import": "./lib/jsx-runtime.js",
+      "require": "./lib-commonjs/jsx-runtime.js"
+    },
     "./package.json": "./package.json"
   }
 }

--- a/packages/react-components/react-jsx-runtime/src/createElement.ts
+++ b/packages/react-components/react-jsx-runtime/src/createElement.ts
@@ -1,61 +1,21 @@
 import * as React from 'react';
-import {
-  UnknownSlotProps,
-  isSlot,
-  SlotComponentType,
-  SLOT_ELEMENT_TYPE_SYMBOL,
-  SLOT_RENDER_FUNCTION_SYMBOL,
-} from '@fluentui/react-utilities';
+import { isSlot } from '@fluentui/react-utilities';
+import { createElementFromSlotComponent } from './jsx/createElementFromSlotComponent';
+import { createCompatSlotComponent } from './utils/createCompatSlotComponent';
 
 export function createElement<P extends {}>(
   type: React.ElementType<P>,
   props?: P | null,
   ...children: React.ReactNode[]
-): React.ReactElement<P> | null {
+): React.ReactElement<P> {
   // TODO:
   // this is for backwards compatibility with getSlotsNext
   // it should be removed once getSlotsNext is obsolete
   if (isSlot<P>(props)) {
-    return createElementFromSlotComponent(
-      { ...props, [SLOT_ELEMENT_TYPE_SYMBOL]: type } as SlotComponentType<P>,
-      children,
-    );
+    return createElementFromSlotComponent(createCompatSlotComponent(type, props), children);
   }
   if (isSlot<P>(type)) {
     return createElementFromSlotComponent(type, children);
   }
   return React.createElement(type, props, ...children);
-}
-
-function createElementFromSlotComponent<Props extends UnknownSlotProps>(
-  type: SlotComponentType<Props>,
-  overrideChildren: React.ReactNode[],
-): React.ReactElement<Props> | null {
-  const {
-    as,
-    [SLOT_ELEMENT_TYPE_SYMBOL]: baseElementType,
-    [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
-    ...propsWithoutMetadata
-  } = type;
-  const props = propsWithoutMetadata as UnknownSlotProps as Props;
-
-  const elementType = typeof baseElementType === 'string' ? as ?? baseElementType : baseElementType;
-
-  if (typeof elementType !== 'string' && as) {
-    props.as = as;
-  }
-
-  if (renderFunction) {
-    if (overrideChildren.length > 0) {
-      props.children = React.createElement(React.Fragment, {}, ...overrideChildren);
-    }
-
-    return React.createElement(
-      React.Fragment,
-      {},
-      renderFunction(elementType as React.ElementType<Props>, props),
-    ) as React.ReactElement<Props>;
-  }
-
-  return React.createElement(elementType, props, ...overrideChildren);
 }

--- a/packages/react-components/react-jsx-runtime/src/jsx-dev-runtime.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx-dev-runtime.ts
@@ -1,0 +1,26 @@
+import type * as React from 'react';
+import { isSlot } from '@fluentui/react-utilities';
+import { jsxDEVFromSlotComponent } from './jsx/jsxDEVFromSlotComponent';
+import { createCompatSlotComponent } from './utils/createCompatSlotComponent';
+import { DevRuntime } from './utils/DevRuntime';
+
+export { Fragment } from 'react';
+
+export function jsxDEV<P extends {}>(
+  type: React.ElementType<P>,
+  props: P,
+  key?: React.Key,
+  source?: boolean,
+  self?: unknown,
+): React.ReactElement<P> {
+  // TODO:
+  // this is for backwards compatibility with getSlotsNext
+  // it should be removed once getSlotsNext is obsolete
+  if (isSlot<P>(props)) {
+    return jsxDEVFromSlotComponent(createCompatSlotComponent(type, props), null, key, source, self);
+  }
+  if (isSlot<P>(type)) {
+    return jsxDEVFromSlotComponent(type, props, key, source, self);
+  }
+  return DevRuntime.jsxDEV(type, props, key, source, self);
+}

--- a/packages/react-components/react-jsx-runtime/src/jsx-runtime.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/jsx-runtime.test.tsx
@@ -1,10 +1,8 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
 
 import { render } from '@testing-library/react';
 import { assertSlots, getSlotsNext, resolveShorthand, slot } from '@fluentui/react-utilities';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { createElement } from './createElement';
 
 describe('createElement with getSlotsNext', () => {
   describe('general behavior tests', () => {
@@ -47,7 +45,6 @@ describe('createElement with getSlotsNext', () => {
         <div>
           <div>1</div>
           <div>2</div>
-          <div>3</div>
         </div>,
       );
 
@@ -58,9 +55,6 @@ describe('createElement with getSlotsNext', () => {
           </div>
           <div>
             2
-          </div>
-          <div>
-            3
           </div>
         </div>
       `);
@@ -141,13 +135,11 @@ describe('createElement with getSlotsNext', () => {
       expect(children.mock.calls[0][0]).toBe('div');
       expect(children.mock.calls[0][1].id).toBe('outer');
       expect(children.mock.calls[0][1].children).toMatchInlineSnapshot(`
-        <React.Fragment>
-          <div
-            id="inner"
-          >
-            Inner children
-          </div>
-        </React.Fragment>
+        <div
+          id="inner"
+        >
+          Inner children
+        </div>
       `);
 
       expect(result.container.firstChild).toMatchInlineSnapshot(`
@@ -208,6 +200,7 @@ describe('createElement with assertSlots', () => {
     it('handles an array of children', () => {
       const result = render(
         <div>
+          <div>0</div>
           <div>1</div>
           <div>2</div>
         </div>,
@@ -215,6 +208,9 @@ describe('createElement with assertSlots', () => {
 
       expect(result.container.firstChild).toMatchInlineSnapshot(`
         <div>
+          <div>
+            0
+          </div>
           <div>
             1
           </div>
@@ -299,13 +295,11 @@ describe('createElement with assertSlots', () => {
       expect(children.mock.calls[0][0]).toBe('div');
       expect(children.mock.calls[0][1].id).toBe('outer');
       expect(children.mock.calls[0][1].children).toMatchInlineSnapshot(`
-        <React.Fragment>
-          <div
-            id="inner"
-          >
-            Inner children
-          </div>
-        </React.Fragment>
+        <div
+          id="inner"
+        >
+          Inner children
+        </div>
       `);
 
       expect(result.container.firstChild).toMatchInlineSnapshot(`

--- a/packages/react-components/react-jsx-runtime/src/jsx-runtime.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx-runtime.ts
@@ -1,0 +1,34 @@
+import type * as React from 'react';
+import { isSlot } from '@fluentui/react-utilities';
+import { jsxDynamicFromSlotComponent } from './jsx/jsxDynamicFromSlotComponent';
+import { jsxStaticFromSlotComponent } from './jsx/jsxStaticFromSlotComponent';
+import { createCompatSlotComponent } from './utils/createCompatSlotComponent';
+import { Runtime } from './utils/Runtime';
+
+export { Fragment } from 'react';
+
+export function jsx<P extends {}>(type: React.ElementType<P>, props: P, key?: React.Key): React.ReactElement<P> {
+  // TODO:
+  // this is for backwards compatibility with getSlotsNext
+  // it should be removed once getSlotsNext is obsolete
+  if (isSlot<P>(props)) {
+    return jsxDynamicFromSlotComponent(createCompatSlotComponent(type, props), null, key);
+  }
+  if (isSlot<P>(type)) {
+    return jsxDynamicFromSlotComponent(type, props, key);
+  }
+  return Runtime.jsx(type, props, key);
+}
+
+export function jsxs<P extends {}>(type: React.ElementType<P>, props: P, key?: React.Key): React.ReactElement<P> {
+  // TODO:
+  // this is for backwards compatibility with getSlotsNext
+  // it should be removed once getSlotsNext is obsolete
+  if (isSlot<P>(props)) {
+    return jsxStaticFromSlotComponent(createCompatSlotComponent(type, props), null, key);
+  }
+  if (isSlot<P>(type)) {
+    return jsxStaticFromSlotComponent(type, props, key);
+  }
+  return Runtime.jsxs(type, props, key);
+}

--- a/packages/react-components/react-jsx-runtime/src/jsx/createElementFromSlotComponent.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx/createElementFromSlotComponent.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import type { SlotComponentType, UnknownSlotProps } from '@fluentui/react-utilities';
+import { getMetadataFromSlotComponent } from '../utils/getMetadataFromSlotComponent';
+
+/**
+ * @internal
+ * creates a ReactElement from a slot declaration
+ */
+export function createElementFromSlotComponent<Props extends UnknownSlotProps>(
+  type: SlotComponentType<Props>,
+  overrideChildren: React.ReactNode[],
+): React.ReactElement<Props> {
+  const { elementType, renderFunction, props } = getMetadataFromSlotComponent(type);
+
+  if (renderFunction) {
+    if (overrideChildren.length > 0) {
+      props.children = React.createElement(React.Fragment, {}, ...overrideChildren);
+    }
+
+    return React.createElement(
+      React.Fragment,
+      {},
+      renderFunction(elementType as React.ElementType<Props>, props),
+    ) as React.ReactElement<Props>;
+  }
+
+  return React.createElement(elementType, props, ...overrideChildren);
+}

--- a/packages/react-components/react-jsx-runtime/src/jsx/jsxDEVFromSlotComponent.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx/jsxDEVFromSlotComponent.ts
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import type { SlotComponentType, UnknownSlotProps } from '@fluentui/react-utilities';
+import { getMetadataFromSlotComponent } from '../utils/getMetadataFromSlotComponent';
+import { DevRuntime } from '../utils/DevRuntime';
+
+export function jsxDEVFromSlotComponent<Props extends UnknownSlotProps>(
+  type: SlotComponentType<Props>,
+  overrideProps: Props | null,
+  key?: React.Key,
+  source?: unknown,
+  self?: unknown,
+): React.ReactElement<Props> {
+  const { elementType, renderFunction, props: slotProps } = getMetadataFromSlotComponent(type);
+
+  const props: Props = { ...slotProps, ...overrideProps };
+
+  if (renderFunction) {
+    return DevRuntime.jsxDEV(
+      React.Fragment,
+      {
+        children: renderFunction(elementType, props),
+      },
+      key,
+      source,
+      self,
+    ) as React.ReactElement<Props>;
+  }
+
+  return DevRuntime.jsxDEV(elementType, props, key, source, self);
+}

--- a/packages/react-components/react-jsx-runtime/src/jsx/jsxDynamicFromSlotComponent.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx/jsxDynamicFromSlotComponent.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import type { SlotComponentType, UnknownSlotProps } from '@fluentui/react-utilities';
+import { getMetadataFromSlotComponent } from '../utils/getMetadataFromSlotComponent';
+import { Runtime } from '../utils/Runtime';
+
+/**
+ * @internal
+ */
+export function jsxDynamicFromSlotComponent<Props extends UnknownSlotProps>(
+  type: SlotComponentType<Props>,
+  overrideProps: Props | null,
+  key?: React.Key,
+): React.ReactElement<Props> {
+  const { elementType, renderFunction, props: slotProps } = getMetadataFromSlotComponent(type);
+
+  const props: Props = { ...slotProps, ...overrideProps };
+
+  if (renderFunction) {
+    return Runtime.jsx(
+      React.Fragment,
+      {
+        children: renderFunction(elementType, props),
+      },
+      key,
+    ) as React.ReactElement<Props>;
+  }
+
+  return Runtime.jsx(elementType, props, key);
+}

--- a/packages/react-components/react-jsx-runtime/src/jsx/jsxStaticFromSlotComponent.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx/jsxStaticFromSlotComponent.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import type { SlotComponentType, UnknownSlotProps } from '@fluentui/react-utilities';
+import { getMetadataFromSlotComponent } from '../utils/getMetadataFromSlotComponent';
+import { Runtime } from '../utils/Runtime';
+
+/**
+ * @internal
+ */
+export function jsxStaticFromSlotComponent<Props extends UnknownSlotProps>(
+  type: SlotComponentType<Props>,
+  overrideProps: Props | null,
+  key?: React.Key,
+): React.ReactElement<Props> {
+  const { elementType, renderFunction, props: slotProps } = getMetadataFromSlotComponent(type);
+
+  const props: Props = { ...slotProps, ...overrideProps };
+
+  if (renderFunction) {
+    return Runtime.jsxs(
+      React.Fragment,
+      {
+        children: renderFunction(elementType, props),
+      },
+      key,
+    ) as React.ReactElement<Props>;
+  }
+
+  return Runtime.jsxs(elementType, props, key);
+}

--- a/packages/react-components/react-jsx-runtime/src/utils/DevRuntime.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/DevRuntime.ts
@@ -1,0 +1,6 @@
+import * as ReactDevRuntime from 'react/jsx-dev-runtime';
+import type { JSXRuntime } from './types';
+
+export const DevRuntime = ReactDevRuntime as {
+  jsxDEV: JSXRuntime;
+};

--- a/packages/react-components/react-jsx-runtime/src/utils/Runtime.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/Runtime.ts
@@ -1,0 +1,7 @@
+import * as ReactRuntime from 'react/jsx-runtime';
+import type { JSXRuntime } from './types';
+
+export const Runtime = ReactRuntime as {
+  jsx: JSXRuntime;
+  jsxs: JSXRuntime;
+};

--- a/packages/react-components/react-jsx-runtime/src/utils/createCompatSlotComponent.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/createCompatSlotComponent.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { SLOT_ELEMENT_TYPE_SYMBOL } from '@fluentui/react-utilities';
+import type { SlotComponentType } from '@fluentui/react-utilities';
+
+// TODO:
+// this is for backwards compatibility with getSlotsNext
+// it should be removed once getSlotsNext is obsolete
+export function createCompatSlotComponent<P extends {}>(type: React.ElementType<P>, props: P): SlotComponentType<P> {
+  return {
+    ...props,
+    [SLOT_ELEMENT_TYPE_SYMBOL]: type,
+  } as SlotComponentType<P>;
+}

--- a/packages/react-components/react-jsx-runtime/src/utils/getMetadataFromSlotComponent.test.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/getMetadataFromSlotComponent.test.ts
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from '@fluentui/react-utilities';
+import type { SlotComponentType, SlotRenderFunction } from '@fluentui/react-utilities';
+import { getMetadataFromSlotComponent } from './getMetadataFromSlotComponent';
+
+type TestProps = React.HTMLAttributes<HTMLElement> & { as?: 'div' | 'span' };
+
+describe('getMetadataFromSlotComponent', () => {
+  it('gets metadata from slot component', () => {
+    expect(
+      getMetadataFromSlotComponent({
+        [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
+        tabIndex: 0,
+      } as SlotComponentType<TestProps>),
+    ).toEqual({
+      elementType: 'div',
+      props: { tabIndex: 0 },
+      renderFunction: undefined,
+    });
+  });
+
+  it('handles render props', () => {
+    expect(
+      getMetadataFromSlotComponent({
+        [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
+        [SLOT_RENDER_FUNCTION_SYMBOL]: jest.fn() as SlotRenderFunction<TestProps>,
+        tabIndex: 0,
+      } as SlotComponentType<TestProps>),
+    ).toEqual({
+      elementType: 'div',
+      props: { tabIndex: 0 },
+      renderFunction: expect.any(Function),
+    });
+  });
+  it("should override elementType with 'as' when base element is HTML element", () => {
+    expect(
+      getMetadataFromSlotComponent({
+        [SLOT_ELEMENT_TYPE_SYMBOL]: 'div',
+        as: 'span',
+        tabIndex: 0,
+      } as SlotComponentType<TestProps>),
+    ).toEqual({
+      elementType: 'span',
+      props: { tabIndex: 0 },
+      renderFunction: undefined,
+    });
+  });
+  it("should pass 'as' property to base element that aren't HTML element", () => {
+    const fn = (props: TestProps) => null;
+    expect(
+      getMetadataFromSlotComponent({
+        [SLOT_ELEMENT_TYPE_SYMBOL]: fn,
+        as: 'div',
+        tabIndex: 0,
+      } as SlotComponentType<TestProps>),
+    ).toEqual({
+      elementType: fn,
+      props: { tabIndex: 0, as: 'div' },
+      renderFunction: undefined,
+    });
+  });
+});

--- a/packages/react-components/react-jsx-runtime/src/utils/getMetadataFromSlotComponent.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/getMetadataFromSlotComponent.ts
@@ -1,0 +1,25 @@
+import type * as React from 'react';
+import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from '@fluentui/react-utilities';
+import type { SlotComponentType, UnknownSlotProps } from '@fluentui/react-utilities';
+
+/**
+ * @internal
+ */
+export function getMetadataFromSlotComponent<Props extends UnknownSlotProps>(type: SlotComponentType<Props>) {
+  const {
+    as,
+    [SLOT_ELEMENT_TYPE_SYMBOL]: baseElementType,
+    [SLOT_RENDER_FUNCTION_SYMBOL]: renderFunction,
+    ...propsWithoutMetadata
+  } = type;
+  const props = propsWithoutMetadata as UnknownSlotProps as Props;
+
+  const elementType = (
+    typeof baseElementType === 'string' ? as ?? baseElementType : baseElementType
+  ) as React.ElementType<Props>;
+
+  if (typeof elementType !== 'string' && as) {
+    props.as = as;
+  }
+  return { elementType, props, renderFunction };
+}

--- a/packages/react-components/react-jsx-runtime/src/utils/types.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/types.ts
@@ -1,0 +1,9 @@
+import type * as React from 'react';
+
+export type JSXRuntime = <P extends {}>(
+  type: React.ElementType<P>,
+  props: P | null,
+  key?: React.Key,
+  source?: unknown,
+  self?: unknown,
+) => React.ReactElement<P>;

--- a/tsconfig.base.all.json
+++ b/tsconfig.base.all.json
@@ -113,6 +113,10 @@
       "@fluentui/react-infobutton": ["packages/react-components/react-infobutton/src/index.ts"],
       "@fluentui/react-input": ["packages/react-components/react-input/src/index.ts"],
       "@fluentui/react-jsx-runtime": ["packages/react-components/react-jsx-runtime/src/index.ts"],
+      "@fluentui/react-jsx-runtime/jsx-runtime": ["packages/react-components/react-jsx-runtime/src/jsx-runtime.ts"],
+      "@fluentui/react-jsx-runtime/jsx-dev-runtime": [
+        "packages/react-components/react-jsx-runtime/src/jsx-dev-runtime.ts"
+      ],
       "@fluentui/react-label": ["packages/react-components/react-label/src/index.ts"],
       "@fluentui/react-link": ["packages/react-components/react-link/src/index.ts"],
       "@fluentui/react-menu": ["packages/react-components/react-menu/src/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,6 +47,10 @@
       "@fluentui/react-infobutton": ["packages/react-components/react-infobutton/src/index.ts"],
       "@fluentui/react-input": ["packages/react-components/react-input/src/index.ts"],
       "@fluentui/react-jsx-runtime": ["packages/react-components/react-jsx-runtime/src/index.ts"],
+      "@fluentui/react-jsx-runtime/jsx-runtime": ["packages/react-components/react-jsx-runtime/src/jsx-runtime.ts"],
+      "@fluentui/react-jsx-runtime/jsx-dev-runtime": [
+        "packages/react-components/react-jsx-runtime/src/jsx-dev-runtime.ts"
+      ],
       "@fluentui/react-label": ["packages/react-components/react-label/src/index.ts"],
       "@fluentui/react-link": ["packages/react-components/react-link/src/index.ts"],
       "@fluentui/react-menu": ["packages/react-components/react-menu/src/index.ts"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously `@fluentui/react-jsx-runtime` only supported the classic mode of declaring a JSX pragma, through a signature similar to `React.createElement`

## New Behavior

Add support for React 17's automatic JSX transform (works from React 16.14).

This PR adds support for the [new "automatic" JSX runtime from React 16.14/17+](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27646
