### PR TITLE
fix(useTableColumnSizing): Removes the measuring div and measures parent

### DIFF
--- a/change/@fluentui-react-table-ac6931c6-44ed-41a2-971c-e302cfa5d0ed.json
+++ b/change/@fluentui-react-table-ac6931c6-44ed-41a2-971c-e302cfa5d0ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(useTableColumnSizing): Removes the measuring div and measures parent",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/useMeasureElement.ts
+++ b/packages/react-components/react-table/src/hooks/useMeasureElement.ts
@@ -34,9 +34,8 @@ export function useMeasureElement<TElement extends HTMLElement = HTMLElement>() 
         container.current.remove();
       }
 
-      if (el) {
-        container.current = targetDocument.createElement('div');
-        el.insertAdjacentElement('beforebegin', container.current);
+      if (el?.parentElement) {
+        container.current = el.parentElement;
         resizeObserver.observe(container.current);
         handleResize();
       }


### PR DESCRIPTION
Instead of dropping a div to measure the container size, the measurement is now done directly on the parent element of the DataGrid

Fixes #29352
