### PR TITLE
chore: updates render method generator of react-component to use automatic runtime

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Slots/Slots.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Slots/Slots.stories.mdx
@@ -381,11 +381,9 @@ Both `slot.always` and `slot.optional` methods will create a slot definition tha
 - `renderButton` takes in `ButtonState` and renders content.
 
 ```tsx
-/** @jsxRuntime classic */
-/** @jsx createElement */
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
 
-// createElement custom JSX pragma is required to support slot creation
-import { createElement } from '@fluentui/react-jsx-runtime';
 import { assertSlots } from '@fluentui/react-utilities';
 
 const renderButton_unstable = (state: ButtonState) => {

--- a/tools/workspace-plugin/src/generators/react-component/files/component/render__componentName__.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/component/render__componentName__.tsx__tmpl__
@@ -1,7 +1,6 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
 
-import { createElement } from '@fluentui/react-jsx-runtime';
 import { assertSlots } from '@fluentui/react-utilities';
 import type { <%= componentName %>State, <%= componentName %>Slots } from './<%= componentName %>.types';
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

react-component generator render method uses the classic runtime

## New Behavior

1. adopts automatic runtime

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
