### PR TITLE
chore(react-swatch-picker-preview): migrate from getNativeElementProps to getIntrinsicElementProps

### DIFF
--- a/packages/react-components/react-swatch-picker-preview/etc/react-swatch-picker-preview.api.md
+++ b/packages/react-components/react-swatch-picker-preview/etc/react-swatch-picker-preview.api.md
@@ -32,7 +32,7 @@ export type SwatchPickerSlots = {
 export type SwatchPickerState = ComponentState<SwatchPickerSlots>;
 
 // @public
-export const useSwatchPicker_unstable: (props: SwatchPickerProps, ref: React_2.Ref<HTMLElement>) => SwatchPickerState;
+export const useSwatchPicker_unstable: (props: SwatchPickerProps, ref: React_2.Ref<HTMLDivElement>) => SwatchPickerState;
 
 // @public
 export const useSwatchPickerStyles_unstable: (state: SwatchPickerState) => SwatchPickerState;

--- a/packages/react-components/react-swatch-picker-preview/src/components/SwatchPicker/useSwatchPicker.ts
+++ b/packages/react-components/react-swatch-picker-preview/src/components/SwatchPicker/useSwatchPicker.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeElementProps, slot } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { SwatchPickerProps, SwatchPickerState } from './SwatchPicker.types';
 
 /**
@@ -11,7 +11,10 @@ import type { SwatchPickerProps, SwatchPickerState } from './SwatchPicker.types'
  * @param props - props from this instance of SwatchPicker
  * @param ref - reference to root HTMLElement of SwatchPicker
  */
-export const useSwatchPicker_unstable = (props: SwatchPickerProps, ref: React.Ref<HTMLElement>): SwatchPickerState => {
+export const useSwatchPicker_unstable = (
+  props: SwatchPickerProps,
+  ref: React.Ref<HTMLDivElement>,
+): SwatchPickerState => {
   return {
     // TODO add appropriate props/defaults
     components: {
@@ -21,7 +24,7 @@ export const useSwatchPicker_unstable = (props: SwatchPickerProps, ref: React.Re
     // TODO add appropriate slots, for example:
     // mySlot: resolveShorthand(props.mySlot),
     root: slot.always(
-      getNativeElementProps('div', {
+      getIntrinsicElementProps('div', {
         ref,
         ...props,
       }),


### PR DESCRIPTION
## New Behavior

Follow up on https://github.com/microsoft/fluentui/pull/29310

`getNativeElementProps` has some type safety issues, allowing erroneous properties to be introduced.

1. replaces use cases of `getNativeElementProps` with an equivalent but more restrict method `getIntrinsicElementProps`