### PR TITLE
fix: MessageBarActions should not overflow into grid padding

### DIFF
--- a/change/@fluentui-react-message-bar-preview-a6a0acb0-3fd7-4b96-b883-fbd5711cc593.json
+++ b/change/@fluentui-react-message-bar-preview-a6a0acb0-3fd7-4b96-b883-fbd5711cc593.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MessageBarActions should not overflow into grid padding",
+  "packageName": "@fluentui/react-message-bar-preview",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar-preview/src/components/MessageBar/useMessageBarStyles.styles.ts
+++ b/packages/react-components/react-message-bar-preview/src/components/MessageBar/useMessageBarStyles.styles.ts
@@ -14,7 +14,7 @@ const useRootBaseStyles = makeResetStyles({
   gridTemplateColumns: 'auto 1fr auto auto',
   gridTemplateRows: '1fr',
   gridTemplateAreas: '"icon body secondaryActions actions"',
-  ...shorthands.padding('0', tokens.spacingHorizontalM),
+  paddingLeft: tokens.spacingHorizontalM,
   ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke1),
   ...shorthands.borderRadius(tokens.borderRadiusMedium),
   alignItems: 'center',

--- a/packages/react-components/react-message-bar-preview/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
+++ b/packages/react-components/react-message-bar-preview/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
@@ -15,11 +15,12 @@ const useRootBaseStyles = makeResetStyles({
   ...shorthands.gridArea('secondaryActions'),
   display: 'flex',
   columnGap: tokens.spacingHorizontalM,
-  marginRight: tokens.spacingHorizontalM,
+  paddingRight: tokens.spacingHorizontalM,
 });
 
 const useContainerActionBaseStyles = makeResetStyles({
   ...shorthands.gridArea('actions'),
+  paddingRight: tokens.spacingHorizontalM,
 });
 
 const useMultilineStyles = makeStyles({
@@ -28,6 +29,7 @@ const useMultilineStyles = makeStyles({
     marginTop: tokens.spacingVerticalMNudge,
     marginBottom: tokens.spacingVerticalS,
     marginRight: '0px',
+    paddingRight: tokens.spacingVerticalM,
   },
 });
 

--- a/packages/react-components/react-message-bar-preview/src/components/MessageBarBody/useMessageBarBodyStyles.styles.ts
+++ b/packages/react-components/react-message-bar-preview/src/components/MessageBarBody/useMessageBarBodyStyles.styles.ts
@@ -1,7 +1,7 @@
 import { makeResetStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { MessageBarBodySlots, MessageBarBodyState } from './MessageBarBody.types';
-import { typographyStyles } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 
 export const messageBarBodyClassNames: SlotClassNames<MessageBarBodySlots> = {
   root: 'fui-MessageBarBody',
@@ -10,6 +10,7 @@ export const messageBarBodyClassNames: SlotClassNames<MessageBarBodySlots> = {
 const useRootBaseStyles = makeResetStyles({
   ...typographyStyles.body1,
   ...shorthands.gridArea('body'),
+  paddingRight: tokens.spacingHorizontalM,
 });
 
 /**

--- a/packages/react-components/react-message-bar-preview/stories/MessageBar/Intent.stories.tsx
+++ b/packages/react-components/react-message-bar-preview/stories/MessageBar/Intent.stories.tsx
@@ -1,12 +1,21 @@
 import * as React from 'react';
-import { Link, makeStyles, shorthands } from '@fluentui/react-components';
-import { MessageBar, MessageBarTitle, MessageBarBody, MessageBarIntent } from '@fluentui/react-message-bar-preview';
+import { Button, Link, makeStyles, shorthands } from '@fluentui/react-components';
+import {
+  MessageBar,
+  MessageBarTitle,
+  MessageBarBody,
+  MessageBarIntent,
+  MessageBarActions,
+} from '@fluentui/react-message-bar-preview';
+import { DismissRegular } from '@fluentui/react-icons';
 
 const useClasses = makeStyles({
   container: {
     display: 'flex',
     flexDirection: 'column',
     ...shorthands.gap('10px'),
+    resize: 'horizontal',
+    ...shorthands.overflow('hidden'),
   },
 });
 const intents: MessageBarIntent[] = ['info', 'warning', 'error', 'success'];
@@ -22,6 +31,10 @@ export const Intent = () => {
             <MessageBarTitle>{intent}</MessageBarTitle>
             Message providing information to the user with actionable insights. <Link>Link</Link>
           </MessageBarBody>
+          <MessageBarActions containerAction={<Button icon={<DismissRegular />} />}>
+            <Button>Action</Button>
+            <Button>Action</Button>
+          </MessageBarActions>
         </MessageBar>
       ))}
     </div>

--- a/packages/react-components/react-message-bar-preview/stories/MessageBar/Intent.stories.tsx
+++ b/packages/react-components/react-message-bar-preview/stories/MessageBar/Intent.stories.tsx
@@ -1,21 +1,12 @@
 import * as React from 'react';
-import { Button, Link, makeStyles, shorthands } from '@fluentui/react-components';
-import {
-  MessageBar,
-  MessageBarTitle,
-  MessageBarBody,
-  MessageBarIntent,
-  MessageBarActions,
-} from '@fluentui/react-message-bar-preview';
-import { DismissRegular } from '@fluentui/react-icons';
+import { Link, makeStyles, shorthands } from '@fluentui/react-components';
+import { MessageBar, MessageBarTitle, MessageBarBody, MessageBarIntent } from '@fluentui/react-message-bar-preview';
 
 const useClasses = makeStyles({
   container: {
     display: 'flex',
     flexDirection: 'column',
     ...shorthands.gap('10px'),
-    resize: 'horizontal',
-    ...shorthands.overflow('hidden'),
   },
 });
 const intents: MessageBarIntent[] = ['info', 'warning', 'error', 'success'];
@@ -31,10 +22,6 @@ export const Intent = () => {
             <MessageBarTitle>{intent}</MessageBarTitle>
             Message providing information to the user with actionable insights. <Link>Link</Link>
           </MessageBarBody>
-          <MessageBarActions containerAction={<Button icon={<DismissRegular />} />}>
-            <Button>Action</Button>
-            <Button>Action</Button>
-          </MessageBarActions>
         </MessageBar>
       ))}
     </div>


### PR DESCRIPTION
CSS grid can cause its own padding to overflow cells. The only way to avoid this padding collapse (that I could think of) is to handle the spacing in the grid areas directly.

Fixes #29423