### PR TITLE
fix(TimePicker-compat): fix freeform behavior + add tests

### DIFF
--- a/change/@fluentui-react-combobox-8126d46d-4e84-4804-b216-b86e9feb4b77.json
+++ b/change/@fluentui-react-combobox-8126d46d-4e84-4804-b216-b86e9feb4b77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update `setActiveOption` type to be React Dispatch.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -88,7 +88,7 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     /* Whether the next blur event should be ignored, and the combobox/dropdown will not close.*/
     ignoreNextBlur: React.MutableRefObject<boolean>;
 
-    setActiveOption(option?: OptionValue): void;
+    setActiveOption: React.Dispatch<React.SetStateAction<OptionValue | undefined>>;
 
     setFocusVisible(focusVisible: boolean): void;
 

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { isConformant } from '../../testing/isConformant';
 import { TimePicker } from './TimePicker';
+import { TimePickerProps } from './TimePicker.types';
 
 const dateAnchor = new Date('November 25, 2021 01:00:00');
 
@@ -24,56 +25,160 @@ describe('TimePicker', () => {
     },
   });
 
-  it('when freeform, trigger onTimeSelect only when value change', () => {
-    const handleTimeSelect = jest.fn();
-    const { getByRole, getAllByRole } = render(
-      <TimePicker freeform dateAnchor={dateAnchor} onTimeSelect={handleTimeSelect} startHour={10} />,
-    );
+  it('generates the formatted option', () => {
+    const { getByRole, getAllByRole } = render(<TimePicker dateAnchor={dateAnchor} startHour={8} endHour={9} />);
 
     const input = getByRole('combobox');
-
-    // Call onTimeSelect when select an option
     userEvent.click(input);
-    userEvent.click(getAllByRole('option')[1]);
-    expect(handleTimeSelect).toHaveBeenCalledTimes(1);
-    expect(handleTimeSelect).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ selectedTimeText: '10:30' }),
-    );
-    handleTimeSelect.mockClear();
-
-    // Do not call onTimeSelect on Enter when the value remains the same
-    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    expect(handleTimeSelect).toHaveBeenCalledTimes(0);
-
-    // Call onTimeSelect on Enter when the value changes
-    userEvent.type(input, '111{enter}');
-    expect(handleTimeSelect).toHaveBeenCalledTimes(1);
-    expect(handleTimeSelect).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ selectedTimeText: '10:30111', error: 'invalid-input' }),
-    );
+    const options = getAllByRole('option');
+    expect(options.length).toBe(2);
+    expect(options[0].textContent).toBe('08:00');
+    expect(options[1].textContent).toBe('08:30');
   });
 
