### PR TITLE
chore: bump swc core to mitigate transpilation memory leaks

### DIFF
--- a/apps/ts-minbar-test-react-components/package.json
+++ b/apps/ts-minbar-test-react-components/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "type-check": "tsc -p .",
-    "test": "ts-node --swc ./src/index.ts"
+    "test": "ts-node ./src/index.ts"
   },
   "devDependencies": {
     "@fluentui/scripts-tasks": "*",

--- a/apps/ts-minbar-test-react/package.json
+++ b/apps/ts-minbar-test-react/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "type-check": "tsc -p .",
-    "test": "ts-node --swc ./src/index.ts"
+    "test": "ts-node ./src/index.ts"
   },
   "devDependencies": {
     "@fluentui/scripts-tasks": "*",

--- a/change/@fluentui-babel-preset-global-context-48ba5078-9685-43d5-be71-33658118e703.json
+++ b/change/@fluentui-babel-preset-global-context-48ba5078-9685-43d5-be71-33658118e703.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-global-context-dd88e0e0-601a-4c05-bea7-05d2a69ee35a.json
+++ b/change/@fluentui-global-context-dd88e0e0-601a-4c05-bea7-05d2a69ee35a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-keyboard-keys-b6f7daa5-1cae-4476-af49-7d30dad048d7.json
+++ b/change/@fluentui-keyboard-keys-b6f7daa5-1cae-4476-af49-7d30dad048d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-priority-overflow-740d6f52-2ad9-45b0-ad41-b06fa1e51ecf.json
+++ b/change/@fluentui-priority-overflow-740d6f52-2ad9-45b0-ad41-b06fa1e51ecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-35b21cfd-7176-495a-be20-d7a623eb66c3.json
+++ b/change/@fluentui-react-accordion-35b21cfd-7176-495a-be20-d7a623eb66c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-5da7e39d-3d38-4171-8b3a-27ca98b05331.json
+++ b/change/@fluentui-react-alert-5da7e39d-3d38-4171-8b3a-27ca98b05331.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-alert",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-a092ed88-a310-4304-8f69-8217245e2350.json
+++ b/change/@fluentui-react-aria-a092ed88-a310-4304-8f69-8217245e2350.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-840268ea-d715-4051-8c59-19308dd523e5.json
+++ b/change/@fluentui-react-avatar-840268ea-d715-4051-8c59-19308dd523e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-85ef7c67-992e-4b7a-86f7-26b898f50530.json
+++ b/change/@fluentui-react-badge-85ef7c67-992e-4b7a-86f7-26b898f50530.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-preview-956dd7a5-b750-4434-bd5a-ca54cff00f60.json
+++ b/change/@fluentui-react-breadcrumb-preview-956dd7a5-b750-4434-bd5a-ca54cff00f60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-147576c5-798a-4a2c-a639-cb59e392974f.json
+++ b/change/@fluentui-react-button-147576c5-798a-4a2c-a639-cb59e392974f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-02975682-d759-4a75-9133-1258d2c8addd.json
+++ b/change/@fluentui-react-card-02975682-d759-4a75-9133-1258d2c8addd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-74dfd807-277f-458b-831b-a5843d0efd6b.json
+++ b/change/@fluentui-react-checkbox-74dfd807-277f-458b-831b-a5843d0efd6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-b8f07c98-a6b6-4a99-bf8b-b977a4fcc497.json
+++ b/change/@fluentui-react-combobox-b8f07c98-a6b6-4a99-bf8b-b977a4fcc497.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-7b3ee3ce-c087-448b-9880-03f8bd1cbc23.json
+++ b/change/@fluentui-react-components-7b3ee3ce-c087-448b-9880-03f8bd1cbc23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-c9fec57c-a067-43ec-a8b5-7582d6064e20.json
+++ b/change/@fluentui-react-conformance-c9fec57c-a067-43ec-a8b5-7582d6064e20.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-griffel-7d7b29a5-a800-4447-bfe0-399e7283270e.json
+++ b/change/@fluentui-react-conformance-griffel-7d7b29a5-a800-4447-bfe0-399e7283270e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-69dae89f-8438-42f2-a66d-fe6850a41e48.json
+++ b/change/@fluentui-react-context-selector-69dae89f-8438-42f2-a66d-fe6850a41e48.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-49a53453-9b46-4085-a3b2-3581c1e021fe.json
+++ b/change/@fluentui-react-datepicker-compat-49a53453-9b46-4085-a3b2-3581c1e021fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-946f9d66-8a7c-40d3-b40b-08f8d0b84495.json
+++ b/change/@fluentui-react-dialog-946f9d66-8a7c-40d3-b40b-08f8d0b84495.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-ce47b5bd-f227-462f-b8b8-3dbe247fe8da.json
+++ b/change/@fluentui-react-divider-ce47b5bd-f227-462f-b8b8-3dbe247fe8da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-4dd6f2f4-ca02-4e1b-87d5-6733691e9ffc.json
+++ b/change/@fluentui-react-drawer-4dd6f2f4-ca02-4e1b-87d5-6733691e9ffc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-dd19bc53-9de7-43f0-a790-74f4265fd8a8.json
+++ b/change/@fluentui-react-field-dd19bc53-9de7-43f0-a790-74f4265fd8a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-cdea2d56-68e9-4ed4-b57e-d71fa6dc12d4.json
+++ b/change/@fluentui-react-image-cdea2d56-68e9-4ed4-b57e-d71fa6dc12d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infobutton-a55b9fe6-1e8a-4250-816f-198b43e673d7.json
+++ b/change/@fluentui-react-infobutton-a55b9fe6-1e8a-4250-816f-198b43e673d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-66ad71fd-21b2-4597-a251-060dd9e93596.json
+++ b/change/@fluentui-react-input-66ad71fd-21b2-4597-a251-060dd9e93596.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-jsx-runtime-8d6218b1-e3cf-4747-9232-aaca4ddac9c5.json
+++ b/change/@fluentui-react-jsx-runtime-8d6218b1-e3cf-4747-9232-aaca4ddac9c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-d3f6ff4e-cf13-4d9a-a85e-3f4b9c26efea.json
+++ b/change/@fluentui-react-label-d3f6ff4e-cf13-4d9a-a85e-3f4b9c26efea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-09507447-ecc3-4b30-9469-5a8022296d6d.json
+++ b/change/@fluentui-react-link-09507447-ecc3-4b30-9469-5a8022296d6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-afaa64d8-e210-48a5-a73f-e11a4d5daaf2.json
+++ b/change/@fluentui-react-menu-afaa64d8-e210-48a5-a73f-e11a4d5daaf2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-054573b6-9809-4fef-9244-1f6635fdf302.json
+++ b/change/@fluentui-react-migration-v0-v9-054573b6-9809-4fef-9244-1f6635fdf302.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-f86e5f32-24b4-450e-aba4-920b97636c02.json
+++ b/change/@fluentui-react-migration-v8-v9-f86e5f32-24b4-450e-aba4-920b97636c02.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-preview-4fbe453e-4f14-4aff-bb86-272a6bef26ec.json
+++ b/change/@fluentui-react-motion-preview-4fbe453e-4f14-4aff-bb86-272a6bef26ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-motion-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-8a31758c-000f-439e-8251-fc36c564c879.json
+++ b/change/@fluentui-react-overflow-8a31758c-000f-439e-8251-fc36c564c879.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-7428c318-92f7-4e13-bf1b-efab9b2ff83e.json
+++ b/change/@fluentui-react-persona-7428c318-92f7-4e13-bf1b-efab9b2ff83e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-47b1b207-b42b-4a42-8779-062a751721d4.json
+++ b/change/@fluentui-react-popover-47b1b207-b42b-4a42-8779-062a751721d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-94b0a4f9-fbca-43f3-a208-f1277a822518.json
+++ b/change/@fluentui-react-portal-94b0a4f9-fbca-43f3-a208-f1277a822518.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-92b7a1c5-d9fb-412b-815c-1515601c56e0.json
+++ b/change/@fluentui-react-portal-compat-92b7a1c5-d9fb-412b-815c-1515601c56e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-context-ba2179c2-c572-4032-ae03-aec768f81be7.json
+++ b/change/@fluentui-react-portal-compat-context-ba2179c2-c572-4032-ae03-aec768f81be7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-b8a33304-5599-4319-baa4-91d5ec7720fd.json
+++ b/change/@fluentui-react-positioning-b8a33304-5599-4319-baa4-91d5ec7720fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-eea4bbed-ca1d-4e76-b0bb-400d1938a3e5.json
+++ b/change/@fluentui-react-progress-eea4bbed-ca1d-4e76-b0bb-400d1938a3e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-0452562a-3daf-4965-9855-af403df5a13d.json
+++ b/change/@fluentui-react-provider-0452562a-3daf-4965-9855-af403df5a13d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-509966b8-5f48-4681-953c-560c2d7dcd6a.json
+++ b/change/@fluentui-react-radio-509966b8-5f48-4681-953c-560c2d7dcd6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-preview-cc4a4c9b-99c3-41c8-8285-93701ede1889.json
+++ b/change/@fluentui-react-search-preview-cc4a4c9b-99c3-41c8-8285-93701ede1889.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-search-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-f84e4c1a-3041-48c9-8ee6-a5f4488534c4.json
+++ b/change/@fluentui-react-select-f84e4c1a-3041-48c9-8ee6-a5f4488534c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-select",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-2648feed-9940-4c49-8ad7-3d53fcd7f8dc.json
+++ b/change/@fluentui-react-shared-contexts-2648feed-9940-4c49-8ad7-3d53fcd7f8dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-8dea56a8-8874-4166-b740-5c7103cdf958.json
+++ b/change/@fluentui-react-skeleton-8dea56a8-8874-4166-b740-5c7103cdf958.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-ff9d4197-f376-46ef-857b-1c4cae35623a.json
+++ b/change/@fluentui-react-slider-ff9d4197-f376-46ef-857b-1c4cae35623a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-ea2f81a3-cb95-407e-a036-5e2d46c210aa.json
+++ b/change/@fluentui-react-spinbutton-ea2f81a3-cb95-407e-a036-5e2d46c210aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-b6e43ca2-7310-4899-9569-97e758718c8f.json
+++ b/change/@fluentui-react-spinner-b6e43ca2-7310-4899-9569-97e758718c8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-e31975b8-5e74-439c-babf-61d654405acc.json
+++ b/change/@fluentui-react-switch-e31975b8-5e74-439c-babf-61d654405acc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-15da345c-5778-40cc-afed-9f285a1d168b.json
+++ b/change/@fluentui-react-table-15da345c-5778-40cc-afed-9f285a1d168b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-87c284a9-1c6e-46e2-b424-195c3cfa3614.json
+++ b/change/@fluentui-react-tabs-87c284a9-1c6e-46e2-b424-195c3cfa3614.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-b018ecce-3e83-4500-a015-3ade2913c609.json
+++ b/change/@fluentui-react-tabster-b018ecce-3e83-4500-a015-3ade2913c609.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-preview-5eaf424d-b44d-48dd-9334-232475fdf163.json
+++ b/change/@fluentui-react-tags-preview-5eaf424d-b44d-48dd-9334-232475fdf163.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-21437adb-cc92-473d-85e7-9e4b511c621e.json
+++ b/change/@fluentui-react-text-21437adb-cc92-473d-85e7-9e4b511c621e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-6c692dac-44a7-486a-8b80-fcf72b0e2a3d.json
+++ b/change/@fluentui-react-textarea-6c692dac-44a7-486a-8b80-fcf72b0e2a3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-c6d8bc00-435c-480e-9c34-a37cd541d5b2.json
+++ b/change/@fluentui-react-theme-c6d8bc00-435c-480e-9c34-a37cd541d5b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-sass-bbdf7229-3c80-40a3-96d1-159621d47b92.json
+++ b/change/@fluentui-react-theme-sass-bbdf7229-3c80-40a3-96d1-159621d47b92.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-73767385-faca-4ad5-b739-50312d79fd39.json
+++ b/change/@fluentui-react-toast-73767385-faca-4ad5-b739-50312d79fd39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-57675b09-0039-4372-9af9-e9adf94fd7c9.json
+++ b/change/@fluentui-react-toolbar-57675b09-0039-4372-9af9-e9adf94fd7c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-0ba6fbc3-5d7d-43b5-b1c4-2f7355fc4e84.json
+++ b/change/@fluentui-react-tooltip-0ba6fbc3-5d7d-43b5-b1c4-2f7355fc4e84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-517e1bb9-58be-485c-b787-401447c2e0f8.json
+++ b/change/@fluentui-react-tree-517e1bb9-58be-485c-b787-401447c2e0f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-6ca8ac02-fc92-4e41-8e83-0b92554667ac.json
+++ b/change/@fluentui-react-utilities-6ca8ac02-fc92-4e41-8e83-0b92554667ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-fafb8189-a85a-4de9-9772-2c3330b67746.json
+++ b/change/@fluentui-react-virtualizer-fafb8189-a85a-4de9-9772-2c3330b67746.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-tokens-b8cfbced-265b-43ef-83a2-80c757444fe0.json
+++ b/change/@fluentui-tokens-b8cfbced-265b-43ef-83a2-80c757444fe0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bump swc core to mitigate transpilation memory leaks",
+  "packageName": "@fluentui/tokens",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@storybook/react": "6.5.15",
     "@storybook/theming": "6.5.15",
     "@swc/cli": "0.1.62",
-    "@swc/core": "1.3.79",
+    "@swc/core": "1.3.87",
     "@swc/helpers": "0.5.1",
     "@testing-library/dom": "8.11.3",
     "@testing-library/jest-dom": "5.16.5",

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -19,6 +19,12 @@
     "generate-api": "just-scripts generate-api",
     "type-check": "just-scripts type-check"
   },
