### PR TITLE
feat(react-drawer): add support to override Dialog as slot

### DIFF
--- a/change/@fluentui-react-drawer-d5851106-2615-4746-aac1-931d5e1b69f3.json
+++ b/change/@fluentui-react-drawer-d5851106-2615-4746-aac1-931d5e1b69f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add dialog slot",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -131,7 +131,7 @@ export type DrawerInlineState = Required<ComponentState<DrawerInlineSlots> & Dra
 export const DrawerOverlay: ForwardRefComponent<DrawerOverlayProps>;
 
 // @public (undocumented)
-export const drawerOverlayClassNames: SlotClassNames<DrawerOverlaySlots>;
+export const drawerOverlayClassNames: Omit<SlotClassNames<DrawerOverlaySlots>, 'dialog'>;
 
 // @public
 export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> & DrawerBaseProps & Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus'>;
@@ -139,11 +139,11 @@ export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> & DrawerBase
 // @public (undocumented)
 export type DrawerOverlaySlots = DialogSurfaceSlots & {
     root: Slot<DialogSurfaceProps>;
+    dialog?: Slot<DialogProps>;
 };
 
 // @public
-export type DrawerOverlayState = Required<Omit<ComponentState<DrawerOverlaySlots>, 'backdrop'> & DrawerBaseState & {
-    dialog: DialogProps;
+export type DrawerOverlayState = Omit<ComponentState<DrawerOverlaySlots>, 'backdrop'> & Required<DrawerBaseState & {
     backdropMotion: MotionState<HTMLDivElement>;
 }>;
 

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/DrawerOverlay.types.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/DrawerOverlay.types.ts
@@ -6,6 +6,11 @@ import type { DrawerBaseProps, DrawerBaseState } from '../../shared/DrawerBase.t
 
 export type DrawerOverlaySlots = DialogSurfaceSlots & {
   root: Slot<DialogSurfaceProps>;
+
+  /**
+   * Slot for the dialog component that wraps the drawer.
+   */
+  dialog?: Slot<DialogProps>;
 };
 
 /**
@@ -18,10 +23,9 @@ export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> &
 /**
  * State used in rendering DrawerOverlay
  */
-export type DrawerOverlayState = Required<
-  Omit<ComponentState<DrawerOverlaySlots>, 'backdrop'> &
+export type DrawerOverlayState = Omit<ComponentState<DrawerOverlaySlots>, 'backdrop'> &
+  Required<
     DrawerBaseState & {
-      dialog: DialogProps;
       backdropMotion: MotionState<HTMLDivElement>;
     }
->;
+  >;

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/renderDrawerOverlay.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/renderDrawerOverlay.tsx
@@ -1,7 +1,6 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 import { assertSlots } from '@fluentui/react-utilities';
-import { Dialog } from '@fluentui/react-dialog';
 
 import type { DrawerOverlayState, DrawerOverlaySlots } from './DrawerOverlay.types';
 
@@ -9,15 +8,15 @@ import type { DrawerOverlayState, DrawerOverlaySlots } from './DrawerOverlay.typ
  * Render the final JSX of DrawerOverlay
  */
 export const renderDrawerOverlay_unstable = (state: DrawerOverlayState) => {
-  if (!state.motion.canRender) {
+  if (!state.dialog || !state.motion.canRender) {
     return null;
   }
 
   assertSlots<DrawerOverlaySlots>(state);
 
   return (
-    <Dialog {...state.dialog}>
+    <state.dialog>
       <state.root />
-    </Dialog>
+    </state.dialog>
   );
 };

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { getNativeElementProps, slot, useMergedRefs } from '@fluentui/react-utilities';
-import { DialogProps, DialogSurface, DialogSurfaceProps } from '@fluentui/react-dialog';
+import { slot, useMergedRefs } from '@fluentui/react-utilities';
+import { Dialog, DialogSurface } from '@fluentui/react-dialog';
 import { useMotion } from '@fluentui/react-motion-preview';
 
 import { useDrawerDefaultProps } from '../../shared/useDrawerDefaultProps';
@@ -27,11 +27,11 @@ export const useDrawerOverlay_unstable = (
 
   const hasCustomBackdrop = modalType !== 'non-modal' && props.backdrop !== null;
 
-  const root = slot.always<DialogSurfaceProps>(
-    getNativeElementProps('div', {
+  const root = slot.always(
+    {
       ...props,
       ref: useMergedRefs(ref, drawerMotion.ref),
-    }),
+    },
     {
       elementType: DialogSurface,
       defaultProps: {
@@ -46,28 +46,28 @@ export const useDrawerOverlay_unstable = (
     },
   );
 
-  const dialog = slot.always(
-    {
+  const dialog = slot.optional(props.dialog, {
+    elementType: Dialog,
+    renderByDefault: true,
+    defaultProps: {
       open: true,
       defaultOpen,
       onOpenChange,
       inertTrapFocus,
       modalType,
-    } as DialogProps,
-    {
-      elementType: 'div',
     },
-  );
+  });
 
   return {
     components: {
       root: DialogSurface,
+      dialog: Dialog,
       backdrop: 'div',
     },
 
     root,
-
     dialog,
+
     size,
     position,
     motion: drawerMotion,

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlayStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlayStyles.styles.ts
@@ -10,7 +10,7 @@ import {
   useDrawerDurationStyles,
 } from '../../shared/useDrawerBaseStyles.styles';
 
-export const drawerOverlayClassNames: SlotClassNames<DrawerOverlaySlots> = {
+export const drawerOverlayClassNames: Omit<SlotClassNames<DrawerOverlaySlots>, 'dialog'> = {
   root: 'fui-DrawerOverlay',
   backdrop: 'fui-DrawerOverlay__backdrop',
 };


### PR DESCRIPTION
## Previous Behavior

`<Dialog>` was a fixed React node.

## New Behavior

Create Dialog from slot allowing overrides.
