### PR TITLE
patch(react-table): expose DataGrid related contexts

### DIFF
--- a/change/@fluentui-react-components-b27fbad2-298f-4aac-9fe9-201f3e1f7883.json
+++ b/change/@fluentui-react-components-b27fbad2-298f-4aac-9fe9-201f3e1f7883.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "expose useDataGridContext_unstable etc. contexts",
+  "packageName": "@fluentui/react-components",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-77ca024a-803c-4ed4-9d5d-b2c4aa7d9eaa.json
+++ b/change/@fluentui-react-table-77ca024a-803c-4ed4-9d5d-b2c4aa7d9eaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "expose useDataGridContext_unstable etc. contexts",
+  "packageName": "@fluentui/react-table",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -927,6 +927,7 @@ import { useCardStyles_unstable } from '@fluentui/react-card';
 import { useCheckbox_unstable } from '@fluentui/react-checkbox';
 import { useCheckboxStyles_unstable } from '@fluentui/react-checkbox';
 import { useCheckmarkStyles_unstable } from '@fluentui/react-menu';
+import { useColumnIdContext } from '@fluentui/react-table';
 import { useCombobox_unstable } from '@fluentui/react-combobox';
 import { useComboboxContextValues } from '@fluentui/react-combobox';
 import { useComboboxStyles_unstable } from '@fluentui/react-combobox';
@@ -990,6 +991,7 @@ import { useImage_unstable } from '@fluentui/react-image';
 import { useImageStyles_unstable } from '@fluentui/react-image';
 import { useInput_unstable } from '@fluentui/react-input';
 import { useInputStyles_unstable } from '@fluentui/react-input';
+import { useIsInTableHeader } from '@fluentui/react-table';
 import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { useIsOverflowGroupVisible } from '@fluentui/react-overflow';
 import { useIsOverflowItemVisible } from '@fluentui/react-overflow';
@@ -3016,6 +3018,8 @@ export { useCheckboxStyles_unstable }
 
 export { useCheckmarkStyles_unstable }
 
+export { useColumnIdContext }
+
 export { useCombobox_unstable }
 
 export { useComboboxContextValues }
@@ -3149,6 +3153,8 @@ export { useIsOverflowGroupVisible }
 export { useIsOverflowItemVisible }
 
 export { useIsSSR }
+
+export { useIsInTableHeader }
 
 export { useKeyboardNavAttribute }
 

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -131,7 +131,7 @@ import { CheckboxSlots } from '@fluentui/react-checkbox';
 import { CheckboxState } from '@fluentui/react-checkbox';
 import { ColorPaletteTokens } from '@fluentui/react-theme';
 import { ColorTokens } from '@fluentui/react-theme';
-import { ColumnIdContextProvider } '@fluentui/react-table';
+import { ColumnIdContextProvider } from '@fluentui/react-table';
 import { Combobox } from '@fluentui/react-combobox';
 import { comboboxClassNames } from '@fluentui/react-combobox';
 import { ComboboxContextValue } from '@fluentui/react-combobox';
@@ -3152,6 +3152,8 @@ export { useInput_unstable }
 
 export { useInputStyles_unstable }
 
+export { useIsInTableHeader }
+
 export { useIsomorphicLayoutEffect }
 
 export { useIsOverflowGroupVisible }
@@ -3159,8 +3161,6 @@ export { useIsOverflowGroupVisible }
 export { useIsOverflowItemVisible }
 
 export { useIsSSR }
-
-export { useIsInTableHeader }
 
 export { useKeyboardNavAttribute }
 

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -131,6 +131,7 @@ import { CheckboxSlots } from '@fluentui/react-checkbox';
 import { CheckboxState } from '@fluentui/react-checkbox';
 import { ColorPaletteTokens } from '@fluentui/react-theme';
 import { ColorTokens } from '@fluentui/react-theme';
+import { ColumnIdContextProvider } '@fluentui/react-table';
 import { Combobox } from '@fluentui/react-combobox';
 import { comboboxClassNames } from '@fluentui/react-combobox';
 import { ComboboxContextValue } from '@fluentui/react-combobox';
@@ -718,6 +719,7 @@ import { TableHeaderCellSlots } from '@fluentui/react-table';
 import { TableHeaderCellState } from '@fluentui/react-table';
 import { tableHeaderClassName } from '@fluentui/react-table';
 import { tableHeaderClassNames } from '@fluentui/react-table';
+import { TableHeaderContextProvider } from '@fluentui/react-table';
 import { TableHeaderProps } from '@fluentui/react-table';
 import { TableHeaderSlots } from '@fluentui/react-table';
 import { TableHeaderState } from '@fluentui/react-table';
@@ -1425,6 +1427,8 @@ export { CheckboxState }
 export { ColorPaletteTokens }
 
 export { ColorTokens }
+
+export { ColumnIdContextProvider }
 
 export { Combobox }
 
@@ -2599,6 +2603,8 @@ export { TableHeaderCellState }
 export { tableHeaderClassName }
 
 export { tableHeaderClassNames }
