### PR TITLE
feat(public-docsite): Add topbanner component and use it in the public docsite

### DIFF
--- a/apps/public-docsite/src/components/Site/Site.tsx
+++ b/apps/public-docsite/src/components/Site/Site.tsx
@@ -11,6 +11,7 @@ import {
   trackEvent,
   trackPageView,
   IWithPlatformProps,
+  TopBanner,
   TopNav,
   ScrollBars,
   INavPage,
@@ -158,6 +159,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<
 
     const SiteContent = () => (
       <div key="site" className={styles.siteRoot}>
+        {this._renderTopBanner()}
         {this._renderTopNav()}
         {this._renderMessageBar()}
         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
@@ -328,6 +330,10 @@ export class Site<TPlatforms extends string = string> extends React.Component<
         />
       );
     }
+  };
+
+  private _renderTopBanner = (): JSX.Element | undefined => {
+    return <TopBanner />;
   };
 
   private _renderPlatformPicker = (): JSX.Element | null => {

--- a/apps/public-docsite/src/components/Site/Site.tsx
+++ b/apps/public-docsite/src/components/Site/Site.tsx
@@ -30,6 +30,7 @@ import { AppThemesContext, extractAnchorLink } from '@fluentui/react-docsite-com
 import { getItem, setItem } from '@fluentui/utilities/lib/sessionStorage';
 import * as styles from './Site.module.scss';
 import { appMaximumWidthLg } from '../../styles/constants';
+import { cdnUrl } from '../../utilities/cdn';
 
 export interface ISiteProps<TPlatforms extends string = string> {
   children?: React.ReactNode;
@@ -333,7 +334,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<
   };
 
   private _renderTopBanner = (): JSX.Element | undefined => {
-    return <TopBanner />;
+    return <TopBanner cdnUrl={cdnUrl} />;
   };
 
   private _renderPlatformPicker = (): JSX.Element | null => {

--- a/apps/public-docsite/src/utilities/cdn.ts
+++ b/apps/public-docsite/src/utilities/cdn.ts
@@ -1,3 +1,3 @@
-const version = '20221209.001';
+const version = '20230815.002';
 
 export const cdnUrl = `https://res-1.cdn.office.net/files/fabric-cdn-prod_${version}`;

--- a/change/@fluentui-react-docsite-components-2a60a3d3-f60d-4f53-94b2-533d4d8a7435.json
+++ b/change/@fluentui-react-docsite-components-2a60a3d3-f60d-4f53-94b2-533d4d8a7435.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: Add TopBanner component and use it in the site template.\"",
+  "comment": "feat: Add TopBanner component and use it in the site template.",
   "packageName": "@fluentui/react-docsite-components",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-docsite-components-2a60a3d3-f60d-4f53-94b2-533d4d8a7435.json
+++ b/change/@fluentui-react-docsite-components-2a60a3d3-f60d-4f53-94b2-533d4d8a7435.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add TopBanner component and use it in the site template.\"",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/TopBanner/TopBanner.module.scss
+++ b/packages/react-docsite-components/src/components/TopBanner/TopBanner.module.scss
@@ -1,0 +1,63 @@
+.topBanner {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  background-color: #f4f4f7;
+  width: 100%;
+  height: 92px;
+  padding: 18px 32px 21px 32px;
+  align-items: center;
+}
+
+.topBannerImage {
+  position: absolute;
+  height: 92px;
+  right: 0;
+  top: 0;
+
+  @media (max-width: 500px) {
+    display: none;
+  }
+}
+
+.topBannerContent {
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.topBannerHeader {
+  color: #1b1a19;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 27px;
+  margin-bottom: 6px;
+}
+
+.topBannerText {
+  color: #1b1a19;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 150%;
+
+  @media (max-width: 500px) {
+    display: none;
+  }
+}
+
+.topBannerLink {
+  all: unset;
+  cursor: pointer;
+  background-color: #000000;
+  color: #ffffff;
+  height: 32px;
+  border-radius: 100px;
+  padding: 0px 16px;
+  font-weight: 600;
+  font-size: 12px;
+  z-index: 10;
+  line-height: 32px;
+
+  @media (max-width: 300px) {
+    font-size: 8px;
+  }
+}

--- a/packages/react-docsite-components/src/components/TopBanner/TopBanner.tsx
+++ b/packages/react-docsite-components/src/components/TopBanner/TopBanner.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import * as styles from './TopBanner.module.scss';
+
+export const TopBanner: React.FC = () => (
+  <div className={styles.topBanner}>
+    <div className={styles.topBannerContent}>
+      <span className={styles.topBannerHeader}>
+        Introducing <strong style={{ fontWeight: 'bold' }}>Fluent 2</strong>
+      </span>
+      <span className={styles.topBannerText}>Explore the next evolution of Microsoft's design system</span>
+    </div>
+    <a className={styles.topBannerLink} href="https://fluent2.microsoft.design">
+      Experience Fluent 2
+    </a>
+    <img
+      className={styles.topBannerImage}
+      role="presentation"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/banner_image.webp"
+    />
+  </div>
+);

--- a/packages/react-docsite-components/src/components/TopBanner/TopBanner.tsx
+++ b/packages/react-docsite-components/src/components/TopBanner/TopBanner.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import * as styles from './TopBanner.module.scss';
 
-export const TopBanner: React.FC = () => (
+import type { ITopBannerProps } from './TopBanner.types';
+
+export const TopBanner: React.FC<ITopBannerProps> = ({ cdnUrl }) => (
   <div className={styles.topBanner}>
     <div className={styles.topBannerContent}>
       <span className={styles.topBannerHeader}>
@@ -15,7 +17,7 @@ export const TopBanner: React.FC = () => (
     <img
       className={styles.topBannerImage}
       role="presentation"
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/banner_image.webp"
+      src={cdnUrl + '/fabric-website/images/fluent2-top-banner-image.webp'}
     />
   </div>
 );

--- a/packages/react-docsite-components/src/components/TopBanner/TopBanner.types.ts
+++ b/packages/react-docsite-components/src/components/TopBanner/TopBanner.types.ts
@@ -1,0 +1,3 @@
+export interface ITopBannerProps {
+  cdnUrl: string;
+}

--- a/packages/react-docsite-components/src/components/TopBanner/index.ts
+++ b/packages/react-docsite-components/src/components/TopBanner/index.ts
@@ -1,0 +1,1 @@
+export * from './TopBanner';

--- a/packages/react-docsite-components/src/index2.ts
+++ b/packages/react-docsite-components/src/index2.ts
@@ -19,6 +19,7 @@ export * from './components/ScrollBars/index';
 export * from './components/SideRail/index';
 export * from './components/SiteMessageBar/index';
 export * from './components/Table/index';
+export * from './components/TopBanner/index';
 export * from './components/TopNav/index';
 export * from './components/Video/index';
 export * from './utilities/index2';


### PR DESCRIPTION
This PR adds the top banner that points to the Fluent 2 design website. Note that this is missing adding the correct image to the cdn. The screenshot has a local placeholder.

## Previous Behavior

![image](https://github.com/microsoft/fluentui/assets/5953191/9447392d-a803-457e-ae71-8391abf6afb7)

## New Behavior
|desktop|mobile|
|---|---|
|![image](https://github.com/microsoft/fluentui/assets/5953191/655ab681-e8f1-47ce-a086-c0cc3d228a13)|![image](https://github.com/microsoft/fluentui/assets/5953191/a46254e3-04e7-4464-901a-660e04d12e6d)|





