### PR TITLE
chore(TimePicker-compat): add VR test

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -65,6 +65,7 @@
     "@fluentui/react-text": "*",
     "@fluentui/react-textarea": "*",
     "@fluentui/react-theme": "*",
+    "@fluentui/react-timepicker-compat-preview": "*",
     "@fluentui/react-toast": "*",
     "@fluentui/react-tooltip": "*",
     "@fluentui/react-toolbar": "*",

--- a/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react';
+import { ComponentMeta } from '@storybook/react';
 import { Steps, StoryWright } from 'storywright';
-import { storiesOf } from '@storybook/react';
 import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
-import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
 
-storiesOf('TimePicker compat', module)
-  .addDecorator(TestWrapperDecoratorFixedWidth)
-  .addDecorator(story => <StoryWright steps={new Steps().snapshot('default').end()}>{story()}</StoryWright>)
-  .addStory('Default', () => <TimePicker open startHour={11} endHour={13} />)
-  .addStory('With 12-hour format', () => <TimePicker open startHour={11} endHour={13} hourCycle="h11" />)
-  .addStory('Show seconds', () => <TimePicker open startHour={11} endHour={13} showSeconds />);
+export default {
+  title: 'TimePicker compat',
+  decorators: [
+    Story => (
+      <StoryWright steps={new Steps().snapshot('default').end()}>
+        <Story />
+      </StoryWright>
+    ),
+  ],
+} as ComponentMeta<typeof TimePicker>;
+
+export const Default = () => <TimePicker open startHour={11} endHour={13} />;
+export const With12HourFormat = () => <TimePicker open startHour={11} endHour={13} hourCycle="h11" />;
+export const ShowSeconds = () => <TimePicker open startHour={11} endHour={13} showSeconds />;

--- a/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
@@ -6,13 +6,7 @@ import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorato
 
 storiesOf('TimePicker compat', module)
   .addDecorator(TestWrapperDecoratorFixedWidth)
-  .addDecorator(story => (
-    <StoryWright steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</StoryWright>
-  ))
-  .addStory('Default', () => (
-    <div style={{ paddingBottom: '120px' }}>
-      <TimePicker open startHour={11} endHour={13} />
-    </div>
-  ))
+  .addDecorator(story => <StoryWright steps={new Steps().snapshot('default').end()}>{story()}</StoryWright>)
+  .addStory('Default', () => <TimePicker open startHour={11} endHour={13} />)
   .addStory('With 12-hour format', () => <TimePicker open startHour={11} endHour={13} hourCycle="h11" />)
   .addStory('Show seconds', () => <TimePicker open startHour={11} endHour={13} showSeconds />);

--- a/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Steps, StoryWright } from 'storywright';
+import { storiesOf } from '@storybook/react';
+import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
+import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
+
+storiesOf('TimePicker compat', module)
+  .addDecorator(TestWrapperDecoratorFixedWidth)
+  .addDecorator(story => (
+    <StoryWright steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</StoryWright>
+  ))
+  .addStory('Default', () => <TimePicker open startHour={11} endHour={13} />)
+  .addStory('With 12-hour format', () => <TimePicker open startHour={11} endHour={13} hourCycle="h11" />)
+  .addStory('Show seconds', () => <TimePicker open startHour={11} endHour={13} showSeconds />);

--- a/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
@@ -9,6 +9,10 @@ storiesOf('TimePicker compat', module)
   .addDecorator(story => (
     <StoryWright steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</StoryWright>
   ))
-  .addStory('Default', () => <TimePicker open startHour={11} endHour={13} />)
+  .addStory('Default', () => (
+    <div style={{ paddingBottom: '120px' }}>
+      <TimePicker open startHour={11} endHour={13} />
+    </div>
+  ))
   .addStory('With 12-hour format', () => <TimePicker open startHour={11} endHour={13} hourCycle="h11" />)
   .addStory('Show seconds', () => <TimePicker open startHour={11} endHour={13} showSeconds />);


### PR DESCRIPTION
Add VR test.
Since TimePicker is built on Combobox, the VR test focuses on TimePicker specifics and skips the tests like appearances/sizes that are tested in Combobox