### PR TITLE
docs: fix defaultSelectedOptions for Dropdown and Combobox examples

### DIFF
--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxControlled.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxControlled.stories.tsx
@@ -36,7 +36,7 @@ export const Controlled = (props: Partial<ComboboxProps>) => {
     <div className={styles.root}>
       <div className={styles.field}>
         <label htmlFor={`${comboId}-default`}>Schedule a meeting (default selection)</label>
-        <Combobox id={`${comboId}-default`} {...props} defaultValue="Elvia Atkins" defaultSelectedOptions={['ea']}>
+        <Combobox id={`${comboId}-default`} {...props} defaultValue="Elvia Atkins" defaultSelectedOptions={['eatkins']}>
           <Option text="Katri Athokas" value="kathok">
             <Persona
               avatar={{ color: 'colorful', 'aria-hidden': true }}

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownControlled.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownControlled.stories.tsx
@@ -32,7 +32,7 @@ export const Controlled = (props: Partial<DropdownProps>) => {
     <div className={styles.root}>
       <div className={styles.field}>
         <label htmlFor={`${comboId}-default`}>Schedule a meeting (default selection)</label>
-        <Dropdown id={`${comboId}-default`} {...props} defaultValue="Elvia Atkins" defaultSelectedOptions={['ea']}>
+        <Dropdown id={`${comboId}-default`} {...props} defaultValue="Elvia Atkins" defaultSelectedOptions={['eatkins']}>
           <Option text="Katri Athokas" value="kathok">
             <Persona
               avatar={{ color: 'colorful', 'aria-hidden': true }}


### PR DESCRIPTION
Found a small bug in our docs, the default value wasn't properly selected in either example, as the default value was inconsistend with the option value.