### PR TITLE
fix(react-drawer): use dialog id for drawer title heading element

### DIFF
--- a/change/@fluentui-react-drawer-77aea511-a69a-483b-9bf8-8f6be630ece6.json
+++ b/change/@fluentui-react-drawer-77aea511-a69a-483b-9bf8-8f6be630ece6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use dialog id for drawer title heading element",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/src/components/Drawer/Drawer.types.ts
+++ b/packages/react-components/react-drawer/src/components/Drawer/Drawer.types.ts
@@ -16,10 +16,11 @@ export type DrawerSlots = {
 export type DrawerProps = ComponentProps<DrawerSlots> & {
   /**
    * Type of the drawer.
-   * @default overlay
    *
    * - 'overlay' - Drawer is hidden by default and can be opened by clicking on the trigger.
    * - 'inline' - Drawer is stacked with the content
+   *
+   * @default overlay
    */
   type?: 'inline' | 'overlay';
 };

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { getNativeElementProps, slot } from '@fluentui/react-utilities';
+import { useDialogTitle_unstable } from '@fluentui/react-dialog';
 
 import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
-import { useDialogTitle_unstable } from '@fluentui/react-dialog';
 
 /**
  * @internal

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -2,6 +2,26 @@ import * as React from 'react';
 import { getNativeElementProps, slot } from '@fluentui/react-utilities';
 
 import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
+import { useDialogTitle_unstable } from '@fluentui/react-dialog';
+
+/**
+ * @internal
+ * Create the shorthand for the heading element.
+ * @param props - props from this instance of DrawerHeaderTitle
+ */
+const useHeadingProps = ({ children, heading }: DrawerHeaderTitleProps) => {
+  const resolvedHeading = slot.resolveShorthand(heading) || {};
+  const { root: titleProps } = useDialogTitle_unstable(resolvedHeading, React.createRef());
+
+  return slot.optional(titleProps, {
+    defaultProps: {
+      ...titleProps,
+      children,
+    },
+    renderByDefault: true,
+    elementType: 'h2',
+  });
+};
 
 /**
  * Create the state required to render DrawerHeaderTitle.
@@ -16,13 +36,7 @@ export const useDrawerHeaderTitle_unstable = (
   props: DrawerHeaderTitleProps,
   ref: React.Ref<HTMLDivElement>,
 ): DrawerHeaderTitleState => {
-  let heading = slot.resolveShorthand(props.heading);
-
-  if (!heading) {
-    heading = {
-      children: props.children,
-    };
-  }
+  const headingProps = useHeadingProps(props);
 
   return {
     components: {
@@ -38,13 +52,7 @@ export const useDrawerHeaderTitle_unstable = (
       }),
       { elementType: 'div' },
     ),
-    heading: slot.optional(getNativeElementProps(heading.as ?? 'h2', heading), {
-      defaultProps: {
-        children: props.children,
-      },
-      renderByDefault: true,
-      elementType: 'h2',
-    }),
+    heading: headingProps,
     action: slot.optional(props.action, {
       elementType: 'div',
     }),


### PR DESCRIPTION
## Previous Behavior

DrawerHeaderTitle would render the heading element (h2) without any id by default.

## New Behavior

In case the DrawerHeaderTitle renders inside a DrawerOverlay, it'll get the id from the Dialog and add to the heading element. This is used for accessibility when narrating the Dialog element created by the Drawer.
