### PR TITLE
feat(react-drawer): use useMotionClassNames to create drawer motion styles

### DIFF
--- a/change/@fluentui-react-drawer-6f092714-b539-4d1a-a9ae-30244e5d54d9.json
+++ b/change/@fluentui-react-drawer-6f092714-b539-4d1a-a9ae-30244e5d54d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: use useMotionClassNames to create drawer motion styles",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -154,9 +154,7 @@ export type OverlayDrawerSlots = {
 };
 
 // @public
-export type OverlayDrawerState = Omit<ComponentState<OverlayDrawerInternalSlots>, 'backdrop'> & Required<DrawerBaseState & {
-    backdropMotion: MotionState<HTMLDivElement>;
-}>;
+export type OverlayDrawerState = Omit<ComponentState<OverlayDrawerInternalSlots>, 'backdrop'> & Required<DrawerBaseState>;
 
 // @public
 export const renderDrawer_unstable: (state: DrawerState) => JSX.Element;

--- a/packages/react-components/react-drawer/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
@@ -5,6 +5,7 @@ import { tokens } from '@fluentui/react-theme';
 
 import type { InlineDrawerSlots, InlineDrawerState } from './InlineDrawer.types';
 import { drawerCSSVars, drawerDefaultStyles, useDrawerBaseClassNames } from '../../shared/useDrawerBaseStyles.styles';
