### PR TITLE
Bug9273- change for reducing width and height for tree chart such that it fits the doc site

### DIFF
--- a/change/@fluentui-react-charting-fdcd995e-d8b9-4952-a4a2-2674d8757d49.json
+++ b/change/@fluentui-react-charting-fdcd995e-d8b9-4952-a4a2-2674d8757d49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "change for reducing width and height for tree chart such that it fits the doc site",
+  "packageName": "@fluentui/react-charting",
+  "email": "ankityadav@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/etc/react-charting.api.md
+++ b/packages/react-charting/etc/react-charting.api.md
@@ -1259,12 +1259,7 @@ export interface ITreeProps {
     composition?: NodesComposition.long | NodesComposition.compact;
     height?: number;
     layoutWidth?: number;
-    marign?: {
-        left: number;
-        right: number;
-        top: number;
-        bottom: number;
-    };
+    margins?: IMargins;
     styles?: IStyleFunctionOrObject<ITreeStyleProps, ITreeStyles>;
     theme?: ITheme;
     treeData: ITreeChartDataPoint;

--- a/packages/react-charting/src/components/TreeChart/TreeChart.base.tsx
+++ b/packages/react-charting/src/components/TreeChart/TreeChart.base.tsx
@@ -14,6 +14,7 @@ import {
   ITreeStyleProps,
   ITreeStyles,
 } from '../../index';
+import { IMargins } from '../../utilities/utilities';
 
 const getClassNames = classNamesFunction<ITreeStyleProps, ITreeStyles>();
 
@@ -470,14 +471,19 @@ export class TreeChartBase extends React.Component<ITreeProps, ITreeState> {
   private _height: number;
   private _composition: number | undefined;
   private _classNames: IProcessedStyleSet<ITreeStyles>;
-  private _margin: { left: number; right: number; top: number; bottom: number };
+  private _margin: IMargins;
   private _nodeElements: JSX.Element[] = [];
   private _linkElements: JSX.Element[] = [];
   private _treeTraversal: number | undefined;
 
   constructor(props: ITreeProps) {
     super(props);
-    this._margin = { top: 30, right: 130, bottom: 30, left: 50 };
+    this._margin = {
+      top: this.props.margins?.top || 30,
+      bottom: this.props.margins?.bottom || 30,
+      left: this.props.margins?.left || 50,
+      right: this.props.margins?.right || 20,
+    };
     this._width = this.props.width || 1500;
     this._height = this.props.height || 700;
     this._treeData = this.props.treeData;
@@ -536,7 +542,7 @@ export class TreeChartBase extends React.Component<ITreeProps, ITreeState> {
       linkElements,
       this._treeTraversal,
     );
-    const width = this.state._width - this._margin.left - this._margin.right;
+    const width = this.state._width - this._margin.left! - this._margin.right!;
     treeObject.createTree(this.props.layoutWidth, width);
     this._nodeElements = nodeElements;
     this._linkElements = linkElements;
@@ -548,8 +554,8 @@ export class TreeChartBase extends React.Component<ITreeProps, ITreeState> {
         <div className={this._classNames?.root}>
           <svg
             className="svgTree"
-            width={this.state._width - this._margin.left - this._margin.right}
-            height={this.state._height - this._margin.top - this._margin.bottom}
+            width={this.state._width - this._margin.left! - this._margin.right!}
+            height={this.state._height - this._margin.top! - this._margin.bottom!}
           >
             <g className="svgNode">{this._nodeElements.map(element => element)}</g>
             <g className="svgLink">{this._linkElements.map(element => element)}</g>

--- a/packages/react-charting/src/components/TreeChart/TreeChart.base.tsx
+++ b/packages/react-charting/src/components/TreeChart/TreeChart.base.tsx
@@ -477,7 +477,7 @@ export class TreeChartBase extends React.Component<ITreeProps, ITreeState> {
 
   constructor(props: ITreeProps) {
     super(props);
-    this._margin = { top: 30, right: 20, bottom: 30, left: 50 };
+    this._margin = { top: 30, right: 130, bottom: 30, left: 50 };
     this._width = this.props.width || 1500;
     this._height = this.props.height || 700;
     this._treeData = this.props.treeData;

--- a/packages/react-charting/src/components/TreeChart/TreeChart.types.ts
+++ b/packages/react-charting/src/components/TreeChart/TreeChart.types.ts
@@ -1,5 +1,6 @@
 import { IStyle, ITheme } from '@fluentui/react/lib/Styling';
 import { IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
+import { IMargins } from '../../types/index';
 
 /**
  * ITreeChartDataPoint interface for Treechart component.
@@ -82,10 +83,13 @@ export interface ITreeProps {
    * * @default 700
    */
   height?: number;
+
   /**
-   * Margin for the SVG tree chart
+   * Margins for the chart
+   * @default `{ top: 30, bottom: 30, left: 50, right: 20 }`
+   * To avoid edge cuttings to the chart, we recommend you use default values or greater then default values
    */
-  marign?: { left: number; right: number; top: number; bottom: number };
+  margins?: IMargins;
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */

--- a/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
+++ b/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`TreeChart snapshot testing renders treechart three layer compact compos
     <svg
       className="svgTree"
       height={640}
-      width={1320}
+      width={1430}
     >
       <g
         className="svgNode"
@@ -53,7 +53,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={547.5}
+          x={602.5}
           y={10}
         />
         <text
@@ -69,7 +69,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={660}
+          x={715}
         >
           Root Node 
           <tspan
@@ -84,7 +84,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={660}
+            x={715}
           >
             subtext 
           </tspan>
@@ -112,7 +112,7 @@ subText subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={130}
         />
         <text
@@ -128,7 +128,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           Child 1 
           <tspan
@@ -143,7 +143,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             100% 
           </tspan>
@@ -171,7 +171,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={153.75}
+          x={208.75}
           y={260}
         />
         <text
@@ -187,7 +187,7 @@ subText sub Parent info parentId: 1
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={205}
+          x={260}
         >
           leaf1 
           <tspan
@@ -202,7 +202,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={205}
+            x={260}
           >
             sub 
           </tspan>
@@ -230,7 +230,7 @@ subText undefined Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={276.25}
+          x={331.25}
           y={260}
         />
         <text
@@ -246,7 +246,7 @@ subText undefined Parent info parentId: 1
               }
           dy={300.7608695652174}
           textAnchor="middle"
-          x={327.5}
+          x={382.5}
         >
           leaf2 
         </text>
@@ -273,7 +273,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={153.75}
+          x={208.75}
           y={345.2173913043478}
         />
         <text
@@ -289,7 +289,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={205}
+          x={260}
         >
           leaf3 
           <tspan
@@ -304,7 +304,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={205}
+            x={260}
           >
             The subtext is as follows: sub 
           </tspan>
@@ -332,7 +332,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={276.25}
+          x={331.25}
           y={345.2173913043478}
         />
         <text
@@ -348,7 +348,7 @@ subText sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={327.5}
+          x={382.5}
         >
           leaf4 
           <tspan
@@ -363,7 +363,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={327.5}
+            x={382.5}
           >
             sub 
           </tspan>
@@ -391,7 +391,7 @@ subText undefined Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={130}
         />
         <text
@@ -407,7 +407,7 @@ subText undefined Parent info parentId: 0
               }
           dy={170.76086956521738}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           Child 2 is the child name 
         </text>
@@ -434,7 +434,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={102.5}
-          x={416.25}
+          x={471.25}
           y={260}
         />
         <text
@@ -450,7 +450,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={467.5}
+          x={522.5}
         >
           leaf5 
           <tspan
@@ -465,7 +465,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={467.5}
+            x={522.5}
           >
             sub 
           </tspan>
@@ -493,7 +493,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={102.5}
-          x={538.75}
+          x={593.75}
           y={260}
         />
         <text
@@ -509,7 +509,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={590}
+          x={645}
         >
           leaf6 
           <tspan
@@ -524,7 +524,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={590}
+            x={645}
           >
             sub 
           </tspan>
@@ -552,7 +552,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={130}
         />
         <text
@@ -568,7 +568,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           Child 3 
           <tspan
@@ -583,7 +583,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             The subtext is as follows: subtext 
           </tspan>
@@ -611,7 +611,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={678.75}
+          x={733.75}
           y={260}
         />
         <text
@@ -627,7 +627,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={730}
+          x={785}
         >
           leaf7 
           <tspan
@@ -642,7 +642,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={730}
+            x={785}
           >
             sub 
           </tspan>
@@ -670,7 +670,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={801.25}
+          x={856.25}
           y={260}
         />
         <text
@@ -686,7 +686,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={852.5}
+          x={907.5}
         >
           leaf8 
           <tspan
@@ -701,7 +701,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={852.5}
+            x={907.5}
           >
             sub 
           </tspan>
@@ -729,7 +729,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={678.75}
+          x={733.75}
           y={345.2173913043478}
         />
         <text
@@ -745,7 +745,7 @@ subText sub Parent info parentId: 9
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={730}
+          x={785}
         >
           leaf9 
           <tspan
@@ -760,7 +760,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={730}
+            x={785}
           >
             sub 
           </tspan>
@@ -788,7 +788,7 @@ subText subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={130}
         />
         <text
@@ -804,7 +804,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           Child 4 
           <tspan
@@ -819,7 +819,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             90% 
           </tspan>
@@ -847,7 +847,7 @@ subText sub Parent info parentId: 13
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={260}
         />
         <text
@@ -863,7 +863,7 @@ subText sub Parent info parentId: 13
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           leaf10 
           <tspan
@@ -878,7 +878,7 @@ subText sub Parent info parentId: 13
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             sub 
           </tspan>
@@ -895,7 +895,7 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M153.75,110 H1166.25 M660,110
+          d="M208.75,110 H1221.25 M715,110
     V85.21739130434783"
         />
         <path
@@ -906,8 +906,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M266.25,205.2173913043478 V230
-    H153.75 H378.75"
+          d="M321.25,205.2173913043478 V230
+    H208.75 H433.75"
         />
         <path
           className=
@@ -917,8 +917,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M528.75,205.2173913043478 V230
-    H416.25 H641.25"
+          d="M583.75,205.2173913043478 V230
+    H471.25 H696.25"
         />
         <path
           className=
@@ -928,8 +928,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M791.25,205.2173913043478 V230
-    H678.75 H903.75"
+          d="M846.25,205.2173913043478 V230
+    H733.75 H958.75"
         />
         <path
           className=
@@ -939,8 +939,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M1053.75,205.2173913043478 V230
-    H941.25 H1166.25"
+          d="M1108.75,205.2173913043478 V230
+    H996.25 H1221.25"
         />
       </g>
     </svg>
@@ -975,7 +975,7 @@ exports[`TreeChart snapshot testing renders treechart three layer long compositi
     <svg
       className="svgTree"
       height={640}
-      width={1320}
+      width={1430}
     >
       <g
         className="svgNode"
@@ -1001,7 +1001,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={547.5}
+          x={602.5}
           y={10}
         />
         <text
@@ -1017,7 +1017,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={660}
+          x={715}
         >
           Root Node 
           <tspan
@@ -1032,7 +1032,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={660}
+            x={715}
           >
             subtext 
           </tspan>
@@ -1060,7 +1060,7 @@ subText subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={130}
         />
         <text
@@ -1076,7 +1076,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           Child 1 
           <tspan
@@ -1091,7 +1091,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             100% 
           </tspan>
@@ -1119,7 +1119,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={260}
         />
         <text
@@ -1135,7 +1135,7 @@ subText sub Parent info parentId: 1
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           leaf1 
           <tspan
@@ -1150,7 +1150,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             sub 
           </tspan>
@@ -1178,7 +1178,7 @@ subText undefined Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={345.2173913043478}
         />
         <text
@@ -1194,7 +1194,7 @@ subText undefined Parent info parentId: 1
               }
           dy={385.9782608695652}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           leaf2 
         </text>
@@ -1221,7 +1221,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={430.4347826086956}
         />
         <text
@@ -1237,7 +1237,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               }
           dy={463.04347826086956}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           leaf3 
           <tspan
@@ -1252,7 +1252,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             The subtext is as follows: sub 
           </tspan>
@@ -1280,7 +1280,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={515.6521739130435}
         />
         <text
@@ -1296,7 +1296,7 @@ subText sub Parent info parentId: 1
               }
           dy={548.2608695652174}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           leaf4 
           <tspan
@@ -1311,7 +1311,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             sub 
           </tspan>
@@ -1339,7 +1339,7 @@ subText undefined Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={130}
         />
         <text
@@ -1355,7 +1355,7 @@ subText undefined Parent info parentId: 0
               }
           dy={170.76086956521738}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           Child 2 is the child name 
         </text>
@@ -1382,7 +1382,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={260}
         />
         <text
@@ -1398,7 +1398,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           leaf5 
           <tspan
@@ -1413,7 +1413,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={528.75}
+            x={583.75}
           >
             sub 
           </tspan>
@@ -1441,7 +1441,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={345.2173913043478}
         />
         <text
@@ -1457,7 +1457,7 @@ subText sub Parent info parentId: 6
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           leaf6 
           <tspan
@@ -1472,7 +1472,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={528.75}
+            x={583.75}
           >
             sub 
           </tspan>
@@ -1500,7 +1500,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={130}
         />
         <text
@@ -1516,7 +1516,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           Child 3 
           <tspan
@@ -1531,7 +1531,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             The subtext is as follows: subtext 
           </tspan>
@@ -1559,7 +1559,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={260}
         />
         <text
@@ -1575,7 +1575,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           leaf7 
           <tspan
@@ -1590,7 +1590,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             sub 
           </tspan>
@@ -1618,7 +1618,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={345.2173913043478}
         />
         <text
@@ -1634,7 +1634,7 @@ subText sub Parent info parentId: 9
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           leaf8 
           <tspan
@@ -1649,7 +1649,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             sub 
           </tspan>
@@ -1677,7 +1677,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={430.4347826086956}
         />
         <text
@@ -1693,7 +1693,7 @@ subText sub Parent info parentId: 9
               }
           dy={463.04347826086956}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           leaf9 
           <tspan
@@ -1708,7 +1708,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             sub 
           </tspan>
@@ -1736,7 +1736,7 @@ subText subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={130}
         />
         <text
@@ -1752,7 +1752,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           Child 4 
           <tspan
@@ -1767,7 +1767,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             90% 
           </tspan>
@@ -1795,7 +1795,7 @@ subText sub Parent info parentId: 13
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={260}
         />
         <text
@@ -1811,7 +1811,7 @@ subText sub Parent info parentId: 13
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           leaf10 
           <tspan
@@ -1826,7 +1826,7 @@ subText sub Parent info parentId: 13
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             sub 
           </tspan>
@@ -1843,7 +1843,7 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M153.75,110 H1166.25 M660,110
+          d="M208.75,110 H1221.25 M715,110
     V85.21739130434783"
         />
         <path
@@ -1854,8 +1854,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M266.25,205.2173913043478 V230
-    H153.75 H378.75"
+          d="M321.25,205.2173913043478 V230
+    H208.75 H433.75"
         />
         <path
           className=
@@ -1865,8 +1865,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M528.75,205.2173913043478 V230
-    H416.25 H641.25"
+          d="M583.75,205.2173913043478 V230
+    H471.25 H696.25"
         />
         <path
           className=
@@ -1876,8 +1876,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M791.25,205.2173913043478 V230
-    H678.75 H903.75"
+          d="M846.25,205.2173913043478 V230
+    H733.75 H958.75"
         />
         <path
           className=
@@ -1887,8 +1887,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M1053.75,205.2173913043478 V230
-    H941.25 H1166.25"
+          d="M1108.75,205.2173913043478 V230
+    H996.25 H1221.25"
         />
       </g>
     </svg>
@@ -1923,7 +1923,7 @@ exports[`TreeChart snapshot testing renders treechart three layer without compos
     <svg
       className="svgTree"
       height={640}
-      width={1320}
+      width={1430}
     >
       <g
         className="svgNode"
@@ -1949,7 +1949,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={547.5}
+          x={602.5}
           y={10}
         />
         <text
@@ -1965,7 +1965,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={660}
+          x={715}
         >
           Root Node 
           <tspan
@@ -1980,7 +1980,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={660}
+            x={715}
           >
             subtext 
           </tspan>
@@ -2008,7 +2008,7 @@ subText subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={130}
         />
         <text
@@ -2024,7 +2024,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           Child 1 
           <tspan
@@ -2039,7 +2039,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             100% 
           </tspan>
@@ -2067,7 +2067,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={153.75}
+          x={208.75}
           y={260}
         />
         <text
@@ -2083,7 +2083,7 @@ subText sub Parent info parentId: 1
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={205}
+          x={260}
         >
           leaf1 
           <tspan
@@ -2098,7 +2098,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={205}
+            x={260}
           >
             sub 
           </tspan>
@@ -2126,7 +2126,7 @@ subText undefined Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={276.25}
+          x={331.25}
           y={260}
         />
         <text
@@ -2142,7 +2142,7 @@ subText undefined Parent info parentId: 1
               }
           dy={300.7608695652174}
           textAnchor="middle"
-          x={327.5}
+          x={382.5}
         >
           leaf2 
         </text>
@@ -2169,7 +2169,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={153.75}
+          x={208.75}
           y={345.2173913043478}
         />
         <text
@@ -2185,7 +2185,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={205}
+          x={260}
         >
           leaf3 
           <tspan
@@ -2200,7 +2200,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={205}
+            x={260}
           >
             The subtext is as follows: sub 
           </tspan>
@@ -2228,7 +2228,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={276.25}
+          x={331.25}
           y={345.2173913043478}
         />
         <text
@@ -2244,7 +2244,7 @@ subText sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={327.5}
+          x={382.5}
         >
           leaf4 
           <tspan
@@ -2259,7 +2259,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={327.5}
+            x={382.5}
           >
             sub 
           </tspan>
@@ -2287,7 +2287,7 @@ subText undefined Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={130}
         />
         <text
@@ -2303,7 +2303,7 @@ subText undefined Parent info parentId: 0
               }
           dy={170.76086956521738}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           Child 2 is the child name 
         </text>
@@ -2330,7 +2330,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={260}
         />
         <text
@@ -2346,7 +2346,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           leaf5 
           <tspan
@@ -2361,7 +2361,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={528.75}
+            x={583.75}
           >
             sub 
           </tspan>
@@ -2389,7 +2389,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={345.2173913043478}
         />
         <text
@@ -2405,7 +2405,7 @@ subText sub Parent info parentId: 6
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           leaf6 
           <tspan
@@ -2420,7 +2420,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={528.75}
+            x={583.75}
           >
             sub 
           </tspan>
@@ -2448,7 +2448,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={130}
         />
         <text
@@ -2464,7 +2464,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           Child 3 
           <tspan
@@ -2479,7 +2479,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             The subtext is as follows: subtext 
           </tspan>
@@ -2507,7 +2507,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={678.75}
+          x={733.75}
           y={260}
         />
         <text
@@ -2523,7 +2523,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={730}
+          x={785}
         >
           leaf7 
           <tspan
@@ -2538,7 +2538,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={730}
+            x={785}
           >
             sub 
           </tspan>
@@ -2566,7 +2566,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={801.25}
+          x={856.25}
           y={260}
         />
         <text
@@ -2582,7 +2582,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={852.5}
+          x={907.5}
         >
           leaf8 
           <tspan
@@ -2597,7 +2597,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={852.5}
+            x={907.5}
           >
             sub 
           </tspan>
@@ -2625,7 +2625,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={678.75}
+          x={733.75}
           y={345.2173913043478}
         />
         <text
@@ -2641,7 +2641,7 @@ subText sub Parent info parentId: 9
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={730}
+          x={785}
         >
           leaf9 
           <tspan
@@ -2656,7 +2656,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={730}
+            x={785}
           >
             sub 
           </tspan>
@@ -2684,7 +2684,7 @@ subText subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={130}
         />
         <text
@@ -2700,7 +2700,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           Child 4 
           <tspan
@@ -2715,7 +2715,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             90% 
           </tspan>
@@ -2743,7 +2743,7 @@ subText sub Parent info parentId: 13
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={260}
         />
         <text
@@ -2759,7 +2759,7 @@ subText sub Parent info parentId: 13
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           leaf10 
           <tspan
@@ -2774,7 +2774,7 @@ subText sub Parent info parentId: 13
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             sub 
           </tspan>
@@ -2791,7 +2791,7 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M153.75,110 H1166.25 M660,110
+          d="M208.75,110 H1221.25 M715,110
     V85.21739130434783"
         />
         <path
@@ -2802,8 +2802,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M266.25,205.2173913043478 V230
-    H153.75 H378.75"
+          d="M321.25,205.2173913043478 V230
+    H208.75 H433.75"
         />
         <path
           className=
@@ -2813,8 +2813,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M528.75,205.2173913043478 V230
-    H416.25 H641.25"
+          d="M583.75,205.2173913043478 V230
+    H471.25 H696.25"
         />
         <path
           className=
@@ -2824,8 +2824,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M791.25,205.2173913043478 V230
-    H678.75 H903.75"
+          d="M846.25,205.2173913043478 V230
+    H733.75 H958.75"
         />
         <path
           className=
@@ -2835,8 +2835,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M1053.75,205.2173913043478 V230
-    H941.25 H1166.25"
+          d="M1108.75,205.2173913043478 V230
+    H996.25 H1221.25"
         />
       </g>
     </svg>
@@ -2871,7 +2871,7 @@ exports[`TreeChart snapshot testing renders treechart two layer correctly 1`] = 
     <svg
       className="svgTree"
       height={640}
-      width={1320}
+      width={1430}
     >
       <g
         className="svgNode"
@@ -2897,7 +2897,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={547.5}
+          x={602.5}
           y={10}
         />
         <text
@@ -2913,7 +2913,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={660}
+          x={715}
         >
           Root Node 
           <tspan
@@ -2928,7 +2928,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={660}
+            x={715}
           >
             subtext 
           </tspan>
@@ -2956,7 +2956,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={153.75}
+          x={208.75}
           y={130}
         />
         <text
@@ -2972,7 +2972,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={266.25}
+          x={321.25}
         >
           Child 1 
           <tspan
@@ -2987,7 +2987,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={266.25}
+            x={321.25}
           >
             Subtext val is subtext 
           </tspan>
@@ -3015,7 +3015,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={416.25}
+          x={471.25}
           y={130}
         />
         <text
@@ -3031,7 +3031,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={528.75}
+          x={583.75}
         >
           Child 2 
           <tspan
@@ -3046,7 +3046,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={528.75}
+            x={583.75}
           >
             Subtext val is subtext 
           </tspan>
@@ -3074,7 +3074,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={678.75}
+          x={733.75}
           y={130}
         />
         <text
@@ -3090,7 +3090,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={791.25}
+          x={846.25}
         >
           Child 3 
           <tspan
@@ -3105,7 +3105,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={791.25}
+            x={846.25}
           >
             Subtext val is subtext 
           </tspan>
@@ -3133,7 +3133,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={941.25}
+          x={996.25}
           y={130}
         />
         <text
@@ -3149,7 +3149,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={1053.75}
+          x={1108.75}
         >
           Child 4 
           <tspan
@@ -3164,7 +3164,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1053.75}
+            x={1108.75}
           >
             Subtext val is subtext 
           </tspan>
@@ -3181,7 +3181,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M153.75,110 H1166.25 M660,110
+          d="M208.75,110 H1221.25 M715,110
     V85.21739130434783"
         />
       </g>

--- a/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
+++ b/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`TreeChart snapshot testing renders treechart three layer compact compos
     <svg
       className="svgTree"
       height={640}
-      width={1430}
+      width={1320}
     >
       <g
         className="svgNode"
@@ -53,7 +53,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={602.5}
+          x={547.5}
           y={10}
         />
         <text
@@ -69,7 +69,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={715}
+          x={660}
         >
           Root Node 
           <tspan
@@ -84,7 +84,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={715}
+            x={660}
           >
             subtext 
           </tspan>
@@ -112,7 +112,7 @@ subText subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={130}
         />
         <text
@@ -128,7 +128,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           Child 1 
           <tspan
@@ -143,7 +143,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             100% 
           </tspan>
@@ -171,7 +171,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={208.75}
+          x={153.75}
           y={260}
         />
         <text
@@ -187,7 +187,7 @@ subText sub Parent info parentId: 1
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={260}
+          x={205}
         >
           leaf1 
           <tspan
@@ -202,7 +202,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={260}
+            x={205}
           >
             sub 
           </tspan>
@@ -230,7 +230,7 @@ subText undefined Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={331.25}
+          x={276.25}
           y={260}
         />
         <text
@@ -246,7 +246,7 @@ subText undefined Parent info parentId: 1
               }
           dy={300.7608695652174}
           textAnchor="middle"
-          x={382.5}
+          x={327.5}
         >
           leaf2 
         </text>
@@ -273,7 +273,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={208.75}
+          x={153.75}
           y={345.2173913043478}
         />
         <text
@@ -289,7 +289,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={260}
+          x={205}
         >
           leaf3 
           <tspan
@@ -304,7 +304,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={260}
+            x={205}
           >
             The subtext is as follows: sub 
           </tspan>
@@ -332,7 +332,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={331.25}
+          x={276.25}
           y={345.2173913043478}
         />
         <text
@@ -348,7 +348,7 @@ subText sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={382.5}
+          x={327.5}
         >
           leaf4 
           <tspan
@@ -363,7 +363,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={382.5}
+            x={327.5}
           >
             sub 
           </tspan>
@@ -391,7 +391,7 @@ subText undefined Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={130}
         />
         <text
@@ -407,7 +407,7 @@ subText undefined Parent info parentId: 0
               }
           dy={170.76086956521738}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           Child 2 is the child name 
         </text>
@@ -434,7 +434,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={102.5}
-          x={471.25}
+          x={416.25}
           y={260}
         />
         <text
@@ -450,7 +450,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={522.5}
+          x={467.5}
         >
           leaf5 
           <tspan
@@ -465,7 +465,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={522.5}
+            x={467.5}
           >
             sub 
           </tspan>
@@ -493,7 +493,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={102.5}
-          x={593.75}
+          x={538.75}
           y={260}
         />
         <text
@@ -509,7 +509,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={645}
+          x={590}
         >
           leaf6 
           <tspan
@@ -524,7 +524,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={645}
+            x={590}
           >
             sub 
           </tspan>
@@ -552,7 +552,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={130}
         />
         <text
@@ -568,7 +568,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           Child 3 
           <tspan
@@ -583,7 +583,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             The subtext is as follows: subtext 
           </tspan>
@@ -611,7 +611,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={733.75}
+          x={678.75}
           y={260}
         />
         <text
@@ -627,7 +627,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={785}
+          x={730}
         >
           leaf7 
           <tspan
@@ -642,7 +642,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={785}
+            x={730}
           >
             sub 
           </tspan>
@@ -670,7 +670,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={856.25}
+          x={801.25}
           y={260}
         />
         <text
@@ -686,7 +686,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={907.5}
+          x={852.5}
         >
           leaf8 
           <tspan
@@ -701,7 +701,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={907.5}
+            x={852.5}
           >
             sub 
           </tspan>
@@ -729,7 +729,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={733.75}
+          x={678.75}
           y={345.2173913043478}
         />
         <text
@@ -745,7 +745,7 @@ subText sub Parent info parentId: 9
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={785}
+          x={730}
         >
           leaf9 
           <tspan
@@ -760,7 +760,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={785}
+            x={730}
           >
             sub 
           </tspan>
@@ -788,7 +788,7 @@ subText subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={130}
         />
         <text
@@ -804,7 +804,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           Child 4 
           <tspan
@@ -819,7 +819,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             90% 
           </tspan>
@@ -847,7 +847,7 @@ subText sub Parent info parentId: 13
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={260}
         />
         <text
@@ -863,7 +863,7 @@ subText sub Parent info parentId: 13
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           leaf10 
           <tspan
@@ -878,7 +878,7 @@ subText sub Parent info parentId: 13
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             sub 
           </tspan>
@@ -895,7 +895,7 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M208.75,110 H1221.25 M715,110
+          d="M153.75,110 H1166.25 M660,110
     V85.21739130434783"
         />
         <path
@@ -906,8 +906,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M321.25,205.2173913043478 V230
-    H208.75 H433.75"
+          d="M266.25,205.2173913043478 V230
+    H153.75 H378.75"
         />
         <path
           className=
@@ -917,8 +917,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M583.75,205.2173913043478 V230
-    H471.25 H696.25"
+          d="M528.75,205.2173913043478 V230
+    H416.25 H641.25"
         />
         <path
           className=
@@ -928,8 +928,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M846.25,205.2173913043478 V230
-    H733.75 H958.75"
+          d="M791.25,205.2173913043478 V230
+    H678.75 H903.75"
         />
         <path
           className=
@@ -939,8 +939,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M1108.75,205.2173913043478 V230
-    H996.25 H1221.25"
+          d="M1053.75,205.2173913043478 V230
+    H941.25 H1166.25"
         />
       </g>
     </svg>
@@ -975,7 +975,7 @@ exports[`TreeChart snapshot testing renders treechart three layer long compositi
     <svg
       className="svgTree"
       height={640}
-      width={1430}
+      width={1320}
     >
       <g
         className="svgNode"
@@ -1001,7 +1001,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={602.5}
+          x={547.5}
           y={10}
         />
         <text
@@ -1017,7 +1017,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={715}
+          x={660}
         >
           Root Node 
           <tspan
@@ -1032,7 +1032,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={715}
+            x={660}
           >
             subtext 
           </tspan>
@@ -1060,7 +1060,7 @@ subText subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={130}
         />
         <text
@@ -1076,7 +1076,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           Child 1 
           <tspan
@@ -1091,7 +1091,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             100% 
           </tspan>
@@ -1119,7 +1119,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={260}
         />
         <text
@@ -1135,7 +1135,7 @@ subText sub Parent info parentId: 1
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           leaf1 
           <tspan
@@ -1150,7 +1150,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             sub 
           </tspan>
@@ -1178,7 +1178,7 @@ subText undefined Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={345.2173913043478}
         />
         <text
@@ -1194,7 +1194,7 @@ subText undefined Parent info parentId: 1
               }
           dy={385.9782608695652}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           leaf2 
         </text>
@@ -1221,7 +1221,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={430.4347826086956}
         />
         <text
@@ -1237,7 +1237,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               }
           dy={463.04347826086956}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           leaf3 
           <tspan
@@ -1252,7 +1252,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             The subtext is as follows: sub 
           </tspan>
@@ -1280,7 +1280,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={515.6521739130435}
         />
         <text
@@ -1296,7 +1296,7 @@ subText sub Parent info parentId: 1
               }
           dy={548.2608695652174}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           leaf4 
           <tspan
@@ -1311,7 +1311,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             sub 
           </tspan>
@@ -1339,7 +1339,7 @@ subText undefined Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={130}
         />
         <text
@@ -1355,7 +1355,7 @@ subText undefined Parent info parentId: 0
               }
           dy={170.76086956521738}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           Child 2 is the child name 
         </text>
@@ -1382,7 +1382,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={260}
         />
         <text
@@ -1398,7 +1398,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           leaf5 
           <tspan
@@ -1413,7 +1413,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={583.75}
+            x={528.75}
           >
             sub 
           </tspan>
@@ -1441,7 +1441,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={345.2173913043478}
         />
         <text
@@ -1457,7 +1457,7 @@ subText sub Parent info parentId: 6
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           leaf6 
           <tspan
@@ -1472,7 +1472,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={583.75}
+            x={528.75}
           >
             sub 
           </tspan>
@@ -1500,7 +1500,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={130}
         />
         <text
@@ -1516,7 +1516,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           Child 3 
           <tspan
@@ -1531,7 +1531,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             The subtext is as follows: subtext 
           </tspan>
@@ -1559,7 +1559,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={260}
         />
         <text
@@ -1575,7 +1575,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           leaf7 
           <tspan
@@ -1590,7 +1590,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             sub 
           </tspan>
@@ -1618,7 +1618,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={345.2173913043478}
         />
         <text
@@ -1634,7 +1634,7 @@ subText sub Parent info parentId: 9
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           leaf8 
           <tspan
@@ -1649,7 +1649,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             sub 
           </tspan>
@@ -1677,7 +1677,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={430.4347826086956}
         />
         <text
@@ -1693,7 +1693,7 @@ subText sub Parent info parentId: 9
               }
           dy={463.04347826086956}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           leaf9 
           <tspan
@@ -1708,7 +1708,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             sub 
           </tspan>
@@ -1736,7 +1736,7 @@ subText subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={130}
         />
         <text
@@ -1752,7 +1752,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           Child 4 
           <tspan
@@ -1767,7 +1767,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             90% 
           </tspan>
@@ -1795,7 +1795,7 @@ subText sub Parent info parentId: 13
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={260}
         />
         <text
@@ -1811,7 +1811,7 @@ subText sub Parent info parentId: 13
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           leaf10 
           <tspan
@@ -1826,7 +1826,7 @@ subText sub Parent info parentId: 13
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             sub 
           </tspan>
@@ -1843,7 +1843,7 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M208.75,110 H1221.25 M715,110
+          d="M153.75,110 H1166.25 M660,110
     V85.21739130434783"
         />
         <path
@@ -1854,8 +1854,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M321.25,205.2173913043478 V230
-    H208.75 H433.75"
+          d="M266.25,205.2173913043478 V230
+    H153.75 H378.75"
         />
         <path
           className=
@@ -1865,8 +1865,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M583.75,205.2173913043478 V230
-    H471.25 H696.25"
+          d="M528.75,205.2173913043478 V230
+    H416.25 H641.25"
         />
         <path
           className=
@@ -1876,8 +1876,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M846.25,205.2173913043478 V230
-    H733.75 H958.75"
+          d="M791.25,205.2173913043478 V230
+    H678.75 H903.75"
         />
         <path
           className=
@@ -1887,8 +1887,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M1108.75,205.2173913043478 V230
-    H996.25 H1221.25"
+          d="M1053.75,205.2173913043478 V230
+    H941.25 H1166.25"
         />
       </g>
     </svg>
@@ -1923,7 +1923,7 @@ exports[`TreeChart snapshot testing renders treechart three layer without compos
     <svg
       className="svgTree"
       height={640}
-      width={1430}
+      width={1320}
     >
       <g
         className="svgNode"
@@ -1949,7 +1949,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={602.5}
+          x={547.5}
           y={10}
         />
         <text
@@ -1965,7 +1965,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={715}
+          x={660}
         >
           Root Node 
           <tspan
@@ -1980,7 +1980,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={715}
+            x={660}
           >
             subtext 
           </tspan>
@@ -2008,7 +2008,7 @@ subText subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={130}
         />
         <text
@@ -2024,7 +2024,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           Child 1 
           <tspan
@@ -2039,7 +2039,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             100% 
           </tspan>
@@ -2067,7 +2067,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={208.75}
+          x={153.75}
           y={260}
         />
         <text
@@ -2083,7 +2083,7 @@ subText sub Parent info parentId: 1
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={260}
+          x={205}
         >
           leaf1 
           <tspan
@@ -2098,7 +2098,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={260}
+            x={205}
           >
             sub 
           </tspan>
@@ -2126,7 +2126,7 @@ subText undefined Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={331.25}
+          x={276.25}
           y={260}
         />
         <text
@@ -2142,7 +2142,7 @@ subText undefined Parent info parentId: 1
               }
           dy={300.7608695652174}
           textAnchor="middle"
-          x={382.5}
+          x={327.5}
         >
           leaf2 
         </text>
@@ -2169,7 +2169,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={208.75}
+          x={153.75}
           y={345.2173913043478}
         />
         <text
@@ -2185,7 +2185,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={260}
+          x={205}
         >
           leaf3 
           <tspan
@@ -2200,7 +2200,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={260}
+            x={205}
           >
             The subtext is as follows: sub 
           </tspan>
@@ -2228,7 +2228,7 @@ subText sub Parent info parentId: 1
           stroke="#4F6BED"
           tabIndex={0}
           width={102.5}
-          x={331.25}
+          x={276.25}
           y={345.2173913043478}
         />
         <text
@@ -2244,7 +2244,7 @@ subText sub Parent info parentId: 1
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={382.5}
+          x={327.5}
         >
           leaf4 
           <tspan
@@ -2259,7 +2259,7 @@ subText sub Parent info parentId: 1
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={382.5}
+            x={327.5}
           >
             sub 
           </tspan>
@@ -2287,7 +2287,7 @@ subText undefined Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={130}
         />
         <text
@@ -2303,7 +2303,7 @@ subText undefined Parent info parentId: 0
               }
           dy={170.76086956521738}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           Child 2 is the child name 
         </text>
