### PR TITLE
Hide bar labels of non highlighted bars

### DIFF
--- a/change/@fluentui-react-charting-7bdc342b-897c-41f4-a785-2bed26b30f93.json
+++ b/change/@fluentui-react-charting-7bdc342b-897c-41f4-a785-2bed26b30f93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide bar labels of non highlighted bars",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/react-charting/src/components/DonutChart/Arc/Arc.tsx
@@ -4,7 +4,8 @@ import { classNamesFunction, getRTL } from '@fluentui/react/lib/Utilities';
 import { getStyles } from './Arc.styles';
 import { IChartDataPoint } from '../index';
 import { IArcProps, IArcStyles } from './index';
-import { format as d3Format, formatPrefix as d3FormatPrefix } from 'd3-format';
+import { format as d3Format } from 'd3-format';
+import { formatValueWithSIPrefix } from '../../../utilities/index';
 
 export interface IArcState {
   isCalloutVisible?: boolean;
@@ -94,9 +95,13 @@ export class Arc extends React.Component<IArcProps, IArcState> {
   };
 
   private _renderArcLabel = (className: string) => {
-    const { arc, data, innerRadius, outerRadius, showLabelsInPercent, totalValue, hideLabels } = this.props;
+    const { arc, data, innerRadius, outerRadius, showLabelsInPercent, totalValue, hideLabels, activeArc } = this.props;
 
-    if (hideLabels || Math.abs(data!.endAngle - data!.startAngle) < Math.PI / 12) {
+    if (
+      hideLabels ||
+      Math.abs(data!.endAngle - data!.startAngle) < Math.PI / 12 ||
+      (activeArc !== data!.data.legend && activeArc !== '')
+    ) {
       return null;
     }
 
@@ -117,7 +122,7 @@ export class Arc extends React.Component<IArcProps, IArcState> {
       >
         {showLabelsInPercent
           ? d3Format('.0%')(totalValue! === 0 ? 0 : arcValue / totalValue!)
-          : d3FormatPrefix(arcValue < 1000 ? '.2~' : '.1', arcValue)(arcValue)}
+          : formatValueWithSIPrefix(arcValue)}
       </text>
     );
   };

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -14,6 +14,7 @@ import {
   tooltipOfXAxislabels,
   XAxisTypes,
   getTypeOfAxis,
+  formatValueWithSIPrefix,
 } from '../../utilities/index';
 import {
   IAccessibilityProps,
@@ -29,7 +30,6 @@ import {
   IRefArrayData,
   Legends,
 } from '../../index';
-import { formatPrefix as d3FormatPrefix } from 'd3-format';
 
 const COMPONENT_NAME = 'GROUPED VERTICAL BAR CHART';
 const getClassNames = classNamesFunction<IGroupedVerticalBarChartStyleProps, IGroupedVerticalBarChartStyles>();
@@ -362,7 +362,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
             role="img"
           />,
         );
-      if (pointData.data && !this.props.hideLabels && this._barWidth >= 16) {
+      if (
+        pointData.data &&
+        !this.props.hideLabels &&
+        this._barWidth >= 16 &&
+        (this._legendHighlighted(pointData.legend) || this._noLegendHighlighted())
+      ) {
         barLabelsForGroup.push(
           <text
             x={xPoint + this._barWidth / 2}
@@ -371,7 +376,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
             className={this._classNames.barLabel}
             aria-hidden={true}
           >
-            {d3FormatPrefix(pointData.data < 1000 ? '.2~' : '.1', pointData.data)(pointData.data)}
+            {formatValueWithSIPrefix(pointData.data)}
           </text>,
         );
       }

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -12,9 +12,13 @@ import {
   HorizontalBarChartVariant,
 } from './index';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
-import { ChartHoverCard, convertToLocaleString, getAccessibleDataObject } from '../../utilities/index';
+import {
+  ChartHoverCard,
+  convertToLocaleString,
+  formatValueWithSIPrefix,
+  getAccessibleDataObject,
+} from '../../utilities/index';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { formatPrefix as d3FormatPrefix } from 'd3-format';
 import { FocusableTooltipText } from '../../utilities/FocusableTooltipText';
 
 const getClassNames = classNamesFunction<IHorizontalBarChartStyleProps, IHorizontalBarChartStyles>();
@@ -383,7 +387,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
             className={this._classNames.barLabel}
             aria-hidden={true}
           >
-            {d3FormatPrefix(barValue < 1000 ? '.2~' : '.1', barValue)(barValue)}
+            {formatValueWithSIPrefix(barValue)}
           </text>
         );
       }

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -13,8 +13,12 @@ import {
 } from './index';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartHoverCard, convertToLocaleString, getAccessibleDataObject } from '../../utilities/index';
