### PR TITLE
fix(date-picker): fix month display on date-picker stories

### DIFF
--- a/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerDateBoundaries.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerDateBoundaries.stories.tsx
@@ -13,7 +13,7 @@ const minDate = addMonths(today, -1);
 const maxDate = addYears(today, 1);
 
 const onFormatDate = (date?: Date): string => {
-  return `${date?.getMonth()}/${date?.getDate()}/${date?.getFullYear()}`;
+  return !date ? '' : `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 };
 
 export const DateBoundaries = () => {

--- a/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/DatePicker/DatePickerErrorHandling.stories.tsx
@@ -14,7 +14,7 @@ const minDate = addMonths(today, -1);
 const maxDate = addYears(today, 1);
 
 const onFormatDate = (date?: Date): string => {
-  return `${date?.getMonth()}/${date?.getDate()}/${date?.getFullYear()}`;
+  return !date ? '' : `${date?.getMonth() + 1}/${date?.getDate()}/${date?.getFullYear()}`;
 };
 
 export const ErrorHandling = () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ x ] Code is up-to-date with the `master` branch
* [ x ] Your changes are covered by tests (if possible)
* [ x ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
<img width="591" alt="image" src="https://github.com/microsoft/fluentui/assets/2267792/fd57e6ac-4c56-495e-8135-91229210bd50">

Date shown on the input box is not correct, which is one month earlier. 
## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
<img width="519" alt="image" src="https://github.com/microsoft/fluentui/assets/2267792/6d228172-4cf6-4328-9000-4ff4c4d5b402">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29070
