### PR TITLE
feat: add closeOnIframeFocus prop to Popover

### DIFF
--- a/change/@fluentui-react-popover-734b13f1-e9b6-48f6-8424-854c2b01268e.json
+++ b/change/@fluentui-react-popover-734b13f1-e9b6-48f6-8424-854c2b01268e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add closeOnIframeFocus prop to Popover",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-b19f3b01-374f-42a8-810c-33ad335e5e79.json
+++ b/change/@fluentui-react-utilities-b19f3b01-374f-42a8-810c-33ad335e5e79.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add disabledFocusOnIframe for useOnClickOutside()",
+  "packageName": "@fluentui/react-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluentui/react-bindings/src/hooks/useOnIFrameFocus.ts
+++ b/packages/fluentui/react-bindings/src/hooks/useOnIFrameFocus.ts
@@ -2,7 +2,7 @@ import { useIFrameFocusDispatch } from './useIFrameFocusDispatch';
 import { useIFrameListener } from './useIFrameListener';
 
 /**
- * It enabables a interval to check if the iframe is focused and executes the callback function.
+ * A hook that creates an interval to check if the iframe is focused and executes the callback function once it happens.
  */
 export const useOnIFrameFocus = (
   enableFrameFocusDispatch: boolean,

--- a/packages/react-components/react-popover/etc/react-popover.api.md
+++ b/packages/react-components/react-popover/etc/react-popover.api.md
@@ -54,6 +54,7 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
     open?: boolean;
     openOnContext?: boolean;
     openOnHover?: boolean;
+    closeOnIframeFocus?: boolean;
     positioning?: PositioningShorthand;
     size?: PopoverSize;
     trapFocus?: boolean;

--- a/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.types.ts
@@ -88,6 +88,13 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
   openOnHover?: boolean;
 
   /**
+   * Flag to close the Popover when an iframe outside a PopoverSurface is focused
+   *
+   * @default true
+   */
+  closeOnIframeFocus?: boolean;
+
+  /**
    * Configures the position of the Popover
    */
   positioning?: PositioningShorthand;

--- a/packages/react-components/react-popover/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/src/components/Popover/usePopover.ts
@@ -97,14 +97,15 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   );
 
   const positioningRefs = usePopoverRefs(initialState);
-
   const { targetDocument } = useFluent();
+
   useOnClickOutside({
     contains: elementContains,
     element: targetDocument,
     callback: ev => setOpen(ev, false),
     refs: [positioningRefs.triggerRef, positioningRefs.contentRef],
     disabled: !open,
+    disabledFocusOnIframe: !(props.closeOnIframeFocus ?? true),
   });
 
   // only close on scroll for context, or when closeOnScroll is specified

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -334,6 +334,7 @@ export type UseOnClickOrScrollOutsideOptions = {
     refs: React_2.MutableRefObject<HTMLElement | undefined | null>[];
     contains?(parent: HTMLElement | null, child: HTMLElement): boolean;
     disabled?: boolean;
+    disabledFocusOnIframe?: boolean;
     callback: (ev: MouseEvent | TouchEvent) => void;
 };
 

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.cy.tsx
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.cy.tsx
@@ -1,10 +1,11 @@
 import { mount } from '@cypress/react';
 import * as React from 'react';
 import root from 'react-shadow';
+import Frame from 'react-frame-component';
 
 import { useOnClickOutside } from './useOnClickOutside';
 
