### PR TITLE
chore(react-search-preview): migrate to new slots API

### DIFF
--- a/change/@fluentui-react-search-preview-36bce77d-7b10-45d8-99df-3c4c014bc2be.json
+++ b/change/@fluentui-react-search-preview-36bce77d-7b10-45d8-99df-3c4c014bc2be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate to new slots API",
+  "packageName": "@fluentui/react-search-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search-preview/etc/react-search-preview.api.md
+++ b/packages/react-components/react-search-preview/etc/react-search-preview.api.md
@@ -9,8 +9,9 @@
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { Input } from '@fluentui/react-input';
-import { InputState } from '@fluentui/react-input';
+import type { InputProps } from '@fluentui/react-input';
+import type { InputSlots } from '@fluentui/react-input';
+import type { InputState } from '@fluentui/react-input';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
@@ -25,17 +26,15 @@ export const SearchBox: ForwardRefComponent<SearchBoxProps>;
 export const searchBoxClassNames: SlotClassNames<SearchBoxSlots>;
 
 // @public
-export type SearchBoxProps = ComponentProps<SearchBoxSlots>;
+export type SearchBoxProps = Omit<ComponentProps<Partial<SearchBoxSlots>, 'input'>, 'children' | 'defaultValue' | 'onChange' | 'size' | 'type' | 'value'> & InputProps;
 
 // @public (undocumented)
-export type SearchBoxSlots = {
-    root: NonNullable<Slot<typeof Input>>;
+export type SearchBoxSlots = InputSlots & {
     dismiss?: Slot<'span'>;
-    contentAfter?: Slot<'span'>;
 };
 
 // @public
-export type SearchBoxState = ComponentState<SearchBoxSlots> & Required<Pick<InputState, 'size'>> & Required<Pick<SearchBoxProps, 'disabled'>> & {
+export type SearchBoxState = ComponentState<SearchBoxSlots> & InputState & Required<Pick<InputState, 'size'>> & Required<Pick<SearchBoxProps, 'disabled'>> & {
     focused: boolean;
 };
 

--- a/packages/react-components/react-search-preview/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-components/react-search-preview/src/components/SearchBox/SearchBox.types.ts
@@ -1,26 +1,26 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { Input, InputState } from '@fluentui/react-input';
+import type { InputProps, InputSlots, InputState } from '@fluentui/react-input';
 
-export type SearchBoxSlots = {
-  // Root of the component, wrapping the inputs
-  root: NonNullable<Slot<typeof Input>>;
-
+export type SearchBoxSlots = InputSlots & {
   // Last element in the input, within the input border
   dismiss?: Slot<'span'>;
-
-  // Element after the input text, within the input border
-  contentAfter?: Slot<'span'>;
 };
 
 /**
  * SearchBox Props
  */
-export type SearchBoxProps = ComponentProps<SearchBoxSlots>;
+export type SearchBoxProps = Omit<
+  ComponentProps<Partial<SearchBoxSlots>, 'input'>,
+  // `children` is unsupported. The rest of these native props have customized definitions.
+  'children' | 'defaultValue' | 'onChange' | 'size' | 'type' | 'value'
+> &
+  InputProps;
 
 /**
  * State used in rendering SearchBox
  */
 export type SearchBoxState = ComponentState<SearchBoxSlots> &
+  InputState &
   Required<Pick<InputState, 'size'>> &
   Required<Pick<SearchBoxProps, 'disabled'>> & {
     focused: boolean;

--- a/packages/react-components/react-search-preview/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/react-components/react-search-preview/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SearchBox renders a default state 1`] = `
     class="fui-Input fui-SearchBox"
   >
     <span
-      class="fui-Input__contentBefore"
+      class="fui-Input__contentBefore fui-SearchBox__contentBefore"
     >
       <svg
         aria-hidden="true"
@@ -24,7 +24,7 @@ exports[`SearchBox renders a default state 1`] = `
       </svg>
     </span>
     <input
-      class="fui-Input__input"
+      class="fui-Input__input fui-SearchBox__input"
       type="search"
       value=""
     />

--- a/packages/react-components/react-search-preview/src/components/SearchBox/renderSearchBox.tsx
+++ b/packages/react-components/react-search-preview/src/components/SearchBox/renderSearchBox.tsx
@@ -2,29 +2,26 @@
 /** @jsx createElement */
 /** @jsxFrag React.Fragment */
 
-import * as React from 'react';
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { SearchBoxState, SearchBoxSlots } from './SearchBox.types';
 
 /**
  * Render the final JSX of SearchBox
  */
 export const renderSearchBox_unstable = (state: SearchBoxState) => {
-  const { slots, slotProps } = getSlotsNext<SearchBoxSlots>(state);
+  assertSlots<SearchBoxSlots>(state);
 
-  // TODO Add additional slots in the appropriate place
-  const rootSlots = {
-    contentAfter: slots.contentAfter && {
-      ...slotProps.contentAfter,
-      children: (
-        <>
-          {slotProps.contentAfter.children}
-          {slots.dismiss && <slots.dismiss {...slotProps.dismiss} />}
-        </>
-      ),
-    },
-  };
-
-  return <slots.root {...slotProps.root} {...rootSlots} />;
+  return (
+    <state.root>
+      {state.contentBefore && <state.contentBefore />}
+      <state.input />
+      {state.contentAfter && (
+        <state.contentAfter>
+          {state.contentAfter.children}
+          {state.dismiss && <state.dismiss />}
+        </state.contentAfter>
+      )}
+    </state.root>
+  );
 };

--- a/packages/react-components/react-search-preview/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search-preview/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -2,11 +2,14 @@ import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { SearchBoxSlots, SearchBoxState } from './SearchBox.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
+import { useInputStyles_unstable } from '@fluentui/react-input';
 
 export const searchBoxClassNames: SlotClassNames<SearchBoxSlots> = {
   root: 'fui-SearchBox',
   dismiss: 'fui-SearchBox__dismiss',
   contentAfter: 'fui-SearchBox__contentAfter',
+  contentBefore: 'fui-SearchBox__contentBefore',
+  input: 'fui-SearchBox__input',
 };
 
 /**
@@ -98,7 +101,7 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
   const dismissStyles = useDismissStyles();
 
   state.root.className = mergeClasses(searchBoxClassNames.root, rootStyles[size], state.root.className);
-  state.root.input!.className = rootStyles.input;
+  state.input.className = mergeClasses(searchBoxClassNames.input, rootStyles.input, state.input.className);
 
   if (state.dismiss) {
     state.dismiss.className = mergeClasses(
@@ -109,6 +112,10 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
 
       state.dismiss.className,
     );
+  }
+
+  if (state.contentBefore) {
+    state.contentBefore.className = mergeClasses(searchBoxClassNames.contentBefore, state.contentBefore.className);
   }
 
   if (state.contentAfter) {
@@ -123,6 +130,8 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
   } else if (state.dismiss) {
     state.dismiss.className = mergeClasses(state.dismiss.className, contentAfterStyles.contentAfter);
   }
+
+  useInputStyles_unstable(state);
 
   return state;
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior


1. restructure to ensure no leak of logic from state hook to render method
2. flats all slots into type declaration and uses composition API

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28778