@@ -2330,7 +2330,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={260}
         />
         <text
@@ -2346,7 +2346,7 @@ subText sub Parent info parentId: 6
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           leaf5 
           <tspan
@@ -2361,7 +2361,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={583.75}
+            x={528.75}
           >
             sub 
           </tspan>
@@ -2389,7 +2389,7 @@ subText sub Parent info parentId: 6
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={345.2173913043478}
         />
         <text
@@ -2405,7 +2405,7 @@ subText sub Parent info parentId: 6
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           leaf6 
           <tspan
@@ -2420,7 +2420,7 @@ subText sub Parent info parentId: 6
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={583.75}
+            x={528.75}
           >
             sub 
           </tspan>
@@ -2448,7 +2448,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={130}
         />
         <text
@@ -2464,7 +2464,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           Child 3 
           <tspan
@@ -2479,7 +2479,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             The subtext is as follows: subtext 
           </tspan>
@@ -2507,7 +2507,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={733.75}
+          x={678.75}
           y={260}
         />
         <text
@@ -2523,7 +2523,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={785}
+          x={730}
         >
           leaf7 
           <tspan
@@ -2538,7 +2538,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={785}
+            x={730}
           >
             sub 
           </tspan>
@@ -2566,7 +2566,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={856.25}
+          x={801.25}
           y={260}
         />
         <text
