### PR TITLE
Fix V9 Button focus inset box shadow for FireFox scaling

### DIFF
--- a/change/@fluentui-react-button-09a0ee22-f58e-4010-b397-57c82a77209e.json
+++ b/change/@fluentui-react-button-09a0ee22-f58e-4010-b397-57c82a77209e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: Buttons internal focus border was not consistent on firefox",
+  "packageName": "@fluentui/react-button",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -18,6 +18,9 @@ const buttonSpacingMedium = '5px';
 const buttonSpacingLarge = '8px';
 const buttonSpacingLargeWithIcon = '7px';
 
+// Firefox has a box shadow offset at some zoom levels, this will ensure the boxShadow is always uniform
+const boxShadowStrokeWidthThinMoz = `calc(${tokens.strokeWidthThin} + 0.5px)`;
+
 const useRootBaseClassName = makeResetStyles({
   alignItems: 'center',
   boxSizing: 'border-box',
@@ -104,6 +107,17 @@ const useRootBaseClassName = makeResetStyles({
     `,
     zIndex: 1,
   }),
+  // Firefox box shadow w/ stroke balanced
+  '@supports (-moz-appearance:button)': {
+    ...createCustomFocusIndicatorStyle({
+      borderColor: tokens.colorStrokeFocus2,
+      borderRadius: tokens.borderRadiusMedium,
+      borderWidth: '1px',
+      outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
+      boxShadow: `inset 0px 0px 0px  ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2}`,
+      zIndex: 1,
+    }),
+  },
 });
 
 const useIconBaseClassName = makeResetStyles({

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -472,14 +472,26 @@ const useRootFocusStyles = makeStyles({
   }),
 
   // Primary styles
-  primary: createCustomFocusIndicatorStyle({
-    ...shorthands.borderColor(tokens.colorStrokeFocus2),
-    boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThin} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
-    ':hover': {
-      boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThin} ${tokens.colorStrokeFocus2} inset`,
+  primary: {
+    ...createCustomFocusIndicatorStyle({
       ...shorthands.borderColor(tokens.colorStrokeFocus2),
+      boxShadow: `${tokens.shadow2}, 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
+      ':hover': {
+        boxShadow: `${tokens.shadow2}, 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2} inset`,
+        ...shorthands.borderColor(tokens.colorStrokeFocus2),
+      },
+    }),
+    '@supports (-moz-appearance:none)': {
+      ...createCustomFocusIndicatorStyle({
+        ...shorthands.borderColor(tokens.colorStrokeFocus2),
+        boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
+        ':hover': {
+          boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2} inset`,
+          ...shorthands.borderColor(tokens.colorStrokeFocus2),
+        },
+      }),
     },
-  }),
+  },
 
   // Size variations
   small: createCustomFocusIndicatorStyle({

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -22,7 +22,7 @@ const buttonSpacingLargeWithIcon = '7px';
  * this will ensure the boxShadow is always uniform
  * without affecting other browser platforms
  */
-const boxShadowStrokeWidthThinMoz = `calc(${tokens.strokeWidthThin} + 0.25px)`;
+const boxShadowStrokeWidthThin = `calc(${tokens.strokeWidthThin} + 0.25px)`;
 
 const useRootBaseClassName = makeResetStyles({
   alignItems: 'center',
@@ -105,7 +105,7 @@ const useRootBaseClassName = makeResetStyles({
     borderRadius: tokens.borderRadiusMedium,
     borderWidth: '1px',
     outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
-    boxShadow: `0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2}
+    boxShadow: `0 0 0 ${boxShadowStrokeWidthThin} ${tokens.colorStrokeFocus2}
       inset
     `,
     zIndex: 1,

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -18,8 +18,11 @@ const buttonSpacingMedium = '5px';
 const buttonSpacingLarge = '8px';
 const buttonSpacingLargeWithIcon = '7px';
 
-// Firefox has a box shadow offset at some zoom levels, this will ensure the boxShadow is always uniform
-const boxShadowStrokeWidthThinMoz = `calc(${tokens.strokeWidthThin} + 0.5px)`;
+/* Firefox has box shadow sizing issue at some zoom levels
+ * this will ensure the boxShadow is always uniform
+ * without affecting other browser platforms
+ */
+const boxShadowStrokeWidthThinMoz = `calc(${tokens.strokeWidthThin} + 0.25px)`;
 
 const useRootBaseClassName = makeResetStyles({
   alignItems: 'center',
@@ -102,22 +105,11 @@ const useRootBaseClassName = makeResetStyles({
     borderRadius: tokens.borderRadiusMedium,
     borderWidth: '1px',
     outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
-    boxShadow: `0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2}
+    boxShadow: `0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2}
       inset
     `,
     zIndex: 1,
   }),
-  // Firefox box shadow w/ stroke balanced
-  '@supports (-moz-appearance:button)': {
-    ...createCustomFocusIndicatorStyle({
-      borderColor: tokens.colorStrokeFocus2,
-      borderRadius: tokens.borderRadiusMedium,
-      borderWidth: '1px',
-      outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
-      boxShadow: `inset 0px 0px 0px  ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2}`,
-      zIndex: 1,
-    }),
-  },
 });
 
 const useIconBaseClassName = makeResetStyles({

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -111,16 +111,12 @@ const useRootBaseClassName = makeResetStyles({
     zIndex: 1,
   }),
 
-  '@supports (-moz-appearance:none)': {
+  // BUGFIX: Mozilla specific styles (Mozilla BugID: 1857642)
+  '@supports (-moz-appearance:button)': {
     ...createCustomFocusIndicatorStyle({
-      borderColor: tokens.colorStrokeFocus2,
-      borderRadius: tokens.borderRadiusMedium,
-      borderWidth: '1px',
-      outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
       boxShadow: `0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2}
       inset
     `,
-      zIndex: 1,
     }),
   },
 });
@@ -481,13 +477,13 @@ const useRootFocusStyles = makeStyles({
         ...shorthands.borderColor(tokens.colorStrokeFocus2),
       },
     }),
-    '@supports (-moz-appearance:none)': {
+
+    // BUGFIX: Mozilla specific styles (Mozilla BugID: 1857642)
+    '@supports (-moz-appearance:button)': {
       ...createCustomFocusIndicatorStyle({
-        ...shorthands.borderColor(tokens.colorStrokeFocus2),
         boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
         ':hover': {
           boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2} inset`,
-          ...shorthands.borderColor(tokens.colorStrokeFocus2),
         },
       }),
     },

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -19,10 +19,10 @@ const buttonSpacingLarge = '8px';
 const buttonSpacingLargeWithIcon = '7px';
 
 /* Firefox has box shadow sizing issue at some zoom levels
- * this will ensure the boxShadow is always uniform
+ * this will ensure the inset boxShadow is always uniform
  * without affecting other browser platforms
  */
-const boxShadowStrokeWidthThin = `calc(${tokens.strokeWidthThin} + 0.25px)`;
+const boxShadowStrokeWidthThinMoz = `calc(${tokens.strokeWidthThin} + 0.25px)`;
 
 const useRootBaseClassName = makeResetStyles({
   alignItems: 'center',
@@ -105,11 +105,24 @@ const useRootBaseClassName = makeResetStyles({
     borderRadius: tokens.borderRadiusMedium,
     borderWidth: '1px',
     outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
-    boxShadow: `0 0 0 ${boxShadowStrokeWidthThin} ${tokens.colorStrokeFocus2}
+    boxShadow: `0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2}
       inset
     `,
     zIndex: 1,
   }),
+
+  '@supports (-moz-appearance:none)': {
+    ...createCustomFocusIndicatorStyle({
+      borderColor: tokens.colorStrokeFocus2,
+      borderRadius: tokens.borderRadiusMedium,
+      borderWidth: '1px',
+      outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
+      boxShadow: `0 0 0 ${boxShadowStrokeWidthThinMoz} ${tokens.colorStrokeFocus2}
+      inset
+    `,
+      zIndex: 1,
+    }),
+  },
 });
 
 const useIconBaseClassName = makeResetStyles({

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -461,9 +461,9 @@ const useRootFocusStyles = makeStyles({
   // Primary styles
   primary: createCustomFocusIndicatorStyle({
     ...shorthands.borderColor(tokens.colorStrokeFocus2),
-    boxShadow: `${tokens.shadow2}, 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
+    boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThin} ${tokens.colorStrokeFocus2} inset,  0 0 0 ${tokens.strokeWidthThick} ${tokens.colorNeutralForegroundOnBrand} inset`,
     ':hover': {
-      boxShadow: `${tokens.shadow2}, 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2} inset`,
+      boxShadow: `${tokens.shadow2}, 0 0 0 ${boxShadowStrokeWidthThin} ${tokens.colorStrokeFocus2} inset`,
       ...shorthands.borderColor(tokens.colorStrokeFocus2),
     },
   }),


### PR DESCRIPTION
## Previous Behavior
Previously, in some instances of scaling on FireFox (including at 100%) - button border would not be uniform on focus (inset border box shadow)
<img width="106" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/c134331f-4ffb-4df7-ac29-19f8076c779a">
<img width="90" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/81ea7a6a-4761-4030-be83-a3a6af82f9ff">
<img width="82" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/986231d5-361d-4908-ab04-7f341dfe39eb">


## New Behavior
All button styles should now retain the 1px border + inset 2px box shadow on all browsers
<img width="96" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/ba6d8d5b-4978-43fd-b287-f85e73a5b8fb">
<img width="97" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/6cdb6988-ca3a-4037-a275-b4b0015577bd">
<img width="96" alt="image" src="https://github.com/microsoft/fluentui/assets/99835933/7719de31-ef92-4aee-a00e-af0ce29ac126">



## Related Issue(s)
- Fixes #29417 

