### PR TITLE
chore: Make triage bot add needs triage label to new issues

### DIFF
--- a/.github/triage-bot.config.json
+++ b/.github/triage-bot.config.json
@@ -3,13 +3,13 @@
   "params": [
     {
       "keyword": "(@fluentui/react-northstar)",
-      "labels": ["Fluent UI react-northstar (v0)"],
+      "labels": ["Fluent UI react-northstar (v0)", "Needs: Triage :mag:"],
       "assignees": []
     },
-    { "keyword": "(@fluentui/react)", "labels": ["Fluent UI react (v8)"], "assignees": [] },
+    { "keyword": "(@fluentui/react)", "labels": ["Fluent UI react (v8)", "Needs: Triage :mag:"], "assignees": [] },
     {
       "keyword": "(@fluentui/react-components)",
-      "labels": ["Fluent UI react-components (v9)"],
+      "labels": ["Fluent UI react-components (v9)", "Needs: Triage :mag:"],
       "assignees": []
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Bot only adds which area the issue falls into.

## New Behavior

Bot now adds the area and a "needs: triage" label so the dev in shield can triage respectively.