@@ -2582,7 +2582,7 @@ subText sub Parent info parentId: 9
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={907.5}
+          x={852.5}
         >
           leaf8 
           <tspan
@@ -2597,7 +2597,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={907.5}
+            x={852.5}
           >
             sub 
           </tspan>
@@ -2625,7 +2625,7 @@ subText sub Parent info parentId: 9
           stroke="#AE8C00"
           tabIndex={0}
           width={102.5}
-          x={733.75}
+          x={678.75}
           y={345.2173913043478}
         />
         <text
@@ -2641,7 +2641,7 @@ subText sub Parent info parentId: 9
               }
           dy={377.82608695652175}
           textAnchor="middle"
-          x={785}
+          x={730}
         >
           leaf9 
           <tspan
@@ -2656,7 +2656,7 @@ subText sub Parent info parentId: 9
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={785}
+            x={730}
           >
             sub 
           </tspan>
@@ -2684,7 +2684,7 @@ subText subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={130}
         />
         <text
@@ -2700,7 +2700,7 @@ subText subtext Parent info parentId: 0
               }
           dy={156.08695652173913}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           Child 4 
           <tspan
@@ -2715,7 +2715,7 @@ subText subtext Parent info parentId: 0
                   font-weight: 600;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             90% 
           </tspan>
