### PR TITLE
ci: switch to UseNode@1 from nodeTool@0 to avoid flaky node installs

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -1,10 +1,11 @@
 # Install versions of Node and Yarn required by build pipelines.
 steps:
-  - task: NodeTool@0
+  - task: UseNode@1
     inputs:
-      versionSpec: '16.18.1'
+      version: '16.18.1'
       checkLatest: false
     displayName: 'Install Node.js'
+    retryCountOnTaskFailure: 3
 
   - script: |
       npm i -g yarn@1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

nodeTool@0 became extremely flaky in last 3 months, more than 70% of pipeline runs because node install errors

## New Behavior

based on [their issue board](https://github.com/microsoft/azure-pipelines-tasks/issues/17787#issuecomment-1545752409) I discovered that there is a new [`useNode@1`](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-node-v1?view=azure-pipelines) which should be more stable

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
