### PR TITLE
fix(public-docsite): Remove image clipping and move top banner under top nav to avoid header issues

### DIFF
--- a/apps/public-docsite/src/components/Site/Site.tsx
+++ b/apps/public-docsite/src/components/Site/Site.tsx
@@ -160,8 +160,8 @@ export class Site<TPlatforms extends string = string> extends React.Component<
 
     const SiteContent = () => (
       <div key="site" className={styles.siteRoot}>
-        {this._renderTopBanner()}
         {this._renderTopNav()}
+        {this._renderTopBanner()}
         {this._renderMessageBar()}
         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
           {this._renderPageNav()}

--- a/change/@fluentui-react-docsite-components-39f2229f-7780-419d-8bbf-76bdf9bbec81.json
+++ b/change/@fluentui-react-docsite-components-39f2229f-7780-419d-8bbf-76bdf9bbec81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove top clip for image to work correctly and move top banner under top nav.",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/TopBanner/TopBanner.module.scss
+++ b/packages/react-docsite-components/src/components/TopBanner/TopBanner.module.scss
@@ -12,7 +12,6 @@
   position: absolute;
   height: 92px;
   right: 0;
-  top: 0;
 
   @media (max-width: 500px) {
     display: none;


### PR DESCRIPTION
Since header will always be on top, move top banner under top nav and remove the top clipping to the top to avoid image movement.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://github.com/microsoft/fluentui/assets/5953191/c74a247c-7caf-41b0-89f2-9bfb7744d235)

## New Behavior

![image](https://github.com/microsoft/fluentui/assets/5953191/74d301a3-3b9b-479d-bcf7-c12ea0c8b5a8)


