### PR TITLE
Virtualizer: Merge scrollref prop with container ref

### DIFF
--- a/change/@fluentui-react-virtualizer-5bc6cfeb-7159-424d-8126-dc7da21c53ff.json
+++ b/change/@fluentui-react-virtualizer-5bc6cfeb-7159-424d-8126-dc7da21c53ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[FIX] Ensure scrollViewRef is merged with container ref",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-5bc6cfeb-7159-424d-8126-dc7da21c53ff.json
+++ b/change/@fluentui-react-virtualizer-5bc6cfeb-7159-424d-8126-dc7da21c53ff.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "[FIX] Ensure scrollViewRef is merged with container ref",
+  "comment": "Fix: Ensure scrollViewRef is merged with container ref",
   "packageName": "@fluentui/react-virtualizer",
   "email": "mifraser@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -19,7 +19,7 @@ export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewPr
   if (virtualizerLengthRef.current !== virtualizerLength) {
     virtualizerLengthRef.current = virtualizerLength;
   }
-  const scrollViewRef = useMergedRefs(React.useRef<HTMLDivElement>(null), scrollRef) as React.RefObject<HTMLDivElement>;
+  const scrollViewRef = useMergedRefs(props.scrollViewRef, scrollRef) as React.RefObject<HTMLDivElement>;
   const imperativeVirtualizerRef = React.useRef<VirtualizerDataRef | null>(null);
   const scrollCallbackRef = React.useRef<null | ((index: number) => void)>(null);
 

--- a/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.ts
+++ b/packages/react-components/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.ts
@@ -29,7 +29,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
   if (virtualizerLengthRef.current !== virtualizerLength) {
     virtualizerLengthRef.current = virtualizerLength;
   }
-  const scrollViewRef = useMergedRefs(React.useRef<HTMLDivElement>(null), scrollRef) as React.RefObject<HTMLDivElement>;
+  const scrollViewRef = useMergedRefs(props.scrollViewRef, scrollRef) as React.RefObject<HTMLDivElement>;
   const scrollCallbackRef = React.useRef<null | ((index: number) => void)>(null);
 
   const _imperativeVirtualizerRef = useMergedRefs(React.useRef<VirtualizerDataRef>(null), imperativeVirtualizerRef);


### PR DESCRIPTION
## Previous Behavior
We were not passing through scrollViewRef into the merged refs

## New Behavior
ScrollViewRef prop should now be merged with container prop in scrollview virtualizers.

## Related Issue(s)
N/A