### PR TITLE
fix(CI): increase pipeline agent timeout threshold 

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -31,6 +31,7 @@ extends:
       - stage: main
         jobs:
           - job: BuildTestLint
+            timeoutInMinutes: 120
             pool:
               name: '1ES-Host-Ubuntu'
               image: '1ES-PT-Ubuntu-20.04'
@@ -42,6 +43,7 @@ extends:
 
           - job: DeployE2E
             displayName: Deploy and E2E
+            timeoutInMinutes: 120
             workspace:
               clean: all
             pool:

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -18,6 +18,7 @@ pool: '1ES-Host-Ubuntu'
 
 jobs:
   - job: BuildTestLint
+    timeoutInMinutes: 120
     workspace:
       clean: all
     steps:
@@ -25,6 +26,7 @@ jobs:
 
   - job: DeployE2E
     displayName: Deploy and E2E
+    timeoutInMinutes: 120
     workspace:
       clean: all
     steps:


### PR DESCRIPTION
## Issue:
- after #29702 which migrated our pipelines to the 1ESPT, our pipelines now have extra steps that run and thus are likely to take over 60 minutes to complete.
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
- agents for the PR and CI pipelines timeout after 60 minutes.
<!-- This is the behavior we have today -->

## New Behavior
- agents for the PR and CI pipelines timeout after 120 minutes. Follows docs here: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #29702