+
+export { TableHeaderContextProvider }
 
 export { TableHeaderProps }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1017,6 +1017,12 @@ export {
   TableRowIdContextProvider,
   useTableRowIdContext,
   useTableColumnSizing_unstable,
+  ColumnIdContextProvider,
+  useColumnIdContext,
+  DataGridContextProvider,
+  useDataGridContext_unstable,
+  TableHeaderContextProvider,
+  useIsInTableHeader,
 } from '@fluentui/react-table';
 
 export type {

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1019,8 +1019,6 @@ export {
   useTableColumnSizing_unstable,
   ColumnIdContextProvider,
   useColumnIdContext,
-  DataGridContextProvider,
-  useDataGridContext_unstable,
   TableHeaderContextProvider,
   useIsInTableHeader,
 } from '@fluentui/react-table';

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -29,6 +29,9 @@ import { TabsterDOMAttribute } from '@fluentui/react-tabster';
 // @public (undocumented)
 export type CellRenderFunction<TItem = unknown> = (column: TableColumnDefinition<TItem>, dataGridContextValue: DataGridContextValue) => React_2.ReactNode;
 
+// @public (undocumented)
+export const ColumnIdContextProvider: React_2.Provider<TableColumnId | undefined>;
+
 // @public
 export function createTableColumn<TItem>(options: CreateTableColumnOptions<TItem>): {
     columnId: TableColumnId;
@@ -367,9 +370,6 @@ export interface TableColumnDefinition<TItem> {
 
 // @public (undocumented)
 export type TableColumnId = string | number;
-
-// @public (undocumented)
-export const ColumnIdContextProvider: React_2.Provider<TableColumnId | undefined>;
 
 // @public (undocumented)
 export type TableColumnSizingOptions = Record<TableColumnId, Partial<Pick<ColumnWidthState, 'minWidth' | 'idealWidth' | 'padding'>> & {

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -559,6 +559,9 @@ export interface TableSortState<TItem> {
 export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'> & TableContextValue;
 
 // @public
+export const useColumnIdContext: () => TableColumnId;
+
+// @public
 export const useDataGrid_unstable: (props: DataGridProps, ref: React_2.Ref<HTMLElement>) => DataGridState;
 
 // @public
@@ -605,6 +608,9 @@ export const useDataGridSelectionCellStyles_unstable: (state: DataGridSelectionC
 
 // @public
 export const useDataGridStyles_unstable: (state: DataGridState) => DataGridState;
+
+// @public (undocumented)
+export const useIsInTableHeader: () => boolean;
 
 // @public
 export const useTable_unstable: (props: TableProps, ref: React_2.Ref<HTMLElement>) => TableState;

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -369,6 +369,9 @@ export interface TableColumnDefinition<TItem> {
 export type TableColumnId = string | number;
 
 // @public (undocumented)
+export const ColumnIdContextProvider: React_2.Provider<TableColumnId | undefined>;
+
+// @public (undocumented)
 export type TableColumnSizingOptions = Record<TableColumnId, Partial<Pick<ColumnWidthState, 'minWidth' | 'idealWidth' | 'padding'>> & {
     defaultWidth?: number;
 }>;
@@ -434,6 +437,9 @@ export const tableHeaderClassName = "fui-TableHeader";
 
 // @public (undocumented)
 export const tableHeaderClassNames: SlotClassNames<TableHeaderSlots>;
+
+// @public (undocumented)
+export const TableHeaderContextProvider: React_2.Provider<string | undefined>;
 
 // @public
 export type TableHeaderProps = ComponentProps<TableHeaderSlots> & {};
@@ -558,7 +564,7 @@ export interface TableSortState<TItem> {
 // @public
 export type TableState = ComponentState<TableSlots> & Pick<Required<TableProps>, 'size' | 'noNativeElements'> & TableContextValue;
 
-// @public
+// @public (undocumented)
 export const useColumnIdContext: () => TableColumnId;
 
 // @public

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -91,7 +91,6 @@ export {
 export type { TableResizeHandleProps, TableResizeHandleSlots, TableResizeHandleState } from './TableResizeHandle';
 
 export { ColumnIdContextProvider, useColumnIdContext } from './contexts/columnIdContext';
-export { DataGridContextProvider, useDataGridContext_unstable } from './contexts/dataGridContext';
 export { TableContextProvider, useTableContext } from './contexts/tableContext';
 export { useTableRowIdContext, TableRowIdContextProvider } from './contexts/rowIdContext';
 export { TableHeaderContextProvider, useIsInTableHeader } from './contexts/tableHeaderContext';

--- a/packages/react-components/react-table/src/index.ts
+++ b/packages/react-components/react-table/src/index.ts
@@ -90,8 +90,11 @@ export {
 } from './TableResizeHandle';
 export type { TableResizeHandleProps, TableResizeHandleSlots, TableResizeHandleState } from './TableResizeHandle';
 
+export { ColumnIdContextProvider, useColumnIdContext } from './contexts/columnIdContext';
+export { DataGridContextProvider, useDataGridContext_unstable } from './contexts/dataGridContext';
 export { TableContextProvider, useTableContext } from './contexts/tableContext';
 export { useTableRowIdContext, TableRowIdContextProvider } from './contexts/rowIdContext';
+export { TableHeaderContextProvider, useIsInTableHeader } from './contexts/tableHeaderContext';
 export {
   TableSelectionCell,
   useTableSelectionCellStyles_unstable,


### PR DESCRIPTION
## Previous Behavior

``useColumnIdContext``, ``useIsInTableHeader`` are not exposed from react-table, expose this let users implement their own datagrid header cell from primitives.


## New Behavior
``useColumnIdContext``, ``useIsInTableHeader`` are exposed so that user can customize own DataGridHeaderCell to support different behaviour.
