### PR TITLE
feat: add `matchTargetSize` positioning option

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -1141,6 +1141,24 @@ const MultiScrollParent = () => {
   );
 };
 
+const MatchTargetSize = () => {
+  const { targetRef, containerRef } = usePositioning({ matchTargetSize: 'width' });
+
+  return (
+    <>
+      <button id="target" ref={targetRef} style={{ width: 350 }}>
+        Trigger
+      </button>
+      <div
+        ref={containerRef}
+        style={{ border: '2px solid blue', padding: 20, backgroundColor: 'white', boxSizing: 'border-box' }}
+      >
+        Should have same width as trigger
+      </div>
+    </>
+  );
+};
+
 storiesOf('Positioning', module)
   .addDecorator(story => (
     <div
@@ -1223,7 +1241,8 @@ storiesOf('Positioning', module)
     <StoryWright steps={new Steps().click('#scroll').snapshot('container attached to target').end()}>
       <MultiScrollParent />
     </StoryWright>
-  ));
+  ))
+  .addStory('Match target size', () => <MatchTargetSize />);
 
 storiesOf('Positioning (no decorator)', module)
   .addStory('scroll jumps', () => (

--- a/packages/react-components/react-combobox/src/utils/useComboboxPopup.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxPopup.ts
@@ -1,26 +1,12 @@
 import { PositioningShorthandValue, resolvePositioningShorthand, usePositioning } from '@fluentui/react-positioning';
-import { ExtractSlotProps, Slot, useMergedRefs } from '@fluentui/react-utilities';
 import type { ComboboxBaseProps } from './ComboboxBase.types';
-import { Listbox } from '../components/Listbox/Listbox';
+import * as React from 'react';
 
-export function useComboboxPopup(
-  props: ComboboxBaseProps,
-  triggerShorthand?: ExtractSlotProps<Slot<'button'>>,
-  listboxShorthand?: ExtractSlotProps<Slot<typeof Listbox>>,
-): [trigger: ExtractSlotProps<Slot<'button'>>, listbox?: ExtractSlotProps<Slot<typeof Listbox>>];
-export function useComboboxPopup(
-  props: ComboboxBaseProps,
-  triggerShorthand?: ExtractSlotProps<Slot<'input'>>,
-  listboxShorthand?: ExtractSlotProps<Slot<typeof Listbox>>,
-): [trigger: ExtractSlotProps<Slot<'input'>>, listbox?: ExtractSlotProps<Slot<typeof Listbox>>];
-
-export function useComboboxPopup(
-  props: ComboboxBaseProps,
-  triggerShorthand?: ExtractSlotProps<Slot<'input'>> | ExtractSlotProps<Slot<'button'>>,
-  listboxShorthand?: ExtractSlotProps<Slot<typeof Listbox>>,
-): [
-  trigger: ExtractSlotProps<Slot<'input'>> | ExtractSlotProps<Slot<'button'>>,
-  listbox?: ExtractSlotProps<Slot<typeof Listbox>>,
+export function useComboboxPopup(props: ComboboxBaseProps): [
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  listboxRef: React.MutableRefObject<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  triggerRef: React.MutableRefObject<any>,
 ] {
   const { positioning } = props;
 
@@ -33,13 +19,11 @@ export function useComboboxPopup(
     align: 'start' as const,
     offset: { crossAxis: 0, mainAxis: 2 },
     fallbackPositions,
+    matchTargetSize: 'width' as const,
     ...resolvePositioningShorthand(positioning),
   };
 
   const { targetRef, containerRef } = usePositioning(popperOptions);
 
-  const listboxRef = useMergedRefs(listboxShorthand?.ref, containerRef);
-  const listbox = listboxShorthand && { ...listboxShorthand, ref: listboxRef };
-
-  return [{ ...triggerShorthand, ref: useMergedRefs(triggerShorthand?.ref, targetRef) }, listbox];
+  return [containerRef, targetRef];
 }

--- a/packages/react-components/react-components/stories/Concepts/Positioning/MatchTargetSize.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/MatchTargetSize.stories.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Button, Popover, PopoverSurface, PopoverTrigger, makeStyles } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  target: {
+    width: '350px',
+  },
+});
+
+export const MatchTargetSize = () => {
+  const styles = useStyles();
+  return (
+    <Popover open positioning={{ matchTargetSize: 'width' }}>
+      <PopoverTrigger disableButtonEnhancement>
+        <Button className={styles.target} appearance="primary">
+          Click me
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverSurface>This popover has the same width as its target anchor</PopoverSurface>
+    </Popover>
+  );
+};
+
+MatchTargetSize.parameters = {
+  docs: {
+    description: {
+      story: [
+        'The `matchTargetSize` option will automatically style the positioned element so that the chosen dimension',
+        'matches that of the target element. This can be useful for autocomplete or combobox input fields where the',
+        'popover should match the width of the text input field.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-components/stories/Concepts/Positioning/index.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/index.stories.tsx
@@ -13,6 +13,7 @@ export { ImperativePositionUpdate } from './PositioningImperativePositionUpdate.
 export { OverflowBoundary } from './PositioningOverflowBoundary.stories';
 export { OverflowBoundaryPadding } from './OverflowBoundaryPadding.stories';
 export { FlipBoundary } from './PositioningFlipBoundary.stories';
+export { MatchTargetSize } from './MatchTargetSize.stories';
 export { DisableTransform } from './PositioningDisableTransform.stories';
 
 export default {

--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -75,7 +75,7 @@ export type PositioningImperativeRef = {
 };
 
 // @public
-export interface PositioningProps extends Pick<PositioningOptions, 'align' | 'arrowPadding' | 'autoSize' | 'coverTarget' | 'flipBoundary' | 'offset' | 'overflowBoundary' | 'overflowBoundaryPadding' | 'pinned' | 'position' | 'strategy' | 'useTransform'> {
+export interface PositioningProps extends Pick<PositioningOptions, 'align' | 'arrowPadding' | 'autoSize' | 'coverTarget' | 'flipBoundary' | 'offset' | 'overflowBoundary' | 'overflowBoundaryPadding' | 'pinned' | 'position' | 'strategy' | 'useTransform' | 'matchTargetSize'> {
     positioningRef?: React_2.Ref<PositioningImperativeRef>;
     target?: TargetElement | null;
 }

--- a/packages/react-components/react-positioning/src/middleware/index.ts
+++ b/packages/react-components/react-positioning/src/middleware/index.ts
@@ -4,3 +4,4 @@ export * from './intersecting';
 export * from './maxSize';
 export * from './offset';
 export * from './shift';
+export * from './matchTargetSize';

--- a/packages/react-components/react-positioning/src/middleware/matchTargetSize.test.ts
+++ b/packages/react-components/react-positioning/src/middleware/matchTargetSize.test.ts
@@ -1,0 +1,105 @@
+import type { MiddlewareArguments } from '@floating-ui/dom';
+import { matchTargetSize } from './matchTargetSize';
+
+describe('matchTargetSize', () => {
+  const middlewareFn = matchTargetSize().fn;
+  it('should match reference width if not same', async () => {
+    expect.assertions(3);
+    const floatingElement = document.createElement('div');
+    const referenceWidth = 100;
+    const middlewareArguments = {
+      middlewareData: {},
+      elements: {
+        floating: floatingElement,
+      },
+
+      rects: {
+        reference: { width: referenceWidth },
+        floating: { width: '1px' },
+      },
+    } as unknown as MiddlewareArguments;
+
+    const result = await middlewareFn(middlewareArguments);
+
+    expect(result).toEqual({
+      data: {
+        matchTargetSizeAttempt: 1,
+      },
+      reset: {
+        rects: true,
+      },
+    });
+    expect(floatingElement.style.width).toBe(`${referenceWidth}px`);
+    expect(floatingElement.style.boxSizing).toBe('border-box');
+  });
+
+  it('should do nothing if reference width is equal to floating width', async () => {
+    expect.assertions(1);
+    const floatingElement = document.createElement('div');
+    const referenceWidth = 100;
+    const middlewareArguments = {
+      middlewareData: {},
+      elements: {
+        floating: floatingElement,
+      },
+
+      rects: {
+        reference: { width: referenceWidth },
+        floating: { width: referenceWidth },
+      },
+    } as unknown as MiddlewareArguments;
+
+    const result = await middlewareFn(middlewareArguments);
+
+    expect(result).toEqual({});
+  });
+
+  it('should do nothing if there have been 3 match attempts', async () => {
+    expect.assertions(1);
+    const floatingElement = document.createElement('div');
+    const referenceWidth = 100;
+    const middlewareArguments = {
+      middlewareData: { matchTargetSizeAttempt: 3 },
+      elements: {
+        floating: floatingElement,
+      },
+
+      rects: {
+        reference: { width: referenceWidth },
+        floating: { width: '1px' },
+      },
+    } as unknown as MiddlewareArguments;
+
+    const result = await middlewareFn(middlewareArguments);
+
+    expect(result).toEqual({});
+  });
+
+  it('should increment match attempt', async () => {
+    expect.assertions(1);
+    const floatingElement = document.createElement('div');
+    const referenceWidth = 100;
+    const middlewareArguments = {
+      middlewareData: { matchTargetSizeAttempt: 2 },
+      elements: {
+        floating: floatingElement,
+      },
+
+      rects: {
+        reference: { width: referenceWidth },
+        floating: { width: '1px' },
+      },
+    } as unknown as MiddlewareArguments;
+
+    const result = await middlewareFn(middlewareArguments);
+
+    expect(result).toEqual({
+      data: {
+        matchTargetSizeAttempt: 3,
+      },
+      reset: {
+        rects: true,
+      },
+    });
+  });
+});

--- a/packages/react-components/react-positioning/src/middleware/matchTargetSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/matchTargetSize.ts
@@ -1,0 +1,35 @@
+import type { Middleware } from '@floating-ui/dom';
+
+export function matchTargetSize(): Middleware {
+  return {
+    name: 'matchTargetSize',
+    fn: async middlewareArguments => {
+      const {
+        rects: { reference: referenceRect, floating: floatingRect },
+        elements: { floating: floatingElement },
+        middlewareData: { matchTargetSizeAttempt = 0 },
+      } = middlewareArguments;
+
+      if (referenceRect.width === floatingRect.width || matchTargetSizeAttempt > 2) {
+        if (matchTargetSizeAttempt > 2 && process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.error(
+            '@fluentui/react-positioning: matchTargetSize middleware could be running in a loop. Please report this error',
+          );
+        }
+        return {};
+      }
+
+      const { width } = referenceRect;
+      floatingElement.style.width = `${width}px`;
+      floatingElement.style.boxSizing = 'border-box';
+
+      return {
+        data: { matchTargetSizeAttempt: matchTargetSizeAttempt + 1 },
+        reset: {
+          rects: true,
+        },
+      };
+    },
+  };
+}

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -179,6 +179,11 @@ export interface PositioningOptions {
    * If false, does not position anything
    */
   enabled?: boolean;
+
+  /**
+   * When set, the positioned element matches the chosen dimension(s) of the target element
+   */
+  matchTargetSize?: 'width';
 }
 
 /**
@@ -199,6 +204,7 @@ export interface PositioningProps
     | 'position'
     | 'strategy'
     | 'useTransform'
+    | 'matchTargetSize'
   > {
   /** An imperative handle to Popper methods. */
   positioningRef?: React.Ref<PositioningImperativeRef>;

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -19,6 +19,7 @@ import {
   resetMaxSize as resetMaxSizeMiddleware,
   offset as offsetMiddleware,
   intersecting as intersectingMiddleware,
+  matchTargetSize as matchTargetSizeMiddleware,
 } from './middleware';
 import { createPositionManager } from './createPositionManager';
 
@@ -168,6 +169,7 @@ function usePositioningOptions(options: PositioningOptions) {
     overflowBoundaryPadding,
     fallbackPositions,
     useTransform,
+    matchTargetSize,
   } = options;
 
   const { dir } = useFluent();
@@ -180,6 +182,7 @@ function usePositioningOptions(options: PositioningOptions) {
       const hasScrollableElement = hasScrollParent(container);
 
       const middleware = [
+        matchTargetSize && matchTargetSizeMiddleware(),
         autoSize && resetMaxSizeMiddleware(autoSize),
         offset && offsetMiddleware(offset),
         coverTarget && coverTargetMiddleware(),
@@ -224,6 +227,7 @@ function usePositioningOptions(options: PositioningOptions) {
       overflowBoundaryPadding,
       fallbackPositions,
       useTransform,
+      matchTargetSize,
     ],
   );
 }


### PR DESCRIPTION
Adds an option `matchTargetSize` powered by a middleware of the same name to set the floating element's dimension to be the same as the target element's dimension.

This removes the need for a double re-render to achieve the same affect as seen in combobox. Also unblocks folks in microsoft/fluentai#589