### PR TITLE
feat(react-breadcrumb) add custom styling hooks for Breadcrumb component and its sub-components

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-7e339c0f-d934-42c0-b2a7-6fb8d5459508.json
+++ b/change/@fluentui-react-breadcrumb-preview-7e339c0f-d934-42c0-b2a7-6fb8d5459508.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add custom styling hooks for Breadcrumb component and its sub-components",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-b480c3d3-5c89-4560-a945-758668b5a2f1.json
+++ b/change/@fluentui-react-provider-b480c3d3-5c89-4560-a945-758668b5a2f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add custom styling hooks for Breadcrumb component and its sub-components",
+  "packageName": "@fluentui/react-provider",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-f0edee23-7871-47c5-b75b-1b7ba839e5df.json
+++ b/change/@fluentui-react-shared-contexts-f0edee23-7871-47c5-b75b-1b7ba839e5df.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add custom styling hooks for Breadcrumb component and its sub-components",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.tsx
@@ -5,6 +5,7 @@ import { useBreadcrumbStyles_unstable } from './useBreadcrumbStyles.styles';
 import type { BreadcrumbProps } from './Breadcrumb.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useBreadcrumbContextValues_unstable } from './useBreadcrumbContextValue';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Breadcrumb component - TODO: add more docs
@@ -14,6 +15,8 @@ export const Breadcrumb: ForwardRefComponent<BreadcrumbProps> = React.forwardRef
   const contextValues = useBreadcrumbContextValues_unstable(state);
 
   useBreadcrumbStyles_unstable(state);
+  useCustomStyleHook_unstable('useBreadcrumbStyles_unstable')(state);
+
   return renderBreadcrumb_unstable(state, contextValues);
 });
 

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useBreadcrumbButton_unstable } from './useBreadcrumbButton';
 import { renderBreadcrumbButton_unstable } from './renderBreadcrumbButton';
 import { useBreadcrumbButtonStyles_unstable } from './useBreadcrumbButtonStyles.styles';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import type { BreadcrumbButtonProps } from './BreadcrumbButton.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 
@@ -12,6 +13,8 @@ export const BreadcrumbButton: ForwardRefComponent<BreadcrumbButtonProps> = Reac
   const state = useBreadcrumbButton_unstable(props, ref);
 
   useBreadcrumbButtonStyles_unstable(state);
+  useCustomStyleHook_unstable('useBreadcrumbButtonStyles_unstable')(state);
+
   return renderBreadcrumbButton_unstable(state);
 });
 

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbDivider/BreadcrumbDivider.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbDivider/BreadcrumbDivider.tsx
@@ -4,6 +4,7 @@ import { renderBreadcrumbDivider_unstable } from './renderBreadcrumbDivider';
 import { useBreadcrumbDividerStyles_unstable } from './useBreadcrumbDividerStyles.styles';
 import type { BreadcrumbDividerProps } from './BreadcrumbDivider.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * A divider component which is used inside the Breadcrumb
@@ -12,6 +13,7 @@ export const BreadcrumbDivider: ForwardRefComponent<BreadcrumbDividerProps> = Re
   const state = useBreadcrumbDivider_unstable(props, ref);
 
   useBreadcrumbDividerStyles_unstable(state);
+  useCustomStyleHook_unstable('useBreadcrumbDividerStyles_unstable')(state);
 
   return renderBreadcrumbDivider_unstable(state);
 });

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbItem/BreadcrumbItem.tsx
@@ -4,6 +4,7 @@ import { renderBreadcrumbItem_unstable } from './renderBreadcrumbItem';
 import { useBreadcrumbItemStyles_unstable } from './useBreadcrumbItemStyles.styles';
 import type { BreadcrumbItemProps } from './BreadcrumbItem.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * BreadcrumbItem component is a wrapper for BreadcrumbLink and BreadcrumbButton.
@@ -13,6 +14,7 @@ export const BreadcrumbItem: ForwardRefComponent<BreadcrumbItemProps> = React.fo
   const state = useBreadcrumbItem_unstable(props, ref);
 
   useBreadcrumbItemStyles_unstable(state);
