### PR TITLE
feat(tools): create package.json#files based on project setup within migrate-converged-pkg generator, dont dupe tsConfig in conformance setup

### DIFF
--- a/tools/workspace-plugin/project.json
+++ b/tools/workspace-plugin/project.json
@@ -71,5 +71,5 @@
       "command": "node ./tools/workspace-plugin/scripts/check-dep-graph.js"
     }
   },
-  "tags": ["platform:any", "tools"]
+  "tags": ["platform:node", "tools"]
 }

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -243,7 +243,7 @@ describe('migrate-converged-pkg generator', () => {
       const tsConfigTest = getTsConfig.test();
 
       expect(tsConfigMain).toEqual({
-        extends: '../../../../../tsconfig.base.json',
+        extends: '../../tsconfig.base.json',
         compilerOptions: {
           importHelpers: true,
           isolatedModules: true,
@@ -439,7 +439,7 @@ describe('migrate-converged-pkg generator', () => {
          */
         module.exports = {
           displayName: 'react-dummy',
-          preset: '../../../../../jest.preset.js',
+          preset: '../../jest.preset.js',
           transform: {
             '^.+\\\\\\\\.tsx?$': [
               'ts-jest',
@@ -585,10 +585,10 @@ describe('migrate-converged-pkg generator', () => {
       );
 
       expect(tree.read(`${projectStorybookConfigPath}/main.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
-        "const rootMain = require('../../../../../../.storybook/main');
+        "const rootMain = require('../../../.storybook/main');
 
         module.exports =
-          /** @type {Omit<import('../../../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+          /** @type {Omit<import('../../../.storybook/main'), 'typescript'|'babel'>} */ ({
             ...rootMain,
             stories: [
               ...rootMain.stories,
@@ -608,7 +608,7 @@ describe('migrate-converged-pkg generator', () => {
       `);
 
       expect(tree.read(`${projectStorybookConfigPath}/preview.js`)?.toString('utf-8')).toMatchInlineSnapshot(`
-        "import * as rootPreview from '../../../../../../.storybook/preview';
+        "import * as rootPreview from '../../../.storybook/preview';
 
         /** @type {typeof rootPreview.decorators} */
         export const decorators = [...rootPreview.decorators];
@@ -1307,6 +1307,27 @@ describe('migrate-converged-pkg generator', () => {
         }
         "
       `);
+
+      // make sure it is added only once
+
+      await generator(tree, options);
+
+      expect(stripIndents`${tree.read(conformanceSetupPath, 'utf-8')}`).toEqual(
+        expect.stringContaining(stripIndents`
+          const defaultOptions: Partial<IsConformantOptions<TProps>> = {
+            tsConfig: { configName: 'tsconfig.spec.json' },
+            componentPath: require.main?.filename.replace('.test', ''),
+            extraTests: griffelTests as TestObject<TProps>,
+            testOptions: {
+              'make-styles-overrides-win': {
+                callCount: 2,
+              },
+              // TODO: https://github.com/microsoft/fluentui/issues/19618
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+          };
+      `),
+      );
     });
   });
 

--- a/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
@@ -7,7 +7,12 @@
   "module": "lib/index.js",
   "typings": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": ["lib", "lib-commonjs", "dist/*.d.ts"],
+  "files": [
+    "*.md",
+    "dist/*.d.ts",
+    "lib",
+    "lib-commonjs"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -101,6 +101,7 @@ describe('react-library generator', () => {
         name: '@proj/react-one-preview',
         private: true,
         version: '0.0.0',
+        files: ['*.md', 'dist/*.d.ts', 'lib', 'lib-commonjs'],
         dependencies: {
           '@fluentui/react-jsx-runtime': '^9.0.0',
           '@fluentui/react-theme': '^9.0.0',

--- a/tools/workspace-plugin/src/types.ts
+++ b/tools/workspace-plugin/src/types.ts
@@ -28,6 +28,20 @@ export interface PackageJson {
   name: string;
   main: string;
   module?: string;
+  /**
+   * Vite and Webpack(sass-loader) consume this field
+   * @see https://github.com/microsoft/fluentui/pull/27274
+   */
+  style?: string;
+  /**
+   * https://storybook.js.org/docs/6.5/react/addons/integration-catalog
+   */
+  storybook?: Partial<{
+    displayName: string;
+    icon: string;
+    unsupportedFrameworks: string[];
+    supportedFrameworks: string[];
+  }>;
   version: string;
   scripts?: Record<string, string>;
   dependencies?: Record<string, string>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

features:

- migrate-converged-pkg:
  - `package.json#files` property is created based on project context/setup 

bufixes:

- `migrate-converged-pkg`:
  - `tsConfig` property is no longer added to conformance setup on consecutive migrate generator runs
  - fixes relative path generation
  - adds `styles` to export maps if specified
  - `test-ssr`  npm task is added based on project context/setup instead adding it to every one
- `react-library`
  - adds test for `files` 
  - adds `*.md` to files 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/29616
- Implements partially https://github.com/microsoft/fluentui/issues/27758
