### PR TITLE
chore(react-dialog): adds CSS containment to DialogSurface

### DIFF
--- a/change/@fluentui-react-dialog-864397b3-e850-464f-b5f2-ae89863fed07.json
+++ b/change/@fluentui-react-dialog-864397b3-e850-464f-b5f2-ae89863fed07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adds CSS containment to DialogSurface",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -21,6 +21,7 @@ export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots> = {
 const useStyles = makeStyles({
   focusOutline: createFocusOutlineStyle(),
   root: {
+    contain: 'content',
     display: 'block',
     userSelect: 'unset',
     visibility: 'unset',


### PR DESCRIPTION

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

1. adds [CSS containment](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment) to `DialogSurface` styles

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28612
