### PR TITLE
fix(ssr-tests-v9): use correct path for ssr-tests-v9 stories

### DIFF
--- a/apps/ssr-tests-v9/package.json
+++ b/apps/ssr-tests-v9/package.json
@@ -15,7 +15,7 @@
     "storybook": "start-storybook",
     "test": "jest --passWithNoTests",
     "type-check": "tsc -b tsconfig.json",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
+    "test-ssr": "test-ssr \"./src/stories/**/*.stories.tsx\""
   },
   "dependencies": {
     "@fluentui/react-components": "*"


### PR DESCRIPTION
Currently the ssr-tests-v9 stories are located within `./src/stories/*` and the NPM task was trying to get the stories from `./stories/*`