### PR TITLE
chore(react-tree): adds console error when mixing Tree and FlatTree components

### DIFF
--- a/change/@fluentui-react-tree-971f2603-bff0-4558-93ea-267be83d77cb.json
+++ b/change/@fluentui-react-tree-971f2603-bff0-4558-93ea-267be83d77cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adds console error when mixing Tree and FlatTree components",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/FlatTree/useFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useFlatTree.ts
@@ -11,16 +11,17 @@ import { useTreeContext_unstable } from '../../contexts/treeContext';
 import { useSubtree } from '../../hooks/useSubtree';
 import { ImmutableSet } from '../../utils/ImmutableSet';
 import { ImmutableMap } from '../../utils/ImmutableMap';
+import { SubtreeContext } from '../../contexts/subtreeContext';
 
 export const useFlatTree_unstable: (props: FlatTreeProps, ref: React.Ref<HTMLElement>) => FlatTreeState = (
   props,
   ref,
 ) => {
-  const level = useTreeContext_unstable(ctx => ctx.level);
+  const isRoot = React.useContext(SubtreeContext) === undefined;
   // as level is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return level > 1 ? useSubFlatTree(props, ref) : useRootFlatTree(props, ref);
+  return isRoot ? useRootFlatTree(props, ref) : useSubFlatTree(props, ref);
 };
 
 function useRootFlatTree(props: FlatTreeProps, ref: React.Ref<HTMLElement>): FlatTreeState {
@@ -60,6 +61,13 @@ function useSubFlatTree(props: FlatTreeProps, ref: React.Ref<HTMLElement>): Flat
       @fluentui/react-tree [useFlatTree]:
       Subtrees are not allowed in a FlatTree!
       You cannot use a <FlatTree> component inside of another <FlatTree> component.
+    `);
+  }
+  if (useTreeContext_unstable(ctx => ctx.treeType) === 'nested' && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.error(/* #__DE-INDENT__ */ `
+      @fluentui/react-tree [useFlatTree]:
+      Error: <FlatTree> component cannot be used inside of a nested <Tree> component and vice versa.
     `);
   }
   return {

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -12,20 +12,21 @@ import type {
 } from './Tree.types';
 import { createNextOpenItems, useControllableOpenItems } from '../../hooks/useControllableOpenItems';
 import { createNextNestedCheckedItems, useNestedCheckedItems } from './useNestedControllableCheckedItems';
-import { useSubtreeContext_unstable } from '../../contexts/subtreeContext';
+import { SubtreeContext } from '../../contexts/subtreeContext';
 import { useRootTree } from '../../hooks/useRootTree';
 import { useSubtree } from '../../hooks/useSubtree';
 import { HTMLElementWalker, createHTMLElementWalker } from '../../utils/createHTMLElementWalker';
 import { treeItemFilter } from '../../utils/treeItemFilter';
 import { useTreeNavigation } from './useTreeNavigation';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
+import { useTreeContext_unstable } from '../../contexts/treeContext';
 
 export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>): TreeState => {
-  const { level } = useSubtreeContext_unstable();
+  const isRoot = React.useContext(SubtreeContext) === undefined;
   // as level is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return level > 0 ? useSubtree(props, ref) : useNestedRootTree(props, ref);
+  return isRoot ? useNestedRootTree(props, ref) : useNestedSubtree(props, ref);
 };
 
 function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
@@ -86,4 +87,15 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
       useMergedRefs(ref, initializeWalker),
     ),
   };
+}
+
+function useNestedSubtree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
+  if (useTreeContext_unstable(ctx => ctx.treeType) === 'flat' && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.error(/* #__DE-INDENT__ */ `
+      @fluentui/react-tree [useTree]:
+      Error: <Tree> component cannot be used inside of a nested <FlatTree> component and vice versa.
+    `);
+  }
+  return useSubtree(props, ref);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. adds a warning for the mixing of `Tree` and `FlatTree` in the same Tree. here's an example: https://github.com/microsoft/fluentui/issues/29444

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
