### PR TITLE
Fix overlapping bars in single group

### DIFF
--- a/change/@fluentui-react-charting-d116410a-f17d-45c3-bef4-a87cd431d3da.json
+++ b/change/@fluentui-react-charting-d116410a-f17d-45c3-bef4-a87cd431d3da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix overlapping bars in single group",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -84,6 +84,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
   private _barWidth: number;
   private _domainMargin: number;
   private _emptyChartId: string;
+  private _groupWidth: number;
 
   public constructor(props: IGroupedVerticalBarChartProps) {
     super(props);
@@ -202,7 +203,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
     xElement?: SVGElement | null,
   ) => {
     const xScale0 = this._createX0Scale(containerWidth);
-    const xScale1 = this._createX1Scale(xScale0);
+    const xScale1 = this._createX1Scale();
     const allGroupsBars: JSX.Element[] = [];
     this._datasetForBars.forEach((singleSet: IGVSingleDataPoint) => {
       allGroupsBars.push(this._buildGraph(singleSet, xScale0, xScale1, containerHeight, xElement!));
@@ -331,7 +332,9 @@ export class GroupedVerticalBarChartBase extends React.Component<
     tempDataSet.forEach((datasetKey: string, index: number) => {
       const refIndexNumber = singleSet.indexNum * tempDataSet.length + index;
       const pointData = singleSet[datasetKey];
-      const xPoint = xScale1(datasetKey)!;
+      // To align the centers of the generated bandwidth and the calculated one when they differ,
+      // use the following addend.
+      const xPoint = xScale1(datasetKey) + (xScale1.bandwidth() - this._barWidth) / 2;
       const yPoint = Math.max(containerHeight! - this.margins.bottom! - yBarScale(pointData.data), 0);
       // Not rendering data with 0.
       pointData.data &&
@@ -388,7 +391,10 @@ export class GroupedVerticalBarChartBase extends React.Component<
       xAxisElement && tooltipOfXAxislabels(tooltipProps);
     }
     return (
-      <g key={singleSet.indexNum} transform={`translate(${xScale0(singleSet.xAxisPoint)}, 0)`}>
+      <g
+        key={singleSet.indexNum}
+        transform={`translate(${xScale0(singleSet.xAxisPoint) + (xScale0.bandwidth() - this._groupWidth) / 2}, 0)`}
+      >
         {singleGroup}
         {barLabelsForGroup}
       </g>
@@ -443,13 +449,16 @@ export class GroupedVerticalBarChartBase extends React.Component<
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _createX1Scale = (xScale0: any): any => {
-    const bandWidth = xScale0.bandwidth();
-
-    return d3ScaleBand()
-      .domain(this._keys)
-      .range(this._isRtl ? [bandWidth, 0] : [0, bandWidth])
-      .paddingInner(X1_INNER_PADDING);
+  private _createX1Scale = (): any => {
+    return (
+      d3ScaleBand()
+        .domain(this._keys)
+        // When there is only one group, xScale0 adds padding around it,
+        // causing the bandwidth to become smaller than the actual group width.
+        // So to render bars in the group correctly, use groupWidth instead of the generated scale bandwidth.
+        .range(this._isRtl ? [this._groupWidth, 0] : [0, this._groupWidth])
+        .paddingInner(X1_INNER_PADDING)
+    );
   };
 
   private _closeCallout = () => {
@@ -582,6 +591,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
       barWidth = groupWidth / (this._keys.length + (this._keys.length - 1) * BAR_GAP_RATE);
     }
     this._barWidth = barWidth;
+    this._groupWidth = groupWidth;
 
     return {
       ...this.margins,

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -146,7 +146,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -168,13 +168,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -217,7 +217,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -239,7 +239,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -863,7 +863,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -906,7 +906,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -928,13 +928,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -977,7 +977,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -999,7 +999,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -1543,7 +1543,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -1586,7 +1586,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -1608,13 +1608,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -1657,7 +1657,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -1679,7 +1679,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -2135,7 +2135,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -2178,7 +2178,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -2200,13 +2200,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -2249,7 +2249,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -2271,7 +2271,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -2707,7 +2707,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -2750,7 +2750,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={273.3152173913044}
           />
           <rect
@@ -2772,13 +2772,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={205.97826086956522}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -2821,7 +2821,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={26.413043478260875}
           />
           <rect
@@ -2843,7 +2843,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={209.18478260869566}
           />
         </g>
@@ -2956,7 +2956,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -2999,7 +2999,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -3021,13 +3021,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -3070,7 +3070,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -3092,7 +3092,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -3548,7 +3548,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -3591,7 +3591,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -3613,13 +3613,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -3662,7 +3662,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -3684,7 +3684,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -4140,7 +4140,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -4183,7 +4183,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -4205,13 +4205,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -4254,7 +4254,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -4276,7 +4276,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -4732,7 +4732,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -4775,7 +4775,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -4797,13 +4797,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -4846,7 +4846,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -4868,7 +4868,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChartRTL.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
         />
         <g>
           <g
-            transform="translate(32.47311827956989, 0)"
+            transform="translate(48, 0)"
           >
             <rect
               aria-label="2020/04/30. MetaData1, 33%."
@@ -123,7 +123,7 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
               role="img"
               tabindex="0"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -140,12 +140,12 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="13.399999999999999"
             />
           </g>
           <g
-            transform="translate(2.2365591397849443, 0)"
+            transform="translate(17.763440860215052, 0)"
           >
             <rect
               aria-label="2020/05/30. MetaData1, 33%."
@@ -161,7 +161,7 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -178,12 +178,12 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="0"
             />
           </g>
           <g
-            transform="translate(-28, 0)"
+            transform="translate(-12.473118279569892, 0)"
           >
             <rect
               aria-label="2020/06/30. MetaData1, 14%."
@@ -199,7 +199,7 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="0"
             />
             <rect
@@ -216,7 +216,7 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="20"
             />
           </g>
@@ -553,7 +553,7 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
         />
         <g>
           <g
-            transform="translate(32.47311827956989, 0)"
+            transform="translate(48, 0)"
           >
             <rect
               aria-label="2020/04/30. MetaData1, 33%."
@@ -569,7 +569,7 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
               role="img"
               tabindex="0"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -586,12 +586,12 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="13.399999999999999"
             />
           </g>
           <g
-            transform="translate(2.2365591397849443, 0)"
+            transform="translate(17.763440860215052, 0)"
           >
             <rect
               aria-label="2020/05/30. MetaData1, 33%."
@@ -607,7 +607,7 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -624,12 +624,12 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="0"
             />
           </g>
           <g
-            transform="translate(-28, 0)"
+            transform="translate(-12.473118279569892, 0)"
           >
             <rect
               aria-label="2020/06/30. MetaData1, 14%."
@@ -645,7 +645,7 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="0"
             />
             <rect
@@ -662,7 +662,7 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="20"
             />
           </g>
@@ -999,7 +999,7 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
         />
         <g>
           <g
-            transform="translate(32.47311827956989, 0)"
+            transform="translate(48, 0)"
           >
             <rect
               aria-label="2020/04/30. MetaData1, 33%."
@@ -1015,7 +1015,7 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
               role="img"
               tabindex="0"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -1032,12 +1032,12 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="13.399999999999999"
             />
           </g>
           <g
-            transform="translate(2.2365591397849443, 0)"
+            transform="translate(17.763440860215052, 0)"
           >
             <rect
               aria-label="2020/05/30. MetaData1, 33%."
@@ -1053,7 +1053,7 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -1070,12 +1070,12 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="0"
             />
           </g>
           <g
-            transform="translate(-28, 0)"
+            transform="translate(-12.473118279569892, 0)"
           >
             <rect
               aria-label="2020/06/30. MetaData1, 14%."
@@ -1091,7 +1091,7 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="0"
             />
             <rect
@@ -1108,7 +1108,7 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="20"
             />
           </g>
@@ -1445,7 +1445,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
         />
         <g>
           <g
-            transform="translate(32.47311827956989, 0)"
+            transform="translate(48, 0)"
           >
             <rect
               aria-label="2020/04/30. MetaData1, 33%."
@@ -1461,7 +1461,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="0"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -1478,12 +1478,12 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="13.399999999999999"
             />
           </g>
           <g
-            transform="translate(2.2365591397849443, 0)"
+            transform="translate(17.763440860215052, 0)"
           >
             <rect
               aria-label="2020/05/30. MetaData1, 33%."
@@ -1499,7 +1499,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -1516,12 +1516,12 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="0"
             />
           </g>
           <g
-            transform="translate(-28, 0)"
+            transform="translate(-12.473118279569892, 0)"
           >
             <rect
               aria-label="2020/06/30. MetaData1, 14%."
@@ -1537,7 +1537,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="0"
             />
             <rect
@@ -1554,7 +1554,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="20"
             />
           </g>
@@ -1891,7 +1891,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
         />
         <g>
           <g
-            transform="translate(32.47311827956989, 0)"
+            transform="translate(48, 0)"
           >
             <rect
               aria-label="2020/04/30. MetaData1, 33%."
@@ -1907,7 +1907,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="0"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -1924,12 +1924,12 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="13.399999999999999"
             />
           </g>
           <g
-            transform="translate(2.2365591397849443, 0)"
+            transform="translate(17.763440860215052, 0)"
           >
             <rect
               aria-label="2020/05/30. MetaData1, 33%."
@@ -1945,7 +1945,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="1.3000000000000043"
             />
             <rect
@@ -1962,12 +1962,12 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="0"
             />
           </g>
           <g
-            transform="translate(-28, 0)"
+            transform="translate(-12.473118279569892, 0)"
           >
             <rect
               aria-label="2020/06/30. MetaData1, 14%."
@@ -1983,7 +1983,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="0"
+              x="-8.881784197001252e-16"
               y="0"
             />
             <rect
@@ -2000,7 +2000,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
               role="img"
               tabindex="-1"
               width="-7.354838709677419"
-              x="8.172043010752688"
+              x="-8.172043010752688"
               y="20"
             />
           </g>
@@ -2344,7 +2344,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -2387,7 +2387,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -2409,13 +2409,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -2458,7 +2458,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -2480,7 +2480,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -3104,7 +3104,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -3147,7 +3147,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -3169,13 +3169,13 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -3218,7 +3218,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -3240,7 +3240,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -3784,7 +3784,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -3827,7 +3827,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -3849,13 +3849,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -3898,7 +3898,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -3920,7 +3920,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders GroupedVerticalBarChar
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -4376,7 +4376,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -4419,7 +4419,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -4441,13 +4441,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -4490,7 +4490,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -4512,7 +4512,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -4948,7 +4948,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -4991,7 +4991,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={273.3152173913044}
           />
           <rect
@@ -5013,13 +5013,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={205.97826086956522}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -5062,7 +5062,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={26.413043478260875}
           />
           <rect
@@ -5084,7 +5084,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={209.18478260869566}
           />
         </g>
@@ -5197,7 +5197,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -5240,7 +5240,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -5262,13 +5262,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -5311,7 +5311,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -5333,7 +5333,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideTooltip correctly 
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -5789,7 +5789,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -5832,7 +5832,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -5854,13 +5854,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -5903,7 +5903,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -5925,7 +5925,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders showXAxisLablesTooltip
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -6381,7 +6381,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -6424,7 +6424,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -6446,13 +6446,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -6495,7 +6495,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -6517,7 +6517,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders wrapXAxisLables correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -6973,7 +6973,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
       <g>
         <g
           key="0"
-          transform="translate(19, 0)"
+          transform="translate(48, 0)"
         >
           <rect
             aria-label="2000. MetaData1, 66."
@@ -7016,7 +7016,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={238.9673913043478}
           />
           <rect
@@ -7038,13 +7038,13 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={180.76086956521738}
           />
         </g>
         <g
           key="1"
-          transform="translate(-28, 0)"
+          transform="translate(1, 0)"
         >
           <rect
             aria-label="2010. MetaData1, 14."
@@ -7087,7 +7087,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={10}
+            x={-10}
             y={25.543478260869563}
           />
           <rect
@@ -7109,7 +7109,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders yAxisTickFormat correc
             opacity=""
             role="img"
             width={-9}
-            x={20}
+            x={-20}
             y={183.5326086956522}
           />
         </g>
@@ -7571,7 +7571,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
           />
           <g>
             <g
-              transform="translate(32.47311827956989, 0)"
+              transform="translate(48, 0)"
             >
               <rect
                 aria-label="2020/04/30. MetaData1, 33%."
@@ -7587,7 +7587,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
                 role="img"
                 tabindex="0"
                 width="-7.354838709677419"
-                x="0"
+                x="-8.881784197001252e-16"
                 y="1.3000000000000043"
               />
               <rect
@@ -7604,12 +7604,12 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
                 role="img"
                 tabindex="-1"
                 width="-7.354838709677419"
-                x="8.172043010752688"
+                x="-8.172043010752688"
                 y="13.399999999999999"
               />
             </g>
             <g
-              transform="translate(2.2365591397849443, 0)"
+              transform="translate(17.763440860215052, 0)"
             >
               <rect
                 aria-label="2020/05/30. MetaData1, 33%."
@@ -7625,7 +7625,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
                 role="img"
                 tabindex="-1"
                 width="-7.354838709677419"
-                x="0"
+                x="-8.881784197001252e-16"
                 y="1.3000000000000043"
               />
               <rect
@@ -7642,12 +7642,12 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
                 role="img"
                 tabindex="-1"
                 width="-7.354838709677419"
-                x="8.172043010752688"
+                x="-8.172043010752688"
                 y="0"
               />
             </g>
             <g
-              transform="translate(-28, 0)"
+              transform="translate(-12.473118279569892, 0)"
             >
               <rect
                 aria-label="2020/06/30. MetaData1, 14%."
@@ -7663,7 +7663,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
                 role="img"
                 tabindex="-1"
                 width="-7.354838709677419"
-                x="0"
+                x="-8.881784197001252e-16"
                 y="0"
               />
               <rect
@@ -7680,7 +7680,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
                 role="img"
                 tabindex="-1"
                 width="-7.354838709677419"
-                x="8.172043010752688"
+                x="-8.172043010752688"
                 y="20"
               />
             </g>


### PR DESCRIPTION
## Previous Behavior

![Before](https://github.com/microsoft/fluentui/assets/110246001/0ef6aa56-f7bf-40e8-ba02-e965dab65b5b)

## New Behavior

![After](https://github.com/microsoft/fluentui/assets/110246001/d015da31-031f-4dbf-bc26-d40d4c05c926)

## Related Issue(s)

- Fixes #29335