### PR TITLE
chore(react-link): adds style to remove default outline style

### DIFF
--- a/change/@fluentui-react-link-a0a06b2e-a83e-44b3-b2bd-f432395554c8.json
+++ b/change/@fluentui-react-link-a0a06b2e-a83e-44b3-b2bd-f432395554c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adds style to remove default outline style",
+  "packageName": "@fluentui/react-link",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-97c6497b-b398-446f-b711-66f7f0a76796.json
+++ b/change/@fluentui-react-tabster-97c6497b-b398-446f-b711-66f7f0a76796.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adds comments on createCustomFocusIndicatorStyle to explain that the default outline style is not removed",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/src/components/Link/useLinkStyles.styles.ts
@@ -17,6 +17,9 @@ const useStyles = makeStyles({
   }),
   // Common styles.
   root: {
+    ':focus-visible': {
+      outlineStyle: 'none',
+    },
     backgroundColor: 'transparent',
     boxSizing: 'border-box',
     color: tokens.colorBrandForegroundLink,

--- a/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createCustomFocusIndicatorStyle.ts
@@ -30,6 +30,29 @@ export interface CreateCustomFocusIndicatorStyleOptions {
  * Creates a style for @see makeStyles that includes the necessary selectors for focus.
  * Should be used only when @see createFocusOutlineStyle does not fit requirements
  *
+ * If you're using `createCustomFocusIndicatorStyle` instead of `createFocusOutlineStyle`
+ * keep in mind that the default outline style is not going to be removed
+ * (as it is in `createFocusOutlineStyle`),
+ * and is your responsibility to manually remove it from your styles.
+ *
+ * @example
+ * ```ts
+ * // Link styles
+ * const useStyles = makeStyles({
+  focusIndicator: createCustomFocusIndicatorStyle({
+    textDecorationColor: tokens.colorStrokeFocus2,
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'double',
+    outlineStyle: 'none',
+  }),
+  // Common styles.
+  root: {
+    // ❗️ DO NOT FORGET TO REMOVE THE DEFAULT OUTLINE STYLE
+    ':focus-visible': {
+      outlineStyle: 'none',
+    },
+ * ```
+ *
  * @param style - styling applied on focus, defaults to @see getDefaultFocusOutlineStyles
  * @param options - Configure the style of the focus outline
  */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Link component does not add styles to remove the default outline provided by browsers

## New Behavior

1. manually add styles to remove focus outline on `focus-visible`
2. adds comments to `createCustomFocusIndicatorStyle` to make it clear that this method does not remove the outline style

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29251