@@ -2743,7 +2743,7 @@ subText sub Parent info parentId: 13
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={260}
         />
         <text
@@ -2759,7 +2759,7 @@ subText sub Parent info parentId: 13
               }
           dy={292.60869565217394}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           leaf10 
           <tspan
@@ -2774,7 +2774,7 @@ subText sub Parent info parentId: 13
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             sub 
           </tspan>
@@ -2791,7 +2791,7 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M208.75,110 H1221.25 M715,110
+          d="M153.75,110 H1166.25 M660,110
     V85.21739130434783"
         />
         <path
@@ -2802,8 +2802,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M321.25,205.2173913043478 V230
-    H208.75 H433.75"
+          d="M266.25,205.2173913043478 V230
+    H153.75 H378.75"
         />
         <path
           className=
@@ -2813,8 +2813,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M583.75,205.2173913043478 V230
-    H471.25 H696.25"
+          d="M528.75,205.2173913043478 V230
+    H416.25 H641.25"
         />
         <path
           className=
@@ -2824,8 +2824,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M846.25,205.2173913043478 V230
-    H733.75 H958.75"
+          d="M791.25,205.2173913043478 V230
+    H678.75 H903.75"
         />
         <path
           className=
@@ -2835,8 +2835,8 @@ subText sub Parent info parentId: 13
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M1108.75,205.2173913043478 V230
-    H996.25 H1221.25"
+          d="M1053.75,205.2173913043478 V230
+    H941.25 H1166.25"
         />
       </g>
     </svg>
