### PR TITLE
chore: use default prevention instead of stop propagation for Escape handling

### DIFF
--- a/change/@fluentui-react-dialog-638853b4-442a-44da-b79c-3b3071a063e3.json
+++ b/change/@fluentui-react-dialog-638853b4-442a-44da-b79c-3b3071a063e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use default prevention instead of stop propagation for Escape handling",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-7fdfa4f1-981a-4942-b8b2-28989af08745.json
+++ b/change/@fluentui-react-menu-7fdfa4f1-981a-4942-b8b2-28989af08745.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use default prevention instead of stop propagation for Escape handling",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-68102fa6-ec06-4d3b-b2a9-5ef9e3f56ce1.json
+++ b/change/@fluentui-react-popover-68102fa6-ec06-4d3b-b2a9-5ef9e3f56ce1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use default prevention instead of stop propagation for Escape handling",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-5d73642d-79d9-455c-b084-ee5beab476fd.json
+++ b/change/@fluentui-react-tooltip-5d73642d-79d9-455c-b084-ee5beab476fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: use default prevention instead of stop propagation for Escape handling",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurface.ts
@@ -54,7 +54,7 @@ export const useDialogSurface_unstable = (
       });
       // stop propagation to avoid conflicting with other elements that listen for `Escape`
       // e,g: nested Dialog, Popover, Menu and Tooltip
-      event.stopPropagation();
+      event.preventDefault();
     }
   });
 

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -79,11 +79,11 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
   rootProps.onKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLElement>) => {
     const key = event.key;
     if (key === Escape || (isSubmenu && key === CloseArrowKey)) {
-      if (open && popoverRef.current?.contains(event.target as HTMLElement)) {
+      if (open && popoverRef.current?.contains(event.target as HTMLElement) && !event.isDefaultPrevented()) {
         setOpen(event, { open: false, keyboard: true, type: 'menuPopoverKeyDown', event });
         // stop propagation to avoid conflicting with other elements that listen for `Escape`
-        // e,g: Dialog, Popover and Tooltip
-        event.stopPropagation();
+        // e,g: Dialog, Popover, Menu and Tooltip
+        event.preventDefault();
       }
     }
     if (key === Tab) {

--- a/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
+++ b/packages/react-components/react-popover/src/components/PopoverTrigger/usePopoverTrigger.ts
@@ -46,11 +46,11 @@ export const usePopoverTrigger_unstable = (props: PopoverTriggerProps): PopoverT
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-    if (e.key === Escape && open) {
+    if (e.key === Escape && open && !e.isDefaultPrevented()) {
       setOpen(e, false);
       // stop propagation to avoid conflicting with other elements that listen for `Escape`
-      // e,g: Dialog, Menu
-      e.stopPropagation();
+      // e,g: Dialog, Popover, Menu and Tooltip
+      e.preventDefault();
     }
   };
 

--- a/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/src/components/Tooltip/useTooltip.tsx
@@ -125,11 +125,11 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
       context.visibleTooltip = thisTooltip;
 
       const onDocumentKeyDown = (ev: KeyboardEvent) => {
-        if (ev.key === Escape) {
+        if (ev.key === Escape && !ev.defaultPrevented) {
           thisTooltip.hide(ev);
           // stop propagation to avoid conflicting with other elements that listen for `Escape`
-          // e,g: Dialog, Popover, Menu
-          ev.stopPropagation();
+          // e,g: Dialog, Popover, Menu and Tooltip
+          ev.preventDefault();
         }
       };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Uses `stopPropagation` to stop Escape key down event to ensure no conflict between different components.

## New Behavior

Uses `preventDefault` + verification of default prevention to ensure Escape key press is being handled properly.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
