### PR TITLE
Revert "Keytips: Align keytipData with visible instance for dupes"

### DIFF
--- a/change/@fluentui-react-0078b842-450a-442c-b9da-1c591f0299fb.json
+++ b/change/@fluentui-react-0078b842-450a-442c-b9da-1c591f0299fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"Keytips: Align keytipData with visible instance for dupes (#28522)\"",
+  "packageName": "@fluentui/react",
+  "email": "makopch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -12,7 +12,6 @@ import {
   Async,
   initializeComponentRef,
   KeyCodes,
-  isElementVisibleAndNotHidden,
 } from '../../Utilities';
 import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { KeytipTree } from './KeytipTree';
@@ -376,15 +375,7 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
         // Account for overflow set sequences when checking for duplicates
         keytipId = sequencesToID(mergeOverflows(keytip.keySequences, keytip.overflowSetSequence));
       }
-      const targetSelector = ktpTargetFromSequences(keytip.keySequences);
-      const matchingElements = document.querySelectorAll(targetSelector);
       seenIds[keytipId] = seenIds[keytipId] ? seenIds[keytipId] + 1 : 1;
-
-      // If there are multiple elements for the keytip sequence, return true if the element instance
-      // that corresponds to the keytip instance is visible
-      if (matchingElements.length > 1 && seenIds[keytipId] <= matchingElements.length) {
-        return keytip.visible && isElementVisibleAndNotHidden(matchingElements[seenIds[keytipId] - 1] as HTMLElement);
-      }
       return keytip.visible && seenIds[keytipId] === 1;
     });
   }


### PR DESCRIPTION
Reverts microsoft/fluentui#28522

This is causing perf regressions with the querySelectorAll in Office online apps.