### PR TITLE
feat(react-infolabel-preview): Copy over files from react-infobutton to react-infolabel-preview

### DIFF
--- a/packages/react-components/react-infolabel-preview/etc/react-infolabel-preview.api.md
+++ b/packages/react-components/react-infolabel-preview/etc/react-infolabel-preview.api.md
@@ -4,6 +4,48 @@
 
 ```ts
 
+/// <reference types="react" />
+
+import type { ComponentProps } from '@fluentui/react-utilities';
+import type { ComponentState } from '@fluentui/react-utilities';
+import { ForwardRefComponent } from '@fluentui/react-utilities';
+import { Label } from '@fluentui/react-label';
+import type { PopoverProps } from '@fluentui/react-popover';
+import type { PopoverSurface } from '@fluentui/react-popover';
+import * as React_2 from 'react';
+import type { Slot } from '@fluentui/react-utilities';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+// @public
+export const InfoLabel: ForwardRefComponent<InfoLabelProps>;
+
+// @public (undocumented)
+export const infoLabelClassNames: SlotClassNames<InfoLabelSlots>;
+
+// @public
+export type InfoLabelProps = ComponentProps<Partial<InfoLabelSlots>, 'label'> & {
+    info?: InfoButtonProps['info'];
+};
+
+// @public (undocumented)
+export type InfoLabelSlots = {
+    root: NonNullable<Slot<'span'>>;
+    label: NonNullable<Slot<typeof Label>>;
+    infoButton: Slot<typeof InfoButton>;
+};
+
+// @public
+export type InfoLabelState = ComponentState<InfoLabelSlots> & Pick<InfoLabelProps, 'size'>;
+
+// @public
+export const renderInfoLabel_unstable: (state: InfoLabelState) => JSX.Element;
+
+// @public
+export const useInfoLabel_unstable: (props: InfoLabelProps, ref: React_2.Ref<HTMLLabelElement>) => InfoLabelState;
+
+// @public
+export const useInfoLabelStyles_unstable: (state: InfoLabelState) => InfoLabelState;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-infolabel-preview/package.json
+++ b/packages/react-components/react-infolabel-preview/package.json
@@ -31,6 +31,10 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
+    "@fluentui/react-icons": "^2.0.217",
+    "@fluentui/react-label": "^9.1.45",
+    "@fluentui/react-popover": "^9.8.15",
+    "@fluentui/react-tabster": "^9.13.6",
     "@fluentui/react-jsx-runtime": "^9.0.17",
     "@fluentui/react-theme": "^9.1.14",
     "@fluentui/react-utilities": "^9.15.0",

--- a/packages/react-components/react-infolabel-preview/src/InfoButton.ts
+++ b/packages/react-components/react-infolabel-preview/src/InfoButton.ts
@@ -1,0 +1,1 @@
+export * from './components/InfoButton/index';

--- a/packages/react-components/react-infolabel-preview/src/InfoLabel.ts
+++ b/packages/react-components/react-infolabel-preview/src/InfoLabel.ts
@@ -1,0 +1,1 @@
+export * from './components/InfoLabel/index';

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/DefaultInfoButtonIcons.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/DefaultInfoButtonIcons.tsx
@@ -1,0 +1,13 @@
+import {
+  Info12Regular,
+  Info12Filled,
+  Info16Regular,
+  Info16Filled,
+  Info20Regular,
+  Info20Filled,
+  bundleIcon,
+} from '@fluentui/react-icons';
+
+export const DefaultInfoButtonIcon12 = bundleIcon(Info12Filled, Info12Regular);
+export const DefaultInfoButtonIcon16 = bundleIcon(Info16Filled, Info16Regular);
+export const DefaultInfoButtonIcon20 = bundleIcon(Info20Filled, Info20Regular);

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/InfoButton.test.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/InfoButton.test.tsx
@@ -1,0 +1,50 @@
+import { InfoButton } from './InfoButton';
+import { isConformant } from '../../testing/isConformant';
+import { infoButtonClassNames } from './useInfoButtonStyles.styles';
+import type { RenderResult } from '@testing-library/react';
+
+// testing-library's queryByRole function doesn't look inside portals
+function queryByRoleNote(result: RenderResult) {
+  const notes = result.baseElement.querySelectorAll('[role="note"]');
+  if (!notes?.length) {
+    return null;
+  } else {
+    expect(notes.length).toBe(1);
+    return notes.item(0) as HTMLElement;
+  }
+}
+
+const getPopoverSurfaceElement = (result: RenderResult) => {
+  // button needs to be clicked otherwise content won't be rendered.
+  result.getByRole('button').click();
+  const dialog = queryByRoleNote(result);
+  expect(dialog).not.toBeNull();
+  return dialog!;
+};
+
+describe('InfoButton', () => {
+  isConformant({
+    Component: InfoButton,
+    displayName: 'InfoButton',
+    requiredProps: {
+      info: "This is an InfoButton's information.",
+    },
+    testOptions: {
+      'has-static-classnames': [
+        {
+          props: {
+            info: "This is an InfoButton's information.",
+          },
+          expectedClassNames: {
+            root: infoButtonClassNames.root,
+            info: infoButtonClassNames.info,
+          },
+          getPortalElement: getPopoverSurfaceElement,
+        },
+      ],
+    },
+    // InfoButton is not to be exported by the package nor added to react-components, therefore these tests
+    // need to be disabled.
+    disabledTests: ['component-has-static-classnames-object', 'exported-top-level'],
+  });
+});

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/InfoButton.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/InfoButton.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { ForwardRefComponent } from '@fluentui/react-utilities';
+import { renderInfoButton_unstable } from './renderInfoButton';
+import { useInfoButton_unstable } from './useInfoButton';
+import { useInfoButtonStyles_unstable } from './useInfoButtonStyles.styles';
+import type { InfoButtonProps } from './InfoButton.types';
+
+/**
+ * InfoButtons provide a way to display additional information about a form field or an area in the UI.
+ */
+export const InfoButton: ForwardRefComponent<InfoButtonProps> = React.forwardRef((props, ref) => {
+  const state = useInfoButton_unstable(props, ref);
+
+  useInfoButtonStyles_unstable(state);
+  return renderInfoButton_unstable(state);
+});
+
+InfoButton.displayName = 'InfoButton';

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/InfoButton.types.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/InfoButton.types.ts
@@ -1,0 +1,40 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { PopoverProps, PopoverSurface } from '@fluentui/react-popover';
+
+export type InfoButtonSlots = {
+  root: NonNullable<Slot<'button'>>;
+
+  /**
+   * The Popover element that wraps the info and root slots. Use this slot to pass props to the Popover.
+   */
+  popover: NonNullable<Slot<Partial<Omit<PopoverProps, 'openOnHover'>>>>;
+
+  /**
+   * The information to be displayed in the PopoverSurface when the button is pressed.
+   */
+  info: NonNullable<Slot<typeof PopoverSurface>>;
+};
+
+/**
+ * InfoButton Props
+ */
+export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'disabled'> & {
+  /**
+   * Size of the InfoButton.
+   *
+   * @default medium
+   */
+  size?: 'small' | 'medium' | 'large';
+
+  /**
+   * Whether the InfoButton should be rendered inline or on a Portal.
+   *
+   * @default true
+   */
+  inline?: boolean;
+};
+
+/**
+ * State used in rendering InfoButton
+ */
+export type InfoButtonState = ComponentState<InfoButtonSlots> & Required<Pick<InfoButtonProps, 'inline' | 'size'>>;

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/index.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/index.ts
@@ -1,0 +1,5 @@
+export * from './InfoButton';
+export * from './InfoButton.types';
+export * from './renderInfoButton';
+export * from './useInfoButton';
+export * from './useInfoButtonStyles.styles';

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/renderInfoButton.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/renderInfoButton.tsx
@@ -1,0 +1,22 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import { PopoverTrigger } from '@fluentui/react-popover';
+import type { InfoButtonState, InfoButtonSlots } from './InfoButton.types';
+
+/**
+ * Render the final JSX of InfoButton
+ */
+export const renderInfoButton_unstable = (state: InfoButtonState) => {
+  assertSlots<InfoButtonSlots>(state);
+
+  return (
+    <state.popover>
+      <PopoverTrigger>
+        <state.root />
+      </PopoverTrigger>
+      <state.info />
+    </state.popover>
+  );
+};

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/useInfoButton.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import { DefaultInfoButtonIcon12, DefaultInfoButtonIcon16, DefaultInfoButtonIcon20 } from './DefaultInfoButtonIcons';
+import {
+  getIntrinsicElementProps,
+  mergeCallbacks,
+  useControllableState,
+  slot,
+  useMergedRefs,
+  isHTMLElement,
+  elementContains,
+} from '@fluentui/react-utilities';
+import { Popover, PopoverSurface } from '@fluentui/react-popover';
+import type { InfoButtonProps, InfoButtonState } from './InfoButton.types';
+import type { PopoverProps } from '@fluentui/react-popover';
+
+const infoButtonIconMap = {
+  small: <DefaultInfoButtonIcon12 />,
+  medium: <DefaultInfoButtonIcon16 />,
+  large: <DefaultInfoButtonIcon20 />,
+} as const;
+
+const popoverSizeMap = {
+  small: 'small',
+  medium: 'small',
+  large: 'medium',
+} as const;
+
+/**
+ * Create the state required to render InfoButton.
+ *
+ * The returned state can be modified with hooks such as useInfoButtonStyles_unstable,
+ * before being passed to renderInfoButton_unstable.
+ *
+ * @param props - props from this instance of InfoButton
+ * @param ref - reference to root HTMLElement of InfoButton
+ */
+export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HTMLElement>): InfoButtonState => {
+  const { size = 'medium', inline = true } = props;
+
+  const state: InfoButtonState = {
+    inline,
+    size,
+
+    components: {
+      root: 'button',
+      popover: Popover as React.FC<Partial<PopoverProps>>,
+      info: PopoverSurface,
+    },
+
+    root: slot.always(
+      getIntrinsicElementProps('button', {
+        children: infoButtonIconMap[size],
+        type: 'button',
+        'aria-label': 'information',
+        ...props,
+        // FIXME:
+        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLButtonElement`
+        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
+        ref: ref as React.Ref<HTMLButtonElement>,
+      }),
+      { elementType: 'button' },
+    ),
+    popover: slot.always(props.popover, {
+      defaultProps: {
+        inline,
+        positioning: 'above-start',
+        size: popoverSizeMap[size],
+        withArrow: true,
+      },
+      elementType: Popover as React.FC<Partial<Omit<PopoverProps, 'openOnHover'>>>,
+    }),
+    info: slot.always(props.info, {
+      defaultProps: {
+        role: 'note',
+        tabIndex: -1,
+      },
+      elementType: PopoverSurface,
+    }),
+  };
+
+  const [popoverOpen, setPopoverOpen] = useControllableState({
+    state: state.popover.open,
+    defaultState: state.popover.defaultOpen,
+    initialState: false,
+  });
+
+  state.popover.open = popoverOpen;
+  state.popover.onOpenChange = mergeCallbacks(state.popover.onOpenChange, (e, data) => setPopoverOpen(data.open));
+
+  const focusOutRef = React.useCallback(
+    (el: HTMLDivElement) => {
+      if (!el) {
+        return;
+      }
+
+      el.addEventListener('focusout', e => {
+        const nextFocused = e.relatedTarget;
+
+        if (isHTMLElement(nextFocused) && !elementContains(el, nextFocused)) {
+          setPopoverOpen(false);
+        }
+      });
+    },
+    [setPopoverOpen],
+  );
+
+  state.info.ref = useMergedRefs(state.info.ref, focusOutRef);
+
+  return state;
+};

