### PR TITLE
fix: Tooltip should not dismiss on iframe focus

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `Datepicker`: add onCalendarOpenStateChange prop. @jurokapsiar ([#28136](https://github.com/microsoft/fluentui/pull/28136))
 - Outline color now respects OS force colors settings. @george-cz ([#28182](https://github.com/microsoft/fluentui/pull/28182))
 - Remove `items` from `defaultProps` in Toolbar to fix warnings @layershifter ([#28723](https://github.com/microsoft/fluentui/pull/28723))
+- `Tooltip` should not dismiss on iframe focus @ling1726([#28942](https://github.com/microsoft/fluentui/pull/28942))
 
 <!--------------------------------[ v0.66.4 ]------------------------------- -->
 ## [v0.66.4](https://github.com/microsoft/fluentui/tree/@fluentui/react-northstar_v0.66.4) (2023-03-10)

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,6 @@ import {
   useFluentContext,
   useTriggerElement,
   useUnhandledProps,
-  useOnIFrameFocus,
 } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
@@ -143,13 +142,6 @@ export const Tooltip: React.FC<TooltipProps> &
   const triggerElement = useTriggerElement(props);
 
   const unhandledProps = useUnhandledProps(Tooltip.handledProps, props);
-
-  useOnIFrameFocus(open, context.target, (e: Event) => {
-    setOpen(__ => {
-      _.invoke(props, 'onOpenChange', e, { ...props, ...{ open: false } });
-      return false;
-    });
-  });
 
   const contentRef = React.useRef<HTMLElement>();
   const pointerTargetRef = React.useRef<HTMLDivElement>();


### PR DESCRIPTION
Tooltip should not dismiss with iframe focus because Tooltips generally are not dismissed with outside click - which is what the iframe focus is supposed to simulate. 
