### PR TITLE
fix(react-button): subtle mode hover style now visible in windows HCM

### DIFF
--- a/change/@fluentui-react-button-7a5e0b20-4573-4154-a184-aea484f0a7b1.json
+++ b/change/@fluentui-react-button-7a5e0b20-4573-4154-a184-aea484f0a7b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: subtle mode hover style is now visible in windows HCM.",
+  "packageName": "@fluentui/react-button",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -207,17 +207,17 @@ const useRootStyles = makeStyles({
 
     '@media (forced-colors: active)': {
       ':hover': {
-        color: 'Canvas',
+        color: 'Highlight',
 
         [`& .${buttonClassNames.icon}`]: {
-          color: 'Canvas',
+          color: 'Highlight',
         },
       },
       ':hover:active': {
-        color: 'Canvas',
+        color: 'Highlight',
 
         [`& .${buttonClassNames.icon}`]: {
-          color: 'Canvas',
+          color: 'Highlight',
         },
       },
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://github.com/microsoft/fluentui/assets/8649804/15c7605f-20f6-48a7-8e5e-377f95045f9e)


<!-- This is the behavior we have today -->

## New Behavior
- changes hover style colors in HCM from `canvas` to `Highlight`
![image](https://github.com/microsoft/fluentui/assets/8649804/10da1e27-b9d0-430a-9bc6-e7c9fa5222f9)


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #28546
