### PR TITLE
fix(react-tags-preview): add hover/pressed style for windows high contrast

### DIFF
--- a/change/@fluentui-react-tags-preview-ab59afeb-97d0-4574-b3c5-ba25a5a36ad0.json
+++ b/change/@fluentui-react-tags-preview-ab59afeb-97d0-4574-b3c5-ba25a5a36ad0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add style for windows high contrast",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -43,6 +43,16 @@ const useRootBaseClassName = makeResetStyles({
     ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
     zIndex: 1,
   }),
+
+  // windows high contrast:
+  '@media (forced-colors: active)': {
+    ':hover': {
+      backgroundColor: 'HighlightText',
+    },
+    ':active': {
+      backgroundColor: 'HighlightText',
+    },
+  },
 });
 
 const useRootStyles = makeStyles({

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
@@ -34,6 +34,16 @@ const useRootBaseClassName = makeResetStyles({
   borderLeftColor: tokens.colorNeutralStroke1,
   borderTopLeftRadius: tokens.borderRadiusNone,
   borderBottomLeftRadius: tokens.borderRadiusNone,
+
+  // windows high contrast:
+  '@media (forced-colors: active)': {
+    ':hover': {
+      backgroundColor: 'HighlightText',
+    },
+    ':active': {
+      backgroundColor: 'HighlightText',
+    },
+  },
 });
 
 const useRootStyles = makeStyles({

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTagStyles.styles.ts
@@ -180,6 +180,16 @@ const useDismissIconStyles = makeStyles({
   base: {
     ...shorthands.gridArea('dismissIcon'),
     display: 'flex',
+
+    // windows high contrast:
+    '@media (forced-colors: active)': {
+      ':hover': {
+        color: 'Highlight',
+      },
+      ':active': {
+        color: 'Highlight',
+      },
+    },
   },
   medium: {
     paddingLeft: tokens.spacingHorizontalXS,


### PR DESCRIPTION
Add hover/pressed style for windows high contrast on Tag/InteractionTag:

Hover dismiss icon on Tag:
| before | after |
|---| ---|
| <img width="113" alt="Screenshot 2023-08-31 at 13 42 44" src="https://github.com/microsoft/fluentui/assets/28751745/61f2d67a-2f37-491c-b75e-fbb6330f7972">| <img width="112" alt="Screenshot 2023-08-31 at 13 42 30" src="https://github.com/microsoft/fluentui/assets/28751745/4636f8d6-4035-4b7c-ac46-389cdee814ac">|


Hover InteractionTagPrimary:
| before | after |
|---| ---|
| <img width="125" alt="Screenshot 2023-08-31 at 13 31 46" src="https://github.com/microsoft/fluentui/assets/28751745/71555c23-f679-4865-a5f2-8b56b2ce33a7">| <img width="125" alt="Screenshot 2023-08-31 at 13 36 48" src="https://github.com/microsoft/fluentui/assets/28751745/2546bda7-afca-439b-8680-b225bb859282">|


Hover InteractionTagSecondary:
| before | after |
|---| ---|
| <img width="128" alt="Screenshot 2023-08-31 at 13 31 50" src="https://github.com/microsoft/fluentui/assets/28751745/af049082-9179-43f9-b446-c601593a3db7">|<img width="117" alt="Screenshot 2023-08-31 at 13 37 06" src="https://github.com/microsoft/fluentui/assets/28751745/147af99c-e324-4fc0-b1cc-abe58f432e0d">|