### PR TITLE
Remove cxe-coastal as an option for package owner in create-package script

### DIFF
--- a/scripts/generators/create-package/index.ts
+++ b/scripts/generators/create-package/index.ts
@@ -61,7 +61,6 @@ module.exports = (plop: NodePlopAPI) => {
         choices: [
           '@microsoft/fluentui-react-build',
           '@microsoft/teams-prg',
-          '@microsoft/cxe-coastal',
           '@microsoft/cxe-red',
           '@microsoft/cxe-prg',
         ],

--- a/tools/workspace-plugin/src/generators/react-library/schema.json
+++ b/tools/workspace-plugin/src/generators/react-library/schema.json
@@ -22,13 +22,7 @@
       "x-prompt": {
         "message": "Which team will own this library",
         "type": "list",
-        "items": [
-          "@microsoft/cxe-coastal",
-          "@microsoft/cxe-red",
-          "@microsoft/cxe-prg",
-          "@microsoft/fluentui-react-build",
-          "@microsoft/teams-prg"
-        ]
+        "items": ["@microsoft/cxe-red", "@microsoft/cxe-prg", "@microsoft/fluentui-react-build", "@microsoft/teams-prg"]
       }
     },
     "kind": {


### PR DESCRIPTION
The cxe-coastal team is being merged into the cxe-red team. This removes cxe-coastal as an option to pick as a codeowner.

Related:
* #29248