### PR TITLE
fix: Transparent buttons visible in teams high contrast mode

### DIFF
--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -268,12 +268,10 @@ const useRootStyles = makeStyles({
 
     '@media (forced-colors: active)': {
       ':hover': {
-        backgroundColor: tokens.colorTransparentBackgroundHover,
         ...shorthands.borderColor('transparent'),
         color: 'Highlight',
       },
       ':hover:active': {
-        backgroundColor: tokens.colorTransparentBackgroundHover,
         ...shorthands.borderColor('transparent'),
         color: 'Highlight',
       },


### PR DESCRIPTION
Teams applies the teamsHighContrastTheme along with the operating system forced colours mode. This combo results in a strange behaviour with the transparent button since it applies `colorTransparentBackgroundHover` using a forced colours media query.

The above token is hard coded to cyan in the teamsHighContrastTheme, since the button uses `force-colors-adjust: none`, this cyan clashes with foreground text and makes the text for transparent buttons unreadable.

This PR removes the use of this tokens, it doesn't affect light or dark themes.
