### PR TITLE
fix(react-tags-preview): tag with secondary text has no top border under windows high contrast

### DIFF
--- a/change/@fluentui-react-tags-preview-94eb29aa-e1eb-4bc6-a747-23edc4f50642.json
+++ b/change/@fluentui-react-tags-preview-94eb29aa-e1eb-4bc6-a747-23edc4f50642.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: tag with secondary text has no top border under windows high contrast",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -9,6 +9,7 @@ import {
   useMediaStyles,
   usePrimaryTextStyles,
   useSecondaryTextStyles,
+  useTagWithSecondaryTextContrastStyles,
 } from '../Tag/useTagStyles.styles';
 
 export const interactionTagPrimaryClassNames: SlotClassNames<InteractionTagPrimarySlots> = {
@@ -189,6 +190,8 @@ export const useInteractionTagPrimaryStyles_unstable = (
   const primaryTextStyles = usePrimaryTextStyles();
   const secondaryTextStyles = useSecondaryTextStyles();
 
+  const tagWithSecondaryTextContrastStyles = useTagWithSecondaryTextContrastStyles();
+
   const { shape, size, appearance } = state;
 
   state.root.className = mergeClasses(
@@ -202,6 +205,8 @@ export const useInteractionTagPrimaryStyles_unstable = (
     !state.media && !state.icon && rootWithoutMediaStyles[size],
     state.hasSecondaryAction && rootWithSecondaryActionStyles.base,
     state.hasSecondaryAction && rootWithSecondaryActionStyles[size],
+
+    state.secondaryText && tagWithSecondaryTextContrastStyles[shape],
 
     state.root.className,
   );

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTagStyles.styles.ts
@@ -258,6 +258,43 @@ export const usePrimaryTextStyles = makeStyles({
   },
 });
 
+/**
+ * Styles for root slot under windows high contrast mode when Tag is with secondary text.
+ * Tag's primary text has negative margin that covers the border. Pseudo element is used to draw the border.
+ */
+export const useTagWithSecondaryTextContrastStyles = makeStyles({
+  rounded: {
+    '@media (forced-colors: active)': {
+      position: 'relative',
+      '::before': {
+        content: '""',
+        ...shorthands.border(tokens.strokeWidthThin, 'solid'),
+        position: 'absolute',
+        top: '-1px',
+        left: '-1px',
+        right: '-1px',
+        bottom: '-1px',
+        ...shorthands.borderRadius(tokens.borderRadiusMedium),
+      },
+    },
+  },
+  circular: {
+    '@media (forced-colors: active)': {
+      position: 'relative',
+      '::before': {
+        content: '""',
+        ...shorthands.border(tokens.strokeWidthThin, 'solid'),
+        position: 'absolute',
+        top: '-1px',
+        left: '-1px',
+        right: '-1px',
+        bottom: '-1px',
+        ...shorthands.borderRadius(tokens.borderRadiusCircular),
+      },
+    },
+  },
+});
+
 export const useSecondaryTextStyles = makeStyles({
   base: {
     ...shorthands.gridArea('secondary'),
@@ -283,6 +320,8 @@ export const useTagStyles_unstable = (state: TagState): TagState => {
   const primaryTextStyles = usePrimaryTextStyles();
   const secondaryTextStyles = useSecondaryTextStyles();
 
+  const tagWithSecondaryTextContrastStyles = useTagWithSecondaryTextContrastStyles();
+
   const { shape, size, appearance } = state;
 
   state.root.className = mergeClasses(
@@ -296,6 +335,8 @@ export const useTagStyles_unstable = (state: TagState): TagState => {
 
     !state.media && !state.icon && rootWithoutMediaStyles[size],
     !state.dismissIcon && rootWithoutDismissStyles[size],
+
+    state.secondaryText && tagWithSecondaryTextContrastStyles[shape],
 
     state.root.className,
   );


### PR DESCRIPTION
 

## Previous Behavior

When tag has secondary text, the primary text has `margin-top: -2px`, which overlaps with the tag border under windows high contrast:
<img width="389" alt="Screenshot 2023-08-23 at 17 38 48" src="https://github.com/microsoft/fluentui/assets/28751745/55452e13-5821-446e-a870-b9ef1507c695">


## New Behavior
Add a pseudo element to draw the border
<img width="339" alt="Screenshot 2023-08-23 at 17 38 24" src="https://github.com/microsoft/fluentui/assets/28751745/00abdd93-1517-4275-8a1e-6030b7014e09">

 
