### PR TITLE
Table: enable unconstrained column width changes

### DIFF
--- a/packages/react-components/react-table/src/hooks/types.ts
+++ b/packages/react-components/react-table/src/hooks/types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SortDirection } from '../components/Table/Table.types';
+import { SortDirection, TableProps } from '../components/Table/Table.types';
 import { TableHeaderCellProps } from '../components/TableHeaderCell/TableHeaderCell.types';
 import { SelectionMode } from '@fluentui/react-utilities';
 
@@ -176,6 +176,7 @@ export interface ColumnWidthState {
 }
 
 export type ColumnSizingTableHeaderCellProps = Pick<TableHeaderCellProps, 'style' | 'aside'>;
+export type ColumnSizingTableProps = Partial<TableProps>;
 export type ColumnSizingTableCellProps = Pick<TableHeaderCellProps, 'style'>;
 
 export type EnableKeyboardModeOnChangeCallback = (columnId: TableColumnId, isKeyboardMode: boolean) => void;
@@ -184,6 +185,7 @@ export interface TableColumnSizingState {
   getOnMouseDown: (columnId: TableColumnId) => (e: React.MouseEvent | React.TouchEvent) => void;
   setColumnWidth: (columnId: TableColumnId, newSize: number) => void;
   getColumnWidths: () => ColumnWidthState[];
+  getTableProps: () => ColumnSizingTableProps;
   getTableHeaderCellProps: (columnId: TableColumnId) => ColumnSizingTableHeaderCellProps;
   getTableCellProps: (columnId: TableColumnId) => ColumnSizingTableCellProps;
   enableKeyboardMode: (
@@ -214,4 +216,6 @@ export type UseTableColumnSizingParams = {
     data: { columnId: TableColumnId; width: number },
   ) => void;
   containerWidthOffset?: number;
+  constrainMinWidth?: boolean;
+  constrainMaxWidth?: boolean;
 };

--- a/packages/react-components/react-table/src/hooks/useTableColumnSizing.tsx
+++ b/packages/react-components/react-table/src/hooks/useTableColumnSizing.tsx
@@ -75,6 +75,13 @@ function useTableColumnSizingState<TItem>(
       setColumnWidth: (columnId: TableColumnId, w: number) =>
         columnResizeState.setColumnWidth(undefined, { columnId, width: w }),
       getColumnWidths: columnResizeState.getColumns,
+      getTableProps: () => {
+        return {
+          style: {
+            width: columnResizeState.getColumns().reduce((acc, col) => acc + col.width, 0),
+          },
+        };
+      },
       getTableHeaderCellProps: (columnId: TableColumnId) => {
         const col = columnResizeState.getColumnById(columnId);
 

--- a/packages/react-components/react-table/src/utils/columnResizeUtils.ts
+++ b/packages/react-components/react-table/src/utils/columnResizeUtils.ts
@@ -148,12 +148,17 @@ export function setColumnProperty(
  * @param containerWidth
  * @returns
  */
-export function adjustColumnWidthsToFitContainer(state: ColumnWidthState[], containerWidth: number) {
+export function adjustColumnWidthsToFitContainer(
+  state: ColumnWidthState[],
+  containerWidth: number,
+  constrainMinWidth = true,
+  constrainMaxWidth = true,
+) {
   let newState = state;
   const totalWidth = getTotalWidth(newState);
 
   // The total width is smaller, we are expanding columns
-  if (totalWidth < containerWidth) {
+  if (totalWidth < containerWidth && constrainMinWidth) {
     let difference = containerWidth - totalWidth;
     let i = 0;
     // We start at the beginning and assign the columns their ideal width
@@ -174,7 +179,7 @@ export function adjustColumnWidthsToFitContainer(state: ColumnWidthState[], cont
   }
 
   // The total width is larger than container, we need to squash the columns
-  else if (totalWidth >= containerWidth) {
+  else if (totalWidth >= containerWidth && constrainMaxWidth) {
     let difference = totalWidth - containerWidth;
     // We start with the last column
     let j = newState.length - 1;

--- a/packages/react-components/react-table/stories/Table/ResizableColumnsUnconstrained.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/ResizableColumnsUnconstrained.stories.tsx
@@ -1,0 +1,219 @@
+import * as React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableCellLayout,
+  TableColumnDefinition,
+  TableColumnSizingOptions,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  createTableColumn,
+  useTableColumnSizing_unstable,
+  useTableFeatures,
+  PresenceBadgeStatus,
+  Avatar,
+  Input,
+  useId,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+} from '@fluentui/react-components';
+import {
+  DocumentPdfRegular,
+  DocumentRegular,
+  EditRegular,
+  FolderRegular,
+  OpenRegular,
+  PeopleRegular,
+  VideoRegular,
+} from '@fluentui/react-icons';
+
+const columnsDef: TableColumnDefinition<Item>[] = [
+  createTableColumn<Item>({
+    columnId: 'file',
+    renderHeaderCell: () => <>File</>,
+  }),
+  createTableColumn<Item>({
+    columnId: 'author',
+    renderHeaderCell: () => <>Author</>,
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdated',
+    renderHeaderCell: () => <>Last updated</>,
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdate',
+    renderHeaderCell: () => <>Last update</>,
+  }),
+];
+
+type FileCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type LastUpdatedCell = {
+  label: string;
+  timestamp: number;
+};
+
+type LastUpdateCell = {
+  label: string;
+  icon: JSX.Element;
+};
+
+type AuthorCell = {
+  label: string;
+  status: PresenceBadgeStatus;
+};
+
+type Item = {
+  file: FileCell;
+  author: AuthorCell;
+  lastUpdated: LastUpdatedCell;
+  lastUpdate: LastUpdateCell;
+};
+
+const items: Item[] = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 3 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 1 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
+
+export const ResizableColumnsUnconstrained = () => {
+  const [columns] = React.useState<TableColumnDefinition<Item>[]>(columnsDef);
+  const [columnSizingOptions] = React.useState<TableColumnSizingOptions>({
+    file: {
+      idealWidth: 300,
+      minWidth: 150,
+    },
+    author: {
+      minWidth: 110,
+      defaultWidth: 250,
+    },
+    lastUpdate: {
+      minWidth: 150,
+    },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { getRows, columnSizing_unstable, tableRef } = useTableFeatures(
+    {
+      columns,
+      items,
+    },
+    [useTableColumnSizing_unstable({ columnSizingOptions, constrainMaxWidth: false, constrainMinWidth: false })],
+  );
+
+  const rows = getRows();
+
+  return (
+    <>
+      <div style={{ overflow: 'auto' }}>
+        <Table sortable aria-label="Table with sort" ref={tableRef} {...columnSizing_unstable.getTableProps()}>
+          <TableHeader>
+            <TableRow>
+              {columns.map(column => (
+                <Menu openOnContext key={column.columnId}>
+                  <MenuTrigger>
+                    <TableHeaderCell
+                      key={column.columnId}
+                      {...columnSizing_unstable.getTableHeaderCellProps(column.columnId)}
+                    >
+                      {column.renderHeaderCell()}
+                    </TableHeaderCell>
+                  </MenuTrigger>
+                  <MenuPopover>
+                    <MenuList>
+                      <MenuItem onClick={columnSizing_unstable.enableKeyboardMode(column.columnId)}>
+                        Keyboard Column Resizing
+                      </MenuItem>
+                    </MenuList>
+                  </MenuPopover>
+                </Menu>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map(({ item }) => (
+              <TableRow key={item.file.label}>
+                <TableCell {...columnSizing_unstable.getTableCellProps('file')}>
+                  <TableCellLayout truncate media={item.file.icon}>
+                    {item.file.label}
+                  </TableCellLayout>
+                </TableCell>
+                <TableCell {...columnSizing_unstable.getTableCellProps('author')}>
+                  <TableCellLayout
+                    truncate
+                    media={
+                      <Avatar name={item.author.label} badge={{ status: item.author.status as PresenceBadgeStatus }} />
+                    }
+                  >
+                    {item.author.label}
+                  </TableCellLayout>
+                </TableCell>
+                <TableCell {...columnSizing_unstable.getTableCellProps('lastUpdated')}>
+                  <TableCellLayout truncate>{item.lastUpdated.label}</TableCellLayout>
+                </TableCell>
+                <TableCell {...columnSizing_unstable.getTableCellProps('lastUpdate')}>
+                  <TableCellLayout truncate media={item.lastUpdate.icon}>
+                    {item.lastUpdate.label}
+                  </TableCellLayout>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
+  );
+};
+ResizableColumnsUnconstrained.storyName = 'Resizable Columns - unconstrained width';
+ResizableColumnsUnconstrained.parameters = {
+  docs: {
+    description: {
+      story: [
+        'Sometimes it is not desirable for the columns to be constrained by the container width and you would rather have the columns change widths without influencing width of any other column, at the cost of introducing scrollbars.',
+        ``,
+        'This is now possible using the `constrainMinWidth` and `constrainMaxWidth` parameters.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-table/stories/Table/index.stories.tsx
+++ b/packages/react-components/react-table/stories/Table/index.stories.tsx
@@ -23,6 +23,7 @@ export { CompositeNavigation } from './CompositeNavigation.stories';
 export { Sort } from './Sort.stories';
 export { ResizableColumnsUncontrolled } from './ResizableColumnsUncontrolled.stories';
 export { ResizableColumnsControlled } from './ResizableColumnsControlled.stories';
+export { ResizableColumnsUnconstrained } from './ResizableColumnsUnconstrained.stories';
 
 export { SortControlled } from './SortControlled.stories';
 export { MultipleSelect } from './MultipleSelect.stories';


### PR DESCRIPTION
A draft to explore if this is something we want to do.

This PR allows the devs to disable constrains when it comes to resizing columns. Subsequently its possible to change width of a column without ever impacting other column widths at the cost of introducing a scrollbar.

No changes to DataGrid yet, that would come after we validate the approach/behavior and after we decide if this is wanted/needed.