### PR TITLE
fix: GroupedList.scrollToIndex() now targets group index

### DIFF
--- a/change/@fluentui-react-144ea3d7-6cc3-4aed-8fb4-aae163604755.json
+++ b/change/@fluentui-react-144ea3d7-6cc3-4aed-8fb4-aae163604755.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: GroupedList.scrollToIndex() now targets group index",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -105,8 +105,10 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   public scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void {
+    const groupIndex = this._getGroupIndexFromItemIndex(index);
+    const scrollIndex = groupIndex > -1 ? groupIndex : index;
     if (this._list.current) {
-      this._list.current.scrollToIndex(index, measureItem, scrollToMode);
+      this._list.current.scrollToIndex(scrollIndex, measureItem, scrollToMode);
     }
   }
 
@@ -403,5 +405,23 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       }
       this._isSomeGroupExpanded = newIsSomeGroupExpanded;
     }
+  }
+
+  private _getGroupIndexFromItemIndex(itemIndex: number): number {
+    const { groups } = this.state;
+
+    if (!groups) {
+      return -1;
+    }
+
+    for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      const group = groups[groupIndex];
+
+      if (itemIndex >= group.startIndex && itemIndex < group.startIndex + group.count) {
+        return groupIndex;
+      }
+    }
+
+    return -1;
   }
 }


### PR DESCRIPTION
## Previous Behavior

`scrollToIndex()` for a `GroupedList` (or grouped `DetailsList` -- `GroupedList` is used under the hood in this scenario) does not always scroll to the provided index.

## New Behavior

`scrollToIndex()` now works.

The reason this did not work is that `GroupedList` is actually `List` of `List`s and internally it maintains two lists:

1. `items` a flat list of items
2. `groups` a nested list of groups that `items` is projected into

In `GroupedList` the root `List`, which is the list that `scrollToIndex()` is called only has `groups.length` items in it (where `groups.length` is the number of root level groups) and in many (most?) cases `items.length > groups.length`. When this is the case any item index `> groups.length` is out of bounds and the list is not scrolled because the item in question cannot be found.

 [This is an example of `scrollToIndex` working because `items.length < groups.length`.](https://codepen.io/seanms/pen/WNLZqKE)

This change updates the `scrollToIndex()` implementation in `GroupedList` to map the provided `index` back to a group index which is guaranteed to be in bounds since this method is only called on the root list in a `GroupedList`.

**NOTE:** this issue does not affect `GroupedListV2` as that is implemented as a flat list.

A similar API, `focusIndex()` does not exhibit this problem. The reason for this is that it looks up the item in question and calls `focus()` on it which triggers the browser to bring the element in to view.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29169
