### PR TITLE
feat: adds treeType to tree context

### DIFF
--- a/change/@fluentui-react-tree-8a0b1f0e-38a0-4010-a3f4-4c8f6dd52a21.json
+++ b/change/@fluentui-react-tree-8a0b1f0e-38a0-4010-a3f4-4c8f6dd52a21.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds treeType to tree context",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -135,6 +135,7 @@ export const treeClassNames: SlotClassNames<TreeSlots>;
 
 // @public (undocumented)
 export type TreeContextValue = {
+    treeType: 'nested' | 'flat';
     level: number;
     selectionMode: 'none' | SelectionMode_2;
     appearance: 'subtle' | 'subtle-alpha' | 'transparent';

--- a/packages/react-components/react-tree/src/components/FlatTree/useFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useFlatTree.ts
@@ -2,4 +2,9 @@ import * as React from 'react';
 import { useRootTree } from '../../hooks/useRootTree';
 import { FlatTreeProps, FlatTreeState } from './FlatTree.types';
 
-export const useFlatTree_unstable: (props: FlatTreeProps, ref: React.Ref<HTMLElement>) => FlatTreeState = useRootTree;
+export const useFlatTree_unstable = (props: FlatTreeProps, ref: React.Ref<HTMLElement>): FlatTreeState => {
+  return {
+    treeType: 'flat',
+    ...useRootTree(props, ref),
+  };
+};

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -25,7 +25,7 @@ export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>):
   // as isSubTree is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return isSubtree ? useSubtree(props, ref) : useNestedRootTree(props, ref);
+  return isSubtree ? { ...useSubtree(props, ref), treeType: 'nested' } : useNestedRootTree(props, ref);
 };
 
 function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
@@ -71,15 +71,18 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
     },
   );
 
-  return useRootTree(
-    {
-      ...props,
-      openItems,
-      checkedItems,
-      onOpenChange: handleOpenChange,
-      onNavigation: handleNavigation,
-      onCheckedChange: handleCheckedChange,
-    },
-    useMergedRefs(ref, initializeWalker),
-  );
+  return {
+    treeType: 'nested',
+    ...useRootTree(
+      {
+        ...props,
+        openItems,
+        checkedItems,
+        onOpenChange: handleOpenChange,
+        onNavigation: handleNavigation,
+        onCheckedChange: handleCheckedChange,
+      },
+      useMergedRefs(ref, initializeWalker),
+    ),
+  };
 }

--- a/packages/react-components/react-tree/src/components/Tree/useTreeContextValues.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTreeContextValues.ts
@@ -2,12 +2,13 @@ import { TreeContextValue } from '../../contexts';
 import { TreeContextValues, TreeState } from './Tree.types';
 
 export function useTreeContextValues_unstable(state: TreeState): TreeContextValues {
-  const { openItems, checkedItems, selectionMode, level, appearance, size, requestTreeResponse } = state;
+  const { openItems, checkedItems, selectionMode, level, appearance, size, requestTreeResponse, treeType } = state;
   /**
    * This context is created with "@fluentui/react-context-selector",
    * there is no sense to memoize it
    */
   const tree: TreeContextValue = {
+    treeType,
     size,
     level,
     openItems,

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -18,6 +18,10 @@ import { dataTreeItemValueAttrName } from '../../utils/getTreeItemValueFromEleme
  * @param ref - reference to root HTMLElement of TreeItem
  */
 export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDivElement>): TreeItemState {
+  const treeType = useTreeContext_unstable(ctx => ctx.treeType);
+  if (treeType === 'flat') {
+    warnIfNoProperPropsFlatTreeItem(props);
+  }
   const requestTreeResponse = useTreeContext_unstable(ctx => ctx.requestTreeResponse);
   const contextLevel = useTreeContext_unstable(ctx => ctx.level);
 
@@ -253,4 +257,24 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
       { elementType: 'div' },
     ),
   };
+}
+
+function warnIfNoProperPropsFlatTreeItem(props: Pick<TreeItemProps, 'aria-setsize' | 'aria-posinset' | 'aria-level'>) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (
+      props['aria-posinset'] === undefined ||
+      props['aria-setsize'] === undefined ||
+      props['aria-level'] === undefined
+    ) {
+      // eslint-disable-next-line no-console
+      console.error(/** #__DE-INDENT__ */ `
+        @fluentui/react-tree [${useTreeItem_unstable.name}]:
+        A flat treeitem must have "aria-posinset", "aria-setsize", "aria-level" to ensure a11y and navigation.
+
+        - "aria-posinset": the position of this treeitem in the current level of the tree.
+        - "aria-setsize": the number of siblings in this level of the tree.
+        - "aria-level": the current level of the treeitem.
+      `);
+    }
+  }
 }

--- a/packages/react-components/react-tree/src/contexts/treeContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeContext.ts
@@ -6,6 +6,7 @@ import { ImmutableMap } from '../utils/ImmutableMap';
 import { TreeCheckedChangeData, TreeNavigationData_unstable, TreeOpenChangeData } from '../Tree';
 
 export type TreeContextValue = {
+  treeType: 'nested' | 'flat';
   level: number;
   selectionMode: 'none' | SelectionMode;
   appearance: 'subtle' | 'subtle-alpha' | 'transparent';
@@ -28,6 +29,7 @@ export type TreeItemRequest = { itemType: TreeItemType } & (
 type OmitWithoutExpanding<P, K extends string | number | symbol> = P extends unknown ? Omit<P, K> : P;
 
 const defaultContextValue: TreeContextValue = {
+  treeType: 'nested',
   level: 0,
   selectionMode: 'none',
   openItems: ImmutableSet.empty,

--- a/packages/react-components/react-tree/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/src/hooks/useRootTree.ts
@@ -35,7 +35,7 @@ export function useRootTree(
   >,
 
   ref: React.Ref<HTMLElement>,
-): TreeState {
+): Omit<TreeState, 'treeType'> {
   warnIfNoProperPropsRootTree(props);
 
   const { appearance = 'subtle', size = 'medium', selectionMode = 'none' } = props;

--- a/packages/react-components/react-tree/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/src/hooks/useSubtree.ts
@@ -9,7 +9,10 @@ import { getNativeElementProps, useMergedRefs, slot } from '@fluentui/react-util
  * @param props - props from this instance of tree
  * @param ref - reference to root HTMLElement of tree
  */
-export function useSubtree(props: Pick<TreeProps, 'appearance' | 'size'>, ref: React.Ref<HTMLElement>): TreeState {
+export function useSubtree(
+  props: Pick<TreeProps, 'appearance' | 'size'>,
+  ref: React.Ref<HTMLElement>,
+): Omit<TreeState, 'treeType'> {
   const contextAppearance = useTreeContext_unstable(ctx => ctx.appearance);
   const contextSize = useTreeContext_unstable(ctx => ctx.size);
   const subtreeRef = useTreeItemContext_unstable(ctx => ctx.subtreeRef);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. adds `treeType` to tree context, allowing to internally identify if a tree is `nested` or `flat`. This will help to console warn the user in the case a property is missing on some specific scenarios.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
