### PR TITLE
feat(react-calendar-compat): Add missing Calendar exports and docs about compat components

### DIFF
--- a/packages/react-components/react-calendar-compat/README.md
+++ b/packages/react-components/react-calendar-compat/README.md
@@ -1,5 +1,46 @@
 # @fluentui/react-calendar-compat
 
-**React Calendar components for [Fluent UI React](https://react.fluentui.dev/)**
+**React Calendar component for [Fluent UI React](https://react.fluentui.dev/)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+The calendar control lets people select and view a single date or a range of dates in their calendar. It’s made up of 3 separate views: the month view, year view, and decade view.
+
+## Usage
+
+To import Calendar:
+
+```js
+import { Calendar } from '@fluentui/react-calendar-compat';
+```
+
+### Examples
+
+```jsx
+<Calendar />
+```
+
+Alternatively, run Storybook locally with:
+
+```sh
+yarn workspace @fluentui/react-calendar-compat start
+```
+
+# Compat components
+
+## What makes a compat component?
+
+A compat component is a component taken from v8 and partially updated with the v9 toolset while keeping its original functionality and most of the original API surface. The most noticeable change being the removal of all v8 dependencies and using only v9 dependencies. While this is a good first step, this is not the final v9 component. We are working on a fully fleshed v9 replacement that will follow all v9 patterns and conventions.
+
+## How publishing the package will be handled
+
+Compat components are not added in the `@fluentui/react-components` package suite. Instead, these components should be imported from their respective package as shown above. In contrast with components that live in `@fluentui/react-components`, compat components are to be released as `0.x.1` and there won't be an unstable release (`beta/alpha`) before this release. This is due to the way we will handle versioning for changes, allowing for breaking changes when necessary.
+
+### Versioning for changes
+
+We will take a similar approach as v0 where we will follow this pattern:
+
+- `breaking change (major)`: Since this is a compat component, we will allow breaking changes if absolutely necessary. To accommodate for this, we will denote those changes as a minor version in semver, i.e. `0.(change will be reflected here).x`.
+- `minor and patch`: These changes will be reflected in the patch version in semver as `0.x.(change will be reflected here)`.
+
+## Calendar compat Slots API special case
+
+Due to time constraints, Calendar compat is a special case for compat components. We are not moving the API to our slots API. Calendar is extracted from DatePicker compat and moved to this package as is.

--- a/packages/react-components/react-calendar-compat/etc/react-calendar-compat.api.md
+++ b/packages/react-components/react-calendar-compat/etc/react-calendar-compat.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import * as React_2 from 'react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
 export function addDays(date: Date, days: number): Date;
@@ -27,6 +28,84 @@ export enum AnimationDirection {
 // @internal (undocumented)
 export const Calendar: React_2.FunctionComponent<CalendarProps>;
 
+// @internal (undocumented)
+export const calendarClassNames: SlotClassNames<CalendarStyles>;
+
+// @internal (undocumented)
+export const CalendarDay: React_2.FunctionComponent<CalendarDayProps>;
+
+// @internal (undocumented)
+export const calendarDayClassNames: SlotClassNames<CalendarDayStyles>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "CalendarDayGrid" is marked as @public, but its signature references "CalendarDayGridProps" which is marked as @internal
+//
+// @public (undocumented)
+export const CalendarDayGrid: React_2.FunctionComponent<CalendarDayGridProps>;
+
+// @internal (undocumented)
+export const calendarDayGridClassNames: SlotClassNames<CalendarDayGridStyles>;
+
+// @internal (undocumented)
+export interface CalendarDayGridProps extends DayGridOptions {
+    allFocusable?: boolean;
+    animationDirection?: AnimationDirection;
+    className?: string;
+    componentRef?: React_2.RefObject<ICalendarDayGrid>;
+    customDayCellRef?: (element: HTMLElement, date: Date, classNames: CalendarDayGridStyles) => void;
+    dateRangeType: DateRangeType;
+    dateTimeFormatter: DateFormatting;
+    daysToSelectInDayView?: number;
+    firstDayOfWeek: DayOfWeek;
+    firstWeekOfYear: FirstWeekOfYear;
+    getMarkedDays?: (startingDate: Date, endingDate: Date) => Date[];
+    labelledBy?: string;
+    lightenDaysOutsideNavigatedMonth?: boolean;
+    maxDate?: Date;
+    minDate?: Date;
+    navigatedDate: Date;
+    onDismiss?: () => void;
+    onNavigateDate: (date: Date, focusOnNavigatedDay: boolean) => void;
+    onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
+    restrictedDates?: Date[];
+    selectedDate: Date;
+    showCloseButton?: boolean;
+    showWeekNumbers?: boolean;
+    strings: CalendarStrings;
+    today?: Date;
+    weeksToShow?: number;
+    workWeekDays?: DayOfWeek[];
+}
+
+// @internal (undocumented)
+export interface CalendarDayGridStyleProps {
+    animateBackwards?: boolean;
+    animationDirection?: AnimationDirection;
+    className?: string;
+    dateRangeType?: DateRangeType;
+    lightenDaysOutsideNavigatedMonth?: boolean;
+    showWeekNumbers?: boolean;
+}
+
+// @internal (undocumented)
+export interface CalendarDayGridStyles {
+    dayButton?: string;
+    dayCell?: string;
+    dayIsToday?: string;
+    dayMarker?: string;
+    dayOutsideBounds?: string;
+    dayOutsideNavigatedMonth?: string;
+    daySelected?: string;
+    firstTransitionWeek?: string;
+    lastTransitionWeek?: string;
+    table?: string;
+    weekDayLabelCell?: string;
+    weekNumberCell?: string;
+    weekRow?: string;
+    wrapper?: string;
+}
+
+// Warning: (ae-incompatible-release-tags) The symbol "CalendarDayProps" is marked as @public, but its signature references "CalendarDayGridProps" which is marked as @internal
+//
 // @public (undocumented)
 export interface CalendarDayProps extends CalendarDayGridProps {
     allFocusable?: boolean;
@@ -45,6 +124,26 @@ export interface CalendarDayProps extends CalendarDayGridProps {
     showWeekNumbers?: boolean;
     strings: CalendarStrings;
 }
+
+// @internal (undocumented)
+export interface CalendarDayStyleProps extends CalendarDayGridStyleProps {
+    className?: string;
+    headerIsClickable?: boolean;
+    showWeekNumbers?: boolean;
+}
+
+// @internal (undocumented)
+export interface CalendarDayStyles {
+    disabledStyle: string;
+    header: string;
+    headerIconButton: string;
+    monthAndYear: string;
+    monthComponents: string;
+    root: string;
+}
+
+// @internal (undocumented)
+export const CalendarMonth: React_2.FunctionComponent<CalendarMonthProps>;
 
 // @public (undocumented)
 export interface CalendarMonthProps {
@@ -65,6 +164,52 @@ export interface CalendarMonthProps {
     strings: CalendarStrings;
     today?: Date;
     yearPickerHidden?: boolean;
+}
+
+// @internal (undocumented)
+export interface CalendarMonthStyleProps extends CalendarPickerStyleProps {
+}
+
+// @internal (undocumented)
+export interface CalendarMonthStyles extends CalendarPickerStyles {
+}
+
+// @internal (undocumented)
+export const calendarPickerClassNames: SlotClassNames<CalendarPickerStyles>;
+
+// @internal (undocumented)
+export interface CalendarPickerStyleProps {
+    animateBackwards?: boolean;
+    animationDirection?: AnimationDirection;
+    className?: string;
+    hasHeaderClickCallback?: boolean;
+    highlightCurrent?: boolean;
+    highlightSelected?: boolean;
+}
+
+// @internal (undocumented)
+export interface CalendarPickerStyles {
+    // (undocumented)
+    buttonRow: string;
+    // (undocumented)
+    current: string;
+    // (undocumented)
+    currentItemButton: string;
+    // (undocumented)
+    disabled: string;
+    // (undocumented)
+    gridContainer: string;
+    // (undocumented)
+    headerContainer: string;
+    // (undocumented)
+    itemButton: string;
+    // (undocumented)
+    navigationButton: string;
+    // (undocumented)
+    navigationButtonsContainer: string;
+    root: string;
+    // (undocumented)
+    selected: string;
 }
 
 // @public (undocumented)
@@ -117,6 +262,95 @@ export interface CalendarStrings extends DateGridStrings {
     yearPickerHeaderAriaLabel?: string;
 }
 
+// @internal (undocumented)
+export interface CalendarStyleProps {
+    className?: string;
+    isDayPickerVisible?: boolean;
+    isMonthPickerVisible?: boolean;
+    monthPickerOnly?: boolean;
+    overlaidWithButton?: boolean;
+    // @deprecated (undocumented)
+    overlayedWithButton?: boolean;
+    showGoToToday?: boolean;
+    showMonthPickerAsOverlay?: boolean;
+    showWeekNumbers?: boolean;
+}
+
+// @internal (undocumented)
+export interface CalendarStyles {
+    // (undocumented)
+    divider: string;
+    // (undocumented)
+    goTodayButton: string;
+    // (undocumented)
+    liveRegion: string;
+    // (undocumented)
+    monthPickerWrapper: string;
+    root: string;
+}
+
+// @internal (undocumented)
+export const CalendarYear: React_2.FunctionComponent<CalendarYearProps>;
+
+// @internal (undocumented)
+export interface CalendarYearHeaderProps extends CalendarYearProps, CalendarYearRange {
+    animateBackwards?: boolean;
+    onSelectNext?: () => void;
+    onSelectPrev?: () => void;
+}
+
+// @internal (undocumented)
+export interface CalendarYearProps {
+    animationDirection?: AnimationDirection;
+    className?: string;
+    componentRef?: React_2.RefObject<ICalendarYear>;
+    highlightCurrentYear?: boolean;
+    highlightSelectedYear?: boolean;
+    maxYear?: number;
+    minYear?: number;
+    navigatedYear?: number;
+    onHeaderSelect?: (focus: boolean) => void;
+    onRenderTitle?: (props: CalendarYearHeaderProps) => React_2.ReactNode;
+    onRenderYear?: (year: number) => React_2.ReactNode;
+    onSelectYear?: (year: number) => void;
+    selectedYear?: number;
+    strings?: CalendarYearStrings;
+}
+
+// @internal (undocumented)
+export interface CalendarYearRange {
+    // (undocumented)
+    fromYear: number;
+    // (undocumented)
+    toYear: number;
+}
+
+// @internal (undocumented)
+export interface CalendarYearRangeToString {
+    // (undocumented)
+    (range: CalendarYearRange): string;
+}
+
+// @internal (undocumented)
+export interface CalendarYearStrings {
+    // (undocumented)
+    headerAriaLabelFormatString?: string;
+    // (undocumented)
+    nextRangeAriaLabel?: string | CalendarYearRangeToString;
+    // (undocumented)
+    prevRangeAriaLabel?: string | CalendarYearRangeToString;
+    // (undocumented)
+    rangeAriaLabel?: string | CalendarYearRangeToString;
+}
+
+// @internal (undocumented)
+export interface CalendarYearStyleProps extends CalendarPickerStyleProps {
+}
+
+// @internal (undocumented)
+export interface CalendarYearStyles extends CalendarPickerStyles {
+}
+
 // @public
 export function compareDatePart(date1: Date, date2: Date): Number;
 
@@ -152,6 +386,14 @@ export enum DateRangeType {
     WorkWeek = 3
 }
 
+// @public (undocumented)
+export interface DayInfo extends Day {
+    // (undocumented)
+    onSelected: () => void;
+    // (undocumented)
+    setRef(element: HTMLElement | null): void;
+}
+
 // @public
 export enum DayOfWeek {
     // (undocumented)
@@ -172,6 +414,24 @@ export enum DayOfWeek {
 
 // @public (undocumented)
 export const DAYS_IN_WEEK = 7;
+
+// @public (undocumented)
+export const DEFAULT_CALENDAR_STRINGS: CalendarStrings;
+
+// @public (undocumented)
+export const DEFAULT_DATE_FORMATTING: DateFormatting;
+
+// @public (undocumented)
+export const DEFAULT_DATE_GRID_STRINGS: DateGridStrings;
+
+// @public (undocumented)
+export const defaultCalendarStrings: CalendarStrings;
+
+// @internal (undocumented)
+export const extraCalendarDayGridClassNames: {
+    hoverStyle: string;
+    pressedStyle: string;
+};
 
 // @public
 export enum FirstWeekOfYear {
@@ -224,8 +484,20 @@ export interface ICalendarDay {
     focus(): void;
 }
 
+// @internal (undocumented)
+export interface ICalendarDayGrid {
+    // (undocumented)
+    focus(): void;
+}
+
 // @public (undocumented)
 export interface ICalendarMonth {
+    // (undocumented)
+    focus(): void;
+}
+
+// @internal (undocumented)
+export interface ICalendarYear {
     // (undocumented)
     focus(): void;
 }
@@ -280,6 +552,30 @@ export const TimeConstants: {
     OffsetTo24HourFormat: number;
     TimeFormatRegex: RegExp;
 };
+
+// @internal
+export const useCalendarDayGridStyles_unstable: (props: CalendarDayGridStyleProps) => CalendarDayGridStyles;
+
+// @internal
+export const useCalendarDayStyles_unstable: (props: CalendarDayStyleProps) => CalendarDayStyles;
+
+// @internal
+export const useCalendarMonthStyles_unstable: (props: CalendarMonthStyleProps) => CalendarMonthStyles;
+
+// @internal
+export const useCalendarPickerStyles_unstable: (props: CalendarPickerStyleProps) => CalendarPickerStyles;
+
+// @internal
+export const useCalendarStyles_unstable: (props: CalendarStyleProps) => CalendarStyles;
+
+// @internal
+export const useCalendarYearStyles_unstable: (props: CalendarYearStyleProps) => CalendarYearStyles;
+
+// @internal (undocumented)
+export interface WeekCorners {
+    // (undocumented)
+    [key: string]: string;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-calendar-compat/src/index.ts
+++ b/packages/react-components/react-calendar-compat/src/index.ts
@@ -1,15 +1,55 @@
-export { AnimationDirection } from './Calendar';
-export { Calendar } from './Calendar';
-export type { CalendarProps, ICalendar } from './Calendar';
+export {
+  AnimationDirection,
+  Calendar,
+  calendarClassNames,
+  defaultCalendarStrings,
+  useCalendarStyles_unstable,
+} from './Calendar';
+export type { CalendarProps, CalendarStyleProps, CalendarStyles, ICalendar } from './Calendar';
 
-export type { CalendarDayProps, ICalendarDay } from './CalendarDay';
+export { CalendarDay, calendarDayClassNames, useCalendarDayStyles_unstable } from './CalendarDay';
+export type { CalendarDayProps, CalendarDayStyleProps, CalendarDayStyles, ICalendarDay } from './CalendarDay';
 
-export type { CalendarMonthProps, ICalendarMonth } from './CalendarMonth';
+export {
+  CalendarDayGrid,
+  calendarDayGridClassNames,
+  extraCalendarDayGridClassNames,
+  useCalendarDayGridStyles_unstable,
+} from './CalendarDayGrid';
+export type {
+  CalendarDayGridProps,
+  CalendarDayGridStyleProps,
+  CalendarDayGridStyles,
+  DayInfo,
+  ICalendarDayGrid,
+  WeekCorners,
+} from './CalendarDayGrid';
+
+export { CalendarMonth, useCalendarMonthStyles_unstable } from './CalendarMonth';
+export type { CalendarMonthProps, CalendarMonthStyleProps, CalendarMonthStyles, ICalendarMonth } from './CalendarMonth';
+
+export { calendarPickerClassNames, useCalendarPickerStyles_unstable } from './CalendarPicker';
+export type { CalendarPickerStyleProps, CalendarPickerStyles } from './CalendarPicker';
+
+export { CalendarYear, useCalendarYearStyles_unstable } from './CalendarYear';
+export type {
+  CalendarYearHeaderProps,
+  CalendarYearProps,
+  CalendarYearRange,
+  CalendarYearRangeToString,
+  CalendarYearStrings,
+  CalendarYearStyleProps,
+  CalendarYearStyles,
+  ICalendarYear,
+} from './CalendarYear';
 
 export {
   DAYS_IN_WEEK,
   DateRangeType,
   DayOfWeek,
+  DEFAULT_CALENDAR_STRINGS,
+  DEFAULT_DATE_GRID_STRINGS,
+  DEFAULT_DATE_FORMATTING,
   FirstWeekOfYear,
   MonthOfYear,
   TimeConstants,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

There were missing exports from the Calendar components.

## New Behavior

All missing exports have been added to the Calendar compat package.

There's now docs about the compat components and specifically the case of Calendar not moving to slots API. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29538
- Fixes #29541
