### PR TITLE
bugfix(react-tree): Tree indentation broken

### DIFF
--- a/change/@fluentui-react-tree-98b121f2-403e-4504-8aef-bd3ea55c02fc.json
+++ b/change/@fluentui-react-tree-98b121f2-403e-4504-8aef-bd3ea55c02fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Tree indentation broken due to wrongly consuming root context instead of subtree context",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/src/hooks/useSubtree.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TreeProps, TreeState } from '../Tree';
-import { SubtreeContextValue, useTreeContext_unstable, useTreeItemContext_unstable } from '../contexts/index';
+import { SubtreeContextValue, useSubtreeContext_unstable, useTreeItemContext_unstable } from '../contexts/index';
 import { getIntrinsicElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 
 /**
@@ -15,7 +15,7 @@ export function useSubtree(
 ): Omit<TreeState & SubtreeContextValue, 'treeType'> {
   const subtreeRef = useTreeItemContext_unstable(ctx => ctx.subtreeRef);
 
-  const parentLevel = useTreeContext_unstable(ctx => ctx.level);
+  const { level: parentLevel } = useSubtreeContext_unstable();
 
   const open = useTreeItemContext_unstable(ctx => ctx.open);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`useSubtree` was consuming the current parent level of the tree by the root context (which is always 1)

## New Behavior

`useSubtree` should consume the current parent level of the tree by the subtree context (which will vary depending on the level of the subtree)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29447
