### PR TITLE
fix(react-infobutton): Cursor should be pointer when hovering the button to show it's a button

### DIFF
--- a/change/@fluentui-react-infobutton-142725f6-a65b-4ed0-b46f-2b77476a220b.json
+++ b/change/@fluentui-react-infobutton-142725f6-a65b-4ed0-b46f-2b77476a220b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Cursor should be pointer when hovering the button to show it's a button.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -43,6 +43,7 @@ const useButtonStyles = makeStyles({
     ':hover': {
       backgroundColor: tokens.colorTransparentBackgroundHover,
       color: tokens.colorNeutralForeground2BrandHover,
+      cursor: 'pointer',
 
       [`& .${iconFilledClassName}`]: {
         display: 'inline-flex',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The cursor when hovering over the button was default (as per native behavior).


https://github.com/microsoft/fluentui/assets/5953191/d4a20111-6427-4aca-8085-f3c6629d35d1


## New Behavior

To show that the icon is in fact a button that can be pressed, the cursor should be pointer. This should help differentiate the behavior between the tooltip variant and the popover variant.


https://github.com/microsoft/fluentui/assets/5953191/c2df8f3d-d951-49b9-986b-faaba3660c70

