### PR TITLE
fix(react-drawer): remove defaultOpen from DrawerInline as it had no effect

### DIFF
--- a/change/@fluentui-react-drawer-1ce8b229-ee2d-4271-87fa-317811ba7a89.json
+++ b/change/@fluentui-react-drawer-1ce8b229-ee2d-4271-87fa-317811ba7a89.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove defaultOpen prop from DrawerInline as it had no effect",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -134,7 +134,7 @@ export const DrawerOverlay: ForwardRefComponent<DrawerOverlayProps>;
 export const drawerOverlayClassNames: Omit<SlotClassNames<DrawerOverlaySlots>, 'dialog'>;
 
 // @public
-export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> & DrawerBaseProps & Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus'>;
+export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> & Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus' | 'defaultOpen'> & DrawerBaseProps;
 
 // @public (undocumented)
 export type DrawerOverlaySlots = DialogSurfaceSlots & {

--- a/packages/react-components/react-drawer/src/components/DrawerInline/useDrawerInline.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/useDrawerInline.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, slot, useControllableState, useMergedRefs } from '@fluentui/react-utilities';
+import { getNativeElementProps, slot, useMergedRefs } from '@fluentui/react-utilities';
 import { useMotion } from '@fluentui/react-motion-preview';
 
 import type { DrawerInlineProps, DrawerInlineState } from './DrawerInline.types';
@@ -18,14 +18,8 @@ export const useDrawerInline_unstable = (
   props: DrawerInlineProps,
   ref: React.Ref<HTMLDivElement>,
 ): DrawerInlineState => {
-  const { size, position, ...defaultProps } = useDrawerDefaultProps(props);
+  const { size, position, open } = useDrawerDefaultProps(props);
   const { separator = false } = props;
-
-  const [open] = useControllableState({
-    state: defaultProps.open,
-    defaultState: defaultProps.defaultOpen,
-    initialState: false,
-  });
 
   const motion = useMotion<HTMLDivElement>(open);
 

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/DrawerOverlay.types.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/DrawerOverlay.types.ts
@@ -17,8 +17,8 @@ export type DrawerOverlaySlots = DialogSurfaceSlots & {
  * DrawerOverlay Props
  */
 export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> &
-  DrawerBaseProps &
-  Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus'>;
+  Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus' | 'defaultOpen'> &
+  DrawerBaseProps;
 
 /**
  * State used in rendering DrawerOverlay

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
@@ -19,8 +19,8 @@ export const useDrawerOverlay_unstable = (
   props: DrawerOverlayProps,
   ref: React.Ref<HTMLDivElement>,
 ): DrawerOverlayState => {
-  const { open, defaultOpen, size, position } = useDrawerDefaultProps(props);
-  const { modalType = 'modal', inertTrapFocus, onOpenChange } = props;
+  const { open, size, position } = useDrawerDefaultProps(props);
+  const { modalType = 'modal', inertTrapFocus, defaultOpen = false, onOpenChange } = props;
 
   const drawerMotion = useMotion<HTMLDivElement>(open);
   const backdropMotion = useMotion<HTMLDivElement>(open);

--- a/packages/react-components/react-drawer/src/shared/DrawerBase.types.ts
+++ b/packages/react-components/react-drawer/src/shared/DrawerBase.types.ts
@@ -26,13 +26,6 @@ export type DrawerBaseProps = {
    * @default false
    */
   open?: MotionShorthand<HTMLDivElement>;
-
-  /**
-   * Default value for the uncontrolled open state of the Drawer.
-   *
-   * @default false
-   */
-  defaultOpen?: boolean;
 };
 
 export type DrawerBaseState = Required<Pick<DrawerBaseProps, 'position' | 'size'>> & {

--- a/packages/react-components/react-drawer/src/shared/useDrawerDefaultProps.ts
+++ b/packages/react-components/react-drawer/src/shared/useDrawerDefaultProps.ts
@@ -1,12 +1,11 @@
 import { DrawerBaseProps } from './DrawerBase.types';
 
 export function useDrawerDefaultProps(props: DrawerBaseProps) {
-  const { open = false, defaultOpen = false, size = 'small', position = 'start' } = props;
+  const { open = false, size = 'small', position = 'start' } = props;
 
   return {
     size,
     position,
     open,
-    defaultOpen,
   };
 }


### PR DESCRIPTION
## Previous Behavior
The DrawerInline had defaultOpen and open to have the same API as the DrawerOverlay, but that was unnecessary as defaultOpen was never used.

## New Behavior
Removes defaultOpen as it had no effect.
