### PR TITLE
bugfix(react-dialog): removes tabindex -1 from DialogSurface if not required

### DIFF
--- a/change/@fluentui-react-dialog-11f40c4c-d502-49ea-a93c-b3255726e196.json
+++ b/change/@fluentui-react-dialog-11f40c4c-d502-49ea-a93c-b3255726e196.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: removes tabindex -1 from DialogSurface if not required",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`DialogSurface` by default has `tabIndex` set to `-1`, which is required for it to work properly on some edge cases https://github.com/microsoft/fluentui/issues/25150, but may cause some problems on some other https://github.com/microsoft/fluentui/issues/28404

## New Behavior

1. Removes `tabIndex=-1` by default
2. adds callback to add tabindex -1 on mount in cases where is necessary

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/28404
