### PR TITLE
fix(react-swatch-picker): mismatch dependencies

### DIFF
--- a/packages/react-components/react-swatch-picker-preview/package.json
+++ b/packages/react-components/react-swatch-picker-preview/package.json
@@ -31,7 +31,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-jsx-runtime": "^9.0.16",
+    "@fluentui/react-jsx-runtime": "^9.0.17",
     "@fluentui/react-theme": "^9.1.14",
     "@fluentui/react-utilities": "^9.15.0",
     "@griffel/react": "^1.5.14",


### PR DESCRIPTION
Fix dependencies after releasing a new v9 version