### PR TITLE
fix: Icon in disabled Button shouldn't change color on hover or pressed

### DIFF
--- a/change/@fluentui-react-button-d89ce90d-cbf8-4b16-9a02-2d6606cea56e.json
+++ b/change/@fluentui-react-button-d89ce90d-cbf8-4b16-9a02-2d6606cea56e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Icon in disabled Button shouldn't change color on hover",
+  "comment": "fix: Icon in disabled Button shouldn't change color on hover or pressed.",
   "packageName": "@fluentui/react-button",
   "email": "vkozlova@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-button-d89ce90d-cbf8-4b16-9a02-2d6606cea56e.json
+++ b/change/@fluentui-react-button-d89ce90d-cbf8-4b16-9a02-2d6606cea56e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Icon in disabled Button shouldn't change color on hover",
+  "packageName": "@fluentui/react-button",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -332,7 +332,7 @@ const useRootDisabledStyles = makeStyles({
       [`& .${iconRegularClassName}`]: {
         display: 'inline',
       },
-      [`&:disabled .${buttonClassNames.icon}`]: {
+      [`& .${buttonClassNames.icon}`]: {
         color: tokens.colorNeutralForegroundDisabled,
       },
     },

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -318,6 +318,9 @@ const useRootDisabledStyles = makeStyles({
     color: tokens.colorNeutralForegroundDisabled,
 
     cursor: 'not-allowed',
+    [`& .${buttonClassNames.icon}`]: {
+      color: tokens.colorNeutralForegroundDisabled,
+    },
 
     ':hover': {
       backgroundColor: tokens.colorNeutralBackgroundDisabled,
@@ -349,6 +352,9 @@ const useRootDisabledStyles = makeStyles({
       },
       [`& .${iconRegularClassName}`]: {
         display: 'inline',
+      },
+      [`& .${buttonClassNames.icon}`]: {
+        color: tokens.colorNeutralForegroundDisabled,
       },
     },
   },

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -332,6 +332,9 @@ const useRootDisabledStyles = makeStyles({
       [`& .${iconRegularClassName}`]: {
         display: 'inline',
       },
+      [`&:disabled .${buttonClassNames.icon}`]: {
+        color: tokens.colorNeutralForegroundDisabled,
+      },
     },
 
     ':hover:active': {


### PR DESCRIPTION
Hover Button component with icon and appearance="subtle" and disabled state

## Previous Behavior
<img width="252" alt="image" src="https://github.com/microsoft/fluentui/assets/11574680/8bc22614-3815-4f6e-9ff9-2446317467ce">

## New Behavior
<img width="246" alt="image" src="https://github.com/microsoft/fluentui/assets/11574680/ce9edf87-b39e-4bc5-ba7d-448402389dc7">

- Fixes #29341
