### PR TITLE
Handle RTL margin and mutations on useIntersectionObserver

### DIFF
--- a/change/@fluentui-react-virtualizer-ce60aa55-792e-4691-b912-97ac20583078.json
+++ b/change/@fluentui-react-virtualizer-ce60aa55-792e-4691-b912-97ac20583078.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Ensure IO handles RTL margin and mutations",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/etc/react-virtualizer.api.md
@@ -76,7 +76,7 @@ export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtua
 // @public
 export const useIntersectionObserver: (callback: IntersectionObserverCallback, options?: IntersectionObserverInit) => {
     setObserverList: Dispatch<SetStateAction<Element[] | undefined>>;
-    setObserverInit: Dispatch<SetStateAction<IntersectionObserverInit | undefined>>;
+    setObserverInit: (newInit: IntersectionObserverInit | undefined) => void;
     observer: MutableRefObject<IntersectionObserver | undefined>;
 };
 

--- a/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
@@ -2,7 +2,38 @@ import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 
-const { useState, useRef } = React;
+const { useCallback, useState, useRef } = React;
+import { useMutationObserver } from './useMutationObserver';
+
+/**
+ * This function will take the rootMargin and flip the sides if we are in RTL based on the computed reading direction of the target element.
+ * @param ltrRootMargin the margin to be processed and flipped if required
+ * @param target target element that will have its current reading direction determined
+ * @returns the corrected rootMargin (if it was necessary to correct)
+ */
+export const getRTLRootMargin = (ltrRootMargin: string, target?: Element | Document | null | undefined): string => {
+  if (target) {
+    // get the computed dir for the target element
+    const newDir = getComputedStyle(target as Element).direction;
+
+    // If we're in rtl reading direction, we might need to flip the margins on the left/right sides
+    if (newDir === 'rtl') {
+      let newMargin = ltrRootMargin;
+      const splitMargins = ltrRootMargin.split(' ');
+
+      // We only need to do this if we get four values, otherwise the sides are equal and don't require flipping.
+      if (splitMargins.length === 4) {
+        newMargin = `${splitMargins[0]} ${splitMargins[3]} ${splitMargins[2]} ${splitMargins[1]}`;
+      }
+
+      return newMargin;
+    } else {
+      return ltrRootMargin;
+    }
+  }
+
+  return ltrRootMargin;
+};
 
 /**
  * React hook that allows easy usage of the browser API IntersectionObserver within React
@@ -19,16 +50,59 @@ export const useIntersectionObserver = (
   options?: IntersectionObserverInit,
 ): {
   setObserverList: Dispatch<SetStateAction<Element[] | undefined>>;
-  setObserverInit: Dispatch<SetStateAction<IntersectionObserverInit | undefined>>;
+  setObserverInit: (newInit: IntersectionObserverInit | undefined) => void;
   observer: MutableRefObject<IntersectionObserver | undefined>;
 } => {
   const observer = useRef<IntersectionObserver>();
   const [observerList, setObserverList] = useState<Element[]>();
-  const [observerInit, setObserverInit] = useState<IntersectionObserverInit | undefined>(options);
+
+  // set the initial init with corrected margins based on the observed root's calculated reading direction.
+  const [observerInit, setObserverInit] = useState<IntersectionObserverInit | undefined>(
+    options && {
+      ...options,
+      rootMargin: getRTLRootMargin(options.rootMargin ?? '0px', options.root as Element),
+    },
+  );
+
+  // We have to assume that any values passed in for rootMargin by the consuming app are ltr values. As such we will store the ltr value.
+  const ltrRootMargin = useRef<string>(options?.rootMargin ?? '0px');
+
+  // Callback function to execute when mutations are observed
+  const mutationObserverCallback: MutationCallback = useCallback(
+    mutationList => {
+      for (const mutation of mutationList) {
+        // Ensuring that the right attribute is being observed and that the root is within the tree of the element being mutated.
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'dir' &&
+          options?.root &&
+          mutation.target.contains(options?.root)
+        ) {
+          setObserverInit({
+            ...observerInit,
+            rootMargin: getRTLRootMargin(ltrRootMargin.current, observerInit?.root),
+          });
+        }
+      }
+    },
+    [ltrRootMargin, observerInit, options?.root],
+  );
+
+  // Observer only dir attribute changes in the document
+  useMutationObserver(document, mutationObserverCallback, {
+    attributes: true,
+    subtree: true,
+    attributeFilter: ['dir'],
+  });
 
   // Observer elements in passed in list and clean up previous list
   // This effect is only triggered when observerList is updated
   useIsomorphicLayoutEffect(() => {
+    observer.current = new IntersectionObserver(callback, {
+      ...observerInit,
+      rootMargin: getRTLRootMargin(ltrRootMargin.current, observerInit?.root),
+    });
+
     observer.current = new IntersectionObserver(callback, observerInit);
 
     // If we have an instance of IO and a list with elements, observer the elements
@@ -46,5 +120,20 @@ export const useIntersectionObserver = (
     };
   }, [observerList, observerInit, callback]);
 
-  return { setObserverList, setObserverInit, observer };
+  // Do not use internally, we need to track external settings only here
+  const setObserverInitExternal = useCallback(
+    (newInit: IntersectionObserverInit | undefined) => {
+      // Since we know this is coming from consumers, we can store this value as LTR somewhat safely.
+      ltrRootMargin.current = newInit?.rootMargin ?? '0px';
+
+      // Call the internal setter to update the value and ensure if our calculated direction is rtl, we flip the margin
+      setObserverInit({
+        ...newInit,
+        rootMargin: getRTLRootMargin(ltrRootMargin.current, newInit?.root as Element),
+      });
+    },
+    [ltrRootMargin, setObserverInit],
+  );
+
+  return { setObserverList, setObserverInit: setObserverInitExternal, observer };
 };

--- a/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
@@ -1,10 +1,12 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
 const { useCallback, useState, useRef } = React;
 import { useMutationObserver } from './useMutationObserver';
 
+const { targetDocument } = useFluent();
 /**
  * This function will take the rootMargin and flip the sides if we are in RTL based on the computed reading direction of the target element.
  * @param ltrRootMargin the margin to be processed and flipped if required
@@ -88,12 +90,14 @@ export const useIntersectionObserver = (
     [ltrRootMargin, observerInit, options?.root],
   );
 
-  // Observer only dir attribute changes in the document
-  useMutationObserver(document, mutationObserverCallback, {
-    attributes: true,
-    subtree: true,
-    attributeFilter: ['dir'],
-  });
+  if (targetDocument) {
+    // Observer only dir attribute changes in the document
+    useMutationObserver(targetDocument, mutationObserverCallback, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: ['dir'],
+    });
+  }
 
   // Observer elements in passed in list and clean up previous list
   // This effect is only triggered when observerList is updated

--- a/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
@@ -6,7 +6,6 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 const { useCallback, useState, useRef } = React;
 import { useMutationObserver } from './useMutationObserver';
 
-const { targetDocument } = useFluent();
 /**
  * This function will take the rootMargin and flip the sides if we are in RTL based on the computed reading direction of the target element.
  * @param ltrRootMargin the margin to be processed and flipped if required
@@ -57,6 +56,7 @@ export const useIntersectionObserver = (
 } => {
   const observer = useRef<IntersectionObserver>();
   const [observerList, setObserverList] = useState<Element[]>();
+  const { targetDocument } = useFluent();
 
   // set the initial init with corrected margins based on the observed root's calculated reading direction.
   const [observerInit, setObserverInit] = useState<IntersectionObserverInit | undefined>(
@@ -90,14 +90,12 @@ export const useIntersectionObserver = (
     [ltrRootMargin, observerInit, options?.root],
   );
 
-  if (targetDocument) {
-    // Observer only dir attribute changes in the document
-    useMutationObserver(targetDocument, mutationObserverCallback, {
-      attributes: true,
-      subtree: true,
-      attributeFilter: ['dir'],
-    });
-  }
+  // Mutation observer for dir attribute changes in the document
+  useMutationObserver(targetDocument, mutationObserverCallback, {
+    attributes: true,
+    subtree: true,
+    attributeFilter: ['dir'],
+  });
 
   // Observer elements in passed in list and clean up previous list
   // This effect is only triggered when observerList is updated

--- a/packages/react-components/react-virtualizer/src/hooks/useMutationObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useMutationObserver.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 const { useRef, useEffect } = React;
 
 export const useMutationObserver = (
-  target: Element | Document,
+  target: Element | Document | undefined,
   callback: MutationCallback,
   options?: MutationObserverInit,
 ): {
@@ -18,8 +18,10 @@ export const useMutationObserver = (
   }, [callback]);
 
   useEffect(() => {
-    // Start observing the target node for configured mutations
-    observer.current?.observe(target, options);
+    if (target) {
+      // Start observing the target node for configured mutations
+      observer.current?.observe(target, options);
+    }
 
     return () => {
       observer.current?.disconnect();

--- a/packages/react-components/react-virtualizer/src/hooks/useMutationObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useMutationObserver.ts
@@ -1,0 +1,30 @@
+import type { MutableRefObject } from 'react';
+import * as React from 'react';
+
+const { useRef, useEffect } = React;
+
+export const useMutationObserver = (
+  target: Element | Document,
+  callback: MutationCallback,
+  options?: MutationObserverInit,
+): {
+  observer: MutableRefObject<MutationObserver | undefined>;
+} => {
+  const observer = useRef<MutationObserver>();
+
+  useEffect(() => {
+    // Create an observer instance linked to the callback function
+    observer.current = new MutationObserver(callback);
+  }, [callback]);
+
+  useEffect(() => {
+    // Start observing the target node for configured mutations
+    observer.current?.observe(target, options);
+
+    return () => {
+      observer.current?.disconnect();
+    };
+  }, [target, options]);
+
+  return { observer };
+};


### PR DESCRIPTION
## Previous Behavior
IO Margin could be flipped in RTL and was incorrectly calculated by Intersection Observer.

## New Behavior
IO Margin can now be flipped by RTL mutation and will correctly calculate margin positioning for IO events.
