### PR TITLE
feat(react-theme): export brand colors from tokens & theme

### DIFF
--- a/change/@fluentui-react-theme-9d5b956c-cf21-4e4d-95be-6676372dcac5.json
+++ b/change/@fluentui-react-theme-9d5b956c-cf21-4e4d-95be-6676372dcac5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export brand colors",
+  "packageName": "@fluentui/react-theme",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-tokens-842d9ca5-974e-4a9b-bf30-1f95b7351c48.json
+++ b/change/@fluentui-tokens-842d9ca5-974e-4a9b-bf30-1f95b7351c48.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export brand colors",
+  "packageName": "@fluentui/tokens",
+  "email": "tigeroakes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-theme/src/index.ts
+++ b/packages/react-components/react-theme/src/index.ts
@@ -1,4 +1,7 @@
 export {
+  brandWeb,
+  brandOffice,
+  brandTeams,
   teamsDarkTheme,
   teamsHighContrastTheme,
   teamsLightTheme,

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -4,6 +4,7 @@ export { createDarkTheme, createHighContrastTheme, createLightTheme, createTeams
 export { themeToTokensObject } from './themeToTokensObject';
 export { tokens } from './tokens';
 export { typographyStyles } from './global/index';
+export { brandWeb, brandOffice, brandTeams } from './global/brandColors';
 
 export type {
   Brands,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Brand colors were used internally but not available to packages outside this repo.

## New Behavior

Brand colors are available to other packages. This is wanted by Loop so devs who aren't using v9 can just specify a default branding color.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

