### PR TITLE
doc(react-dialog): updates documentation on alert dialog escape dismiss

### DIFF
--- a/change/@fluentui-react-dialog-39510a22-5d1b-4d26-8492-07fa341c4332.json
+++ b/change/@fluentui-react-dialog-39510a22-5d1b-4d26-8492-07fa341c4332.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "doc: updates documentation on alert dialog escape dismiss",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -59,7 +59,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
    * `alert`: is a special type of modal dialogs that interrupts the user's workflow
    * to communicate an important message or ask for a decision.
    * Unlike a typical modal dialog, the user must take an action through the options given to dismiss the dialog,
-   * and it cannot be dismissed through the dimmed background or escape key.
+   * and it cannot be dismissed through the dimmed background.
    *
    * @default modal
    */

--- a/packages/react-components/react-dialog/stories/Dialog/DialogAlert.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogAlert.md
@@ -1,3 +1,3 @@
 An `alert` Dialog is a modal dialog that interrupts the user's workflow to communicate an important message and acquire a response. Examples include action confirmation prompts and error message confirmations. The `alert` Dialog role enables assistive technologies and browsers to distinguish alert dialogs from other dialogs so they have the option of giving alert dialogs special treatment, such as playing a system alert sound.
 
-By default clicking on `backdrop` and pressing `Escape` will not dismiss an `alert` Dialog.
+By default clicking on `backdrop` will not dismiss an `alert` Dialog.


### PR DESCRIPTION
## New Behavior

1. Follow up on https://github.com/microsoft/fluentui/pull/28276#issuecomment-1728200141
    * This change is due to [WAI-ARIA alertdialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)  compliance. You should always be able to close a dialog by pressing the `Escape` button.
2. Updates documentation on alert dialogs

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
