### PR TITLE
docs: Move MessageBar docs to stable section in docsite

### DIFF
--- a/packages/react-components/react-message-bar/stories/MessageBar/MessageBarDescription.md
+++ b/packages/react-components/react-message-bar/stories/MessageBar/MessageBarDescription.md
@@ -1,16 +1,3 @@
 Communicates important information about the state of the entire application or surface.
 For example, the status of a page, panel, dialog or card. The information shouldn't require someone
 to take immediate action, but should persist until the user performs one of the required actions.
-
-<!-- Don't allow prettier to collapse code block into single line -->
-<!-- prettier-ignore -->
-> **⚠️ Preview components are considered unstable:**
->
-> ```jsx
->
-> import { MessageBar } from '@fluentui/react-message-bar-preview';
->
-> ```
->
-> - Features and APIs may change before final release
-> - Please contact us if you intend to use this in your product

--- a/packages/react-components/react-message-bar/stories/MessageBar/index.stories.tsx
+++ b/packages/react-components/react-message-bar/stories/MessageBar/index.stories.tsx
@@ -19,7 +19,7 @@ export { Reflow } from './Reflow.stories';
 export { ManualLayout } from './ManualLayout.stories';
 
 export default {
-  title: 'Preview Components/MessageBar',
+  title: 'Components/MessageBar',
   component: MessageBar,
   subcomponents: {
     MessageBarGroup,


### PR DESCRIPTION
See title.

This manual step was added to #29510 to be automated