### PR TITLE
8.0 Azure Theme: Details list row focus contrast a11y bug fix 

### DIFF
--- a/change/@fluentui-azure-themes-cfae358f-02a7-46ba-8e4d-ee45180e9eb8.json
+++ b/change/@fluentui-azure-themes-cfae358f-02a7-46ba-8e4d-ee45180e9eb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated focus state border for detailslist",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -904,7 +904,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
     background: BaseColors.WHITE,
     disabled: BaseColors.GRAY_F3F2F1,
     hover: BaseColors.GRAY_605E5C,
-    accent: BaseColors.BLUE_0078D4,
+    accent: BaseColors.GRAY_605E5C,
     focus: BaseColors.BLUE_0078D4,
     error: BaseColors.RED_A4262C,
     dirty: BaseColors.PURPLE_8A2DA5,

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -17,7 +17,6 @@ export const CheckStyles = (props: ICheckStyleProps): Partial<ICheckStyles> => {
     circle: [
       {
         fontSize: 0,
-        paddingTop: 1,
         paddingLeft: 1,
         borderRadius: StyleConstants.borderRadius,
         color: semanticColors.listBackground,
@@ -133,9 +132,6 @@ export const DetailsRowStyles = (props: IDetailsRowStyleProps): Partial<IDetails
                   color: extendedSemanticColors.listLinkHovered,
                 },
               },
-            },
-            ':after': {
-              border: `1px solid ${extendedSemanticColors.listItemBackgroundSelected} !important`,
             },
             ':focus': {
               backgroundColor: extendedSemanticColors.rowFocus,


### PR DESCRIPTION
## Previous Behavior
When unselected or selected row is tabbed into (focus state) the contrast ratio did not pass accessibility standards of 3:1. Bug states: "Luminosity ratio of the focus boundary around the "rule id row" is 1.2:1 which is less than 3:1 under "Edit Exclusion" page."

Note: light theme fix only. Other themes unaffected
<img width="380" alt="Screenshot 2023-08-08 at 11 04 37 AM" src="https://github.com/microsoft/fluentui/assets/30805892/d5a1fbc7-5596-4f82-8356-daf58eec55cf">

## New Behavior
Design team concluded that aligning to what is live on Fluent site is best, which is #605E5C
Source: https://developer.microsoft.com/en-us/fluentui#/controls/web/detailslist/compact
<img width="390" alt="Screenshot 2023-08-08 at 11 03 18 AM" src="https://github.com/microsoft/fluentui/assets/30805892/b783504c-eb5a-4094-879c-8d4c69ba96d2">

Cherry picked from [#28781](https://github.com/microsoft/fluentui/pull/28781)
