### PR TITLE
fix: use timeout instead of requestAnimationFrame for ssr

### DIFF
--- a/change/@fluentui-react-utilities-b4af8469-27c7-4b29-a6a9-13ef542e6779.json
+++ b/change/@fluentui-react-utilities-b4af8469-27c7-4b29-a6a9-13ef542e6779.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use timeout instead of requestAnimationFrame for ssr",
+  "packageName": "@fluentui/react-utilities",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/useAnimationFrame.ts
+++ b/packages/react-components/react-utilities/src/hooks/useAnimationFrame.ts
@@ -1,3 +1,4 @@
+import { canUseDOM } from '../ssr/canUseDOM';
 import { useBrowserTimer } from './useBrowserTimer';
 
 /**
@@ -9,6 +10,11 @@ import { useBrowserTimer } from './useBrowserTimer';
  * @returns A pair of [requestAnimationFrame, cancelAnimationFrame] that are stable between renders.
  */
 export function useAnimationFrame() {
+  const isDOM = canUseDOM();
+
   // TODO: figure it out a way to not call global.requestAnimationFrame and instead infer window from some context
-  return useBrowserTimer(requestAnimationFrame, cancelAnimationFrame);
+  const setAnimationFrame = isDOM ? requestAnimationFrame : setTimeout;
+  const clearAnimationFrame = isDOM ? cancelAnimationFrame : clearTimeout;
+
+  return useBrowserTimer(setAnimationFrame, clearAnimationFrame);
 }


### PR DESCRIPTION
Use simple timeout when in SSR environment. This is due to requestAnimationFrame not being available on the server. The setTimeout will be immediate in this case and will keep the code working async.