+  "beachball": {
+    "disallowedChangeTypes": [
+      "major",
+      "prerelease"
+    ]
+  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-jest": "*",

--- a/scripts/test-ssr/bin/test-ssr.js
+++ b/scripts/test-ssr/bin/test-ssr.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
 
-require('@fluentui/scripts-ts-node/register');
+const { joinPathFragments } = require('@nx/devkit');
+const { registerTsProject } = require('nx/src/utils/register');
+
+registerTsProject(joinPathFragments(__dirname, '..'), 'tsconfig.lib.json');
+
 require('../src/cli.ts');

--- a/scripts/ts-node/register.js
+++ b/scripts/ts-node/register.js
@@ -3,5 +3,6 @@ const tsNode = require('ts-node');
 tsNode.register({
   // https://github.com/TypeStrong/ts-node#skipproject - don't read tsconfig within ts-node
   skipProject: true,
-  swc: true,
+  // @deprecated: we cannot use this until new version of ts-node is released https://github.com/TypeStrong/ts-node/pull/2062
+  // swc: true,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,73 +4476,73 @@
     slash "3.0.0"
     source-map "^0.7.3"
 
-"@swc/core-darwin-arm64@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.79.tgz#adbb70e5cc8f985d30b237c33e6ce7f25c8fdcca"
-  integrity sha512-yK8uetckyfRoQ0m4ymRr8y6CRtB9+IeMcDYXfoy4yYbI1U6bedO1Py9u+70h2XRYNvCamyMj7I2NiCOaIoAYhw==
+"@swc/core-darwin-arm64@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.87.tgz#0547ec3297424ff89de503a07509646f48519e2a"
+  integrity sha512-/LxLjPat1LA9CXS7Cn2M4MIqwNOoDF4KjcikPkO08H54rd6WubhaJnr0sLDjms3adRr+pmcCL0yfsUBTX//85A==
 
-"@swc/core-darwin-x64@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.79.tgz#1372424ca2c892a76182ac45847db216a0e9a7b5"
-  integrity sha512-mPeyHCFVOY1Jhw3DBHrJ7n759rlwRTaTgUN1U9TmM3WjfojR9NmQsg9vkdnXZz6saQ2rMCB5x8je/rZg9TMxag==
+"@swc/core-darwin-x64@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.87.tgz#cbbe47ce93d7893db1649d6b16b0be187d12438b"
+  integrity sha512-hjSQNcW9BN8gEz3UQZ7Ye80ymbkFHLkUDeEek4lorRyq6S+uxvbL1f1mJAZnFPBpove7AXusykIalWMPvyOR2A==
 
-"@swc/core-linux-arm-gnueabihf@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.79.tgz#82e4a6e4322566d6cabcf7484e7e52f7e036fb8c"
-  integrity sha512-Lh/AmaR9Mul7nUt6pdCZYyMPQjBkUtWWM9JYFUErmCU/k85RbWfnklbuN83k5GR8FsR5hARtysl5bHJlBBUVgQ==
+"@swc/core-linux-arm-gnueabihf@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.87.tgz#b1c066f49232caacde9300dd12c2a4d13b495d30"
+  integrity sha512-JVyNIO3tGLPSQ59rJXeKaykTpPhRNozB+7PtYMvMcxpUbYGpEzWxTPkFAX2KKPvl0ejBdA0GW5OXeuPMvTwE0w==
 
-"@swc/core-linux-arm64-gnu@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.79.tgz#0160c89f9d51f175d37031fde0241ac4078d0a12"
-  integrity sha512-np+vpbYoi28a0frJtywV+gTYhEtEgCwmc+Jh0WyBQkrbuR4efiy7h88huiB+9EXH1PHSUfuq6JHC+ZNEw0FAEg==
+"@swc/core-linux-arm64-gnu@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.87.tgz#36c2c7ea1ec0622858e16fa16a706922c12cb4ac"
+  integrity sha512-gLdZKIoql5vjrNjrwwsiS7d3vOAIzYUWqN97iGCSscQOg0MgYbfUnSTO4UEvH4BYlwRNlHepfTZ7ALoG8areUQ==
 
-"@swc/core-linux-arm64-musl@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.79.tgz#c131a9088afbd000c1dca73cb076979d0c3c6272"
-  integrity sha512-UfQV8fqunwf9huahNQ62+0NyYIXEZplk2/yEXb/wFOMv0lEAL5+6Sc8dzdWOup6agYMsUpjTOoPCtsaLKjGe/w==
+"@swc/core-linux-arm64-musl@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.87.tgz#b7f34b2dd352a2f71aecd1c093452cfa9d5f8983"
+  integrity sha512-WQ5tirVBiU8lUODQ25dt8JRCZHyRDInBe4fkGuxzImMa017zYPWa2WxrKK8LdDF7DzrAITlGl9VeoeE/l0WJbw==
 
-"@swc/core-linux-x64-gnu@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.79.tgz#4213fea5bab36ed69c6787950d0c0d4933978f0c"
-  integrity sha512-b0wYbWIoxf7SH+NlZ0uqXX6W4hsu5T+HKP4RaPOFRmhfLhkdx5h67x88bUvXUaM7W8UUTG6hoKTK8Q0ERH+vuA==
+"@swc/core-linux-x64-gnu@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.87.tgz#42a9fff0212893b0868e048686443dac148f4e9f"
+  integrity sha512-/vQSH7ZKOuT1It9GzpJ9UFnsOP/dQr1VLUrKQFBlHp9owIWNb2oUrZdNla+KhljCIIahh0JfQ08sycKeycCNzQ==
 
-"@swc/core-linux-x64-musl@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.79.tgz#2bf2538a13a99383f49859ae77471fb331a4ba74"
-  integrity sha512-Q6bGZ9C9gWnZUVG0LI6ootW8f/tv60QmJZGkKmX58yHAE72nhUbVMWhdsXPDsxXC6p/DZkatA6rmavFwo+HSKQ==
+"@swc/core-linux-x64-musl@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.87.tgz#b21a089d785895eb71fbcfe695ccfc454b70017f"
+  integrity sha512-C1NUeISJDyMlIk4919bjcpHvjyjzbkjW7v53gUdN41Y4BPlEk7UKcLez7UHMjdMGA/o9721SLqYVp4/NrQErUw==
 
-"@swc/core-win32-arm64-msvc@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.79.tgz#27150cb46abafa38491fa37d4e48661f12328e90"
-  integrity sha512-LZ5I/NkdIllrWN3+8HBEk6Jry2yQB3DKHRoniy7XE9Cm7UxIeP3sJIvaH963cOFaQhZPCa16WdTwjNtarDvWIQ==
+"@swc/core-win32-arm64-msvc@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.87.tgz#c32366a5782cb1fd2a7484c34fd879cefbb883e4"
+  integrity sha512-AE7JKDJ0OsV9LsYGFfYKMTkGNfsy1au4RT5jT1rxr5MTOsmMD7P2mgiRF8drgc1WX3uOJbTHQfgdVTYroAGfdA==
 
-"@swc/core-win32-ia32-msvc@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.79.tgz#cdff85872dbbabc4d2aa1c5aea96b8de25262b60"
-  integrity sha512-/UpcljcsMgsX9NkAdPiGaKf4r3X5mLcQxRC7lEIG3PZRYSQevSpmB7v1Pq/5kFKU1asA80ljUR5f29EmeShTzQ==
+"@swc/core-win32-ia32-msvc@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.87.tgz#c2e0de986c733c6fbeecdf99330c5b6260560974"
+  integrity sha512-2V+5uvisaTPXd5lvTujNLNlEC2LPo07gEUQVGdKGsbhtLAYAggVXBnHjxU1TkuyA6NlciMS59tPKW+L2u2KpTw==
 
-"@swc/core-win32-x64-msvc@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.79.tgz#b63d69a13136c25ce295601c217ef3cc45ee5009"
-  integrity sha512-h4bCK2qce5yJttwuaVaiSZ1yeOJoU8At/7oT0C2yCqupx3i5/iswYZZy5gU/CsO6ccg5kGwKtngnlL5HKQyRSw==
+"@swc/core-win32-x64-msvc@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.87.tgz#24b5b50814062fb3cee0945ee5c09da2313b7f0c"
+  integrity sha512-2Xak7TidlRuNQamLZC3fEOdUCmMiBzD2BW8+Dnn29f4odzamgAFfeYJ/PnqN7jdTWOINLn95tex4JBm3Pm11HQ==
 
-"@swc/core@1.3.79":
-  version "1.3.79"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.79.tgz#c30e2bdb6e72de494a62d5e1542fb21bfe3fea23"
-  integrity sha512-lzpO9okKZ0TxS8D5zYo7n/ZfZJviExZ9DKPqwmfu/BCPXXv1NbeYWevtF9zXmrUEt7VuYSehzkKBr0ehvzj4Fw==
+"@swc/core@1.3.87":
+  version "1.3.87"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.87.tgz#b84cffd0d03f49e04b165088bc733a43ac59281e"
+  integrity sha512-u33Mi/EBvb+g/xpYKyxODB5XvKYqISmy81J+lhFS/Oahja0PbJWZdKEGwSQEFvBecp6E+PfaTOLPOoF1EWcRrw==
   dependencies:
-    "@swc/types" "^0.1.3"
+    "@swc/types" "^0.1.4"
   optionalDependencies:
-    "@swc/core-darwin-arm64" "1.3.79"
-    "@swc/core-darwin-x64" "1.3.79"
-    "@swc/core-linux-arm-gnueabihf" "1.3.79"
-    "@swc/core-linux-arm64-gnu" "1.3.79"
-    "@swc/core-linux-arm64-musl" "1.3.79"
-    "@swc/core-linux-x64-gnu" "1.3.79"
-    "@swc/core-linux-x64-musl" "1.3.79"
-    "@swc/core-win32-arm64-msvc" "1.3.79"
-    "@swc/core-win32-ia32-msvc" "1.3.79"
-    "@swc/core-win32-x64-msvc" "1.3.79"
+    "@swc/core-darwin-arm64" "1.3.87"
+    "@swc/core-darwin-x64" "1.3.87"
+    "@swc/core-linux-arm-gnueabihf" "1.3.87"
+    "@swc/core-linux-arm64-gnu" "1.3.87"
+    "@swc/core-linux-arm64-musl" "1.3.87"
+    "@swc/core-linux-x64-gnu" "1.3.87"
+    "@swc/core-linux-x64-musl" "1.3.87"
+    "@swc/core-win32-arm64-msvc" "1.3.87"
+    "@swc/core-win32-ia32-msvc" "1.3.87"
+    "@swc/core-win32-x64-msvc" "1.3.87"
 
 "@swc/helpers@0.5.1", "@swc/helpers@^0.5.1":
   version "0.5.1"
@@ -4551,10 +4551,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@swc/types@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.3.tgz#dd35a74e7eeb153d39d9a7b5ca4ac7e41a73f2fe"
-  integrity sha512-3Oq9V7tRV5+hlKHPr/8RpByJ1HXB4mAbZxh/sKAjyvNRBxTASjBx4j+gN9iXMBTllhZCZgYUfOqvbCtU3tqOHQ==
+"@swc/types@^0.1.4":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
+  integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- bumped monorepo swc core which fixes memory leaks
- force generated changefiles for all published packages using swc for transpilation.
- removes direct usage of ts-node/register with nx in memory transpilation as ts-node blocks this PR otherwise https://github.com/TypeStrong/ts-node/pull/2062
- adds beachball config to react-conformance package for consistency 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29192
- Replaces https://github.com/microsoft/fluentui/pull/29195 
