### PR TITLE
feat(Toaster): Adds `inline` prop

### DIFF
--- a/change/@fluentui-react-toast-4eae7e9f-93a7-4029-9e40-b47e89a6d12c.json
+++ b/change/@fluentui-react-toast-4eae7e9f-93a7-4029-9e40-b47e89a6d12c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(Toaster): Adds `inline` prop",
+  "packageName": "@fluentui/react-toast",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toast/etc/react-toast.api.md
+++ b/packages/react-components/react-toast/etc/react-toast.api.md
@@ -73,6 +73,7 @@ export const toasterClassNames: SlotClassNames<ToasterSlots>;
 // @public
 export type ToasterProps = Omit<ComponentProps<ToasterSlots>, 'children'> & Partial<ToasterOptions> & Pick<PortalProps, 'mountNode'> & {
     announce?: Announce;
+    inline?: boolean;
 };
 
 // @public (undocumented)
@@ -81,7 +82,7 @@ export type ToasterSlots = {
 };
 
 // @public
-export type ToasterState = ComponentState<ToasterSlotsInternal> & Pick<AriaLiveProps, 'announceRef'> & Pick<PortalProps, 'mountNode'> & Pick<Required<ToasterProps>, 'announce'> & {
+export type ToasterState = ComponentState<ToasterSlotsInternal> & Pick<AriaLiveProps, 'announceRef'> & Pick<PortalProps, 'mountNode'> & Pick<Required<ToasterProps>, 'announce' | 'inline'> & {
     offset: ToasterOptions['offset'] | undefined;
     renderAriaLive: boolean;
     dir: 'rtl' | 'ltr';

--- a/packages/react-components/react-toast/src/components/Toast/Toast.cy.tsx
+++ b/packages/react-components/react-toast/src/components/Toast/Toast.cy.tsx
@@ -733,4 +733,34 @@ describe('Toast', () => {
 
     cy.get(`.${toastContainerClassNames.root}`).should('not.exist').get('#make').should('be.focused');
   });
+
+  it('should render toasts in DOM order', () => {
+    const Example = () => {
+      const { dispatchToast } = useToastController();
+      const onClick = () => {
+        dispatchToast(
+          <Toast>
+            <ToastTitle>This is a toast</ToastTitle>
+          </Toast>,
+        );
+      };
+
+      return (
+        <>
+          <button onClick={onClick}>Make toast</button>
+          <div id="container">
+            <Toaster inline />
+          </div>
+        </>
+      );
+    };
+
+    mount(<Example />);
+    cy.get('button')
+      .click()
+      .get(`#container .${toastClassNames.root}`)
+      .should('exist')
+      .get(`body .${toastClassNames.root}`)
+      .should('not.exist');
+  });
 });

--- a/packages/react-components/react-toast/src/components/Toaster/Toaster.types.ts
+++ b/packages/react-components/react-toast/src/components/Toaster/Toaster.types.ts
@@ -30,6 +30,8 @@ export type ToasterProps = Omit<ComponentProps<ToasterSlots>, 'children'> &
      * User override API for aria-live narration for toasts
      */
     announce?: Announce;
