### PR TITLE
bugfix(react-tree): headless flat tree itemType manual definition

### DIFF
--- a/change/@fluentui-react-tree-5db5f312-385a-4073-a98c-320f5de3da2f.json
+++ b/change/@fluentui-react-tree-5db5f312-385a-4073-a98c-320f5de3da2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: headless flat tree itemType manual definition",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
+++ b/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
@@ -126,7 +126,7 @@ export function createHeadlessTree<Props extends HeadlessTreeItemProps>(
           'aria-setsize': parentItem.childrenValues.length,
           itemType: item.itemType,
         }),
-        itemType: 'leaf',
+        itemType: propsWithoutParentValue.itemType ?? 'leaf',
         level: parentItem.level + 1,
         parentValue,
         childrenValues: [],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. bugfix: headless flat tree should allow the user to define the `itemType` value of a tree item instead of just assuming it's a `leaf`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