+  useCustomStyleHook_unstable('useBreadcrumbItemStyles_unstable')(state);
 
   return renderBreadcrumbItem_unstable(state);
 });

--- a/packages/react-components/react-provider/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/etc/react-provider.api.md
@@ -124,6 +124,10 @@ export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentPro
         useInteractionTagSecondaryStyles_unstable: (state: unknown) => void;
         useTagStyles_unstable: (state: unknown) => void;
         useTagGroupStyles_unstable: (state: unknown) => void;
+        useBreadcrumbStyles_unstable: (state: unknown) => void;
+        useBreadcrumbButtonStyles_unstable: (state: unknown) => void;
+        useBreadcrumbItemStyles_unstable: (state: unknown) => void;
+        useBreadcrumbDividerStyles_unstable: (state: unknown) => void;
     }> | undefined;
     dir?: "ltr" | "rtl" | undefined;
     targetDocument?: Document | undefined;

--- a/packages/react-components/react-shared-contexts/etc/react-shared-contexts.api.md
+++ b/packages/react-components/react-shared-contexts/etc/react-shared-contexts.api.md
@@ -119,6 +119,10 @@ export const CustomStyleHooksContext_unstable: React_2.Context<Partial<{
     useInteractionTagSecondaryStyles_unstable: CustomStyleHook;
     useTagStyles_unstable: CustomStyleHook;
     useTagGroupStyles_unstable: CustomStyleHook;
+    useBreadcrumbStyles_unstable: CustomStyleHook;
+    useBreadcrumbButtonStyles_unstable: CustomStyleHook;
+    useBreadcrumbItemStyles_unstable: CustomStyleHook;
+    useBreadcrumbDividerStyles_unstable: CustomStyleHook;
 }> | undefined>;
 
 // @public (undocumented)
@@ -219,6 +223,10 @@ export type CustomStyleHooksContextValue_unstable = Partial<{
     useInteractionTagSecondaryStyles_unstable: CustomStyleHook;
     useTagStyles_unstable: CustomStyleHook;
     useTagGroupStyles_unstable: CustomStyleHook;
+    useBreadcrumbStyles_unstable: CustomStyleHook;
+    useBreadcrumbButtonStyles_unstable: CustomStyleHook;
+    useBreadcrumbItemStyles_unstable: CustomStyleHook;
+    useBreadcrumbDividerStyles_unstable: CustomStyleHook;
 }>;
 
 // @internal (undocumented)
@@ -319,6 +327,10 @@ export const CustomStyleHooksProvider_unstable: React_2.Provider<Partial<{
     useInteractionTagSecondaryStyles_unstable: CustomStyleHook;
     useTagStyles_unstable: CustomStyleHook;
     useTagGroupStyles_unstable: CustomStyleHook;
+    useBreadcrumbStyles_unstable: CustomStyleHook;
+    useBreadcrumbButtonStyles_unstable: CustomStyleHook;
+    useBreadcrumbItemStyles_unstable: CustomStyleHook;
+    useBreadcrumbDividerStyles_unstable: CustomStyleHook;
 }> | undefined>;
 
 // @internal (undocumented)

--- a/packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+++ b/packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
@@ -102,6 +102,10 @@ export type CustomStyleHooksContextValue = Partial<{
   useInteractionTagSecondaryStyles_unstable: CustomStyleHook;
   useTagStyles_unstable: CustomStyleHook;
   useTagGroupStyles_unstable: CustomStyleHook;
+  useBreadcrumbStyles_unstable: CustomStyleHook;
+  useBreadcrumbButtonStyles_unstable: CustomStyleHook;
+  useBreadcrumbItemStyles_unstable: CustomStyleHook;
+  useBreadcrumbDividerStyles_unstable: CustomStyleHook;
 }>;
 
 /**


### PR DESCRIPTION
## Previous Behavior
None of Breadcrumb components contained custom styling hooks

## New Behavior
Added custom styling hooks for Breadcrumb component and its sub-components

- Fixes #29257
