### PR TITLE
chore(react-tree): delegate focus outline to layout components

### DIFF
--- a/change/@fluentui-react-tree-b5db8474-a1ba-4ec8-9c42-18215b9e2632.json
+++ b/change/@fluentui-react-tree-b5db8474-a1ba-4ec8-9c42-18215b9e2632.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: delegate focus outline to layout components",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItemStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItemStyles.styles.ts
@@ -1,9 +1,11 @@
-import { GriffelStyle, makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { GriffelStyle, makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { TreeItemCSSProperties, TreeItemSlots, TreeItemState } from './TreeItem.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
-import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { treeItemLevelToken } from '../../utils/tokens';
+import { treeItemLayoutClassNames } from '../TreeItemLayout/useTreeItemLayoutStyles.styles';
+import { treeItemPersonaLayoutClassNames } from '../TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles';
 
 export const treeItemClassNames: SlotClassNames<TreeItemSlots> = {
   root: 'fui-TreeItem',
@@ -18,7 +20,28 @@ const useBaseStyles = makeResetStyles({
   backgroundColor: tokens.colorSubtleBackground,
   color: tokens.colorNeutralForeground2,
   paddingRight: tokens.spacingHorizontalNone,
-  ...createFocusOutlineStyle(),
+  // if using createCustomFocusIndicatorStyle then we need to remove default outline styles provided by the browser
+  ':focus': {
+    outlineStyle: 'none',
+  },
+  ':focus-visible': {
+    outlineStyle: 'none',
+  },
+  // This adds the focus outline for the TreeItemLayout element
+  ...createCustomFocusIndicatorStyle(
+    {
+      ...shorthands.borderRadius(tokens.borderRadiusMedium),
+      outlineColor: tokens.colorStrokeFocus2,
+      outlineRadius: tokens.borderRadiusMedium,
+      // FIXME: tokens.strokeWidthThick causes some weird bugs
+      outlineWidth: '2px',
+      outlineStyle: 'solid',
+    },
+    {
+      customizeSelector: selector =>
+        `${selector} > .${treeItemLayoutClassNames.root}, ${selector} > .${treeItemPersonaLayoutClassNames.root}`,
+    },
+  ),
 });
 
 type StaticLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -23,7 +23,6 @@ const useRootBaseStyles = makeResetStyles({
   minHeight: '32px',
   boxSizing: 'border-box',
   ...shorthands.gridArea('layout'),
-  ...shorthands.borderRadius(tokens.borderRadiusMedium),
   ':active': {
     color: tokens.colorNeutralForeground2Pressed,
     backgroundColor: tokens.colorSubtleBackgroundPressed,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Focus outline is on the `TreeItem` component as this is the actual focused component, this is a problem on nested trees as the `TreeItem` will contain inside of it a subtree with more tree items

<img width="1500" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/deee42dc-57c6-489a-bfde-f60e4cfe826f">


## New Behavior

Focus outline should be on the `TreeItemLayout` component (although the actual focus is on the `TreeItem`), this way the focus will be visually on a single element even when focusing on a tree item with other tree items inside of it.

<img width="1500" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/a41a66c6-9d88-441e-afa4-9373483618d4">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