@@ -2871,7 +2871,7 @@ exports[`TreeChart snapshot testing renders treechart two layer correctly 1`] = 
     <svg
       className="svgTree"
       height={640}
-      width={1430}
+      width={1320}
     >
       <g
         className="svgNode"
@@ -2897,7 +2897,7 @@ subText subtext Root Node"
           stroke="#0099BC"
           tabIndex={0}
           width={225}
-          x={602.5}
+          x={547.5}
           y={10}
         />
         <text
@@ -2913,7 +2913,7 @@ subText subtext Root Node"
               }
           dy={42.608695652173914}
           textAnchor="middle"
-          x={715}
+          x={660}
         >
           Root Node 
           <tspan
@@ -2928,7 +2928,7 @@ subText subtext Root Node"
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={715}
+            x={660}
           >
             subtext 
           </tspan>
@@ -2956,7 +2956,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#4F6BED"
           tabIndex={0}
           width={225}
-          x={208.75}
+          x={153.75}
           y={130}
         />
         <text
@@ -2972,7 +2972,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={321.25}
+          x={266.25}
         >
           Child 1 
           <tspan
@@ -2987,7 +2987,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={321.25}
+            x={266.25}
           >
             Subtext val is subtext 
           </tspan>
@@ -3015,7 +3015,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#881798"
           tabIndex={0}
           width={225}