+
+    inline?: boolean;
   };
 
 /**
@@ -38,7 +40,7 @@ export type ToasterProps = Omit<ComponentProps<ToasterSlots>, 'children'> &
 export type ToasterState = ComponentState<ToasterSlotsInternal> &
   Pick<AriaLiveProps, 'announceRef'> &
   Pick<PortalProps, 'mountNode'> &
-  Pick<Required<ToasterProps>, 'announce'> & {
+  Pick<Required<ToasterProps>, 'announce' | 'inline'> & {
     offset: ToasterOptions['offset'] | undefined;
     renderAriaLive: boolean;
     dir: 'rtl' | 'ltr';

--- a/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
@@ -10,43 +10,37 @@ import { AriaLive } from '../AriaLive';
  * Render the final JSX of Toaster
  */
 export const renderToaster_unstable = (state: ToasterState) => {
-  const { announceRef, renderAriaLive } = state;
+  const { announceRef, renderAriaLive, inline, mountNode } = state;
   assertSlots<ToasterSlotsInternal>(state);
 
   const hasToasts =
     !!state.bottomStart || !!state.bottomEnd || !!state.topStart || !!state.topEnd || !!state.top || !!state.bottom;
 
-  if (state.inline) {
+  const ariaLive = renderAriaLive ? <AriaLive announceRef={announceRef} /> : null;
+  const positionSlots = (
+    <>
+      {state.bottom ? <state.bottom /> : null}
+      {state.bottomStart ? <state.bottomStart /> : null}
+      {state.bottomEnd ? <state.bottomEnd /> : null}
+      {state.topStart ? <state.topStart /> : null}
+      {state.topEnd ? <state.topEnd /> : null}
+      {state.top ? <state.top /> : null}
+    </>
+  );
+
+  if (inline) {
     return (
       <>
-        {renderAriaLive ? <AriaLive announceRef={announceRef} /> : null}
-        {hasToasts ? (
-          <>
-            {state.bottom ? <state.bottom /> : null}
-            {state.bottomStart ? <state.bottomStart /> : null}
-            {state.bottomEnd ? <state.bottomEnd /> : null}
-            {state.topStart ? <state.topStart /> : null}
-            {state.topEnd ? <state.topEnd /> : null}
-            {state.top ? <state.top /> : null}
-          </>
-        ) : null}
+        {ariaLive}
+        {hasToasts ? positionSlots : null}
       </>
     );
   }
 
   return (
     <>
-      {renderAriaLive ? <AriaLive announceRef={announceRef} /> : null}
-      {hasToasts ? (
-        <Portal mountNode={state.mountNode}>
-          {state.bottom ? <state.bottom /> : null}
-          {state.bottomStart ? <state.bottomStart /> : null}
-          {state.bottomEnd ? <state.bottomEnd /> : null}
-          {state.topStart ? <state.topStart /> : null}
-          {state.topEnd ? <state.topEnd /> : null}
-          {state.top ? <state.top /> : null}
-        </Portal>
-      ) : null}
+      {ariaLive}
+      {hasToasts ? <Portal mountNode={mountNode}>{positionSlots}</Portal> : null}
     </>
   );
 };

--- a/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/renderToaster.tsx
@@ -16,6 +16,24 @@ export const renderToaster_unstable = (state: ToasterState) => {
   const hasToasts =
     !!state.bottomStart || !!state.bottomEnd || !!state.topStart || !!state.topEnd || !!state.top || !!state.bottom;
 
+  if (state.inline) {
+    return (
+      <>
+        {renderAriaLive ? <AriaLive announceRef={announceRef} /> : null}
+        {hasToasts ? (
+          <>
+            {state.bottom ? <state.bottom /> : null}
+            {state.bottomStart ? <state.bottomStart /> : null}
+            {state.bottomEnd ? <state.bottomEnd /> : null}
+            {state.topStart ? <state.topStart /> : null}
+            {state.topEnd ? <state.topEnd /> : null}
+            {state.top ? <state.top /> : null}
+          </>
+        ) : null}
+      </>
+    );
+  }
+
   return (
     <>
       {renderAriaLive ? <AriaLive announceRef={announceRef} /> : null}

--- a/packages/react-components/react-toast/src/components/Toaster/useToaster.tsx
+++ b/packages/react-components/react-toast/src/components/Toaster/useToaster.tsx
@@ -23,7 +23,7 @@ import { useToastAnnounce } from './useToastAnnounce';
  * @param props - props from this instance of Toaster
  */
 export const useToaster_unstable = (props: ToasterProps): ToasterState => {
-  const { offset, announce: announceProp, mountNode, ...rest } = props;
+  const { offset, announce: announceProp, mountNode, inline = false, ...rest } = props;
   const announceRef = React.useRef<Announce>(() => null);
   const { toastsToRender, isToastVisible, pauseAllToasts, playAllToasts, tryRestoreFocus, closeAllToasts } =
     useToaster<HTMLDivElement>(rest);
@@ -93,5 +93,6 @@ export const useToaster_unstable = (props: ToasterProps): ToasterState => {
     offset,
     announce: announceProp ?? announce,
     renderAriaLive: !announceProp,
+    inline,
   };
 };

--- a/packages/react-components/react-toast/src/components/Toaster/useToasterStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/Toaster/useToasterStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { ToasterSlots, ToasterState } from './Toaster.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { TOAST_POSITIONS, getPositionStyles } from '../../state/index';
@@ -16,12 +16,24 @@ const useRootBaseClassName = makeResetStyles({
   pointerEvents: 'none',
 });
 
+const useToasterStyles = makeStyles({
+  inline: {
+    position: 'absolute',
+  },
+});
+
 /**
  * Apply styling to the Toaster slots based on the state
  */
 export const useToasterStyles_unstable = (state: ToasterState): ToasterState => {
   const rootBaseClassName = useRootBaseClassName();
-  const className = mergeClasses(toasterClassNames.root, rootBaseClassName, state.root.className);
+  const styles = useToasterStyles();
+  const className = mergeClasses(
+    toasterClassNames.root,
+    rootBaseClassName,
+    state.inline && styles.inline,
+    state.root.className,
+  );
   if (state.bottomStart) {
     state.bottomStart.className = className;
     state.bottomStart.style ??= {};

--- a/packages/react-components/react-toast/src/state/vanilla/getPositionStyles.test.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/getPositionStyles.test.ts
@@ -1,0 +1,52 @@
+import { getPositionStyles } from './getPositionStyles';
+
+describe('getPositionStyles', () => {
+  it.each([
+    ['bottom', 'ltr', { bottom: 16, left: 'calc(50% + 0px)', transform: 'translateX(-50%)' }],
+    ['bottom-end', 'ltr', { bottom: 16, right: 20 }],
+    ['bottom-start', 'ltr', { bottom: 16, left: 20 }],
+    ['top', 'ltr', { top: 16, left: 'calc(50% + 0px)', transform: 'translateX(-50%)' }],
+    ['top-end', 'ltr', { top: 16, right: 20 }],
+    ['top-start', 'ltr', { top: 16, left: 20 }],
+    ['bottom', 'rtl', { bottom: 16, left: 'calc(50% + 0px)', transform: 'translateX(-50%)' }],
+    ['bottom-end', 'rtl', { bottom: 16, left: 20 }],
+    ['bottom-start', 'rtl', { bottom: 16, right: 20 }],
+    ['top', 'rtl', { top: 16, left: 'calc(50% + 0px)', transform: 'translateX(-50%)' }],
+    ['top-end', 'rtl', { top: 16, left: 20 }],
+    ['top-start', 'rtl', { top: 16, right: 20 }],
+  ] as const)('should return default styles for %s with text direction %s', (position, dir, expected) => {
+    expect(getPositionStyles(position, dir)).toEqual(expected);
+  });
+
+  it('should handle offset shorthand', () => {
+    expect(getPositionStyles('bottom-end', 'ltr', { horizontal: 1, vertical: 1 })).toEqual({
+      bottom: 1,
+      right: 1,
+    });
+  });
+
+  it('should handle offset long hand', () => {
+    expect(
+      getPositionStyles('bottom-end', 'ltr', {
+        'bottom-end': { horizontal: 1, vertical: 1 },
+        'bottom-start': { horizontal: 2, vertical: 2 },
+      }),
+    ).toEqual({
+      bottom: 1,
+      right: 1,
+    });
+  });
+
+  it('should handle offset for centered positions', () => {
+    expect(
+      getPositionStyles('bottom', 'ltr', {
+        horizontal: 1,
+        vertical: 1,
+      }),
+    ).toEqual({
+      bottom: 1,
+      left: 'calc(50% + 1px)',
+      transform: 'translateX(-50%)',
+    });
+  });
+});

--- a/packages/react-components/react-toast/src/state/vanilla/getPositionStyles.ts
+++ b/packages/react-components/react-toast/src/state/vanilla/getPositionStyles.ts
@@ -1,7 +1,6 @@
 import { ToastOffsetObject, ToastOffset, ToastPosition } from '../types';
 
 interface PositionStyles {
-  position: 'fixed';
   top?: number;
   left?: number;
   right?: number;
@@ -9,13 +8,13 @@ interface PositionStyles {
 }
 
 export const getPositionStyles = (position: ToastPosition, dir: 'rtl' | 'ltr', offset?: ToastOffset) => {
-  const positionStyles: PositionStyles = {
-    position: 'fixed',
-  };
+  const positionStyles: PositionStyles = {};
 
   const offsetStyles: ToastOffsetObject = offset ? (isShorthandOffset(offset) ? offset : offset[position] ?? {}) : {};
 
-  const { horizontal = 20, vertical = 16 } = offsetStyles;
+  const centered = position === 'top' || position === 'bottom';
+
+  const { horizontal = centered ? 0 : 20, vertical = 16 } = offsetStyles;
   const start = dir === 'ltr' ? 'left' : 'right';
   const end = dir === 'ltr' ? 'right' : 'left';
 

--- a/packages/react-components/react-toast/stories/Toast/Inline.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/Inline.stories.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import {
+  useId,
+  Link,
+  Button,
+  Toaster,
+  useToastController,
+  Toast,
+  ToastTitle,
+  Text,
+  makeStyles,
+  shorthands,
+} from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  container: {
+    ...shorthands.border('2px', 'dashed', 'green'),
+    height: '500px',
+    width: '500px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+    marginTop: '20px',
+  },
+});
+
+export const Inline = () => {
+  const styles = useStyles();
+  const toasterId = useId('toaster');
+  const { dispatchToast } = useToastController(toasterId);
+  const notify = () =>
+    dispatchToast(
+      <Toast>
+        <ToastTitle action={<Link>Undo</Link>}>Email sent</ToastTitle>
+      </Toast>,
+      { intent: 'success' },
+    );
+
+  return (
+    <>
+      <Button onClick={notify}>Make toast</Button>
+      <div className={styles.container}>
+        <Text weight="bold">Toasts appear here</Text>
+
+        <Toaster inline toasterId={toasterId} position="bottom" />
+      </div>
+    </>
+  );
+};
+
+Inline.parameters = {
+  docs: {
+    description: {
+      story: [
+        'Setting the `inline` prop on a toaster will render toasts in DOM order, positioned relative to the closest',
+        'positioned ancestor. The simplest way to achieve this is to render the toaster inside an element',
+        'with `position: relavtive`.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-toast/stories/Toast/index.stories.tsx
+++ b/packages/react-components/react-toast/stories/Toast/index.stories.tsx
@@ -18,6 +18,7 @@ export { ToastLifecycle } from './ToastLifecycle.stories';
 export { MultipleToasters } from './MultipleToasters.stories';
 export { ToasterLimit } from './ToasterLimit.stories';
 export { FocusKeyboardShortcut } from './FocusKeyboardShortcut.stories';
+export { Inline } from './Inline.stories';
 
 import descriptionMd from './ToastDescription.md';
 


### PR DESCRIPTION
Adds the `inline` prop to the Toaster. This will render the toasts in DOM order instead of in a portal.

The positioning of the toasts will be relative to the closest positioned ancestor.

![image](https://github.com/microsoft/fluentui/assets/20744592/3213d71a-303f-4da4-9482-a9ec1351bf27)


Fixes #29078
