### PR TITLE
chore(react-jsx-runtime): add warning for resolution problems

### DIFF
--- a/change/@fluentui-react-jsx-runtime-5a65abfa-83a9-4296-a8b9-2ace31e4e547.json
+++ b/change/@fluentui-react-jsx-runtime-5a65abfa-83a9-4296-a8b9-2ace31e4e547.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add warning for resolution problems",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-jsx-runtime/.swcrc
+++ b/packages/react-components/react-jsx-runtime/.swcrc
@@ -10,6 +10,9 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "experimental": {
+      "plugins": [["swc-plugin-de-indent-template-literal", {}]]
+    },
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@fluentui/react-utilities": "^9.15.0",
+    "react-is": "^17.0.2",
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {

--- a/packages/react-components/react-jsx-runtime/src/jsx/createJSX.ts
+++ b/packages/react-components/react-jsx-runtime/src/jsx/createJSX.ts
@@ -2,16 +2,16 @@ import { isSlot } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { createCompatSlotComponent } from '../utils/createCompatSlotComponent';
 import { JSXRuntime, JSXSlotRuntime } from '../utils/types';
+import { warnIfElementTypeIsInvalid } from '../utils/warnIfElementTypeIsInvalid';
 
-export const createJSX =
-  (runtime: JSXRuntime, slotRuntime: JSXSlotRuntime) =>
-  <Props extends {}>(
+export function createJSX(runtime: JSXRuntime, slotRuntime: JSXSlotRuntime) {
+  return function jsx<Props extends {}>(
     type: React.ElementType<Props>,
     overrideProps: Props | null,
     key?: React.Key,
     source?: unknown,
     self?: unknown,
-  ): React.ReactElement<Props> => {
+  ): React.ReactElement<Props> {
     // TODO:
     // this is for backwards compatibility with getSlotsNext
     // it should be removed once getSlotsNext is obsolete
@@ -21,5 +21,7 @@ export const createJSX =
     if (isSlot<Props>(type)) {
       return slotRuntime(type, overrideProps, key, source, self);
     }
+    warnIfElementTypeIsInvalid(type);
     return runtime(type, overrideProps, key, source, self);
   };
+}

--- a/packages/react-components/react-jsx-runtime/src/utils/warnIfElementTypeIsInvalid.ts
+++ b/packages/react-components/react-jsx-runtime/src/utils/warnIfElementTypeIsInvalid.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { isValidElementType } from 'react-is';
+
+export function warnIfElementTypeIsInvalid(type: React.ElementType) {
+  if (typeof type === 'object' && !isValidElementType(type) && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.error(/** #__DE-INDENT__ */ `
+        @fluentui/react-jsx-runtime:
+        Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: ${type}.
+
+        If this happened in a slot of Fluent UI component, you might be facing package resolution issues.
+        Please make sure you don't have multiple versions of "@fluentui/react-utilities" installed in your dependencies or sub-dependencies.
+        You can check this by searching up for matching entries in a lockfile produced by your package manager (yarn.lock, pnpm-lock.yaml or package-lock.json).
+      `);
+  }
+}


### PR DESCRIPTION
## Previous Behavior

Some clients are facing some issues, where multiple versions of `@fluentui/react-utilities` are installled in their dependencies and that may cause `isSlot` to errounesouly return `false` in situations it should return `true` due to the fact Symbols are unique and having different instancies of `react-utilities` running means having multiple Symbols, which means `isSlot` may fail to determine if a certain object is a slot or not.

## New Behavior

1. Adds warning in development environment to explain the user what the problem is.
2. Adds `swc-plugin-de-indent-template-literal` plugin to `.swcrc`