-  it('when freeform, trigger onTimeSelect on blur when value change', () => {
-    const handleTimeSelect = jest.fn();
-    const { getByRole } = render(
-      <TimePicker freeform dateAnchor={dateAnchor} onTimeSelect={handleTimeSelect} startHour={10} />,
+  it('generates the formatted option using formatDateToTimeString', () => {
+    const { getByRole, getAllByRole } = render(
+      <TimePicker dateAnchor={dateAnchor} formatDateToTimeString={() => 'custom'} />,
     );
 
     const input = getByRole('combobox');
-    const expandIcon = getByRole('button');
+    userEvent.click(input);
+    expect(getAllByRole('option')[0].textContent).toBe('custom');
+  });
 
-    // Do not call onTimeSelect when clicking dropdown icon
-    userEvent.type(input, '111');
-    userEvent.click(expandIcon);
-    expect(handleTimeSelect).toHaveBeenCalledTimes(0);
+  it('shows controlled time correctly', () => {
+    const TestExample = () => {
+      const [selectedTime, setSelectedTime] = React.useState<Date | null>(dateAnchor);
+      const onTimeSelect: TimePickerProps['onTimeSelect'] = (_e, data) => setSelectedTime(data.selectedTime);
+      return (
+        <TimePicker dateAnchor={dateAnchor} increment={60} selectedTime={selectedTime} onTimeSelect={onTimeSelect} />
+      );
+    };
 
-    // Call onTimeSelect on focus lose
-    userEvent.tab();
-    expect(handleTimeSelect).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ selectedTimeText: '111' }),
+    const { getByRole, getAllByRole } = render(<TestExample />);
+
+    const input = getByRole('combobox');
+    userEvent.click(input);
+    expect(getAllByRole('option')[1].getAttribute('aria-selected')).toBe('true'); // '1:00' is selected
+
+    userEvent.click(getAllByRole('option')[10]);
+    expect(getByRole('combobox').getAttribute('value')).toBe('10:00');
+  });
+
+  describe('freeform', () => {
+    const handleTimeSelect = jest.fn();
+
+    const ControlledFreeFormExample = () => {
+      const [selectedTime, setSelectedTime] = React.useState<Date | null>(dateAnchor);
+      const onTimeSelect: TimePickerProps['onTimeSelect'] = (e, data) => {
+        handleTimeSelect(e, data);
+        setSelectedTime(data.selectedTime);
+      };
+      return (
+        <TimePicker
+          freeform
+          dateAnchor={dateAnchor}
+          startHour={10}
+          selectedTime={selectedTime}
+          onTimeSelect={onTimeSelect}
+        />
+      );
+    };
+
+    const UnControlledFreeFormExample = () => (
+      <TimePicker freeform dateAnchor={dateAnchor} onTimeSelect={handleTimeSelect} startHour={10} />
     );
+
+    beforeEach(() => {
+      handleTimeSelect.mockClear();
+    });
+
+    it.each`
+      name              | Component
+      ${'uncontrolled'} | ${UnControlledFreeFormExample}
+      ${'controlled'}   | ${ControlledFreeFormExample}
+    `(
+      '$name - when input value is not prefix of any option, submit the value as selectedTime on Enter',
+      ({ Component }) => {
+        const { getByRole } = render(<Component />);
+        const input = getByRole('combobox');
+        userEvent.type(input, '111{enter}');
+        expect(handleTimeSelect).toHaveBeenCalledTimes(1);
+        expect(handleTimeSelect).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ selectedTime: null, selectedTimeText: '111', error: 'invalid-input' }),
+        );
+      },
+    );
+
+    it.each`
+      name              | Component
+      ${'uncontrolled'} | ${UnControlledFreeFormExample}
+      ${'controlled'}   | ${ControlledFreeFormExample}
+    `('$name - when input value is prefix of an option, select the option from dropdown on Enter', ({ Component }) => {
+      const { getByRole } = render(<Component />);
+      const input = getByRole('combobox');
+      userEvent.type(input, '11:{enter}');
+      expect(handleTimeSelect).toHaveBeenCalledTimes(1);
+      expect(handleTimeSelect).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ selectedTimeText: '11:00', error: undefined }),
+      );
+    });
+
+    it.each`
+      name              | Component
+      ${'uncontrolled'} | ${UnControlledFreeFormExample}
+      ${'controlled'}   | ${ControlledFreeFormExample}
+    `('$name - trigger onTimeSelect only when value change', ({ Component }) => {
+      const { getByRole, getAllByRole } = render(<Component />);
+
+      const input = getByRole('combobox');
+
+      // Call onTimeSelect when select an option
+      userEvent.click(input);
+      userEvent.click(getAllByRole('option')[1]);
+      expect(handleTimeSelect).toHaveBeenCalledTimes(1);
+      expect(handleTimeSelect).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ selectedTimeText: '10:30' }),
+      );
+      handleTimeSelect.mockClear();
+
+      // Do not call onTimeSelect on Enter when the value remains the same
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+      expect(handleTimeSelect).toHaveBeenCalledTimes(0);
+
+      // Call onTimeSelect on Enter when the value changes
+      userEvent.type(input, '111{enter}');
+      expect(handleTimeSelect).toHaveBeenCalledTimes(1);
+      expect(handleTimeSelect).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ selectedTimeText: '10:30111', error: 'invalid-input' }),
+      );
+    });
+
+    it.each`
+      name              | Component
+      ${'uncontrolled'} | ${UnControlledFreeFormExample}
+      ${'controlled'}   | ${ControlledFreeFormExample}
+    `('$name - trigger onTimeSelect on blur when value change', ({ Component }) => {
+      const { getByRole } = render(<Component />);
+
+      const input = getByRole('combobox');
+      const expandIcon = getByRole('button');
+
+      // Do not call onTimeSelect when clicking dropdown icon
+      userEvent.type(input, '111');
+      userEvent.click(expandIcon);
+      expect(handleTimeSelect).toHaveBeenCalledTimes(0);
+
+      // Call onTimeSelect on focus lose
+      userEvent.tab();
+      expect(handleTimeSelect).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ selectedTimeText: '111' }),
+      );
+    });
   });
 });

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -186,7 +186,7 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
     }
 
     setActiveOption(undefined);
