### PR TITLE
fix(hotfix/5.135.6): Remove ReallyClean pipeline task 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,11 +57,3 @@ steps:
   #    displayName: run VR Test
   #    env:
   #      SCREENER_API_KEY: $(screener.key)
-
-  # In theory the "workspace: clean: all" setting should handle this, but it doesn't always seem to work.
-  # ReallyClean is a custom task from our internal UI Fabric azure-devops-tasks repo which attempts to
-  # delete the given directory with multiple retries.
-  - task: ReallyClean@0
-    inputs:
-      directory: $(Agent.BuildDirectory)
-    condition: always()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Changes:
- `ComponentGovernance` ADO task is failing due to `ReallyClean` task deleting everything before the pipeline completes. Removing this task enables ComponentGovernance to run correctly once again

## Issue: 
   <img width="1579" alt="image" src="https://github.com/microsoft/fluentui/assets/8649804/6e62cc1f-b671-4465-9b83-a9f01176d41f">
