### PR TITLE
fix(react-infolabel-preview): InfoButton's ref should be of type HTMLButtonElement

### DIFF
--- a/packages/react-components/react-infolabel-preview/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infolabel-preview/src/components/InfoButton/useInfoButton.tsx
@@ -32,9 +32,9 @@ const popoverSizeMap = {
  * before being passed to renderInfoButton_unstable.
  *
  * @param props - props from this instance of InfoButton
- * @param ref - reference to root HTMLElement of InfoButton
+ * @param ref - reference to root HTMLButtonElement of InfoButton
  */
-export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HTMLElement>): InfoButtonState => {
+export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HTMLButtonElement>): InfoButtonState => {
   const { size = 'medium', inline = true } = props;
 
   const state: InfoButtonState = {
@@ -53,10 +53,7 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
         type: 'button',
         'aria-label': 'information',
         ...props,
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLButtonElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: ref as React.Ref<HTMLButtonElement>,
+        ref,
       }),
       { elementType: 'button' },
     ),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

InfoButton's ref was casted to HTMLButtonElement due to making the ref change would involve a breaking change.

## New Behavior

InfoButton's ref is now of type HTMLButtonElement.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29557
