### PR TITLE
Fix Breadcrumb icon spacing

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-3e3c117d-535c-4eb4-8b75-7c46c919bc35.json
+++ b/change/@fluentui-react-breadcrumb-preview-3e3c117d-535c-4eb4-8b75-7c46c919bc35.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: icon spacing in Breadcrumb",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
@@ -29,6 +29,7 @@ const useStyles = makeStyles({
   root: {
     minWidth: 'unset',
     textWrap: 'nowrap',
+    ...shorthands.border('none'),
   },
   small: {
     height: '24px',
@@ -73,6 +74,7 @@ const useIconStyles = makeStyles({
     height: `var(${breadcrumbCSSVars.breadcrumbIconSizeVar})`,
     lineHeight: `var(${breadcrumbCSSVars.breadcrumbIconLineHeightVar})`,
     width: `var(${breadcrumbCSSVars.breadcrumbIconSizeVar})`,
+    marginRight: tokens.spacingHorizontalXS,
   },
   small: {
     [breadcrumbCSSVars.breadcrumbIconSizeVar]: '12px',

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
@@ -20,9 +20,10 @@ const useStyles = makeStyles({
     textWrap: 'nowrap',
   },
   icon: {
-    display: 'flex',
+    display: 'inline-flex',
     alignItems: 'center',
-    ...shorthands.padding(tokens.spacingHorizontalXS),
+    justifyContent: 'center',
+    marginRight: tokens.spacingHorizontalXS,
   },
   small: {
     height: '24px',


### PR DESCRIPTION
Fix icon spacing in Breadcrumb

## New Behavior
![image](https://github.com/microsoft/fluentui/assets/11574680/9bc0197a-3cd2-4b66-af9d-da325b3c2f5d)
