### PR TITLE
Remove width prop from horizontal bar chart examples

### DIFF
--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx
@@ -104,5 +104,9 @@ export const HorizontalBarChartBasicExample: React.FunctionComponent<{}> = () =>
     },
   ];
 
-  return <HorizontalBarChart culture={window.navigator.language} data={data} hideRatio={hideRatio} width={600} />;
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <HorizontalBarChart culture={window.navigator.language} data={data} hideRatio={hideRatio} />
+    </div>
+  );
 };

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Benchmark.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Benchmark.Example.tsx
@@ -24,5 +24,9 @@ export const HorizontalBarChartBenchmarkExample: React.FunctionComponent<{}> = (
     },
   ];
 
-  return <HorizontalBarChart data={data} hideRatio={hideRatio} width={600} chartDataMode="fraction" />;
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <HorizontalBarChart data={data} hideRatio={hideRatio} chartDataMode="fraction" />
+    </div>
+  );
 };

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx
@@ -126,5 +126,9 @@ export const HorizontalBarChartCustomAccessibilityExample: React.FunctionCompone
     },
   ];
 
-  return <HorizontalBarChart data={data} width={600} />;
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <HorizontalBarChart data={data} />
+    </div>
+  );
 };

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomCallout.Example.tsx
@@ -107,36 +107,37 @@ export const HorizontalBarChartCustomCalloutExample: React.FunctionComponent<{}>
   ];
 
   return (
-    <HorizontalBarChart
-      data={data}
-      hideRatio={hideRatio}
-      calloutProps={{
-        directionalHint: DirectionalHint.topAutoEdge,
-      }}
-      // eslint-disable-next-line react/jsx-no-bind
-      barChartCustomData={(props: IChartProps) => {
-        const chartData: IChartDataPoint = props!.chartData![0];
-        const x = chartData.horizontalBarChartdata!.x;
-        const y = chartData.horizontalBarChartdata!.y;
-        return (
-          <div>
-            <span style={{ fontWeight: 'bold' }}>{d3.format('.2s')(x)}</span>
-            <span>{`/${d3.format('.2s')(y)} hours`}</span>
-          </div>
-        );
-      }}
-      // eslint-disable-next-line react/jsx-no-bind
-      onRenderCalloutPerHorizontalBar={(props: IChartDataPoint) =>
-        props ? (
-          <ChartHoverCard
-            XValue={props.xAxisCalloutData}
-            Legend={props.legend}
-            YValue={`${props.yAxisCalloutData || props.horizontalBarChartdata?.y} h`}
-            color={props.color}
-          />
-        ) : null
-      }
-      width={600}
-    />
+    <div style={{ maxWidth: 600 }}>
+      <HorizontalBarChart
+        data={data}
+        hideRatio={hideRatio}
+        calloutProps={{
+          directionalHint: DirectionalHint.topAutoEdge,
+        }}
+        // eslint-disable-next-line react/jsx-no-bind
+        barChartCustomData={(props: IChartProps) => {
+          const chartData: IChartDataPoint = props!.chartData![0];
+          const x = chartData.horizontalBarChartdata!.x;
+          const y = chartData.horizontalBarChartdata!.y;
+          return (
+            <div>
+              <span style={{ fontWeight: 'bold' }}>{d3.format('.2s')(x)}</span>
+              <span>{`/${d3.format('.2s')(y)} hours`}</span>
+            </div>
+          );
+        }}
+        // eslint-disable-next-line react/jsx-no-bind
+        onRenderCalloutPerHorizontalBar={(props: IChartDataPoint) =>
+          props ? (
+            <ChartHoverCard
+              XValue={props.xAxisCalloutData}
+              Legend={props.legend}
+              YValue={`${props.yAxisCalloutData || props.horizontalBarChartdata?.y} h`}
+              color={props.color}
+            />
+          ) : null
+        }
+      />
+    </div>
   );
 };

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Variant.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Variant.Example.tsx
@@ -108,11 +108,13 @@ export class HorizontalBarChartVariantExample extends React.Component<{}, IHBCVa
           onChange={this._onCheckChange}
           styles={{ root: { marginBottom: '20px' } }}
         />
-        <HorizontalBarChart
-          data={data}
-          variant={HorizontalBarChartVariant.AbsoluteScale}
-          hideLabels={this.state.hideLabels}
-        />
+        <div style={{ maxWidth: 600 }}>
+          <HorizontalBarChart
+            data={data}
+            variant={HorizontalBarChartVariant.AbsoluteScale}
+            hideLabels={this.state.hideLabels}
+          />
+        </div>
       </>
     );
   }


### PR DESCRIPTION
## Previous Behavior

Reflow is not visible in horizontal bar chart examples due to their fixed width. 

## New Behavior

Horizontal bar chart examples have a maximum width of 600px and will shrink with their container.