### PR TITLE
fix(react-drawer): accessibility tweaks

### DIFF
--- a/change/@fluentui-react-drawer-b7d10669-1f23-47cb-bc3e-21e001e940f1.json
+++ b/change/@fluentui-react-drawer-b7d10669-1f23-47cb-bc3e-21e001e940f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: improve high contrast mode",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
@@ -14,25 +14,30 @@ describe('DrawerInline', () => {
   testDrawerBaseScenarios(DrawerInline);
 
   describe('separator prop', () => {
-    it('should not render any border when separator is false', () => {
+    it('should not render any border when separator is false and position is start', () => {
       mountFluent(<DrawerInline id="drawer" position="start" open />);
 
       cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
+    });
+
+    it('should not render any border when separator is false and position is end', () => {
+      mountFluent(<DrawerInline id="drawer" position="end" open />);
+
       cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
     });
 
     it('should render correct border when when position is `start`', () => {
       mountFluent(<DrawerInline id="drawer" position="start" separator open />);
 
-      cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
-      cy.get('#drawer').should('not.have.css', `border-right-color`, 'transparent');
+      cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
+      cy.get('#drawer').should('not.have.css', `border-left-color`, 'transparent');
     });
 
     it('should render correct border when when position is `end`', () => {
       mountFluent(<DrawerInline id="drawer" position="end" separator open />);
 
-      cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
-      cy.get('#drawer').should('not.have.css', `border-left-color`, 'transparent');
+      cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
+      cy.get('#drawer').should('not.have.css', `border-right-color`, 'transparent');
     });
   });
 });

--- a/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
@@ -17,22 +17,22 @@ describe('DrawerInline', () => {
     it('should not render any border when separator is false', () => {
       mountFluent(<DrawerInline id="drawer" position="start" open />);
 
-      cy.get('#drawer').should('not.have.css', `border-right-width`, '1px');
-      cy.get('#drawer').should('not.have.css', `border-left-width`, '1px');
+      cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
+      cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
     });
 
     it('should render correct border when when position is `start`', () => {
       mountFluent(<DrawerInline id="drawer" position="start" separator open />);
 
-      cy.get('#drawer').should('not.have.css', `border-left-width`, '1px');
-      cy.get('#drawer').should('have.css', `border-right-width`, '1px');
+      cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
+      cy.get('#drawer').should('not.have.css', `border-right-color`, '1px');
     });
 
     it('should render correct border when when position is `end`', () => {
       mountFluent(<DrawerInline id="drawer" position="end" separator open />);
 
-      cy.get('#drawer').should('not.have.css', `border-right-width`, '1px');
-      cy.get('#drawer').should('have.css', `border-left-width`, '1px');
+      cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
+      cy.get('#drawer').should('not.have.css', `border-left-color`, 'transparent');
     });
   });
 });

--- a/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
@@ -14,18 +14,6 @@ describe('DrawerInline', () => {
   testDrawerBaseScenarios(DrawerInline);
 
   describe('separator prop', () => {
-    it('should not render any border when separator is false and position is start', () => {
-      mountFluent(<DrawerInline id="drawer" position="start" open />);
-
-      cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
-    });
-
-    it('should not render any border when separator is false and position is end', () => {
-      mountFluent(<DrawerInline id="drawer" position="end" open />);
-
-      cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
-    });
-
     it('should render correct border when when position is `start`', () => {
       mountFluent(<DrawerInline id="drawer" position="start" separator open />);
 

--- a/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
@@ -25,7 +25,7 @@ describe('DrawerInline', () => {
       mountFluent(<DrawerInline id="drawer" position="start" separator open />);
 
       cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
-      cy.get('#drawer').should('not.have.css', `border-right-color`, '1px');
+      cy.get('#drawer').should('not.have.css', `border-right-color`, 'transparent');
     });
 
     it('should render correct border when when position is `end`', () => {

--- a/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
+++ b/packages/react-components/react-drawer/src/components/DrawerInline/DrawerInline.cy.tsx
@@ -17,15 +17,13 @@ describe('DrawerInline', () => {
     it('should render correct border when when position is `start`', () => {
       mountFluent(<DrawerInline id="drawer" position="start" separator open />);
 
-      cy.get('#drawer').should('have.css', `border-right-color`, 'transparent');
-      cy.get('#drawer').should('not.have.css', `border-left-color`, 'transparent');
+      cy.get('#drawer').should('not.have.css', `border-right-color`, 'transparent');
     });
 
     it('should render correct border when when position is `end`', () => {
       mountFluent(<DrawerInline id="drawer" position="end" separator open />);
 
-      cy.get('#drawer').should('have.css', `border-left-color`, 'transparent');
-      cy.get('#drawer').should('not.have.css', `border-right-color`, 'transparent');
+      cy.get('#drawer').should('not.have.css', `border-left-color`, 'transparent');
     });
   });
 });

--- a/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlayStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/components/DrawerOverlay/useDrawerOverlayStyles.styles.ts
@@ -59,6 +59,10 @@ const useBackdropStyles = makeStyles({
     transitionProperty: 'opacity',
     transitionTimingFunction: tokens.curveEasyEase,
     willChange: 'opacity',
+
+    '@media screen and (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.001ms',
+    },
   },
 
   visible: {

--- a/packages/react-components/react-drawer/src/shared/useDrawerBaseStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/shared/useDrawerBaseStyles.styles.ts
@@ -48,10 +48,14 @@ const useDrawerStyles = makeStyles({
 
   /* Positioning */
   start: {
+    ...shorthands.borderRight(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+
     left: 0,
     right: 'auto',
   },
   end: {
+    ...shorthands.borderLeft(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+
     right: 0,
     left: 'auto',
   },


### PR DESCRIPTION
This PR introduces two fixes for accessibility:
- Remove CSS transitions for Drawer backdrop
- Add line separator when in "high contrast" mode

## Related Issue(s)

- Fixes #29206
