### PR TITLE
chore: adds swc-plugin-de-indent-template-literal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ rush.json
 
 # tsdoc
 tsdoc-metadata.json
+
+# swc cache
+.swc

--- a/package.json
+++ b/package.json
@@ -333,6 +333,7 @@
     "strip-ansi": "6.0.0",
     "style-loader": "2.0.0",
     "swc-loader": "0.2.3",
+    "swc-plugin-de-indent-template-literal": "1.0.0",
     "syncpack": "10.6.1",
     "tachometer": "0.7.0",
     "terser": "5.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24512,6 +24512,11 @@ swc-loader@0.2.3, swc-loader@^0.1.15, swc-loader@^0.2.3:
   resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
   integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
 
+swc-plugin-de-indent-template-literal@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/swc-plugin-de-indent-template-literal/-/swc-plugin-de-indent-template-literal-1.0.0.tgz#ec0fc840f5b10b8631aaa20c71b04cac56db223e"
+  integrity sha512-Qb4G8h8hKlwWYFCJUVbmiELRmjzBM1hPmJh5+p0GiY/b6imGSIuEWV2zBAYcQyNvR2DI2MJ3OxJC2SCT9Ld7lA==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. adds dependency to `swc-plugin-de-indent-template-literal` to strip indentation from template literals on build time
2. adds `.swc` cache folder to `.gitignore`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
