### PR TITLE
Removed iconPosition from the Breadcrumb

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-d29e00b6-09e4-4092-abba-d4030da7d9aa.json
+++ b/change/@fluentui-react-breadcrumb-preview-d29e00b6-09e4-4092-abba-d4030da7d9aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "removed iconPosition prop from the Breadcrumb",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/docs/MIGRATION.md
+++ b/packages/react-components/react-breadcrumb-preview/docs/MIGRATION.md
@@ -9,7 +9,6 @@ Here's how the API of v8's `Breadcrumb` compares to the one from v9's `Breadcrum
 
 - `appearance`
 - `size`
-- `iconPosition`
 
 #### Props no longer supported with an equivalent functionality in Breadcrumb V9:
 
@@ -60,7 +59,6 @@ BreadcrumbItem component contains similar props in V9.
 | `componentRef`      |                 |
 | `dividerAs`         | `dividerType`   |
 | `focusZoneProps`    |                 |
-|                     | `iconPosition`  |
 | `maxDisplayedItems` |                 |
 |                     | `size`          |
 
@@ -91,7 +89,6 @@ BreadcrumbDivider has default `span`. BreadcrumbLink has `a` and Breadcrumb has 
 | `content`              |                 |
 | `design`               |                 |
 |                        | `dividerType`   |
-|                        | `iconPosition`  |
 | `size`                 | `size`          |
 | `styles`               |                 |
 | `variables`            |                 |

--- a/packages/react-components/react-breadcrumb-preview/docs/Spec.md
+++ b/packages/react-components/react-breadcrumb-preview/docs/Spec.md
@@ -172,13 +172,12 @@ Dropdown contains collapsed items.
 
 #### API
 
-| Property     | Values                     | Default       | Purpose                          |
-| ------------ | -------------------------- | ------------- | -------------------------------- |
-| appearance   | `transparent`, `subtle`    | `transparent` | Sets appearance                  |
-| dividerType  | `chevron`, `slash`         | `chevron`     | Sets type of divider             |
-| focusMode    | `tab`, `arrow`             | `tab`         | Sets focus mode                  |
-| iconPosition | `before`, `after`          | `before`      | Sets icon position for all items |
-| size         | `small`, `medium`, `large` | `medium`      | Defines size of the Breadcrumb   |
+| Property    | Values                     | Default       | Purpose                        |
+| ----------- | -------------------------- | ------------- | ------------------------------ |
+| appearance  | `transparent`, `subtle`    | `transparent` | Sets appearance                |
+| dividerType | `chevron`, `slash`         | `chevron`     | Sets type of divider           |
+| focusMode   | `tab`, `arrow`             | `tab`         | Sets focus mode                |
+| size        | `small`, `medium`, `large` | `medium`      | Defines size of the Breadcrumb |
 
 ### BreadcrumbItem
 