-  }, [freeform, setActiveOption, prefixMatchActiveOption]);
+  }, [freeform, prefixMatchActiveOption, setActiveOption]);
 
   const selectTimeFromValue = React.useCallback(
     (e: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>) => {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -169,17 +169,14 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
   // This effect ensures that the activeOption is cleared when the input doesn't match any option.
   // This behavior is specific to a freeform TimePicker where the input value is treated as a valid time even if it's not in the dropdown.
   React.useEffect(() => {
-    setActiveOption(prevActiveOption => {
-      if (!freeform) {
-        return prevActiveOption;
-      }
-
-      const prefixMatchActiveOption = value && prevActiveOption?.text?.indexOf(value) === 0;
-      if (prefixMatchActiveOption) {
-        return prevActiveOption;
-      }
-      return undefined;
-    });
+    if (freeform && value) {
+      setActiveOption(prevActiveOption => {
+        if (prevActiveOption?.text?.indexOf(value) === 0) {
+          return prevActiveOption;
+        }
+        return undefined;
+      });
+    }
   }, [freeform, setActiveOption, value]);
 
   const selectTimeFromValue = React.useCallback(

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -174,7 +174,7 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
         return prevActiveOption;
       }
 
-      const prefixMatchActiveOption = value && prevActiveOption?.text && prevActiveOption.text.indexOf(value) === 0;
+      const prefixMatchActiveOption = value && prevActiveOption?.text?.indexOf(value) === 0;
       if (prefixMatchActiveOption) {
         return prevActiveOption;
       }

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -102,16 +102,22 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     [freeform, selectTime],
   );
 
+  const children = React.useMemo(
+    () =>
+      options.map(date => (
+        <Option key={date.key} value={date.key}>
+          {date.text}
+        </Option>
+      )),
+    [options],
+  );
+
   const baseState = useCombobox_unstable(
     {
       ...rest,
       selectedOptions,
       onOptionSelect: handleOptionSelect,
-      children: options.map(date => (
-        <Option key={date.key} value={date.key}>
-          {date.text}
-        </Option>
-      )),
+      children,
     },
     ref,
   );
@@ -163,17 +169,17 @@ const useStableDateAnchor = (providedDate: Date | undefined, startHour: Hour, en
  * - TimePicker loses focus, signifying a possible change.
  */
 const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProps['onTimeSelect']) => {
-  const { activeOption, freeform, validateFreeFormTime, options, submittedText, setActiveOption, value } = state;
+  const { activeOption, freeform, validateFreeFormTime, submittedText, setActiveOption, value } = state;
 
   // Base Combobox has activeOption default to first option in dropdown even if it doesn't match input value, and Enter key will select it.
   // This effect ensures that the activeOption is cleared when the input doesn't match any option.
   // This behavior is specific to a freeform TimePicker where the input value is treated as a valid time even if it's not in the dropdown.
-  const isValueOptionPrefix = value ? options.some(({ text }) => text.indexOf(value) === 0) : false;
+  const prefixNotMatchActiveOption = value && (!activeOption || activeOption.text.indexOf(value) !== 0);
   React.useEffect(() => {
-    if (freeform && value && !isValueOptionPrefix) {
+    if (freeform && activeOption && prefixNotMatchActiveOption) {
       setActiveOption(undefined);
     }
-  }, [freeform, isValueOptionPrefix, setActiveOption, value]);
+  }, [activeOption, freeform, prefixNotMatchActiveOption, setActiveOption]);
 
   const selectTimeFromValue = React.useCallback(
     (e: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>) => {


### PR DESCRIPTION
When typing in a freeform TimePicker and hit enter key, if the input value is not prefix of an option in the dropdown, TimePicker should submit the value as is.
However Combobox behaves differently. It is trying to set the 1st option in listbox as active option (so it will be selected on Enter key). So TimePicker is trying to clear the activeOption state set by combobox.

Before this PR, when typing an invalid option, TimePicker re-renders and re-creates new `children`, triggering [`useEffect` in `useComboboxBaseState`](https://github.com/microsoft/fluentui/blob/61d4a2910a5039af8b8509422ecfe58bc636191c/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts#L102), setting activeOption to 1st option, and it is reset to undefined by TimePicker.
This PR use set state callback to prevent the unnecessary triggering of `useEffect` in `useComboboxBaseState`. It also adds test for controlled/uncontrolled freeform scenarios.