### PR TITLE
fix: codesandbox exports now work

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -48,6 +48,10 @@ export const parameters = {
       'react-dom': '^17',
       // necessary when using typescript in CodeSandbox
       'react-scripts': 'latest',
+      // Most recent minor version of @swc/helpers 0.4 depends on
+      // @swc/helpers version 0.4.14 which CodeSanbox doesn't seem to pick up.
+      // Explicitly adding 0.4.14 is necessary to properly build react-components in CodeSandbox.
+      '@swc/helpers': '0.4.14',
     },
     optionalDependencies: {
       '@fluentui/react-components': '^9.0.0', // necessary for FluentProvider


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- codesandbox exports are broken:

   <img width="506" alt="Pasted Graphic 4" src="https://github.com/microsoft/fluentui/assets/8649804/803b4e66-7581-4bfb-b85a-be19cd81119c">


## New Behavior
- codesanbox exports now work. Reason for the break is that the latest 0.4 version of `@swc/helpers` depends on  `@swc/helpers` version `0.4.14`. Codesandbox doesn't seem to pick up that dependency so explicitly adding that version is what's needed to make it work. 

   <img width="346" alt="Pasted Graphic 3" src="https://github.com/microsoft/fluentui/assets/8649804/328aef0b-63b6-4b84-a8f6-51cb34b66881">


<!-- This is the behavior we should expect with the changes in this PR -->


