### PR TITLE
feat: re-export useFluentProviderThemeStyleTag

### DIFF
--- a/change/@fluentui-react-components-c4eb2fca-e103-4a84-a1b9-1e1b6273a8f8.json
+++ b/change/@fluentui-react-components-c4eb2fca-e103-4a84-a1b9-1e1b6273a8f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export useFluentProviderThemeStyleTag",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1002,6 +1002,7 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import { useFluentProvider_unstable } from '@fluentui/react-provider';
 import { useFluentProviderContextValues_unstable } from '@fluentui/react-provider';
 import { useFluentProviderStyles_unstable } from '@fluentui/react-provider';
+import { useFluentProviderThemeStyleTag } from '@fluentui/react-provider';
 import { useFocusableGroup } from '@fluentui/react-tabster';
 import { UseFocusableGroupOptions } from '@fluentui/react-tabster';
 import { useFocusFinders } from '@fluentui/react-tabster';
@@ -3189,6 +3190,8 @@ export { useFluentProvider_unstable }
 export { useFluentProviderContextValues_unstable }
 
 export { useFluentProviderStyles_unstable }
+
+export { useFluentProviderThemeStyleTag }
 
 export { useFocusableGroup }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -22,6 +22,7 @@ export {
   useFluentProvider_unstable,
   useFluentProviderContextValues_unstable,
   useFluentProviderStyles_unstable,
+  useFluentProviderThemeStyleTag,
 } from '@fluentui/react-provider';
 export type {
   FluentProviderContextValues,


### PR DESCRIPTION
## New Behavior

Re-exports `useFluentProviderThemeStyleTag` as public APIs should be reachable through `@fluentui/react-components`.