### PR TITLE
ci: use custom yarn dedupe alias for local and ci dx

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -26,11 +26,11 @@ jobs:
         run: |
           echo "yarn.lock changed! Verifying package deduplication ..."
 
-          npx yarn-deduplicate --strategy fewer --list --fail
+          yarn run dedupe --list --fail
 
           if [[ $? -ne 0 ]]; then
             echo "Your changes introduced package duplication 🚨"
-            echo "Run 'npx yarn-deduplicate --strategy fewer' to fix those."
+            echo "Run 'yarn run dedupe' to fix those."
           else
             echo "No duplicate packages introduced ✅"
           fi

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": "^16.18.1 || ^18.0.0"
   },
   "scripts": {
+    "dedupe": "npx yarn-deduplicate --strategy fewer",
     "build": "lage build --verbose",
     "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components",
     "build:fluentui:docs": "gulp build:docs",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

finding how to dedupe deps is not the best DX at the moment

## New Behavior

deduping via 3rd party packages in now aliased under `yarn run dedupe` npm script alias. 

> NOTE:  `run` needs to be used explicitly as yarn v1 ships `dedupe` command ( which doesnt work as it should )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
