### PR TITLE
chore(react-tree): throws if FlatTree is used as a subtree

### DIFF
--- a/change/@fluentui-react-tree-0174e77b-7502-4cae-aaff-b17e91eb770e.json
+++ b/change/@fluentui-react-tree-0174e77b-7502-4cae-aaff-b17e91eb770e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: throws if FlatTree is used as a subtree",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/FlatTree/useFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useFlatTree.ts
@@ -5,9 +5,8 @@ import { useFlatTreeNavigation } from './useFlatTreeNavigation';
 import { HTMLElementWalker, createHTMLElementWalker } from '../../utils/createHTMLElementWalker';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { treeItemFilter } from '../../utils/treeItemFilter';
-import { slot, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
+import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import type { TreeNavigationData_unstable, TreeNavigationEvent_unstable } from '../Tree/Tree.types';
-import { useTreeContext_unstable } from '../../contexts/treeContext';
 import { useSubtree } from '../../hooks/useSubtree';
 import { ImmutableSet } from '../../utils/ImmutableSet';
 import { ImmutableMap } from '../../utils/ImmutableMap';
@@ -56,18 +55,10 @@ function useRootFlatTree(props: FlatTreeProps, ref: React.Ref<HTMLElement>): Fla
 
 function useSubFlatTree(props: FlatTreeProps, ref: React.Ref<HTMLElement>): FlatTreeState {
   if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.error(/* #__DE-INDENT__ */ `
+    throw new Error(/* #__DE-INDENT__ */ `
       @fluentui/react-tree [useFlatTree]:
       Subtrees are not allowed in a FlatTree!
-      You cannot use a <FlatTree> component inside of another <FlatTree> component.
-    `);
-  }
-  if (useTreeContext_unstable(ctx => ctx.treeType) === 'nested' && process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.error(/* #__DE-INDENT__ */ `
-      @fluentui/react-tree [useFlatTree]:
-      Error: <FlatTree> component cannot be used inside of a nested <Tree> component and vice versa.
+      You cannot use a <FlatTree> component inside of another <FlatTree> nor a <Tree> component!
     `);
   }
   return {
@@ -84,8 +75,6 @@ function useSubFlatTree(props: FlatTreeProps, ref: React.Ref<HTMLElement>): Flat
     size: 'medium',
     // ------ defaultTreeContextValue
     open: false,
-    components: { root: React.Fragment },
-    root: slot.always(props, { elementType: React.Fragment }),
   };
 }
 

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -90,12 +90,17 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
 }
 
 function useNestedSubtree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
-  if (useTreeContext_unstable(ctx => ctx.treeType) === 'flat' && process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.error(/* #__DE-INDENT__ */ `
-      @fluentui/react-tree [useTree]:
-      Error: <Tree> component cannot be used inside of a nested <FlatTree> component and vice versa.
-    `);
+  if (process.env.NODE_ENV === 'development') {
+    // this doesn't break rule of hooks, as environment is a static value
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const treeType = useTreeContext_unstable(ctx => ctx.treeType);
+    if (treeType === 'flat') {
+      throw new Error(/* #__DE-INDENT__ */ `
+        @fluentui/react-tree [useTree]:
+        Subtrees are not allowed in a FlatTree!
+        You cannot use a <Tree> component inside of a <FlatTree> component!
+      `);
+    }
   }
   return useSubtree(props, ref);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

FlatTree just console error about the fact user should not be using a FlatTree as a subtree

## New Behavior

As multiple clients were detected using FlatTree as a subtree, this PR ensure that in development FlatTree will throw if used  as a subtree

1. Throws in development if FlatTree is used as a subtree
2. Throws in development if Tree is used as a subtree of a FlatTree

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
