### PR TITLE
chore: add warning text to v8 ContextualMenu example

### DIFF
--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
@@ -89,7 +89,7 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
       <p>
         <Text>
           Warning: adding an input to a menu is not technically allowed, and will trigger errors in Accessibility
-          Insights and axe-core. Accessibility issues in practice are minimal, however.
+          Insights and axe-core. However, real world accessibility issues are minimal and not blocking.
         </Text>
       </p>
       <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />

--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from '@fluentui/react/lib/Button';
 import { ISearchBoxStyles, SearchBox } from '@fluentui/react/lib/SearchBox';
+import { Text } from '@fluentui/react/lib/Text';
 import { Icon } from '@fluentui/react/lib/Icon';
 import { IContextualMenuListProps, IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
 import { IRenderFunction } from '@fluentui/react/lib/Utilities';
@@ -83,7 +84,17 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
     [items, renderMenuList, onDismiss],
   );
 
-  return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;
+  return (
+    <>
+      <p>
+        <Text>
+          Warning: adding an input to a menu is not technically allowed, and will trigger errors in Accessibility
+          Insights and axe-core. Accessibility issues in practice are minimal, however.
+        </Text>
+      </p>
+      <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />
+    </>
+  );
 };
 
 const filteredItemsStyle: React.CSSProperties = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

We have a ContextualMenu example showing how to customize it to add a text input before the menu items. Technically this is not an allowed parent/child role structure, though it more or less works in practice.

## New Behavior

We still have that example, but now with warning text about the error.

- Fixes #29127
