### PR TITLE
fix(react-tags-preview): use `:active` for pressed style instead of `:hover:active`

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Tag/InteractionTagAppearances.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tag/InteractionTagAppearances.stories.tsx
@@ -15,10 +15,12 @@ const steps = new Steps()
   .snapshot('hover content', { cropTo: '.testWrapper' })
   .mouseDown(`#${contentId}`)
   .snapshot('pressed content', { cropTo: '.testWrapper' })
+  .mouseUp(`#${contentId}`)
   .hover(`#${dismissButtonId}`)
   .snapshot('hover dismiss', { cropTo: '.testWrapper' })
   .mouseDown(`#${dismissButtonId}`)
   .snapshot('pressed dismiss', { cropTo: '.testWrapper' })
+  .mouseUp(`#${dismissButtonId}`)
   .end();
 
 export default {

--- a/change/@fluentui-react-tags-preview-ec023340-9146-4eb3-b535-b0d3230ecbac.json
+++ b/change/@fluentui-react-tags-preview-ec023340-9146-4eb3-b535-b0d3230ecbac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use `:active` selector for pressed style instead of `:hover:active`",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -55,7 +55,7 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackground3Hover,
       color: tokens.colorNeutralForeground2Hover,
     },
-    ':hover:active': {
+    ':active': {
       backgroundColor: tokens.colorNeutralBackground3Pressed,
       color: tokens.colorNeutralForeground2Pressed,
     },
@@ -77,7 +77,7 @@ const useRootStyles = makeStyles({
         display: 'none',
       },
     },
-    ':hover:active': {
+    ':active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       color: tokens.colorNeutralForeground2Pressed,
 
@@ -98,7 +98,7 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorBrandBackground2Hover,
       color: tokens.colorCompoundBrandForeground1Hover,
     },
-    ':hover:active': {
+    ':active': {
       backgroundColor: tokens.colorBrandBackground2Pressed,
       color: tokens.colorCompoundBrandForeground1Pressed,
     },

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
@@ -45,7 +45,7 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackground3Hover,
       color: tokens.colorNeutralForeground2BrandHover,
     },
-    ':hover:active': {
+    ':active': {
       backgroundColor: tokens.colorNeutralBackground3Pressed,
       color: tokens.colorNeutralForeground2BrandPressed,
     },
@@ -59,7 +59,7 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundHover,
       color: tokens.colorNeutralForeground2BrandHover,
     },
-    ':hover:active': {
+    ':active': {
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       color: tokens.colorNeutralForeground2BrandPressed,
     },
@@ -73,7 +73,7 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorBrandBackground2Hover,
       color: tokens.colorCompoundBrandForeground1Hover,
     },
-    ':hover:active': {
+    ':active': {
       backgroundColor: tokens.colorBrandBackground2Pressed,
       color: tokens.colorCompoundBrandForeground1Pressed,
     },

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTagStyles.styles.ts
@@ -204,7 +204,7 @@ const useDismissIconStyles = makeStyles({
       cursor: 'pointer',
       color: tokens.colorCompoundBrandForeground1Hover,
     },
-    ':hover:active': {
+    ':active': {
       color: tokens.colorCompoundBrandForeground1Pressed,
     },
   },
@@ -213,7 +213,7 @@ const useDismissIconStyles = makeStyles({
       cursor: 'pointer',
       color: tokens.colorCompoundBrandForeground1Hover,
     },
-    ':hover:active': {
+    ':active': {
       color: tokens.colorCompoundBrandForeground1Pressed,
     },
   },
@@ -222,7 +222,7 @@ const useDismissIconStyles = makeStyles({
       cursor: 'pointer',
       color: tokens.colorCompoundBrandForeground1Hover,
     },
-    ':hover:active': {
+    ':active': {
       color: tokens.colorCompoundBrandForeground1Pressed,
     },
   },


### PR DESCRIPTION
Tag should show pressed style on keyboard enter/space as well.