### PR TITLE
chore(react-tree): removes preview warning from the docs

### DIFF
--- a/packages/react-components/react-tree/stories/Tree/TreeDescription.md
+++ b/packages/react-components/react-tree/stories/Tree/TreeDescription.md
@@ -1,16 +1,3 @@
 A hierarchical list structure component for displaying data in a collapsible and expandable way.
 
 Use this component when you need to present your users with a clear visual structure of content or data, allowing them to efficiently interact and navigate through the information. If the information is less hierarchical or node-based, consider using a list or table instead.
-
-<!-- Don't allow prettier to collapse code block into single line -->
-<!-- prettier-ignore -->
-> **⚠️ Preview components are considered unstable:**
->
-> ```jsx
->
-> import { Tree } from '@fluentui/react-tree';
->
-> ```
->
-> - Features and APIs may change before final release
-> - Please contact us if you intend to use this in your product


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. Removes preview waning from the docs 

<img width="1007" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/fb9edaf1-f469-43f8-8126-6773accfd11a">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
