### PR TITLE
RFC: Extending Event Handlers Event Typing

### DIFF
--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -30,7 +30,7 @@ We cannot just add the `Event` type to the existing callbacks as this is a break
 
 ## Detailed Proposal
 
-Use generic [`Event`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v17/global.d.ts#L10) type and strongly-typed events in "data bag".
+Change the first argument of event handlers to be generic [`Event`](https://github.com/microsoft/TypeScript/blob/cf73e5af5d225c9d963dd501f24c6e0fc0bf8314/src/lib/dom.generated.d.ts#L7971) or [`React.SyntheticEvent`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6c9c7db2ac452f97b8e20e0d8b99bcf47625ed54/types/react/index.d.ts#L1251) types, and include strongly-typed events in the second `data` argument.
 
 ### Implementation
 

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -47,8 +47,8 @@ export type EventHandler<TData extends EventData<string, unknown>> = (
 ) => void;
 ```
 
-- For existing event handlers where we can't change the type:
-
+- Add `EventData<...>` to the `data` argument of all existing events in the library.
+- If a new event type needs to be added to an existing event handler that has a strongly-typed event:
   - Deprecate the existing `onSomeEvent` handler and introduce `onSomeEvent2` with the new proposed type signatures.
   - Continue to call the deprecated `onSomeEvent` in all cases. If the event object is of the wrong type for the existing function, do a cast.
 

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -134,8 +134,8 @@ import * as React from 'react';
              open: boolean;
            });
        const onOpenChange = (_e: Event, data: OnSomeEventData) => {
-         console.log(data.event?.currentTarget); // base event data can be used without checking data.type
-         console.log(data.event?.clientX); // Typescript will give an error here as expected
+         console.log(data.event.currentTarget); // ✅ base event data can be used without checking data.type
+         console.log(data.event.clientX); // ❌ Typescript will give an error here as expected
          if (data.type === 'click') {
            console.log(data.event.clientX); // ✅ this won't blow as `data.type` verification will ensure `data.event` is a mouse event
          }

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -42,7 +42,7 @@ export type EventData<Type extends string, TEvent> =
   | { type: Type; event: TEvent };
 
 export type EventHandler<TData extends EventData<string, unknown>> = (
-  ev: React.SyntheticEvent | Event | undefined,
+  ev: React.SyntheticEvent | Event,
   data: TData,
 ) => void;
 ```

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -94,11 +94,12 @@ import * as React from 'react';
     open: boolean;
   };
   // If one day we need to add more events, we can just add them to the union:
-  // type OnSomeEventData =
-  //   | EventData<'click', React.MouseEvent<MyComponentElement>>
-  //   | (EventData<'focus', React.FocusEvent<MyComponentElement>> & {
-  //       open: boolean;
-  //     });
+ // type OnSomeEventData = (
+//     | EventData<'click', React.MouseEvent<MyComponentElement>>
+//     | EventData<'focus', React.FocusEvent<MyComponentElement>>
+//   ) & {
+//     open: boolean;
+//   };
 
   type SomeProps = {
     onSomeEvent?: EventHandler<OnSomeEventData>;

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -38,7 +38,7 @@ Define two helper types `EventData` and `EventHandler` to ensure consistency acr
 
 ```ts
 export type EventData<Type extends string, TEvent> =
-  | { type: undefined; event: React.SyntheticEvent | Event | undefined }
+  | { type: undefined; event: React.SyntheticEvent | Event}
   | { type: Type; event: TEvent };
 
 export type EventHandler<TData extends EventData<string, unknown>> = (

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -8,11 +8,12 @@ This RFC proposes solutions to enhance event typing within callbacks.
 
 ## Summary
 
-We encounter challenges when attempting to extend event types within callbacks without introducing breaking changes. This RFC offers potential solutions to manage such event type changes for both current stable components and future components.
+We encounter challenges when attempting to extend event types within callbacks without introducing breaking changes. This RFC offers potential solutions to manage such event type changes for v9 components.
+Notably, this RFC explores alternatives for v10 in discarded solutions, but it is not aiming for proposing a v10 callback type design.
 
-## Problem statement
+## Problem Statement
 
-Our current design for event callbacks in v9 has the type signature `callback: (e: SomeEvents, data: SomeData) => void;`, where `SomeEvents` represents specific event types like MouseEvent or KeyboardEvent, or a union of specific event types. While our intention is to maintain strong type checking, this design complicates the process of expanding or altering event types without causing breaks.
+Our current design for event callbacks in v9 has the type signature `onSomeEvent: (e: SomeEvents, data: SomeData) => void;`, where `SomeEvents` represents specific event types like MouseEvent or KeyboardEvent, or a union of specific event types. While our intention is to maintain strong type checking, this design complicates the process of expanding or altering event types without causing breaks.
 
 We experienced this challenge when when adding a scroll event listener to the Popover `onOpenChange` callback. The callback has type `onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;`, where `OpenPopoverEvents` is a union of specific events. But the scroll event has just type `Event`. And we are facing issues when updating the type:
 
@@ -25,15 +26,41 @@ const onOpenChange = (e: MouseEvent | KeyboardEvent) => {};
 const props: Props = { onOpenChange }; // 💣 This breaks when we add Event to OpenPopoverEvents. The error: '(e: MouseEvent | KeyboardEvent) => void' is not assignable to type '(e: OpenPopoverEvents) => void'.
 ```
 
-This is a challenge especially when unforeseen events need to be added in the future.
+We cannot just add the `Event` type to the existing callbacks as this is a breaking change for any code that explicitly types its event argument. This is a challenge especially when unforeseen events need to be added in the future.
 
-## Detailed Design or Proposal
+## Detailed Proposal
 
-### 1. Solution for existing components in v9:
+### Proposal
 
-We cannot introduce generic Event type to the existing callbacks as this is a breaking change for any code that explicitly types its event argument (as in the example in "Problem statement").
+Change callbacks arrow functions to method declarations when event type needs to be extended:
 
-#### Solution 1 - cast the new event to the existing type
+```ts
+type OpenPopoverEvents = KeyboardEvent | MouseEvent | Event;
+type Props = {
+  onOpenChange(e: OpenPopoverEvents): void; // method instead of arrow function
+};
+const onOpenChange = (e: MouseEvent | KeyboardEvent) => {};
+const props: Props = { onOpenChange }; // ✅
+```
+
+### Reasoning
+
+The error described in the "Problem Statement" only occurs in TypeScript when the `strictFunctionType` option is enabled. This happens because the type `KeyboardEvent | MouseEvent | Event` is more specific than `KeyboardEvent | MouseEvent`. When attempting to assign a function with a less specific argument type (`const onOpenChange = (e: MouseEvent | KeyboardEvent) => {}`) to a function expecting a more specific argument type `onOpenChange: (e: KeyboardEvent | MouseEvent | Event) => void;`, TypeScript's `strictFunctionType` check fails.
+
+However, this stricter checking does not apply to method or constructor declarations: https://github.com/microsoft/TypeScript/pull/18654. This is why we don't see the error in the following example:
+
+`strictFunctionType` check is a valuable TypeScript feature. However, there is no harm to use method to bypass this check for our callbacks. This is because we commit to only adding event types to the events union, never removing them (removal would be a breaking change). Therefore we can permit less specific event type arguments on the user side without compromising overall type safety.
+
+Another option following the same principle is [bivarance hack](https://www.typescriptlang.org/play?#code/C4TwDgpgBAQglgNwIYCc5IHYGMIAklYDWAPACoBiGUEAHsBBgCYDOUAFAHReoDmzAXFEwgA2gF0AlFAC8APiEYQ86VADeAKChQARolTpseAoU7cUfQQAVUSALYR6KZmUqyJggEoOArigylwCBcMWQBudQBfEQByXWQ0TBx8ImixcPVQSCgAeUgMSwB7MAKECBQAUVKMYFYVAGkIEG0C1EZKhmAoAB8oAFkC72YIduruqBHgcMzoSxQi2rVNKAKMXIYAYQALTB4IQXh4gyTjYjY9nLzC4tKKqpqpOSgEArhGMMjwrBXmTpW1jC2O2gKjOgn6g2GdzGDSaLRQbTuD3kqgin2+nTAczAAigs3mMjUy1WeUBGF2UFRUAA9FSoIBQcnU6i+GB+RP+pN2MCQjAJoLUKEwjAKtkEGG8tm0ZQiSLUqKZ6KgmPmXMYVixC1UbJJ2zJ5z+2qBKopoWptLp1BokCw9B5wAKOmgZTmTiAA) which is widely used in open-source repositories. This RFC propose the method solution because of its simplicity compared to the bivariance hack.
+
+### Lint/Test
+
+We do not have lint rules for event callbacks.
+We have conformance test `'consistent-callback-args'` to ensure the consistency of callback arguments. This test checks prop type for [property signature](https://github.com/microsoft/fluentui/blob/d8ccb09308a24eea6adf419896254116546296ee/packages/react-conformance/src/utils/getCallbackArguments.ts#L286C32-L286C32). It will need to be updated to look for method signature as well.
+
+## Discarded Solutions
+
+#### Discarded Solution 1 - cast the new event to the existing type
 
 ```ts
 // Within our codebase:
@@ -52,66 +79,47 @@ const onOpenChange = (e: MouseEvent | KeyboardEvent) => {
 const props: Props = { onOpenChange };
 ```
 
-- Pros 👍: No modifications to types.
-- Cons 👎: Run-time type inaccuracies as illustrated in the code comment above.
+This solution has been discarded due to its potential for runtime type inaccuracies as illustrated in the code comment above.
 
-### 2. Solutions for both existing components and upcoming components:
+#### Discarded Solution 2 - generic [`Event`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v17/global.d.ts#L10) type and strongly-typed events in "data bag"
 
-For new components without backward compatibility concerns, new type signatures can be directly adopted.
+- For existing event handlers where we can't change the type:
 
-#### Solution 2 - callbacks with generic event type:
+  - Deprecate the existing `onSomeEvent` handler and introduce `onSomeEvent2` with the new proposed type signatures.
+  - Continue to call the deprecated `onSomeEvent` in all cases. If the event object is of the wrong type for the existing function, do a cast.
+
+- For new event handlers (and the "2" versions of existing ones):
+  - Always use the type `React.SyntheticEvent | Event | undefined` for the first argument.
+  - "Data bag" - always add a strongly-typed event to the data object for all currently possible event types, as optional (?) properties.
 
 ```ts
-// For an existing component
+export type CallbackEvents = React.SyntheticEvent | Event | undefined;
+
+// ======= For an existing component =======
+export type OnOpenChangeData = {
+  open: boolean;
+  // Assuming 'open' state change can be triggered by mouse or keyboard events:
+  mouseEvent?: MouseEvent;
+  keyboardEvent?: KeyboardEvent;
+};
+
 export type PopoverProps = {
   /**
    * @deprecated Use onOpenChange2 instead.
    */
   onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
 
-  onOpenChange2?: (e: OpenPopoverEvents | Event, data: OnOpenChangeData) => void;
+  onOpenChange2?: (e: CallbackEvents, data: OnOpenChangeData) => void;
 };
 
-// For a new component
+// ======= For a new component =======
+export type onSomeEventData = {
+  open: boolean;
+  // Assuming state change can be triggered by focus event:
+  focusEvent?: FocusEvent;
+};
 export type SomeProps = {
-  callback?: (e: MouseEvent | Event, data: SomeData) => void;
-};
-```
-
-- Pros 👍: Ensures correct typing and it can accommodate future, unforeseen event types.
-- Cons 👎:
-
-  1. Consumers will need to use type assertion or type predict to use a strongly-typed event:
-
-     ```ts
-     function isMouseEvent(e: Event): e is MouseEvent {
-       return e instanceof MouseEvent;
-     }
-     const onOpenChange = (e: Event | MouseEvent | TouchEvent) => {
-       console.log(e.clientX); // ❌ type error - Property 'clientX' does not exist on type 'Event'
-       if (isMouseEvent(e)) {
-         console.log(e.clientX); // ✅
-       }
-       if (e instanceof MouseEvent) {
-         console.log(e.clientX); // ✅
-       }
-     };
-     ```
-
-- Extra cons 👎 for existing components:
-  1. This is fragile - old `onOpenChange` won't be invoked when generic event happens (for example on scroll).
-  2. Code bloat - we have many callbacks, there will be a bunch of extra codes to keep both versions of callbacks working.
-
-Also perhaps there will be a case where generic event is inappropriate. For instance, if we can confidently assert that a callback only triggers on keyboard events. Although no such cases are identified yet, it remains a potential concern.
-
-#### Solution 3 - "Data Bag" Approach - strongly-typed events are passed in the data argument.
-
-Here, if the event could be a mouse or keyboard event, the callback receives two data fields (mouseEvent and keyboardEvent) which could be undefined.
-
-```ts
-export type OnOpenChangeData = { open: boolean; mouseEvent?: MouseEvent; keyboardEvent?: KeyboardEvent };
-export type PopoverProps = {
-  onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
+  onSomeEvent?: (e: CallbackEvents, data: SomeData) => void;
 };
 ```
 
@@ -121,5 +129,24 @@ export type PopoverProps = {
   2. Consumers can use the strongly-typed event in data without runtime checks.
 
 - Cons 👎:
-
   1. The complexity of the callback signature increases. Users need to discern the differences between the event argument and the events within the data argument.
+  2. Code bloat - as there are many callbacks, maintaining both versions of callbacks can become cumbersome. This is a problem that can only be solved in v10.
+
+Additionally, there may be a case where generic event is inappropriate. For instance, if we can confidently assert that a callback only triggers on keyboard events. Although no such cases are identified yet, it remains a potential concern.
+
+✨ Even though this solution has been discarded, it offers insights into how we can improve the event typing in v10.
+In v9 we use unions to type events when a callback can be triggered by multiple events. Consumers will need to use type assertion or type predict to use a strongly-typed event:
+
+```ts
+function isMouseEvent(e: MouseEvent | TouchEvent): e is MouseEvent {
+  return e instanceof MouseEvent; // This type check is just for demo purpose. There are issues with using `instanceof` in multi-window scenarios: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms
+}
+const onOpenChange = (e: MouseEvent | TouchEvent) => {
+  console.log(e.clientX); // ❌ type error - Property 'clientX' does not exist on type 'TouchEvent'
+  if (isMouseEvent(e)) {
+    console.log(e.clientX); // ✅
+  }
+};
+```
+
+We can consider the data bag approach in v10 to eliminate the need for type assertion. V9 Tree is already implementing a similar approach in [`TreeItemOpenChangeData`](https://github.com/microsoft/fluentui/blob/2eedc2ec54397253a4e3076fbfa382f4fe3c1175/packages/react-components/react-tree/src/components/TreeItem/TreeItem.types.ts#L25C1-L31C3).

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -1,45 +1,125 @@
 # RFC: Standardize Event Handlers Event Typing
 
-This RFC proposes solutions to enhance the event typing in the callback.
+This RFC proposes solutions to enhance event typing within callbacks.
 
 ---
 
-_List contributors to the proposal here_
-
-_Date the RFC was originally authored here_
-
-<!-- If substantial updates are made add an "Updated on: $date" below, don't replace the original date -->
+@yuanboxue-amber
 
 ## Summary
 
-<!-- Explain the proposed change -->
-
-## Background
-
-<!-- If there is relevant background include it here -->
+We encounter challenges when attempting to extend event types within callbacks without introducing breaking changes. This RFC offers potential solutions to manage such event type changes for both current stable components and future components.
 
 ## Problem statement
 
-<!--
-Why are we making this change? What problem are we solving? What do we expect to gain from this?
+Our current design for event callbacks in v9 has the type signature `callback: (e: SomeEvents, data: SomeData) => void;`, where `SomeEvents` represents specific event types like MouseEvent or KeyboardEvent, or a union of specific event types. While our intention is to maintain strong type checking, this design complicates the process of expanding or altering event types without causing breaks.
 
-This section is important as the motivation or problem statement is indepenent from the proposed change. Even if this RFC is not accepted this Motivation can be used for alternative solutions.
+We experienced this challenge when when adding a scroll event listener to the Popover `onOpenChange` callback. The callback has type `onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;`, where `OpenPopoverEvents` is a union of specific events. But the scroll event has just type `Event`. And we are facing issues when updating the type:
 
-In the end, please make sure to present a neutral Problem statement, rather than one that motivates a particular solution
--->
+```ts
+export type OpenPopoverEvents = KeyboardEvent | MouseEvent;
+type Props = {
+  onOpenChange: (e: OpenPopoverEvents) => void;
+};
+const onOpenChange = (e: MouseEvent | KeyboardEvent) => {};
+const props: Props = { onOpenChange }; // 💣 This breaks when we add Event to OpenPopoverEvents. The error: '(e: MouseEvent | KeyboardEvent) => void' is not assignable to type '(e: OpenPopoverEvents) => void'.
+```
+
+This is a challenge especially when unforeseen events need to be added in the future.
 
 ## Detailed Design or Proposal
 
-<!-- This is the bulk of the RFC. Explain the proposal or design in enough detail for the inteded audience to understand. -->
+### 1. Solution for existing components in v9:
 
-### Pros and Cons
+We cannot introduce generic Event type to the existing callbacks as this is a breaking change for any code that explicitly types its event argument (as in the example in "Problem statement").
 
-<!-- Enumerate the pros and cons of the proposal. Make sure to think about and be clear on the cons or drawbacks of this propsoal. If there are multiple proposals include this for each. -->
+#### Solution 1 - cast the new event to the existing type
 
-## Discarded Solutions
+```ts
+// Within our codebase:
+export type OpenPopoverEvents = KeyboardEvent | MouseEvent;
 
-<!-- As you enumerate possible solutions, try to keep track of the discarded ones. This should include why we discarded the solution. -->
+const usePopover = () => {
+  const handleScroll = (e: Event) => {
+    onOpenChange(e as OpenPopoverEvents, data);
+  };
+};
 
-## Open Issues
+// In consumer implementations:
+const onOpenChange = (e: MouseEvent | KeyboardEvent) => {
+  console.log(e.shiftKey); // 💣 This would fail since shiftKey doesn't exist on 'Event'
+};
+const props: Props = { onOpenChange };
+```
 
-<!-- Optional section, but useful for first drafts. Use this section to track open issues on unanswered questions regarding the design or proposal.  -->
+- Pros 👍: No modifications to types.
+- Cons 👎: Run-time type inaccuracies as illustrated in the code comment above.
+
+### 2. Solutions for both existing components and upcoming components:
+
+For new components without backward compatibility concerns, new type signatures can be directly adopted.
+
+#### Solution 2 - callbacks with generic event type:
+
+```ts
+// For an existing component
+export type PopoverProps = {
+  /**
+   * @deprecated Use onOpenChange2 instead.
+   */
+  onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
+
+  onOpenChange2?: (e: OpenPopoverEvents | Event, data: OnOpenChangeData) => void;
+};
+
+// For a new component
+export type SomeProps = {
+  callback?: (e: MouseEvent | Event, data: SomeData) => void;
+};
+```
+
+- Pros 👍: Ensures correct typing and it can accommodate future, unforeseen event types.
+- Cons 👎:
+
+  1. Consumers will need to use type assertion or type predict to use a strongly-typed event:
+
+     ```ts
+     function isMouseEvent(e: Event): e is MouseEvent {
+       return e instanceof MouseEvent;
+     }
+     const onOpenChange = (e: Event | MouseEvent | TouchEvent) => {
+       console.log(e.clientX); // ❌ type error - Property 'clientX' does not exist on type 'Event'
+       if (isMouseEvent(e)) {
+         console.log(e.clientX); // ✅
+       }
+       if (e instanceof MouseEvent) {
+         console.log(e.clientX); // ✅
+       }
+     };
+     ```
+
+- Extra cons 👎 for existing components:
+  1. This is fragile - old `onOpenChange` won't be invoked when generic event happens (for example on scroll).
+  2. Code bloat - we have many callbacks, there will be a bunch of extra codes to keep both versions of callbacks working.
+
+Also perhaps there will be a case where generic event is inappropriate. For instance, if we can confidently assert that a callback only triggers on keyboard events. Although no such cases are identified yet, it remains a potential concern.
+
+#### Solution 3 - "Data Bag" Approach - strongly-typed events are passed in the data argument.
+
+Here, if the event could be a mouse or keyboard event, the callback receives two data fields (mouseEvent and keyboardEvent) which could be undefined.
+
+```ts
+export type OnOpenChangeData = { open: boolean; mouseEvent?: MouseEvent; keyboardEvent?: KeyboardEvent };
+export type PopoverProps = {
+  onOpenChange?: (e: OpenPopoverEvents, data: OnOpenChangeData) => void;
+};
+```
+
+- Pros 👍:
+
+  1. Ensures correct typing and it can accommodate future, unforeseen event types.
+  2. Consumers can use the strongly-typed event in data without runtime checks.
+
+- Cons 👎:
+
+  1. The complexity of the callback signature increases. Users need to discern the differences between the event argument and the events within the data argument.

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -1,0 +1,45 @@
+# RFC: Standardize Event Handlers Event Typing
+
+This RFC proposes solutions to enhance the event typing in the callback.
+
+---
+
+_List contributors to the proposal here_
+
+_Date the RFC was originally authored here_
+
+<!-- If substantial updates are made add an "Updated on: $date" below, don't replace the original date -->
+
+## Summary
+
+<!-- Explain the proposed change -->
+
+## Background
+
+<!-- If there is relevant background include it here -->
+
+## Problem statement
+
+<!--
+Why are we making this change? What problem are we solving? What do we expect to gain from this?
+
+This section is important as the motivation or problem statement is indepenent from the proposed change. Even if this RFC is not accepted this Motivation can be used for alternative solutions.
+
+In the end, please make sure to present a neutral Problem statement, rather than one that motivates a particular solution
+-->
+
+## Detailed Design or Proposal
+
+<!-- This is the bulk of the RFC. Explain the proposal or design in enough detail for the inteded audience to understand. -->
+
+### Pros and Cons
+
+<!-- Enumerate the pros and cons of the proposal. Make sure to think about and be clear on the cons or drawbacks of this propsoal. If there are multiple proposals include this for each. -->
+
+## Discarded Solutions
+
+<!-- As you enumerate possible solutions, try to keep track of the discarded ones. This should include why we discarded the solution. -->
+
+## Open Issues
+
+<!-- Optional section, but useful for first drafts. Use this section to track open issues on unanswered questions regarding the design or proposal.  -->

--- a/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -1,4 +1,4 @@
-# RFC: Standardize Event Handlers Event Typing
+# RFC: Extending Event Handlers Event Typing
 
 This RFC proposes solutions to enhance event typing within callbacks.
 


### PR DESCRIPTION
## Summary

We encounter challenges when attempting to extend event types within callbacks without introducing breaking changes. This RFC offers potential solutions to manage such event type changes for both current stable components and future components.

[**Preview**](https://github.com/YuanboXue-Amber/fluentui/blob/event-rfc/rfcs/react-components/convergence/event-handlers-event-type.md)