### PR TITLE
chore: migrate to use JSX importSource

### DIFF
--- a/change/@fluentui-react-dialog-e2643f9f-5c8b-400a-b856-3e1ee63e0b19.json
+++ b/change/@fluentui-react-dialog-e2643f9f-5c8b-400a-b856-3e1ee63e0b19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrates to JSX importSource",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/.swcrc
+++ b/packages/react-components/react-dialog/.swcrc
@@ -19,7 +19,8 @@
     "externalHelpers": true,
     "transform": {
       "react": {
-        "runtime": "classic",
+        "runtime": "automatic",
+        "importSource": "@fluentui/react-jsx-runtime",
         "useSpread": true
       }
     },

--- a/packages/react-components/react-dialog/jest.config.js
+++ b/packages/react-components/react-dialog/jest.config.js
@@ -10,7 +10,11 @@ module.exports = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        tsconfig: '<rootDir>/tsconfig.spec.json',
+        tsconfig: {
+          module: 'CommonJS',
+          jsx: 'react-jsx',
+          jsxImportSource: '@fluentui/react-jsx-runtime',
+        },
         isolatedModules: true,
       },
     ],

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -1,3 +1,6 @@
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
 import { Dialog } from './Dialog';
 import { DialogProps } from './Dialog.types';

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { DialogProvider, DialogSurfaceProvider } from '../../contexts';
 import type { DialogState, DialogContextValues } from './Dialog.types';
 

--- a/packages/react-components/react-dialog/src/components/DialogActions/DialogActions.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogActions/DialogActions.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DialogActions } from './DialogActions';
 import { isConformant } from '../../testing/isConformant';

--- a/packages/react-components/react-dialog/src/components/DialogActions/renderDialogActions.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogActions/renderDialogActions.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogActionsState, DialogActionsSlots } from './DialogActions.types';
 

--- a/packages/react-components/react-dialog/src/components/DialogBody/DialogBody.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogBody/DialogBody.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DialogBody } from './DialogBody';
 import { isConformant } from '../../testing/isConformant';

--- a/packages/react-components/react-dialog/src/components/DialogBody/renderDialogBody.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogBody/renderDialogBody.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogBodyState, DialogBodySlots } from './DialogBody.types';
 

--- a/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogContent/DialogContent.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DialogContent } from './DialogContent';
 import { isConformant } from '../../testing/isConformant';

--- a/packages/react-components/react-dialog/src/components/DialogContent/renderDialogContent.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogContent/renderDialogContent.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogContentState, DialogContentSlots } from './DialogContent.types';
 

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DialogSurface } from './DialogSurface';
 import { resetIdsForTests } from '@fluentui/react-utilities';

--- a/packages/react-components/react-dialog/src/components/DialogSurface/renderDialogSurface.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/renderDialogSurface.tsx
@@ -1,8 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
-import { createElement } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogSurfaceState, DialogSurfaceSlots, DialogSurfaceContextValues } from './DialogSurface.types';
 import { DialogSurfaceProvider } from '../../contexts';

--- a/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.cy.tsx
@@ -1,3 +1,6 @@
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 

--- a/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.test.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/DialogTitle.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DialogTitle } from './DialogTitle';
 import { isConformant } from '../../testing/isConformant';

--- a/packages/react-components/react-dialog/src/components/DialogTitle/renderDialogTitle.tsx
+++ b/packages/react-components/react-dialog/src/components/DialogTitle/renderDialogTitle.tsx
@@ -1,9 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsxFrag Fragment */
-/** @jsx createElement */
-
-import { createElement, Fragment } from '@fluentui/react-jsx-runtime';
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { DialogTitleState, DialogTitleSlots } from './DialogTitle.types';
 

--- a/packages/react-components/react-dialog/stories/Dialog/DialogAlert.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogAlert.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogDefault.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogDefault.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogFluidDialogActions.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogNoFocusableElement.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogNoFocusableElement.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogNonModal.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogNonModal.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogScrollingLongContent.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogScrollingLongContent.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogTitleCustomAction.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogTitleCustomAction.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/stories/Dialog/DialogTitleNoAction.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogTitleNoAction.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/react-components/react-dialog/tsconfig.json
+++ b/packages/react-components/react-dialog/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "isolatedModules": true,
     "importHelpers": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "noUnusedLocals": true,
     "preserveConstEnums": true
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously `@fluentui/react-dialog` used to use classic pragma instead of JSX importSource

## New Behavior

1. Migrates to use the new automatic runtime https://github.com/microsoft/fluentui/pull/28810

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
