### PR TITLE
feat: react-tree allows control of individual tree item open state

### DIFF
--- a/change/@fluentui-react-components-1ad3aa57-1ce9-452a-9bf1-c63b715c3371.json
+++ b/change/@fluentui-react-components-1ad3aa57-1ce9-452a-9bf1-c63b715c3371.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: react-tree allows control of individual tree item open state",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-275dcd5a-6c13-4b74-8bc7-38031fbca1c2.json
+++ b/change/@fluentui-react-tree-275dcd5a-6c13-4b74-8bc7-38031fbca1c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: react-tree allows control of individual tree item open state",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -866,6 +866,8 @@ import { TreeItemLayoutProps } from '@fluentui/react-tree';
 import { TreeItemLayoutSlots } from '@fluentui/react-tree';
 import { TreeItemLayoutState } from '@fluentui/react-tree';
 import { treeItemLevelToken } from '@fluentui/react-tree';
+import { TreeItemOpenChangeData } from '@fluentui/react-tree';
+import { TreeItemOpenChangeEvent } from '@fluentui/react-tree';
 import { TreeItemPersonaLayout } from '@fluentui/react-tree';
 import { treeItemPersonaLayoutClassNames } from '@fluentui/react-tree';
 import { TreeItemPersonaLayoutProps } from '@fluentui/react-tree';
@@ -2897,6 +2899,10 @@ export { TreeItemLayoutSlots }
 export { TreeItemLayoutState }
 
 export { treeItemLevelToken }
+
+export { TreeItemOpenChangeData }
+
+export { TreeItemOpenChangeEvent }
 
 export { TreeItemPersonaLayout }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1272,6 +1272,8 @@ export type {
   TreeItemSlots,
   TreeItemState,
   TreeItemValue,
+  TreeItemOpenChangeData,
+  TreeItemOpenChangeEvent,
   TreeNavigationData_unstable,
   TreeNavigationEvent_unstable,
   TreeOpenChangeData,

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -190,6 +190,31 @@ export type TreeItemLayoutState = ComponentState<TreeItemLayoutSlots> & {
 // @public (undocumented)
 export const treeItemLevelToken: "--fluent-TreeItem--level";
 
+// @public (undocumented)
+export type TreeItemOpenChangeData = {
+    open: boolean;
+    value: TreeItemValue;
+    target: HTMLElement;
+} & ({
+    event: React_2.MouseEvent<HTMLElement>;
+    type: 'ExpandIconClick';
+} | {
+    event: React_2.MouseEvent<HTMLElement>;
+    type: 'Click';
+} | {
+    event: React_2.KeyboardEvent<HTMLElement>;
+    type: typeof Enter;
+} | {
+    event: React_2.KeyboardEvent<HTMLElement>;
+    type: typeof ArrowRight;
+} | {
+    event: React_2.KeyboardEvent<HTMLElement>;
+    type: typeof ArrowLeft;
+});
+
+// @public (undocumented)
+export type TreeItemOpenChangeEvent = TreeItemOpenChangeData['event'];
+
 // @public
 export const TreeItemPersonaLayout: ForwardRefComponent<TreeItemPersonaLayoutProps>;
 
@@ -217,6 +242,8 @@ export type TreeItemPersonaLayoutState = ComponentState<TreeItemPersonaLayoutSlo
 export type TreeItemProps = ComponentProps<Partial<TreeItemSlots>> & {
     itemType: TreeItemType;
     value?: TreeItemValue;
+    open?: boolean;
+    onOpenChange?: (e: TreeItemOpenChangeEvent, data: TreeItemOpenChangeData) => void;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
@@ -239,4 +239,130 @@ describe('Tree', () => {
       });
     });
   });
