### PR TITLE
Shadow DOM layers

### DIFF
--- a/change/@fluentui-react-hooks-2a9a3785-211f-4a01-8343-0dec3306fc82.json
+++ b/change/@fluentui-react-hooks-2a9a3785-211f-4a01-8343-0dec3306fc82.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add support for shadow roots",
+  "packageName": "@fluentui/react-hooks",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/ShadowDOM/ShadowDOM.ChildWindow.Example.tsx
+++ b/packages/react-examples/src/react/ShadowDOM/ShadowDOM.ChildWindow.Example.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {
+  Callout,
   DefaultButton,
   PrimaryButton,
   Checkbox,
@@ -47,6 +48,34 @@ const options: IComboBoxOption[] = [
   { key: 'J', text: 'Option J' },
 ];
 
+const TestLayer: React.FC = () => {
+  const [showCallout, setShowCallout] = React.useState(false);
+
+  return (
+    <>
+      {/* eslint-disable-next-line react/jsx-no-bind */}
+      <DefaultButton id="callout-button" text="Show callout" onClick={() => setShowCallout(!showCallout)} />
+      {showCallout && (
+        <Callout
+          role="dialog"
+          gapSpace={0}
+          target={`#callout-button`}
+          // eslint-disable-next-line react/jsx-no-bind
+          onDismiss={() => setShowCallout(false)}
+          setInitialFocus
+          styles={{ root: { padding: '1rem' } }}
+        >
+          <Text as="h1" block>
+            Callout shows up next to target within shadow DOM as expected. Default layer host is also created within the
+            corresponding shadow DOM if no layer host is provided. Note that if providing a custom layer host, it must
+            be in the same shadow DOM as the target.
+          </Text>
+        </Callout>
+      )}
+    </>
+  );
+};
+
 type TestCompProps = {
   inShadow: boolean;
 };
@@ -77,6 +106,7 @@ const TestComp: React.FC<TestCompProps> = ({ inShadow }) => {
 
       {/* eslint-disable-next-line */}
       <Checkbox label="Disable controls" checked={disabled} onChange={onClick} />
+      <TestLayer />
       <Stack tokens={{ childrenGap: 5 }}>
         <Text>FontIcons</Text>
         <Stack horizontal tokens={{ childrenGap: 5 }}>

--- a/packages/react-hooks/src/useTarget.ts
+++ b/packages/react-hooks/src/useTarget.ts
@@ -34,8 +34,16 @@ export function useTarget<TElement extends HTMLElement = HTMLElement>(
     const currentElement = hostElement?.current;
     if (target) {
       if (typeof target === 'string') {
-        const currentDoc: Document = getDocument(currentElement)!;
-        targetRef.current = currentDoc ? currentDoc.querySelector(target) : null;
+        // const currentDoc: Document = getDocument(currentElement)!;
+        // targetRef.current = currentDoc ? currentDoc.querySelector(target) : null;
+
+        // If element is part of shadow dom, then querySelector on shadow root, else query on document
+        if ((currentElement?.getRootNode() as ShadowRoot)?.host) {
+          targetRef.current = (currentElement?.getRootNode() as ShadowRoot)?.querySelector(target) ?? null;
+        } else {
+          const currentDoc: Document = getDocument(currentElement)!;
+          targetRef.current = currentDoc ? currentDoc.querySelector(target) : null;
+        }
       } else if ('stopPropagation' in target) {
         targetRef.current = target;
       } else if ('getBoundingClientRect' in target) {

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -976,7 +976,7 @@ export function clamp(value: number, max: number, min?: number): number;
 export { classNamesFunction }
 
 // @public
-export function cleanupDefaultLayerHost(doc: Document): void;
+export function cleanupDefaultLayerHost(doc: Document, shadowRoot?: ShadowRoot | null): void;
 
 // @public (undocumented)
 export const Coachmark: React_2.FunctionComponent<ICoachmarkProps>;
@@ -1156,7 +1156,7 @@ export function correctRGB(color: IRGB): IRGB;
 export { createArray }
 
 // @public
-export function createDefaultLayerHost(doc: Document): Node | null;
+export function createDefaultLayerHost(doc: Document, shadowRoot?: ShadowRoot | null): Node | null;
 
 export { createFontStyles }
 

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -128,7 +128,7 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
     // If a doc or host exists, it will remove and update layer parentNodes.
     const createLayerElement = () => {
       const doc = getDocument(rootRef.current);
-      const shadowRoot = (rootRef.current?.getRootNode() as ShadowRoot).host
+      const shadowRoot = (rootRef.current?.getRootNode() as ShadowRoot)?.host
         ? (rootRef?.current?.getRootNode() as ShadowRoot)
         : undefined;
 

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -85,7 +85,8 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
 
     // Returns the user provided hostId props element, the default target selector,
     // or undefined if document doesn't exist.
-    const getHost = (doc: Document): Node | null => {
+    const getHost = (doc: Document, shadowRoot: ShadowRoot | null = null): Node | null => {
+      const root = shadowRoot ?? doc;
       if (hostId) {
         const layerHost = getLayerHost(hostId);
 
@@ -93,17 +94,17 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
           return layerHost.rootRef.current ?? null;
         }
 
-        return doc.getElementById(hostId) ?? null;
+        return root.getElementById(hostId) ?? null;
       } else {
         const defaultHostSelector = getDefaultTarget();
 
         // Find the host.
-        let host: Node | null = defaultHostSelector ? (doc.querySelector(defaultHostSelector) as Node) : null;
+        let host: Node | null = defaultHostSelector ? (root.querySelector(defaultHostSelector) as Node) : null;
 
         // If no host is available, create a container for injecting layers in.
         // Having a container scopes layout computation.
         if (!host) {
-          host = createDefaultLayerHost(doc);
+          host = createDefaultLayerHost(doc, shadowRoot);
         }
 
         return host;
@@ -127,12 +128,15 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
     // If a doc or host exists, it will remove and update layer parentNodes.
     const createLayerElement = () => {
       const doc = getDocument(rootRef.current);
+      const shadowRoot = (rootRef.current?.getRootNode() as ShadowRoot).host
+        ? (rootRef?.current?.getRootNode() as ShadowRoot)
+        : undefined;
 
-      if (!doc) {
+      if (!doc || (!doc && !shadowRoot)) {
         return;
       }
 
-      const host = getHost(doc);
+      const host = getHost(doc, shadowRoot);
 
       if (!host) {
         return;

--- a/packages/react/src/components/Layer/Layer.notification.ts
+++ b/packages/react/src/components/Layer/Layer.notification.ts
@@ -116,12 +116,18 @@ export function unregisterLayerHost(hostId: string, layerHost: ILayerHost): void
 /**
  * When no default layer host is provided, this function is executed to create the default host.
  */
-export function createDefaultLayerHost(doc: Document): Node | null {
+export function createDefaultLayerHost(doc: Document, shadowRoot: ShadowRoot | null = null): Node | null {
   const host = doc.createElement('div');
   host.setAttribute('id', defaultHostId);
   (host as HTMLElement).style.cssText = 'position:fixed;z-index:1000000';
 
-  doc?.body.appendChild(host);
+  if (shadowRoot) {
+    shadowRoot.appendChild(host);
+  } else {
+    doc?.body.appendChild(host);
+  }
+
+  // doc?.body.appendChild(host);
 
   return host;
 }
@@ -129,11 +135,12 @@ export function createDefaultLayerHost(doc: Document): Node | null {
 /**
  * This function can be optionally called to clean up the default layer host as needed.
  */
-export function cleanupDefaultLayerHost(doc: Document) {
-  const host = doc.querySelector(`#${defaultHostId}`);
+export function cleanupDefaultLayerHost(doc: Document, shadowRoot: ShadowRoot | null = null) {
+  const root = shadowRoot ?? doc;
+  const host = root.querySelector(`#${defaultHostId}`);
 
   if (host) {
-    doc.removeChild(host);
+    root.removeChild(host);
   }
 }
 


### PR DESCRIPTION
## Previous Behavior

Components inside a shadow root would not render their layers in the shadow root, potentially breaking layout and styles.

## New Behavior

Components inside a shadow root render their layers in the same shadow root.

## Related Issue(s)

- Fixes #28060
