### PR TITLE
fix(Stack): Allow rendering of values that aren't falsy elements and aren't valid elements

### DIFF
--- a/change/@fluentui-react-d265a3da-39e3-4b9d-be1e-b0ed8a0ee1d5.json
+++ b/change/@fluentui-react-d265a3da-39e3-4b9d-be1e-b0ed8a0ee1d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Treat false values separate from values that aren't valid elements in stack.",
+  "packageName": "@fluentui/react",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -61,8 +61,14 @@ function _processStackChildren(
   let childrenArray = React.Children.toArray(children);
 
   childrenArray = React.Children.map(childrenArray, child => {
-    if (!child || !React.isValidElement(child)) {
+    if (!child) {
       return doNotRenderFalsyValues ? null : child;
+    }
+
+    // We need to allow children that aren't falsy values, but not valid elements since they could be
+    // a string like <Stack>{'sample string'}</Stack>
+    if (!React.isValidElement(child)) {
+      return child;
     }
 
     if (child.type === React.Fragment) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Values such as strings that aren't elements were not rendered when using the doNotRenderFalsyValues flag due to getting the same treatment as falsy values.

## New Behavior

Values like the ones said before are now rendered regardless of the doNotRenderFalsyValues flag.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29289
