### PR TITLE
chore: use TsconfigPathsPlugin in cypress test config

### DIFF
--- a/scripts/cypress/src/base.config.ts
+++ b/scripts/cypress/src/base.config.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 
 import { defineConfig } from 'cypress';
+import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import type { Configuration } from 'webpack';
 
 /**
@@ -31,6 +32,14 @@ const cypressWebpackConfig = (): Configuration => {
       },
     });
   }
+
+  baseWebpackConfig.resolve ??= {};
+  baseWebpackConfig.resolve.plugins ??= [];
+  baseWebpackConfig.resolve.plugins.push(
+    new TsconfigPathsPlugin({
+      configFile: path.resolve(__dirname, '../../../tsconfig.base.json'),
+    }),
+  );
 
   return baseWebpackConfig;
 };


### PR DESCRIPTION
Cypress test config previously did not use TsConfigPathsPlugin so it relied on code being built in CI. This is a similar approach to our storybook config

However there is an edge case encountered in #29313. Lage will run the cypress tests of depednencies which *_can depend on depedencies not in the package.json tree_* 💣💣

```
- react-message-bar-preview
  - react-button
    - react-tabster
      - react-provider (not in package.json, but used in cypress test)
```