### PR TITLE
feat(TimePicker compat): new prop `formatDateToTimeString` to custom time display format

### DIFF
--- a/packages/react-components/react-timepicker-compat-preview/etc/react-timepicker-compat-preview.api.md
+++ b/packages/react-components/react-timepicker-compat-preview/etc/react-timepicker-compat-preview.api.md
@@ -19,16 +19,15 @@ export const TimePicker: ForwardRefComponent<TimePickerProps>;
 export const timePickerClassNames: SlotClassNames<TimePickerSlots>;
 
 // @public
-export type TimePickerProps = Omit<ComboboxProps, 'children' | 'defaultSelectedOptions' | 'multiselect' | 'onOptionSelect' | 'selectedOptions'> & {
-    hour12?: boolean;
+export type TimePickerProps = Omit<ComboboxProps, 'children' | 'defaultSelectedOptions' | 'multiselect' | 'onOptionSelect' | 'selectedOptions'> & TimeFormatOptions & {
     startHour?: Hour;
     endHour?: Hour;
     increment?: number;
     dateAnchor?: Date;
-    showSeconds?: boolean;
     selectedTime?: Date;
     defaultSelectedTime?: Date;
     onTimeSelect?: (event: TimeSelectionEvents, data: TimeSelectionData) => void;
+    formatDateToTimeString?: (date: Date) => string;
 };
 
 // @public (undocumented)
@@ -40,6 +39,7 @@ export type TimePickerState = ComboboxState;
 // @public (undocumented)
 export type TimeSelectionData = {
     selectedTime: Date | undefined;
+    selectedTimeText: string | undefined;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -52,6 +52,19 @@ export type TimePickerSlots = ComboboxSlots;
 export type TimeSelectionEvents = SelectionEvents;
 export type TimeSelectionData = {
   selectedTime: Date | undefined;
+  selectedTimeText: string | undefined;
+};
+
+export type TimeFormatOptions = {
+  /**
+   * If true, use 12-hour time format. Otherwise, use 24-hour format.
+   */
+  hour12?: boolean;
+
+  /**
+   * If true, show seconds in the dropdown options and consider seconds for default validation purposes.
+   */
+  showSeconds?: boolean;
 };
 
 /**
@@ -66,52 +79,48 @@ export type TimePickerProps = Omit<
   | 'multiselect'
   | 'onOptionSelect'
   | 'selectedOptions'
-> & {
-  /**
-   * If true, use 12-hour time format. Otherwise, use 24-hour format.
-   */
-  hour12?: boolean;
+> &
+  TimeFormatOptions & {
+    /**
+     * Start hour (inclusive) for the time range, 0-24.
+     */
+    startHour?: Hour;
 
-  /**
-   * Start hour (inclusive) for the time range, 0-24.
-   */
-  startHour?: Hour;
+    /**
+     * End hour (exclusive) for the time range, 0-24.
+     */
+    endHour?: Hour;
 
-  /**
-   * End hour (exclusive) for the time range, 0-24.
-   */
-  endHour?: Hour;
+    /**
+     * Time increment, in minutes, of the options in the dropdown.
+     */
+    increment?: number;
 
-  /**
-   * Time increment, in minutes, of the options in the dropdown.
-   */
-  increment?: number;
+    /**
+     * The date in which all dropdown options are based off of.
+     */
+    dateAnchor?: Date;
 
-  /**
-   * The date in which all dropdown options are based off of.
-   */
-  dateAnchor?: Date;
+    /**
+     * Currently selected time in the TimePicker.
+     */
+    selectedTime?: Date;
 
-  /**
-   * If true, show seconds in the dropdown options and consider seconds for default validation purposes.
-   */
-  showSeconds?: boolean;
+    /**
+     * Default selected time in the TimePicker, for uncontrolled scenarios.
+     */
+    defaultSelectedTime?: Date;
 
-  /**
-   * Currently selected time in the TimePicker.
-   */
-  selectedTime?: Date;
+    /**
+     * Callback for when a time selection is made.
+     */
+    onTimeSelect?: (event: TimeSelectionEvents, data: TimeSelectionData) => void;
 
-  /**
-   * Default selected time in the TimePicker, for uncontrolled scenarios.
-   */
-  defaultSelectedTime?: Date;
-
-  /**
-   * Callback for when a time selection is made.
-   */
-  onTimeSelect?: (event: TimeSelectionEvents, data: TimeSelectionData) => void;
-};
+    /**
+     * Custom the date strings displayed (in dropdown options and input).
+     */
+    formatDateToTimeString?: (date: Date) => string;
+  };
 
 /**
  * State used in rendering TimePicker

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.test.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.test.ts
@@ -1,7 +1,7 @@
 import {
   dateToKey,
   keyToDate,
-  formatTimeString,
+  formatDateToTimeString,
   getDateEndAnchor,
   getDateStartAnchor,
   getTimesBetween,
@@ -65,24 +65,37 @@ describe('Time Utilities', () => {
     });
   });
 
-  describe('formatTimeString', () => {
+  describe('formatDateToTimeString', () => {
     const testDate = new Date(2023, 9, 6, 23, 45, 12);
 
     it('should format time in 24-hour format without seconds', () => {
-      expect(formatTimeString(testDate)).toBe('23:45');
+      expect(formatDateToTimeString(testDate)).toBe('23:45');
     });
 
     it('should format time in 24-hour format with seconds', () => {
-      expect(formatTimeString(testDate, true)).toBe('23:45:12');
+      expect(formatDateToTimeString(testDate, { showSeconds: true })).toBe('23:45:12');
     });
 
     it('should format time in 12-hour format with seconds', () => {
-      expect(formatTimeString(testDate, true, true)).toBe('11:45:12 PM');
+      expect(formatDateToTimeString(testDate, { showSeconds: true, hour12: true })).toBe('11:45:12 PM');
     });
 
     it('should format midnight correctly in 24-hour format', () => {
       const midnight = new Date(2023, 9, 7, 0, 0, 0);
-      expect(formatTimeString(midnight)).toBe('00:00');
+      expect(formatDateToTimeString(midnight)).toBe('00:00');
+    });
+
+    it('should format time in Japanese locale', () => {
+      const { toLocaleTimeString } = Date.prototype;
+      const toLocaleTimeStringMock = jest.spyOn(Date.prototype, 'toLocaleTimeString');
+      // Mock toLocaleTimeString to simulate running in a Japanese locale
+      toLocaleTimeStringMock.mockImplementation(function (this: Date, _locales, options) {
+        return toLocaleTimeString.call(this, 'ja-JP', options);
+      });
+
+      expect(formatDateToTimeString(testDate, { showSeconds: true, hour12: true })).toBe('午後11:45:12');
+
+      toLocaleTimeStringMock.mockClear();
     });
   });
 

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.ts
@@ -1,3 +1,5 @@
+import type { TimeFormatOptions } from './TimePicker.types';
+
 function isValidDate(date: Date): boolean {
   return !isNaN(date.getTime());
 }
@@ -28,20 +30,22 @@ export function keyToDate(key: string): Date | undefined {
 }
 
 /**
- * Formats a Date object into a localized time string based on the provided parameters.
+ * Formats a Date object into a time string based on provided options.
  *
  * @param date - The Date object to be formatted.
- * @param showSeconds - Indicates whether seconds should be included in the formatted string.
- * @param hour12 - If true, the time will be formatted in 12-hour format. Otherwise, it will use a 24-hour format.
- * @returns - A formatted time string.
+ * @param options - Formatting options. It has two properties:
+ *      1. hour12 (default: false): Determines if the time format should be 12-hour (AM/PM) or 24-hour.
+ *      2. showSeconds (default: false): Determines if the seconds should be included in the formatted string.
+ * @returns Formatted time string based on the given options.
  *
  * @example
  * const date = new Date(2023, 9, 6, 23, 45, 12);
- * formatTimeString(date);           // Returns "23:45"
- * formatTimeString(date, true);     // Returns "23:45:12"
- * formatTimeString(date, true, true); // Returns "11:45:12 PM"
+ * formatDateToTimeString(date);                         // Returns "23:45"
+ * formatDateToTimeString(date, { showSeconds: true });  // Returns "23:45:12"
+ * formatDateToTimeString(date, { hour12: true, showSeconds: true }); // Returns "11:45:12 PM"
  */
-export function formatTimeString(date: Date, showSeconds: boolean = false, hour12: boolean = false): string {
+export function formatDateToTimeString(date: Date, options: TimeFormatOptions = {}): string {
+  const { hour12 = false, showSeconds = false } = options;
   const timeFormatOptions: Intl.DateTimeFormatOptions = {
     hour: 'numeric',
     minute: '2-digit',

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -5,7 +5,7 @@ import { ComboboxProps, useCombobox_unstable, Option } from '@fluentui/react-com
 import {
   dateToKey,
   keyToDate,
-  formatTimeString,
+  formatDateToTimeString as defaultFormatDateToTimeString,
   getDateStartAnchor,
   getDateEndAnchor,
   getTimesBetween,
@@ -29,6 +29,7 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     endHour = 24,
     hour12 = false,
     increment = 30,
+    formatDateToTimeString,
     onTimeSelect,
     selectedTime: selectedTimeInProps,
     showSeconds = false,
@@ -42,14 +43,21 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     endHour,
   );
 
+  const dateToText = React.useCallback(
+    (dateTime: Date) =>
+      formatDateToTimeString
+        ? formatDateToTimeString(dateTime)
+        : defaultFormatDateToTimeString(dateTime, { showSeconds, hour12 }),
+    [hour12, formatDateToTimeString, showSeconds],
+  );
   const options: TimePickerOption[] = React.useMemo(
     () =>
       getTimesBetween(dateStartAnchor, dateEndAnchor, increment).map(time => ({
         date: time,
         key: dateToKey(time),
-        text: formatTimeString(time, showSeconds, hour12),
+        text: dateToText(time),
       })),
-    [dateStartAnchor, dateEndAnchor, increment, showSeconds, hour12],
+    [dateStartAnchor, dateEndAnchor, increment, dateToText],
   );
 
   const [selectedTime, setSelectedTime] = useControllableState<Date | undefined>({
@@ -65,7 +73,10 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
 
   const handleOptionSelect: ComboboxProps['onOptionSelect'] = React.useCallback(
     (e, data) => {
-      const timeSelectionData: TimeSelectionData = { selectedTime: keyToDate(data.optionValue) };
+      const timeSelectionData: TimeSelectionData = {
+        selectedTime: keyToDate(data.optionValue),
+        selectedTimeText: data.optionText,
+      };
       onTimeSelect?.(e, timeSelectionData);
       setSelectedTime(timeSelectionData.selectedTime);
     },

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerCustomTimeString.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerCustomTimeString.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
+
+export const CustomTimeString = () => {
+  const [anchor] = React.useState(new Date(2023, 1, 1, 12, 0, 0, 0));
+  const formatDate = React.useCallback((date: Date) => `Custom prefix + ${date.toLocaleTimeString()}`, []);
+  return <TimePicker startHour={8} endHour={20} dateAnchor={anchor} formatDateToTimeString={formatDate} />;
+};
+
+CustomTimeString.parameters = {
+  docs: {
+    description: {
+      story: 'The time display format can be customized using `formatDateToTimeString`.',
+    },
+  },
+};

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/index.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/index.stories.tsx
@@ -4,6 +4,7 @@ import descriptionMd from './TimePickerDescription.md';
 import bestPracticesMd from './TimePickerBestPractices.md';
 
 export { Default } from './TimePickerDefault.stories';
+export { CustomTimeString } from './TimePickerCustomTimeString.stories';
 
 export default {
   title: 'Preview Components/TimePicker',


### PR DESCRIPTION
Add a new prop `formatDateToTimeString` that allows custom time display format:
<img width="324" alt="Screenshot 2023-10-13 at 10 18 25" src="https://github.com/microsoft/fluentui/assets/28751745/7912ab4d-944e-4fcc-9c09-b261f8319933">
