### PR TITLE
Exported DataGridContextProvider and useDataGridContext_unstable hook

### DIFF
--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -120,6 +120,8 @@ export {
 } from './TableCellLayout';
 export type { TableCellLayoutProps, TableCellLayoutSlots, TableCellLayoutState } from './TableCellLayout';
 
+export { DataGridContextProvider, useDataGridContext_unstable } from './contexts/dataGridContext';
+
 export {
   DataGridCell,
   dataGridCellClassNames,


### PR DESCRIPTION
Exported DataGridContextProvider and useDataGridContext_unstable hook.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
The library didn't export the context provider and its associated hooks.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

The library exports the context provider and its associated hooks.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28944 
