### PR TITLE
chore: move tag stories under components

### DIFF
--- a/packages/react-components/react-tags/stories/InteractionTag/index.stories.tsx
+++ b/packages/react-components/react-tags/stories/InteractionTag/index.stories.tsx
@@ -15,7 +15,7 @@ export { Disabled } from './InteractionTagDisabled.stories';
 export { HasPrimaryAction } from './InteractionTagHasPrimaryAction.stories';
 
 export default {
-  title: 'Tag/InteractionTag',
+  title: 'Components/Tag/InteractionTag',
   component: InteractionTag,
   subcomponents: {
     InteractionTagPrimary,

--- a/packages/react-components/react-tags/stories/Tag/index.stories.tsx
+++ b/packages/react-components/react-tags/stories/Tag/index.stories.tsx
@@ -14,7 +14,7 @@ export { Appearance } from './TagAppearance.stories';
 export { Disabled } from './TagDisabled.stories';
 
 export default {
-  title: 'Tag/Tag',
+  title: 'Components/Tag/Tag',
   component: Tag,
   parameters: {
     docs: {

--- a/packages/react-components/react-tags/stories/TagGroup/index.stories.tsx
+++ b/packages/react-components/react-tags/stories/TagGroup/index.stories.tsx
@@ -9,7 +9,7 @@ export { Sizes } from './TagGroupSizes.stories';
 export { WithOverflow } from './TagGroupOverflow.stories';
 
 export default {
-  title: 'Tag/TagGroup',
+  title: 'Components/Tag/TagGroup',
   component: TagGroup,
   parameters: {
     docs: {


### PR DESCRIPTION
see title.

After fix:
<img width="215" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/bcc7d867-a951-4544-ac3d-ce5afb3e95df">
