### PR TITLE
fix(react-tooltip): Tooltip example should rely on relationship, not aria-labelledby

### DIFF
--- a/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/Tooltip/TooltipIcon.stories.tsx
@@ -15,7 +15,6 @@ const useStyles = makeStyles({
 
 export const Icon = (props: Partial<TooltipProps>) => {
   const styles = useStyles();
-  const iconId = useId('icon');
   const contentId = useId('content');
   const [visible, setVisible] = React.useState(false);
 
@@ -33,12 +32,7 @@ export const Icon = (props: Partial<TooltipProps>) => {
         onVisibleChange={(e, data) => setVisible(data.visible)}
         {...props}
       >
-        <Info16Regular
-          tabIndex={0}
-          id={iconId}
-          aria-labelledby={`${iconId} ${contentId}`}
-          className={mergeClasses(visible && styles.visible)}
-        />
+        <Info16Regular tabIndex={0} className={mergeClasses(visible && styles.visible)} />
       </Tooltip>
     </div>
   );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Screen reader reads out the content of the tooltip three times.

## New Behavior

Screen reader now reads out only one time the content. The example now uses the relationship prop in tooltip rather than applying the aria-labelledby.

