### PR TITLE
fix: update Popover guidance and examples to show how to set focus on static popovers

### DIFF
--- a/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -41,7 +41,7 @@ export const AnchorToCustomTarget = () => {
           <Button>Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface tabIndex={-1}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverAppearance.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAppearance.stories.tsx
@@ -36,7 +36,7 @@ export const Appearance = () => {
           <Button>Default appearance Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface tabIndex={-1}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>
@@ -46,7 +46,7 @@ export const Appearance = () => {
           <Button>Brand appearance Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface tabIndex={-1}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>
@@ -56,7 +56,7 @@ export const Appearance = () => {
           <Button>Inverted appearance Popover trigger</Button>
         </PopoverTrigger>
 
-        <PopoverSurface>
+        <PopoverSurface tabIndex={-1}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverBestPractices.md
+++ b/packages/react-components/react-popover/stories/Popover/PopoverBestPractices.md
@@ -9,6 +9,7 @@
 
 - Use the `trapFocus` prop when focusable elements are in the `Popover`.
 - Create nested `Popovers` as separate components.
+- If there are no interactive items in the `Popover` content, set `tabIndex={-1}` on the `PopoverSurface`.
 - Use `Popover` to reduce screen clutter to host non-essential information.
 
 ### Don't

--- a/packages/react-components/react-popover/stories/Popover/PopoverControllingOpenAndClose.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverControllingOpenAndClose.stories.tsx
@@ -33,7 +33,7 @@ export const ControllingOpenAndClose = () => {
         <PopoverTrigger disableButtonEnhancement>
           <Button>Controlled trigger</Button>
         </PopoverTrigger>
-        <PopoverSurface>
+        <PopoverSurface tabIndex={-1}>
           <ExampleContent />
         </PopoverSurface>
       </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverCustomTrigger.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverCustomTrigger.stories.tsx
@@ -32,7 +32,7 @@ export const CustomTrigger = () => {
       <PopoverTrigger>
         <CustomPopoverTrigger />
       </PopoverTrigger>
-      <PopoverSurface>
+      <PopoverSurface tabIndex={-1}>
         <ExampleContent />
       </PopoverSurface>
     </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverDefault.stories.tsx
@@ -25,7 +25,7 @@ export const Default = (props: PopoverProps) => (
       <Button>Popover trigger</Button>
     </PopoverTrigger>
 
-    <PopoverSurface>
+    <PopoverSurface tabIndex={-1}>
       <ExampleContent />
     </PopoverSurface>
   </Popover>

--- a/packages/react-components/react-popover/stories/Popover/PopoverInternalUpdateContent.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverInternalUpdateContent.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import { makeStyles, Button, Link, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 import type { PopoverProps } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -21,6 +21,7 @@ const ExampleContent = () => {
 
 export const InternalUpdateContent = () => {
   const [visible, setVisible] = React.useState(false);
+  const focusRef = React.useRef<HTMLAnchorElement>(null);
 
   const changeContent = () => setVisible(true);
   const onOpenChange: PopoverProps['onOpenChange'] = (e, data) => {
@@ -28,6 +29,12 @@ export const InternalUpdateContent = () => {
       setVisible(false);
     }
   };
+
+  React.useEffect(() => {
+    if (visible) {
+      focusRef.current?.focus();
+    }
+  }, [visible]);
 
   return (
     <Popover onOpenChange={onOpenChange}>
@@ -39,7 +46,12 @@ export const InternalUpdateContent = () => {
         <ExampleContent />
 
         {visible ? (
-          <div>The second panel</div>
+          <div>
+            The second panel content{' '}
+            <Link href="#" ref={focusRef}>
+              and a link
+            </Link>
+          </div>
         ) : (
           <div>
             <Button onClick={changeContent}>Action</Button>

--- a/packages/react-components/react-popover/stories/Popover/PopoverWithArrow.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverWithArrow.stories.tsx
@@ -24,7 +24,7 @@ export const WithArrow = () => (
       <Button>Popover trigger</Button>
     </PopoverTrigger>
 
-    <PopoverSurface>
+    <PopoverSurface tabIndex={-1}>
       <ExampleContent />
     </PopoverSurface>
   </Popover>


### PR DESCRIPTION
Previously, our Popover examples without nested interactive items weren't getting focus when opened. This PR does two things:

1. Updates those examples to add `tabIndex={-1}` to the `PopoverSurface`
2. Adds Best Practices guidance to tell authors to do so

I also updated the example with changing content to prevent focus from being lost.