### PR TITLE
chore: Adding cxe-red and cxe-coastal as owners of mdl2-branded package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -157,6 +157,7 @@ packages/react-examples/src/react-charting @microsoft/charting-team
 packages/react-file-type-icons @microsoft/cxe-red @jahnp @bigbadcapers
 packages/react-hooks @microsoft/cxe-red
 packages/react-icons-mdl2 @microsoft/cxe-red @microsoft/cxe-coastal
+packages/react-icons-mdl2-branded @microsoft/cxe-red @microsoft/cxe-coastal
 packages/react-monaco-editor @microsoft/fluentui-v8-website
 packages/react-components/react-positioning @microsoft/teams-prg
 packages/react-components/react-overflow @microsoft/teams-prg


### PR DESCRIPTION
This PR adds cxe-red and cxe-coastal as owners of the mdl2-branded package to the codeowners file.