### PR TITLE
chore(react-infolabel-preview): Make react-infolabel-preview public

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -41,6 +41,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-window": "^1.8.6",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "@fluentui/react-infolabel-preview": "*"
   }
 }

--- a/change/@fluentui-react-infolabel-preview-02b3708e-7fe6-485f-9722-ad5d9a2c4f89.json
+++ b/change/@fluentui-react-infolabel-preview-02b3708e-7fe6-485f-9722-ad5d9a2c4f89.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: release preview package",
+  "packageName": "@fluentui/react-infolabel-preview",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infolabel-preview/package.json
+++ b/packages/react-components/react-infolabel-preview/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-infolabel-preview",
   "version": "0.0.0",
-  "private": true,
   "description": "InfoLabel component for Fluent UI v9",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Release preview version of infolabel. Ran the following command: `yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project @fluentui/react-one-preview --phase=preview` as shown in https://github.com/microsoft/fluentui/wiki/new-release-process---v9-packages

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #29561
