### PR TITLE
bugfix: fixes DialogActions position on breakpoint

### DIFF
--- a/change/@fluentui-react-dialog-ca3365f9-0885-4e75-989a-7a7bb419ef85.json
+++ b/change/@fluentui-react-dialog-ca3365f9-0885-4e75-989a-7a7bb419ef85.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: fixes DialogActions position on breakpoint",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogActions/useDialogActionsStyles.styles.ts
@@ -26,6 +26,8 @@ const useStyles = makeStyles({
     gridColumnEnd: 4,
     [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
       gridColumnStart: 1,
+      gridRowStart: 4,
+      gridRowEnd: 'auto',
     },
   },
   gridPositionStart: {
@@ -34,6 +36,8 @@ const useStyles = makeStyles({
     gridColumnEnd: 2,
     [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
       gridColumnEnd: 4,
+      gridRowStart: 3,
+      gridRowEnd: 'auto',
     },
   },
   fluidStart: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Seems like actions on position `start` are being positioned in the same grid position than the position `end` when the viewport reaches small size breakpoint. This causes actions to vanish

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Ensures that actions position start have a different position in the grid when the viewport breakpoint is reached.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
