### PR TITLE
refactor(react-drawer): change DrawerHeaderTitle slot creation while keeping the same API

### DIFF
--- a/change/@fluentui-react-drawer-93fb2624-7aa8-4c3a-9333-635dcac41292.json
+++ b/change/@fluentui-react-drawer-93fb2624-7aa8-4c3a-9333-635dcac41292.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: refactor DrawerHeaderTitle slot creation while keeping the same API",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -11,7 +11,6 @@ import type { ComponentState } from '@fluentui/react-utilities';
 import { DialogProps } from '@fluentui/react-dialog';
 import { DialogSurfaceProps } from '@fluentui/react-dialog';
 import { DialogSurfaceSlots } from '@fluentui/react-dialog';
-import { DialogTitleSlots } from '@fluentui/react-dialog';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { MotionShorthand } from '@fluentui/react-motion-preview';
 import { MotionState } from '@fluentui/react-motion-preview';
@@ -97,15 +96,13 @@ export const DrawerHeaderTitle: ForwardRefComponent<DrawerHeaderTitleProps>;
 export const drawerHeaderTitleClassNames: SlotClassNames<DrawerHeaderTitleSlots>;
 
 // @public
-export type DrawerHeaderTitleProps = ComponentProps<DrawerHeaderTitleSlots> & {
-    children: React_2.ReactNode | undefined;
-};
+export type DrawerHeaderTitleProps = ComponentProps<DrawerHeaderTitleSlots>;
 
 // @public (undocumented)
 export type DrawerHeaderTitleSlots = {
     root: Slot<'div'>;
-    heading?: DialogTitleSlots['root'];
-    action?: DialogTitleSlots['action'];
+    heading?: Slot<'h2', 'h1' | 'h3' | 'h4' | 'h5' | 'h6' | 'div'>;
+    action?: Slot<'div'>;
 };
 
 // @public

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/DrawerHeaderTitle.types.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/DrawerHeaderTitle.types.ts
@@ -1,6 +1,4 @@
-import { DialogTitleSlots } from '@fluentui/react-dialog';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import * as React from 'react';
 
 export type DrawerHeaderTitleSlots = {
   root: Slot<'div'>;
@@ -9,24 +7,18 @@ export type DrawerHeaderTitleSlots = {
    * By default this is a h2, but can be any heading or div.
    * If `div` is provided do not forget to also provide proper `role="heading"` and `aria-level` attributes
    */
-  heading?: DialogTitleSlots['root'];
+  heading?: Slot<'h2', 'h1' | 'h3' | 'h4' | 'h5' | 'h6' | 'div'>;
 
   /**
    * Action slot for the close button
    */
-  action?: DialogTitleSlots['action'];
+  action?: Slot<'div'>;
 };
 
 /**
  * DrawerHeaderTitle Props
  */
-export type DrawerHeaderTitleProps = ComponentProps<DrawerHeaderTitleSlots> & {
-  /**
-   * Content of the DrawerHeaderTitle
-   * Children is mandatory because DrawerHeaderTitle is a wrapper component
-   */
-  children: React.ReactNode | undefined;
-};
+export type DrawerHeaderTitleProps = ComponentProps<DrawerHeaderTitleSlots>;
 
 /**
  * State used in rendering DrawerHeaderTitle

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -1,7 +1,24 @@
 import * as React from 'react';
-import { getNativeElementProps, slot } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot, resolveShorthand } from '@fluentui/react-utilities';
 import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
-import { useDialogTitle_unstable } from '@fluentui/react-dialog';
+
+const getHeadingSlot = (props: DrawerHeaderTitleProps) => {
+  let heading = resolveShorthand(props.heading);
+
+  if (!heading) {
+    heading = {
+      children: props.children,
+    };
+  }
+
+  return slot.optional(getNativeElementProps(heading.as ?? 'h2', heading), {
+    defaultProps: {
+      children: heading.children || props.children,
+    },
+    renderByDefault: true,
+    elementType: 'h2',
+  });
+};
 
 /**
  * Create the state required to render DrawerHeaderTitle.
@@ -16,33 +33,23 @@ export const useDrawerHeaderTitle_unstable = (
   props: DrawerHeaderTitleProps,
   ref: React.Ref<HTMLDivElement>,
 ): DrawerHeaderTitleState => {
-  const { root: heading, action, components: titleComponents } = useDialogTitle_unstable(props, ref);
-
   return {
     components: {
       root: 'div',
-      heading: titleComponents.root,
-      action: titleComponents.action,
+      heading: 'h2',
+      action: 'div',
     },
 
     root: slot.always(
       getNativeElementProps('div', {
-        ref,
         ...props,
+        ref,
       }),
       { elementType: 'div' },
     ),
-    heading: slot.optional(props.heading, {
-      renderByDefault: true,
-      defaultProps: {
-        ...heading,
-        className: undefined, // remove className from heading
-      },
-      elementType: titleComponents.root,
-    }),
+    heading: getHeadingSlot(props),
     action: slot.optional(props.action, {
-      defaultProps: action,
-      elementType: titleComponents.action,
+      elementType: 'div',
     }),
   };
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -1,24 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps, slot, resolveShorthand } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
-
-const getHeadingSlot = (props: DrawerHeaderTitleProps) => {
-  let heading = resolveShorthand(props.heading);
-
-  if (!heading) {
-    heading = {
-      children: props.children,
-    };
-  }
-
-  return slot.optional(getNativeElementProps(heading.as ?? 'h2', heading), {
-    defaultProps: {
-      children: heading.children || props.children,
-    },
-    renderByDefault: true,
-    elementType: 'h2',
-  });
-};
 
 /**
  * Create the state required to render DrawerHeaderTitle.
@@ -33,6 +15,14 @@ export const useDrawerHeaderTitle_unstable = (
   props: DrawerHeaderTitleProps,
   ref: React.Ref<HTMLDivElement>,
 ): DrawerHeaderTitleState => {
+  let heading = slot.resolveShorthand(props.heading);
+
+  if (!heading) {
+    heading = {
+      children: props.children,
+    };
+  }
+
   return {
     components: {
       root: 'div',
@@ -42,12 +32,18 @@ export const useDrawerHeaderTitle_unstable = (
 
     root: slot.always(
       getNativeElementProps('div', {
-        ...props,
         ref,
+        ...props,
       }),
       { elementType: 'div' },
     ),
-    heading: getHeadingSlot(props),
+    heading: slot.optional(getNativeElementProps(heading.as ?? 'h2', heading), {
+      defaultProps: {
+        children: props.children,
+      },
+      renderByDefault: true,
+      elementType: 'h2',
+    }),
     action: slot.optional(props.action, {
       elementType: 'div',
     }),

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerWithTitle.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerWithTitle.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { DrawerInline, DrawerHeader, DrawerHeaderTitle } from '@fluentui/react-drawer';
+import { Button, makeStyles } from '@fluentui/react-components';
+import { Dismiss24Regular } from '@fluentui/react-icons';
+
+const useStyles = makeStyles({
+  drawer: {
+    width: '400px',
+    height: '600px',
+  },
+});
+
+export const WithTitle = () => {
+  return (
+    <DrawerInline className={useStyles().drawer} open>
+      <DrawerHeader>
+        <DrawerHeaderTitle>Drawer with title</DrawerHeaderTitle>
+        <DrawerHeaderTitle heading={{ as: 'h1' }}>Drawer with custom tag</DrawerHeaderTitle>
+        <DrawerHeaderTitle action={<Button appearance="subtle" aria-label="Close" icon={<Dismiss24Regular />} />}>
+          Drawer with title and action
+        </DrawerHeaderTitle>
+      </DrawerHeader>
+    </DrawerInline>
+  );
+};
+
+WithTitle.parameters = {
+  docs: {
+    controls: {
+      disable: true,
+    },
+    description: {
+      story: [
+        '`DrawerHeaderTitle` is a component that provides a structured heading for a Drawer and can be used to display a title and an action.',
+        'Although it works as a standalone component, it is intended to be used within a `DrawerHeader`.',
+        'The title renders an `h2` element by default but it can be customized using the `heading` prop.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-drawer/stories/Drawer/index.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/index.stories.tsx
@@ -19,6 +19,7 @@ export { Position } from './DrawerPosition.stories';
 export { Size } from './DrawerSize.stories';
 export { CustomSize } from './DrawerCustomSize.stories';
 export { Separator } from './DrawerSeparator.stories';
+export { WithTitle } from './DrawerWithTitle.stories';
 export { WithNavigation } from './DrawerWithNavigation.stories';
 export { WithScroll } from './DrawerWithScroll.stories';
 export { AlwaysOpen } from './DrawerAlwaysOpen.stories';


### PR DESCRIPTION
This is a simple refactor of the `DrawerHeaderTitle` to remove Dialog dependencies.

### Why?
To make the component more lightweight and simpler to reason about.

### Previous
We were relying on `DialogTitle` to make `DrawerHeaderTitle`.

### Current
We now create all the slots with dependency free. This makes it easier to create the component state.

_Note: The styles are still using the `useDialogTitleStyles`, as we want the same styling to be applied._
