### PR TITLE
fix(react-table): Added flag to make header button click trigger column sort customizable

### DIFF
--- a/change/@fluentui-react-table-29c2f444-d560-44d0-b1c0-2cc8c6b6f231.json
+++ b/change/@fluentui-react-table-29c2f444-d560-44d0-b1c0-2cc8c6b6f231.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "user can disable the default header button click trigger column sort while keep datagrid sorting feature",
+  "packageName": "@fluentui/react-table",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.types.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/DataGridHeaderCell.types.ts
@@ -9,7 +9,12 @@ export type DataGridHeaderCellSlots = TableHeaderCellSlots;
 /**
  * DataGridHeaderCell Props
  */
-export type DataGridHeaderCellProps = TableHeaderCellProps;
+export type DataGridHeaderCellProps = TableHeaderCellProps & {
+  /**
+   * @default true, user can disable the default header button click trigger column sort by setting this flag false.
+   */
+  clickTriggerSort?: boolean;
+};
 
 /**
  * State used in rendering DataGridHeaderCell

--- a/packages/react-components/react-table/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
+++ b/packages/react-components/react-table/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
@@ -19,6 +19,9 @@ export const useDataGridHeaderCell_unstable = (
   props: DataGridHeaderCellProps,
   ref: React.Ref<HTMLElement>,
 ): DataGridHeaderCellState => {
+  const {
+    clickTriggerSort = true
+  } = props;
   const columnId = useColumnIdContext();
   const { sortable } = useTableContext();
   const toggleColumnSort = useDataGridContext_unstable(ctx => ctx.sort.toggleColumnSort);
@@ -31,7 +34,7 @@ export const useDataGridHeaderCell_unstable = (
 
   // eslint-disable-next-line deprecation/deprecation -- prefer HTMLTableCellElement
   const onClick = useEventCallback((e: React.MouseEvent<HTMLTableHeaderCellElement>) => {
-    if (sortable) {
+    if (sortable && clickTriggerSort) {
       toggleColumnSort(e, columnId);
     }
     props.onClick?.(e);


### PR DESCRIPTION
## Previous Behavior
When DataGrid enables sortable, DataGridHeaderCell by default trigger column sort when user click header button, user has no way to override the onClick event as the``onClick`` defined in ``useDataGridHeaderCell_unstable`` is passed after ``...props``.
While setting sortable = false directly will lose all sort related table features.
```ts
const onClick = useEventCallback((e: React.MouseEvent<HTMLTableHeaderCellElement>) => {
    if (sortable) {
      toggleColumnSort(e, columnId);
    }
    props.onClick?.(e);
  });

  return useTableHeaderCell_unstable(
    {
      sortDirection,
      as: 'div',
      tabIndex: sortable ? undefined : 0,
      ...(resizableColumns ? columnSizing.getTableHeaderCellProps(columnId) : {}),
      ...props,
      onClick,
    },
    ref,
  );
```

## New Behavior

User can disable the default header button click trigger column sort by setting this flag false in DataGridHeaderCellProps. By default it is true which is backward compatible.
```
export type DataGridHeaderCellProps = TableHeaderCellProps & {
  /**
   * @default true
   */
  clickTriggerSort?: boolean;
};
```