-          x={471.25}
+          x={416.25}
           y={130}
         />
         <text
@@ -3031,7 +3031,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={583.75}
+          x={528.75}
         >
           Child 2 
           <tspan
@@ -3046,7 +3046,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={583.75}
+            x={528.75}
           >
             Subtext val is subtext 
           </tspan>
@@ -3074,7 +3074,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#AE8C00"
           tabIndex={0}
           width={225}
-          x={733.75}
+          x={678.75}
           y={130}
         />
         <text
@@ -3090,7 +3090,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={846.25}
+          x={791.25}
         >
           Child 3 
           <tspan
@@ -3105,7 +3105,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={846.25}
+            x={791.25}
           >
             Subtext val is subtext 
           </tspan>
@@ -3133,7 +3133,7 @@ subText Subtext val is subtext Parent info parentId: 0
           stroke="#FF00FF"
           tabIndex={0}
           width={225}
-          x={996.25}
+          x={941.25}
           y={130}
         />
         <text
@@ -3149,7 +3149,7 @@ subText Subtext val is subtext Parent info parentId: 0
               }
           dy={162.6086956521739}
           textAnchor="middle"
-          x={1108.75}
+          x={1053.75}
         >
           Child 4 
           <tspan
@@ -3164,7 +3164,7 @@ subText Subtext val is subtext Parent info parentId: 0
                   font-weight: 400;
                 }
             dy="1.4em"