-const Example: React.FC<{ useShadowDOM: boolean; onOutsideClick: () => void }> = props => {
+const OutsideClickExample: React.FC<{ useShadowDOM: boolean; onOutsideClick: () => void }> = props => {
   const innerRef = React.useRef<HTMLDivElement>(null);
 
   useOnClickOutside({
@@ -38,11 +39,48 @@ const Example: React.FC<{ useShadowDOM: boolean; onOutsideClick: () => void }> =
   );
 };
 
+const IFrameExample: React.FC<{ disabledFocusOnIframe?: boolean; onOutsideClick: () => void }> = props => {
+  const innerRef = React.useRef<HTMLDivElement>(null);
+
+  useOnClickOutside({
+    element: document,
+    disabledFocusOnIframe: props.disabledFocusOnIframe,
+    callback: props.onOutsideClick,
+    refs: [innerRef],
+  });
+
+  return (
+    <div style={{ border: '3px solid green', padding: 20, display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div
+        id="inside-area"
+        ref={innerRef}
+        style={{ display: 'flex', flexDirection: 'column', gap: 20, border: '3px solid blue', padding: 20 }}
+      >
+        <button id="inside-button" style={{ width: 'fit-content' }}>
+          a button inside
+        </button>
+
+        <Frame style={{ height: 140, width: 400 }}>
+          <div id="inside-area-frame" style={{ border: '3px solid violet', padding: 20 }}>
+            <button id="inside-frame-button">a button inside (iframe)</button>
+          </div>
+        </Frame>
+      </div>
+
+      <Frame style={{ height: 140, width: 400 }}>
+        <div id="outside-area-frame" style={{ border: '3px solid violet', padding: 20 }}>
+          <button id="inside-frame-button">a button outside (iframe)</button>
+        </div>
+      </Frame>
+    </div>
+  );
+};
+
 describe('useOnClickOutside', () => {
   it('should work within Light DOM', () => {
     const onOutsideClick = cy.spy();
 
-    mount(<Example useShadowDOM={false} onOutsideClick={onOutsideClick} />);
+    mount(<OutsideClickExample useShadowDOM={false} onOutsideClick={onOutsideClick} />);
 
     cy.get('#inside-button')
       .click()
@@ -66,7 +104,7 @@ describe('useOnClickOutside', () => {
   it('should work within Shadow DOM', () => {
     const onOutsideClick = cy.spy();
 
-    mount(<Example useShadowDOM onOutsideClick={onOutsideClick} />);
+    mount(<OutsideClickExample useShadowDOM onOutsideClick={onOutsideClick} />);
 
     cy.get('#shadow-host')
       .shadow()
@@ -94,7 +132,7 @@ describe('useOnClickOutside', () => {
   it('should not call callback with inside text selection finishing outside', () => {
     const onOutsideClick = cy.spy();
 
-    mount(<Example useShadowDOM={false} onOutsideClick={onOutsideClick} />);
+    mount(<OutsideClickExample useShadowDOM={false} onOutsideClick={onOutsideClick} />);
 
     cy.get('#inside-button')
       .trigger('mousedown', { which: 1 })
@@ -106,5 +144,54 @@ describe('useOnClickOutside', () => {
       .then(() => {
         expect(onOutsideClick).to.not.be.called;
       });
+  });
+
+  describe('iframes', () => {
+    beforeEach(() => {
+      cy.clock(new Date(), ['setInterval']);
+    });
+
+    it('is invoked on a frame focus (disabledFocusOnIframe={false})', () => {
+      const onOutsideClick = cy.spy();
+
+      mount(<IFrameExample disabledFocusOnIframe={false} onOutsideClick={onOutsideClick} />);
+
+      cy.get('#inside-button')
+        .click()
+        .then(() => {
+          expect(onOutsideClick).to.not.be.called;
+        });
+
+      cy.realPress('Tab')
+        .tick(2000)
+        .then(() => {
+          expect(onOutsideClick).to.not.be.called;
+        });
+
+      cy.realPress('Tab')
+        .tick(2000)
+        .then(() => {
+          expect(onOutsideClick).to.be.called;
+        });
+    });
+
+    it('is not invoked on a frame focus (disabledFocusOnIframe={true})', () => {
+      const onOutsideClick = cy.spy();
+
+      mount(<IFrameExample disabledFocusOnIframe onOutsideClick={onOutsideClick} />);
+
+      cy.get('#inside-button')
+        .click()
+        .then(() => {
+          expect(onOutsideClick).to.not.be.called;
+        });
+
+      cy.realPress('Tab')
+        .realPress('Tab')
+        .tick(2000)
+        .then(() => {
+          expect(onOutsideClick).to.not.be.called;
+        });
+    });
   });
 });

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.test.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.test.ts
@@ -61,6 +61,22 @@ describe('useOnClickOutside', () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  it('should not invoke callback when active element is an iframe and focus events for iframes are disabled', () => {
+    // Arrange
+    jest.useFakeTimers();
+    const iframe = document.createElement('iframe');
+    const callback = jest.fn();
+    document.body.appendChild(iframe);
+    renderHook(() => useOnClickOutside({ element: document, disabledFocusOnIframe: true, callback, refs: [] }));
+
+    // Act
+    iframe.focus();
+    jest.runOnlyPendingTimers();
+
+    // Assert
+    expect(callback).not.toBeCalled();
+  });
+
   it('should invoke callback when active element is a webview', () => {
     // Arrange
     jest.useFakeTimers();

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
@@ -28,25 +28,29 @@ export type UseOnClickOrScrollOutsideOptions = {
   disabled?: boolean;
 
   /**
+   * Disables custom focus event listeners for iframes
+   */
+  disabledFocusOnIframe?: boolean;
+
+  /**
    * Called if the click is outside the element refs
    */
   callback: (ev: MouseEvent | TouchEvent) => void;
 };
+
+const DEFAULT_CONTAINS: UseOnClickOrScrollOutsideOptions['contains'] = (parent, child) => !!parent?.contains(child);
 
 /**
  * @internal
  * Utility to perform checks where a click/touch event was made outside a component
  */
 export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => {
-  const { refs, callback, element, disabled, contains: containsProp } = options;
+  const { refs, callback, element, disabled, disabledFocusOnIframe, contains = DEFAULT_CONTAINS } = options;
   const timeoutId = React.useRef<number | undefined>(undefined);
-  useIFrameFocus(options);
+
+  useIFrameFocus({ element, disabled: disabledFocusOnIframe || disabled, callback, refs, contains });
 
   const isMouseDownInsideRef = React.useRef(false);
-
-  const contains: UseOnClickOrScrollOutsideOptions['contains'] =
-    containsProp || ((parent, child) => !!parent?.contains(child));
-
   const listener = useEventCallback((ev: MouseEvent | TouchEvent) => {
     if (isMouseDownInsideRef.current) {
       isMouseDownInsideRef.current = false;
@@ -127,7 +131,8 @@ const getWindowEvent = (target: Node | Window): Event | undefined => {
 
 const FUI_FRAME_EVENT = 'fuiframefocus';
 
-interface UseIFrameFocusOptions extends UseOnClickOrScrollOutsideOptions {
+interface UseIFrameFocusOptions
+  extends Pick<UseOnClickOrScrollOutsideOptions, 'disabled' | 'element' | 'callback' | 'contains' | 'refs'> {
   /**
    * Millisecond duration to poll
    */
@@ -149,16 +154,15 @@ const useIFrameFocus = (options: UseIFrameFocusOptions) => {
     disabled,
     element: targetDocument,
     callback,
-    contains: containsProp = (parent, child) => !!parent?.contains(child),
+    contains = DEFAULT_CONTAINS,
     pollDuration = 1000,
     refs,
   } = options;
   const timeoutRef = React.useRef<number>();
 
   const listener = useEventCallback((e: Event) => {
-    const contains = containsProp || ((parent, child) => !!parent?.contains(child));
-
     const isOutside = refs.every(ref => !contains(ref.current || null, e.target as HTMLElement));
+
     if (isOutside && !disabled) {
       callback(e as MouseEvent);
     }


### PR DESCRIPTION
## New Behavior

- This PR adds `closeOnIframeFocus` (defaults to `true`) to `Popover` that allows to keep popovers opened if an iframe outside a popover is focused.
- This PR adds `disabledFocusOnIframe` to options of `useOnClickOutside()` hook and covers this functionality with Cypress tests.

## Related Issue(s)

Fixes #28556