-import { formatPrefix as d3FormatPrefix } from 'd3-format';
+import {
+  ChartHoverCard,
+  convertToLocaleString,
+  formatValueWithSIPrefix,
+  getAccessibleDataObject,
+} from '../../utilities/index';
 import { FocusableTooltipText } from '../../utilities/FocusableTooltipText';
 
 const getClassNames = classNamesFunction<IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>();
@@ -306,7 +310,20 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       );
     });
     if (this.props.variant === MultiStackedBarChartVariant.AbsoluteScale) {
-      if (!this.props.hideLabels) {
+      let showLabel = false;
+      let barLabel = 0;
+      if (this._noLegendHighlighted()) {
+        showLabel = true;
+        barLabel = barTotalValue;
+      } else {
+        data.chartData?.forEach(point => {
+          if (this._legendHighlighted(point.legend!)) {
+            showLabel = true;
+            barLabel += point.data ? point.data : 0;
+          }
+        });
+      }
+      if (!this.props.hideLabels && showLabel) {
         bars.push(
           <text
             key="text"
@@ -320,10 +337,10 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             dominantBaseline="central"
             transform={`translate(${this._isRTL ? -4 : 4})`}
             className={this._classNames.barLabel}
-            aria-label={`Total: ${barTotalValue}`}
+            aria-label={`Total: ${barLabel}`}
             role="img"
           >
-            {d3FormatPrefix(barTotalValue < 1000 ? '.2~' : '.1', barTotalValue)(barTotalValue)}
+            {formatValueWithSIPrefix(barLabel)}
           </text>,
         );
       }

--- a/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -309,7 +309,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         </g>
       );
     });
-    if (this.props.variant === MultiStackedBarChartVariant.AbsoluteScale) {
+    if (this.props.variant === MultiStackedBarChartVariant.AbsoluteScale && !this.props.hideLabels) {
       let showLabel = false;
       let barLabel = 0;
       if (this._noLegendHighlighted()) {
@@ -323,7 +323,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           }
         });
       }
-      if (!this.props.hideLabels && showLabel) {
+      if (showLabel) {
         bars.push(
           <text
             key="text"

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -32,8 +32,8 @@ import {
   StringAxis,
   getTypeOfAxis,
   tooltipOfXAxislabels,
+  formatValueWithSIPrefix,
 } from '../../utilities/index';
-import { formatPrefix as d3FormatPrefix } from 'd3-format';
 
 enum CircleVisbility {
   show = 'visibility',
@@ -568,7 +568,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
             onBlur={this._onBarLeave}
             fill={point.color && !useSingleColor ? point.color : colorScale(point.y)}
           />
-          {this._renderBarLabel(xPoint, yPoint, point.y)}
+          {this._renderBarLabel(xPoint, yPoint, point.y, point.legend!)}
         </g>
       );
     });
@@ -632,7 +632,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
             onFocus={this._onBarFocus.bind(this, point, index, colorScale(point.y))}
             fill={point.color ? point.color : colorScale(point.y)}
           />
-          {this._renderBarLabel(xPoint, yPoint, point.y)}
+          {this._renderBarLabel(xPoint, yPoint, point.y, point.legend!)}
         </g>
       );
     });
@@ -788,8 +788,12 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     );
   };
 
-  private _renderBarLabel(xPoint: number, yPoint: number, barValue: number) {
-    if (this.props.hideLabels || this._barWidth < 16) {
+  private _renderBarLabel(xPoint: number, yPoint: number, barValue: number, legend: string) {
+    if (
+      this.props.hideLabels ||
+      this._barWidth < 16 ||
+      !(this._legendHighlighted(legend) || this._noLegendHighlighted())
+    ) {
       return null;
     }
 
@@ -801,7 +805,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
         className={this._classNames.barLabel}
         aria-hidden={true}
       >
-        {d3FormatPrefix(barValue < 1000 ? '.2~' : '.1', barValue)(barValue)}
+        {formatValueWithSIPrefix(barValue)}
       </text>
     );
   }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -850,16 +850,18 @@ export class VerticalStackedBarChartBase extends React.Component<
       };
       let showLabel = false;
       let barLabel = 0;
