### PR TITLE
fix: MenuSplitGroup styles should target MenuItems

### DIFF
--- a/change/@fluentui-react-menu-1c0c1294-fdc5-4546-99db-70488ce9b036.json
+++ b/change/@fluentui-react-menu-1c0c1294-fdc5-4546-99db-70488ce9b036.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuSplitGroup styles should target MenuItems",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
+++ b/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
@@ -13,10 +13,10 @@ export const menuSplitGroupClassNames: SlotClassNames<MenuSplitGroupSlots> = {
 const useStyles = makeStyles({
   root: {
     display: 'flex',
-    [`& > .${menuItemClassNames.root}:nth-child(1)`]: {
+    [`& > .${menuItemClassNames.root}:nth-of-type(1)`]: {
       flexGrow: 1,
     },
-    [`& > .${menuItemClassNames.root}:nth-child(2)`]: {
+    [`& > .${menuItemClassNames.root}:nth-of-type(2)`]: {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
       paddingLeft: 0,


### PR DESCRIPTION
Currently the MenuSplitGroup targets any first and second elements in DOM, this can cause problems when MenuItems are wrapped in components like Tooltip which will drop an span in DOM to be a virtual parent.

Updates the selector to be `nth-of-type` so that only MenuItem children are targeted.

Fixes #29125