### PR TITLE
chore(react-nav-preview): migrates to use new slot API

### DIFF
--- a/packages/react-components/react-nav-preview/src/components/Nav/renderNav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Nav/renderNav.tsx
@@ -2,15 +2,15 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { NavState, NavSlots } from './Nav.types';
 
 /**
  * Render the final JSX of Nav
  */
 export const renderNav_unstable = (state: NavState) => {
-  const { slots, slotProps } = getSlotsNext<NavSlots>(state);
+  assertSlots<NavSlots>(state);
 
   // TODO Add additional slots in the appropriate place
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { NavProps, NavState } from './Nav.types';
 
 /**
@@ -20,9 +20,12 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLElement>): N
     },
     // TODO add appropriate slots, for example:
     // mySlot: resolveShorthand(props.mySlot),
-    root: getNativeElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getNativeElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Seems like this package has been scaffolded after the new slot API has been implemented, but before updating the scaffolding tools 🙈 (https://github.com/microsoft/fluentui/pull/28916)

1. migrates to use the new slot API

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
