### PR TITLE
Text: Add disableDefaultStyling prop to suppress all styles unless a prop was provided

### DIFF
--- a/change/@fluentui-react-text-c208d106-d92b-4624-b4e4-94fa5c21afba.json
+++ b/change/@fluentui-react-text-c208d106-d92b-4624-b4e4-94fa5c21afba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Text: Adds prop disableDefaultStyling",
+  "packageName": "@fluentui/react-text",
+  "email": "swese44@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-text/etc/react-text.api.md
+++ b/packages/react-components/react-text/etc/react-text.api.md
@@ -113,6 +113,7 @@ export type TextPresetProps = Omit<TextProps, 'font' | 'size' | 'weight'>;
 export type TextProps = ComponentProps<TextSlots> & {
     align?: 'start' | 'center' | 'end' | 'justify';
     block?: boolean;
+    disableDefaultStyling?: boolean;
     font?: 'base' | 'monospace' | 'numeric';
     italic?: boolean;
     size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
@@ -129,7 +130,7 @@ export type TextSlots = {
 };
 
 // @public
-export type TextState = ComponentState<TextSlots> & Required<Pick<TextProps, 'align' | 'block' | 'font' | 'italic' | 'size' | 'strikethrough' | 'truncate' | 'underline' | 'weight' | 'wrap'>>;
+export type TextState = ComponentState<TextSlots> & Pick<TextProps, TextStateProps>;
 
 // @public
 export const Title1: FunctionComponent<TextPresetProps>;

--- a/packages/react-components/react-text/src/components/Text/Text.test.tsx
+++ b/packages/react-components/react-text/src/components/Text/Text.test.tsx
@@ -176,4 +176,11 @@ describe('Text', () => {
       text-align: ${expectedValue};
     `);
   });
+
+  it('renders without default styling', () => {
+    const { getByText } = render(<Text disableDefaultStyling={true}>Test</Text>);
+
+    const textElement = getByText('Test');
+    expect(textElement).toHaveClass('fui-Text', { exact: true });
+  });
 });

--- a/packages/react-components/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-components/react-text/src/components/Text/Text.types.ts
@@ -26,6 +26,13 @@ export type TextProps = ComponentProps<TextSlots> & {
   block?: boolean;
 
   /**
+   * Suppresses all default styling. Styles will only be applied for provided props.
+   *
+   * @default false
+   */
+  disableDefaultStyling?: boolean;
+
+  /**
    * Applies the font family to the content.
    *
    * @default base
@@ -88,13 +95,20 @@ export type TextProps = ComponentProps<TextSlots> & {
  */
 export type TextPresetProps = Omit<TextProps, 'font' | 'size' | 'weight'>;
 
+export type TextStateProps =
+  | 'align'
+  | 'block'
+  | 'disableDefaultStyling'
+  | 'font'
+  | 'italic'
+  | 'size'
+  | 'strikethrough'
+  | 'truncate'
+  | 'underline'
+  | 'weight'
+  | 'wrap';
+
 /**
  * State used in rendering Text
  */
-export type TextState = ComponentState<TextSlots> &
-  Required<
-    Pick<
-      TextProps,
-      'align' | 'block' | 'font' | 'italic' | 'size' | 'strikethrough' | 'truncate' | 'underline' | 'weight' | 'wrap'
-    >
-  >;
+export type TextState = ComponentState<TextSlots> & Pick<TextProps, TextStateProps>;

--- a/packages/react-components/react-text/src/components/Text/useText.ts
+++ b/packages/react-components/react-text/src/components/Text/useText.ts
@@ -1,6 +1,20 @@
 import * as React from 'react';
 import { getNativeElementProps, slot } from '@fluentui/react-utilities';
-import type { TextProps, TextState } from './Text.types';
+import type { TextStateProps, TextProps, TextState } from './Text.types';
+
+const defaultProps: Required<Pick<TextProps, TextStateProps>> = {
+  align: 'start',
+  block: false,
+  disableDefaultStyling: false,
+  font: 'base',
+  italic: false,
+  size: 300,
+  strikethrough: false,
+  truncate: false,
+  underline: false,
+  weight: 'regular',
+  wrap: true,
+};
 
 /**
  * Create the state required to render Text.
@@ -12,20 +26,22 @@ import type { TextProps, TextState } from './Text.types';
  * @param ref - reference to root HTMLElement of Text
  */
 export const useText_unstable = (props: TextProps, ref: React.Ref<HTMLElement>): TextState => {
-  const { wrap, truncate, block, italic, underline, strikethrough, size, font, weight, align } = props;
+  const { align, block, disableDefaultStyling, font, italic, size, strikethrough, truncate, underline, weight, wrap } =
+    props.disableDefaultStyling ? props : { ...defaultProps, ...props };
   const as = props.as ?? 'span';
 
   const state: TextState = {
-    align: align ?? 'start',
-    block: block ?? false,
-    font: font ?? 'base',
-    italic: italic ?? false,
-    size: size ?? 300,
-    strikethrough: strikethrough ?? false,
-    truncate: truncate ?? false,
-    underline: underline ?? false,
-    weight: weight ?? 'regular',
-    wrap: wrap ?? true,
+    align,
+    block,
+    disableDefaultStyling,
+    font,
+    italic,
+    size,
+    strikethrough,
+    truncate,
+    underline,
+    weight,
+    wrap,
 
     components: { root: 'span' },
 

--- a/packages/react-components/react-text/src/components/Text/useTextStyles.styles.ts
+++ b/packages/react-components/react-text/src/components/Text/useTextStyles.styles.ts
@@ -11,16 +11,9 @@ export const textClassNames: SlotClassNames<TextSlots> = {
  * Styles for the root slot
  */
 const useStyles = makeStyles({
-  root: {
-    fontFamily: tokens.fontFamilyBase,
-    fontSize: tokens.fontSizeBase300,
-    lineHeight: tokens.lineHeightBase300,
-    fontWeight: tokens.fontWeightRegular,
-    textAlign: 'start',
-    display: 'inline',
+  wrap: {
     whiteSpace: 'normal',
     ...shorthands.overflow('visible'),
-    textOverflow: 'clip',
   },
   nowrap: {
     whiteSpace: 'nowrap',
@@ -28,6 +21,12 @@ const useStyles = makeStyles({
   },
   truncate: {
     textOverflow: 'ellipsis',
+  },
+  noTruncate: {
+    textOverflow: 'clip',
+  },
+  inline: {
+    display: 'inline',
   },
   block: {
     display: 'block',
@@ -51,6 +50,10 @@ const useStyles = makeStyles({
   base200: {
     fontSize: tokens.fontSizeBase200,
     lineHeight: tokens.lineHeightBase200,
+  },
+  base300: {
+    fontSize: tokens.fontSizeBase300,
+    lineHeight: tokens.lineHeightBase300,
   },
   base400: {
     fontSize: tokens.fontSizeBase400,
@@ -80,11 +83,17 @@ const useStyles = makeStyles({
     fontSize: tokens.fontSizeHero1000,
     lineHeight: tokens.lineHeightHero1000,
   },
-  monospace: {
+  fontBase: {
+    fontFamily: tokens.fontFamilyBase,
+  },
+  fontMonospace: {
     fontFamily: tokens.fontFamilyMonospace,
   },
-  numeric: {
+  fontNumeric: {
     fontFamily: tokens.fontFamilyNumeric,
+  },
+  weightRegular: {
+    fontWeight: tokens.fontWeightRegular,
   },
   weightMedium: {
     fontWeight: tokens.fontWeightMedium,
@@ -94,6 +103,9 @@ const useStyles = makeStyles({
   },
   weightBold: {
     fontWeight: tokens.fontWeightBold,
+  },
+  alignStart: {
+    textAlign: 'start',
   },
   alignCenter: {
     textAlign: 'center',
@@ -114,16 +126,19 @@ export const useTextStyles_unstable = (state: TextState): TextState => {
 
   state.root.className = mergeClasses(
     textClassNames.root,
-    styles.root,
+    state.wrap === true && styles.wrap,
     state.wrap === false && styles.nowrap,
-    state.truncate && styles.truncate,
-    state.block && styles.block,
+    state.truncate === true && styles.truncate,
+    state.truncate === false && styles.noTruncate,
+    state.block === true && styles.block,
+    state.block === false && styles.inline,
     state.italic && styles.italic,
     state.underline && styles.underline,
     state.strikethrough && styles.strikethrough,
     state.underline && state.strikethrough && styles.strikethroughUnderline,
     state.size === 100 && styles.base100,
     state.size === 200 && styles.base200,
+    state.size === 300 && styles.base300,
     state.size === 400 && styles.base400,
     state.size === 500 && styles.base500,
     state.size === 600 && styles.base600,
@@ -131,11 +146,14 @@ export const useTextStyles_unstable = (state: TextState): TextState => {
     state.size === 800 && styles.hero800,
     state.size === 900 && styles.hero900,
     state.size === 1000 && styles.hero1000,
-    state.font === 'monospace' && styles.monospace,
-    state.font === 'numeric' && styles.numeric,
+    state.font === 'base' && styles.fontBase,
+    state.font === 'monospace' && styles.fontMonospace,
+    state.font === 'numeric' && styles.fontNumeric,
+    state.weight === 'regular' && styles.weightRegular,
     state.weight === 'medium' && styles.weightMedium,
     state.weight === 'semibold' && styles.weightSemibold,
     state.weight === 'bold' && styles.weightBold,
+    state.align === 'start' && styles.alignStart,
     state.align === 'center' && styles.alignCenter,
     state.align === 'end' && styles.alignEnd,
     state.align === 'justify' && styles.alignJustify,


### PR DESCRIPTION
## Previous Behavior
Text rendered default styles for all default prop values.

## New Behavior
The `disableDefaultStyling` prop suppresses this behavior so styles are only applied for provided props. No change in behavior if this prop is not set to `true`.

## Related Issue(s)
- Fixes #29153
