### PR TITLE
doc(react-dialog): update Dialog documentation on trigger outside of dialog

### DIFF
--- a/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.md
@@ -1,3 +1,6 @@
-When using a `Dialog` without a `DialogTrigger`, it is up to the user to make sure that the focus is restored correctly
-when the dialog is closed. This can be done quite easily by using the `useRestoreFocusTarget` hook. The `Dialog` already
-uses the `useRestoreFocusSource` hook directly, which will restore focus to the most recently focused target on close.
+When using a `Dialog` without a `DialogTrigger` (or when using a `DialogTrigger` outside of a `Dialog`), it becomes your responsibility to control some of the dialog's behavior.
+
+1. You must make sure that the `open` state is set accordingly to the dialog's visibility (mostly this means to properly react to the events provided by `onOpenChange` callback on `Dialog` component).
+2. You must make sure that focus is properly restored once the dialog is closed (this can be achieved by using the `useRestoreFocusTarget` hook, or by manually invoking `.focus()` on the target element).
+
+The example bellow showcases both explicit responsibilities:

--- a/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogTriggerOutsideDialog.stories.tsx
@@ -19,8 +19,10 @@ export const TriggerOutsideDialog = () => {
   return (
     <>
       <Button
+        // restoreFocusTargetAttribute ensures that focus is restored to this button when the dialog closes
         {...restoreFocusTargetAttribute}
         onClick={() => {
+          // it is the user responsibility to open the dialog
           setOpen(true);
         }}
       >
@@ -28,8 +30,10 @@ export const TriggerOutsideDialog = () => {
       </Button>
 
       <Dialog
+        // this controls the dialog open state
         open={open}
         onOpenChange={(event, data) => {
+          // it is the users responsibility to react accordingly to the open state change
           setOpen(data.open);
         }}
       >
@@ -43,6 +47,7 @@ export const TriggerOutsideDialog = () => {
             </DialogContent>
 
             <DialogActions>
+              {/* DialogTrigger inside of a Dialog still works properly */}
               <DialogTrigger disableButtonEnhancement>
                 <Button appearance="secondary">Close</Button>
               </DialogTrigger>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Updates the documentation to make it more clear that it is the user's responsibility to update open state once dialog is controlled by the user

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29516
