### PR TITLE
fix: Tabster should support virtual parents

### DIFF
--- a/change/@fluentui-react-dialog-e7703ba0-5918-4d1d-8ab6-b353dd5b2426.json
+++ b/change/@fluentui-react-dialog-e7703ba0-5918-4d1d-8ab6-b353dd5b2426.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add e2e tests for virtual parents",
+  "packageName": "@fluentui/react-dialog",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-a85665ab-54f3-46a0-aafc-a513ddfe135d.json
+++ b/change/@fluentui-react-popover-a85665ab-54f3-46a0-aafc-a513ddfe135d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Add e2e tests for virtual parents",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-04feba9e-faa2-49d5-a828-8fd549454e5c.json
+++ b/change/@fluentui-react-tabster-04feba9e-faa2-49d5-a828-8fd549454e5c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Tabster should support virtual parents",
+  "comment": "feat: bump to tabster 4.8.0 in order to support support virtual parents",
   "packageName": "@fluentui/react-tabster",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-tabster-04feba9e-faa2-49d5-a828-8fd549454e5c.json
+++ b/change/@fluentui-react-tabster-04feba9e-faa2-49d5-a828-8fd549454e5c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Tabster should support virtual parents",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-04feba9e-faa2-49d5-a828-8fd549454e5c.json
+++ b/change/@fluentui-react-tabster-04feba9e-faa2-49d5-a828-8fd549454e5c.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "feat: bump to tabster 4.8.0 in order to support support virtual parents",
   "packageName": "@fluentui/react-tabster",
   "email": "lingfangao@hotmail.com",

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -259,11 +259,13 @@ describe('Dialog', () => {
     cy.get('#open-menu-btn').realClick();
     cy.focused().realType('{esc}');
     cy.get(dialogSurfaceSelector).should('exist');
+    cy.get('#open-menu-btn').should('have.focus');
 
     // Open Popover and then close it with Escape
     cy.get('#open-popover-btn').realClick();
     cy.focused().realType('{esc}');
     cy.get(dialogSurfaceSelector).should('exist');
+    cy.get('#open-popover-btn').should('have.focus');
 
     // Open Tooltip, wait for the tooltip to appear and then close it with Escape
     cy.get(dialogTriggerCloseSelector).focus().wait(0).realType('{esc}');

--- a/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/src/components/Popover/Popover.cy.tsx
@@ -5,6 +5,7 @@ import { FluentProvider } from '@fluentui/react-provider';
 import { teamsLightTheme } from '@fluentui/react-theme';
 
 import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItem } from '@fluentui/react-menu';
 import type { PopoverProps } from '@fluentui/react-popover';
 const mount = (element: JSX.Element) => {
   mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
@@ -565,6 +566,79 @@ describe('Popover', () => {
         .get(popoverContentSelector)
         .should('not.exist')
         .get('#trigger')
+        .should('have.focus');
+    });
+  });
+
+  describe('Opens menu', () => {
+    it('should keep focus in popover once menu is dismissed with mouse', () => {
+      mount(
+        <Popover trapFocus>
+          <PopoverTrigger>
+            <button>Popover trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface>
+            <Menu>
+              <MenuTrigger disableButtonEnhancement>
+                <button id="menu-trigger">Menu trigger</button>
+              </MenuTrigger>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem id="first-item">Item a</MenuItem>
+                  <MenuItem>Item b</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </PopoverSurface>
+        </Popover>,
+      );
+
+      cy.get(popoverTriggerSelector)
+        .click()
+        .get('#menu-trigger')
+        .click()
+        .get('#first-item')
+        .should('have.focus')
+        .get('#menu-trigger')
+        .click()
+        .get('#first-item')
+        .should('not.exist')
+        .get('#menu-trigger')
+        .should('have.focus');
+    });
+
+    it('should keep focus in popover once menu is dismissed with keyboard', () => {
+      mount(
+        <Popover trapFocus>
+          <PopoverTrigger>
+            <button>Popover trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface>
+            <Menu>
+              <MenuTrigger disableButtonEnhancement>
+                <button id="menu-trigger">Menu trigger</button>
+              </MenuTrigger>
+
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem id="first-item">Item a</MenuItem>
+                  <MenuItem>Item b</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </PopoverSurface>
+        </Popover>,
+      );
+
+      cy.get(popoverTriggerSelector)
+        .click()
+        .get('#menu-trigger')
+        .click()
+        .get('#first-item')
+        .should('have.focus')
+        .type('{esc}')
+        .get('#menu-trigger')
         .should('have.focus');
     });
   });

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -37,7 +37,7 @@
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",
     "keyborg": "^2.1.0",
-    "tabster": "^4.7.0"
+    "tabster": "^4.8.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-tabster/src/hooks/useTabster.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabster.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { createTabster, disposeTabster, Types as TabsterTypes } from 'tabster';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useIsomorphicLayoutEffect, getParent } from '@fluentui/react-utilities';
 
 /**
  * Tries to get a tabster instance on the current window or creates a new one
@@ -19,7 +19,7 @@ export const useTabster = (): TabsterTypes.TabsterCore | null => {
       return null;
     }
 
-    return createTabster(defaultView, { autoRoot: {}, controlTab: false });
+    return createTabster(defaultView, { autoRoot: {}, controlTab: false, getParent });
   }, [defaultView]);
 
   useIsomorphicLayoutEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23934,10 +23934,10 @@ table@^6.0.4, table@^6.0.7:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-4.7.0.tgz#0c12e9e14e83a950e3a97e35ead17c255e8f2772"
-  integrity sha512-8+arpE2WOvhdU2bvU5GEaoaICbLBNNh8WhW9q85KeSOg4sIvRPfAI2/j18UxUnKT8Fv32zkbvEfToEf9Y1Sfug==
+tabster@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-4.8.0.tgz#e1f9b5c7c8e4b642d6a91e243de0dfc09d8cacc5"
+  integrity sha512-R1ib3x0Rd+iepvrzXdEkd2Qa2O5dV7jaZtR4BhkhE9sBYMolbVc6EgHGTHBQvdXQBdU8I2MXCMn0c6jarJb+GA==
   dependencies:
     keyborg "^2.0.0"
     tslib "^2.3.1"


### PR DESCRIPTION
Bumps tabster version to enable support for virtual parents. e2e tests to prevet regression

Fixes #28915
Fixes #29519