### PR TITLE
Fixing zero callout value not visible bug for cartesian charts

### DIFF
--- a/change/@fluentui-react-charting-bb39437e-09f9-49d3-b237-f3ed33095167.json
+++ b/change/@fluentui-react-charting-bb39437e-09f9-49d3-b237-f3ed33095167.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing zero callout value not visible bug for cartesian charts",
+  "packageName": "@fluentui/react-charting",
+  "email": "srmukher@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -755,7 +755,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
               <div className={_classNames.calloutlegendText}> {xValue.legend}</div>
               <div className={_classNames.calloutContentY}>
                 {convertToLocaleString(
-                  xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y !== undefined ? xValue.y : xValue.data,
+                  xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y ?? xValue.data,
                   culture,
                 )}
               </div>

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -755,7 +755,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
               <div className={_classNames.calloutlegendText}> {xValue.legend}</div>
               <div className={_classNames.calloutContentY}>
                 {convertToLocaleString(
-                  xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y || xValue.data,
+                  xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y !== undefined ? xValue.y : xValue.data,
                   culture,
                 )}
               </div>


### PR DESCRIPTION
Work item https://uifabric.visualstudio.com/iss/_workitems/edit/9457
If Y values are zero, the callout is not displaying the values for Cartesian Charts.

Before fix:

Area Chart
<img width="519" alt="image" src="https://github.com/microsoft/fluentui/assets/120183316/fd9a1e48-4a35-49cd-b924-e7b0dd93fe85">

Line Chart
<img width="523" alt="image" src="https://github.com/microsoft/fluentui/assets/120183316/396380b0-6b44-4ade-8c41-5d9af812bbbd">


After fix:

Area Chart
![image](https://github.com/microsoft/fluentui/assets/120183316/2c91ac5f-539c-4017-8dcf-c61d6d075911)

Line Chart
![image](https://github.com/microsoft/fluentui/assets/120183316/78a6558a-52c1-4de5-96be-7588ac8eb144)
