### PR TITLE
fix: v8 ComboBox preventDismissOnEvent does not override passed-in prop

### DIFF
--- a/change/@fluentui-react-1c4645e3-a3e3-49b1-9e15-df952be33941.json
+++ b/change/@fluentui-react-1c4645e3-a3e3-49b1-9e15-df952be33941.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: preventDismissOnEvent does not override passed-in prop",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -853,6 +853,12 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * @returns a boolean indicating whether the callout dismissal should be prevented
    */
   private _preventDismissOnScrollOrResize(ev: Event) {
+    // default to passed-in preventDismiss
+    const { calloutProps } = this.props;
+    if (calloutProps?.preventDismissOnEvent) {
+      return calloutProps.preventDismissOnEvent(ev);
+    }
+
     if (this._overrideScrollDismiss && (ev.type === 'scroll' || ev.type === 'resize')) {
       return true;
     }


### PR DESCRIPTION
A fix for a team requires passing in `preventDismissOnEvent` to `calloutProps` in ComboBox, but it is currently overridden by the internal `preventDismissOnEvent`. Quick fix to respect the passed-in prop.