### PR TITLE
refactor(tools): replace deprecated apis

### DIFF
--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -9,7 +9,6 @@ import {
   readJson,
   stripIndents,
   addProjectConfiguration,
-  readWorkspaceConfiguration,
   updateJson,
   logger,
   updateProjectConfiguration,
@@ -17,9 +16,10 @@ import {
   names,
   visitNotIgnoredFiles,
   writeJson,
-  WorkspaceConfiguration,
   ProjectConfiguration,
   joinPathFragments,
+  readNxJson,
+  NxJsonConfiguration,
 } from '@nx/devkit';
 
 import { PackageJson, TsConfig } from '../../types';
@@ -387,7 +387,7 @@ describe('migrate-converged-pkg generator', () => {
     });
 
     it(`should not add 3rd party packages that use same scope as our repo `, async () => {
-      const workspaceConfig = readWorkspaceConfiguration(tree);
+      const workspaceConfig = readNxJson(tree)!;
       const normalizedPkgName = getNormalizedPkgName({ pkgName: options.name, workspaceConfig });
       const thirdPartyPackageName = '@proj/jango-fet';
 
@@ -502,7 +502,7 @@ describe('migrate-converged-pkg generator', () => {
 
   describe(`storybook updates`, () => {
     function setup(config: Partial<{ createDummyStories: boolean }> = {}) {
-      const workspaceConfig = readWorkspaceConfiguration(tree);
+      const workspaceConfig = assertAndReadNxJson(tree);
       const projectConfig = readProjectConfiguration(tree, options.name);
       const normalizedProjectName = options.name.replace(`@${workspaceConfig.npmScope}/`, '');
       const projectStorybookConfigPath = `${projectConfig.root}/.storybook`;
@@ -1479,7 +1479,7 @@ describe('migrate-converged-pkg generator', () => {
 // ==== helpers ====
 
 function getScopedPkgName(tree: Tree, pkgName: string) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
 
   return `@${workspaceConfig.npmScope}/${pkgName}`;
 }
@@ -1495,7 +1495,7 @@ function setupDummyPackage(
       projectConfiguration: Partial<ReadProjectConfiguration>;
     }>,
 ) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
   const defaults = {
     version: '9.0.0-alpha.40',
     dependencies: {
@@ -1632,7 +1632,7 @@ function append(tree: Tree, filePath: string, content: string) {
   return tree;
 }
 
-function getNormalizedPkgName(options: { pkgName: string; workspaceConfig: WorkspaceConfiguration }) {
+function getNormalizedPkgName(options: { pkgName: string; workspaceConfig: NxJsonConfiguration }) {
   return options.pkgName.replace(`@${options.workspaceConfig.npmScope}/`, '');
 }
 
@@ -1643,4 +1643,14 @@ function getNormalizedPkgName(options: { pkgName: string; workspaceConfig: Works
  */
 function getFixture(src: string) {
   return fs.readFileSync(path.join(__dirname, '__fixtures__', src), 'utf-8');
+}
+
+function assertAndReadNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  if (!nxJson) {
+    throw new Error('nx.json doesnt exist');
+  }
+
+  return nxJson;
 }

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -387,7 +387,7 @@ describe('migrate-converged-pkg generator', () => {
     });
 
     it(`should not add 3rd party packages that use same scope as our repo `, async () => {
-      const workspaceConfig = readNxJson(tree)!;
+      const workspaceConfig = assertAndReadNxJson(tree);
       const normalizedPkgName = getNormalizedPkgName({ pkgName: options.name, workspaceConfig });
       const thirdPartyPackageName = '@proj/jango-fet';
 

--- a/tools/workspace-plugin/src/generators/migrate-fixed-versions/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-fixed-versions/index.spec.ts
@@ -2,10 +2,10 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   Tree,
   readProjectConfiguration,
-  readWorkspaceConfiguration,
   serializeJson,
   addProjectConfiguration,
   readJson,
+  readNxJson,
 } from '@nx/devkit';
 
 import generator from './index';
@@ -200,7 +200,7 @@ function setupDummyPackage(
       projectConfiguration: Partial<ReturnType<typeof readProjectConfiguration>>;
     }>,
 ) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
   const defaults = {
     version: '9.0.0-alpha.40',
     dependencies: {
@@ -239,4 +239,14 @@ function setupDummyPackage(
   });
 
   return tree;
+}
+
+function assertAndReadNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  if (!nxJson) {
+    throw new Error('nx.json doesnt exist');
+  }
+
+  return nxJson;
 }

--- a/tools/workspace-plugin/src/generators/move-packages/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/move-packages/index.spec.ts
@@ -2,11 +2,9 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   Tree,
   readProjectConfiguration,
-  readWorkspaceConfiguration,
   stripIndents,
   addProjectConfiguration,
   serializeJson,
-  WorkspaceConfiguration,
   parseJson,
   getProjects,
   joinPathFragments,
@@ -14,6 +12,7 @@ import {
   readJson,
   updateJson,
   NxJsonConfiguration,
+  readNxJson,
 } from '@nx/devkit';
 
 import generator from './index';
@@ -273,7 +272,7 @@ function setupDummyPackage(
       projectConfiguration: Partial<ReadProjectConfiguration>;
     }>,
 ) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
   const defaults = {
     version: '9.0.0-alpha.40',
     dependencies: {
@@ -386,6 +385,16 @@ function setupDummyPackage(
   return tree;
 }
 
-function getNormalizedPkgName(options: { pkgName: string; workspaceConfig: WorkspaceConfiguration }) {
+function getNormalizedPkgName(options: { pkgName: string; workspaceConfig: NxJsonConfiguration }) {
   return options.pkgName.replace(`@${options.workspaceConfig.npmScope}/`, '');
+}
+
+function assertAndReadNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  if (!nxJson) {
+    throw new Error('nx.json doesnt exist');
+  }
+
+  return nxJson;
 }

--- a/tools/workspace-plugin/src/generators/rc-caret/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/rc-caret/index.spec.ts
@@ -2,10 +2,10 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   Tree,
   readProjectConfiguration,
-  readWorkspaceConfiguration,
   serializeJson,
   addProjectConfiguration,
   readJson,
+  readNxJson,
 } from '@nx/devkit';
 
 import generator from './index';
@@ -24,7 +24,7 @@ describe('rc-caret generator', () => {
     jest.spyOn(console, 'warn').mockImplementation(noop);
 
     tree = createTreeWithEmptyWorkspace();
-    npmScope = readWorkspaceConfiguration(tree).npmScope ?? '@proj';
+    npmScope = assertAndReadNxJson(tree).npmScope ?? '@proj';
   });
 
   it('should work for dependencies', async () => {
@@ -131,7 +131,7 @@ function setupDummyPackage(
       projectConfiguration: Partial<ReturnType<typeof readProjectConfiguration>>;
     }>,
 ) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
   const defaults = {
     name: `@${workspaceConfig.npmScope}/react-components`,
     version: '9.0.0-alpha.40',
@@ -170,4 +170,14 @@ function setupDummyPackage(
   });
 
   return tree;
+}
+
+function assertAndReadNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  if (!nxJson) {
+    throw new Error('nx.json doesnt exist');
+  }
+
+  return nxJson;
 }

--- a/tools/workspace-plugin/src/generators/recipe-generator/index.ts
+++ b/tools/workspace-plugin/src/generators/recipe-generator/index.ts
@@ -1,4 +1,4 @@
-import { Tree, formatFiles, generateFiles, readWorkspaceConfiguration, joinPathFragments } from '@nx/devkit';
+import { Tree, formatFiles, generateFiles, joinPathFragments, readNxJson } from '@nx/devkit';
 import { RecipeGeneratorGeneratorSchema } from './schema';
 import { getProjectConfig } from '../../utils';
 
@@ -13,7 +13,7 @@ export default async function (tree: Tree, schema: RecipeGeneratorGeneratorSchem
 }
 
 function normalizeOptions(tree: Tree, schema: RecipeGeneratorGeneratorSchema) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
   const recipesProject = getProjectConfig(tree, {
     packageName: `@${workspaceConfig.npmScope}/recipes-react-components`,
   });
@@ -45,4 +45,14 @@ function validateSchema(tree: Tree, schema: RecipeGeneratorGeneratorSchema) {
   }
 
   return newSchema;
+}
+
+function assertAndReadNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  if (!nxJson) {
+    throw new Error('nx.json doesnt exist');
+  }
+
+  return nxJson;
 }

--- a/tools/workspace-plugin/src/generators/version-bump/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/version-bump/index.spec.ts
@@ -2,10 +2,10 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   Tree,
   readProjectConfiguration,
-  readWorkspaceConfiguration,
   serializeJson,
   addProjectConfiguration,
   readJson,
+  readNxJson,
 } from '@nx/devkit';
 
 import generator from './index';
@@ -308,7 +308,7 @@ function setupDummyPackage(
       beachball: PackageJsonWithBeachball['beachball'];
     }>,
 ) {
-  const workspaceConfig = readWorkspaceConfiguration(tree);
+  const workspaceConfig = assertAndReadNxJson(tree);
   const defaults = {
     version: '9.0.0-alpha.40',
     dependencies: {
@@ -348,4 +348,14 @@ function setupDummyPackage(
   });
 
   return tree;
+}
+
+function assertAndReadNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  if (!nxJson) {
+    throw new Error('nx.json doesnt exist');
+  }
+
+  return nxJson;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

removes `@nx/devkit` deprecated apis that will no longer work with nx 17

```diff
-readWorkspaceConfiguration
+readNxJson

-WorkspaceConfiguration
+NxJsonConfiguration
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/29617
