### PR TITLE
fix: exported BreadcrumbProvider and useBreadcrumbContext

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-0301b962-b42e-4817-bf07-a23daeb8eaa5.json
+++ b/change/@fluentui-react-breadcrumb-preview-0301b962-b42e-4817-bf07-a23daeb8eaa5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: exported BreadcrumbProvider and useBreadcrumbContext",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
+++ b/packages/react-components/react-breadcrumb-preview/etc/react-breadcrumb-preview.api.md
@@ -40,6 +40,9 @@ export type BreadcrumbButtonState = ComponentState<BreadcrumbButtonSlots> & Omit
 export const breadcrumbClassNames: SlotClassNames<BreadcrumbSlots>;
 
 // @public
+export type BreadcrumbContextValue = Required<Pick<BreadcrumbProps, 'appearance' | 'dividerType' | 'size'>>;
+
+// @public
 export const BreadcrumbDivider: ForwardRefComponent<BreadcrumbDividerProps>;
 
 // @public (undocumented)
@@ -85,6 +88,9 @@ export type BreadcrumbProps = ComponentProps<BreadcrumbSlots> & {
     dividerType?: 'chevron' | 'slash';
     size?: 'small' | 'medium' | 'large';
 };
+
+// @internal (undocumented)
+export const BreadcrumbProvider: React_2.Provider<Required<Pick<BreadcrumbProps, "size" | "appearance" | "dividerType">> | undefined>;
 
 // @public (undocumented)
 export type BreadcrumbSlots = {
@@ -141,6 +147,9 @@ export const useBreadcrumbButton_unstable: (props: BreadcrumbButtonProps, ref: R
 
 // @public
 export const useBreadcrumbButtonStyles_unstable: (state: BreadcrumbButtonState) => BreadcrumbButtonState;
+
+// @internal (undocumented)
+export const useBreadcrumbContext_unstable: () => Required<Pick<BreadcrumbProps, "size" | "appearance" | "dividerType">>;
 
 // @public
 export const useBreadcrumbDivider_unstable: (props: BreadcrumbDividerProps, ref: React_2.Ref<HTMLLIElement>) => BreadcrumbDividerState;

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/index.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/index.ts
@@ -1,5 +1,6 @@
 export * from './Breadcrumb';
 export * from './Breadcrumb.types';
+export * from './BreadcrumbContext';
 export * from './renderBreadcrumb';
 export * from './useBreadcrumb';
 export * from './useBreadcrumbStyles.styles';

--- a/packages/react-components/react-breadcrumb-preview/src/index.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/index.ts
@@ -37,3 +37,5 @@ export {
   useBreadcrumbButton_unstable,
 } from './BreadcrumbButton';
 export type { BreadcrumbButtonProps, BreadcrumbButtonSlots, BreadcrumbButtonState } from './BreadcrumbButton';
+export { BreadcrumbProvider, useBreadcrumbContext_unstable } from './Breadcrumb';
+export type { BreadcrumbContextValue } from './Breadcrumb';


### PR DESCRIPTION
## Previous Behavior
- BreadcrumbContext wasn't exported

## New Behavior
BreadcrumbProvider and useBreadcrumbContext are now exported

- Fixes #29259
