### PR TITLE
feat(react-dialog): exports contexts

### DIFF
--- a/change/@fluentui-react-components-57399e77-0cc7-4a9b-ab6e-0e4c3f117c87.json
+++ b/change/@fluentui-react-components-57399e77-0cc7-4a9b-ab6e-0e4c3f117c87.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: exports contexts from react-dialog",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-759f95da-5eb2-47a5-b653-5e1f74b53164.json
+++ b/change/@fluentui-react-dialog-759f95da-5eb2-47a5-b653-5e1f74b53164.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: exports contexts",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -226,6 +226,7 @@ import { dialogContentClassNames } from '@fluentui/react-dialog';
 import { DialogContentProps } from '@fluentui/react-dialog';
 import { DialogContentSlots } from '@fluentui/react-dialog';
 import { DialogContentState } from '@fluentui/react-dialog';
+import { DialogContextValue } from '@fluentui/react-dialog';
 import { DialogOpenChangeData } from '@fluentui/react-dialog';
 import { DialogOpenChangeEvent } from '@fluentui/react-dialog';
 import { DialogProps } from '@fluentui/react-dialog';
@@ -233,6 +234,7 @@ import { DialogSlots } from '@fluentui/react-dialog';
 import { DialogState } from '@fluentui/react-dialog';
 import { DialogSurface } from '@fluentui/react-dialog';
 import { dialogSurfaceClassNames } from '@fluentui/react-dialog';
+import { DialogSurfaceContextValue } from '@fluentui/react-dialog';
 import { DialogSurfaceProps } from '@fluentui/react-dialog';
 import { DialogSurfaceSlots } from '@fluentui/react-dialog';
 import { DialogSurfaceState } from '@fluentui/react-dialog';
@@ -973,7 +975,9 @@ import { useDialogBody_unstable } from '@fluentui/react-dialog';
 import { useDialogBodyStyles_unstable } from '@fluentui/react-dialog';
 import { useDialogContent_unstable } from '@fluentui/react-dialog';
 import { useDialogContentStyles_unstable } from '@fluentui/react-dialog';
+import { useDialogContext_unstable } from '@fluentui/react-dialog';
 import { useDialogSurface_unstable } from '@fluentui/react-dialog';
+import { useDialogSurfaceContext_unstable } from '@fluentui/react-dialog';
 import { useDialogSurfaceStyles_unstable } from '@fluentui/react-dialog';
 import { useDialogTitle_unstable } from '@fluentui/react-dialog';
 import { useDialogTitleStyles_unstable } from '@fluentui/react-dialog';
@@ -1631,6 +1635,8 @@ export { DialogContentSlots }
 
 export { DialogContentState }
 
+export { DialogContextValue }
+
 export { DialogOpenChangeData }
 
 export { DialogOpenChangeEvent }
@@ -1644,6 +1650,8 @@ export { DialogState }
 export { DialogSurface }
 
 export { dialogSurfaceClassNames }
+
+export { DialogSurfaceContextValue }
 
 export { DialogSurfaceProps }
 
@@ -3125,7 +3133,11 @@ export { useDialogContent_unstable }
 
 export { useDialogContentStyles_unstable }
 
+export { useDialogContext_unstable }
+
 export { useDialogSurface_unstable }
+
+export { useDialogSurfaceContext_unstable }
 
 export { useDialogSurfaceStyles_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -822,6 +822,8 @@ export {
   useDialogContentStyles_unstable,
   useDialogContent_unstable,
   renderDialogContent_unstable,
+  useDialogContext_unstable,
+  useDialogSurfaceContext_unstable,
 } from '@fluentui/react-dialog';
 
 export type {
@@ -850,6 +852,8 @@ export type {
   DialogContentProps,
   DialogContentSlots,
   DialogContentState,
+  DialogContextValue,
+  DialogSurfaceContextValue,
 } from '@fluentui/react-dialog';
 
 export {

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -10,9 +10,11 @@ import { ARIAButtonResultProps } from '@fluentui/react-aria';
 import { ARIAButtonType } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import { ContextSelector } from '@fluentui/react-context-selector';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElementConstructor } from 'react';
 import type { PortalProps } from '@fluentui/react-portal';
+import { Provider } from 'react';
 import * as React_2 from 'react';
 import { ReactElement } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
@@ -81,6 +83,17 @@ export type DialogContentSlots = {
 export type DialogContentState = ComponentState<DialogContentSlots>;
 
 // @public (undocumented)
+export type DialogContextValue = {
+    open: boolean;
+    inertTrapFocus: boolean;
+    dialogTitleId?: string;
+    isNestedDialog: boolean;
+    dialogRef: React_2.Ref<DialogSurfaceElement>;
+    modalType: DialogModalType;
+    requestOpenChange: (data: DialogOpenChangeData) => void;
+} & Partial<ReturnType<typeof useModalAttributes>>;
+
+// @public (undocumented)
 export type DialogOpenChangeData = {
     type: 'escapeKeyDown';
     open: boolean;
@@ -112,6 +125,9 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
 };
 
 // @public (undocumented)
+export const DialogProvider: React_2.Provider<DialogContextValue | undefined> & React_2.FC<React_2.ProviderProps<DialogContextValue | undefined>>;
+
+// @public (undocumented)
 export type DialogSlots = {};
 
 // @public (undocumented)
@@ -126,11 +142,17 @@ export const DialogSurface: ForwardRefComponent<DialogSurfaceProps>;
 // @public (undocumented)
 export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots>;
 
+// @public (undocumented)
+export type DialogSurfaceContextValue = boolean;
+
 // @public
 export type DialogSurfaceElement = HTMLElement;
 
 // @public
 export type DialogSurfaceProps = ComponentProps<DialogSurfaceSlots> & Pick<PortalProps, 'mountNode'>;
+
+// @public (undocumented)
+export const DialogSurfaceProvider: Provider<boolean | undefined>;
 
 // @public (undocumented)
 export type DialogSurfaceSlots = {
@@ -223,8 +245,14 @@ export const useDialogContent_unstable: (props: DialogContentProps, ref: React_2
 // @public
 export const useDialogContentStyles_unstable: (state: DialogContentState) => DialogContentState;
 
+// @public (undocumented)
+export const useDialogContext_unstable: <T>(selector: ContextSelector<DialogContextValue, T>) => T;
+
 // @public
 export const useDialogSurface_unstable: (props: DialogSurfaceProps, ref: React_2.Ref<DialogSurfaceElement>) => DialogSurfaceState;
+
+// @public (undocumented)
+export const useDialogSurfaceContext_unstable: () => boolean;
 
 // @public
 export const useDialogSurfaceStyles_unstable: (state: DialogSurfaceState) => DialogSurfaceState;

--- a/packages/react-components/react-dialog/src/index.ts
+++ b/packages/react-components/react-dialog/src/index.ts
@@ -65,3 +65,12 @@ export {
   renderDialogContent_unstable,
 } from './DialogContent';
 export type { DialogContentProps, DialogContentSlots, DialogContentState } from './DialogContent';
+
+export {
+  useDialogContext_unstable,
+  useDialogSurfaceContext_unstable,
+  DialogProvider,
+  DialogSurfaceProvider,
+} from './contexts/index';
+
+export type { DialogContextValue, DialogSurfaceContextValue } from './contexts/index';


### PR DESCRIPTION
## New Behavior

1. exports hooks, providers and types to access internal contexts from `Dialog` and `DialogSurface`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28806
