### PR TITLE
fix: Toast text content should wrap

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Toast/Toast.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Toast/Toast.stories.tsx
@@ -248,7 +248,9 @@ export const ToastTitleWordBreak = () => {
   const dispatchToasts = () => {
     dispatchToast(
       <Toast ref={toastRef}>
-        <ToastTitle>This is a really long messagexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</ToastTitle>
+        <ToastTitle action={<Link>Action</Link>}>
+          This is a really long messagexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        </ToastTitle>
       </Toast>,
       {
         onStatusChange,

--- a/apps/vr-tests-react-components/src/stories/Toast/Toast.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Toast/Toast.stories.tsx
@@ -241,3 +241,51 @@ export const TitleOnlyInverted = () => {
 
 export const TitleOnlyInvertedDarkMode = getStoryVariant(TitleOnlyInverted, DARK_MODE);
 export const TitleOnlyInvertedHighContrastMode = getStoryVariant(TitleOnlyInverted, HIGH_CONTRAST);
+
+export const ToastTitleWordBreak = () => {
+  const { dispatchToast } = useToastController();
+  const { toastRef, onStatusChange } = useToastScreenshotData();
+  const dispatchToasts = () => {
+    dispatchToast(
+      <Toast ref={toastRef}>
+        <ToastTitle>This is a really long messagexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</ToastTitle>
+      </Toast>,
+      {
+        onStatusChange,
+        timeout: -1,
+      },
+    );
+  };
+  return (
+    <>
+      <button id="dispatch" onClick={dispatchToasts}>
+        Dispatch toasts
+      </button>
+      <Toaster />
+    </>
+  );
+};
+
+export const ToastBodyWordBreak = () => {
+  const { dispatchToast } = useToastController();
+  const { toastRef, onStatusChange } = useToastScreenshotData();
+  const dispatchToasts = () => {
+    dispatchToast(
+      <Toast ref={toastRef}>
+        <ToastBody>This is a really long messagexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</ToastBody>
+      </Toast>,
+      {
+        onStatusChange,
+        timeout: -1,
+      },
+    );
+  };
+  return (
+    <>
+      <button id="dispatch" onClick={dispatchToasts}>
+        Dispatch toasts
+      </button>
+      <Toaster />
+    </>
+  );
+};

--- a/change/@fluentui-react-toast-1c4a93c3-4066-4744-a222-490672ba5925.json
+++ b/change/@fluentui-react-toast-1c4a93c3-4066-4744-a222-490672ba5925.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Toast text content should wrap",
+  "packageName": "@fluentui/react-toast",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toast/src/components/ToastBody/useToastBodyStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastBody/useToastBodyStyles.styles.ts
@@ -16,6 +16,7 @@ const useRootBaseClassName = makeResetStyles({
   lineHeight: tokens.fontSizeBase300,
   fontWeight: tokens.fontWeightRegular,
   color: tokens.colorNeutralForeground1,
+  wordBreak: 'break-word',
 });
 
 const useSubtitleBaseClassName = makeResetStyles({

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -11,7 +11,6 @@ export const toastTitleClassNames: SlotClassNames<ToastTitleSlots> = {
 
 const useRootBaseClassName = makeResetStyles({
   display: 'flex',
-  alignItems: 'center',
   gridColumnEnd: 3,
   color: tokens.colorNeutralForeground1,
   wordBreak: 'break-word',
@@ -19,7 +18,7 @@ const useRootBaseClassName = makeResetStyles({
 
 const useMediaBaseClassName = makeResetStyles({
   display: 'flex',
-  alignItems: 'center',
+  paddingTop: '2px',
   gridColumnEnd: 2,
   paddingRight: '8px',
   fontSize: '16px',
@@ -28,7 +27,7 @@ const useMediaBaseClassName = makeResetStyles({
 
 const useActionBaseClassName = makeResetStyles({
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'start',
   paddingLeft: '12px',
   gridColumnEnd: -1,
   color: tokens.colorBrandForeground1,

--- a/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -14,6 +14,7 @@ const useRootBaseClassName = makeResetStyles({
   alignItems: 'center',
   gridColumnEnd: 3,
   color: tokens.colorNeutralForeground1,
+  wordBreak: 'break-word',
 });
 
 const useMediaBaseClassName = makeResetStyles({


### PR DESCRIPTION
The toast is a small surface even without reflow. Adds `word-wrap: break-word` to both the title and body so that the text content wraps with long text.

Before
![image](https://github.com/microsoft/fluentui/assets/20744592/102824b9-cdc3-4f38-b341-819686cf290b)
![image](https://github.com/microsoft/fluentui/assets/20744592/8068ae30-bc81-4fbf-8ae2-682c32e88eeb)

After 

![image](https://github.com/microsoft/fluentui/assets/20744592/a3a6e759-f0e2-4b22-8608-da15702d8f36)

![image](https://github.com/microsoft/fluentui/assets/20744592/9879d694-7a3c-400c-a459-00fa0a52c3fb)