@@ -253,7 +252,7 @@ Usage
 
 ```jsx
 <BreadcrumbItem>
-  <BreadcrumbButton icon={<IconComponent />} iconPosition="after">Item</BreadcrumbButton>
+  <BreadcrumbButton icon={<IconComponent />}>Item</BreadcrumbButton>
 </BreadcrumbItem>
 <BreadcrumbItem>
   <BreadcrumbLink icon={<IconComponent />}>Item</BreadcrumbLink>
@@ -318,11 +317,10 @@ Under the hood @fluentui/react-button component is used.
 
 #### API
 
-| Property     | Values            | Default  | Purpose                |
-| ------------ | ----------------- | -------- | ---------------------- |
-| current      | boolean           | false    | Indicates current page |
-| icon         | _slot_            |          | Sets icon              |
-| iconPosition | `before`, `after` | `before` | Sets icon position     |
+| Property | Values  | Default | Purpose                |
+| -------- | ------- | ------- | ---------------------- |
+| current  | boolean | false   | Indicates current page |
+| icon     | _slot_  |         | Sets icon              |
 
 For Link @fluentui/react-link component is used.
 

--- a/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
+++ b/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
@@ -27,7 +27,7 @@ export const BreadcrumbButton: ForwardRefComponent<BreadcrumbButtonProps>;
 export const breadcrumbButtonClassNames: SlotClassNames<BreadcrumbButtonSlots>;
 
 // @public
-export type BreadcrumbButtonProps = ComponentProps<BreadcrumbButtonSlots> & Pick<BreadcrumbProps, 'appearance' | 'iconPosition' | 'size'> & Pick<ButtonProps, 'disabled'> & {
+export type BreadcrumbButtonProps = ComponentProps<BreadcrumbButtonSlots> & Pick<BreadcrumbProps, 'appearance' | 'size'> & Pick<ButtonProps, 'disabled'> & {
     current?: boolean;
 };
 
@@ -66,7 +66,6 @@ export const breadcrumbItemClassNames: SlotClassNames<BreadcrumbItemSlots>;
 // @public
 export type BreadcrumbItemProps = ComponentProps<BreadcrumbItemSlots> & Pick<BreadcrumbProps, 'size'> & {
     current?: boolean;
-    iconPosition?: 'before' | 'after';
 };
 
 // @public (undocumented)
@@ -76,9 +75,7 @@ export type BreadcrumbItemSlots = {
 };
 
 // @public
-export type BreadcrumbItemState = ComponentState<BreadcrumbItemSlots> & Required<Pick<BreadcrumbItemProps, 'size' | 'current' | 'iconPosition'>> & {
-    iconOnly: boolean;
-};
+export type BreadcrumbItemState = ComponentState<BreadcrumbItemSlots> & Required<Pick<BreadcrumbItemProps, 'size' | 'current'>>;
 
 // @public
 export const BreadcrumbLink: ForwardRefComponent<BreadcrumbLinkProps>;
@@ -89,7 +86,6 @@ export const breadcrumbLinkClassNames: SlotClassNames<BreadcrumbLinkSlots>;
 // @public
 export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> & Pick<LinkProps, 'appearance' | 'disabled'> & {
     current?: boolean;
-    iconPosition?: 'before' | 'after';
     overflow?: boolean;
     size?: 'small' | 'medium' | 'large';
 };
@@ -101,16 +97,13 @@ export type BreadcrumbLinkSlots = {
 };
 
 // @public
-export type BreadcrumbLinkState = ComponentState<BreadcrumbLinkSlots> & Partial<Omit<BreadcrumbLinkProps, 'size'>> & Required<Pick<BreadcrumbLinkProps, 'size'>> & {
-    iconOnly: boolean;
-};
+export type BreadcrumbLinkState = ComponentState<BreadcrumbLinkSlots> & Partial<Omit<BreadcrumbLinkProps, 'size'>> & Required<Pick<BreadcrumbLinkProps, 'size'>>;
 
 // @public
 export type BreadcrumbProps = ComponentProps<BreadcrumbSlots> & {
     appearance?: 'transparent' | 'subtle';
     focusMode?: 'arrow' | 'tab';
     dividerType?: 'chevron' | 'slash';
-    iconPosition?: 'before' | 'after';
     size?: 'small' | 'medium' | 'large';
 };
 
@@ -121,7 +114,7 @@ export type BreadcrumbSlots = {
 };
 
 // @public
-export type BreadcrumbState = ComponentState<BreadcrumbSlots> & Required<Pick<BreadcrumbProps, 'appearance' | 'iconPosition' | 'size' | 'dividerType'>>;
+export type BreadcrumbState = ComponentState<BreadcrumbSlots> & Required<Pick<BreadcrumbProps, 'appearance' | 'size' | 'dividerType'>>;
 
 // @public (undocumented)
 export const isTruncatableBreadcrumbContent: (content: string, maxLength: number) => boolean;

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -3,9 +3,7 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 /**
  * Data shared between breadcrumb components
  */
-export type BreadcrumbContextValue = Required<
-  Pick<BreadcrumbProps, 'appearance' | 'dividerType' | 'iconPosition' | 'size'>
->;
+export type BreadcrumbContextValue = Required<Pick<BreadcrumbProps, 'appearance' | 'dividerType' | 'size'>>;
 
 export type BreadcrumbContextValues = {
   breadcrumb: BreadcrumbContextValue;
@@ -55,13 +53,6 @@ export type BreadcrumbProps = ComponentProps<BreadcrumbSlots> & {
   dividerType?: 'chevron' | 'slash';
 
   /**
-   * Icon position for BreadcrumbButton or BreadcrumbLink.
-   *
-   * @default 'before'
-   */
-  iconPosition?: 'before' | 'after';
-
-  /**
    * Controls size of Breadcrumb items and dividers.
    *
    * @default 'medium'
@@ -73,4 +64,4 @@ export type BreadcrumbProps = ComponentProps<BreadcrumbSlots> & {
  * State used in rendering Breadcrumb
  */
 export type BreadcrumbState = ComponentState<BreadcrumbSlots> &
-  Required<Pick<BreadcrumbProps, 'appearance' | 'iconPosition' | 'size' | 'dividerType'>>;
+  Required<Pick<BreadcrumbProps, 'appearance' | 'size' | 'dividerType'>>;

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/BreadcrumbContext.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/BreadcrumbContext.ts
@@ -8,7 +8,6 @@ const BreadcrumbContext = React.createContext<BreadcrumbContextValue | undefined
  */
 export const breadcrumbDefaultValue: BreadcrumbContextValue = {
   appearance: 'transparent',
-  iconPosition: 'before',
   size: 'medium',
   dividerType: 'chevron',
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/useBreadcrumb.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/useBreadcrumb.ts
@@ -17,7 +17,6 @@ export const useBreadcrumb_unstable = (props: BreadcrumbProps, ref: React.Ref<HT
     appearance = 'transparent',
     focusMode = 'tab',
     dividerType = 'chevron',
-    iconPosition = 'before',
     size = 'medium',
     list,
     ...rest
@@ -46,7 +45,6 @@ export const useBreadcrumb_unstable = (props: BreadcrumbProps, ref: React.Ref<HT
     list: slot.optional(list, { renderByDefault: true, defaultProps: { role: 'list' }, elementType: 'ol' }),
     appearance,
     dividerType,
-    iconPosition,
     size,
   };
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/useBreadcrumbContextValue.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/useBreadcrumbContextValue.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import type { BreadcrumbContextValues, BreadcrumbState } from './Breadcrumb.types';
 
 export function useBreadcrumbContextValues_unstable(state: BreadcrumbState): BreadcrumbContextValues {
-  const { appearance, dividerType, iconPosition, size } = state;
+  const { appearance, dividerType, size } = state;
 
   const breadcrumb = React.useMemo(() => {
-    return { appearance, dividerType, iconPosition, size };
-  }, [appearance, dividerType, iconPosition, size]);
+    return { appearance, dividerType, size };
+  }, [appearance, dividerType, size]);
 
   return { breadcrumb };
 }

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
@@ -38,7 +38,7 @@ describe('BreadcrumbButton', () => {
     `);
   });
 
