### PR TITLE
feat(TimePicker-compat): use `hourCycle` to set 12-hour/24-hour time format

### DIFF
--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -51,7 +51,7 @@ export type TimePickerOption = {
 /**
  * Error types returned by the `onValidationResult` callback.
  */
-export type TimePickerErrorType = 'invalid-input' | 'out-of-bounds';
+export type TimePickerErrorType = 'invalid-input' | 'out-of-bounds' | 'required-input';
 
 export type TimeStringValidationResult = {
   date: Date | null;
@@ -78,9 +78,12 @@ export type TimeSelectionData = {
 
 export type TimeFormatOptions = {
   /**
-   * If true, use 12-hour time format. Otherwise, use 24-hour format.
+   * A string value indicating whether the 12-hour format ("h11", "h12") or the 24-hour format ("h23", "h24") should be used.
+   * - 'h11' and 'h23' start with hour 0 and go up to 11 and 23 respectively.
+   * - 'h12' and 'h24' start with hour 1 and go up to 12 and 24 respectively.
+   * @default 'h23'
    */
-  hour12?: boolean;
+  hourCycle?: 'h11' | 'h12' | 'h23' | 'h24' | undefined;
 
   /**
    * If true, show seconds in the dropdown options and consider seconds for default validation purposes.
@@ -138,7 +141,7 @@ export type TimePickerProps = Omit<
     onTimeSelect?: (event: TimeSelectionEvents, data: TimeSelectionData) => void;
 
     /**
-     * Custom the date strings displayed (in dropdown options and input).
+     * Custom the date strings displayed in dropdown options.
      */
     formatDateToTimeString?: (date: Date) => string;
 

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.test.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.test.ts
@@ -78,7 +78,7 @@ describe('Time Utilities', () => {
     });
 
     it('should format time in 12-hour format with seconds', () => {
-      expect(formatDateToTimeString(testDate, { showSeconds: true, hour12: true })).toBe('11:45:12 PM');
+      expect(formatDateToTimeString(testDate, { showSeconds: true, hourCycle: 'h11' })).toBe('11:45:12 PM');
     });
 
     it('should format midnight correctly in 24-hour format', () => {
@@ -94,7 +94,7 @@ describe('Time Utilities', () => {
         return toLocaleTimeString.call(this, 'ja-JP', options);
       });
 
-      expect(formatDateToTimeString(testDate, { showSeconds: true, hour12: true })).toBe('午後11:45:12');
+      expect(formatDateToTimeString(testDate, { showSeconds: true, hourCycle: 'h11' })).toBe('午後11:45:12');
 
       toLocaleTimeStringMock.mockClear();
     });
@@ -155,7 +155,7 @@ describe('Time Utilities', () => {
 
     it('returns a valid date when given a valid time string', () => {
       const result = getDateFromTimeString('2:30 PM', dateStartAnchor, dateEndAnchor, {
-        hour12: true,
+        hourCycle: 'h11',
         showSeconds: false,
       });
       expect(result.date?.getHours()).toBe(14);
@@ -166,7 +166,7 @@ describe('Time Utilities', () => {
     it('returns an error when no time string is provided', () => {
       const result = getDateFromTimeString(undefined, dateStartAnchor, dateEndAnchor, {});
       expect(result.date).toBeNull();
-      expect(result.error).toBe('invalid-input');
+      expect(result.error).toBe('required-input');
     });
 
     it('returns an error for an invalid time string', () => {
@@ -176,12 +176,23 @@ describe('Time Utilities', () => {
     });
 
     it('returns a date in the next day and an out-of-bounds error when the time is before the dateStartAnchor', () => {
-      const result = getDateFromTimeString('1:30 PM', dateStartAnchor, new Date('November 25, 2023 13:00:00'), {
-        hour12: true,
+      const result = getDateFromTimeString('11:30 AM', dateStartAnchor, new Date('November 25, 2023 13:00:00'), {
+        hourCycle: 'h11',
+        showSeconds: false,
+      });
+      expect(result.date?.getDate()).toBe(26);
+      expect(result.date?.getHours()).toBe(11);
+      expect(result.date?.getMinutes()).toBe(30);
+      expect(result.error).toBe('out-of-bounds');
+    });
+
+    it('returns an out-of-bounds error when the time is same as the dateEndAnchor', () => {
+      const result = getDateFromTimeString('1:00 PM', dateStartAnchor, new Date('November 25, 2023 13:00:00'), {
+        hourCycle: 'h11',
         showSeconds: false,
       });
       expect(result.date?.getHours()).toBe(13);
-      expect(result.date?.getMinutes()).toBe(30);
+      expect(result.date?.getMinutes()).toBe(0);
       expect(result.error).toBe('out-of-bounds');
     });
   });

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -30,7 +30,7 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     defaultSelectedTime: defaultSelectedTimeInProps,
     endHour = 24,
     formatDateToTimeString,
-    hour12 = false,
+    hourCycle = 'h23',
     increment = 30,
     onTimeSelect,
     selectedTime: selectedTimeInProps,
@@ -51,8 +51,8 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     (dateTime: Date) =>
       formatDateToTimeString
         ? formatDateToTimeString(dateTime)
-        : defaultFormatDateToTimeString(dateTime, { showSeconds, hour12 }),
-    [hour12, formatDateToTimeString, showSeconds],
+        : defaultFormatDateToTimeString(dateTime, { showSeconds, hourCycle }),
+    [hourCycle, formatDateToTimeString, showSeconds],
   );
   const options: TimePickerOption[] = React.useMemo(
     () =>
@@ -117,8 +117,9 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
   );
 
   const defaultValidateTime = React.useCallback(
-    (time: string | undefined) => getDateFromTimeString(time, dateStartAnchor, dateEndAnchor, { hour12, showSeconds }),
-    [dateEndAnchor, dateStartAnchor, hour12, showSeconds],
+    (time: string | undefined) =>
+      getDateFromTimeString(time, dateStartAnchor, dateEndAnchor, { hourCycle, showSeconds }),
+    [dateEndAnchor, dateStartAnchor, hourCycle, showSeconds],
   );
 
   const state: TimePickerState = {

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerCustomTimeString.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerCustomTimeString.stories.tsx
@@ -1,10 +1,34 @@
 import * as React from 'react';
+import { Field, makeStyles } from '@fluentui/react-components';
 import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
 
+const useStyles = makeStyles({
+  root: {
+    maxWidth: '300px',
+  },
+});
+
+const formatDateToTimeString = (date: Date) => {
+  const localeTimeString = date.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    hourCycle: 'h12',
+  });
+  if (date.getHours() < 12) {
+    return `Morning: ${localeTimeString}`;
+  }
+  return `Afternoon: ${localeTimeString}`;
+};
+
 export const CustomTimeString = () => {
-  const [anchor] = React.useState(new Date(2023, 1, 1, 12, 0, 0, 0));
-  const formatDate = React.useCallback((date: Date) => `Custom prefix + ${date.toLocaleTimeString()}`, []);
-  return <TimePicker startHour={8} endHour={20} dateAnchor={anchor} formatDateToTimeString={formatDate} />;
+  const styles = useStyles();
+
+  const [anchor] = React.useState(new Date(2023, 1, 1));
+  return (
+    <Field label="Coffee time" className={styles.root}>
+      <TimePicker dateAnchor={anchor} formatDateToTimeString={formatDateToTimeString} />
+    </Field>
+  );
 };
 
 CustomTimeString.parameters = {

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerDefault.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerDefault.stories.tsx
@@ -1,4 +1,18 @@
 import * as React from 'react';
+import { Field, makeStyles } from '@fluentui/react-components';
 import { TimePicker, TimePickerProps } from '@fluentui/react-timepicker-compat-preview';
 
-export const Default = (props: Partial<TimePickerProps>) => <TimePicker {...props} />;
+const useStyles = makeStyles({
+  root: {
+    maxWidth: '300px',
+  },
+});
+
+export const Default = (props: Partial<TimePickerProps>) => {
+  const styles = useStyles();
+  return (
+    <Field label="Coffee time" className={styles.root}>
+      <TimePicker {...props} />
+    </Field>
+  );
+};

--- a/packages/react-components/react-timepicker-compat-preview/tsconfig.lib.json
+++ b/packages/react-components/react-timepicker-compat-preview/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "lib": ["ES2019", "dom"],
+    "lib": ["ES2019", "dom", "ES2020.Intl"],
     "declaration": true,
     "declarationDir": "../../../dist/out-tsc/types",
     "outDir": "../../../dist/out-tsc",


### PR DESCRIPTION
## Main change:

### Previous Behavior
TimePicker has `hour12: boolean` prop controls if the time format is 12-hour or 24-hour. This is the same as V8 TimePicker. But v8 TimePicker has an [open bug](https://github.com/microsoft/fluentui/issues/25041) that 24:00 and 24:30 can be displayed when 00:00 00:30 is desired. This is because `hour12: boolean` doesn't give enough control over the start and end hour of time format.

### New Behavior
Change `hour12` prop to `hourCycle?: 'h11' | 'h12' | 'h23' | 'h24' | undefined`. This is aligned with [Intl hourCycle](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle). 
'h11' and 'h23' start with hour 0 and go up to 11 and 23 respectively. 'h12' and 'h24' start with hour 1 and go up to 12 and 24 respectively. Also the support of Intl API is within our browser support matrix. 
 
## Side change:
This PR also extends the error type of time selection to add `'required-input'` type. This is to align with DatePicker compat.