### PR TITLE
doc(react-dialog): updates non-modal dialog documentation

### DIFF
--- a/packages/react-components/react-dialog/stories/Dialog/DialogNonModal.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogNonModal.md
@@ -1,5 +1,5 @@
-A `non-modal` Dialog by default presents no `backdrop`, allowing elements outside of the Dialog to be interacted with (unless `DialogSurface` `noTrapFocus` property is provided).
+A `non-modal` Dialog by default presents no `backdrop`, allowing elements outside of the Dialog to be interacted with.
 
 `DialogTitle` compound component will present by default a `closeButton`.
 
-To ensure that `Escape` key still works for dismissing the Dialog an event listener in the `document` is added. `onOpenChange` method from `Dialog` will return data as: `{ type: 'documentEscapeKeyDown'; open: boolean; event: KeyboardEvent };`
+> Note: if an element outside of the dialog is focused then it will not be possible to close the dialog with the `Escape` key.


### PR DESCRIPTION
## New Behavior

1. removes from documentation citation of `noTrapFocus` property
2. removes from documentation the addition of a global listener
3. adds to documention a note about `Escape` key press

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28928
