### PR TITLE
fix(useMeasureElement): Should not remove parent element

### DIFF
--- a/change/@fluentui-react-table-101edd5b-5a5e-4855-830d-a0f6feca0891.json
+++ b/change/@fluentui-react-table-101edd5b-5a5e-4855-830d-a0f6feca0891.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(useMeasureElement): Should not remove parent element",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/useMeasureElement.test.tsx
+++ b/packages/react-components/react-table/src/hooks/useMeasureElement.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { useMeasureElement } from './useMeasureElement';
+import { render } from '@testing-library/react';
+
+describe('useMeasureElement', () => {
+  beforeAll(() => {
+    // https://github.com/jsdom/jsdom/issues/3368
+    global.ResizeObserver = class ResizeObserver {
+      public observe() {
+        // do nothing
+      }
+      public unobserve() {
+        // do nothing
+      }
+      public disconnect() {
+        // do nothing
+      }
+    };
+  });
+
+  it('should not remove parent element on unmount', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+
+    const TestComponent = () => {
+      const { measureElementRef } = useMeasureElement();
+
+      return ReactDOM.createPortal(<div ref={measureElementRef} />, container);
+    };
+
+    const { unmount } = render(<TestComponent />);
+    unmount();
+
+    expect(container.parentElement).toBe(document.body);
+  });
+});

--- a/packages/react-components/react-table/src/hooks/useMeasureElement.ts
+++ b/packages/react-components/react-table/src/hooks/useMeasureElement.ts
@@ -31,9 +31,9 @@ export function useMeasureElement<TElement extends HTMLElement = HTMLElement>() 
       // cleanup previous container
       if (container.current) {
         resizeObserver.unobserve(container.current);
-        container.current.remove();
       }
 
+      container.current = undefined;
       if (el?.parentElement) {
         container.current = el.parentElement;
         resizeObserver.observe(container.current);


### PR DESCRIPTION
Follow up fix of #29363. There should be no element cleanup anymore since, the ref is attached to the parent.

Fixes https://github.com/microsoft/fluentui/issues/29443