### PR TITLE
ci: use nodejs version that is preinstalled on 1es containers in order to avoid flaky pipeline issues while installing nodejs

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -9,8 +9,10 @@ steps:
     retryCountOnTaskFailure: 1
 
   - script: |
-      npm i -g yarn@1
-    displayName: 'Install yarn'
+      echo "nodejs:" && node -v
+      echo "yarn:" && yarn -v
+      echo "npm:" && npm -v
+    displayName: 'print NodeJS,package managers versions'
 
   # For multiline scripts, we want the whole task to fail if any line of the script fails.
   # ADO doesn't have bash configured this way by default. To fix we override the SHELLOPTS built-in variable.

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,10 +2,11 @@
 steps:
   - task: UseNode@1
     inputs:
-      version: '16.18.1'
+      # https://github.com/actions/runner-images/blob/ubuntu20/20230924.1/images/linux/Ubuntu2004-Readme.md#nodejs
+      version: '16.20.2'
       checkLatest: false
     displayName: 'Install Node.js'
-    retryCountOnTaskFailure: 3
+    retryCountOnTaskFailure: 1
 
   - script: |
       npm i -g yarn@1

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,9 +2,11 @@
 steps:
   - task: UseNode@1
     inputs:
-      # 👉 NOTE: we can use only versions that ship with container, otherwise we will run into nodejs installation issues
+      # 👉 NOTE:
+      # - we can use only versions that ship with container, otherwise we will run into nodejs installation issues.
+      # - as 1es bumps those versions within container automatically we need to use `<major>.x` to not run into issues once they bump the versions.
       # https://github.com/actions/runner-images/blob/ubuntu20/20230924.1/images/linux/Ubuntu2004-Readme.md#nodejs
-      version: '16.20.2'
+      version: '16.x'
       checkLatest: false
     displayName: 'Install Node.js'
     retryCountOnTaskFailure: 1

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,6 +2,7 @@
 steps:
   - task: UseNode@1
     inputs:
+      # 👉 NOTE: we can use only versions that ship with container, otherwise we will run into nodejs installation issues
       # https://github.com/actions/runner-images/blob/ubuntu20/20230924.1/images/linux/Ubuntu2004-Readme.md#nodejs
       version: '16.20.2'
       checkLatest: false

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 16.20.2
           cache: 'yarn'
 
       - uses: tj-actions/changed-files@v34
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 16.20.2
 
       - uses: actions/github-script@v6
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 16.20.2
 
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/docsite-publish-chromatic.yml
+++ b/.github/workflows/docsite-publish-chromatic.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 16.20.2
           cache: 'yarn'
 
       - name: Install packages

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 16.20.2
           cache: 'yarn'
 
       - name: Install packages

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@types/lodash": "4.14.182",
     "@types/markdown-table": "2.0.0",
     "@types/micromatch": "4.0.2",
-    "@types/node": "16.18.1",
+    "@types/node": "16.18.58",
     "@types/prettier": "2.7.2",
     "@types/progress": "2.0.5",
     "@types/prompts": "2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5342,10 +5342,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@16.18.1", "@types/node@>=10.0.0", "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
-  version "16.18.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.1.tgz#fd860a5efc505a5417d25a99cbff78077447a391"
-  integrity sha512-Z659t5cj2Tt2SaqbJxXRo5EaU86E4l2CxtklCY1VftxYXhR81Z75UsugwdI7l5MUAR1I+l8sdt3B5Y++ZV76WQ==
+"@types/node@*", "@types/node@16.18.58", "@types/node@>=10.0.0", "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
+  version "16.18.58"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.58.tgz#bf66f63983104ed57c754f4e84ccaf16f8235adb"
+  integrity sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==
 
 "@types/node@12.20.24":
   version "12.20.24"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

nodejs install within our jobs are extremely unreliable which makes whole CI very flaky.

![image](https://github.com/microsoft/fluentui/assets/1223799/a56aa7ae-8769-4cac-884b-28cca4dc7f9e)

[example of failing pipeline](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=322792&view=results)


## New Behavior

<img width="882" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/81995239-b3ee-4085-8fed-8e51f1b804d1">

- we use only nodejs that is being shipped with 1es container
- yarn@1 is part of this container so there is no need to install it manually

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
