### PR TITLE
Adds Menu Component to sideEffects

### DIFF
--- a/change/@fluentui-web-components-eb7910d3-4886-4c46-a3d3-4cb448a176eb.json
+++ b/change/@fluentui-web-components-eb7910d3-4886-4c46-a3d3-4cb448a176eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updates package with Menu component sideEffect.",
+  "packageName": "@fluentui/web-components",
+  "email": "hale.rankin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -153,6 +153,7 @@
     "./dist/esm/divider/define.js",
     "./dist/esm/image/define.js",
     "./dist/esm/label/define.js",
+    "./dist/esm/menu/define.js",
     "./dist/esm/menu-list/define.js",
     "./dist/esm/menu-button/define.js",
     "./dist/esm/menu-item/define.js",


### PR DESCRIPTION
## Previous Behavior
Menu web component definition was missing from the package.json sideEffects.

## New Behavior
Menu web component definition is now included in the list of component definitions in package.json sideEffects.

<!-- This is the behavior we should expect with the changes in this PR -->
Menu component is now properly exported.

## Related Issue(s)

- Fixes #[1230608](https://powerbi.visualstudio.com/Trident/_workitems/edit/1230608)