-      if (this._noLegendHighlighted()) {
-        showLabel = true;
-        barLabel = barTotalValue;
-      } else {
-        barsToDisplay.forEach(point => {
-          if (this._legendHighlighted(point.legend)) {
-            showLabel = true;
-            barLabel += point.data;
-          }
-        });
+      if (!this.props.hideLabels) {
+        if (this._noLegendHighlighted()) {
+          showLabel = true;
+          barLabel = barTotalValue;
+        } else {
+          barsToDisplay.forEach(point => {
+            if (this._legendHighlighted(point.legend)) {
+              showLabel = true;
+              barLabel += point.data;
+            }
+          });
+        }
       }
       return (
         <g key={indexNumber + `${shouldFocusWholeStack}`}>

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -31,8 +31,8 @@ import {
   XAxisTypes,
   getTypeOfAxis,
   tooltipOfXAxislabels,
+  formatValueWithSIPrefix,
 } from '../../utilities/index';
-import { formatPrefix as d3FormatPrefix } from 'd3-format';
 
 const getClassNames = classNamesFunction<IVerticalStackedBarChartStyleProps, IVerticalStackedBarChartStyles>();
 type NumericAxis = D3Axis<number | { valueOf(): number }>;
@@ -848,22 +848,35 @@ export class VerticalStackedBarChartBase extends React.Component<
         onClick: this._onClick.bind(this, singleChartData),
         role: 'img',
       };
+      let showLabel = false;
+      let barLabel = 0;
+      if (this._noLegendHighlighted()) {
+        showLabel = true;
+        barLabel = barTotalValue;
+      } else {
+        barsToDisplay.forEach(point => {
+          if (this._legendHighlighted(point.legend)) {
+            showLabel = true;
+            barLabel += point.data;
+          }
+        });
+      }
       return (
         <g key={indexNumber + `${shouldFocusWholeStack}`}>
           <g id={`${indexNumber}-singleBar`} ref={e => (groupRef.refElement = e)} {...stackFocusProps}>
             {singleBar}
           </g>
-          {!this.props.hideLabels && this._barWidth >= 16 && (
+          {!this.props.hideLabels && this._barWidth >= 16 && showLabel && (
             <text
               x={xPoint + this._barWidth / 2}
               y={yPoint - 6}
               textAnchor="middle"
               className={this._classNames.barLabel}
-              aria-label={`Total: ${barTotalValue}`}
+              aria-label={`Total: ${barLabel}`}
               role="img"
               transform={`translate(${xScaleBandwidthTranslate}, 0)`}
             >
-              {d3FormatPrefix(barTotalValue < 1000 ? '.2~' : '.1', barTotalValue)(barTotalValue)}
+              {formatValueWithSIPrefix(barLabel)}
             </text>
           )}
         </g>


### PR DESCRIPTION
## Previous Behavior

<img src="https://github.com/microsoft/fluentui/assets/110246001/bebee4c3-cb98-4e9f-9fbf-3a4904f644cc" alt="Before (1)" width="500" />
<img src="https://github.com/microsoft/fluentui/assets/110246001/f5536157-1e0c-4e00-bace-8b00bdef164d" alt="Before (2)" width="500" />
<img src="https://github.com/microsoft/fluentui/assets/110246001/0ec96583-cea1-4c14-be09-ecc8709e02ff" alt="Before (3)" width="500" />
<img src="https://github.com/microsoft/fluentui/assets/110246001/86303e34-8beb-4bcb-a885-0426c3e04d1c" alt="Before (4)" width="500" />

## New Behavior

<img src="https://github.com/microsoft/fluentui/assets/110246001/e2e68493-e592-48e0-8a87-c875d994b09f" alt="After (1)" width="500" />
<img src="https://github.com/microsoft/fluentui/assets/110246001/7a022489-6b4e-4cf4-8ae5-9f13efeabe02" alt="After (2)" width="500" />
<img src="https://github.com/microsoft/fluentui/assets/110246001/773ec00f-e236-4967-a356-a1d292b3fec3" alt="After (3)" width="500" />
<img src="https://github.com/microsoft/fluentui/assets/110246001/d64e23c1-f91c-43fb-b43a-71ba37229623" alt="After (4)" width="500" />