--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -1,0 +1,128 @@
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
+import type { InfoButtonSlots, InfoButtonState } from './InfoButton.types';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+
+export const infoButtonClassNames: SlotClassNames<InfoButtonSlots> = {
+  root: 'fui-InfoButton',
+  // this className won't be used, but it's needed to satisfy the type checker
+  popover: 'fui-InfoButton__popover',
+  info: 'fui-InfoButton__info',
+};
+
+/**
+ * Styles for the root slot
+ */
+const useButtonStyles = makeStyles({
+  base: {
+    alignItems: 'center',
+    boxSizing: 'border-box',
+    display: 'inline-flex',
+    justifyContent: 'center',
+    textDecorationLine: 'none',
+    verticalAlign: 'middle',
+    position: 'relative',
+
+    backgroundColor: tokens.colorTransparentBackground,
+    color: tokens.colorNeutralForeground2,
+
+    ...shorthands.borderStyle('none'),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.margin(0),
+    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalXS),
+
+    [`& .${iconFilledClassName}`]: {
+      display: 'none',
+    },
+    [`& .${iconRegularClassName}`]: {
+      display: 'inline-flex',
+    },
+
+    ':hover': {
+      backgroundColor: tokens.colorTransparentBackgroundHover,
+      color: tokens.colorNeutralForeground2BrandHover,
+      cursor: 'pointer',
+
+      [`& .${iconFilledClassName}`]: {
+        display: 'inline-flex',
+      },
+      [`& .${iconRegularClassName}`]: {
+        display: 'none',
+      },
+    },
+    ':hover:active': {
+      backgroundColor: tokens.colorTransparentBackgroundPressed,
+      color: tokens.colorNeutralForeground2BrandPressed,
+    },
+  },
+
+  selected: {
+    backgroundColor: tokens.colorTransparentBackgroundSelected,
+    color: tokens.colorNeutralForeground2BrandSelected,
+
+    [`& .${iconFilledClassName}`]: {
+      display: 'inline-flex',
+    },
+    [`& .${iconRegularClassName}`]: {
+      display: 'none',
+    },
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Highlight',
+      color: 'Canvas',
+    },
+  },
+
+  highContrast: {
+    '@media (forced-colors: active)': {
+      color: 'CanvasText',
+
+      ':hover,:hover:active': {
+        forcedColorAdjust: 'none',
+        backgroundColor: 'Highlight',
+        color: 'Canvas',
+      },
+    },
+  },
+
+  focusIndicator: createFocusOutlineStyle(),
+
+  large: {
+    ...shorthands.padding(tokens.spacingVerticalXXS, tokens.spacingVerticalXXS),
+  },
+});
+
+const usePopoverSurfaceStyles = makeStyles({
+  smallMedium: typographyStyles.caption1,
+  large: typographyStyles.body1,
+});
+
+/**
+ * Apply styling to the InfoButton slots based on the state
+ */
+export const useInfoButtonStyles_unstable = (state: InfoButtonState): InfoButtonState => {
+  const { size } = state;
+  const { open } = state.popover;
+  const buttonStyles = useButtonStyles();
+  const popoverSurfaceStyles = usePopoverSurfaceStyles();
+
+  state.info.className = mergeClasses(
+    infoButtonClassNames.info,
+    size === 'large' ? popoverSurfaceStyles.large : popoverSurfaceStyles.smallMedium,
+    state.info.className,
+  );
+
+  state.root.className = mergeClasses(
+    infoButtonClassNames.root,
+    buttonStyles.base,
+    buttonStyles.highContrast,
+    buttonStyles.focusIndicator,
+    open && buttonStyles.selected,
+    size === 'large' && buttonStyles.large,
+    state.root.className,
+  );
+
+  return state;
+};

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.cy.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.cy.tsx
@@ -1,0 +1,82 @@
+/// <reference types="cypress-real-events" />
+
+import * as React from 'react';
+import { mount as mountBase } from '@cypress/react';
+import { FluentProvider } from '@fluentui/react-provider';
+import { teamsLightTheme } from '@fluentui/react-theme';
+import { InfoLabel } from '@fluentui/react-infolabel-preview';
+
+const mount = (element: JSX.Element) => {
+  mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
+};
+
+const surfaceSelector = '[role="note"]';
+
+describe('InfoLabel - close on tab-out', () => {
+  const openInfoButton = () => {
+    cy.get('button').focus().realPress('{enter}');
+  };
+
+  it('no focusable elements', () => {
+    mount(<InfoLabel label="InfoLabel's label" info="Example non-focusable info" />);
+
+    openInfoButton();
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    openInfoButton();
+    cy.realPress('Tab').get(surfaceSelector).should('not.exist');
+  });
+
+  it('single focusable element', () => {
+    mount(
+      <InfoLabel
+        label="InfoLabel's label"
+        info={
+          <>
+            Example non-focusable info
+            <button>one</button>
+          </>
+        }
+      />,
+    );
+
+    openInfoButton();
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    openInfoButton();
+    // moving into the focusable item
+    cy.realPress('Tab').get(surfaceSelector).should('exist');
+    // tabbing out with shift + tab from the first focusable item should close the surface since
+    // the surface is only focusable programmatically
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    openInfoButton();
+    cy.realPress('Tab').realPress('Tab').get(surfaceSelector).should('not.exist');
+  });
+
+  it('one or more focusable elements', () => {
+    mount(
+      <InfoLabel
+        label="InfoLabel's label"
+        info={
+          <>
+            Example non-focusable info
+            <button>one</button>
+            <button>two</button>
+            <button>three</button>
+          </>
+        }
+      />,
+    );
+
+    openInfoButton();
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    openInfoButton();
+    // moving into the focusable item
+    cy.realPress('Tab').get(surfaceSelector).should('exist');
+    // tabbing out with shift + tab from the first focusable item should close the surface since
+    // the surface is only focusable programmatically
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    openInfoButton();
+    // checking that event does not propagate to children
+    cy.realPress('Tab').realPress('Tab').realPress(['Shift', 'Tab']).get(surfaceSelector).should('exist');
+    cy.realPress('Tab').realPress('Tab').realPress('Tab').get(surfaceSelector).should('not.exist');
+  });
+});

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.test.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.test.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { InfoLabel } from './InfoLabel';
+
+describe('InfoLabel', () => {
+  isConformant({
+    Component: InfoLabel,
+    displayName: 'InfoLabel',
+    primarySlot: 'label',
+    testOptions: {
+      'has-static-classnames': [
+        {
+          props: {
+            info: 'Test',
+          },
+        },
+      ],
+    },
+  });
+
+  it('renders an InfoButton when info is set', () => {
+    const result = render(<InfoLabel info="Test">Test label</InfoLabel>);
+    expect(result.getByRole('button')).toBeTruthy();
+  });
+
+  it("renders an InfoButton when the infoButton's info slot is set", () => {
+    const result = render(<InfoLabel infoButton={{ info: 'Test' }}>Test label</InfoLabel>);
+    expect(result.getByRole('button')).toBeTruthy();
+  });
+
+  it('does not render an InfoButton when info is not set', () => {
+    const result = render(<InfoLabel>Test label</InfoLabel>);
+    expect(result.queryByRole('button')).toBeNull();
+  });
+
+  it('sets the infoButton aria-labelledby to the label and infoButton', () => {
+    const result = render(<InfoLabel info="Test">Test label</InfoLabel>);
+
+    const infoButton = result.getByRole('button');
+    const label = result.getByText('Test label') as HTMLLabelElement;
+
+    expect(infoButton.getAttribute('aria-labelledby')).toBe(`${label.id} ${infoButton.id}`);
+  });
+
+  it("applies InfoButton's info slot id to aria-owns on the InfoLabel's wrapper when open", () => {
+    const { container } = render(<InfoLabel className="info-label-wrapper" info={{ id: 'test-id' }} />);
+    expect(container.getElementsByClassName('info-label-wrapper')[0].getAttribute('aria-owns')).toBeNull();
+
+    fireEvent.click(container.getElementsByTagName('button')[0]);
+
+    expect(container.getElementsByClassName('info-label-wrapper')[0].getAttribute('aria-owns')).toBe('test-id');
+  });
+
+  it("applies InfoButton's correct id to aria-owns on the InfoLabel's wrapper when id is provided to the infoButton slot", () => {
+    const { container } = render(<InfoLabel className="info-label-wrapper" infoButton={{ info: { id: 'test-id' } }} />);
+    expect(container.getElementsByClassName('info-label-wrapper')[0].getAttribute('aria-owns')).toBeNull();
+
+    fireEvent.click(container.getElementsByTagName('button')[0]);
+
+    expect(container.getElementsByClassName('info-label-wrapper')[0].getAttribute('aria-owns')).toBe('test-id');
+  });
+});

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { InfoLabelProps } from './InfoLabel.types';
+import { renderInfoLabel_unstable } from './renderInfoLabel';
+import { useInfoLabel_unstable } from './useInfoLabel';
+import { useInfoLabelStyles_unstable } from './useInfoLabelStyles.styles';
+
+/**
+ * InfoLabel component
+ */
+export const InfoLabel: ForwardRefComponent<InfoLabelProps> = React.forwardRef((props, ref) => {
+  const state = useInfoLabel_unstable(props, ref);
+
+  useInfoLabelStyles_unstable(state);
+  return renderInfoLabel_unstable(state);
+});
+
+InfoLabel.displayName = 'InfoLabel';

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.types.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/InfoLabel.types.ts
@@ -1,0 +1,41 @@
+import { Label } from '@fluentui/react-label';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { InfoButton } from '../InfoButton';
+import type { InfoButtonProps } from '../InfoButton';
+
+export type InfoLabelSlots = {
+  root: NonNullable<Slot<'span'>>;
+
+  /**
+   * The Label component.
+   *
+   * It is not typically necessary to use this prop. The label text is the child of the `<InfoLabel>`, and other props
+   * such as `size` and `required` should be set directly on the `InfoLabel`.
+   *
+   * This is the PRIMARY slot: all native properties specified directly on `<InfoLabel>` will be applied to this slot,
+   * except `className` and `style`, which remain on the root slot.
+   */
+  label: NonNullable<Slot<typeof Label>>;
+
+  /**
+   * The InfoButton component.
+   *
+   * It is not typically necessary to use this prop. The content can be set using the `info` prop of the InfoLabel.
+   */
+  infoButton: Slot<typeof InfoButton>;
+};
+
+/**
+ * InfoLabel Props
+ */
+export type InfoLabelProps = ComponentProps<Partial<InfoLabelSlots>, 'label'> & {
+  /**
+   * The content of the InfoButton's popover.
+   */
+  info?: InfoButtonProps['info'];
+};
+
+/**
+ * State used in rendering InfoLabel
+ */
+export type InfoLabelState = ComponentState<InfoLabelSlots> & Pick<InfoLabelProps, 'size'>;

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/index.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/index.ts
@@ -1,0 +1,5 @@
+export * from './InfoLabel';
+export * from './InfoLabel.types';
+export * from './renderInfoLabel';
+export * from './useInfoLabel';
+export * from './useInfoLabelStyles.styles';

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/renderInfoLabel.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/renderInfoLabel.tsx
@@ -1,0 +1,19 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { InfoLabelSlots, InfoLabelState } from './InfoLabel.types';
+
+/**
+ * Render the final JSX of InfoLabel
+ */
+export const renderInfoLabel_unstable = (state: InfoLabelState) => {
+  assertSlots<InfoLabelSlots>(state);
+
+  return (
+    <state.root>
+      <state.label />
+      {state.infoButton && <state.infoButton />}
+    </state.root>
+  );
+};

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/useInfoLabel.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/useInfoLabel.ts
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import { Label } from '@fluentui/react-label';
+import { mergeCallbacks, useEventCallback, useId, slot } from '@fluentui/react-utilities';
+import { InfoButton } from '../InfoButton/InfoButton';
+import type { InfoLabelProps, InfoLabelState } from './InfoLabel.types';
+
+/**
+ * Create the state required to render InfoLabel.
+ *
+ * The returned state can be modified with hooks such as useInfoLabelStyles_unstable,
+ * before being passed to renderInfoLabel_unstable.
+ *
+ * @param props - props from this instance of InfoLabel
+ * @param ref - reference to label element of InfoLabel
+ */
+export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTMLLabelElement>): InfoLabelState => {
+  const {
+    root: rootShorthand,
+    label: labelShorthand,
+    infoButton: infoButtonShorthand,
+    info,
+    size,
+    className,
+    style,
+    ...labelProps
+  } = props;
+  const baseId = useId('infolabel-');
+  const [open, setOpen] = React.useState(false);
+
+  const root = slot.always(rootShorthand, {
+    defaultProps: {
+      className,
+      style,
+    },
+    elementType: 'span',
+  });
+
+  const label = slot.always(labelShorthand, {
+    defaultProps: {
+      id: baseId + '__label',
+      ref,
+      size,
+      ...labelProps,
+    },
+    elementType: Label,
+  });
+
+  const infoButton = slot.optional(infoButtonShorthand, {
+    renderByDefault: !!info,
+    defaultProps: {
+      id: baseId + '__infoButton',
+      size,
+      info,
+    },
+    elementType: InfoButton,
+  });
+
+  const infoButtonPopover = slot.always(infoButton?.popover, {
+    elementType: 'div',
+  });
+  infoButtonPopover.onOpenChange = useEventCallback(
+    mergeCallbacks(infoButtonPopover.onOpenChange, (e, data) => {
+      setOpen(data.open);
+    }),
+  );
+
+  if (infoButton) {
+    infoButton.popover = infoButtonPopover;
+    infoButton.info = slot.optional(infoButton?.info, {
+      defaultProps: {
+        id: baseId + '__info',
+      },
+      elementType: 'div',
+    });
+
+    infoButton['aria-labelledby'] ??= `${label.id} ${infoButton.id}`;
+
+    if (open) {
+      root['aria-owns'] ??= infoButton.info?.id;
+    }
+  }
+
+  return {
+    size,
+    components: {
+      root: 'span',
+      label: Label,
+      infoButton: InfoButton,
+    },
+    root,
+    label,
+    infoButton,
+  };
+};

