### PR TITLE
chore(react-dialog): remove animation from test environments

### DIFF
--- a/change/@fluentui-react-dialog-583dc616-fa6f-4401-8ee9-6f25dd159aac.json
+++ b/change/@fluentui-react-dialog-583dc616-fa6f-4401-8ee9-6f25dd159aac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove animation from test environments",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -16,16 +16,20 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
     <DialogProvider value={contextValues.dialog}>
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         {trigger}
-        <Transition
-          mountOnEnter
-          unmountOnExit
-          in={state.open}
-          nodeRef={state.dialogRef}
-          // FIXME: this should not be hardcoded tokens.durationGentle
-          timeout={250}
-        >
-          {status => <DialogTransitionProvider value={status}>{content}</DialogTransitionProvider>}
-        </Transition>
+        {process.env.NODE_ENV === 'test' ? (
+          state.open && <DialogTransitionProvider value={'entered'}>{content}</DialogTransitionProvider>
+        ) : (
+          <Transition
+            mountOnEnter
+            unmountOnExit
+            in={state.open}
+            nodeRef={state.dialogRef}
+            // FIXME: this should not be hardcoded tokens.durationGentle
+            timeout={250}
+          >
+            {status => <DialogTransitionProvider value={status}>{content}</DialogTransitionProvider>}
+          </Transition>
+        )}
       </DialogSurfaceProvider>
     </DialogProvider>
   );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Conditionally removes the usage of `Transition` component to disable animations on tests environments

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29704
