### PR TITLE
fix(react-tags-preview): add memorizeCurrent on TagGroup

### DIFF
--- a/change/@fluentui-react-tags-preview-ef93566d-2d55-4b12-bf0c-06571aeda63d.json
+++ b/change/@fluentui-react-tags-preview-ef93566d-2d55-4b12-bf0c-06571aeda63d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remember last focused element in TagGroup",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags-preview/src/components/TagGroup/useTagGroup.ts
+++ b/packages/react-components/react-tags-preview/src/components/TagGroup/useTagGroup.ts
@@ -48,6 +48,7 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLEl
   const arrowNavigationProps = useArrowNavigationGroup({
     circular: true,
     axis: 'both',
+    memorizeCurrent: true,
   });
 
   return {


### PR DESCRIPTION
TagGroup should remember the last focused element