+
+  describe('Control open state per item', () => {
+    it('should remain open when opening/closing a controlled item', () => {
+      const OpenItemControlled = () => {
+        return (
+          <Tree aria-label="Open Item Controlled">
+            <TreeItem open itemType="branch" value="tree-item-1" data-testid="tree-item-1">
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <Tree>
+                <TreeItem value="tree-item-1-1" data-testid="tree-item-1-1" itemType="leaf">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                </TreeItem>
+                <TreeItem value="tree-tem-1-2" data-testid="tree-tem-1-2" itemType="leaf">
+                  <TreeItemLayout>level 2, item 2</TreeItemLayout>
+                </TreeItem>
+                <TreeItem value="tree-item-1-3" data-testid="tree-item-1-3" itemType="leaf">
+                  <TreeItemLayout>level 2, item 3</TreeItemLayout>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+            <TreeItem itemType="branch" value="tree-item-2" data-testid="tree-item-2">
+              <TreeItemLayout>level 1, item 2</TreeItemLayout>
+              <Tree>
+                <TreeItem value="tree-item-2-1" data-testid="tree-item-2-1" itemType="branch">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                  <Tree>
+                    <TreeItem itemType="leaf">
+                      <TreeItemLayout>level 3, item 1</TreeItemLayout>
+                    </TreeItem>
+                  </Tree>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+          </Tree>
+        );
+      };
+      mount(<OpenItemControlled />);
+      cy.get('[data-testid="tree-item-1"]').should('exist');
+      cy.get('[data-testid="tree-item-2"]').should('exist');
+      cy.get('[data-testid="tree-item-2-1"]').should('not.exist');
+      cy.get('[data-testid="tree-item-1-1"]').should('exist');
+      cy.get('[data-testid="tree-item-1"]').realClick();
+      cy.get('[data-testid="tree-item-1-1"]').should('exist');
+    });
+    it('should remain closed when opening/closing a controlled item', () => {
+      const OpenItemControlled = () => {
+        return (
+          <Tree aria-label="Open Item Controlled">
+            <TreeItem open={false} itemType="branch" data-testid="tree-item-1" value="tree-item-1">
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <Tree>
+                <TreeItem data-testid="tree-item-1-1" value="tree-item-1-1" itemType="leaf">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                </TreeItem>
+                <TreeItem data-testid="tree-tem-1-2" value="tree-tem-1-2" itemType="leaf">
+                  <TreeItemLayout>level 2, item 2</TreeItemLayout>
+                </TreeItem>
+                <TreeItem data-testid="tree-item-1-3" value="tree-item-1-3" itemType="leaf">
+                  <TreeItemLayout>level 2, item 3</TreeItemLayout>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+            <TreeItem itemType="branch" data-testid="tree-item-2" value="tree-item-2">
+              <TreeItemLayout>level 1, item 2</TreeItemLayout>
+              <Tree>
+                <TreeItem data-testid="tree-item-2-1" value="tree-item-2-1" itemType="branch">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                  <Tree>
+                    <TreeItem data-testid="tree-item-2-1-1" value="tree-item-2-1-1" itemType="leaf">
+                      <TreeItemLayout>level 3, item 1</TreeItemLayout>
+                    </TreeItem>
+                  </Tree>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+          </Tree>
+        );
+      };
+      mount(<OpenItemControlled />);
+      cy.get('[data-testid="tree-item-1"]').should('exist');
+      cy.get('[data-testid="tree-item-1-1"]').should('not.exist');
+      cy.get('[data-testid="tree-item-1"]').realClick();
+      cy.get('[data-testid="tree-item-1-1"]').should('not.exist');
+    });
+    it('should not affect other items open state when opening/closing a controlled item', () => {
+      const OpenItemControlled = () => {
+        return (
+          <Tree aria-label="Open Item Controlled">
+            <TreeItem open={false} itemType="branch" data-testid="tree-item-1" value="tree-item-1">
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <Tree>
+                <TreeItem data-testid="tree-item-1-1" value="tree-item-1-1" itemType="leaf">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                </TreeItem>
+                <TreeItem data-testid="tree-tem-1-2" value="tree-tem-1-2" itemType="leaf">
+                  <TreeItemLayout>level 2, item 2</TreeItemLayout>
+                </TreeItem>
+                <TreeItem data-testid="tree-item-1-3" value="tree-item-1-3" itemType="leaf">
+                  <TreeItemLayout>level 2, item 3</TreeItemLayout>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+            <TreeItem open={true} itemType="branch" data-testid="tree-item-2" value="tree-item-2">
+              <TreeItemLayout>level 1, item 2</TreeItemLayout>
+              <Tree>
+                <TreeItem data-testid="tree-item-2-1" value="tree-item-2-1" itemType="branch">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                  <Tree>
+                    <TreeItem data-testid="tree-item-2-1-1" value="tree-item-2-1-1" itemType="leaf">
+                      <TreeItemLayout>level 3, item 1</TreeItemLayout>
+                    </TreeItem>
+                  </Tree>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+          </Tree>
+        );
+      };
+      mount(<OpenItemControlled />);
+      cy.get('[data-testid="tree-item-2"]').should('exist');
+      cy.get('[data-testid="tree-item-2-1"]').should('exist');
+      cy.get('[data-testid="tree-item-2-1-1"]').should('not.exist');
+      cy.get('[data-testid="tree-item-2-1"]').realClick();
+      cy.get('[data-testid="tree-item-2-1-1"]').should('exist');
+    });
+  });
 });

