### PR TITLE
bugfix(react-slider): fix input slot erroneously declared

### DIFF
--- a/change/@fluentui-react-slider-03a8f0ec-a0d3-4cd2-9ae6-ccdbba705d33.json
+++ b/change/@fluentui-react-slider-03a8f0ec-a0d3-4cd2-9ae6-ccdbba705d33.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: fix input slot erroneously declared",
+  "packageName": "@fluentui/react-slider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/etc/react-slider.api.md
+++ b/packages/react-components/react-slider/etc/react-slider.api.md
@@ -8,6 +8,7 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
@@ -52,9 +53,9 @@ export type SliderSlots = {
     root: NonNullable<Slot<'div'>>;
     rail: NonNullable<Slot<'div'>>;
     thumb: NonNullable<Slot<'div'>>;
-    input: NonNullable<Slot<'input'>> & {
+    input: NonNullable<Slot<ExtractSlotProps<Slot<'input'>> & {
         orient?: 'horizontal' | 'vertical';
-    };
+    }>>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-components/react-slider/src/components/Slider/Slider.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ComponentState, ComponentProps, Slot } from '@fluentui/react-utilities';
+import type { ComponentState, ComponentProps, Slot, ExtractSlotProps } from '@fluentui/react-utilities';
 
 export type SliderSlots = {
   /**
@@ -26,15 +26,19 @@ export type SliderSlots = {
    * except `className` and `style`, which remain on the root slot.
    *
    */
-  input: NonNullable<Slot<'input'>> & {
-    /**
-     * Orient is a non standard attribute that allows for vertical orientation in Firefox. It is set internally
-     * when `vertical` is set to true.
-     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#non_standard_attributes
-     * Webkit/Chromium support for vertical inputs is provided via -webkit-appearance css property
-     */
-    orient?: 'horizontal' | 'vertical';
-  };
+  input: NonNullable<
+    Slot<
+      ExtractSlotProps<Slot<'input'>> & {
+        /**
+         * Orient is a non standard attribute that allows for vertical orientation in Firefox. It is set internally
+         * when `vertical` is set to true.
+         * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#non_standard_attributes
+         * Webkit/Chromium support for vertical inputs is provided via -webkit-appearance css property
+         */
+        orient?: 'horizontal' | 'vertical';
+      }
+    >
+  >;
 };
 
 export type SliderProps = Omit<


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## New Behavior

1. fix `input` slot declaration

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- This was found while investigating https://github.com/microsoft/fluentui/issues/29578, having a wrongly defined slot *will* break in v18
