### PR TITLE
fix: handle multiple classes in PortalCompatProvider

### DIFF
--- a/change/@fluentui-react-portal-compat-89771dd5-317e-4567-a861-92ddaecdbfdd.json
+++ b/change/@fluentui-react-portal-compat-89771dd5-317e-4567-a861-92ddaecdbfdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle multiple classes in PortalCompatProvider",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
@@ -1,14 +1,121 @@
 import { ThemeClassNameProvider_unstable as ThemeClassNameProvider } from '@fluentui/react-shared-contexts';
 import { usePortalCompat } from '@fluentui/react-portal-compat-context';
-import { FluentProvider } from '@fluentui/react-provider';
+import { FluentProvider, useFluentProviderThemeStyleTag } from '@fluentui/react-provider';
 import { IdPrefixProvider, resetIdsForTests } from '@fluentui/react-utilities';
 import { renderHook } from '@testing-library/react-hooks';
 import * as React from 'react';
 
-import { PortalCompatProvider } from './PortalCompatProvider';
+import { PortalCompatProvider, useProviderThemeClasses } from './PortalCompatProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
+
+const TestWrapperWithMultipleClasses: React.FC = props => {
+  // Creates a second className with CSS variables
+  const { styleTagId } = useFluentProviderThemeStyleTag({
+    theme: { borderRadiusCircular: '50px' },
+    targetDocument: document,
+    rendererAttributes: {},
+  });
+
+  return (
+    <FluentProvider className={styleTagId} theme={{ colorNeutralBackground1: '#ccc' }}>
+      <PortalCompatProvider>{props.children}</PortalCompatProvider>
+    </FluentProvider>
+  );
+};
+
+describe('useProviderThemeClasses', () => {
+  afterEach(() => {
+    resetIdsForTests();
+  });
+
+  it('handles classes from FluentProvider', () => {
+    const { result } = renderHook(() => useProviderThemeClasses(), {
+      wrapper: props => (
+        <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
+          <PortalCompatProvider>{props.children}</PortalCompatProvider>
+        </FluentProvider>
+      ),
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Array [
+        "fui-FluentProvider1",
+      ]
+    `);
+  });
+
+  it('handles multiple classes from FluentProvider', () => {
+    const { result } = renderHook(() => useProviderThemeClasses(), {
+      wrapper: TestWrapperWithMultipleClasses,
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Array [
+        "fui-FluentProvider2",
+        "fui-FluentProvider1",
+      ]
+    `);
+  });
+
+  it('handles classes with custom ID prefix', () => {
+    const { result } = renderHook(() => useProviderThemeClasses(), {
+      wrapper: props => (
+        <IdPrefixProvider value="custom1-">
+          <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
+            <PortalCompatProvider>{props.children}</PortalCompatProvider>
+          </FluentProvider>
+        </IdPrefixProvider>
+      ),
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Array [
+        "custom1-fui-FluentProvider1",
+      ]
+    `);
+  });
+
+  it('handles classes with a React 18 compatible ID', () => {
+    const { result } = renderHook(() => useProviderThemeClasses(), {
+      wrapper: props => (
+        <ThemeClassNameProvider value="fui-FluentProviderR1a">
+          <PortalCompatProvider>{props.children}</PortalCompatProvider>
+        </ThemeClassNameProvider>
+      ),
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Array [
+        "fui-FluentProviderR1a",
+      ]
+    `);
+  });
+
+  it('returns only proper classes', () => {
+    const { result } = renderHook(() => useProviderThemeClasses(), {
+      wrapper: props => (
+        <ThemeClassNameProvider value="foo bar baz">
+          <PortalCompatProvider>{props.children}</PortalCompatProvider>
+        </ThemeClassNameProvider>
+      ),
+    });
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('logs a warning when does not have top level FluentProvider', () => {
+    const warn = jest.fn().mockImplementation(noop);
+    jest.spyOn(console, 'warn').mockImplementation(warn);
+
+    renderHook(() => useProviderThemeClasses(), { wrapper: PortalCompatProvider });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('PortalCompatProvider: "useThemeClassName()" hook returned an empty string'),
+    );
+  });
+});
 
 describe('PortalCompatProvider', () => {
   afterEach(() => {
@@ -41,40 +148,17 @@ describe('PortalCompatProvider', () => {
     `);
   });
 
-  it('during register adds a className from "ThemeClassNameContext" context with custom ID prefix', () => {
+  it('during register adds multiple classes from "ThemeClassNameContext" context if they exist', () => {
     const element = document.createElement('div');
     const { result } = renderHook(() => usePortalCompat(), {
-      wrapper: props => (
-        <IdPrefixProvider value="custom1-">
-          <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
-            <PortalCompatProvider>{props.children}</PortalCompatProvider>
-          </FluentProvider>
-        </IdPrefixProvider>
-      ),
+      wrapper: TestWrapperWithMultipleClasses,
     });
 
     expect(result.current(element)).toBeInstanceOf(Function);
     expect(element.classList).toMatchInlineSnapshot(`
       DOMTokenList {
-        "0": "custom1-fui-FluentProvider1",
-      }
-    `);
-  });
-
-  it('during register adds a className from "ThemeClassNameContext" context with a React 18 compatible ID', () => {
-    const element = document.createElement('div');
-    const { result } = renderHook(() => usePortalCompat(), {
-      wrapper: props => (
-        <ThemeClassNameProvider value="fui-FluentProviderR1a">
-          <PortalCompatProvider>{props.children}</PortalCompatProvider>
-        </ThemeClassNameProvider>
-      ),
-    });
-
-    expect(result.current(element)).toBeInstanceOf(Function);
-    expect(element.classList).toMatchInlineSnapshot(`
-      DOMTokenList {
-        "0": "fui-FluentProviderR1a",
+        "0": "fui-FluentProvider2",
+        "1": "fui-FluentProvider1",
       }
     `);
   });
@@ -100,30 +184,5 @@ describe('PortalCompatProvider', () => {
 
     expect(unregister()).toBeUndefined();
     expect(element.classList.length).toBe(0);
-  });
-
-  it('during register adds only proper className', () => {
-    const element = document.createElement('div');
-    const { result } = renderHook(() => usePortalCompat(), {
-      wrapper: props => (
-        <ThemeClassNameProvider value="foo bar baz">
-          <PortalCompatProvider>{props.children}</PortalCompatProvider>
-        </ThemeClassNameProvider>
-      ),
-    });
-    result.current(element);
-
-    expect(element.classList.length).toBe(0);
-  });
-
-  it('logs a warning when does not have top level FluentProvider', () => {
-    const warn = jest.fn().mockImplementation(noop);
-    jest.spyOn(console, 'warn').mockImplementation(warn);
-
-    renderHook(() => usePortalCompat(), { wrapper: PortalCompatProvider });
-
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('PortalCompatProvider: "useThemeClassName()" hook returned an empty string'),
-    );
   });
 });

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
@@ -5,37 +5,15 @@ import { applyFocusVisiblePolyfill } from '@fluentui/react-tabster';
 
 import type { RegisterPortalFn } from '@fluentui/react-portal-compat-context';
 
-const CLASS_NAME_REGEX = new RegExp(`([^\\s]*${fluentProviderClassNames.root}\\w+)`);
+const CLASS_NAME_REGEX = new RegExp(`([^\\s]*${fluentProviderClassNames.root}\\w+)`, 'g');
 
-export const PortalCompatProvider: React.FC<{ children?: React.ReactNode }> = props => {
-  const { children } = props;
-
+export function useProviderThemeClasses(): string[] {
   const themeClassName = useThemeClassName();
-  const cssVariablesClassName = React.useMemo<string | undefined>(
-    // "themeClassName" may contain multiple classes while we want to add only a class that hosts CSS variables
+  const cssVariablesClasses = React.useMemo<string[]>(
+    // "themeClassName" may contain multiple classes while we want to add only classes that host CSS variables
     // Keep in sync with "packages/react-provider/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts"
-    () => themeClassName.match(CLASS_NAME_REGEX)?.[1],
+    () => themeClassName.match(CLASS_NAME_REGEX) ?? [],
     [themeClassName],
-  );
-
-  const registerPortalEl = React.useCallback<RegisterPortalFn>(
-    element => {
-      let disposeFocusVisiblePolyfill: () => void = () => undefined;
-      if (cssVariablesClassName) {
-        element.classList.add(cssVariablesClassName);
-        if (element.ownerDocument.defaultView) {
-          disposeFocusVisiblePolyfill = applyFocusVisiblePolyfill(element, element.ownerDocument.defaultView);
-        }
-      }
-
-      return () => {
-        if (cssVariablesClassName) {
-          element.classList.remove(cssVariablesClassName);
-        }
-        disposeFocusVisiblePolyfill();
-      };
-    },
-    [cssVariablesClassName],
   );
 
   if (process.env.NODE_ENV !== 'production') {
@@ -53,6 +31,30 @@ export const PortalCompatProvider: React.FC<{ children?: React.ReactNode }> = pr
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
   }
+
+  return cssVariablesClasses;
+}
+
+export const PortalCompatProvider: React.FC<{ children?: React.ReactNode }> = props => {
+  const { children } = props;
+  const cssVariablesClasses = useProviderThemeClasses();
+
+  const registerPortalEl = React.useCallback<RegisterPortalFn>(
+    element => {
+      let disposeFocusVisiblePolyfill: () => void = () => undefined;
+
+      element.classList.add(...cssVariablesClasses);
+      if (element.ownerDocument.defaultView) {
+        disposeFocusVisiblePolyfill = applyFocusVisiblePolyfill(element, element.ownerDocument.defaultView);
+      }
+
+      return () => {
+        element.classList.remove(...cssVariablesClasses);
+        disposeFocusVisiblePolyfill();
+      };
+    },
+    [cssVariablesClasses],
+  );
 
   return <PortalCompatContextProvider value={registerPortalEl}>{children}</PortalCompatContextProvider>;
 };


### PR DESCRIPTION
## Previous Behavior

`PortalCompatProvider` can handle only one `fui-FluentProvider*` class from a context.

## New Behavior

`PortalCompatProvider` can handle multiple `fui-FluentProvider*` classes from a context. This a customer scenario when additional tokens are added with `useFluentProviderThemeStyleTag()`.