### PR TITLE
chore(react-tags-preview): tiny fixes to make stories more accessible

### DIFF
--- a/packages/react-components/react-tags-preview/stories/InteractionTag/InteractionTagHasPrimaryAction.stories.tsx
+++ b/packages/react-components/react-tags-preview/stories/InteractionTag/InteractionTagHasPrimaryAction.stories.tsx
@@ -19,7 +19,7 @@ export const HasPrimaryAction = () => {
   const toggleSecondary = () => setLiked(v => !v);
   return (
     <InteractionTag>
-      <Popover>
+      <Popover trapFocus>
         <PopoverTrigger>
           <InteractionTagPrimary hasSecondaryAction id="golden-retriever-primary">
             golden retriever

--- a/packages/react-components/react-tags-preview/stories/TagGroup/TagGroupOverflow.stories.tsx
+++ b/packages/react-components/react-tags-preview/stories/TagGroup/TagGroupOverflow.stories.tsx
@@ -43,6 +43,7 @@ const defaultItems: DefaultItem[] = names.map(name => ({
   children: name,
   media: (
     <Avatar
+      aria-hidden="true" // use aria-hidden because InteractionTag contains information in the avatar
       name={name}
       badge={{
         status: 'available',


### PR DESCRIPTION
1. add aria-hidden to TagGroup overflow story:
<img width="311" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/f927bd7f-e202-416f-8320-ba0b3eace9fe">
 
| Before  |  After |   
|---|---| 
|  <img width="1383" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/71f25b46-6496-487c-81b2-ccd6de86ee04"> duplicated info in a11y name, coming from avatar and tag itself  | <img width="735" alt="Screenshot 2023-09-07 at 10 50 38" src="https://github.com/microsoft/fluentui/assets/28751745/0a008938-7669-4403-808a-891f0a96dcd7"> no duplicated info  |    


2. add `TrapFocus` to InteractionTag with popover story because the popover has focusable inside:
<img width="409" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/b22e9d9f-39a8-4646-825f-9c72a0d335f7">

 


