### PR TITLE
feat: Add center aligned positions for Toast

### DIFF
--- a/change/@fluentui-react-toast-dc9d3ea5-c361-420b-ae74-a27cc995e694.json
+++ b/change/@fluentui-react-toast-dc9d3ea5-c361-420b-ae74-a27cc995e694.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add center aligned positions for Toast",
+  "packageName": "@fluentui/react-toast",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -117,7 +117,7 @@ export type ToastOffset = Partial<Record<ToastPosition, ToastOffsetObject>> | To
 export type ToastPoliteness = 'assertive' | 'polite';
 
 // @public (undocumented)
-export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start';
+export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start' | 'top' | 'bottom';
 
 // @public
 export type ToastProps = ComponentProps<ToastSlots> & {

--- a/packages/react-components/react-toast/src/components/Toaster/Toaster.types.ts
+++ b/packages/react-components/react-toast/src/components/Toaster/Toaster.types.ts
@@ -16,6 +16,8 @@ export type ToasterSlotsInternal = ToasterSlots & {
   bottomStart?: Slot<'div'>;
   topEnd?: Slot<'div'>;
   topStart?: Slot<'div'>;
+  top?: Slot<'div'>;
+  bottom?: Slot<'div'>;
 };
 
 /**

--- a/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
@@ -13,17 +13,20 @@ export const renderToaster_unstable = (state: ToasterState) => {
   const { announceRef, renderAriaLive } = state;
   assertSlots<ToasterSlotsInternal>(state);
 
-  const hasToasts = !!state.bottomStart || !!state.bottomEnd || !!state.topStart || !!state.topEnd;
+  const hasToasts =
+    !!state.bottomStart || !!state.bottomEnd || !!state.topStart || !!state.topEnd || !!state.top || !!state.bottom;
 
   return (
     <>
       {renderAriaLive ? <AriaLive announceRef={announceRef} /> : null}
       {hasToasts ? (
         <Portal mountNode={state.mountNode}>
+          {state.bottom ? <state.bottom /> : null}
           {state.bottomStart ? <state.bottomStart /> : null}
           {state.bottomEnd ? <state.bottomEnd /> : null}
           {state.topStart ? <state.topStart /> : null}
           {state.topEnd ? <state.topEnd /> : null}
+          {state.top ? <state.top /> : null}
         </Portal>
       ) : null}
     </>

--- a/packages/react-components/react-toast/src/components/Toaster/useToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/useToaster.tsx
@@ -69,15 +69,26 @@ export const useToaster_unstable = (props: ToasterProps): ToasterState => {
       elementType: 'div',
     });
   };
+
   return {
     dir,
     mountNode,
-    components: { root: 'div', bottomStart: 'div', bottomEnd: 'div', topStart: 'div', topEnd: 'div' },
+    components: {
+      root: 'div',
+      bottomStart: 'div',
+      bottomEnd: 'div',
+      topStart: 'div',
+      topEnd: 'div',
+      top: 'div',
+      bottom: 'div',
+    },
     root: slot.always(rootProps, { elementType: 'div' }),
     bottomStart: usePositionSlot(TOAST_POSITIONS.bottomStart),
     bottomEnd: usePositionSlot(TOAST_POSITIONS.bottomEnd),
     topStart: usePositionSlot(TOAST_POSITIONS.topStart),
     topEnd: usePositionSlot(TOAST_POSITIONS.topEnd),
+    top: usePositionSlot(TOAST_POSITIONS.top),
+    bottom: usePositionSlot(TOAST_POSITIONS.bottom),
     announceRef,
     offset,
     announce: announceProp ?? announce,

--- a/packages/react-components/react-toast/src/components/Toaster/useToasterStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/Toaster/useToasterStyles.styles.ts
@@ -46,5 +46,17 @@ export const useToasterStyles_unstable = (state: ToasterState): ToasterState => 
     Object.assign(state.topEnd.style, getPositionStyles(TOAST_POSITIONS.topEnd, state.dir, state.offset));
   }
 
+  if (state.top) {
+    state.top.className = className;
+    state.top.style ??= {};
+    Object.assign(state.top.style, getPositionStyles(TOAST_POSITIONS.top, state.dir, state.offset));
+  }
+
+  if (state.bottom) {
+    state.bottom.className = className;
+    state.bottom.style ??= {};
+    Object.assign(state.bottom.style, getPositionStyles(TOAST_POSITIONS.bottom, state.dir, state.offset));
+  }
+
   return state;
 };

--- a/packages/react-components/react-toast/src/state/constants.ts
+++ b/packages/react-components/react-toast/src/state/constants.ts
@@ -8,8 +8,10 @@ export const EVENTS = {
 } as const;
 
 export const TOAST_POSITIONS = {
+  bottom: 'bottom',
   bottomEnd: 'bottom-end',
   bottomStart: 'bottom-start',
+  top: 'top',
   topEnd: 'top-end',
   topStart: 'top-start',
 } as const;

--- a/packages/react-components/react-toast/src/state/types.ts
+++ b/packages/react-components/react-toast/src/state/types.ts
@@ -5,7 +5,7 @@ import * as React from 'react';
 export type ToastId = string;
 export type ToasterId = string;
 
-export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start';
+export type ToastPosition = 'top-end' | 'top-start' | 'bottom-end' | 'bottom-start' | 'top' | 'bottom';
 export type ToastPoliteness = 'assertive' | 'polite';
 export type ToastStatus = 'queued' | 'visible' | 'dismissed' | 'unmounted';
 export type ToastIntent = 'info' | 'success' | 'error' | 'warning';

--- a/packages/react-components/react-toast/src/state/vanilla/getPositionStyles.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/getPositionStyles.ts
@@ -20,6 +20,22 @@ export const getPositionStyles = (position: ToastPosition, dir: 'rtl' | 'ltr', o
   const end = dir === 'ltr' ? 'right' : 'left';
 
   switch (position) {
+    case 'top':
+      Object.assign(positionStyles, {
+        top: vertical,
+        left: `calc(50% + ${horizontal}px)`,
+        transform: 'translateX(-50%)',
+      });
+      break;
+
+    case 'bottom':
+      Object.assign(positionStyles, {
+        bottom: vertical,
+        left: `calc(50% + ${horizontal}px)`,
+        transform: 'translateX(-50%)',
+      });
+      break;
+
     case 'top-start':
       Object.assign(positionStyles, {
         top: vertical,

--- a/packages/react-components/react-toast/stories/Toast/Offset.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Offset.stories.tsx
@@ -91,8 +91,10 @@ export const Offset = () => {
         </Field>
         <Field label="Toast position" className={styles.positions}>
           <RadioGroup value={position} onChange={(e, data) => setPosition(data.value as ToastPosition)}>
+            <Radio label="bottom" value="bottom" />
             <Radio label="bottom-start" value="bottom-start" />
             <Radio label="bottom-end" value="bottom-end" />
+            <Radio label="top" value="top" />
             <Radio label="top-start" value="top-start" />
             <Radio label="top-end" value="top-end" />
           </RadioGroup>

--- a/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/ToastPositions.stories.tsx
@@ -15,7 +15,7 @@ import {
 export const ToastPositions = () => {
   const toasterId = useId('toaster');
   const { dispatchToast } = useToastController(toasterId);
-  const [position, setPosition] = React.useState<ToastPosition>('bottom-end');
+  const [position, setPosition] = React.useState<ToastPosition>('top');
   const notify = () =>
     dispatchToast(
       <Toast>
@@ -28,8 +28,10 @@ export const ToastPositions = () => {
     <>
       <Field label="Select a position">
         <RadioGroup value={position} onChange={(e, data) => setPosition(data.value as ToastPosition)}>
+          <Radio label="bottom" value="bottom" />
           <Radio label="bottom-start" value="bottom-start" />
           <Radio label="bottom-end" value="bottom-end" />
+          <Radio label="top" value="top" />
           <Radio label="top-start" value="top-start" />
           <Radio label="top-end" value="top-end" />
         </RadioGroup>


### PR DESCRIPTION
Adds `top` and `bottom` potision for toasts so that they are centre aligned with the viewport

![image](https://github.com/microsoft/fluentui/assets/20744592/67cae380-af36-4bc8-beb3-ca3b16988264)

![image](https://github.com/microsoft/fluentui/assets/20744592/6820486e-20d0-4f93-8ee5-4bbb987ee599)


Fixes #29077