-            x={1108.75}
+            x={1053.75}
           >
             Subtext val is subtext 
           </tspan>
@@ -3181,7 +3181,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 stroke-width: 2px;
                 stroke: #A1A1A1;
               }
-          d="M208.75,110 H1221.25 M715,110
+          d="M153.75,110 H1166.25 M660,110
     V85.21739130434783"
         />
       </g>

--- a/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerCompactDocSite.Example.tsx
+++ b/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerCompactDocSite.Example.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { TreeChart, ITreeProps, TreeTraverse, NodesComposition, ITreeState } from '@fluentui/react-charting';
+const threeLayerChart = {
+  name: 'Root Node',
+  subname: 'subtext',
+  fill: '#0099BC',
+  children: [
+    {
+      name: 'Child 1',
+      subname: 'subtext',
+      metric: '100%',
+      fill: '#4F6BED',
+      children: [
+        {
+          name: 'leaf1',
+          subname: 'sub',
+          fill: '#4F6BED',
+        },
+        {
+          name: 'leaf2',
+          fill: '#4F6BED',
+        },
+        {
+          name: 'leaf3',
+          subname: 'The subtext is as follows: sub',
+          fill: '#FF00FF',
+        },
+        {
+          name: 'leaf4',
+          subname: 'sub',
+          fill: '#FF00FF',
+        },
+      ],
+    },
+    {
+      name: 'Child 2 is the child name',
+      fill: '#881798',
+      children: [
+        {
+          name: 'leaf5',
+          subname: 'sub',
+          fill: '#AE8C00',
+        },
+        {
+          name: 'leaf6',
+          subname: 'sub',
+          fill: '#AE8C00',
+        },
+      ],
+    },
+  ],
+};
+
+export class TreeChartThreeLayerCompactDocSiteExample extends React.Component<{}, ITreeState> {
+  constructor(props: ITreeProps) {
+    super(props);
+    this.state = {
+      _height: 460,
+      _width: 800,
+      _layoutWidth: 65,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._createTreeChart()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ _layoutWidth: parseInt(e.target.value, 10) });
+  };
+
+  private _createTreeChart(): JSX.Element {
+    return (
+      <>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
+        <input
+          type="range"
+          value={this.state?._layoutWidth}
+          min={65}
+          max={90}
+          id="changeWidth_Basic"
+          onChange={this._onWidthChange}
+          aria-valuetext={`ChangeWidthSlider${this.state?._layoutWidth}`}
+        />
+        <TreeChart
+          treeData={threeLayerChart}
+          composition={NodesComposition.compact}
+          treeTraversal={TreeTraverse.levelOrder}
+          layoutWidth={this.state?._layoutWidth}
+          width={this.state._width}
+          height={this.state._height}
+        />
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerCompactDocSite.Example.tsx
+++ b/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerCompactDocSite.Example.tsx
@@ -89,6 +89,7 @@ export class TreeChartThreeLayerCompactDocSiteExample extends React.Component<{}
           layoutWidth={this.state?._layoutWidth}
           width={this.state._width}
           height={this.state._height}
+          margins={{ top: 30, right: 130, bottom: 30, left: 50 }}
         />
       </>
     );

--- a/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerDocSite.Example.tsx
+++ b/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerDocSite.Example.tsx
@@ -88,6 +88,7 @@ export class TreeChartThreeLayerDocSiteExample extends React.Component<{}, ITree
           layoutWidth={this.state?._layoutWidth}
           width={this.state._width}
           height={this.state._height}
+          margins={{ top: 30, right: 130, bottom: 30, left: 50 }}
         />
       </>
     );