-  it('renders with an icon in a default position', () => {
+  it('renders with an icon', () => {
     const result = render(
       <BreadcrumbButton icon={<ArrowRight16Filled />}>BreadcrumbButton with icon</BreadcrumbButton>,
     );
@@ -67,73 +67,6 @@ describe('BreadcrumbButton', () => {
             </svg>
           </span>
           BreadcrumbButton with icon
-        </button>
-      </div>
-    `);
-  });
-
-  it('renders with an icon in a position `after`', () => {
-    const result = render(
-      <BreadcrumbButton icon={<ArrowRight16Filled />} iconPosition="after">
-        BreadcrumbButton with icon
-      </BreadcrumbButton>,
-    );
-    expect(result.container).toMatchInlineSnapshot(`
-      <div>
-        <button
-          class="fui-Button fui-BreadcrumbButton"
-          type="button"
-        >
-          BreadcrumbButton with icon
-          <span
-            class="fui-Button__icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              fill="currentColor"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M2 8c0-.41.34-.75.75-.75h8.79L8.25 4.31a.75.75 0 0 1 1-1.12L14 7.44a.75.75 0 0 1 0 1.12L9.25 12.8a.75.75 0 1 1-1-1.12l3.29-2.94H2.75A.75.75 0 0 1 2 8Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    `);
-  });
-
-  it('renders only icon', () => {
-    const result = render(<BreadcrumbButton icon={<ArrowRight16Filled />} />);
-    expect(result.container).toMatchInlineSnapshot(`
-      <div>
-        <button
-          class="fui-Button fui-BreadcrumbButton"
-          type="button"
-        >
-          <span
-            class="fui-Button__icon"
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              fill="currentColor"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M2 8c0-.41.34-.75.75-.75h8.79L8.25 4.31a.75.75 0 0 1 1-1.12L14 7.44a.75.75 0 0 1 0 1.12L9.25 12.8a.75.75 0 1 1-1-1.12l3.29-2.94H2.75A.75.75 0 0 1 2 8Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
         </button>
       </div>
     `);

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.types.ts
@@ -8,7 +8,7 @@ export type BreadcrumbButtonSlots = ButtonSlots;
  * BreadcrumbButton Props
  */
 export type BreadcrumbButtonProps = ComponentProps<BreadcrumbButtonSlots> &
-  Pick<BreadcrumbProps, 'appearance' | 'iconPosition' | 'size'> &
+  Pick<BreadcrumbProps, 'appearance' | 'size'> &
   Pick<ButtonProps, 'disabled'> & {
     /**
      * Defines current sate of BreadcrumbButton.

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButton.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButton.ts
@@ -16,7 +16,7 @@ export const useBreadcrumbButton_unstable = (
   props: BreadcrumbButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): BreadcrumbButtonState => {
-  const { appearance, iconPosition, size } = useBreadcrumbContext_unstable();
+  const { appearance, size } = useBreadcrumbContext_unstable();
   const { current = false, icon, ...rest } = props;
 
   return {
@@ -24,7 +24,7 @@ export const useBreadcrumbButton_unstable = (
       {
         ...rest,
         appearance: props.appearance || appearance,
-        iconPosition: props.iconPosition || iconPosition,
+        iconPosition: 'before',
         icon,
         'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
       },

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.types.ts
@@ -21,24 +21,10 @@ export type BreadcrumbItemProps = ComponentProps<BreadcrumbItemSlots> &
      * @default false
      */
     current?: boolean;
-
-    /**
-     * Icon position for BreadcrumbLink or BreadcrumbLink.
-     *
-     * @default 'before'
-     */
-    iconPosition?: 'before' | 'after';
   };
 
 /**
  * State used in rendering BreadcrumbItem
  */
 export type BreadcrumbItemState = ComponentState<BreadcrumbItemSlots> &
-  Required<Pick<BreadcrumbItemProps, 'size' | 'current' | 'iconPosition'>> & {
-    /**
-     * A BreadcrumbItem can contain only an icon.
-     *
-     * @default false
-     */
-    iconOnly: boolean;
-  };
+  Required<Pick<BreadcrumbItemProps, 'size' | 'current'>>;

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.types.ts
@@ -5,7 +5,7 @@ export type BreadcrumbItemSlots = {
   root: Slot<'li'>;
 
   /**
-   * Icon that renders either before or after the `children` as specified by the `iconPosition` prop.
+   * Icon that renders before the `children`.
    */
   icon?: Slot<'span'>;
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/renderBreadcrumbItem.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/renderBreadcrumbItem.tsx
@@ -11,13 +11,11 @@ import type { BreadcrumbItemState, BreadcrumbItemSlots } from './BreadcrumbItem.
  */
 export const renderBreadcrumbItem_unstable = (state: BreadcrumbItemState) => {
   assertSlots<BreadcrumbItemSlots>(state);
-  const { iconOnly, iconPosition } = state;
 
   return (
     <state.root>
-      {iconPosition !== 'after' && state.icon && <state.icon />}
-      {!iconOnly && state.root.children}
-      {iconPosition === 'after' && state.icon && <state.icon />}
+      {state.icon && <state.icon />}
+      {state.root.children}
     </state.root>
   );
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItem.ts
@@ -16,7 +16,7 @@ export const useBreadcrumbItem_unstable = (
   props: BreadcrumbItemProps,
   ref: React.Ref<HTMLElement>,
 ): BreadcrumbItemState => {
-  const { size, iconPosition } = useBreadcrumbContext_unstable();
+  const { size } = useBreadcrumbContext_unstable();
   const { current = false, icon } = props;
 
   const iconSlot = slot.optional(icon, { elementType: 'span' });
@@ -32,7 +32,5 @@ export const useBreadcrumbItem_unstable = (
     size,
     current,
     icon: iconSlot,
-    iconOnly: Boolean(iconSlot?.children && !props.children),
-    iconPosition: props.iconPosition || iconPosition,
   };
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.test.tsx
@@ -39,7 +39,7 @@ describe('BreadcrumbLink', () => {
     `);
   });
 
-  it('renders with an icon in a default position', () => {
+  it('renders with an icon', () => {
     const result = render(
       <BreadcrumbLink href="#" icon={<ArrowRight16Filled />}>
         BreadcrumbLink with icon
@@ -71,75 +71,6 @@ describe('BreadcrumbLink', () => {
             </svg>
           </span>
           BreadcrumbLink with icon
-        </a>
-      </div>
-    `);
-  });
-
-  it('renders with an icon in a position `after`', () => {
-    const result = render(
-      <BreadcrumbLink href="#" icon={<ArrowRight16Filled />} iconPosition="after">
-        BreadcrumbLink with icon
-      </BreadcrumbLink>,
-    );
-    expect(result.container).toMatchInlineSnapshot(`
-      <div>
-        <a
-          class="fui-Link fui-BreadcrumbLink"
-          href="#"
-          tabindex="0"
-        >
-          BreadcrumbLink with icon
-          <span
-            class=""
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              fill="currentColor"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M2 8c0-.41.34-.75.75-.75h8.79L8.25 4.31a.75.75 0 0 1 1-1.12L14 7.44a.75.75 0 0 1 0 1.12L9.25 12.8a.75.75 0 1 1-1-1.12l3.29-2.94H2.75A.75.75 0 0 1 2 8Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
-    `);
-  });
-
-  it('renders only icon', () => {
-    const result = render(<BreadcrumbLink href="#" icon={<ArrowRight16Filled />} />);
-    expect(result.container).toMatchInlineSnapshot(`
-      <div>
-        <a
-          class="fui-Link fui-BreadcrumbLink"
-          href="#"
-          tabindex="0"
-        >
-          <span
-            class=""
-          >
-            <svg
-              aria-hidden="true"
-              class=""
-              fill="currentColor"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M2 8c0-.41.34-.75.75-.75h8.79L8.25 4.31a.75.75 0 0 1 1-1.12L14 7.44a.75.75 0 0 1 0 1.12L9.25 12.8a.75.75 0 1 1-1-1.12l3.29-2.94H2.75A.75.75 0 0 1 2 8Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
         </a>
       </div>
     `);

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.types.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/BreadcrumbLink.types.ts
@@ -8,7 +8,7 @@ export type BreadcrumbLinkSlots = {
   root: LinkProps;
 
   /**
-   * Icon that renders either before or after the `children` as specified by the `iconPosition` prop.
+   * Icon that renders before the `children`.
    */
   icon?: Slot<'span'>;
 };
@@ -24,13 +24,6 @@ export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> &
      * @default false
      */
     current?: boolean;
-
-    /**
-     * Icon position for BreadcrumbLink or BreadcrumbLink.
-     *
-     * @default 'before'
-     */
-    iconPosition?: 'before' | 'after';
 
     /**
      * Defines a sate when the Link is part of overflow menu.
@@ -52,11 +45,4 @@ export type BreadcrumbLinkProps = ComponentProps<BreadcrumbLinkSlots> &
  */
 export type BreadcrumbLinkState = ComponentState<BreadcrumbLinkSlots> &
   Partial<Omit<BreadcrumbLinkProps, 'size'>> &
-  Required<Pick<BreadcrumbLinkProps, 'size'>> & {
-    /**
-     * A BreadcrumbLink can contain only an icon.
-     *
-     * @default false
-     */
-    iconOnly: boolean;
-  };
+  Required<Pick<BreadcrumbLinkProps, 'size'>>;

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/renderBreadcrumbLink.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/renderBreadcrumbLink.tsx
@@ -11,12 +11,11 @@ import type { BreadcrumbLinkState, BreadcrumbLinkSlots } from './BreadcrumbLink.
  */
 export const renderBreadcrumbLink_unstable = (state: BreadcrumbLinkState) => {
   assertSlots<BreadcrumbLinkSlots>(state);
-  const { iconOnly, iconPosition } = state;
+
   return (
     <state.root>
-      {iconPosition !== 'after' && state.icon && <state.icon />}
-      {!iconOnly && state.root.children}
-      {iconPosition === 'after' && state.icon && <state.icon />}
+      {state.icon && <state.icon />}
+      {state.root.children}
     </state.root>
   );
 };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLink.ts
@@ -16,7 +16,7 @@ export const useBreadcrumbLink_unstable = (
   props: BreadcrumbLinkProps,
   ref: React.Ref<HTMLAnchorElement | HTMLButtonElement>,
 ): BreadcrumbLinkState => {
-  const { appearance, iconPosition, size } = useBreadcrumbContext_unstable();
+  const { appearance, size } = useBreadcrumbContext_unstable();
   const { current = false, disabled = false, icon, overflow = false } = props;
 
   const link = useLink_unstable(props, ref);
@@ -41,8 +41,6 @@ export const useBreadcrumbLink_unstable = (
     current,
     disabled,
     icon: iconShorthand,
-    iconOnly: Boolean(iconShorthand?.children && !props.children),
-    iconPosition: props.iconPosition || iconPosition,
     overflow,
     size: props.size || size,
   };

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLinkStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbLink/useBreadcrumbLinkStyles.styles.ts
@@ -29,12 +29,6 @@ const useStyles = makeStyles({
     alignItems: 'center',
     ...shorthands.padding(tokens.spacingHorizontalXS),
   },
-  iconOnly: {
-    '&:hover': {
-      ...shorthands.borderBottom(tokens.strokeWidthThin, 'solid'),
-      ...shorthands.padding(tokens.spacingVerticalNone, tokens.spacingHorizontalXS),
-    },
-  },
   small: {
     height: '24px',
     ...typographyStyles.caption1,
@@ -118,8 +112,7 @@ export const useBreadcrumbLinkStyles_unstable = (state: BreadcrumbLinkState): Br
   );
 
   if (state.icon) {
-    const iconOnlyClass = state.iconOnly ? styles.iconOnly : '';
-    state.icon.className = mergeClasses(iconStyles[state.size], styles.icon, state.icon.className, iconOnlyClass);
+    state.icon.className = mergeClasses(iconStyles[state.size], styles.icon, state.icon.className);
   }
 
   useLinkStyles_unstable(state as LinkState);

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbDefault.stories.tsx
@@ -7,16 +7,10 @@ import {
   BreadcrumbButton,
   BreadcrumbLink,
 } from '@fluentui/react-breadcrumb-preview';
-import { RadioGroup, Radio, Label, ButtonProps } from '@fluentui/react-components';
+import { RadioGroup, Radio, Label } from '@fluentui/react-components';
 type Item = {
   key: number;
   value: string;
-  buttonProps?: {
-    'aria-label'?: string;
-    icon?: ButtonProps['icon'];
-    disabled?: boolean;
-    iconPosition?: 'before' | 'after';
-  };
 };
 const items: Item[] = [
   {

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbFocusMode.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbFocusMode.tsx
@@ -13,7 +13,6 @@ type Item = {
     onClick?: () => void;
     icon?: ButtonProps['icon'];
     disabled?: boolean;
-    iconPosition?: 'before' | 'after';
   };
 };
 
@@ -24,6 +23,7 @@ const buttonItems: Item[] = [
   },
   {
     key: 1,
+    item: 'Item 1',
     buttonProps: {
       icon: <CalendarMonth />,
       'aria-label': 'Item 1',
@@ -45,7 +45,6 @@ const buttonItems: Item[] = [
     item: 'Item 4',
     buttonProps: {
       icon: <CalendarMonth />,
-      iconPosition: 'after',
     },
   },
   {

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbLinkWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbLinkWithOverflow.stories.tsx
@@ -44,7 +44,6 @@ type LinkItem = {
     href: string;
     icon?: BreadcrumbLinkProps['icon'];
     disabled?: boolean;
-    iconPosition?: 'before' | 'after';
   };
 };
 
@@ -73,6 +72,7 @@ const linkItems: LinkItem[] = [
   },
   {
     key: 3,
+    item: 'Item 3',
     linkProps: {
       'aria-label': 'Item 3',
       href: 'https://developer.microsoft.com/',
@@ -85,7 +85,6 @@ const linkItems: LinkItem[] = [
     linkProps: {
       href: 'https://developer.microsoft.com/',
       icon: <CalendarMonthRegular />,
-      iconPosition: 'after',
     },
   },
   {

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbButton/BreadcrumbButtonDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbButton/BreadcrumbButtonDefault.stories.tsx
@@ -19,7 +19,6 @@ type Item = {
     onClick?: () => void;
     icon?: ButtonProps['icon'];
     disabled?: boolean;
-    iconPosition?: 'before' | 'after';
   };
 };
 
@@ -33,10 +32,12 @@ const buttonItems: Item[] = [
   },
   {
     key: 1,
+    item: 'Item 1',
     buttonProps: {
       icon: <CalendarMonth />,
       'aria-label': 'Item 1',
       onClick: () => console.log('item 1 was clicked'),
+      disabled: true,
     },
   },
   {
@@ -59,7 +60,6 @@ const buttonItems: Item[] = [
     item: 'Item 4',
     buttonProps: {
       icon: <CalendarMonth />,
-      iconPosition: 'after',
       onClick: () => console.log('item 4 was clicked'),
     },
   },

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbItem/BreadcrumbItemDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbItem/BreadcrumbItemDefault.stories.tsx
@@ -95,11 +95,9 @@ export const Default = () => {
       <Breadcrumb aria-label="breadcrumb-item-icon-example">
         <BreadcrumbItem icon={<CalendarMonth />}>Item with an icon</BreadcrumbItem>
         <BreadcrumbDivider />
-        <BreadcrumbItem icon={<CalendarMonth />} />
+        <BreadcrumbItem>Item 1</BreadcrumbItem>
         <BreadcrumbDivider />
-        <BreadcrumbItem icon={<CalendarMonth />} iconPosition="after">
-          Item with an icon
-        </BreadcrumbItem>
+        <BreadcrumbItem>Item 2</BreadcrumbItem>
       </Breadcrumb>
     </>
   );

--- a/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbLink/BreadcrumbLinkDefault.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/BreadcrumbLink/BreadcrumbLinkDefault.stories.tsx
@@ -48,10 +48,12 @@ const linkItems: Item[] = [
   },
   {
     key: 3,
+    item: 'Item 3',
     linkProps: {
       'aria-label': 'Item 3',
       href: 'https://developer.microsoft.com/',
       icon: <CalendarMonth />,
+      disabled: true,
     },
   },
   {
@@ -59,8 +61,6 @@ const linkItems: Item[] = [
     item: 'Item 4',
     linkProps: {
       href: 'https://developer.microsoft.com/',
-      icon: <CalendarMonthRegular />,
-      iconPosition: 'after',
     },
   },
   {


### PR DESCRIPTION
After discussion with design team we can have only left icon in the Breadcrumb

## Previous Behavior
It was possible to have only icon and iconPosition: 'after'

![image](https://github.com/microsoft/fluentui/assets/11574680/06dda957-22c0-44de-a173-f4578aebf49e)
![image](https://github.com/microsoft/fluentui/assets/11574680/08860d59-10c6-41d1-9fe9-08ec60031529)
![image](https://github.com/microsoft/fluentui/assets/11574680/0581304b-67e8-4c96-a6a1-445aa19c1216)

## New Behavior
Only left icon is supported.

![image](https://github.com/microsoft/fluentui/assets/11574680/18a65abd-62d7-4193-b851-f40d33d99cf8)
![image](https://github.com/microsoft/fluentui/assets/11574680/060e6fa8-7550-4b95-bce5-4d965ddd0bdf)
![image](https://github.com/microsoft/fluentui/assets/11574680/6b1f813c-d4b9-4d51-903c-c5d445f9adbc)
