### PR TITLE
doc: updates doc to make it "codesandbox" compliant

### DIFF
--- a/packages/react-components/react-tree/stories/Tree/FlatTree.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/FlatTree.stories.tsx
@@ -7,7 +7,7 @@ import {
   TreeItemLayout,
   useHeadlessFlatTree_unstable,
   HeadlessFlatTreeItemProps,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 import {
   Button,
   Menu,

--- a/packages/react-components/react-tree/stories/Tree/OpenItemsControlled.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/OpenItemsControlled.stories.tsx
@@ -6,7 +6,7 @@ import {
   TreeItemLayout,
   TreeOpenChangeData,
   TreeOpenChangeEvent,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 
 export const OpenItemsControlled = () => {
   const [openItems, setOpenItems] = React.useState<Iterable<TreeItemValue>>([]);

--- a/packages/react-components/react-tree/stories/Tree/TreeActions.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeActions.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout, TreeItemProps } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout, TreeItemProps } from '@fluentui/react-components';
 import { Edit20Regular, MoreHorizontal20Regular } from '@fluentui/react-icons';
 import {
   Button,

--- a/packages/react-components/react-tree/stories/Tree/TreeAppearance.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeAppearance.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
 
 export const Appearance = () => {
   return (

--- a/packages/react-components/react-tree/stories/Tree/TreeAside.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeAside.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
 import { CounterBadge } from '@fluentui/react-components';
 import { FluentIconsProps, Important16Regular } from '@fluentui/react-icons';
 

--- a/packages/react-components/react-tree/stories/Tree/TreeCustomizingInteraction.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeCustomizingInteraction.stories.tsx
@@ -6,7 +6,7 @@ import {
   TreeItemValue,
   TreeOpenChangeData,
   TreeOpenChangeEvent,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 
 export const CustomizingInteraction = () => {
   const [openItems, setOpenItems] = React.useState<Iterable<TreeItemValue>>([]);

--- a/packages/react-components/react-tree/stories/Tree/TreeDefault.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
 
 export const Default = () => {
   return (

--- a/packages/react-components/react-tree/stories/Tree/TreeDefaultOpen.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeDefaultOpen.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
 
 export const DefaultOpen = () => (
   <Tree aria-label="Default Open" defaultOpenItems={['default-subtree-1', 'default-subtree-2', 'default-subtree-2-1']}>

--- a/packages/react-components/react-tree/stories/Tree/TreeDragAndDrop.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeDragAndDrop.stories.tsx
@@ -6,7 +6,7 @@ import {
   useHeadlessFlatTree_unstable,
   HeadlessFlatTreeItemProps,
   TreeItemProps,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 
 import {
   DndContext,

--- a/packages/react-components/react-tree/stories/Tree/TreeExpandIcon.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeExpandIcon.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout, TreeItemValue } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout, TreeItemValue } from '@fluentui/react-components';
 import { AddSquare16Regular, SubtractSquare16Regular } from '@fluentui/react-icons';
 import { TreeOpenChangeData, TreeOpenChangeEvent } from './../../src/Tree';
 

--- a/packages/react-components/react-tree/stories/Tree/TreeIconBeforeAndAfter.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeIconBeforeAndAfter.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
 import { Image20Regular, LockClosed20Regular, Person20Regular, Warning20Regular } from '@fluentui/react-icons';
 
 export const IconBeforeAndAfter = () => {

--- a/packages/react-components/react-tree/stories/Tree/TreeInfiniteScrolling.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeInfiniteScrolling.stories.tsx
@@ -6,7 +6,7 @@ import {
   HeadlessFlatTreeItemProps,
   useHeadlessFlatTree_unstable,
   TreeItemValue,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 import { makeStyles, shorthands, Spinner } from '@fluentui/react-components';
 
 const ITEMS_PER_PAGE = 10;

--- a/packages/react-components/react-tree/stories/Tree/TreeInlineStylingTreeItemLevel.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeInlineStylingTreeItemLevel.stories.tsx
@@ -6,7 +6,7 @@ import {
   treeItemLevelToken,
   useTreeContext_unstable,
   useTreeItemContext_unstable,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 
 const RecursiveTreeItem: React.FC = () => {
   const level = useTreeContext_unstable(ctx => ctx.level);

--- a/packages/react-components/react-tree/stories/Tree/TreeLayouts.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeLayouts.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout, TreeItemPersonaLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout, TreeItemPersonaLayout } from '@fluentui/react-components';
 import { Avatar } from '@fluentui/react-components';
 
 export const Layouts = () => {

--- a/packages/react-components/react-tree/stories/Tree/TreeLazyLoading.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeLazyLoading.stories.tsx
@@ -8,7 +8,7 @@ import {
   HeadlessFlatTreeItemProps,
   useHeadlessFlatTree_unstable,
   TreeItemValue,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 import { makeStyles, Spinner, shorthands } from '@fluentui/react-components';
 
 interface Result {

--- a/packages/react-components/react-tree/stories/Tree/TreeManipulation.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeManipulation.stories.tsx
@@ -9,7 +9,7 @@ import {
   useHeadlessFlatTree_unstable,
   TreeItemProps,
   TreeItemValue,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 import { Delete20Regular } from '@fluentui/react-icons';
 import {
   Button,

--- a/packages/react-components/react-tree/stories/Tree/TreeSelection.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeSelection.stories.tsx
@@ -5,7 +5,7 @@ import {
   TreeItemLayout,
   HeadlessFlatTreeItemProps,
   useHeadlessFlatTree_unstable,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 
 const SELECTION_MODE = 'multiselect'; // change to "single" for single selection
 

--- a/packages/react-components/react-tree/stories/Tree/TreeSize.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/TreeSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
 
 export const Size = () => {
   return (

--- a/packages/react-components/react-tree/stories/Tree/Virtualization.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/Virtualization.stories.tsx
@@ -13,7 +13,7 @@ import {
   useFlatTreeContextValues_unstable,
   HeadlessFlatTreeItem,
   useHeadlessFlatTree_unstable,
-} from '@fluentui/react-tree';
+} from '@fluentui/react-components';
 import { FixedSizeList, FixedSizeListProps, ListChildComponentProps } from 'react-window';
 import { ForwardRefComponent, getSlots } from '@fluentui/react-components';
 

--- a/packages/react-components/react-tree/stories/Tree/index.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Tree, TreeItem, TreeItemLayout, TreeItemPersonaLayout, FlatTree } from '@fluentui/react-tree';
+import { Tree, TreeItem, TreeItemLayout, TreeItemPersonaLayout, FlatTree } from '@fluentui/react-components';
 
 import descriptionMd from './TreeDescription.md';
 import bestPracticesMd from './TreeBestPractices.md';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Seems like something between our storybook code generation and codesandbox seems to break when aliasing an import, we're getting a duplicate identifier error on codesanbox when trying to open the flat tree example.

<img width="722" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/6e527586-e03f-464b-ba2d-9c4b3013e86f">


## New Behavior


1. imports tree components from `@fluentui/react-components` instead of `@fluentui/react-tree`


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
