### PR TITLE
docs: update input migration with more multiline information

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Input.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Input.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs';
 
 # TextField to Input Migration
 
-Fluent UI v8 provides the `TextField` control for entering and editing text. In Fluent UI v9 `TextField` is replaced with `Input`.
+Fluent UI v8 provides the `TextField` control for entering and editing text. In Fluent UI v9 `TextField` is replaced with `Input` for single line input. For multiline input, use `Textarea`.
 
 While basic usage is largely the same, `Input` omits some features found in `TextField`, preferring to compose several components together for greater flexibility.
 


### PR DESCRIPTION
## Previous Behavior

FUIv8's `Textarea` has a "multiline" prop while FUIv9's `Input` does not. In FUIv9 we have the `Textarea` component for multiline input instead. While this is noted in the migration table toward the end of the doc it was not clearly stated at the top of the document.

## New Behavior

In the summary section, at the top of the migration doc, adds a statement to use `Textarea` for multiline input.

