### PR TITLE
fix(scripts-generators): create manifest only from v8 monorepo packages within `generate-package-manifest` 

### DIFF
--- a/scripts/generators/generate-package-manifest.js
+++ b/scripts/generators/generate-package-manifest.js
@@ -1,37 +1,77 @@
 /**
  * This is used solely for V8 release.
- * @see {@link ../../azure-pipelines.release.yml}
+ * {@link file://./../../azure-pipelines.release.yml}
  */
 
+const fs = require('fs');
 const path = require('path');
-const fs = require('fs-extra');
+
+const { getAllPackageInfo, workspaceRoot } = require('@fluentui/scripts-monorepo');
 const semver = require('semver');
-const { getAllPackageInfo, findGitRoot } = require('@fluentui/scripts-monorepo');
 
-// Generate "manifest" file with package.jsons of all the monorepo packages (mainly for ODSP)
+main('v8', path.join(workspaceRoot, 'package-manifest'), '@fluentui/react');
 
-const ommittedPackagePaths = ['react-components', 'packages/fluentui', 'web-components', 'apps/'];
+/**
+ * Generate "manifest" JSON file with map of package.json of monorepo packages that belong under provided tag group
+ * @remarks This is mainly/only for ODSP
+ * @param {string} tag - based on this only project containing this tag will be processed
+ * @param {string} manifestRoot - directory path where it should be generated
+ * @param {string} rootPackage
+ */
+function main(tag, manifestRoot, rootPackage) {
+  const allPackageInfo = getAllPackageInfo();
 
-const allPackageInfo = getAllPackageInfo();
+  const filteredPackages = Object.entries(allPackageInfo).reduce((acc, curr) => {
+    const projectJsonPath = path.join(curr[1].packagePath, 'project.json');
+    /** @type {import('@nx/devkit').ProjectConfiguration}  */
+    const projectJson = JSON.parse(fs.readFileSync(projectJsonPath, 'utf-8'));
+    const { tags = [], projectType } = projectJson;
 
-// eslint-disable-next-line guard-for-in
-for (const key in allPackageInfo) {
-  const normalizedPath = allPackageInfo[key]?.packagePath.split('\\').join('/');
-  ommittedPackagePaths.forEach(omittedPath => {
-    if (normalizedPath.includes(omittedPath)) {
-      delete allPackageInfo[key];
-      return;
+    if (projectType === 'application') {
+      return acc;
     }
-  });
+
+    if (tags.length === 0) {
+      return acc;
+    }
+
+    if (tags.indexOf(tag) !== -1) {
+      acc[curr[0]] = curr[1];
+    }
+
+    return acc;
+  }, /** @type {typeof allPackageInfo} */ ({}));
+
+  const rootPackageVersion = filteredPackages[rootPackage].packageJson.version;
+  const packageInfoString = JSON.stringify(filteredPackages, null, 2);
+
+  const dests = [rootPackageVersion, path.join('latest', String(semver.major(rootPackageVersion)))];
+
+  for (const dest of dests) {
+    const destFolder = path.join(manifestRoot, dest);
+    fs.mkdirSync(destFolder, { recursive: true });
+    fs.writeFileSync(path.join(destFolder, 'package-manifest.json'), packageInfoString, 'utf8');
+  }
+
+  console.log('Manifest generated:\n');
+  console.log(getFileList(manifestRoot).join('\n'));
 }
-const fuirVersion = allPackageInfo['@fluentui/react'].packageJson.version;
-const packageInfoString = JSON.stringify(allPackageInfo, null, 2);
 
-const manifestRoot = path.join(findGitRoot(), 'package-manifest');
-const dests = [fuirVersion, path.join('latest', String(semver.major(fuirVersion)))];
+/**
+ * @param {string} dirName
+ */
+function getFileList(dirName) {
+  /** @type {string[]} */
+  let files = [];
+  const items = fs.readdirSync(dirName, { withFileTypes: true });
 
-for (const dest of dests) {
-  const destFolder = path.join(manifestRoot, dest);
-  fs.mkdirpSync(destFolder);
-  fs.writeFileSync(path.join(destFolder, 'package-manifest.json'), packageInfoString);
+  for (const item of items) {
+    if (item.isDirectory()) {
+      files = [...files, ...getFileList(`${dirName}/${item.name}`)];
+    } else {
+      files.push(`${dirName}/${item.name}`);
+    }
+  }
+
+  return files;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

generate manifests adds packages that are not v8 related.

## New Behavior

- generate manifests adds only v8 related packages and makes the contract correct

<img width="840" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/b0876840-4d2d-4e58-b6f1-48d0b9f3f1a4">

- script prints paths that have been created for better DX 

<img width="819" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/fe1017dc-c4f0-4483-a30f-afb101516b45">


- script is now generic and can be customized via CLI in future if needed

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
