### PR TITLE
fix(react-utilities): click scrollbar should invoke callback in `useOnClickOutside`

### DIFF
--- a/change/@fluentui-react-utilities-bdfc2f99-6dbb-4819-8c64-ce9383c3d94d.json
+++ b/change/@fluentui-react-utilities-bdfc2f99-6dbb-4819-8c64-ce9383c3d94d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: `useOnClickOutside` should invoke callback on clicking scrollbar",
+  "packageName": "@fluentui/react-utilities",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
@@ -89,9 +89,8 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
     };
 
     // use capture phase because React can update DOM before the event bubbles to the document
-    element?.addEventListener('click', conditionalHandler, true);
     element?.addEventListener('touchstart', conditionalHandler, true);
-    element?.addEventListener('contextmenu', conditionalHandler, true);
+    element?.addEventListener('mouseup', conditionalHandler, true);
     element?.addEventListener('mousedown', handleMouseDown, true);
 
     // Garbage collect this event after it's no longer useful to avoid memory leaks
@@ -100,9 +99,8 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
     }, 1);
 
     return () => {
-      element?.removeEventListener('click', conditionalHandler, true);
       element?.removeEventListener('touchstart', conditionalHandler, true);
-      element?.removeEventListener('contextmenu', conditionalHandler, true);
+      element?.removeEventListener('mouseup', conditionalHandler, true);
       element?.removeEventListener('mousedown', handleMouseDown, true);
 
       clearTimeout(timeoutId.current);


### PR DESCRIPTION
Fix issue 1 in #28938

## Previous Behavior

In the codesandbox in the original issue: https://codesandbox.io/s/inspiring-fast-5jm9wc?file=/example.tsx
Click scrollbar in the scrollable container does not close the popover

## New Behavior
I updated the `useOnClickOutside` to listen to `mouseup` instead of `click` so it can close the popover when clicking the scrollbar.

When scrollbar is clicked, these are the events on `document` during capture phase:
<img width="804" alt="click-scrollbar" src="https://github.com/microsoft/fluentui/assets/28751745/f88d03ce-5ad1-469d-b4cb-5b2a9033715d">

And on context menu click:
<img width="793" alt="context-click" src="https://github.com/microsoft/fluentui/assets/28751745/85b34c3b-d5e1-426f-8364-9d22563d7bc9">

So we can rely on `mouseup` event instead of `click`.

 
