### PR TITLE
fix(scripts-ts-node): disable ts checks when invoking ts-node/register untill swc works

### DIFF
--- a/scripts/beachball/package.json
+++ b/scripts/beachball/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fluentui/scripts-github": "*",
-    "@fluentui/scripts-monorepo": "*"
+    "@fluentui/scripts-monorepo": "*",
+    "@fluentui/scripts-ts-node": "*"
   }
 }

--- a/scripts/beachball/register.js
+++ b/scripts/beachball/register.js
@@ -1,0 +1,10 @@
+exports.register = register;
+
+/**
+ * in memory TypeScript compilation helper
+ */
+function register() {
+  if (process.env.NODE_ENV !== 'test') {
+    require('@fluentui/scripts-ts-node/register');
+  }
+}

--- a/scripts/beachball/register.js
+++ b/scripts/beachball/register.js
@@ -5,6 +5,7 @@ exports.register = register;
  */
 function register() {
   if (process.env.NODE_ENV !== 'test') {
+    // @ts-expect-error - ts-node/register doesn't provide types so this would error
     require('@fluentui/scripts-ts-node/register');
   }
 }

--- a/scripts/beachball/release-v8.config.js
+++ b/scripts/beachball/release-v8.config.js
@@ -1,11 +1,9 @@
 // @ts-check
 
-if (process.env.NODE_ENV !== 'test') {
-  require('../ts-node/register');
-}
+require('./register').register();
 
-const { getConfig } = require('./utils');
 const { config: sharedConfig } = require('./shared.config');
+const { getConfig } = require('./utils');
 
 const { scope } = getConfig({ version: 'v8' });
 

--- a/scripts/beachball/release-v8.config.js
+++ b/scripts/beachball/release-v8.config.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 require('./register').register();
 
 const { config: sharedConfig } = require('./shared.config');

--- a/scripts/beachball/release-vNext.config.js
+++ b/scripts/beachball/release-vNext.config.js
@@ -1,9 +1,7 @@
-if (process.env.NODE_ENV !== 'test') {
-  require('../ts-node/register');
-}
+require('./register').register();
 
-const { getConfig } = require('./utils');
 const { config: sharedConfig } = require('./shared.config');
+const { getConfig } = require('./utils');
 
 const { scope, groupConfig } = getConfig({ version: 'vNext' });
 

--- a/scripts/ts-node/register.js
+++ b/scripts/ts-node/register.js
@@ -3,6 +3,9 @@ const tsNode = require('ts-node');
 tsNode.register({
   // https://github.com/TypeStrong/ts-node#skipproject - don't read tsconfig within ts-node
   skipProject: true,
+
   // @deprecated: we cannot use this until new version of ts-node is released https://github.com/TypeStrong/ts-node/pull/2062
   // swc: true,
+  // remove this once `swc` will start working again
+  transpileOnly: true,
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

release pipeline doesn't work

## New Behavior

- tsc is used only in transpilation mode to unblock release
- refactored ts-node calls within scripts-beachball

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/29253
