### PR TITLE
feat: add helper functions and docs

### DIFF
--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -469,6 +469,9 @@ export interface IStyleSheetConfig {
 // @public
 export function keyframes(timeline: IKeyframes): string;
 
+// @public (undocumented)
+export const makeShadowConfig: (stylesheetKey: string, inShadow: boolean, window?: Window) => ShadowConfig;
+
 // Warning: (ae-forgotten-export) The symbol "IStyleOptions" needs to be exported by the entry point index.d.ts
 //
 // @public

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -39,7 +39,7 @@ export { setRTL } from './StyleOptionsState';
 
 export type { ObjectOnly } from './ObjectOnly';
 
-export { GLOBAL_STYLESHEET_KEY } from './shadowConfig';
+export { GLOBAL_STYLESHEET_KEY, makeShadowConfig } from './shadowConfig';
 export type { ShadowConfig } from './shadowConfig';
 
 import './version';

--- a/packages/merge-styles/src/shadowConfig.ts
+++ b/packages/merge-styles/src/shadowConfig.ts
@@ -14,6 +14,15 @@ export const DEFAULT_SHADOW_CONFIG: ShadowConfig = {
   __isShadowConfig__: true,
 } as const;
 
+export const makeShadowConfig = (stylesheetKey: string, inShadow: boolean, window?: Window): ShadowConfig => {
+  return {
+    stylesheetKey,
+    inShadow,
+    window,
+    __isShadowConfig__: true,
+  };
+};
+
 export const isShadowConfig = (obj: unknown): obj is ShadowConfig => {
   if (!obj) {
     return false;

--- a/packages/utilities/src/customizations/customizable.tsx
+++ b/packages/utilities/src/customizations/customizable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Customizations } from './Customizations';
 import { hoistStatics } from '../hoistStatics';
 import { CustomizerContext } from './CustomizerContext';
-import { concatStyleSets } from '@fluentui/merge-styles';
+import { concatStyleSets, makeShadowConfig } from '@fluentui/merge-styles';
 import type { ICustomizerContext } from './CustomizerContext';
 import { MergeStylesShadowRootConsumer } from '../shadowDom/MergeStylesShadowRootContext';
 import type { ShadowConfig } from '@fluentui/merge-styles';
@@ -56,14 +56,8 @@ export function customizable(
                       this._shadowConfig.stylesheetKey !== scope ||
                       this._shadowConfig.inShadow !== inShadow ||
                       this._shadowConfig.window !== win
-                      // false
                     ) {
-                      this._shadowConfig = {
-                        stylesheetKey: scope,
-                        inShadow,
-                        window: win,
-                        __isShadowConfig__: true,
-                      };
+                      this._shadowConfig = makeShadowConfig(scope, inShadow, win);
                     }
 
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/utilities/src/shadowDom/MergeStylesRootContext.tsx
+++ b/packages/utilities/src/shadowDom/MergeStylesRootContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GLOBAL_STYLESHEET_KEY, Stylesheet } from '@fluentui/merge-styles';
+import { GLOBAL_STYLESHEET_KEY, Stylesheet, makeShadowConfig } from '@fluentui/merge-styles';
 import { getWindow } from '../dom';
 
 declare global {
@@ -82,12 +82,8 @@ export const MergeStylesRootProvider: React.FC<MergeStylesRootProviderProps> = (
 
     let changed = false;
     const next = new Map<string, CSSStyleSheet>(stylesheets);
-    const sheet = Stylesheet.getInstance({
-      window: win,
-      inShadow: false,
-      stylesheetKey: GLOBAL_STYLESHEET_KEY,
-      __isShadowConfig__: true,
-    });
+    const sheet = Stylesheet.getInstance(makeShadowConfig(GLOBAL_STYLESHEET_KEY, false, win));
+
     sheet.forEachAdoptedStyleSheet((adoptedSheet, key) => {
       next.set(key, adoptedSheet);
       changed = true;

--- a/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
+++ b/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GLOBAL_STYLESHEET_KEY } from '@fluentui/merge-styles';
+import { GLOBAL_STYLESHEET_KEY, makeShadowConfig } from '@fluentui/merge-styles';
 import { FocusRectsProvider } from '../FocusRectsProvider';
 import { useMergeStylesRootStylesheets } from './MergeStylesRootContext';
 
@@ -80,7 +80,6 @@ const GlobalStyles: React.FC = props => {
 export const useAdoptedStylesheet = (stylesheetKey: string): boolean => {
   const shadowCtx = useMergeStylesShadowRootContext();
   const rootMergeStyles = useMergeStylesRootStylesheets();
-  // console.log('useAdoptedStylesheets', stylesheetKey);
 
   if (!shadowCtx) {
     return false;
@@ -111,4 +110,17 @@ export const useHasMergeStylesShadowRootContext = () => {
  */
 export const useMergeStylesShadowRootContext = () => {
   return React.useContext(MergeStylesShadowRootContext);
+};
+
+/**
+ * Get a shadow config.
+ * @param stylesheetKey - Globally unique key
+ * @param win - Reference to the `window` global.
+ * @returns ShadowConfig
+ */
+export const useShadowConfig = (stylesheetKey: string, win?: Window) => {
+  const inShadow = useHasMergeStylesShadowRootContext();
+  return React.useMemo(() => {
+    return makeShadowConfig(stylesheetKey, inShadow, win);
+  }, [stylesheetKey, inShadow, win]);
 };

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { concatStyleSetsWithProps } from '@fluentui/merge-styles';
-import { useAdoptedStylesheet, useHasMergeStylesShadowRootContext } from './shadowDom/MergeStylesShadowRootContext';
+import { useAdoptedStylesheet, useShadowConfig } from './shadowDom/MergeStylesShadowRootContext';
 import { useCustomizationSettings } from './customizations/useCustomizationSettings';
 import type { IStyleSet, IStyleFunctionOrObject, ShadowConfig } from '@fluentui/merge-styles';
 import { getWindow } from './dom/getWindow';
@@ -103,21 +103,7 @@ export function styled<
     const additionalProps = getProps ? getProps(props) : undefined;
 
     const win = useWindow() ?? getWindow();
-
-    const inShadow = useHasMergeStylesShadowRootContext();
-    const shadowConfig = React.useRef<ShadowConfig>({ stylesheetKey: scope, inShadow, __isShadowConfig__: true });
-    if (
-      shadowConfig.current.stylesheetKey !== scope ||
-      shadowConfig.current.inShadow !== inShadow ||
-      shadowConfig.current.window !== win
-    ) {
-      shadowConfig.current = {
-        stylesheetKey: scope,
-        inShadow,
-        window: win,
-        __isShadowConfig__: true,
-      };
-    }
+    const shadowConfig = useShadowConfig(scope, win);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cache = (styles.current && (styles.current as any).__cachedInputs__) || [];
@@ -143,7 +129,7 @@ export function styled<
       styles.current = concatenatedStyles as StyleFunction<TStyleProps, TStyleSet>;
     }
 
-    styles.current.__shadowConfig__ = shadowConfig.current;
+    styles.current.__shadowConfig__ = shadowConfig;
 
     useAdoptedStylesheet(scope);
 


### PR DESCRIPTION


## Previous Behavior

Working with shadow DOM APIs is harder than it needs to be and nothing is documented.

## New Behavior

Adds helper functions to simplify working with `merge-styles` shadow DOM APIs.

Adds documentation explaining basic usage of shadow DOM features.