--- a/packages/react-components/react-infolabel-preview/src/components/InfoLabel/useInfoLabelStyles.styles.ts
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoLabel/useInfoLabelStyles.styles.ts
@@ -1,0 +1,56 @@
+import { tokens } from '@fluentui/react-theme';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { InfoLabelSlots, InfoLabelState } from './InfoLabel.types';
+
+export const infoLabelClassNames: SlotClassNames<InfoLabelSlots> = {
+  root: 'fui-InfoLabel',
+  label: 'fui-InfoLabel__label',
+  infoButton: 'fui-InfoLabel__infoButton',
+};
+
+const useLabelStyles = makeStyles({
+  base: {
+    verticalAlign: 'top',
+    cursor: 'inherit',
+    color: 'inherit',
+  },
+});
+
+const useInfoButtonStyles = makeStyles({
+  base: {
+    verticalAlign: 'top',
+
+    // Negative margin to align with the text
+    marginTop: `calc(0px - ${tokens.spacingVerticalXXS})`,
+    marginBottom: `calc(0px - ${tokens.spacingVerticalXXS})`,
+  },
+
+  large: {
+    // Negative margin to align with the text
+    marginTop: '-1px',
+    marginBottom: '-1px',
+  },
+});
+
+/**
+ * Apply styling to the InfoLabel slots based on the state
+ */
+export const useInfoLabelStyles_unstable = (state: InfoLabelState): InfoLabelState => {
+  state.root.className = mergeClasses(infoLabelClassNames.root, state.root.className);
+
+  const labelStyles = useLabelStyles();
+  state.label.className = mergeClasses(infoLabelClassNames.label, labelStyles.base, state.label.className);
+
+  const infoButtonStyles = useInfoButtonStyles();
+  if (state.infoButton) {
+    state.infoButton.className = mergeClasses(
+      infoLabelClassNames.infoButton,
+      infoButtonStyles.base,
+      state.size === 'large' && infoButtonStyles.large,
+      state.infoButton.className,
+    );
+  }
+
+  return state;
+};