--- a/packages/react-components/react-tree/src/components/TreeItem/TreeItem.test.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/TreeItem.test.tsx
@@ -12,7 +12,7 @@ describe('TreeItem', () => {
     getTargetElement(renderResult, attr) {
       return renderResult.container.querySelector(`.${treeItemClassNames.root}`) ?? renderResult.container;
     },
-    disabledTests: ['component-has-static-classnames-object'],
+    disabledTests: ['component-has-static-classnames-object', 'consistent-callback-args'],
     testOptions: {
       'has-static-classnames': [
         {

--- a/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts
@@ -1,7 +1,8 @@
+import * as React from 'react';
+import type { ArrowLeft, ArrowRight, Enter } from '@fluentui/keyboard-keys';
 import type { ComponentProps, ComponentState, ExtractSlotProps, Slot } from '@fluentui/react-utilities';
 import type { TreeItemContextValue } from '../../contexts';
-import { treeItemLevelToken } from '../../utils/tokens';
-import * as React from 'react';
+import type { treeItemLevelToken } from '../../utils/tokens';
 
 export type TreeItemCSSProperties = React.CSSProperties & { [treeItemLevelToken]?: string | number };
 
@@ -17,6 +18,20 @@ export type TreeItemContextValues = {
   treeItem: TreeItemContextValue;
 };
 
+export type TreeItemOpenChangeData = {
+  open: boolean;
+  value: TreeItemValue;
+  target: HTMLElement;
+} & (
+  | { event: React.MouseEvent<HTMLElement>; type: 'ExpandIconClick' }
+  | { event: React.MouseEvent<HTMLElement>; type: 'Click' }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof Enter }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }
+);
+
+export type TreeItemOpenChangeEvent = TreeItemOpenChangeData['event'];
+
 /**
  * TreeItem Props
  */
@@ -25,7 +40,21 @@ export type TreeItemProps = ComponentProps<Partial<TreeItemSlots>> & {
    * A tree item can be a leaf or a branch
    */
   itemType: TreeItemType;
+  /**
+   * A tree item should have a well defined value, in case one is not provided by the user by this prop
+   * one will be inferred internally.
+   */
   value?: TreeItemValue;
+  /**
+   * Whether the tree item is in an open state
+   *
+   * This overrides the open value provided by the root tree,
+   * and ensure control of the visibility of the tree item per tree item.
+   *
+   * NOTE: controlling the open state of a tree item will not affect the open state of its children
+   */
+  open?: boolean;
+  onOpenChange?: (e: TreeItemOpenChangeEvent, data: TreeItemOpenChangeData) => void;
 };
 
 /**

--- a/packages/react-components/react-tree/src/contexts/treeContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeContext.ts
@@ -20,7 +20,7 @@ export type TreeContextValue = {
 
 export type TreeItemRequest = { itemType: TreeItemType } & (
   | OmitWithoutExpanding<TreeOpenChangeData, 'open' | 'openItems'>
-  | TreeNavigationData_unstable
+  | OmitWithoutExpanding<TreeNavigationData_unstable, 'preventInternals'>
   | OmitWithoutExpanding<TreeCheckedChangeData, 'selectionMode' | 'checkedItems'>
 );
 

--- a/packages/react-components/react-tree/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/src/hooks/useSubtree.ts
@@ -13,7 +13,6 @@ export function useSubtree(props: Pick<TreeProps, 'appearance' | 'size'>, ref: R
   const contextAppearance = useTreeContext_unstable(ctx => ctx.appearance);
   const contextSize = useTreeContext_unstable(ctx => ctx.size);
   const subtreeRef = useTreeItemContext_unstable(ctx => ctx.subtreeRef);
-  const value = useTreeItemContext_unstable(ctx => ctx.value);
 
   const { appearance = contextAppearance ?? 'subtle', size = contextSize ?? 'medium' } = props;
 
@@ -23,7 +22,7 @@ export function useSubtree(props: Pick<TreeProps, 'appearance' | 'size'>, ref: R
   const checkedItems = useTreeContext_unstable(ctx => ctx.checkedItems);
   const requestTreeResponse = useTreeContext_unstable(ctx => ctx.requestTreeResponse);
 
-  const open = openItems.has(value);
+  const open = useTreeItemContext_unstable(ctx => ctx.open);
 
   return {
     open,

--- a/packages/react-components/react-tree/src/index.ts
+++ b/packages/react-components/react-tree/src/index.ts
@@ -54,7 +54,14 @@ export {
   useTreeItemContextValues_unstable,
   useTreeItem_unstable,
 } from './TreeItem';
-export type { TreeItemProps, TreeItemState, TreeItemSlots, TreeItemValue } from './TreeItem';
+export type {
+  TreeItemProps,
+  TreeItemState,
+  TreeItemSlots,
+  TreeItemValue,
+  TreeItemOpenChangeData,
+  TreeItemOpenChangeEvent,
+} from './TreeItem';
 
 export {
   TreeItemLayout,

--- a/packages/react-components/react-tree/stories/Tree/OpenItemControlled.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/OpenItemControlled.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {
+  Tree,
+  TreeItem,
+  TreeItemLayout,
+  TreeItemOpenChangeData,
+  TreeItemOpenChangeEvent,
+} from '@fluentui/react-components';
+
+export const OpenItemControlled = () => {
+  const [open, setOpen] = React.useState(true);
+  const handleOpenChange = (event: TreeItemOpenChangeEvent, data: TreeItemOpenChangeData) => {
+    setOpen(data.open);
+  };
+  return (
+    <Tree aria-label="Open Item Controlled">
+      <TreeItem open={open} onOpenChange={handleOpenChange} itemType="branch" value="tree-item-1">
+        <TreeItemLayout>level 1, item 1</TreeItemLayout>
+        <Tree>
+          <TreeItem itemType="leaf">
+            <TreeItemLayout>level 2, item 1</TreeItemLayout>
+          </TreeItem>
+          <TreeItem itemType="leaf">
+            <TreeItemLayout>level 2, item 2</TreeItemLayout>
+          </TreeItem>
+          <TreeItem itemType="leaf">
+            <TreeItemLayout>level 2, item 3</TreeItemLayout>
+          </TreeItem>
+        </Tree>
+      </TreeItem>
+      <TreeItem itemType="branch" value="tree-item-2">
+        <TreeItemLayout>level 1, item 2</TreeItemLayout>
+        <Tree>
+          <TreeItem itemType="branch" value="tree-item-3">
+            <TreeItemLayout>level 2, item 1</TreeItemLayout>
+            <Tree>
+              <TreeItem itemType="leaf">
+                <TreeItemLayout>level 3, item 1</TreeItemLayout>
+              </TreeItem>
+            </Tree>
+          </TreeItem>
+        </Tree>
+      </TreeItem>
+    </Tree>
+  );
+};
+
+OpenItemControlled.parameters = {
+  docs: {
+    description: {
+      story: `
+You can also control the open/closed state of a single \`TreeItem\` component directly. This will override the internal value of \`openItems\` in favor of the \`open\` property.
+
+> Note: It's not recommended to use both \`openItems\` and \`open\` at the same time, as this can lead to unexpected behavior! Stick to one or the other.
+      `,
+    },
+  },
+};

--- a/packages/react-components/react-tree/stories/Tree/index.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/index.stories.tsx
@@ -17,6 +17,7 @@ export { Actions } from './TreeActions.stories';
 // FUNCTIONAL EXAMPLES
 export { DefaultOpen } from './TreeDefaultOpen.stories';
 export { OpenItemsControlled } from './OpenItemsControlled.stories';
+export { OpenItemControlled } from './OpenItemControlled.stories';
 export { CustomizingInteraction } from './TreeCustomizingInteraction.stories';
 export { InlineStylingTreeItemLevel } from './TreeInlineStylingTreeItemLevel.stories';
 export { FlatTree } from './FlatTree.stories';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. Allows control of open state per tree item
2. adds story on the new control case for nested tree
3. adds cypress test on the new control case for the nested tree

## TODO

1. update `useHeadlessFlatTree` hook to support controlling the open state of a single tree item (perhaps a `useHeadlessFlatTreeItem` hook?)
