### PR TITLE
bugfix(react-tree): stop coercing numbers to string on TreeItemValue

### DIFF
--- a/change/@fluentui-react-tree-006fbe59-9dfe-471f-aab7-99f77c1fb4f2.json
+++ b/change/@fluentui-react-tree-006fbe59-9dfe-471f-aab7-99f77c1fb4f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix(react-tree): stop coercing numbers to string on TreeItemValue",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -8,7 +8,7 @@ import {
   slot,
   elementContains,
 } from '@fluentui/react-utilities';
-import type { TreeItemProps, TreeItemState } from './TreeItem.types';
+import type { TreeItemProps, TreeItemState, TreeItemValue } from './TreeItem.types';
 import { Space } from '@fluentui/keyboard-keys';
 import { treeDataTypes } from '../../utils/tokens';
 import { useTreeContext_unstable, useSubtreeContext_unstable, useTreeItemContext_unstable } from '../../contexts';
@@ -34,7 +34,8 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
 
   // note, if the value is not externally provided,
   // then selection and expansion will not work properly
-  const value = useId('fuiTreeItemValue-', props.value?.toString());
+  const internalValue = useId('fuiTreeItemValue-');
+  const value: TreeItemValue = props.value ?? internalValue;
 
   const {
     onClick,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`TreeItem` internally converts `props.value` to string

## New Behavior

Stops converting `props.value` to string and keep it as is.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29528