--- a/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerDocSite.Example.tsx
+++ b/packages/react-examples/src/react-charting/TreeChart/TreeChart.ThreeLayerDocSite.Example.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { TreeChart, ITreeProps, ITreeState } from '@fluentui/react-charting';
+
+const threeLayerChart = {
+  name: 'Root Node',
+  subname: 'subtext',
+  bodytext: 'bodytext',
+  fill: '#0099BC',
+  children: [
+    {
+      name: 'Child 1',
+      subname: 'subtext',
+      metric: '100%',
+      fill: '#4F6BED',
+      children: [
+        {
+          name: 'leaf1',
+          subname: 'sub',
+          fill: '#4F6BED',
+        },
+        {
+          name: 'leaf2',
+          fill: '#4F6BED',
+        },
+        {
+          name: 'leaf3',
+          subname: 'The subtext is as follows: sub',
+          fill: '#4F6BED',
+        },
+        {
+          name: 'leaf4',
+          subname: 'sub',
+          fill: '#4F6BED',
+        },
+      ],
+    },
+    {
+      name: 'Child 2 is the child name',
+      fill: '#881798',
+      children: [
+        {
+          name: 'leaf5',
+          subname: 'sub',
+          fill: '#881798',
+        },
+        {
+          name: 'leaf6',
+          subname: 'sub',
+          fill: '#881798',
+        },
+      ],
+    },
+  ],
+};
+
+export class TreeChartThreeLayerDocSiteExample extends React.Component<{}, ITreeState> {
+  constructor(props: ITreeProps) {
+    super(props);
+    this.state = {
+      _height: 460,
+      _width: 800,
+      _layoutWidth: 65,
+    };
+  }
+  public render(): JSX.Element {
+    return <div>{this._createTreeChart()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ _layoutWidth: parseInt(e.target.value, 10) });
+  };
+
+  private _createTreeChart(): JSX.Element {
+    return (
+      <>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
+        <input
+          type="range"
+          value={this.state?._layoutWidth}
+          min={65}
+          max={90}
+          id="changeWidth_Basic"
+          onChange={this._onWidthChange}
+          aria-valuetext={`ChangeWidthSlider${this.state?._layoutWidth}`}
+        />
+        <TreeChart
+          treeData={threeLayerChart}
+          layoutWidth={this.state?._layoutWidth}
+          width={this.state._width}
+          height={this.state._height}
+        />
+      </>
+    );
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
 Tree chart not fitting in doc site
<!-- This is the behavior we have today -->

## New Behavior
 Adding new examples for Tree chart to be added in doc site.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
