### PR TITLE
docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN

### DIFF
--- a/apps/perf-test-react-components/src/scenarios/Persona.tsx
+++ b/apps/perf-test-react-components/src/scenarios/Persona.tsx
@@ -10,7 +10,7 @@ const Scenario = () => (
     presence={{ status: 'available' }}
     avatar={{
       image: {
-        src: 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-male.png',
+        src: 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-male.png',
       },
     }}
   />

--- a/apps/pr-deploy-site/chiclet-test.html
+++ b/apps/pr-deploy-site/chiclet-test.html
@@ -16,7 +16,7 @@
     />
     <meta
       property="og:image"
-      content="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/48/docx.svg"
+      content="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/48/docx.svg"
     />
 
     <title>Chiclet Test Page</title>

--- a/apps/pr-deploy-site/index.html
+++ b/apps/pr-deploy-site/index.html
@@ -5,7 +5,7 @@
     <title>PR Deployed Sites</title>
     <link
       rel="stylesheet"
-      href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-core/11.1.0/css/fabric.min.css"
+      href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.1.0/css/fabric.min.css"
     />
     <link rel="stylesheet" href="./pr-deploy-site.css" />
   </head>

--- a/apps/public-docsite/src/pages/Controls/AvatarPage/docs/android/AvatarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/AvatarPage/docs/android/AvatarOverview.md
@@ -3,17 +3,17 @@
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Initials
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_avatar_02_initials_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_avatar_02_initials_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_avatar_02_initials_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_avatar_02_initials_dark.png?text=DarkMode" />
 
 ### Profile
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_avatar_01_profilepicture_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_avatar_01_profilepicture_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_avatar_01_profilepicture_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_avatar_01_profilepicture_dark.png?text=DarkMode" />
 
 ### Group
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_avatar_03_square_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_avatar_03_square_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_avatar_03_square_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_avatar_03_square_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/AvatarPage/docs/ios/AvatarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/AvatarPage/docs/ios/AvatarOverview.md
@@ -3,17 +3,17 @@
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Initials
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_avatar_02_initials.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_avatar_02_initials_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_avatar_02_initials.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_avatar_02_initials_dark.png?text=DarkMode" />
 
 ### Profile
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_avatar_01_profilepicture_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_avatar_01_profilepicture_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_avatar_01_profilepicture_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_avatar_01_profilepicture_dark.png?text=DarkMode" />
 
 ### Group
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_avatar_03_groups_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_avatar_03_groups_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_avatar_03_groups_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_avatar_03_groups_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/AvatarPage/docs/mac/AvatarUsage.md
+++ b/apps/public-docsite/src/pages/Controls/AvatarPage/docs/mac/AvatarUsage.md
@@ -8,8 +8,8 @@ To determine initials for an avatar, the code initially tries to extract two-let
 AvatarView(avatarSize: size, contactName: "Amanda Brady", contactEmail: "Amanda.Brady@example.com", contactImage: nil)
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Persona/avatar_initials_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Persona/avatar_initials_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Persona/avatar_initials_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Persona/avatar_initials_dark.png?text=DarkMode" />
 
 ### Profile
 
@@ -18,7 +18,7 @@ AvatarView(avatarSize: size, contactName: "Amanda Brady", contactEmail: "Amanda.
 AvatarView(avatarSize: size, contactName: "Amanda Brady", contactEmail: "Amanda.Brady@example.com", contactImage: NSImage(named: "Amanda"))
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Persona/avatar_profilepicture_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Persona/avatar_profilepicture_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Persona/avatar_profilepicture_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Persona/avatar_profilepicture_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/android/BottomNavigationOverview.md
+++ b/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/android/BottomNavigationOverview.md
@@ -3,6 +3,6 @@ The bottom navigation displays icons and optional text at the bottom of the scre
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Bottom Navigation
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_bottomnavigation_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_bottomnavigation_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_bottomnavigation_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_bottomnavigation_01_dark.png?text=DarkMode" />
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationOverview.md
+++ b/apps/public-docsite/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationOverview.md
@@ -5,13 +5,13 @@ The tab bar displays tabs at the bottom of the window for switching between diff
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Portrait
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tabbar_01_portrait_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tabbar_01_portrait_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tabbar_01_portrait_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tabbar_01_portrait_dark.png?text=DarkMode" />
 
 ### Landscape
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tabbar_02_landscape_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tabbar_02_landscape_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tabbar_02_landscape_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tabbar_02_landscape_dark.png?text=DarkMode" />
 
 </DisplayToggle>
 <!-- prettier-ignore-end -->

--- a/apps/public-docsite/src/pages/Controls/BottomSheetPage/docs/android/BottomSheetOverview.md
+++ b/apps/public-docsite/src/pages/Controls/BottomSheetPage/docs/android/BottomSheetOverview.md
@@ -3,6 +3,6 @@
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### BottomSheet
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_bottomsheet_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_bottomsheet_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_bottomsheet_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_bottomsheet_01_dark.png?text=DarkMode" />
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/android/ButtonOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/android/ButtonOverview.md
@@ -3,12 +3,12 @@ Buttons are one of the core controls that make an app feel native to the platfor
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Primary Filled
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_button_01_primaryfilled_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_button_01_primaryfilled_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_button_01_primaryfilled_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_button_01_primaryfilled_dark.png?text=DarkMode" />
 
 ### Borderless Button
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_button_02_borderless_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_button_02_borderless_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_button_02_borderless_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_button_02_borderless_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/cross/ButtonUsage.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/cross/ButtonUsage.md
@@ -4,19 +4,19 @@ Fluent UI React Native Buttons have default styling based on the Fluent UI Desig
 
 #### Default Button (Windows)
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/cross/Button/Default_button_windows.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/cross/Button/Default_button_windows.PNG"/>
 
 #### Primary Button (Windows)
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/cross/Button/Primary_button_windows.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/cross/Button/Primary_button_windows.PNG"/>
 
 #### Default Button (macOS)
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/cross/Button/Default_button_macos.png"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/cross/Button/Default_button_macos.png"/>
 
 #### Primary Button (macOS)
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/cross/Button/Primary_button_macos.png"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/cross/Button/Primary_button_macos.png"/>
 
 #### Example usage (from [ButtonFocusTest.tsx](https://github.com/microsoft/fluentui-react-native/blob/master/apps/fluent-tester/src/FluentTester/TestComponents/Button/ButtonFocusTest.tsx))
 

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/ios/ButtonOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/ios/ButtonOverview.md
@@ -3,22 +3,22 @@ Buttons are one of the core controls that make an app feel native to the platfor
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Primary Filled
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_01_primaryfilled_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_01_primaryfilled_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_01_primaryfilled_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_01_primaryfilled_dark.png?text=DarkMode" />
 
 ### Primary Outlined
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_02_primaryoutlined_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_02_primaryoutlined_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_02_primaryoutlined_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_02_primaryoutlined_dark.png?text=DarkMode" />
 
 ### Secondary Outlined
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_03_secondaryoutlined_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_03_secondaryoutlined_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_03_secondaryoutlined_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_03_secondaryoutlined_dark.png?text=DarkMode" />
 
 ### Tertiary Outlined
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_04_tertiaryoutlined_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_button_04_tertiaryoutlined_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_04_tertiaryoutlined_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_button_04_tertiaryoutlined_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ButtonPage/docs/mac/ButtonOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ButtonPage/docs/mac/ButtonOverview.md
@@ -3,17 +3,17 @@ Buttons give people a way to trigger an action. They're typically found in windo
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Primary filled
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Button/button_primaryfilled_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Button/button_primaryfilled_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Button/button_primaryfilled_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Button/button_primaryfilled_dark.png?text=DarkMode" />
 
 ### Primary outlined
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Button/button_primaryoutlined_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Button/button_primaryoutlined_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Button/button_primaryoutlined_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Button/button_primaryoutlined_dark.png?text=DarkMode" />
 
 ### Borderless
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Button/button_primaryborderless_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/macos/Button/button_primaryborderless_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Button/button_primaryborderless_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/macos/Button/button_primaryborderless_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/CalendarPage/docs/android/CalendarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/CalendarPage/docs/android/CalendarOverview.md
@@ -3,7 +3,7 @@ The `CalendarView` is used to display calendar dates and to allow a user to sele
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Calendar
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_calendar_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_calendar_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_calendar_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_calendar_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ChipPage/docs/android/ChipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ChipPage/docs/android/ChipOverview.md
@@ -3,7 +3,7 @@ Chips are compact representations of entities (most commonly, people) that can b
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Persona Chips
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_chip_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_chip_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_chip_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_chip_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ChipPage/docs/ios/ChipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ChipPage/docs/ios/ChipOverview.md
@@ -5,17 +5,17 @@ The chip field control handles keyboard input, wrapping and truncation automatic
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Small Chip
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_badges_03_small_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_badges_03_small_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_badges_03_small_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_badges_03_small_dark.png?text=DarkMode" />
 
 ### Medium Chip
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_badges_01_medium_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_badges_01_medium_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_badges_01_medium_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_badges_01_medium_dark.png?text=DarkMode" />
 
 ### Badge Field
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_badges_02_example_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_badges_02_example_light-1.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_badges_02_example_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_badges_02_example_light-1.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/android/DateTimePickerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/android/DateTimePickerOverview.md
@@ -7,17 +7,17 @@ These pickers let users quickly choose a date or time through a familiar popup a
 
 ### Date Picker
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_dateandtime_01_datepicker_light.png?text=LightMode"/>
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_dateandtime_01_datepicker_dark.png?text=DarkMode"/>
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_dateandtime_01_datepicker_light.png?text=LightMode"/>
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_dateandtime_01_datepicker_dark.png?text=DarkMode"/>
 
 ### Time Picker
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_dateandtime_03_timepicker_light.png?text=LightMode"/>
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_dateandtime_03_timepicker_dark.png?text=DarkMode"/>
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_dateandtime_03_timepicker_light.png?text=LightMode"/>
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_dateandtime_03_timepicker_dark.png?text=DarkMode"/>
 
 ### Range Picker for Dates
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_dateandtime_02_rangepicker_light.png?text=LightMode"/>
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_dateandtime_02_rangepicker_dark.png?text=DarkMode"/>
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_dateandtime_02_rangepicker_light.png?text=LightMode"/>
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_dateandtime_02_rangepicker_dark.png?text=DarkMode"/>
 <!-- prettier-ignore-end -->
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/ios/DateTimePickerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/ios/DateTimePickerOverview.md
@@ -3,8 +3,8 @@ These pickers let users quickly choose a date or time through a familiar popup a
 <!-- prettier-ignore-start -->
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_date_timepicker_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_date_timepicker_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_date_timepicker_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_date_timepicker_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>
 <!-- prettier-ignore-end -->

--- a/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/mac/DatePickerUsage.md
+++ b/apps/public-docsite/src/pages/Controls/DatePickerPage/docs/mac/DatePickerUsage.md
@@ -8,8 +8,8 @@ The DatePicker uses the provided [`Calendar`](https://developer.apple.com/docume
 DatePickerController(date: nil, calendar: nil, style: .date)
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_dark.png?text=DarkMode" />
 
 ### DatePicker with time text field
 
@@ -18,8 +18,8 @@ DatePickerController(date: nil, calendar: nil, style: .date)
 DatePickerController(date: nil, calendar: nil, style: .dateTime)
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_time_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_time_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_time_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_currentdate_time_dark.png?text=DarkMode" />
 
 ### Custom initial date
 
@@ -29,8 +29,8 @@ let date = Calendar.current.date(from: DateComponents(year: 2019, month: 1, day:
 DatePickerController(date: date, calendar: nil, style: .date)
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_specificdate_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_specificdate_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_specificdate_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_specificdate_dark.png?text=DarkMode" />
 
 ### Custom calendar
 
@@ -41,8 +41,8 @@ calendar.locale = Locale(identifier: "ar")
 DatePickerController(date: nil, calendar: calendar, style: .date)
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_ar_currentdate_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_ar_currentdate_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_ar_currentdate_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_ar_currentdate_dark.png?text=DarkMode" />
 
 ### Secondary calendar
 
@@ -54,8 +54,8 @@ let controller = DatePickerController(date: nil, calendar: nil, style: .date)
 controller.secondaryCalendar = calendar
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_secondary_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_secondary_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_secondary_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_secondary_dark.png?text=DarkMode" />
 
 ### No text field
 
@@ -65,7 +65,7 @@ let controller = DatePickerController(date: nil, calendar: nil, style: .date)
 controller.hasTextField = false
 ```
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_notextpicker_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_notextpicker_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_notextpicker_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200504.001/fabric-website/images/controls/macos/DateTimePicker/datepicker_notextpicker_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/DrawerPage/docs/android/DrawerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/DrawerPage/docs/android/DrawerOverview.md
@@ -2,7 +2,7 @@
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_drawer_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_drawer_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_drawer_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_drawer_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/DrawerPage/docs/ios/DrawerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/DrawerPage/docs/ios/DrawerOverview.md
@@ -3,12 +3,12 @@ Drawers let you reveal lightweight views inside your application without being a
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Vertical
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_03_floatingsheet_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_03_floatingsheet_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_03_floatingsheet_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_03_floatingsheet_dark.png?text=DarkMode" />
 
 ### Horizontal
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_04_leftrightsheet_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_04_leftrightsheet_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_04_leftrightsheet_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_04_leftrightsheet_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/LinkPage/docs/cross/LinkUsage.md
+++ b/apps/public-docsite/src/pages/Controls/LinkPage/docs/cross/LinkUsage.md
@@ -2,7 +2,7 @@ Fluent UI React Native Link has default styling based on the Fluent Design Langu
 
 ### Link example
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200511.001/fabric-website/images/controls/cross/Link/Link_windows.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200511.001/fabric-website/images/controls/cross/Link/Link_windows.PNG"/>
 
 #### Example usage (from [LinkTest.tsx](https://github.com/microsoft/fluentui-react-native/blob/master/apps/fluent-tester/src/FluentTester/TestComponents/Link/LinkTest.tsx))
 

--- a/apps/public-docsite/src/pages/Controls/LinkPage/docs/mac/LinkUsage.md
+++ b/apps/public-docsite/src/pages/Controls/LinkPage/docs/mac/LinkUsage.md
@@ -2,8 +2,8 @@ The Link control is implemented as a stylized NSButton, and thus inherits all of
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200701.001/fabric-website/images/controls/macos/Link/link_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200701.001/fabric-website/images/controls/macos/Link/link_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200701.001/fabric-website/images/controls/macos/Link/link_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200701.001/fabric-website/images/controls/macos/Link/link_dark.png?text=DarkMode" />
 
 ### Default configuration
 

--- a/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/android/ListCellsOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/android/ListCellsOverview.md
@@ -3,17 +3,17 @@ When displaying fundamental content types like files or people, it's important t
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### One line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_list_01_oneline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_list_01_oneline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_list_01_oneline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_list_01_oneline_dark.png?text=DarkMode" />
 
 ### Two line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_list_02_twoline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_list_02_twoline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_list_02_twoline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_list_02_twoline_dark.png?text=DarkMode" />
 
 ### Three line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_list_03_threeline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_list_03_threeline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_list_03_threeline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_list_03_threeline_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/ios/ListCellsOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ListCellsPage/docs/ios/ListCellsOverview.md
@@ -3,32 +3,32 @@ When displaying fundamental content types like files or people, it's important t
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### One line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_02_oneline_sharedleft_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_02_oneline_sharedleft_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_02_oneline_sharedleft_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_02_oneline_sharedleft_dark.png?text=DarkMode" />
 
 ### Two line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_06_twoline_sharedleft_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_06_twoline_sharedleft.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_06_twoline_sharedleft_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_06_twoline_sharedleft.png?text=DarkMode" />
 
 ### Three line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_08_threeline_sharedleft_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_08_threeline_sharedleft_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_08_threeline_sharedleft_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_08_threeline_sharedleft_dark.png?text=DarkMode" />
 
 ### Center line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_04_oneline_sharedcentered_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_04_oneline_sharedcentered_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_04_oneline_sharedcentered_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_04_oneline_sharedcentered_dark.png?text=DarkMode" />
 
 ### Selection
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_09_selection_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_09_selection_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_09_selection_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_09_selection_dark.png?text=DarkMode" />
 
 ### Description
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_10_description_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_list_10_description_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_10_description_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_list_10_description_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/MessageBarPage/docs/ios/MessageBarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/MessageBarPage/docs/ios/MessageBarOverview.md
@@ -3,12 +3,12 @@
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Toast
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_notifications_03_toast_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_notifications_03_toast_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_notifications_03_toast_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_notifications_03_toast_dark.png?text=DarkMode" />
 
 ### Bar
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_notifications_01_standard_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_notifications_01_standard_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_notifications_01_standard_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_notifications_01_standard_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/NavBarPage/docs/android/NavBarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/NavBarPage/docs/android/NavBarOverview.md
@@ -3,11 +3,11 @@
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Top App bar
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_topappbar_01_standard_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_topappbar_01_standard_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_topappbar_01_standard_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_topappbar_01_standard_dark.png?text=DarkMode" />
 
 ### Top App bar with Search
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_topappbar_02_search_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_topappbar_02_search_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_topappbar_02_search_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_topappbar_02_search_dark.png?text=DarkMode" />
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/NavBarPage/docs/ios/NavBarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/NavBarPage/docs/ios/NavBarOverview.md
@@ -4,13 +4,13 @@ This navigation controller provides supports the Large Title presentation and an
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Portrait
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_navigation_01_iphoneportrait_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_navigation_01_iphoneportrait_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_navigation_01_iphoneportrait_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_navigation_01_iphoneportrait_dark.png?text=DarkMode" />
 
 ### Landscape
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_navigation_01_iphonelandscape_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_navigation_01_iphonelandscape_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_navigation_01_iphonelandscape_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_navigation_01_iphonelandscape_dark.png?text=DarkMode" />
 
 </DisplayToggle>
 <!-- prettier-ignore-end -->

--- a/apps/public-docsite/src/pages/Controls/PeoplePickerPage/docs/android/PeoplePickerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PeoplePickerPage/docs/android/PeoplePickerOverview.md
@@ -5,7 +5,7 @@ The `PeoplePicker` control handles keyboard input, field expanding and collapsin
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### People Picker
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_peoplepicker_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_peoplepicker_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_peoplepicker_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_peoplepicker_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/PersonaPage/docs/android/PersonaOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PersonaPage/docs/android/PersonaOverview.md
@@ -8,7 +8,7 @@ Persona controls are also available as a performant list view. The `PersonaListV
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_personaview_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_personaview_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_personaview_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_personaview_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/PersonaPage/docs/cross/PersonaUsage.md
+++ b/apps/public-docsite/src/pages/Controls/PersonaPage/docs/cross/PersonaUsage.md
@@ -1,6 +1,6 @@
 ### Persona in various sizes
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200511.001/fabric-website/images/controls/cross/Persona/Persona_ramp.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200511.001/fabric-website/images/controls/cross/Persona/Persona_ramp.PNG"/>
 
 #### Example usage (from [PersonaCoinTest.tsx](https://github.com/microsoft/fluentui-react-native/tree/master/apps/fluent-tester/src/FluentTester/TestComponents/PersonaCoin))
 

--- a/apps/public-docsite/src/pages/Controls/PersonaPage/docs/ios/PersonaOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PersonaPage/docs/ios/PersonaOverview.md
@@ -8,7 +8,7 @@ Persona controls are also available as a performant list view. The `PersonaListV
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_personalistview_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_personalistview_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_personalistview_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_personalistview_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarOverview.md
@@ -3,8 +3,8 @@
 <!-- prettier-ignore-start -->
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pillbar_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pillbar_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pillbar_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pillbar_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>
 <!-- prettier-ignore-end -->

--- a/apps/public-docsite/src/pages/Controls/PivotPage/docs/ios/PivotOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PivotPage/docs/ios/PivotOverview.md
@@ -3,17 +3,17 @@ Pivots are used for switching between sub-views or different pre-defined filteri
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Two
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pivot_03_twosegments_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pivot_03_twosegments_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pivot_03_twosegments_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pivot_03_twosegments_dark.png?text=DarkMode" />
 
 ### Three
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pivot_02_threesegments_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pivot_02_threesegments_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pivot_02_threesegments_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pivot_02_threesegments_dark.png?text=DarkMode" />
 
 ### Four
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pivot_01_foursegments_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_pivot_01_foursegments_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pivot_01_foursegments_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_pivot_01_foursegments_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/PopupMenuPage/docs/android/PopupMenuOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PopupMenuPage/docs/android/PopupMenuOverview.md
@@ -3,16 +3,16 @@
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Popup Menu with icons
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_popupmenu_01_large_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_popupmenu_01_large_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_popupmenu_01_large_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_popupmenu_01_large_dark.png?text=DarkMode" />
 
 ### Popup Menu with Radio Buttons
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_popupmenu_02_small_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_popupmenu_02_small_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_popupmenu_02_small_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_popupmenu_02_small_dark.png?text=DarkMode" />
 
 ### Popup Menu with Check Boxes
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_popupmenu_02_checkbox_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_popupmenu_02_checkbox_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_popupmenu_02_checkbox_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_popupmenu_02_checkbox_dark.png?text=DarkMode" />
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuOverview.md
+++ b/apps/public-docsite/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuOverview.md
@@ -4,13 +4,13 @@ PopupMenus provide a set of commands or options inside of a drawer. Two types of
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Top down
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_02_topsheet_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_02_topsheet.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_02_topsheet_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_02_topsheet.png?text=DarkMode" />
 
 ### Bottom up
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_01_bottomsheet_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_drawer_01_bottomsheet_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_01_bottomsheet_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_drawer_01_bottomsheet_dark.png?text=DarkMode" />
 
 </DisplayToggle>
 <!-- prettier-ignore-end -->

--- a/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/android/SeparatorOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/android/SeparatorOverview.md
@@ -2,7 +2,7 @@ A separator visually separates content into groups.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_separator_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_separator_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_separator_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_separator_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/cross/SeparatorUsage.md
+++ b/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/cross/SeparatorUsage.md
@@ -1,6 +1,6 @@
 ### Link example
 
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200511.001/fabric-website/images/controls/cross/Separator/Separator_windows.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200511.001/fabric-website/images/controls/cross/Separator/Separator_windows.PNG"/>
 
 #### Example usage (from [SeparatorTest.tsx](https://github.com/microsoft/fluentui-react-native/blob/master/apps/fluent-tester/src/FluentTester/TestComponents/Separator/SeparatorTest.tsx))
 

--- a/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/ios/SeparatorOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/ios/SeparatorOverview.md
@@ -2,7 +2,7 @@ A separator visually separates content into groups.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_separators_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_separators_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_separators_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_separators_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/mac/SeparatorOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SeparatorPage/docs/mac/SeparatorOverview.md
@@ -2,7 +2,7 @@ A separator visually separates content into groups.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200701.001/fabric-website/images/controls/macos/Separator/separator_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200701.001/fabric-website/images/controls/macos/Separator/separator_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200701.001/fabric-website/images/controls/macos/Separator/separator_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200701.001/fabric-website/images/controls/macos/Separator/separator_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/ShimmerPage/docs/ios/ShimmerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/ShimmerPage/docs/ios/ShimmerOverview.md
@@ -2,7 +2,7 @@ Shimmer is a temporary animation placeholder for when a service call takes time 
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_shimmer_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_shimmer_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_shimmer_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_shimmer_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/SnackbarPage/docs/android/SnackbarOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SnackbarPage/docs/android/SnackbarOverview.md
@@ -3,11 +3,11 @@ Snackbars provide a brief message about an operation at the bottom of the screen
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Snackbar
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_snackbar_01_standard_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_snackbar_01_standard_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_snackbar_01_standard_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_snackbar_01_standard_dark.png?text=DarkMode" />
 
 ### Announcement Snackbar
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_snackbar_02_announcement_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_snackbar_02_announcement_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_snackbar_02_announcement_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_snackbar_02_announcement_dark.png?text=DarkMode" />
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/SpinnerPage/docs/android/SpinnerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SpinnerPage/docs/android/SpinnerOverview.md
@@ -7,6 +7,6 @@ Use a standalone spinner when you need a progress indicator on an existing surfa
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Spinner
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_spinner_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_spinner_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_spinner_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_spinner_01_dark.png?text=DarkMode" />
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/SpinnerPage/docs/ios/SpinnerOverview.md
+++ b/apps/public-docsite/src/pages/Controls/SpinnerPage/docs/ios/SpinnerOverview.md
@@ -9,12 +9,12 @@ For actions that happen "between views", you can use the progress indicator that
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### Activity Indicator
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_spinner_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_spinner_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_spinner_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_spinner_01_dark.png?text=DarkMode" />
 
 ### HUD
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_hud_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_hud_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_hud_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_hud_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/TextPage/docs/android/TextOverview.md
+++ b/apps/public-docsite/src/pages/Controls/TextPage/docs/android/TextOverview.md
@@ -2,7 +2,7 @@ Use these typography styles to standardize text across your app.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_text_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_text_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_text_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_text_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/TextPage/docs/cross/TextUsage.md
+++ b/apps/public-docsite/src/pages/Controls/TextPage/docs/cross/TextUsage.md
@@ -5,15 +5,15 @@ If you need to customize the fontFamily, fontSize, or fontWeight of your Text, y
 ### Text example
 
 On Windows, Text uses the Segoe UI font family.
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200511.001/fabric-website/images/controls/cross/Text/Text_quickbrownfox_windows.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200511.001/fabric-website/images/controls/cross/Text/Text_quickbrownfox_windows.PNG"/>
 
 On macOS, Text uses the San Francisco font family.
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200511.001/fabric-website/images/controls/cross/Text/Text_quickbrownfox_macos.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200511.001/fabric-website/images/controls/cross/Text/Text_quickbrownfox_macos.PNG"/>
 
 ### Text ramp example
 
 You can specify the `variant` prop to apply font styles to Text. Examples of `variant` values are shown below.
-<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001-cdn-prod_20200511.001/fabric-website/images/controls/cross/Text/FURN_windows_text_ramp.PNG"/>
+<img src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002-cdn-prod_20200511.001/fabric-website/images/controls/cross/Text/FURN_windows_text_ramp.PNG"/>
 
 #### Example usage (from [TextTest.tsx](https://github.com/microsoft/fluentui-react-native/tree/master/apps/fluent-tester/src/FluentTester/TestComponents/Text))
 

--- a/apps/public-docsite/src/pages/Controls/TextPage/docs/ios/TextOverview.md
+++ b/apps/public-docsite/src/pages/Controls/TextPage/docs/ios/TextOverview.md
@@ -2,7 +2,7 @@ Use `Label` to standardize text across your app.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_text_01_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_text_01_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_text_01_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_text_01_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/TooltipPage/docs/android/TooltipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/TooltipPage/docs/android/TooltipOverview.md
@@ -3,12 +3,12 @@ Use tooltips to show small unobtrusive hints on top of your app's UI. These can 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### One line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_tooltip_01_oneline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_tooltip_01_oneline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_tooltip_01_oneline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_tooltip_01_oneline_dark.png?text=DarkMode" />
 
 ### Two line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_tooltip_02_twoline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/android/updated/img_tooltip_02_twoline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_tooltip_02_twoline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/android/updated/img_tooltip_02_twoline_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Controls/TooltipPage/docs/ios/TooltipOverview.md
+++ b/apps/public-docsite/src/pages/Controls/TooltipPage/docs/ios/TooltipOverview.md
@@ -3,12 +3,12 @@ Use tooltips to show small unobtrusive hints on top of your app's UI. These can 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 ### One line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tooltip_01_oneline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tooltip_01_oneline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tooltip_01_oneline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tooltip_01_oneline_dark.png?text=DarkMode" />
 
 ### Two line
 
-<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tooltip_02_twoline_light.png?text=LightMode" />
-<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/controls/ios/updated/img_tooltip_02_twoline_dark.png?text=DarkMode" />
+<img className="off" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tooltip_02_twoline_light.png?text=LightMode" />
+<img className="on" src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/controls/ios/updated/img_tooltip_02_twoline_dark.png?text=DarkMode" />
 
 </DisplayToggle>

--- a/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopCore.md
+++ b/apps/public-docsite/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopCore.md
@@ -13,7 +13,7 @@ To add the latest version of Fabric Core to your site, link to this CSS file in 
 ```html
 <link
   rel="stylesheet"
-  href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-core/11.1.0/css/fabric.min.css"
+  href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.1.0/css/fabric.min.css"
 />
 ```
 

--- a/apps/public-docsite/src/pages/Styles/Colors/docs/web/ColorsNeutrals.md
+++ b/apps/public-docsite/src/pages/Styles/Colors/docs/web/ColorsNeutrals.md
@@ -1,5 +1,5 @@
 These are commonly used for backgrounds, strokes, and interactive states within controls.
 
-This palette can be used to customize your `theme.palette`. See how our default `theme.palette` maps to new Fluent colors with this [web color conversion table](https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/files/fabric-neutrals-web-color-conversion.pdf).​​
+This palette can be used to customize your `theme.palette`. See how our default `theme.palette` maps to new Fluent colors with this [web color conversion table](https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/files/fabric-neutrals-web-color-conversion.pdf).​​
 
 In case you have a need to create a custom neutral theme palette to use in your application, you can use the [Theme Designer](https://aka.ms/themedesigner).​

--- a/apps/public-docsite/src/pages/Styles/M365ProductIconsPage/docs/web/M365ProductIconsImplementation.md
+++ b/apps/public-docsite/src/pages/Styles/M365ProductIconsPage/docs/web/M365ProductIconsImplementation.md
@@ -6,7 +6,7 @@ The following code shows you how to specify a 96px product icon by brand using t
 // Sample code for using office-ui-fabric-core version 11.1.0 to display an Word 96x96px Icon
 <link
   rel="stylesheet"
-  href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-core/11.1.0/css/fabric.css"
+  href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.1.0/css/fabric.css"
 />
 
 <div class="ms-BrandIcon--icon96 ms-BrandIcon--word"></div>
@@ -16,7 +16,7 @@ This following code shows you how to specify a 48px product icon by brand using 
 
 ```jsx
 <img
-  src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/brand-icons/product/svg/word_48x1.svg"
+  src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/brand-icons/product/svg/word_48x1.svg"
   width="48"
   height="48"
   alt="Word product icon"

--- a/apps/public-docsite/src/pages/Styles/ThemeSlotsPage/docs/web/ThemeSlotsOverview.md
+++ b/apps/public-docsite/src/pages/Styles/ThemeSlotsPage/docs/web/ThemeSlotsOverview.md
@@ -1,4 +1,4 @@
-Fluent UI includes 9 theme colors, 14 neutral colors, and 24 accent colors. In Fluent UI React, these are all within the `theme.palette` object. In Fabric Core, each has helper classes for text, background, border, and hover states. When selecting colors, refer to the [color accessibility guidance (PDF)](https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/files/coloraccessibility_29sep2016.pdf) to ensure your text can be read by everyone. If you need to customize your theme, see the [Theme Designer](https://aka.ms/themedesigner).
+Fluent UI includes 9 theme colors, 14 neutral colors, and 24 accent colors. In Fluent UI React, these are all within the `theme.palette` object. In Fabric Core, each has helper classes for text, background, border, and hover states. When selecting colors, refer to the [color accessibility guidance (PDF)](https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/files/coloraccessibility_29sep2016.pdf) to ensure your text can be read by everyone. If you need to customize your theme, see the [Theme Designer](https://aka.ms/themedesigner).
 
 ### What is theming?
 

--- a/apps/vr-tests/src/stories/Tile.stories.tsx
+++ b/apps/vr-tests/src/stories/Tile.stories.tsx
@@ -187,7 +187,7 @@ storiesOf('Tile', module)
         itemActivity={<SignalField before={<SharedSignal />}>{'Test Activity'}</SignalField>}
         foreground={
           <img
-            src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/48/docx.svg"
+            src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/48/docx.svg"
             style={{
               display: 'block',
               width: '64px',

--- a/change/@fluentui-example-data-2699a3dd-4627-4247-9215-7a9061074f49.json
+++ b/change/@fluentui-example-data-2699a3dd-4627-4247-9215-7a9061074f49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN.",
+  "packageName": "@fluentui/example-data",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-public-docsite-setup-3cb2b9d0-e9dd-497d-b0a4-87bd95845c86.json
+++ b/change/@fluentui-public-docsite-setup-3cb2b9d0-e9dd-497d-b0a4-87bd95845c86.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN.",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-12023b56-79dc-4e46-9bd3-ef73ff165d64.json
+++ b/change/@fluentui-react-12023b56-79dc-4e46-9bd3-ef73ff165d64.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-da2dbed7-32a4-43cc-bdea-d1a722f403c1.json
+++ b/change/@fluentui-react-experiments-da2dbed7-32a4-43cc-bdea-d1a722f403c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN.",
+  "packageName": "@fluentui/react-experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-f8204db1-ea31-4ab0-8625-24db530bc2bf.json
+++ b/change/@fluentui-style-utilities-f8204db1-ea31-4ab0-8625-24db530bc2bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN.",
+  "packageName": "@fluentui/style-utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-theme-80504e49-c119-43e2-83ae-876dbe67ae95.json
+++ b/change/@fluentui-theme-80504e49-c119-43e2-83ae-876dbe67ae95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: Updating version of CDN used and replacing usage of via.placeholder.com with SVG from CDN.",
+  "packageName": "@fluentui/theme",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/example-data/src/testImages.ts
+++ b/packages/example-data/src/testImages.ts
@@ -1,4 +1,4 @@
-const baseProductionCdnUrl = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/';
+const baseProductionCdnUrl = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/';
 
 /** @internal */
 export const TestImages = {

--- a/packages/public-docsite-setup/homepage.htm
+++ b/packages/public-docsite-setup/homepage.htm
@@ -37,7 +37,7 @@ var appInsights=window.appInsights||(function(e){function n(e){t[e]=function(){v
   <div class="loading">
     <img
       class="loadingImage"
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/spinner.gif"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/spinner.gif"
       alt="Loading"
       width="32"
       height="32"

--- a/packages/public-docsite-setup/index.html
+++ b/packages/public-docsite-setup/index.html
@@ -77,7 +77,7 @@
       <div class="loading">
         <img
           class="loadingImage"
-          src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/fabric-website/images/spinner.gif"
+          src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/fabric-website/images/spinner.gif"
           alt="Loading"
           width="32"
           height="32"

--- a/packages/react-components/react-persona/stories/Persona/PersonaDefault.stories.tsx
+++ b/packages/react-components/react-persona/stories/Persona/PersonaDefault.stories.tsx
@@ -10,7 +10,7 @@ export const Default = (props: Partial<PersonaProps>) => {
       presence={{ status: 'available' }}
       avatar={{
         image: {
-          src: 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-male.png',
+          src: 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-male.png',
         },
       }}
       {...props}

--- a/packages/react-examples/src/react-cards/Card/Card.Horizontal.Example.tsx
+++ b/packages/react-examples/src/react-cards/Card/Card.Horizontal.Example.tsx
@@ -54,7 +54,12 @@ export const CardHorizontalExample: React.FunctionComponent = () => {
 
       <Card aria-label="Clickable horizontal card " horizontal onClick={alertClicked} tokens={cardTokens}>
         <Card.Item fill>
-          <Image src="//via.placeholder.com/180x135" alt="Placeholder image." />
+          <Image
+            src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+            alt="Placeholder image."
+            height={135}
+            width={180}
+          />
         </Card.Item>
         <Card.Section>
           <Text variant="small" styles={siteTextStyles}>

--- a/packages/react-examples/src/react-cards/Card/Card.Vertical.Example.tsx
+++ b/packages/react-examples/src/react-cards/Card/Card.Vertical.Example.tsx
@@ -115,7 +115,12 @@ export const CardVerticalExample: React.FunctionComponent = () => {
           <Persona text="Kevin Jameson" secondaryText="Feb 2, 2019" />
         </Card.Item>
         <Card.Item fill>
-          <Image src="//via.placeholder.com/256x144" width="100%" alt="Placeholder image." />
+          <Image
+            src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+            width="100%"
+            alt="Placeholder image."
+            height={144}
+          />
         </Card.Item>
         <Card.Section>
           <Text variant="small" styles={siteTextStyles}>

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Basic.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Basic.Example.tsx
@@ -8,7 +8,7 @@ export const ChicletBasicExample: React.FunctionComponent<{}> = () => {
     <Chiclet
       url={SAMPLE_URL}
       title={'WordTest with a really long title that will wrap around to the second line.docx'}
-      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/96/docx.svg"
+      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/96/docx.svg"
       itemType="docx"
       size={ChicletSize.medium}
     />

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Breadcrumb.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Breadcrumb.Example.tsx
@@ -51,7 +51,7 @@ export class ChicletBreadcrumbExample extends React.Component {
       <Chiclet
         url={SAMPLE_URL}
         title="Quarterly Results.docx"
-        image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/96/docx.svg"
+        image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/96/docx.svg"
         size={ChicletSize.medium}
         description={breadcrumb}
       />

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Footer.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Footer.Example.tsx
@@ -55,7 +55,7 @@ export const ChicletFooterExample: React.FunctionComponent<{}> = () => {
   return (
     <Chiclet
       url={SAMPLE_URL}
-      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/96/docx.svg"
+      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/96/docx.svg"
       title="Quarterly Results.docx"
       size={ChicletSize.medium}
       footer={footer}

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Preview.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Preview.Example.tsx
@@ -5,7 +5,14 @@ const SAMPLE_URL = 'https://contoso.sharepoint.com';
 
 export const ChicletPreviewExample: React.FunctionComponent<{}> = () => {
   const Preview: React.FunctionComponent<{}> = props => {
-    return <img src="http://via.placeholder.com/100x100" {...props} />;
+    return (
+      <img
+        src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+        {...props}
+        height={100}
+        width={100}
+      />
+    );
   };
 
   return (

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Xsmall.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Xsmall.Example.tsx
@@ -8,7 +8,7 @@ export const ChicletXsmallExample: React.FunctionComponent<{}> = () => {
     <Chiclet
       url={SAMPLE_URL}
       title={'WordTest with a long title that will wrap around.docx'}
-      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/48/docx.svg"
+      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/48/docx.svg"
       itemType="docx"
       size={ChicletSize.xSmall}
     />

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Xsmall.Footer.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Xsmall.Footer.Example.tsx
@@ -50,7 +50,7 @@ export const ChicletXsmallFooterExample: React.FunctionComponent<{}> = () => {
     <Chiclet
       url={SAMPLE_URL}
       title="Quarterly Results.docx"
-      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/48/docx.svg"
+      image="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/48/docx.svg"
       itemType="docx"
       size={ChicletSize.xSmall}
       footer={footer}

--- a/packages/react-examples/src/react-experiments/CollapsibleSection/CollapsibleSection.Recursive.Example.tsx
+++ b/packages/react-examples/src/react-experiments/CollapsibleSection/CollapsibleSection.Recursive.Example.tsx
@@ -142,7 +142,7 @@ export class CollapsibleSectionRecursiveExample extends React.Component<{}, {}> 
     const docType: string = fileIcons[Math.floor(Math.random() * fileIcons.length) + 0].name;
     return {
       docType,
-      url: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/16/${docType}.svg`,
+      url: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/16/${docType}.svg`,
     };
   }
 }

--- a/packages/react-examples/src/react-experiments/FolderCover/FolderCover.Basic.Example.tsx
+++ b/packages/react-examples/src/react-experiments/FolderCover/FolderCover.Basic.Example.tsx
@@ -30,7 +30,13 @@ const FolderCoverWithImage: React.FunctionComponent<IFolderCoverWithImageProps> 
   });
 
   return renderFolderCoverWithLayout(folderCover, {
-    children: <img src={`//via.placeholder.com/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`} />,
+    children: (
+      <img
+        src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+        height={Math.round(imageSize.height)}
+        width={Math.round(imageSize.width)}
+      />
+    ),
   });
 };
 

--- a/packages/react-examples/src/react-experiments/Tile/Tile.Document.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Tile/Tile.Document.Example.tsx
@@ -74,8 +74,10 @@ const DocumentTileWithThumbnail: React.FunctionComponent<IDocumentTileWithThumbn
       {renderTileWithLayout(tile, {
         foreground: (
           <img
-            src={`//via.placeholder.com/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`}
+            src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
             className={css(TileExampleStyles.tileImage)}
+            height={Math.round(imageSize.height)}
+            width={Math.round(imageSize.width)}
           />
         ),
       })}
@@ -142,7 +144,7 @@ export class TileDocumentExample extends React.Component<{}, ITileDocumentExampl
             itemActivity={<SignalField before={<SharedSignal />}>{ITEMS[3].activity}</SignalField>}
             foreground={
               <img
-                src={`https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/64/docx.svg`}
+                src={`https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/64/docx.svg`}
                 style={{
                   display: 'block',
                   width: '64px',

--- a/packages/react-examples/src/react-experiments/Tile/Tile.Folder.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Tile/Tile.Folder.Example.tsx
@@ -86,8 +86,10 @@ const FolderTileWithThumbnail: React.FunctionComponent<IFolderTileWithThumbnailP
             {renderFolderCoverWithLayout(folderCover, {
               children: imageSize ? (
                 <img
-                  src={`//via.placeholder.com/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`}
+                  src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svgs"
                   className={css(TileExampleStyles.tileImage)}
+                  height={Math.round(imageSize.height)}
+                  width={Math.round(imageSize.width)}
                 />
               ) : null,
             })}

--- a/packages/react-examples/src/react-experiments/Tile/Tile.Media.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Tile/Tile.Media.Example.tsx
@@ -145,7 +145,9 @@ const ImageTile: React.FunctionComponent<IImageTileProps> = (props: IImageTilePr
         background: (
           <img
             className={css(TileExampleStyles.tileImage)}
-            src={`//via.placeholder.com/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`}
+            src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+            height={Math.round(imageSize.height)}
+            width={Math.round(imageSize.width)}
           />
         ),
       })}

--- a/packages/react-examples/src/react-experiments/TilesList/TilesList.Media.Example.tsx
+++ b/packages/react-examples/src/react-experiments/TilesList/TilesList.Media.Example.tsx
@@ -183,7 +183,9 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
       background: (
         <img
           className={TilesListExampleStyles.tileImage}
-          src={`//via.placeholder.com/${Math.round(backgroundSize.width)}x${Math.round(backgroundSize.height)}`}
+          src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+          height={Math.round(backgroundSize.height)}
+          width={Math.round(backgroundSize.width)}
         />
       ),
     });

--- a/packages/react-examples/src/react-focus/FocusZone/FocusZone.Photos.Example.tsx
+++ b/packages/react-examples/src/react-focus/FocusZone/FocusZone.Photos.Example.tsx
@@ -52,7 +52,7 @@ const getItems = (): IPhoto[] => {
     const randomWidth = 50 + Math.floor(Math.random() * 150);
     items.push({
       id: getId('photo'),
-      url: `http://via.placeholder.com/${randomWidth}x100`,
+      url: 'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg',
       width: randomWidth,
       height: 100,
     });

--- a/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Documents.Example.tsx
@@ -389,7 +389,7 @@ function _randomFileIcon(): { docType: string; url: string } {
   const docType: string = FILE_ICONS[Math.floor(Math.random() * FILE_ICONS.length)].name;
   return {
     docType,
-    url: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/16/${docType}.svg`,
+    url: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/16/${docType}.svg`,
   };
 }
 

--- a/packages/react-examples/src/react/List/List.Basic.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Basic.Example.tsx
@@ -59,7 +59,13 @@ const classNames = mergeStyleSets({
 const onRenderCell = (item: IExampleItem, index: number | undefined): JSX.Element => {
   return (
     <div className={classNames.itemCell} data-is-focusable={true}>
-      <Image className={classNames.itemImage} src={item.thumbnail} width={50} height={50} imageFit={ImageFit.cover} />
+      <Image
+        className={classNames.itemImage}
+        src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+        width={50}
+        height={50}
+        imageFit={ImageFit.cover}
+      />
       <div className={classNames.itemContent}>
         <div className={classNames.itemName}>{item.name}</div>
         <div className={classNames.itemIndex}>{`Item ${index}`}</div>

--- a/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
@@ -61,7 +61,11 @@ const onRenderCell = (item: IExampleItem, index: number, isScrolling: boolean): 
     <div className={classNames.itemCell} data-is-focusable={true}>
       <Image
         className={classNames.itemImage}
-        src={isScrolling ? undefined : item.thumbnail}
+        src={
+          isScrolling
+            ? undefined
+            : 'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
+        }
         width={50}
         height={50}
         imageFit={ImageFit.cover}

--- a/packages/react-examples/src/react/List/List.Grid.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Grid.Example.tsx
@@ -60,6 +60,7 @@ const classNames = mergeStyleSets({
     position: 'absolute',
     top: 0,
     left: 0,
+    height: '100%',
     width: '100%',
   },
 });
@@ -87,7 +88,12 @@ export const ListGridExample: React.FunctionComponent = () => {
       >
         <div className={classNames.listGridExampleSizer}>
           <div className={classNames.listGridExamplePadder}>
-            <img src={item.thumbnail} className={classNames.listGridExampleImage} />
+            <img
+              src={
+                'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
+              }
+              className={classNames.listGridExampleImage}
+            />
             <span className={classNames.listGridExampleLabel}>{`item ${index}`}</span>
           </div>
         </div>

--- a/packages/react-examples/src/react/Persona/Persona.Presence.Example.tsx
+++ b/packages/react-examples/src/react/Persona/Persona.Presence.Example.tsx
@@ -6,7 +6,7 @@ import { mergeStyles } from '@fluentui/react/lib/Styling';
 
 const examplePersona: IPersonaSharedProps = {
   imageUrl:
-    'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png',
+    'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png',
   imageInitials: 'AL',
   text: 'Annie Lindqvist',
   secondaryText: 'Software Engineer',

--- a/packages/react-examples/src/react/Persona/Persona.PresenceColor.Example.tsx
+++ b/packages/react-examples/src/react/Persona/Persona.PresenceColor.Example.tsx
@@ -16,7 +16,7 @@ const presenceColors = {
 
 const examplePersona: IPersonaSharedProps = {
   imageUrl:
-    'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png',
+    'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png',
   imageInitials: 'AL',
   text: 'Annie Lindqvist',
   secondaryText: 'Software Engineer',

--- a/packages/react-examples/src/react/Pickers/Picker.CustomResult.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/Picker.CustomResult.Example.tsx
@@ -57,13 +57,13 @@ const rootClass = mergeStyles({
 });
 
 const baseProductionCdnUrl =
-  'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/';
+  'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/';
 
 const TestImages = {
   documentPreview: baseProductionCdnUrl + 'document-preview.png',
   documentPreviewTwo: baseProductionCdnUrl + 'document-preview2.png',
   documentPreviewThree: baseProductionCdnUrl + 'document-preview3.png',
-  iconPpt: 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/32/pptx.png',
+  iconPpt: 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/32/pptx.png',
   personaFemale: baseProductionCdnUrl + 'persona-female.png',
 };
 

--- a/packages/react-examples/src/react/Shimmer/Shimmer.Application.Example.tsx
+++ b/packages/react-examples/src/react/Shimmer/Shimmer.Application.Example.tsx
@@ -50,7 +50,7 @@ const randomFileIcon = (): { docType: string; url: string } => {
   const docType: string = fileIcons[Math.floor(Math.random() * fileIcons.length) + 0].name;
   return {
     docType,
-    url: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets/item-types/16/${docType}.svg`,
+    url: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets/item-types/16/${docType}.svg`,
   };
 };
 

--- a/packages/react-examples/src/react/Shimmer/Shimmer.LoadData.Example.tsx
+++ b/packages/react-examples/src/react/Shimmer/Shimmer.LoadData.Example.tsx
@@ -54,7 +54,7 @@ export const ShimmerLoadDataExample: React.FunctionComponent = () => {
       !isDataLoadedTwo
         ? {
             imageUrl:
-              'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png',
+              'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png',
             imageInitials: 'AL',
             primaryText: 'Annie Lindqvist',
             secondaryText: 'Software Engineer',

--- a/packages/react-experiments/src/common/TestImages.ts
+++ b/packages/react-experiments/src/common/TestImages.ts
@@ -1,7 +1,7 @@
 const baseProductionCdnUrl =
   'https://az742526.vo.msecnd.net/files/odsp-next-release-odc_2018-04-13_20180418.001/odsp-media/images/apps/';
 const fabricAssetsCdnUrl =
-  'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/';
+  'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/';
 
 export const ChicletTestImages = {
   iconWordDoc: baseProductionCdnUrl + 'word_16x1.svg',

--- a/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/react-experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -455,7 +455,7 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
           }
       onError={[Function]}
       onLoad={[Function]}
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets//persona-male.png"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets//persona-male.png"
     />
   </div>
 </div>

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -538,7 +538,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                               }
                           onError={[Function]}
                           onLoad={[Function]}
-                          src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png"
+                          src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png"
                         />
                       </div>
                       <div

--- a/packages/react/src/common/TestImages.ts
+++ b/packages/react/src/common/TestImages.ts
@@ -1,6 +1,6 @@
 // If this file is moved or split, the scripts for building codepen examples will likely need to be updated.
 
-const baseProductionCdnUrl = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/';
+const baseProductionCdnUrl = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/';
 
 /** @deprecated Use the version from `@fluentui/example-data` instead. */
 export const TestImages = {

--- a/packages/react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -655,7 +655,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
                   }
               onError={[Function]}
               onLoad={[Function]}
-              src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png"
+              src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png"
             />
           </div>
         </div>
@@ -1171,7 +1171,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                   }
               onError={[Function]}
               onLoad={[Function]}
-              src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png"
+              src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png"
             />
           </div>
         </div>
@@ -1306,7 +1306,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                   }
               onError={[Function]}
               onLoad={[Function]}
-              src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-male.png"
+              src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-male.png"
             />
           </div>
         </div>

--- a/packages/react/src/components/DocumentCard/__snapshots__/DocumentCardImage.test.tsx.snap
+++ b/packages/react/src/components/DocumentCard/__snapshots__/DocumentCardImage.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`DocumentCard renders DocumentCardImage correctly with a valid image 1`]
       onError={[Function]}
       onLoad={[Function]}
       role="presentation"
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/document-preview2.png"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/document-preview2.png"
     />
   </div>
   <div

--- a/packages/react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                           opacity: 0;
                           width: 100%;
                         }
-                    src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png"
+                    src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png"
                   />
                 </div>
               </div>
@@ -247,7 +247,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                           opacity: 0;
                           width: 100%;
                         }
-                    src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png"
+                    src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png"
                   />
                 </div>
               </div>

--- a/packages/react/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`Icon renders Icon with imageProps correctly 1`] = `
           }
       onError={[Function]}
       onLoad={[Function]}
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/icon-one.png"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/icon-one.png"
     />
   </div>
 </span>

--- a/packages/react/src/components/Icon/__snapshots__/ImageIcon.test.tsx.snap
+++ b/packages/react/src/components/Icon/__snapshots__/ImageIcon.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`ImageIcon renders ImageIcon correctly 1`] = `
           }
       onError={[Function]}
       onLoad={[Function]}
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/icon-one.png"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/icon-one.png"
     />
   </div>
 </div>

--- a/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -1537,7 +1537,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               }
           onError={[Function]}
           onLoad={[Function]}
-          src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-male.png"
+          src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-male.png"
         />
       </div>
       <div

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`PeoplePicker renders correctly 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-
+    
   </div>
   <span
     hidden={true}
@@ -198,7 +198,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-
+    
   </div>
   <span
     hidden={true}

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`PeoplePicker renders correctly 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-    
+
   </div>
   <span
     hidden={true}
@@ -198,7 +198,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
         }
     id="selected-suggestion-alert-id__0"
   >
-    
+
   </div>
   <span
     hidden={true}
@@ -403,7 +403,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           }
                       onError={[Function]}
                       onLoad={[Function]}
-                      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/persona-female.png"
+                      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/persona-female.png"
                     />
                   </div>
                   <div

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -82,7 +82,7 @@ export { DefaultPalette }
 export const EdgeChromiumHighContrastSelector = "@media screen and (-ms-high-contrast: active), screen and (forced-colors: active)";
 
 // @public (undocumented)
-export const FLUENT_CDN_BASE_URL = "https://res.cdn.office.net/files/fabric-cdn-prod_20230524.001";
+export const FLUENT_CDN_BASE_URL = "https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002";
 
 // @public
 export function focusClear(): IRawStyle;

--- a/packages/style-utilities/src/cdn.ts
+++ b/packages/style-utilities/src/cdn.ts
@@ -1,1 +1,1 @@
-export const FLUENT_CDN_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20230524.001';
+export const FLUENT_CDN_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002';

--- a/packages/theme/src/fonts/DefaultFontStyles.ts
+++ b/packages/theme/src/fonts/DefaultFontStyles.ts
@@ -7,7 +7,7 @@ import type { IFontStyles } from '../types/IFontStyles';
 import type { IFabricConfig } from '../types/IFabricConfig';
 
 // Default urls.
-const DefaultBaseUrl = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/assets';
+const DefaultBaseUrl = 'https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/assets';
 
 // Standard font styling.
 export const DefaultFontStyles: IFontStyles = createFontStyles(getLanguage());

--- a/specs/Icon.md
+++ b/specs/Icon.md
@@ -277,7 +277,7 @@ The following section documents the DOM structure for the component from differe
 <div role="presentation" aria-hidden="true" class="ms-Icon root-38 ms-Icon-imageContainer image-40 one-149">
   <div class="ms-Image oneImage-266">
     <img
-      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20221209.001/office-ui-fabric-react-assets/icon-one.png"
+      src="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/icon-one.png"
       class="ms-Image-image is-loaded ms-Image-image--portrait is-fadeIn image-264"
     />
   </div>


### PR DESCRIPTION
## Previous Behavior

The places where `via.placeholder.com` was being used to provision images in our docsite would result in a `Content Security Policy` violation because the URL was not recognized and the image would not be loaded, causing a bad experience for users.

<img width="346" alt="image" src="https://github.com/microsoft/fluentui/assets/7798177/fd36f249-f2a4-4166-9b39-ed14902451a6">

## New Behavior

All usages of `via.placeholder.com` have now been replaced with an SVG coming from our CDN. The version of the CDN that we are using has been updated in the whole repo to have access to this SVG.

<img width="346" alt="image" src="https://github.com/microsoft/fluentui/assets/7798177/164caada-f0cf-4d7d-9ed9-367c9ae76157">

## Related Issue(s)

- Fixes #28465
