### PR TITLE
Remove a11y test ux from v9 Theme Designer

### DIFF
--- a/packages/react-components/theme-designer/src/components/Sidebar/Form.tsx
+++ b/packages/react-components/theme-designer/src/components/Sidebar/Form.tsx
@@ -10,14 +10,13 @@ import {
   Button,
   Input,
   Slider,
-  Switch,
   tokens,
   useId,
   Caption1Stronger,
   Field,
 } from '@fluentui/react-components';
 import { defaultThemePlaceholderName } from '../../Context/ThemeDesignerContext';
-import { AccessibilityPanel } from './AccessibilityPanel';
+// import { AccessibilityPanel } from './AccessibilityPanel';
 import { useDebounce } from '../../utils/useDebounce';
 
 const useStyles = makeStyles({
@@ -89,13 +88,15 @@ export const Form: React.FC = () => {
 
   const {
     dispatch,
-    state: { isDark, themeName, darkThemeOverrides, lightThemeOverrides, brand, keyColorHex },
+    state: { themeName, keyColorHex },
+    // - unused values from a11y panel.
+    // isDark, darkThemeOverrides, lightThemeOverrides, brand,
   } = useThemeDesigner();
   const themeNameInputId = useId('themeNameInputId');
 
-  const handleIsDarkChange = () => {
-    dispatch({ type: 'isDark', payload: !isDark });
-  };
+  // const handleIsDarkChange = () => {
+  //   dispatch({ type: 'isDark', payload: !isDark });
+  // };
 
   const [keyColor, setKeyColor] = React.useState<string>(keyColorHex);
   const [hueTorsion, setHueTorsion] = React.useState<number>(0);
@@ -221,6 +222,9 @@ export const Form: React.FC = () => {
             </div>
           </AccordionPanel>
         </AccordionItem>
+        {/*
+        The accessibility check is not adequate for the theme designer.
+        Removing it for now because we don't want people proceeding with a false sense of security.
         <AccordionItem value="2">
           <AccordionHeader>
             <Caption1Stronger>Step 2 - Accessibility checks</Caption1Stronger>
@@ -233,10 +237,10 @@ export const Form: React.FC = () => {
               lightThemeOverrides={lightThemeOverrides}
             />
           </AccordionPanel>
-        </AccordionItem>
-        <AccordionItem value="3">
+        </AccordionItem> */}
+        <AccordionItem value="2">
           <AccordionHeader>
-            <Caption1Stronger>Step 3 - Export</Caption1Stronger>
+            <Caption1Stronger>Step 2 - Export</Caption1Stronger>
           </AccordionHeader>
           <AccordionPanel className={styles.accordionContainer}>
             <div className={styles.labelName}>


### PR DESCRIPTION
The current theme designer only performs a single contrast ratio test which is not adequate testing, and should not be represented as such.

This PR removes the a11y test UX until a solid plan can be established and implemented with regards to tokens, tooling and accessibility.

Before:
![image](https://github.com/microsoft/fluentui/assets/17346018/b53a6f55-1b80-49fd-b1d8-11ccf9f73ef9)

After:
![image](https://github.com/microsoft/fluentui/assets/17346018/7c3a34b9-0b52-4f2d-9845-768451659680)
