### PR TITLE
fix(react-infobutton): Use caption 1 when size is small or medium

### DIFF
--- a/change/@fluentui-react-infobutton-b36ec3f1-5811-4e2b-ac9e-306c17c23e2e.json
+++ b/change/@fluentui-react-infobutton-b36ec3f1-5811-4e2b-ac9e-306c17c23e2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Use caption 1 when size is small or medium.",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infobutton/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -110,7 +110,7 @@ export const useInfoButtonStyles_unstable = (state: InfoButtonState): InfoButton
 
   state.info.className = mergeClasses(
     infoButtonClassNames.info,
-    size === 'large' && popoverSurfaceStyles.large,
+    size === 'large' ? popoverSurfaceStyles.large : popoverSurfaceStyles.smallMedium,
     state.info.className,
   );
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The figma calls for the popover to use a font style `Caption 1` when size is small or medium, but the style is not used.

|small|medium|
|---|---|
|![image](https://github.com/microsoft/fluentui/assets/5953191/99a8e02e-21b0-48d5-9bcd-1cef4144395b)|![image](https://github.com/microsoft/fluentui/assets/5953191/640623be-5960-44dd-b739-f4b310f4d59a)|

## New Behavior

|small|medium|
|---|---|
|![image](https://github.com/microsoft/fluentui/assets/5953191/e09b5295-308a-4faa-bc2f-a1f0f7284e27)|![image](https://github.com/microsoft/fluentui/assets/5953191/a6683fa1-93a3-46b5-915f-254ed1789bc4)|

The `Caption 1` style is now applied to the small and medium sizes.


