### PR TITLE
bugfix(react-dialog): Dialog children prop should be optional

### DIFF
--- a/change/@fluentui-react-dialog-6fcd1d84-264b-492b-8d54-38e0164c61f3.json
+++ b/change/@fluentui-react-dialog-6fcd1d84-264b-492b-8d54-38e0164c61f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Dialog children prop should be optional",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/etc/react-dialog.api.md
@@ -120,7 +120,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
     open?: boolean;
     defaultOpen?: boolean;
     onOpenChange?: DialogOpenChangeEventHandler;
-    children: [JSX.Element, JSX.Element] | JSX.Element;
+    children?: [JSX.Element, JSX.Element] | JSX.Element;
     inertTrapFocus?: boolean;
 };
 

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.types.ts
@@ -86,7 +86,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
    * Can contain two children including {@link DialogTrigger} and {@link DialogSurface}.
    * Alternatively can only contain {@link DialogSurface} if using trigger outside dialog, or controlling state.
    */
-  children: [JSX.Element, JSX.Element] | JSX.Element;
+  children?: [JSX.Element, JSX.Element] | JSX.Element;
   /**
    * Enables standard behavior according to the [HTML dialog spec](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
    * where the focus trap involves setting outside elements inert.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`Dialog` `children` property is mandatory as a dialog requires at least a surface to properly work.

Having `children` as a required property is problematic as it goes against `UnknownSlotProps` definition of what a slot is, and as a dialog component can be used as a slot (for example on the `DrawerOverlay`), it should properly follow up on slots signature, which requires `children` to be an optional value.


## New Behavior

1. makes `children` property optional meanwhile still warning the user if the proper amount of children is not provided.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

This issue has been verified while investigating https://github.com/microsoft/fluentui/issues/29578, in React v18 the slot API will break if not properly followed, requiring this change to ensure `Dialog` is a proper "slot compliant" component
