### PR TITLE
fix(MessageBar): Align icons with text content

### DIFF
--- a/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
@@ -24,7 +24,7 @@ export default {
 const intents: MessageBarIntent[] = ['info', 'warning', 'error', 'success'];
 
 export const Intents = () => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', padding: 10 }} className="testWrapper">
     {intents.map(intent => (
       <MessageBar key={intent} intent={intent}>
         <MessageBarBody>
@@ -45,7 +45,10 @@ export const IntentsDarkMode = getStoryVariant(Intents, DARK_MODE);
 export const IntentsHighContrast = getStoryVariant(Intents, HIGH_CONTRAST);
 
 export const Multiline = () => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 500 }}>
+  <div
+    style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 500, padding: 10 }}
+    className="testWrapper"
+  >
     {intents.map(intent => (
       <MessageBar layout="multiline" key={intent} intent={intent}>
         <MessageBarBody>
@@ -63,7 +66,10 @@ export const Multiline = () => (
 
 export const Auto = () => {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 400 }}>
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 400, padding: 10 }}
+      className="testWrapper"
+    >
       <MessageBar layout="auto">
         <MessageBarBody>
           <MessageBarTitle>Title</MessageBarTitle>

--- a/change/@fluentui-react-message-bar-preview-78af6acc-f656-41f0-9366-765337219696.json
+++ b/change/@fluentui-react-message-bar-preview-78af6acc-f656-41f0-9366-765337219696.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Align icons with text content",
+  "packageName": "@fluentui/react-message-bar-preview",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar-preview/src/components/MessageBar/useMessageBarStyles.styles.ts
+++ b/packages/react-components/react-message-bar-preview/src/components/MessageBar/useMessageBarStyles.styles.ts
@@ -28,6 +28,8 @@ const useIconBaseStyles = makeResetStyles({
   fontSize: tokens.fontSizeBase500,
   marginRight: tokens.spacingHorizontalS,
   color: tokens.colorNeutralForeground3,
+  display: 'flex',
+  alignItems: 'center',
 });
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-message-bar-preview/stories/MessageBar/Intent.stories.tsx
+++ b/packages/react-components/react-message-bar-preview/stories/MessageBar/Intent.stories.tsx
@@ -19,7 +19,7 @@ export const Intent = () => {
       {intents.map(intent => (
         <MessageBar key={intent} intent={intent}>
           <MessageBarBody>
-            <MessageBarTitle>{intent}</MessageBarTitle>
+            <MessageBarTitle>Intent {intent}</MessageBarTitle>
             Message providing information to the user with actionable insights. <Link>Link</Link>
           </MessageBarBody>
         </MessageBar>


### PR DESCRIPTION
Aligns icons with text content, and updates the itent example to start with an upper case letter, since the icons are only 'truly' aligned with an upper case letter.

Fixes #29416

