### PR TITLE
fix(react-motion): only rerun hook for the dependencies triggered by parent components

### DIFF
--- a/change/@fluentui-react-motion-preview-cdbabe91-7514-4972-b59d-765ef9dc2c82.json
+++ b/change/@fluentui-react-motion-preview-cdbabe91-7514-4972-b59d-765ef9dc2c82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: only rerun hook for the dependencies triggered by parent components",
+  "packageName": "@fluentui/react-motion-preview",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-preview/src/hooks/useMotion.ts
+++ b/packages/react-components/react-motion-preview/src/hooks/useMotion.ts
@@ -165,17 +165,12 @@ function useMotionPresence<Element extends HTMLElement>(
       cancelAnimationFrame();
       clearAnimationTimeout();
     };
-  }, [
-    cancelAnimationFrame,
-    clearAnimationTimeout,
-    currentElement,
-    disableAnimation,
-    isFirstReactRender,
-    onFinished,
-    presence,
-    setAnimationFrame,
-    setAnimationTimeout,
-  ]);
+    /*
+     * Only tracks dependencies that are either not stable or are used in the callbacks
+     * This is to avoid re-running the effect on every render, especially when the element is not rendered
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentElement, disableAnimation, onFinished, presence]);
 
   return React.useMemo<MotionState<Element>>(
     () => ({


### PR DESCRIPTION
Remove the dependencies that were triggering unwanted rerenders.

- Fixes #29134