### PR TITLE
fix: don't apply modalizer attributes when focus trap isn't configured

### DIFF
--- a/change/@fluentui-react-popover-a88a6d1a-e63c-4c03-8d58-35b1065c4396.json
+++ b/change/@fluentui-react-popover-a88a6d1a-e63c-4c03-8d58-35b1065c4396.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: don't apply modalizer attributes when focus trap isn't configured",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-74dae66a-2abe-42d2-87f7-515c21ea4a3e.json
+++ b/change/@fluentui-react-tabster-74dae66a-2abe-42d2-87f7-515c21ea4a3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: don't apply modalizer attributes when focus trap isn't configured",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
@@ -541,4 +541,31 @@ describe('Popover', () => {
         .should('have.length', 2);
     });
   });
+
+  describe('Without trapFocus', () => {
+    it('should restore focus on close', () => {
+      mount(
+        <Popover>
+          <PopoverTrigger>
+            <button id="trigger">trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface>
+            <button id="button">button</button>
+          </PopoverSurface>
+        </Popover>,
+      );
+
+      cy.get('#trigger')
+        .click()
+        .get(popoverContentSelector)
+        .should('exist')
+        .get('#button')
+        .focus()
+        .type('{esc}')
+        .get(popoverContentSelector)
+        .should('not.exist')
+        .get('#trigger')
+        .should('have.focus');
+    });
+  });
 });

--- a/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/__snapshots__/PopoverSurface.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`PopoverSurface renders a default state 1`] = `
 <div
   aria-label="test"
   class="fui-PopoverSurface"
+  data-tabster="{\\"restorer\\":{\\"type\\":0}}"
   data-testid="component"
   role="group"
 >

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurface.ts
@@ -49,7 +49,7 @@ export const usePopoverSurface_unstable = (
         ref: useMergedRefs(ref, contentRef),
         role: trapFocus ? 'dialog' : 'group',
         'aria-modal': trapFocus ? true : undefined,
-        ...(trapFocus ? modalAttributes : {}),
+        ...modalAttributes,
         ...props,
       }),
       { elementType: 'div' },

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -52,12 +52,14 @@ export const useModalAttributes = (
   const id = useId('modal-', options.id);
   const modalAttributes = useTabsterAttributes({
     restorer: { type: TabsterTypes.RestorerTypes.Source },
-    modalizer: {
-      id,
-      isOthersAccessible: !trapFocus,
-      isAlwaysAccessible: alwaysFocusable,
-      isTrapped: legacyTrapFocus && trapFocus,
-    },
+    ...(trapFocus && {
+      modalizer: {
+        id,
+        isOthersAccessible: !trapFocus,
+        isAlwaysAccessible: alwaysFocusable,
+        isTrapped: legacyTrapFocus && trapFocus,
+      },
+    }),
   });
 
   const triggerAttributes = useTabsterAttributes({


### PR DESCRIPTION
Follow up from #28613. Not applying any of the `useModalAttributes()` resulted in focus restoration not working for popovers that don't trap focus.

Now the modalizer attributes are handled from the `useModalAttributes()` hook. This way the popover will still apply the focus restoration attributes if there is no focus trap configured.
