### PR TITLE
ReAdd: Keytips: Align keytipData with visible instance for dupes

### DIFF
--- a/change/@fluentui-react-26552add-8a6c-42a8-93ca-965284270f1f.json
+++ b/change/@fluentui-react-26552add-8a6c-42a8-93ca-965284270f1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keytip: Make keytip data align with which instance is visible (for duplicate registrations)",
+  "packageName": "@fluentui/react",
+  "email": "jspurlin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -12,6 +12,7 @@ import {
   Async,
   initializeComponentRef,
   KeyCodes,
+  isElementVisibleAndNotHidden,
 } from '../../Utilities';
 import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { KeytipTree } from './KeytipTree';
@@ -376,9 +377,22 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
         keytipId = sequencesToID(mergeOverflows(keytip.keySequences, keytip.overflowSetSequence));
       }
       seenIds[keytipId] = seenIds[keytipId] ? seenIds[keytipId] + 1 : 1;
-      return keytip.visible && seenIds[keytipId] === 1;
+
+      // Return true only if the keytip is visible and the corresponding target is also visible
+      return keytip.visible && this._isKeytipInstanceTargetVisible(keytip.keySequences, seenIds[keytipId]);
     });
   }
+
+  private _isKeytipInstanceTargetVisible = (keySequences: string[], instanceCount: number): boolean => {
+    const targetSelector = ktpTargetFromSequences(keySequences);
+    const matchingElements = document.querySelectorAll(targetSelector);
+
+    // If there are multiple elements for the keytip sequence, return true if the element instance
+    // that corresponds to the keytip instance is visible, otherwise return if there is only one instance
+    return matchingElements.length > 1 && instanceCount <= matchingElements.length
+      ? isElementVisibleAndNotHidden(matchingElements[instanceCount - 1] as HTMLElement)
+      : instanceCount === 1;
+  };
 
   private _onDismiss = (ev?: React.MouseEvent<HTMLElement>): void => {
     // if we are in keytip mode, then exit keytip mode


### PR DESCRIPTION
This PR is resubmitting https://github.com/microsoft/fluentui/pull/28522 with a slight alteration to only run querySelectorAll for keytips that are visible. This will greatly reduce the number of times querySelectorAll is run

__From the original PR:_

Previous Behavior
Currently, keytips have the ability to render only for visible instances of target elements, but if there are multiple of the same registration (e.g. keytipData), the first one is always used. This can result in the keytip not being positioned correctly for the instance that's visible. Note, this is related to responsive scaling where the same control can be rendered with the same keytip tree multiple times where only one instance is visible at a time

New Behavior
With this change, the fetching of the keytipData will now return the instance that's associated with the corresponding visible element instance. This makes the keytipData that's used align with how keytips already choose where to be visible (e.g. which element is their target). This new code will only run if there are multiple keytips with the exact same registration (same keytip sequence (e.g. tree and element keytip)) which can happen for responsive scaling.