### PR TITLE
fix: strip comments for JSX pragma

### DIFF
--- a/change/@fluentui-react-jsx-runtime-0290dc47-fd60-47c7-bc75-6d55b6beb5e6.json
+++ b/change/@fluentui-react-jsx-runtime-0290dc47-fd60-47c7-bc75-6d55b6beb5e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: strip comments for JSX pragma",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/scripts/tasks/src/swc.ts
+++ b/scripts/tasks/src/swc.ts
@@ -43,6 +43,11 @@ async function swcTransform(options: Options) {
       outputPath,
     });
 
+    // Strip @jsx comments, see https://github.com/microsoft/fluentui/issues/29126
+    const resultCode = result.code
+      .replace('/** @jsxRuntime automatic */', '')
+      .replace('/** @jsxImportSource @fluentui/react-jsx-runtime */', '');
+
     const compiledFilePath = path.resolve(packageRoot, fileName.replace(`${sourceRootDirName}`, outputPath));
 
     //Create directory folder for new compiled file(s) to live in.
@@ -50,7 +55,7 @@ async function swcTransform(options: Options) {
 
     const compiledFilePathJS = `${compiledFilePath.replace(tsFileExtensionRegex, '.js')}`;
 
-    await fs.promises.writeFile(compiledFilePathJS, result.code);
+    await fs.promises.writeFile(compiledFilePathJS, resultCode);
     if (result.map) {
       await fs.promises.writeFile(`${compiledFilePathJS}.map`, result.map);
     }


### PR DESCRIPTION
## Previous Behavior

We started to use new JSX pragma via comments, for example:

https://github.com/microsoft/fluentui/blob/3bf2de945735d2464b4aa4fcfccbf636a74651ef/packages/react-components/react-image/src/components/Image/renderImage.tsx#L1-L2

The problem is that these comments appeared in our artifacts:

```js
/** @jsxRuntime automatic */
/** @jsxImportSource @fluentui/react-jsx-runtime */
import { jsx as _jsx } from "@fluentui/react-jsx-runtime/jsx-runtime";
```

> https://unpkg.com/browse/@fluentui/react-image@9.1.31/lib/components/Image/renderImage.js

And it causes issues if Babel is used on `node_modules`, see https://github.com/microsoft/fluentui/issues/29126#issuecomment-1718931582

## New Behavior

![image](https://github.com/microsoft/fluentui/assets/14183168/7c430576-1a56-4e26-9a31-b67acaab2417)

These comments are removed during build. No comments => no problems.

**Note: I haven't checked if sourcemaps still work after this change.** 

## Related Issue(s)

Fixes #29126
