### PR TITLE
fix(react-tags-preview): remove disabled InteractionTag hover color under WHCM

### DIFF
--- a/change/@fluentui-react-tags-preview-3da108b0-6f55-4670-b217-734d56287fbb.json
+++ b/change/@fluentui-react-tags-preview-3da108b0-6f55-4670-b217-734d56287fbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove hover color for disabled InteractionTag under windows high contrast",
+  "packageName": "@fluentui/react-tags-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -42,16 +42,6 @@ const baseStyles: GriffelResetStyle = {
     ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorStrokeFocus2),
     zIndex: 1,
   }),
-
-  // windows high contrast:
-  '@media (forced-colors: active)': {
-    ':hover': {
-      backgroundColor: 'HighlightText',
-    },
-    ':active': {
-      backgroundColor: 'HighlightText',
-    },
-  },
 };
 
 const useRootRoundedBaseClassName = makeResetStyles({
@@ -132,6 +122,14 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackground3Pressed,
       color: tokens.colorNeutralForeground2Pressed,
     },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: 'HighlightText',
+      },
+      ':active': {
+        backgroundColor: 'HighlightText',
+      },
+    },
   },
   outline: {
     backgroundColor: tokens.colorSubtleBackground,
@@ -162,6 +160,14 @@ const useRootStyles = makeStyles({
         display: 'none',
       },
     },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: 'HighlightText',
+      },
+      ':active': {
+        backgroundColor: 'HighlightText',
+      },
+    },
   },
   brand: {
     backgroundColor: tokens.colorBrandBackground2,
@@ -174,6 +180,14 @@ const useRootStyles = makeStyles({
     ':active': {
       backgroundColor: tokens.colorBrandBackground2Pressed,
       color: tokens.colorCompoundBrandForeground1Pressed,
+    },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: 'HighlightText',
+      },
+      ':active': {
+        backgroundColor: 'HighlightText',
+      },
     },
   },
 

--- a/packages/react-components/react-tags-preview/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
+++ b/packages/react-components/react-tags-preview/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
@@ -34,16 +34,6 @@ const useRootBaseClassName = makeResetStyles({
   borderLeftColor: tokens.colorNeutralStroke1,
   borderTopLeftRadius: tokens.borderRadiusNone,
   borderBottomLeftRadius: tokens.borderRadiusNone,
-
-  // windows high contrast:
-  '@media (forced-colors: active)': {
-    ':hover': {
-      backgroundColor: 'HighlightText',
-    },
-    ':active': {
-      backgroundColor: 'HighlightText',
-    },
-  },
 });
 
 const useRootStyles = makeStyles({
@@ -59,6 +49,14 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackground3Pressed,
       color: tokens.colorNeutralForeground2BrandPressed,
     },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: 'HighlightText',
+      },
+      ':active': {
+        backgroundColor: 'HighlightText',
+      },
+    },
   },
   outline: {
     backgroundColor: tokens.colorSubtleBackground,
@@ -73,6 +71,14 @@ const useRootStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       color: tokens.colorNeutralForeground2BrandPressed,
     },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: 'HighlightText',
+      },
+      ':active': {
+        backgroundColor: 'HighlightText',
+      },
+    },
   },
   brand: {
     backgroundColor: tokens.colorBrandBackground2,
@@ -86,6 +92,14 @@ const useRootStyles = makeStyles({
     ':active': {
       backgroundColor: tokens.colorBrandBackground2Pressed,
       color: tokens.colorCompoundBrandForeground1Pressed,
+    },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        backgroundColor: 'HighlightText',
+      },
+      ':active': {
+        backgroundColor: 'HighlightText',
+      },
     },
   },
 


### PR DESCRIPTION
fix #29224.

PR #29035 added WHCM background color on hover to InteractionTag, increasing its contrast. However it changed disabled InteractionTag as well. 
This PR removes hover background for disabled InteractionTag, and keep the hover background only for normal InteractionTag.

Before:
<img width="167" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/ff0b1ec8-5cf8-4a3b-b2fb-7ec25a3077f0"><img width="163" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/bc736436-d5a9-4661-8e0c-2c943f26d7d7">

After (no hover style):
<img width="168" alt="Screenshot 2023-09-25 at 13 44 15" src="https://github.com/microsoft/fluentui/assets/28751745/afb26319-b09e-4eba-a873-f566791991b5">


Normal InteractionTag stays the same:
<img width="119" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/a6a4773f-0536-4d02-bb93-2a08b562cd22"><img width="112" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/b927ba2a-8563-4786-96c4-aadec4c17032">
