### PR TITLE
chore(react-portal-compat): changes tsconfig target to ES2019

### DIFF
--- a/change/@fluentui-react-portal-compat-f3f95299-f0a8-4c7e-8de0-e104a03a11fc.json
+++ b/change/@fluentui-react-portal-compat-f3f95299-f0a8-4c7e-8de0-e104a03a11fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: changes tsconfig target to ES2019",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal-compat/tsconfig.json
+++ b/packages/react-components/react-portal-compat/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES5",
-    "lib": ["es5", "dom"],
+    "target": "ES2019",
     "noEmit": true,
     "isolatedModules": true,
     "importHelpers": true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. changes tsconfig target from `ES5` to `ES2019`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
