### PR TITLE
Add focus rect support in shadow dom

### DIFF
--- a/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
+++ b/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { GLOBAL_STYLESHEET_KEY } from '@fluentui/merge-styles';
+import { FocusRectsProvider } from '../FocusRectsProvider';
 import { useMergeStylesRootStylesheets_unstable } from './MergeStylesRootContext';
 /**
  * NOTE: This API is unstable and subject to breaking change or removal without notice.
@@ -36,11 +37,16 @@ export const MergeStylesShadowRootProvider_unstable: React.FC<MergeStylesShadowR
       shadowRoot,
     };
   }, [shadowRoot]);
+  const focusProviderRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <MergeStylesShadowRootContext.Provider value={value} {...props}>
       <GlobalStyles />
-      {props.children}
+      <FocusRectsProvider providerRef={focusProviderRef}>
+        <div className="ms-MergeStylesShadowRootProvider" ref={focusProviderRef}>
+          {props.children}
+        </div>
+      </FocusRectsProvider>
     </MergeStylesShadowRootContext.Provider>
   );
 };


### PR DESCRIPTION
## Previous Behavior

Focus rect styles are not applied to Fluent components within shadow doms

## New Behavior

Added FocusRectProvider within MergeStylesShadowRootProvider.


https://github.com/spmonahan/fluentui/assets/69223766/0bc21347-1dd8-4e28-b76a-f644b916c68d


## Related Issue(s)

https://github.com/microsoft/fluentui/issues/28061

