### PR TITLE
fix(react-drawer): use context to fetch dialog id

### DIFF
--- a/change/@fluentui-react-drawer-30e2677b-918d-444b-b5f3-aca797ecc5ed.json
+++ b/change/@fluentui-react-drawer-30e2677b-918d-444b-b5f3-aca797ecc5ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use context to fetch dialog id",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getNativeElementProps, slot } from '@fluentui/react-utilities';
-import { useDialogTitle_unstable } from '@fluentui/react-dialog';
+import { useDialogContext_unstable } from '@fluentui/react-dialog';
 
 import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
 
@@ -10,12 +10,11 @@ import type { DrawerHeaderTitleProps, DrawerHeaderTitleState } from './DrawerHea
  * @param props - props from this instance of DrawerHeaderTitle
  */
 const useHeadingProps = ({ children, heading }: DrawerHeaderTitleProps) => {
-  const resolvedHeading = slot.resolveShorthand(heading) || {};
-  const { root: titleProps } = useDialogTitle_unstable(resolvedHeading, React.createRef());
+  const id = useDialogContext_unstable(ctx => ctx.dialogTitleId);
 
-  return slot.optional(titleProps, {
+  return slot.optional(heading, {
     defaultProps: {
-      ...titleProps,
+      id,
       children,
     },
     renderByDefault: true,


### PR DESCRIPTION
## Previous Behavior
The Drawer was creating the title to fetch the generated id, as the dialog context was not exported by the react-dialog package.

## New Behavior
Now that the dialog context is available publicly, it is now using the context to fetch the generated dialog id.