### PR TITLE
fix: make listeners for scroll passive

### DIFF
--- a/change/@fluentui-react-positioning-37d24b02-03f1-4038-8fb0-eb1ca1f94e98.json
+++ b/change/@fluentui-react-positioning-37d24b02-03f1-4038-8fb0-eb1ca1f94e98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: make event listners passive",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -73,7 +73,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
       }
 
       scrollParents.forEach(scrollParent => {
-        scrollParent.addEventListener('scroll', updatePosition);
+        scrollParent.addEventListener('scroll', updatePosition, { passive: true });
       });
 
       isFirstUpdate = false;
@@ -130,7 +130,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
   };
 
   if (targetWindow) {
-    targetWindow.addEventListener('scroll', updatePosition);
+    targetWindow.addEventListener('scroll', updatePosition, { passive: true });
     targetWindow.addEventListener('resize', updatePosition);
   }
 


### PR DESCRIPTION
## New Behavior

Scroll listeners are passive like in Floating UI/Popper.js:

- https://github.com/floating-ui/floating-ui/blob/6b12fdef95d7b09f276816ce9aead601be55204d/packages/dom/src/autoUpdate.ts#L157C1-L157C1
- https://github.com/floating-ui/floating-ui/blob/92195083958c9496988ed4526b82b75b7256b5a4/src/modifiers/eventListeners.js#L23-L25

## Related Issue(s)

Fixes #28838
