### PR TITLE
fix(react-tags-preview): remove onClick handler for non-dismissible Tag

### DIFF
--- a/change/@fluentui-react-tags-preview-a76c8ca9-7dd9-415d-b1d5-33e335a81b4c.json
+++ b/change/@fluentui-react-tags-preview-a76c8ca9-7dd9-415d-b1d5-33e335a81b4c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: remove onClick handler for non-dismissible Tag to prevent screen readers announce 'clickable' in Safari",
+  "comment": "fix: remove onClick handler for non-dismissible Tag to prevent screen readers announce 'clickable'",
   "packageName": "@fluentui/react-tags-preview",
   "email": "yuanboxue@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-tags-preview-a76c8ca9-7dd9-415d-b1d5-33e335a81b4c.json
+++ b/change/@fluentui-react-tags-preview-a76c8ca9-7dd9-415d-b1d5-33e335a81b4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove onClick handler for non-dismissible Tag to prevent screen readers announce 'clickable' in Safari",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+import { TagGroupContextProvider } from '../../contexts/tagGroupContext';
+import { useTag_unstable } from './useTag';
+
+describe('useTag_unstable', () => {
+  it('should not attach event handler for non-dismissible tag', () => {
+    const ref = React.createRef<HTMLElement>();
+    const wrapper: React.FC = ({ children }) => (
+      <TagGroupContextProvider
+        value={{
+          handleTagDismiss: () => null,
+          size: 'medium',
+        }}
+      >
+        {children}
+      </TagGroupContextProvider>
+    );
+
+    const { result } = renderHook(() => useTag_unstable({}, ref), { wrapper });
+    expect(result.current.root.onClick).toBeUndefined();
+  });
+});

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
@@ -6,6 +6,9 @@ import { useTag_unstable } from './useTag';
 
 describe('useTag_unstable', () => {
   it.each([true, false])('should %s attach event handler for tag when dismissible:$dismissible', dismissible => {
+    // onClick handler is added only when dismissible is true: this is because Voice Over + Safari and NVDA + Chrome will announce 'clickable' if a click handler is attached.
+    // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
+
     const ref = React.createRef<HTMLElement>();
     const wrapper: React.FC = ({ children }) => (
       <TagGroupContextProvider

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
@@ -5,8 +5,9 @@ import { TagGroupContextProvider } from '../../contexts/tagGroupContext';
 import { useTag_unstable } from './useTag';
 
 describe('useTag_unstable', () => {
-  it.each([true, false])('should %s attach event handler for tag when dismissible:$dismissible', dismissible => {
-    // onClick handler is added only when dismissible is true: this is because Voice Over + Safari and NVDA + Chrome will announce 'clickable' if a click handler is attached.
+  it.each([true, false])('should %s attach click event handler for tag when dismissible:$dismissible', dismissible => {
+    // onClick handler should be added only when dismissible is true.
+    // This is because Voice Over + Safari and NVDA + Chrome will announce 'clickable' if a click handler is attached.
     // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
 
     const ref = React.createRef<HTMLElement>();

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.test.tsx
@@ -5,7 +5,7 @@ import { TagGroupContextProvider } from '../../contexts/tagGroupContext';
 import { useTag_unstable } from './useTag';
 
 describe('useTag_unstable', () => {
-  it('should not attach event handler for non-dismissible tag', () => {
+  it.each([true, false])('should %s attach event handler for tag when dismissible:$dismissible', dismissible => {
     const ref = React.createRef<HTMLElement>();
     const wrapper: React.FC = ({ children }) => (
       <TagGroupContextProvider
@@ -18,7 +18,11 @@ describe('useTag_unstable', () => {
       </TagGroupContextProvider>
     );
 
-    const { result } = renderHook(() => useTag_unstable({}, ref), { wrapper });
-    expect(result.current.root.onClick).toBeUndefined();
+    const { result } = renderHook(() => useTag_unstable({ dismissible }, ref), { wrapper });
+    if (dismissible) {
+      expect(result.current.root.onClick).toBeDefined();
+    } else {
+      expect(result.current.root.onClick).toBeUndefined();
+    }
   });
 });

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
@@ -76,7 +76,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
         ref,
         ...props,
         id,
-        // onClick handler is added only when dismissible is true: this is because Voice Over + Safari will announce 'clickable' if a click handler is attached.
+        // onClick handler is added only when dismissible is true: this is because Voice Over + Safari and NVDA + Chrome will announce 'clickable' if a click handler is attached.
         // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
         ...(dismissible && { onClick: dismissOnClick, onKeyDown: dismissOnKeyDown }),
       }),

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
@@ -76,8 +76,6 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
         ref,
         ...props,
         id,
-        // onClick handler is added only when dismissible is true: this is because Voice Over + Safari and NVDA + Chrome will announce 'clickable' if a click handler is attached.
-        // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
         ...(dismissible && { onClick: dismissOnClick, onKeyDown: dismissOnKeyDown }),
       }),
       { elementType: dismissible ? 'button' : 'span' },

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
@@ -72,24 +72,14 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
     },
 
     root: slot.always(
-      getNativeElementProps(
-        'button',
-        dismissible
-          ? {
-              ref,
-              ...props,
-              id,
-              // onClick handler is added only when dismissible is true: this is because Voice Over + Safari will announce 'clickable' if a click handler is attached.
-              // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
-              onClick: dismissOnClick,
-              onKeyDown: dismissOnKeyDown,
-            }
-          : {
-              ref,
-              ...props,
-              id,
-            },
-      ),
+      getNativeElementProps('button', {
+        ref,
+        ...props,
+        id,
+        // onClick handler is added only when dismissible is true: this is because Voice Over + Safari will announce 'clickable' if a click handler is attached.
+        // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
+        ...(dismissible && { onClick: dismissOnClick, onKeyDown: dismissOnKeyDown }),
+      }),
       { elementType: dismissible ? 'button' : 'span' },
     ),
 

--- a/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags-preview/src/components/Tag/useTag.tsx
@@ -39,14 +39,14 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
     value = id,
   } = props;
 
-  const handleClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
+  const dismissOnClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
     props.onClick?.(ev);
     if (!ev.defaultPrevented) {
       handleTagDismiss?.(ev, value);
     }
   });
 
-  const handleKeyDown = useEventCallback((ev: React.KeyboardEvent<HTMLButtonElement>) => {
+  const dismissOnKeyDown = useEventCallback((ev: React.KeyboardEvent<HTMLButtonElement>) => {
     props?.onKeyDown?.(ev);
     if (!ev.defaultPrevented && (ev.key === Delete || ev.key === Backspace)) {
       handleTagDismiss?.(ev, value);
@@ -72,13 +72,24 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLElement>): T
     },
 
     root: slot.always(
-      getNativeElementProps('button', {
-        ref,
-        ...props,
-        id,
-        onClick: handleClick,
-        onKeyDown: handleKeyDown,
-      }),
+      getNativeElementProps(
+        'button',
+        dismissible
+          ? {
+              ref,
+              ...props,
+              id,
+              // onClick handler is added only when dismissible is true: this is because Voice Over + Safari will announce 'clickable' if a click handler is attached.
+              // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
+              onClick: dismissOnClick,
+              onKeyDown: dismissOnKeyDown,
+            }
+          : {
+              ref,
+              ...props,
+              id,
+            },
+      ),
       { elementType: dismissible ? 'button' : 'span' },
     ),
 


### PR DESCRIPTION
By default Tag is a non-focusable `span`, and when it's dismissible it's a focusable `button`. 

For the default non-focusable Tag, both Voice Over + Safari and NVDA + Chrome announces "clickable" because it has a onClick handler that does nothing:
<img width="761" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/d859d783-078f-456a-a3f6-160cb9d0c96f">

This PR adds onClick handler only when Tag is dismissible to prevent screen readers announce 'clickable'.
 