### PR TITLE
fix: DetailsList columns render correctly when the list is wider than viewport

### DIFF
--- a/change/@fluentui-react-1fc9fcd1-41d9-4c48-8e8a-4595d6d282f5.json
+++ b/change/@fluentui-react-1fc9fcd1-41d9-4c48-8e8a-4595d6d282f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DetailsList columns render correctly when the list is wider than the viewport",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -123,7 +123,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
           draggable={isDraggable}
           style={{
             width:
-              column.calculatedWidth! +
+              (column.calculatedWidth || 0) +
               cellStyleProps.cellLeftPadding +
               cellStyleProps.cellRightPadding +
               (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0),

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -1301,7 +1301,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       const newColumn: IColumn = { ...column, ...this._columnOverrides[column.key] };
 
       // Delay computation until viewport width is available.
-      if (!skipViewportMeasures && newColumn.flexGrow && remainingWidth <= 0) {
+      if (!skipViewportMeasures && newColumn.flexGrow && remainingWidth <= 0 && viewportWidth === 0) {
         return newColumn;
       }
 


### PR DESCRIPTION
## Previous Behavior

When `DetailsList` is set to `fixedColumn` layout mode and columns have `flexGrow: 1` and the initial render of the `DetailsList` is wider than the viewport (i.e., browser window) column widths are never calculated. This results in a `NaN` being computed downstream, corrupting column measurements.

### Repro:

1. Load this Codepen: https://codepen.io/seanms/pen/MWZzbLJ
2. Resize the width of the browser window such that the list is wider than the viewport (using DevTools responsive mode is a good way to do this)
3. Refresh the page so the initial render will be at this size

#### Before screenshot
<img width="450" alt="mis-aligned columns" src="https://github.com/microsoft/fluentui/assets/93940821/de28709a-8914-4b33-8a47-78d08cb05d9c">

#### Error screenshot

<img width="656" alt="console error showing NaN" src="https://github.com/microsoft/fluentui/assets/93940821/530b8d15-3ba4-4e77-a01e-7434091c04e5">

## New Behavior

`DetailsList` computes column widths in the above scenario.

#### After screenshot
<img width="428" alt="correctly aligned columns" src="https://github.com/microsoft/fluentui/assets/93940821/f47e1970-ad66-44c6-9cb0-d01747a2cf9e">

[Example with the fix applied](https://codesandbox.io/s/fluentui-react-8-starter-forked-nygq4r?file=/src/index.tsx&resolutionWidth=380&resolutionHeight=675).