--- a/packages/react-components/react-infolabel-preview/src/index.ts
+++ b/packages/react-components/react-infolabel-preview/src/index.ts
@@ -1,1 +1,8 @@
-export {};
+export {
+  InfoLabel,
+  infoLabelClassNames,
+  renderInfoLabel_unstable,
+  useInfoLabelStyles_unstable,
+  useInfoLabel_unstable,
+} from './InfoLabel';
+export type { InfoLabelProps, InfoLabelSlots, InfoLabelState } from './InfoLabel';

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelBestPractices.md
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelBestPractices.md
@@ -5,6 +5,6 @@ Best Practices
 
 ### Don't
 
-- Because the Popover isn't always visible, don't include information in the InfoButton that people must know in order to complete the field.
+- Because the Popover isn't always visible, don't include information in the `info` prop that people must know in order to complete the field.
 
 </details>

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelBestPractices.md
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelBestPractices.md
@@ -1,0 +1,10 @@
+<details>
+<summary>
+Best Practices
+</summary>
+
+### Don't
+
+- Because the Popover isn't always visible, don't include information in the InfoButton that people must know in order to complete the field.
+
+</details>

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDefault.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDefault.stories.tsx
@@ -7,7 +7,7 @@ export const Default = (props: Partial<InfoLabelProps>) => (
   <InfoLabel
     info={
       <>
-        This is example information for an InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>
+        This is example information for an InfoLabel. <Link href="https://react.fluentui.dev">Learn more</Link>
       </>
     }
     {...props}

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDefault.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDefault.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { Link } from '@fluentui/react-components';
+import { InfoLabel, InfoLabelProps } from '@fluentui/react-infolabel-preview';
+
+export const Default = (props: Partial<InfoLabelProps>) => (
+  <InfoLabel
+    info={
+      <>
+        This is example information for an InfoButton. <Link href="https://react.fluentui.dev">Learn more</Link>
+      </>
+    }
+    {...props}
+  >
+    Example label
+  </InfoLabel>
+);

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDescription.md
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDescription.md
@@ -7,7 +7,7 @@ It can be used as a drop-in replacement for Label when an InfoButton is also nee
 >
 > ```jsx
 >
-> import { InfoLabel } from '@fluentui/react-components/unstable';
+> import { InfoLabel } from '@fluentui/react-infolabel-preview';
 >
 > ```
 >

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDescription.md
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelDescription.md
@@ -1,0 +1,15 @@
+An InfoLabel is a Label with an InfoButton at the end, properly handling layout and accessibility properties.
+It can be used as a drop-in replacement for Label when an InfoButton is also needed.
+
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview components are considered unstable:**
+>
+> ```jsx
+>
+> import { InfoLabel } from '@fluentui/react-components/unstable';
+>
+> ```
+>
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelInField.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelInField.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { Field, Input, LabelProps, makeStyles } from '@fluentui/react-components';
+import { InfoLabel } from '@fluentui/react-infolabel-preview';
+
+const useStyles = makeStyles({
+  infoLabelSurface: {
+    // Since we render the Popover inline and Input uses position: relative, we need to set a zIndex. If we don't,
+    // the Popover surface will render behind the input. See #27891 for more details.
+    zIndex: 1,
+  },
+});
+
+export const InField = () => {
+  const styles = useStyles();
+
+  return (
+    <Field
+      label={{
+        children: (_: unknown, props: LabelProps) => (
+          <InfoLabel {...props} info={{ children: 'Example info', className: styles.infoLabelSurface }}>
+            Field with info label
+          </InfoLabel>
+        ),
+      }}
+    >
+      <Input />
+    </Field>
+  );
+};
+
+InField.storyName = 'In a Field';
+InField.parameters = {
+  docs: {
+    description: {
+      story:
+        'An `InfoLabel` can be used in a `Field` by rendering the label prop as an InfoLabel. This uses the slot ' +
+        '[render function]' +
+        '(./?path=/docs/concepts-developer-customizing-components-with-slots--page#replacing-the-entire-slot) ' +
+        'support. See the code from this story for an example.',
+    },
+  },
+};

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelPatternDecision.md
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelPatternDecision.md
@@ -1,0 +1,38 @@
+<details>
+<summary>
+InfoButton/InfoLabel Pattern decision
+</summary>
+
+### What is an InfoLabel?
+
+An InfoLabel is composed of two components and a wrapper. The main component is a Label and the secondary component is an InfoButton.
+We packaged both components to be able to achieve the correct accessibility out of the box. We automatically link the label to the
+button from the InfoButton component and apply `aria-owns` to the wrapper when the InfoButton's Popover is open. In addition, InfoLabel
+allows you to render only the InfoButton if that's desired. The reason why we don't export InfoButton separately is to avoid having
+issues with `aria-owns`. The PopoverSurface must be linked to the wrapper of the InfoButton when open, not doing so results in a
+violation.
+
+### What is the InfoButton pattern?
+
+The InfoButton pattern is a button that exposes additional information about a field or a concept. To trigger the Popover, the user may
+activate the button by clicking on it and focusing on it and pressing enter or space. When the Popover is open, the focus is programmatically moved
+to the PopoverSurface. To close the Popover, the user may click the button again, click outside the popover, press the escape key, or tab out of
+the PopoverSurface.
+
+#### Why is focus moved to the PopoverSurface?
+
+The reason why we move focus to the PopoverSurface is to allow the user to navigate the Popover with the keyboard. This allows screen reader and keyboard
+users to read the content and interact with it without having to use the mouse and not have unreachable content. We move the focus specifically to the
+PopoverSurface and not the first focusable element because there might be a case where there's a paragraph of text and the first focusable element is at the
+bottom of the Surface. In this case, a screen reader user might not know there's more content above and therefore miss it.
+
+#### Can the InfoButton be opened on focus and not move focus to the PopoverSurface?
+
+InfoButtons can not be opened on focus. The pattern where you have an icon and a tooltip that appears on focus is not the InfoButton pattern. The tooltip
+pattern is meant to have short text and no interaction with the content. We believe that if the content is short or even a few words, it should be included
+in the label or a secondary label. If the content is longer and/or has interaction, then it must be an InfoButton.
+
+> If the tooltip + icon pattern is still needed, refer to the Icon example in tooltip on how to correctly achieve this pattern. Note that when using a
+> tooltip, the content must be short and not have interaction.
+
+</details>

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelRequired.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelRequired.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { InfoLabel } from '@fluentui/react-infolabel-preview';
+
+export const Required = () => (
+  <InfoLabel info="Example info" required>
+    Required label
+  </InfoLabel>
+);
+
+Required.parameters = {
+  docs: {
+    description: {
+      story: 'When marked `required`, the indicator asterisk is placed before the InfoButton.',
+    },
+  },
+};

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelSize.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelSize.stories.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+import { InfoLabel } from '@fluentui/react-infolabel-preview';
+
+const useStyles = makeStyles({
+  container: {
+    alignItems: 'start',
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: tokens.spacingVerticalL,
+  },
+});
+
+export const Size = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.container}>
+      <InfoLabel size="small" info="Example small InfoButton">
+        Small label
+      </InfoLabel>
+      <InfoLabel size="medium" info="Example medium InfoButton">
+        Medium label
+      </InfoLabel>
+      <InfoLabel size="large" info="Example large InfoButton">
+        Large label
+      </InfoLabel>
+    </div>
+  );
+};
+
+Size.parameters = {
+  docs: {
+    description: {
+      story: "InfoLabel's `size` prop affects the size of the Label and InfoButton. The default size is medium.",
+    },
+  },
+};

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelSize.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/InfoLabelSize.stories.tsx
@@ -17,13 +17,13 @@ export const Size = () => {
 
   return (
     <div className={styles.container}>
-      <InfoLabel size="small" info="Example small InfoButton">
+      <InfoLabel size="small" info="Example small InfoLabel">
         Small label
       </InfoLabel>
-      <InfoLabel size="medium" info="Example medium InfoButton">
+      <InfoLabel size="medium" info="Example medium InfoLabel">
         Medium label
       </InfoLabel>
-      <InfoLabel size="large" info="Example large InfoButton">
+      <InfoLabel size="large" info="Example large InfoLabel">
         Large label
       </InfoLabel>
     </div>

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/index.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/index.stories.tsx
@@ -1,4 +1,4 @@
-import { InfoLabel } from '@fluentui/react-infobutton';
+import { InfoLabel } from '@fluentui/react-infolabel-preview';
 
 import descriptionMd from './InfoLabelDescription.md';
 import bestPracticesMd from './InfoLabelBestPractices.md';

--- a/packages/react-components/react-infolabel-preview/stories/InfoLabel/index.stories.tsx
+++ b/packages/react-components/react-infolabel-preview/stories/InfoLabel/index.stories.tsx
@@ -1,1 +1,22 @@
-export {};
+import { InfoLabel } from '@fluentui/react-infobutton';
+
+import descriptionMd from './InfoLabelDescription.md';
+import bestPracticesMd from './InfoLabelBestPractices.md';
+import patternDecision from './InfoLabelPatternDecision.md';
+
+export { Default } from './InfoLabelDefault.stories';
+export { Required } from './InfoLabelRequired.stories';
+export { Size } from './InfoLabelSize.stories';
+export { InField } from './InfoLabelInField.stories';
+
+export default {
+  title: 'Preview Components/InfoLabel',
+  component: InfoLabel,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd, patternDecision].join('\n'),
+      },
+    },
+  },
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Changes

Copy over files from react-infobutton to react-infolabel. Nothing was changed except what's been pointer below.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29544
