### PR TITLE
feat(TimePicker-compat): call onTimeSelect on blur

### DIFF
--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
@@ -42,16 +42,38 @@ describe('TimePicker', () => {
     );
     handleTimeSelect.mockClear();
 
-    // Do not call onTimeSelect when Tab out but the value remains the same
+    // Do not call onTimeSelect on Enter when the value remains the same
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     expect(handleTimeSelect).toHaveBeenCalledTimes(0);
 
-    // Call onTimeSelect when Tab out and the value changes
+    // Call onTimeSelect on Enter when the value changes
     userEvent.type(input, '111{enter}');
     expect(handleTimeSelect).toHaveBeenCalledTimes(1);
     expect(handleTimeSelect).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ selectedTimeText: '10:30111', error: 'invalid-input' }),
+    );
+  });
+
+  it('when freeform, trigger onTimeSelect on blur when value change', () => {
+    const handleTimeSelect = jest.fn();
+    const { getByRole } = render(
+      <TimePicker freeform dateAnchor={dateAnchor} onTimeSelect={handleTimeSelect} startHour={10} />,
+    );
+
+    const input = getByRole('combobox');
+    const expandIcon = getByRole('button');
+
+    // Do not call onTimeSelect when clicking dropdown icon
+    userEvent.type(input, '111');
+    userEvent.click(expandIcon);
+    expect(handleTimeSelect).toHaveBeenCalledTimes(0);
+
+    // Call onTimeSelect on focus lose
+    userEvent.tab();
+    expect(handleTimeSelect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ selectedTimeText: '111' }),
     );
   });
 });

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mergeCallbacks, useControllableState, useMergedRefs } from '@fluentui/react-utilities';
+import { elementContains, mergeCallbacks, useControllableState, useMergedRefs } from '@fluentui/react-utilities';
 import { Enter } from '@fluentui/keyboard-keys';
 import type { Hour, TimePickerOption, TimePickerProps, TimePickerState, TimeSelectionData } from './TimePicker.types';
 import { ComboboxProps, useCombobox_unstable, Option } from '@fluentui/react-combobox';
@@ -204,10 +204,7 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
   const rootRef = React.useRef<HTMLDivElement>(null);
   state.root.ref = useMergedRefs(state.root.ref, rootRef);
 
-  const listboxRef = React.useRef<HTMLDivElement>(null);
-  const mergedListboxRef = useMergedRefs(state.listbox?.ref, listboxRef);
   if (state.listbox) {
-    state.listbox.ref = mergedListboxRef;
     state.listbox.tabIndex = -1; // allows it to be the relatedTarget of a blur event.
   }
 
@@ -217,9 +214,7 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
 
   const handleInputBlur = React.useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
-      const isOutside = e.relatedTarget
-        ? [rootRef, listboxRef].every(({ current }) => !current?.contains(e.relatedTarget as HTMLElement))
-        : true;
+      const isOutside = e.relatedTarget ? !elementContains(rootRef.current, e.relatedTarget) : true;
       if (isOutside) {
         selectTimeFromValue(e);
       }


### PR DESCRIPTION
This PR adds onblur event listener to TimePicker, and update `selectedTime` state when TimePicker loses focus. Similar to browser native `onChange` event