### PR TITLE
fix(react-calendar-compat): Classnames removed and added to day cells need to be split instead of providing a string with spaces

### DIFF
--- a/change/@fluentui-react-calendar-compat-8241b3ac-9f23-473b-be97-cfbe2c70475d.json
+++ b/change/@fluentui-react-calendar-compat-8241b3ac-9f23-473b-be97-cfbe2c70475d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Classnames removed and added to day cells need to be split instead of providing a string with spaces.",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -137,7 +137,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
 
           const classNamesToAdd = calculateRoundedStyles(false, false, index > 0, index < dayRefs.length - 1).trim();
           if (classNamesToAdd) {
-            dayRef.classList.add(...classNamesToAdd);
+            dayRef.classList.add(...classNamesToAdd.trim().split(' '));
           }
         }
       }
@@ -182,7 +182,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
         ) {
           const classNamesToAdd = calculateRoundedStyles(false, false, index > 0, index < dayRefs.length - 1).trim();
           if (classNamesToAdd) {
-            dayRef.classList.remove(...classNamesToAdd);
+            dayRef.classList.remove(...classNamesToAdd.trim().split(' '));
           }
         }
       }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The classnames added/removed in day cells were the result of a makeStyles call, therefore these items contained spaces like this: `classname1 classname2 classname3`. This is an issue when using classList.add/remove since spaces are not handled, this results in an error: 

```
InvalidCharacterError
Failed to execute 'add' on 'DOMTokenList': The token provided (' ') contains HTML space characters, which are not valid in tokens.
```

## New Behavior

The classnames used in remove/add are now sanitized by splitting through spaces.

