### PR TITLE
breaking(react-drawer): open now only accepts a boolean instead of MotionShorthand

### DIFF
--- a/change/@fluentui-react-drawer-f0b39b94-dc6b-447a-aae1-919873990ecb.json
+++ b/change/@fluentui-react-drawer-f0b39b94-dc6b-447a-aae1-919873990ecb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "breaking: open prop now only accepts a boolean instead of MotionShorthand ",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -11,7 +11,6 @@ import type { ComponentState } from '@fluentui/react-utilities';
 import type { DialogProps } from '@fluentui/react-dialog';
 import type { DialogSurfaceSlots } from '@fluentui/react-dialog';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { MotionShorthand } from '@fluentui/react-motion-preview';
 import { MotionState } from '@fluentui/react-motion-preview';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';

--- a/packages/react-components/react-drawer/src/shared/DrawerBase.types.ts
+++ b/packages/react-components/react-drawer/src/shared/DrawerBase.types.ts
@@ -1,4 +1,4 @@
-import { MotionShorthand, MotionState } from '@fluentui/react-motion-preview';
+import { MotionState } from '@fluentui/react-motion-preview';
 
 export type DrawerBaseProps = {
   /**
@@ -25,7 +25,7 @@ export type DrawerBaseProps = {
    *
    * @default false
    */
-  open?: MotionShorthand<HTMLDivElement>;
+  open?: boolean;
 };
 
 export type DrawerBaseState = Required<Pick<DrawerBaseProps, 'position' | 'size'>> & {

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerMotionCustom.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerMotionCustom.stories.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
-import { Button, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
+import { Button, makeStyles, mergeClasses, shorthands /* tokens */ } from '@fluentui/react-components';
 import { Dismiss24Regular } from '@fluentui/react-icons';
-import { useMotionClassNames, useMotion } from '@fluentui/react-motion-preview';
+// import { useMotionClassNames, useMotion } from '@fluentui/react-motion-preview';
 import { DrawerBody, DrawerHeader, DrawerHeaderTitle, InlineDrawer } from '@fluentui/react-drawer';
 
-const visibleKeyframe = {
-  ...shorthands.borderRadius(0),
-  opacity: 1,
-  transform: 'translate3D(0, 0, 0)',
-};
+/**
+ * TODO: The contents of this file should be uncommented when react-motion is stable.
+ * Note that this file is not included in the documentation, but we can keep it here for use in the future.
+ */
 
-const hiddenKeyframe = {
-  ...shorthands.borderRadius('36px'),
-  opacity: 0,
-  transform: 'translate3D(-100%, 0, 0)',
-};
+// const visibleKeyframe = {
+//   ...shorthands.borderRadius(0),
+//   opacity: 1,
+//   transform: 'translate3D(0, 0, 0)',
+// };
+
+// const hiddenKeyframe = {
+//   ...shorthands.borderRadius('36px'),
+//   opacity: 0,
+//   transform: 'translate3D(-100%, 0, 0)',
+// };
 
 const useStyles = makeStyles({
   root: {
@@ -42,68 +47,68 @@ const useStyles = makeStyles({
   },
 });
 
-const drawerWidth = '360px';
+// const drawerWidth = '360px';
 
-const useDrawerMotionStyles = makeStyles({
-  default: {
-    width: drawerWidth,
-    willChange: 'opacity, transform, border-radius',
-  },
+// const useDrawerMotionStyles = makeStyles({
+//   default: {
+//     width: drawerWidth,
+//     willChange: 'opacity, transform, border-radius',
+//   },
 
-  enter: {
-    animationDuration: tokens.durationGentle,
-    animationTimingFunction: tokens.curveDecelerateMid,
-    animationName: {
-      from: hiddenKeyframe,
-      to: visibleKeyframe,
-    },
-  },
+//   enter: {
+//     animationDuration: tokens.durationGentle,
+//     animationTimingFunction: tokens.curveDecelerateMid,
+//     animationName: {
+//       from: hiddenKeyframe,
+//       to: visibleKeyframe,
+//     },
+//   },
 
-  exit: {
-    transitionDuration: tokens.durationSlower,
-    animationTimingFunction: tokens.curveAccelerateMin,
-    animationName: {
-      from: visibleKeyframe,
-      to: hiddenKeyframe,
-    },
-  },
-});
+//   exit: {
+//     transitionDuration: tokens.durationSlower,
+//     animationTimingFunction: tokens.curveAccelerateMin,
+//     animationName: {
+//       from: visibleKeyframe,
+//       to: hiddenKeyframe,
+//     },
+//   },
+// });
 
-const useContentMotionStyles = makeStyles({
-  default: {
-    transitionProperty: 'transform, background-color',
-    willChange: 'transform, background-color',
-  },
+// const useContentMotionStyles = makeStyles({
+//   default: {
+//     transitionProperty: 'transform, background-color',
+//     willChange: 'transform, background-color',
+//   },
 
-  enter: {
-    transitionDuration: tokens.durationSlower,
-    transitionTimingFunction: tokens.curveDecelerateMid,
-    transform: `translate3D(${drawerWidth}, 0, 0)`,
-    backgroundColor: tokens.colorNeutralBackground4,
-  },
+//   enter: {
+//     transitionDuration: tokens.durationSlower,
+//     transitionTimingFunction: tokens.curveDecelerateMid,
+//     transform: `translate3D(${drawerWidth}, 0, 0)`,
+//     backgroundColor: tokens.colorNeutralBackground4,
+//   },
 
-  exit: {
-    transitionDuration: tokens.durationGentle,
-    transitionTimingFunction: tokens.curveAccelerateMin,
-    backgroundColor: tokens.colorNeutralBackground1,
-  },
+//   exit: {
+//     transitionDuration: tokens.durationGentle,
+//     transitionTimingFunction: tokens.curveAccelerateMin,
+//     backgroundColor: tokens.colorNeutralBackground1,
+//   },
 
-  idle: {
-    width: `calc(100% - ${drawerWidth})`,
-  },
-});
+//   idle: {
+//     width: `calc(100% - ${drawerWidth})`,
+//   },
+// });
 
 export const MotionCustom = () => {
   const styles = useStyles();
 
   const [open, setOpen] = React.useState(false);
-  const motion = useMotion<HTMLDivElement>(open);
-  const drawerMotionClassNames = useMotionClassNames(motion, useDrawerMotionStyles());
-  const contentMotionClassNames = useMotionClassNames(motion, useContentMotionStyles());
+  // const motion = useMotion<HTMLDivElement>(open);
+  // const drawerMotionClassNames = useMotionClassNames(motion, useDrawerMotionStyles());
+  // const contentMotionClassNames = useMotionClassNames(motion, useContentMotionStyles());
 
   return (
     <div className={styles.root}>
-      <InlineDrawer separator open={motion} className={drawerMotionClassNames}>
+      <InlineDrawer separator /* open={motion} className={drawerMotionClassNames} */>
         <DrawerHeader>
           <DrawerHeaderTitle
             action={
@@ -124,7 +129,7 @@ export const MotionCustom = () => {
         </DrawerBody>
       </InlineDrawer>
 
-      <div className={mergeClasses(styles.content, contentMotionClassNames)}>
+      <div className={mergeClasses(styles.content /* contentMotionClassNames */)}>
         <Button appearance="primary" onClick={() => setOpen(!open)}>
           {open ? 'Close' : 'Open'}
         </Button>

--- a/packages/react-components/react-drawer/stories/Drawer/index.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/index.stories.tsx
@@ -22,7 +22,8 @@ export { Separator } from './DrawerSeparator.stories';
 export { WithTitle } from './DrawerWithTitle.stories';
 export { WithNavigation } from './DrawerWithNavigation.stories';
 export { WithScroll } from './DrawerWithScroll.stories';
-export { MotionCustom } from './DrawerMotionCustom.stories';
+// @TODO: enable when react-motion is stable
+// export { MotionCustom } from './DrawerMotionCustom.stories';
 export { MotionDisabled } from './DrawerMotionDisabled.stories';
 export { MultipleLevels } from './DrawerMultipleLevels.stories';
 export { AlwaysOpen } from './DrawerAlwaysOpen.stories';


### PR DESCRIPTION
This is technically a Breaking Change, but as the package is still in preview, we can have that happening.

This change makes the `open` prop on all the main Drawer components to only accept a `boolean` value. Previously it was accepting a MotionShorthand type as well. This will be added back in the future when the react-motion package becomes stable.

For more information: https://github.com/microsoft/fluentui/pull/29711