+import { useMotionClassNames } from '@fluentui/react-motion-preview';
 
 export const inlineDrawerClassNames: SlotClassNames<InlineDrawerSlots> = {
   root: 'fui-InlineDrawer',
@@ -13,9 +14,6 @@ export const inlineDrawerClassNames: SlotClassNames<InlineDrawerSlots> = {
 const useDrawerResetStyles = makeResetStyles({
   ...drawerDefaultStyles,
   position: 'relative',
-  opacity: 0,
-  transitionProperty: 'opacity, transform',
-  willChange: 'opacity, transform',
 });
 
 /**
@@ -38,11 +36,18 @@ const useDrawerRootStyles = makeStyles({
   end: {
     transform: `translate3D(var(${drawerCSSVars.drawerSizeVar}), 0, 0)`,
   },
+});
 
-  /* Visible */
-  visible: {
+const useDrawerMotionStyles = makeStyles({
+  default: {
+    opacity: 0,
+    transitionProperty: 'opacity, transform',
+    willChange: 'opacity, transform',
+  },
+
+  enter: {
     opacity: 1,
-    transform: `translate3D(0, 0, 0)`,
+    transform: 'translate3D(0, 0, 0)',
   },
 });
 
@@ -53,6 +58,7 @@ export const useInlineDrawerStyles_unstable = (state: InlineDrawerState): Inline
   const resetStyles = useDrawerResetStyles();
   const baseClassNames = useDrawerBaseClassNames(state);
   const rootStyles = useDrawerRootStyles();
+  const motionClassNames = useMotionClassNames(state.motion, useDrawerMotionStyles());
 
   const separatorClass = React.useMemo(() => {
     if (!state.separator) {
@@ -68,7 +74,7 @@ export const useInlineDrawerStyles_unstable = (state: InlineDrawerState): Inline
     baseClassNames,
     separatorClass,
     rootStyles[state.position],
-    state.motion.active && rootStyles.visible,
+    motionClassNames,
     state.root.className,
   );
 

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.types.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.types.ts
@@ -1,6 +1,5 @@
 import type { DialogProps } from '@fluentui/react-dialog';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { MotionState } from '@fluentui/react-motion-preview';
 
 import type { DrawerBaseProps, DrawerBaseState } from '../../shared/DrawerBase.types';
 import { OverlayDrawerSurfaceProps } from './OverlayDrawerSurface';
@@ -36,11 +35,4 @@ export type OverlayDrawerProps = ComponentProps<OverlayDrawerSlots> &
  * State used in rendering OverlayDrawer
  */
 export type OverlayDrawerState = Omit<ComponentState<OverlayDrawerInternalSlots>, 'backdrop'> &
-  Required<
-    DrawerBaseState & {
-      /**
-       * Motion state for the drawer backdrop.
-       */
-      backdropMotion: MotionState<HTMLDivElement>;
-    }
-  >;
+  Required<DrawerBaseState>;

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawer.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawer.ts
@@ -23,25 +23,20 @@ export const useOverlayDrawer_unstable = (
   const { open, size, position } = useDrawerDefaultProps(props);
   const { modalType = 'modal', inertTrapFocus, defaultOpen = false, onOpenChange } = props;
 
-  const drawerMotion = useMotion<HTMLDivElement>(open);
-  const backdropMotion = useMotion<HTMLDivElement>(open);
+  const motion = useMotion<HTMLDivElement>(open);
 
-  const backdropInnerProps = slot.resolveShorthand(props.backdrop);
-  const hasCustomBackdrop = modalType !== 'non-modal' && backdropInnerProps !== null;
+  const backdropProps = slot.resolveShorthand(props.backdrop);
+  const hasCustomBackdrop = modalType !== 'non-modal' && backdropProps !== null;
 
-  const backdropProps = {
-    ...backdropInnerProps,
-    ref: useMergedRefs(backdropMotion.ref, backdropInnerProps?.ref),
-  };
   const root = slot.always(
     {
       ...props,
-      backdrop: hasCustomBackdrop ? backdropProps : null,
+      backdrop: hasCustomBackdrop ? { ...backdropProps } : null,
     },
     {
       elementType: OverlayDrawerSurface,
       defaultProps: {
-        ref: useMergedRefs(ref, drawerMotion.ref),
+        ref: useMergedRefs(ref, motion.ref),
       },
     },
   );
@@ -53,7 +48,7 @@ export const useOverlayDrawer_unstable = (
       onOpenChange,
       inertTrapFocus,
       modalType,
-      /*
+      /**
        * children is not needed here because we construct the children in the render function,
        * but it's required by DialogProps
        */
@@ -75,7 +70,6 @@ export const useOverlayDrawer_unstable = (
 
     size,
     position,
-    motion: drawerMotion,
-    backdropMotion,
+    motion,
   };
 };

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawerStyles.styles.ts
@@ -12,6 +12,7 @@ import {
   useDrawerBaseClassNames,
   useDrawerDurationStyles,
 } from '../../shared/useDrawerBaseStyles.styles';
+import { useMotionClassNames } from '@fluentui/react-motion-preview';
 
 export const overlayDrawerClassNames: SlotClassNames<OverlayDrawerSurfaceSlots> = {
   root: 'fui-OverlayDrawer',
@@ -27,10 +28,6 @@ const useDrawerResetStyles = makeResetStyles({
   position: 'fixed',
   top: 0,
   bottom: 0,
-  opacity: 0,
-  boxShadow: `0px ${tokens.colorTransparentBackground}`,
-  transitionProperty: 'transform, box-shadow, opacity',
-  willChange: 'transform, box-shadow, opacity',
 });
 
 const useDrawerRootStyles = makeStyles({
@@ -41,9 +38,16 @@ const useDrawerRootStyles = makeStyles({
   end: {
     transform: `translate3D(calc(var(${drawerCSSVars.drawerSizeVar}) * 1), 0, 0)`,
   },
+});
 
-  /* Visible */
-  visible: {
+const useDrawerMotionStyles = makeStyles({
+  default: {
+    opacity: 0,
+    boxShadow: `0px ${tokens.colorTransparentBackground}`,
+    transitionProperty: 'transform, box-shadow, opacity',
+    willChange: 'transform, box-shadow, opacity',
+  },
+  enter: {
     opacity: 1,
     transform: 'translate3D(0, 0, 0)',
     boxShadow: tokens.shadow64,
@@ -53,19 +57,15 @@ const useDrawerRootStyles = makeStyles({
 /**
  * Styles for the backdrop slot
  */
-const useBackdropStyles = makeStyles({
-  backdrop: {
+const useBackdropMotionStyles = makeStyles({
+  default: {
     opacity: 0,
     transitionProperty: 'opacity',
     transitionTimingFunction: tokens.curveEasyEase,
     willChange: 'opacity',
-
-    '@media screen and (prefers-reduced-motion: reduce)': {
-      transitionDuration: '0.001ms',
-    },
   },
 
-  visible: {
+  enter: {
     opacity: 1,
   },
 });
@@ -77,8 +77,10 @@ export const useOverlayDrawerStyles_unstable = (state: OverlayDrawerState): Over
   const baseClassNames = useDrawerBaseClassNames(state);
   const resetStyles = useDrawerResetStyles();
   const rootStyles = useDrawerRootStyles();
-  const backdropStyles = useBackdropStyles();
   const durationStyles = useDrawerDurationStyles();
+
+  const drawerMotionClassNames = useMotionClassNames(state.motion, useDrawerMotionStyles());
+  const backdropMotionClassNames = useMotionClassNames(state.motion, useBackdropMotionStyles());
 
   const backdrop = state.root.backdrop as React.HTMLAttributes<HTMLDivElement> | undefined;
 
@@ -87,16 +89,15 @@ export const useOverlayDrawerStyles_unstable = (state: OverlayDrawerState): Over
     baseClassNames,
     resetStyles,
     rootStyles[state.position],
-    state.motion.active && rootStyles.visible,
+    drawerMotionClassNames,
     state.root.className,
   );
 
   if (backdrop) {
     backdrop.className = mergeClasses(
       overlayDrawerClassNames.backdrop,
-      backdropStyles.backdrop,
+      backdropMotionClassNames,
       durationStyles[state.size],
-      state.backdropMotion.active && backdropStyles.visible,
       backdrop.className,
     );
   }

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerMotionCustom.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerMotionCustom.stories.tsx
@@ -1,8 +1,20 @@
 import * as React from 'react';
-import { DrawerBody, DrawerHeader, DrawerHeaderTitle, InlineDrawer } from '@fluentui/react-drawer';
 import { Button, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 import { Dismiss24Regular } from '@fluentui/react-icons';
-import { useMotion } from '@fluentui/react-motion-preview';
+import { useMotionClassNames, useMotion } from '@fluentui/react-motion-preview';
+import { DrawerBody, DrawerHeader, DrawerHeaderTitle, InlineDrawer } from '@fluentui/react-drawer';
+
+const visibleKeyframe = {
+  ...shorthands.borderRadius(0),
+  opacity: 1,
+  transform: 'translate3D(0, 0, 0)',
+};
+
+const hiddenKeyframe = {
+  ...shorthands.borderRadius('36px'),
+  opacity: 0,
+  transform: 'translate3D(-100%, 0, 0)',
+};
 
 const useStyles = makeStyles({
   root: {
@@ -11,27 +23,8 @@ const useStyles = makeStyles({
     display: 'flex',
     height: '480px',
     position: 'relative',
+    zIndex: 1,
     backgroundColor: '#fff',
-  },
-
-  drawer: {
-    opacity: 0,
-    transform: 'translate3D(-100%, 0, 0)',
-    transitionDuration: tokens.durationGentle,
-    willChange: 'opacity, transform',
-  },
-
-  drawerVisible: {
-    opacity: 1,
-    transform: 'translate3D(0, 0, 0)',
-  },
-
-  drawerEntering: {
-    transitionTimingFunction: tokens.curveDecelerateMid,
-  },
-
-  drawerExiting: {
-    transitionTimingFunction: tokens.curveAccelerateMin,
   },
 
   content: {
@@ -39,28 +32,64 @@ const useStyles = makeStyles({
     ...shorthands.padding('16px'),
 
     boxSizing: 'border-box',
+    overflowY: 'auto',
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
     bottom: 0,
-    transitionDuration: tokens.durationGentle,
+    zIndex: 2,
+  },
+});
+
+const drawerWidth = '360px';
+
+const useDrawerMotionStyles = makeStyles({
+  default: {
+    width: drawerWidth,
+    willChange: 'opacity, transform, border-radius',
+  },
+
+  enter: {
+    animationDuration: tokens.durationGentle,
+    animationTimingFunction: tokens.curveDecelerateMid,
+    animationName: {
+      from: hiddenKeyframe,
+      to: visibleKeyframe,
+    },
+  },
+
+  exit: {
+    transitionDuration: tokens.durationSlower,
+    animationTimingFunction: tokens.curveAccelerateMin,
+    animationName: {
+      from: visibleKeyframe,
+      to: hiddenKeyframe,
+    },
+  },
+});
+
+const useContentMotionStyles = makeStyles({
+  default: {
     transitionProperty: 'transform, background-color',
     willChange: 'transform, background-color',
-    overflowY: 'auto',
   },
-  contentActive: {
-    transform: 'translate3D(320px, 0, 0)',
+
+  enter: {
+    transitionDuration: tokens.durationSlower,
+    transitionTimingFunction: tokens.curveDecelerateMid,
+    transform: `translate3D(${drawerWidth}, 0, 0)`,
     backgroundColor: tokens.colorNeutralBackground4,
   },
-  contentEntering: {
-    transitionTimingFunction: tokens.curveDecelerateMid,
-  },
-  contentExiting: {
+
+  exit: {
+    transitionDuration: tokens.durationGentle,
     transitionTimingFunction: tokens.curveAccelerateMin,
+    backgroundColor: tokens.colorNeutralBackground1,
   },
-  contentIdle: {
-    width: 'calc(100% - 320px)',
+
+  idle: {
+    width: `calc(100% - ${drawerWidth})`,
   },
 });
 
@@ -69,19 +98,12 @@ export const MotionCustom = () => {
 
   const [open, setOpen] = React.useState(false);
   const motion = useMotion<HTMLDivElement>(open);
+  const drawerMotionClassNames = useMotionClassNames(motion, useDrawerMotionStyles());
+  const contentMotionClassNames = useMotionClassNames(motion, useContentMotionStyles());
 
   return (
     <div className={styles.root}>
-      <InlineDrawer
-        separator
-        open={motion}
-        className={mergeClasses(
-          styles.drawer,
-          motion.active && styles.drawerVisible,
-          motion.type === 'entering' && styles.drawerEntering,
-          motion.type === 'exiting' && styles.drawerExiting,
-        )}
-      >
+      <InlineDrawer separator open={motion} className={drawerMotionClassNames}>
         <DrawerHeader>
           <DrawerHeaderTitle
             action={
@@ -102,15 +124,7 @@ export const MotionCustom = () => {
         </DrawerBody>
       </InlineDrawer>
 
-      <div
-        className={mergeClasses(
-          styles.content,
-          motion.active && styles.contentActive,
-          motion.type === 'entering' && styles.contentEntering,
-          motion.type === 'exiting' && styles.contentExiting,
-          motion.type === 'idle' && styles.contentIdle,
-        )}
-      >
+      <div className={mergeClasses(styles.content, contentMotionClassNames)}>
         <Button appearance="primary" onClick={() => setOpen(!open)}>
           {open ? 'Close' : 'Open'}
         </Button>


### PR DESCRIPTION
## Previous Behavior
Previously the motion styles for the Drawer were created by applying the logic manually.

## New Behavior
Uses `useMotionClassNames` to simplify the logic.
