### PR TITLE
chore: useFocusFirstElement warns only in development

### DIFF
--- a/change/@fluentui-react-dialog-baaa6fee-9c38-4506-9fb4-0cfddb5bd658.json
+++ b/change/@fluentui-react-dialog-baaa6fee-9c38-4506-9fb4-0cfddb5bd658.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: useFocusFirstElement warns only in development",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/utils/useFocusFirstElement.ts
+++ b/packages/react-components/react-dialog/src/utils/useFocusFirstElement.ts
@@ -21,7 +21,7 @@ export function useFocusFirstElement(open: boolean, modalType: DialogModalType) 
       element.focus();
     } else {
       dialogRef.current?.focus(); // https://github.com/microsoft/fluentui/issues/25150
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV === 'development') {
         // eslint-disable-next-line no-console
         console.warn(/** #__DE-INDENT__ */ `
           @fluentui/react-dialog [useFocusFirstElement]:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

1. `useFocusFirstElement` would warn if no focusable element is available in any environment but `production`

## New Behavior

1. `useFocusFirstElement` warns if no focusable element is available in `development` environment only

## Related Issue(s)

As requested by https://github.com/microsoft/fluentui/issues/28209#issuecomment-1727308271