### PR TITLE
chore: stop using global document on HTMLElementWalker

### DIFF
--- a/change/@fluentui-react-tree-fb4c3a51-f9a9-404f-afa0-ae81c66b53e9.json
+++ b/change/@fluentui-react-tree-fb4c3a51-f9a9-404f-afa0-ae81c66b53e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: stop using global document on HTMLElementWalker",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
@@ -20,6 +20,7 @@ import {
 } from '../Tree/Tree.types';
 import { HTMLElementWalker, createHTMLElementWalker } from '../../utils/createHTMLElementWalker';
 import { treeItemFilter } from '../../utils/treeItemFilter';
+import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 
 export type HeadlessFlatTreeItemProps = HeadlessTreeItemProps;
 export type HeadlessFlatTreeItem<Props extends HeadlessFlatTreeItemProps> = HeadlessTreeItem<Props>;
@@ -119,15 +120,16 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
   const [openItems, setOpenItems] = useControllableOpenItems(options);
   const [checkedItems, setCheckedItems] = useFlatControllableCheckedItems(options, headlessTree);
   const { initialize, navigate } = useFlatTreeNavigation(headlessTree);
+  const { targetDocument } = useFluent_unstable();
   const walkerRef = React.useRef<HTMLElementWalker>();
   const initializeWalker = React.useCallback(
     (root: HTMLElement | null) => {
-      if (root) {
-        walkerRef.current = createHTMLElementWalker(root, treeItemFilter);
+      if (root && targetDocument) {
+        walkerRef.current = createHTMLElementWalker(root, targetDocument, treeItemFilter);
         initialize(walkerRef.current);
       }
     },
-    [initialize],
+    [initialize, targetDocument],
   );
 
   const treeRef = React.useRef<HTMLDivElement>(null);

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -18,6 +18,7 @@ import { useSubtree } from '../../hooks/useSubtree';
 import { HTMLElementWalker, createHTMLElementWalker } from '../../utils/createHTMLElementWalker';
 import { treeItemFilter } from '../../utils/treeItemFilter';
 import { useTreeNavigation } from './useTreeNavigation';
+import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 
 export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>): TreeState => {
   const isSubtree = useTreeContext_unstable(ctx => ctx.level > 0);
@@ -32,14 +33,15 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
   const checkedItems = useNestedCheckedItems(props);
   const { navigate, initialize } = useTreeNavigation();
   const walkerRef = React.useRef<HTMLElementWalker>();
+  const { targetDocument } = useFluent_unstable();
   const initializeWalker = React.useCallback(
     (root: HTMLElement | null) => {
-      if (root) {
-        walkerRef.current = createHTMLElementWalker(root, treeItemFilter);
+      if (root && targetDocument) {
+        walkerRef.current = createHTMLElementWalker(root, targetDocument, treeItemFilter);
         initialize(walkerRef.current);
       }
     },
-    [initialize],
+    [initialize, targetDocument],
   );
 
   const handleOpenChange = useEventCallback((event: TreeOpenChangeEvent, data: TreeOpenChangeData) => {

--- a/packages/react-components/react-tree/src/utils/createHTMLElementWalker.ts
+++ b/packages/react-components/react-tree/src/utils/createHTMLElementWalker.ts
@@ -16,10 +16,11 @@ export type HTMLElementFilter = (element: HTMLElement) => number;
 
 export function createHTMLElementWalker(
   root: HTMLElement,
+  targetDocument: Document,
   filter: HTMLElementFilter = () => NodeFilter.FILTER_ACCEPT,
 ): HTMLElementWalker {
   let temporaryFilter: HTMLElementFilter | undefined;
-  const treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
+  const treeWalker = targetDocument.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
     acceptNode(node: Node) {
       if (!isHTMLElement(node)) {
         return NodeFilter.FILTER_REJECT;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Removes usage of global document from `@fluentui/react-tree`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
