### PR TITLE
chore: add story for truncating Dropdown value text

### DIFF
--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownControlled.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownControlled.stories.tsx
@@ -32,7 +32,7 @@ export const Controlled = (props: Partial<DropdownProps>) => {
     <div className={styles.root}>
       <div className={styles.field}>
         <label htmlFor={`${comboId}-default`}>Schedule a meeting (default selection)</label>
-        <Dropdown id={`${comboId}-default`} {...props} defaultValue="Elvia Atkins" defaultSelectedOptions={['ea']}>
+        <Dropdown id={`${comboId}-default`} {...props} defaultValue="Elvia Atkins" defaultSelectedOptions={['eatkins']}>
           <Option text="Katri Athokas" value="kathok">
             <Persona
               avatar={{ color: 'colorful', 'aria-hidden': true }}

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownTruncation.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownTruncation.stories.tsx
@@ -14,7 +14,8 @@ const useStyles = makeStyles({
   listbox: {
     maxHeight: '200px',
   },
-  valueText: {
+  // these styles wrap the value text within the dropdown button and cause it to truncate
+  truncatedText: {
     overflowX: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -39,7 +40,10 @@ export const TruncatedValue = (props: Partial<DropdownProps>) => {
   const styles = useStyles();
 
   const placeholder = 'Select an animal';
-  const [value, setValue] = React.useState(placeholder);
+
+  // show truncated option by default
+  const defaultValue = options[10];
+  const [value, setValue] = React.useState(defaultValue);
 
   return (
     <div className={styles.root}>
@@ -47,8 +51,10 @@ export const TruncatedValue = (props: Partial<DropdownProps>) => {
       <Dropdown
         aria-labelledby={dropdownId}
         listbox={{ className: styles.listbox }}
-        button={<span className={styles.valueText}>{value}</span>}
+        button={<span className={styles.truncatedText}>{value}</span>}
         onOptionSelect={(e, data) => setValue(data.optionText ?? placeholder)}
+        defaultSelectedOptions={[defaultValue]}
+        defaultValue={defaultValue}
         {...props}
       >
         {options.map(option => (

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownTruncation.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownTruncation.stories.tsx
@@ -65,7 +65,7 @@ TruncatedValue.parameters = {
   docs: {
     description: {
       story:
-        'The Dropdown button slot can be customized to render child JSX, which can be used to truncate the value text.',
+        'The Dropdown button slot can be customized to render child JSX, which can be used to truncate the selected value text.',
     },
   },
 };

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownTruncation.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownTruncation.stories.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { Dropdown, makeStyles, Option, shorthands, useId } from '@fluentui/react-components';
+import type { DropdownProps } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    // Stack the label above the field with a gap
+    display: 'grid',
+    gridTemplateRows: 'repeat(1fr)',
+    justifyItems: 'start',
+    ...shorthands.gap('2px'),
+    maxWidth: '200px',
+  },
+  listbox: {
+    maxHeight: '200px',
+  },
+  valueText: {
+    overflowX: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+});
+
+export const TruncatedValue = (props: Partial<DropdownProps>) => {
+  const dropdownId = useId('dropdown');
+  const options = [
+    'Cat',
+    'Caterpillar',
+    'Corgi',
+    'Chupacabra',
+    'Dog',
+    'Ferret',
+    'Fish',
+    'Fox',
+    'Hamster',
+    'Snake',
+    'Screaming hairy armadillo (Chaetophractus vellerosus)',
+  ];
+  const styles = useStyles();
+
+  const placeholder = 'Select an animal';
+  const [value, setValue] = React.useState(placeholder);
+
+  return (
+    <div className={styles.root}>
+      <label id={dropdownId}>Best pet</label>
+      <Dropdown
+        aria-labelledby={dropdownId}
+        listbox={{ className: styles.listbox }}
+        button={<span className={styles.valueText}>{value}</span>}
+        onOptionSelect={(e, data) => setValue(data.optionText ?? placeholder)}
+        {...props}
+      >
+        {options.map(option => (
+          <Option key={option} disabled={option === 'Ferret'}>
+            {option}
+          </Option>
+        ))}
+      </Dropdown>
+    </div>
+  );
+};
+
+TruncatedValue.parameters = {
+  docs: {
+    description: {
+      story:
+        'The Dropdown button slot can be customized to render child JSX, which can be used to truncate the value text.',
+    },
+  },
+};

--- a/packages/react-components/react-combobox/stories/Dropdown/index.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/index.stories.tsx
@@ -14,6 +14,7 @@ export { Controlled } from './DropdownControlled.stories';
 export { Multiselect } from './DropdownMultiselect.stories';
 export { Size } from './DropdownSize.stories';
 export { Disabled } from './DropdownDisabled.stories';
+export { TruncatedValue } from './DropdownTruncation.stories';
 
 export default {
   title: 'Components/Dropdown',


### PR DESCRIPTION
No package changes, just an example addition.

A partner asked how to truncate value text in a Dropdown, which made me think it'd be helpful to have an example showing that, + also shows how to add custom JSX to the trigger slot.