### PR TITLE
Lint: fix fluent v9 warnings

### DIFF
--- a/change/@fluentui-react-positioning-d46e41bd-237b-4c6e-bb3f-b3d88a836fdd.json
+++ b/change/@fluentui-react-positioning-d46e41bd-237b-4c6e-bb3f-b3d88a836fdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix lint warnings",
+  "packageName": "@fluentui/react-positioning",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-7b95053b-1bc4-4f17-b3ea-c2fa43697fae.json
+++ b/change/@fluentui-react-provider-7b95053b-1bc4-4f17-b3ea-c2fa43697fae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix lint warnings",
+  "packageName": "@fluentui/react-provider",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-33deefd7-570d-49cc-b511-97ddc809c813.json
+++ b/change/@fluentui-react-tree-33deefd7-570d-49cc-b511-97ddc809c813.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix lint warnings",
+  "packageName": "@fluentui/react-tree",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/stories/Accordion/AccordionMultiple.stories.tsx
+++ b/packages/react-components/react-accordion/stories/Accordion/AccordionMultiple.stories.tsx
@@ -28,7 +28,6 @@ Multiple.parameters = {
   docs: {
     description: {
       story:
-        // eslint-disable-next-line @fluentui/max-len
         "An accordion supports multiple panels expanded simultaneously. Since it's not simple to determine which panel will be opened by default, `multiple` will also be collapsed by default on the first render",
     },
   },

--- a/packages/react-components/react-components/stories/AccessibilityScenarios/Input.stories.tsx
+++ b/packages/react-components/react-components/stories/AccessibilityScenarios/Input.stories.tsx
@@ -9,7 +9,6 @@ import { usePubSub, PubSubProvider, Handler } from '@cactuslab/usepubsub';
 
 const regexes = {
   onlyNameChars: /^[A-Za-zÀ-ÖØ-öø-ÿěščřžďťňůĚŠČŘŽĎŤŇŮ -]*$/,
-  // eslint-disable-next-line @fluentui/max-len
   startsAndEndsWithLetter:
     /^(([A-Za-zÀ-ÖØ-öø-ÿěščřžďťňůĚŠČŘŽĎŤŇŮ][A-Za-zÀ-ÖØ-öø-ÿěščřžďťňůĚŠČŘŽĎŤŇŮ -]*[A-Za-zÀ-ÖØ-öø-ÿěščřžďťňůĚŠČŘŽĎŤŇŮ])|[A-Za-zÀ-ÖØ-öø-ÿěščřžďťňůĚŠČŘŽĎŤŇŮ])?$/,
   noWhitespace: /^\S*$/,
@@ -18,7 +17,6 @@ const regexes = {
   hasUppercaseLetter: /^\S*[A-Z]\S*$/,
   hasSpecialChar: /^\S*[^0-9a-zA-ZÀ-ÖØ-öø-ÿěščřžďťňůĚŠČŘŽĎŤŇŮ\s]\S*$/,
   validDate: /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4}$/,
-  // eslint-disable-next-line @fluentui/max-len
   validEmail:
     /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i,
 };

--- a/packages/react-components/react-components/stories/Concepts/Positioning/PositioningOffsetValue.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/PositioningOffsetValue.stories.tsx
@@ -23,7 +23,7 @@ export const OffsetValue = () => {
 
         <PopoverSurface style={{ minWidth: 100 }}>Container</PopoverSurface>
       </Popover>
-      <Popover positioning={{ position: 'after', offset: () => ({ crossAxis: crossAxis, mainAxis: mainAxis }) }}>
+      <Popover positioning={{ position: 'after', offset: () => ({ crossAxis, mainAxis }) }}>
         <PopoverTrigger disableButtonEnhancement>
           <Button appearance="primary">Click me</Button>
         </PopoverTrigger>

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -122,7 +122,6 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
       }
       // We run this check once, no need to add deps here
       // TODO: Should be rework to handle options.enabled and contentRef updates
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
   }
 

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderContextValues.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import type { FluentProviderContextValues, FluentProviderState } from './FluentProvider.types';
 
 export function useFluentProviderContextValues_unstable(state: FluentProviderState): FluentProviderContextValues {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const {
     applyStylesToPortals,
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -75,7 +75,6 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
       openItems,
       checkedItems,
       onOpenChange: handleOpenChange,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       onNavigation: handleNavigation,
       onCheckedChange: handleCheckedChange,
     },


### PR DESCRIPTION
## Previous Behavior

There were lint warnings for Fluent v9 controls.

## New Behavior

No lint warnings for Fluent v9 controls.

## Related Issue(s)

Noticed as part of #28145