### PR TITLE
chore: Add lint rules for playwright, enable unit tests

### DIFF
--- a/change/@fluentui-web-components-2eeaa976-b933-4d3c-8f63-a4a0818f1e74.json
+++ b/change/@fluentui-web-components-2eeaa976-b933-4d3c-8f63-a4a0818f1e74.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Enable lint for unit tests",
+  "packageName": "@fluentui/web-components",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "eslint-plugin-jest": "23.20.0",
     "eslint-plugin-jsdoc": "^36.0.7",
     "eslint-plugin-jsx-a11y": "6.4.1",
+    "eslint-plugin-playwright": "0.15.3",
     "eslint-plugin-react": "7.26.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "express": "4.17.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:change": "beachball check --scope packages/web-components -b web-components-v3",
     "check:modified-files": "node -r ./scripts/ts-node/register ./scripts/executors/check-for-modified-files",
     "check:affected-package": "node ./scripts/executors/checkIfPackagesAffected.js",
-    "check:installed-dependencies-versions": "satisfied --skip-invalid --ignore \"prettier|angular|lit|sass|@storybook/html|@storybook/mdx2-csf|svelte|@testing-library|vue|@cypress/react|cypress|@swc/wasm|@cactuslab/usepubsub|react-vis|@microsoft/load-themed-styles\"",
+    "check:installed-dependencies-versions": "satisfied --skip-invalid --ignore \"prettier|angular|lit|sass|@storybook/html|@storybook/mdx2-csf|svelte|@testing-library|vue|@cypress/react|cypress|@swc/wasm|@cactuslab/usepubsub|react-vis|@microsoft/load-themed-styles|eslint-plugin-playwright\"",
     "clean": "lage clean --verbose",
     "code-style": "lage code-style --verbose",
     "codepen": "cd packages/react && node ../../scripts/executors/local-codepen.js",

--- a/packages/web-components/.eslintignore
+++ b/packages/web-components/.eslintignore
@@ -6,5 +6,3 @@ dist
 coverage
 # don't lint storybook
 .storybook
-# don't lint tests
-*.spec.*

--- a/packages/web-components/.eslintrc.json
+++ b/packages/web-components/.eslintrc.json
@@ -6,7 +6,8 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier"
+    "prettier",
+    "plugin:playwright/recommended"
   ],
   "settings": {
     "react": {

--- a/packages/web-components/src/switch/switch.spec.ts
+++ b/packages/web-components/src/switch/switch.spec.ts
@@ -7,15 +7,12 @@ test.describe('Switch', () => {
   let page: Page;
   let element: Locator;
   let root: Locator;
-  let form: Locator;
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
 
     element = page.locator('fluent-switch');
 
     root = page.locator('#root');
-
-    form = page.locator('form');
 
     await page.goto(fixtureURL('components-switch--switch'));
   });
@@ -48,8 +45,7 @@ test.describe('Switch', () => {
     const switchElement = page.locator('fluent-switch');
 
     expect(await switchElement.textContent()).toContain(testValue);
-
-    expect(await switchElement.getAttribute('current-value')).toBe(testValue);
+    await expect(switchElement).toHaveAttribute('current-value', testValue);
   });
 
   test('should set and retrieve the `label-position` property correctly', async () => {

--- a/packages/web-components/src/switch/switch.spec.ts
+++ b/packages/web-components/src/switch/switch.spec.ts
@@ -3,7 +3,7 @@ import type { Locator, Page } from '@playwright/test';
 import { fixtureURL } from '../helpers.tests.js';
 import type { Switch } from './switch.js';
 
-test.describe.only('Switch', () => {
+test.describe('Switch', () => {
   let page: Page;
   let element: Locator;
   let root: Locator;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11815,6 +11815,11 @@ eslint-plugin-node@11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
+eslint-plugin-playwright@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz#9fd8753688351bcaf41797eb6a7df8807fd5eb1b"
+  integrity sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==
+
 eslint-plugin-react-hooks@4.2.0, eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"


### PR DESCRIPTION
## Previous Behavior

- By using `test.describe.only()` in one component test, all tests for other components were ignored.
- No lint rules enforced on spec.ts

## New Behavior

- All tests are executed
- `spec.ts` files are linted
- playwright rules added