### PR TITLE
fix: changed divider in the Breadcrumb with tooltip

### DIFF
--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithTooltip.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithTooltip.stories.tsx
@@ -182,9 +182,7 @@ const getTooltipContent = (breadcrumbItems: readonly Item[] | undefined) => {
     return (
       <>
         {acc}
-        {arr[0].item !== initialValue.item && (
-          <BreadcrumbDivider style={{ display: 'inline', verticalAlign: 'middle' }} />
-        )}
+        {arr[0].item !== initialValue.item && ' > '}
         {initialValue.item}
       </>
     );


### PR DESCRIPTION
## Previous Behavior
Tooltip contained BreadcrumbDivider which is `li` element.
![image](https://github.com/microsoft/fluentui/assets/11574680/203329bb-c7f7-4f17-89bb-16a8743dd870)

## New Behavior
By the design there shouldn't be Breadcrumb divider, there's just `>` symbol
![image](https://github.com/microsoft/fluentui/assets/11574680/eb8490cf-849f-4f26-9470-4f8f0ce86ec0)

- Fixes #29235
