### PR TITLE
breaking-change(react-accordion): removes deprecated method from accordion item context

### DIFF
--- a/change/@fluentui-react-accordion-17ed18cc-e221-4718-afb1-9fceab66408d.json
+++ b/change/@fluentui-react-accordion-17ed18cc-e221-4718-afb1-9fceab66408d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "breaking-change: removes deprecated method from accordion item context",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/etc/react-accordion.api.md
+++ b/packages/react-components/react-accordion/etc/react-accordion.api.md
@@ -98,7 +98,6 @@ export type AccordionItemContextValue<Value = AccordionItemValue> = {
     open: boolean;
     disabled: boolean;
     value: Value;
-    onHeaderClick(event: AccordionToggleEvent): void;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-accordion/src/components/AccordionItem/useAccordionItem.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionItem/useAccordionItem.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps, slot, useEventCallback } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 import type { AccordionItemProps, AccordionItemState } from './AccordionItem.types';
-import type { AccordionToggleEvent } from '../Accordion/Accordion.types';
 import { useAccordionContext_unstable } from '../../contexts/accordion';
 
 /**
@@ -15,15 +14,12 @@ export const useAccordionItem_unstable = (
 ): AccordionItemState => {
   const { value, disabled = false } = props;
 
-  const requestToggle = useAccordionContext_unstable(ctx => ctx.requestToggle);
   const open = useAccordionContext_unstable(ctx => ctx.openItems.includes(value));
-  const onAccordionHeaderClick = useEventCallback((event: AccordionToggleEvent) => requestToggle({ event, value }));
 
   return {
     open,
     value,
     disabled,
-    onHeaderClick: onAccordionHeaderClick,
     components: {
       root: 'div',
     },

--- a/packages/react-components/react-accordion/src/components/AccordionItem/useAccordionItemContextValues.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionItem/useAccordionItemContextValues.ts
@@ -3,11 +3,10 @@ import type { AccordionItemContextValues, AccordionItemState } from './Accordion
 import { AccordionItemContextValue } from '../../contexts/accordionItem';
 
 export function useAccordionItemContextValues_unstable(state: AccordionItemState): AccordionItemContextValues {
-  // eslint-disable-next-line deprecation/deprecation
-  const { disabled, open, value, onHeaderClick } = state;
+  const { disabled, open, value } = state;
   const accordionItem = React.useMemo<AccordionItemContextValue>(
-    () => ({ disabled, open, value, onHeaderClick }),
-    [disabled, open, value, onHeaderClick],
+    () => ({ disabled, open, value }),
+    [disabled, open, value],
   );
 
   return { accordionItem };

--- a/packages/react-components/react-accordion/src/contexts/accordionItem.ts
+++ b/packages/react-components/react-accordion/src/contexts/accordionItem.ts
@@ -1,15 +1,10 @@
 import * as React from 'react';
 import { AccordionItemValue } from '../AccordionItem';
-import { AccordionToggleEvent } from '../Accordion';
 
 export type AccordionItemContextValue<Value = AccordionItemValue> = {
   open: boolean;
   disabled: boolean;
   value: Value;
-  /**
-   * @deprecated - use `requestToggle` from AccordionContent instead
-   */
-  onHeaderClick(event: AccordionToggleEvent): void;
 };
 
 const AccordionItemContext = React.createContext<AccordionItemContextValue<unknown> | undefined>(
@@ -20,9 +15,6 @@ const accordionItemContextDefaultValue: AccordionItemContextValue<unknown> = {
   open: false,
   disabled: false,
   value: undefined,
-  onHeaderClick() {
-    /* noop */
-  },
 };
 
 export const { Provider: AccordionItemProvider } = AccordionItemContext;

--- a/packages/react-components/react-accordion/src/testing/mockContextValue.ts
+++ b/packages/react-components/react-accordion/src/testing/mockContextValue.ts
@@ -21,9 +21,6 @@ export function mockAccordionItemContextValue(
     open: false,
     disabled: false,
     value: undefined,
-    onHeaderClick() {
-      /* noop */
-    },
     ...partialValue,
   };
 }


### PR DESCRIPTION
⚠️⚠️ BREAKING CHANGE ⚠️⚠️

1. removes deprecated method  `onHeaderClick` from accordion item context
2. bumps the minor version, as it's a breaking change

> The method was marked as deprecated and it's not used internally. The decision to remove it is due to possible memory retaining issues reported by clients.