### PR TITLE
fix(react-card): CardHeader grid layout ignoring line-height of content

### DIFF
--- a/change/@fluentui-react-card-97d7abde-06d9-46cc-a71a-147630a0431e.json
+++ b/change/@fluentui-react-card-97d7abde-06d9-46cc-a71a-147630a0431e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: CardHeader grid layout ignoring line-height of content",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeaderStyles.styles.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeaderStyles.styles.ts
@@ -25,7 +25,6 @@ const useStyles = makeStyles({
     [cardHeaderCSSVars.cardHeaderGapVar]: '12px',
     display: 'grid',
     gridAutoColumns: 'min-content 1fr min-content',
-    gridAutoRows: '1fr min-content',
     alignItems: 'center',
   },
   image: {
@@ -37,10 +36,12 @@ const useStyles = makeStyles({
   header: {
     gridColumnStart: '2',
     gridRowStart: '1',
+    display: 'flex',
   },
   description: {
     gridColumnStart: '2',
     gridRowStart: '2',
+    display: 'flex',
   },
   action: {
     marginLeft: `var(${cardHeaderCSSVars.cardHeaderGapVar})`,


### PR DESCRIPTION
CardHeader was ignoring the content line-height by setting `grid-auto-rows`. By removing it, it automatically uses the content size to determine the height of each row.

- Fixes #28890
