### PR TITLE
feat(react-drawer): dialog slot to be only used by internal composition API

### DIFF
--- a/change/@fluentui-react-drawer-840c300d-046b-4ec7-b733-f88067df7dea.json
+++ b/change/@fluentui-react-drawer-840c300d-046b-4ec7-b733-f88067df7dea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: make dialog slot internal to be used for composition only",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-840c300d-046b-4ec7-b733-f88067df7dea.json
+++ b/change/@fluentui-react-drawer-840c300d-046b-4ec7-b733-f88067df7dea.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix: make dialog slot internal to be used for composition only",
+  "comment": "feat: make dialog slot internal to be used for composition only",
   "packageName": "@fluentui/react-drawer",
   "email": "marcosvmmoura@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -131,19 +131,18 @@ export type DrawerInlineState = Required<ComponentState<DrawerInlineSlots> & Dra
 export const DrawerOverlay: ForwardRefComponent<DrawerOverlayProps>;
 
 // @public (undocumented)
-export const drawerOverlayClassNames: Omit<SlotClassNames<DrawerOverlaySlots>, 'dialog'>;
+export const drawerOverlayClassNames: SlotClassNames<DrawerOverlaySlots>;
 
 // @public
 export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> & Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus' | 'defaultOpen'> & DrawerBaseProps;
 
-// @public (undocumented)
+// @public
 export type DrawerOverlaySlots = DialogSurfaceSlots & {
     root: Slot<DialogSurfaceProps>;
-    dialog?: Slot<DialogProps>;
 };
 
 // @public
-export type DrawerOverlayState = Omit<ComponentState<DrawerOverlaySlots>, 'backdrop'> & Required<DrawerBaseState & {
+export type DrawerOverlayState = Omit<ComponentState<DrawerOverlayInternalSlots>, 'backdrop'> & Required<DrawerBaseState & {
     backdropMotion: MotionState<HTMLDivElement>;
 }>;
 

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/DrawerOverlay.types.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/DrawerOverlay.types.ts
@@ -4,13 +4,24 @@ import type { MotionState } from '@fluentui/react-motion-preview';
 
 import type { DrawerBaseProps, DrawerBaseState } from '../../shared/DrawerBase.types';
 
+/**
+ * DrawerOverlay slots
+ */
 export type DrawerOverlaySlots = DialogSurfaceSlots & {
+  /**
+   * Slot for the root element.
+   */
   root: Slot<DialogSurfaceProps>;
+};
 
+/**
+ * DrawerOverlay internal slots for when using with composition API
+ */
+export type DrawerOverlayInternalSlots = DrawerOverlaySlots & {
   /**
    * Slot for the dialog component that wraps the drawer.
    */
-  dialog?: Slot<DialogProps>;
+  dialog: Slot<DialogProps>;
 };
 
 /**
@@ -23,7 +34,7 @@ export type DrawerOverlayProps = ComponentProps<DrawerOverlaySlots> &
 /**
  * State used in rendering DrawerOverlay
  */
-export type DrawerOverlayState = Omit<ComponentState<DrawerOverlaySlots>, 'backdrop'> &
+export type DrawerOverlayState = Omit<ComponentState<DrawerOverlayInternalSlots>, 'backdrop'> &
   Required<
     DrawerBaseState & {
       backdropMotion: MotionState<HTMLDivElement>;

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/renderDrawerOverlay.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/renderDrawerOverlay.tsx
@@ -2,7 +2,7 @@
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 import { assertSlots } from '@fluentui/react-utilities';
 
-import type { DrawerOverlayState, DrawerOverlaySlots } from './DrawerOverlay.types';
+import type { DrawerOverlayState, DrawerOverlayInternalSlots } from './DrawerOverlay.types';
 
 /**
  * Render the final JSX of DrawerOverlay
@@ -12,7 +12,7 @@ export const renderDrawerOverlay_unstable = (state: DrawerOverlayState) => {
     return null;
   }
 
-  assertSlots<DrawerOverlaySlots>(state);
+  assertSlots<DrawerOverlayInternalSlots>(state);
 
   return (
     <state.dialog>

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlay.ts
@@ -46,17 +46,23 @@ export const useDrawerOverlay_unstable = (
     },
   );
 
-  const dialog = slot.optional(props.dialog, {
-    elementType: Dialog,
-    renderByDefault: true,
-    defaultProps: {
+  const dialog = slot.always(
+    {
       open: true,
       defaultOpen,
       onOpenChange,
       inertTrapFocus,
       modalType,
+      /*
+       * children is not needed here because we construct the children in the render function,
+       * but it's required by DialogProps
+       */
+      children: null as unknown as JSX.Element,
     },
-  });
+    {
+      elementType: Dialog,
+    },
+  );
 
   return {
     components: {

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlayStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlayStyles.styles.ts
@@ -11,7 +11,7 @@ import {
   useDrawerDurationStyles,
 } from '../../shared/useDrawerBaseStyles.styles';
 
-export const drawerOverlayClassNames: Omit<SlotClassNames<DrawerOverlaySlots>, 'dialog'> = {
+export const drawerOverlayClassNames: SlotClassNames<DrawerOverlaySlots> = {
   root: 'fui-DrawerOverlay',
   backdrop: 'fui-DrawerOverlay__backdrop',
 };


### PR DESCRIPTION
## Previous Behavior
Dialog was created as an external slot and users could easily override to any other component with the same signature. That could lead to a completely broken Drawer as it is heavily dependent on Dialog.

## New Behavior
Makes the Dialog as an internal slot. That makes it possible to override the Dialog component only when explicitly using the composition API.
