### PR TITLE
chore(public-docsite-v9, react-calendar-compat): Add bundle size fixture for Calendar and add react-calendar-compat dependency to public-docsite-v9

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@fluentui/react-breadcrumb-preview": "*",
-    "@fluentui/react-datepicker-compat": "*",
     "@fluentui/react-calendar-compat": "*",
+    "@fluentui/react-datepicker-compat": "*",
     "@fluentui/react-migration-v8-v9": "*",
     "@fluentui/react-migration-v0-v9": "*",
     "@fluentui/react": "*",

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@fluentui/react-breadcrumb-preview": "*",
     "@fluentui/react-datepicker-compat": "*",
+    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-migration-v8-v9": "*",
     "@fluentui/react-migration-v0-v9": "*",
     "@fluentui/react": "*",

--- a/change/@fluentui-react-calendar-compat-1e17bccb-24fd-4107-9285-54ba3ad1366e.json
+++ b/change/@fluentui-react-calendar-compat-1e17bccb-24fd-4107-9285-54ba3ad1366e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Add bundle size fixture for Calendar.",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/bundle-size/Calendar.fixture.js
+++ b/packages/react-components/react-calendar-compat/bundle-size/Calendar.fixture.js
@@ -1,0 +1,7 @@
+import { Calendar } from '@fluentui/react-calendar-compat';
+
+console.log(Calendar);
+
+export default {
+  name: 'Calendar Compat',
+};

--- a/packages/react-components/react-calendar-compat/package.json
+++ b/packages/react-components/react-calendar-compat/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "bundle-size": "monosize measure",
     "clean": "just-scripts clean",
     "generate-api": "just-scripts generate-api",
     "lint": "just-scripts lint",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Calendar compat stories were not showing up due to missing dependency for calendar-compat.

## New Behavior

Calendar compat stories now show up and bundle size fixtures were added for Calendar compat.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Related #29438
