### PR TITLE
docs(react-infobutton): Update Field example to show how to fix the issue where the surface is rendered behind input

### DIFF
--- a/packages/react-components/react-infobutton/stories/InfoLabel/InfoLabelInField.stories.tsx
+++ b/packages/react-components/react-infobutton/stories/InfoLabel/InfoLabelInField.stories.tsx
@@ -1,21 +1,33 @@
 import * as React from 'react';
 
-import { Field, Input, LabelProps } from '@fluentui/react-components';
+import { Field, Input, LabelProps, makeStyles } from '@fluentui/react-components';
 import { InfoLabel } from '@fluentui/react-components/unstable';
 
-export const InField = () => (
-  <Field
-    label={{
-      children: (_: unknown, props: LabelProps) => (
-        <InfoLabel {...props} info="Example info">
-          Field with info label
-        </InfoLabel>
-      ),
-    }}
-  >
-    <Input />
-  </Field>
-);
+const useStyles = makeStyles({
+  infoLabelSurface: {
+    // Since we render the Popover inline and Input uses position: relative, we need to set a zIndex. If we don't,
+    // the Popover surface will render behind the input. See #27891 for more details.
+    zIndex: 1,
+  },
+});
+
+export const InField = () => {
+  const styles = useStyles();
+
+  return (
+    <Field
+      label={{
+        children: (_: unknown, props: LabelProps) => (
+          <InfoLabel {...props} info={{ children: 'Example info', className: styles.infoLabelSurface }}>
+            Field with info label
+          </InfoLabel>
+        ),
+      }}
+    >
+      <Input />
+    </Field>
+  );
+};
 
 InField.storyName = 'In a Field';
 InField.parameters = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

##  Changes

Added guidance on how to fix issue where input is rendered on top of the PopoverSurface.

|before|after|
|---|---|
|![image](https://github.com/microsoft/fluentui/assets/5953191/31fea2a8-5199-407c-9335-91ac7c6e03c3)|![image](https://github.com/microsoft/fluentui/assets/5953191/db86b558-cfd4-4b44-b1d5-d93d96464bdd)|

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27891
