### PR TITLE
feat(scripts-task): implement initial verify-packaging task

### DIFF
--- a/change/@fluentui-react-text-701383d5-631a-46fc-a991-276a590f6132.json
+++ b/change/@fluentui-react-text-701383d5-631a-46fc-a991-276a590f6132.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add verify-packaging task",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-78031fb1-2f31-4c82-a6e6-921baf28c8f6.json
+++ b/change/@fluentui-utilities-78031fb1-2f31-4c82-a6e6-921baf28c8f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add verify-packaging task",
+  "packageName": "@fluentui/utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -16,6 +16,7 @@ module.exports = {
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
     '@fluentui/docs#build': ['@fluentui/react-northstar#build:info'],
+    'verify-packaging': ['build'],
   },
 
   // Adds some ADO-specific logging commands for reporting failures

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "lage build --verbose",
     "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components",
     "build:fluentui:docs": "gulp build:docs",
-    "buildci": "lage build test lint type-check test-ssr --verbose",
+    "buildci": "lage build test lint type-check test-ssr verify-packaging --verbose",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",
     "buildto:lerna": "node ./scripts/executors/buildTo.js",

--- a/packages/react-components/react-text/package.json
+++ b/packages/react-components/react-text/package.json
@@ -23,7 +23,8 @@
     "storybook": "start-storybook",
     "type-check": "tsc -b tsconfig.json",
     "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
+    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\"",
+    "verify-packaging": "just-scripts verify-packaging"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -21,7 +21,8 @@
     "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest -u"
+    "update-snapshots": "just-scripts jest -u",
+    "verify-packaging": "just-scripts verify-packaging"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/scripts/tasks/src/presets.ts
+++ b/scripts/tasks/src/presets.ts
@@ -21,6 +21,7 @@ import { buildStorybookTask, startStorybookTask } from './storybook';
 import { swc } from './swc';
 import { ts } from './ts';
 import { typeCheck } from './type-check';
+import { verifyPackaging } from './verify-packaging';
 import { webpack, webpackDevServer } from './webpack';
 
 /** Do only the bare minimum setup of options and resolve paths */
@@ -74,6 +75,7 @@ export function preset() {
   task('babel:postprocess', babel);
   task('generate-api', generateApi);
   task('type-check', typeCheck);
+  task('verify-packaging', verifyPackaging);
 
   task('ts:compile', () => {
     const moduleFlag = args.module;

--- a/scripts/tasks/src/verify-packaging.ts
+++ b/scripts/tasks/src/verify-packaging.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export function verifyPackaging() {
+  const cwd = process.cwd();
+  const projectJSON: import('@nx/devkit').ProjectConfiguration = JSON.parse(
+    readFileSync(path.join(cwd, 'project.json'), 'utf-8'),
+  );
+  const tags = projectJSON.tags ?? [];
+
+  const result = spawnSync('npm', ['pack', '--dry-run']);
+
+  const processedResult = result.output
+    .toString()
+    .replace(/\bnpm notice\b\s+[\d.]+[kB]+\s+/gi, '')
+    .replace(/[ ]+/g, '');
+
+  const isV8package = tags.indexOf('v8') !== -1;
+  const isV9package = tags.indexOf('vNext') !== -1;
+
+  if (isV9package) {
+    assert.doesNotMatch(processedResult, /src\/[.a-z0-9/-_]+/i, `wont ship source code from "/src"`);
+    assert.doesNotMatch(processedResult, /config\/[.a-z0-9/-_]+/i, `wont ship config folder`);
+    assert.doesNotMatch(processedResult, /etc\/[.a-z0-9/-_]+/i, `wont ship etc folder`);
+    assert.doesNotMatch(processedResult, /just\.config\.[jt]s/i, `wont ship configuration files`);
+  }
+
+  if (isV8package) {
+    assert.match(processedResult, /lib\/[.a-z0-9/-_]+(.d.ts)/i, 'ships dts');
+  }
+
+  assert.match(processedResult, /package\.json/, 'ships package.json');
+  assert.match(processedResult, /README\.md/, 'ships README.md');
+  assert.match(processedResult, /CHANGELOG\.md/, 'ships CHANGELOG.md');
+  assert.match(processedResult, /dist\/[a-z-]+\.d\.ts/, 'ships rolluped dts');
+  assert.match(processedResult, /lib-commonjs\/[.a-z0-9/-_]+(.js|.map)/i, 'ships cjs');
+  assert.match(processedResult, /lib\/[.a-z0-9/-_]+(.js|.map)/i, 'ships esm');
+
+  assert.doesNotMatch(processedResult, /docs\/[.a-z0-9/-_]+/i, `wont ship docs folder`);
+  assert.doesNotMatch(processedResult, /temp\/[.a-z0-9/-_]+/i, `wont ship temp folder`);
+  assert.doesNotMatch(processedResult, /bundle-size\/[.a-z0-9/-_]+/i, `wont ship bundle-size fixtures`);
+  assert.doesNotMatch(processedResult, /.storybook\/[.a-z0-9/-_]+/i, `wont ship .storybook config`);
+  assert.doesNotMatch(processedResult, /stories\/[.a-z0-9/-_]+/i, `wont ship stories`);
+  assert.doesNotMatch(processedResult, /jest\.config\.js/i, `wont ship configuration files`);
+  assert.doesNotMatch(processedResult, /tsconfig[.a-z]*\.json/i, `wont ship configuration files`);
+  assert.doesNotMatch(processedResult, /project\.json/i, `wont ship configuration files`);
+  assert.doesNotMatch(processedResult, /\.eslintrc\.(json|js)/i, `wont ship configuration files`);
+  assert.doesNotMatch(processedResult, /\.babelrc\.json/i, `wont ship configuration files`);
+  assert.doesNotMatch(processedResult, /\.swcrc/i, `wont ship configuration files`);
+
+  if (isV8package || tags.indexOf('ships-amd') !== -1) {
+    assert.match(processedResult, /lib-amd\/[.a-z0-9/-_]+(.js|.map)/i, 'ships amd');
+  }
+}

--- a/scripts/tasks/src/verify-packaging.ts
+++ b/scripts/tasks/src/verify-packaging.ts
@@ -50,7 +50,9 @@ export function verifyPackaging() {
   assert.doesNotMatch(processedResult, /\.babelrc\.json/i, `wont ship configuration files`);
   assert.doesNotMatch(processedResult, /\.swcrc/i, `wont ship configuration files`);
 
-  if (isV8package || tags.indexOf('ships-amd') !== -1) {
-    assert.match(processedResult, /lib-amd\/[.a-z0-9/-_]+(.js|.map)/i, 'ships amd');
-  }
+  // @FIXME `amd` is created only on release pipeline where `--production` flag is used on build commands which triggers it
+  // we should enable this also on PR pipelines - need to verify time execution impact
+  // if (isV8package || tags.indexOf('ships-amd') !== -1) {
+  //   assert.match(processedResult, /lib-amd\/[.a-z0-9/-_]+(.js|.map)/i, 'ships amd');
+  // }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

we dont know 100% what we actually ship to npm. this caused a lot of headaches in the past while migrating to new major versions of nodejs or in general config tweaks ( see linked epic for more info )

## New Behavior

- implements `verify-packaging` just-script task ( has nothing in particular with just-scripts and will be migrated to nx executor once we will start migration from lage/just).

- new task is being added to 1 v9 and 1 v8 package
- this is a pre-requirement for safe migration to node v18
- v9 (probably v8 should as well) will switch to`"files"` specifier in package.json -> thus the logic will of the task will be updated


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- implements partially https://github.com/microsoft/fluentui/issues/27758
