### PR TITLE
feat(TimePicker-compat): allow custom children through render function

### DIFF
--- a/change/@fluentui-react-timepicker-compat-preview-fb5d79b4-7b32-4997-9fc3-bbbdb39c5176.json
+++ b/change/@fluentui-react-timepicker-compat-preview-fb5d79b4-7b32-4997-9fc3-bbbdb39c5176.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: allow custom children through render function.",
+  "packageName": "@fluentui/react-timepicker-compat-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-timepicker-compat-preview/etc/react-timepicker-compat-preview.api.md
+++ b/packages/react-components/react-timepicker-compat-preview/etc/react-timepicker-compat-preview.api.md
@@ -27,6 +27,7 @@ export type TimePickerErrorType = 'invalid-input' | 'out-of-bounds' | 'required-
 
 // @public
 export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> & Pick<ComboboxProps, 'appearance' | 'defaultOpen' | 'defaultValue' | 'inlinePopup' | 'onOpenChange' | 'open' | 'placeholder' | 'positioning' | 'size' | 'value' | 'mountNode' | 'freeform'> & TimeFormatOptions & {
+    children?: React_2.ReactElement | React_2.ReactElement[] | ((props: TimePickerChildrenProps) => React_2.ReactElement[] | React_2.ReactElement | null) | null;
     startHour?: Hour;
     endHour?: Hour;
     increment?: number;

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -92,14 +92,12 @@ export type TimeFormatOptions = {
   showSeconds?: boolean;
 };
 
+export type TimePickerChildrenProps = { options: TimePickerOption[] };
+
 /**
  * TimePicker Props
  */
-export type TimePickerProps = Omit<
-  ComponentProps<Partial<ComboboxSlots>, 'input'>,
-  | 'children' // TODO add children prop to allow custom children through render function
-  | 'size'
-> &
+export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> &
   Pick<
     ComboboxProps,
     | 'appearance'
@@ -116,6 +114,18 @@ export type TimePickerProps = Omit<
     | 'freeform'
   > &
   TimeFormatOptions & {
+    /**
+     * TimePicker has default children. It can be customized as either:
+     * 1. A single element
+     * 2. A render function that will receive properties and must return a valid element or null
+     * 3. null or undefined
+     */
+    children?:
+      | React.ReactElement
+      | React.ReactElement[]
+      | ((props: TimePickerChildrenProps) => React.ReactElement[] | React.ReactElement | null)
+      | null;
+
     /**
      * Start hour (inclusive) for the time range, 0-24.
      */

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -116,8 +116,8 @@ export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input
   TimeFormatOptions & {
     /**
      * TimePicker has default children. It can be customized as either:
-     * 1. A single element
-     * 2. A render function that will receive properties and must return a valid element or null
+     * 1. A single element or an array of elements
+     * 2. A render function that will receive properties and must return valid element(s) or null
      * 3. null or undefined
      */
     children?:

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -26,6 +26,7 @@ import {
  */
 export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HTMLInputElement>): TimePickerState => {
   const {
+    children: childrenInProps,
     dateAnchor: dateAnchorInProps,
     defaultSelectedTime: defaultSelectedTimeInProps,
     endHour = 24,
@@ -96,16 +97,25 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     [freeform, selectTime],
   );
 
+  const children = React.useMemo(() => {
+    if (typeof childrenInProps === 'function') {
+      return childrenInProps({ options });
+    } else if (childrenInProps) {
+      return childrenInProps;
+    }
+    return options.map(date => (
+      <Option key={date.key} value={date.key}>
+        {date.text}
+      </Option>
+    ));
+  }, [childrenInProps, options]);
+
   const baseState = useCombobox_unstable(
     {
       ...rest,
       selectedOptions,
       onOptionSelect: handleOptionSelect,
-      children: options.map(date => (
-        <Option key={date.key} value={date.key}>
-          {date.text}
-        </Option>
-      )),
+      children,
     },
     ref,
   );

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerCustomOptions.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerCustomOptions.stories.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Option, OptionGroup, Field, makeStyles } from '@fluentui/react-components';
+import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: '300px',
+  },
+  groupLabel: { fontStyle: 'italic' },
+});
+
+export const CustomOptions = () => {
+  const styles = useStyles();
+  return (
+    <Field label="Coffee time" className={styles.root}>
+      <TimePicker startHour={9} endHour={15} hourCycle="h11">
+        {({ options }) => {
+          const morningOptions = options.filter(option => option.text.endsWith('am'));
+          const afternoonOptions = options.filter(option => option.text.endsWith('pm'));
+          return (
+            <>
+              <OptionGroup label={{ children: 'morning', className: styles.groupLabel }}>
+                {morningOptions.map(date => (
+                  <Option key={date.key} value={date.key} disabled={date.text === '11:00 am'}>
+                    {date.text}
+                  </Option>
+                ))}
+              </OptionGroup>
+              <OptionGroup label={{ children: 'afternoon', className: styles.groupLabel }}>
+                {afternoonOptions.map(date => (
+                  <Option key={date.key} value={date.key}>
+                    {date.text}
+                  </Option>
+                ))}
+              </OptionGroup>
+            </>
+          );
+        }}
+      </TimePicker>
+    </Field>
+  );
+};
+
+CustomOptions.parameters = {
+  docs: {
+    description: {
+      story: 'Time options in dropdown can be customized by passing a function as the children of TimePicker.',
+    },
+  },
+};

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/index.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/index.stories.tsx
@@ -7,6 +7,7 @@ export { Default } from './TimePickerDefault.stories';
 export { Controlled } from './TimePickerControlled.stories';
 export { FreeformWithErrorHandling } from './TimePickerFreeform.stories';
 export { CustomTimeString } from './TimePickerCustomTimeString.stories';
+export { CustomOptions } from './TimePickerCustomOptions.stories';
 export { TimePickerWithDatePicker } from './TimePickerWithDatePicker.stories';
 
 export default {


### PR DESCRIPTION
Allow custom children through render function and add a story.

Usage:
```tsx
<TimePicker>
  {({ options }) => {
    // custom options' rendering here
  }}
</TimePicker>;
```