### PR TITLE
Show how to override legend text styles in examples

### DIFF
--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
@@ -45,7 +45,7 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
           { x: new Date('2018/01/26'), y: 35 },
           { x: new Date('2018/01/29'), y: 90 },
         ],
-        legend: 'Week',
+        legend: 'first legend',
         lineOptions: {
           lineBorderWidth: '4',
         },
@@ -88,7 +88,6 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
             data={data}
             strokeWidth={4}
             yMaxValue={90}
-            hideLegend={true}
             showXAxisLablesTooltip
             height={this.state.height}
             width={this.state.width}
@@ -106,6 +105,13 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
               ) : null
             }
             enablePerfOptimization={true}
+            legendProps={{
+              styles: {
+                legend: {
+                  textTransform: 'none',
+                },
+              },
+            }}
           />
         </div>
       </>

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -43,21 +43,21 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
 
   private _basicExample(): JSX.Element {
     const firstChartPoints: IVSChartDataPoint[] = [
-      { legend: 'Metadata1', data: 2, color: getColorFromToken(DataVizPalette.color8) },
-      { legend: 'Metadata2', data: 0.5, color: getColorFromToken(DataVizPalette.color9) },
-      { legend: 'Metadata3', data: 0, color: getColorFromToken(DataVizPalette.color10) },
+      { legend: 'meta data 1', data: 2, color: getColorFromToken(DataVizPalette.color8) },
+      { legend: 'Meta data 2', data: 0.5, color: getColorFromToken(DataVizPalette.color9) },
+      { legend: 'meta Data 3', data: 0, color: getColorFromToken(DataVizPalette.color10) },
     ];
 
     const secondChartPoints: IVSChartDataPoint[] = [
-      { legend: 'Metadata1', data: 30, color: getColorFromToken(DataVizPalette.color8) },
-      { legend: 'Metadata2', data: 3, color: getColorFromToken(DataVizPalette.color9) },
-      { legend: 'Metadata3', data: 40, color: getColorFromToken(DataVizPalette.color10) },
+      { legend: 'meta data 1', data: 30, color: getColorFromToken(DataVizPalette.color8) },
+      { legend: 'Meta data 2', data: 3, color: getColorFromToken(DataVizPalette.color9) },
+      { legend: 'meta Data 3', data: 40, color: getColorFromToken(DataVizPalette.color10) },
     ];
 
     const thirdChartPoints: IVSChartDataPoint[] = [
-      { legend: 'Metadata1', data: 10, color: getColorFromToken(DataVizPalette.color8) },
-      { legend: 'Metadata2', data: 60, color: getColorFromToken(DataVizPalette.color9) },
-      { legend: 'Metadata3', data: 30, color: getColorFromToken(DataVizPalette.color10) },
+      { legend: 'meta data 1', data: 10, color: getColorFromToken(DataVizPalette.color8) },
+      { legend: 'Meta data 2', data: 60, color: getColorFromToken(DataVizPalette.color9) },
+      { legend: 'meta Data 3', data: 30, color: getColorFromToken(DataVizPalette.color10) },
     ];
 
     const data: IVerticalStackedChartProps[] = [
@@ -191,6 +191,9 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
               styles: {
                 rect: {
                   borderRadius: '3px',
+                },
+                legend: {
+                  textTransform: 'none',
                 },
               },
             }}


### PR DESCRIPTION
The legend text styles can be overridden like this:
```jsx
<LineChart
  {...props}
  legendProps={{
    styles: {
      legend: {
        textTransform: 'none',
      },
    },
  }}
/>
```