### PR TITLE
fix(react-calendar-compat, Calendar): Calendar should memoize default value since it's a new Date() to avoid rerenders

### DIFF
--- a/change/@fluentui-react-calendar-compat-b50cbe44-44ed-4b3a-9329-aa9be78d1e75.json
+++ b/change/@fluentui-react-calendar-compat-b50cbe44-44ed-4b3a-9329-aa9be78d1e75.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: Calendar should memoize default value since it's a new Date() to avoid rerenders.",
+  "comment": "fix(Calendar): Calendar should memoize today's default value since it causes rerenders by creating a new object each time.",
   "packageName": "@fluentui/react-calendar-compat",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-calendar-compat-b50cbe44-44ed-4b3a-9329-aa9be78d1e75.json
+++ b/change/@fluentui-react-calendar-compat-b50cbe44-44ed-4b3a-9329-aa9be78d1e75.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Calendar should memoize default value since it's a new Date() to avoid rerenders.",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-f74bc323-4380-4898-a854-205fb9b839f3.json
+++ b/change/@fluentui-react-f74bc323-4380-4898-a854-205fb9b839f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Calendar): Calendar should memoize default value since it's a new Date() to avoid rerenders.",
+  "packageName": "@fluentui/react",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-f74bc323-4380-4898-a854-205fb9b839f3.json
+++ b/change/@fluentui-react-f74bc323-4380-4898-a854-205fb9b839f3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(Calendar): Calendar should memoize default value since it's a new Date() to avoid rerenders.",
+  "comment": "fix(Calendar): Calendar should memoize today's default value since it causes rerenders by creating a new object each time.",
   "packageName": "@fluentui/react",
   "email": "esteban.230@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
@@ -29,7 +29,16 @@ const defaultWorkWeekDays: DayOfWeek[] = [
   DayOfWeek.Friday,
 ];
 
-function useDateState({ value, today = new Date(), onSelectDate }: CalendarProps) {
+function useDateState(props: CalendarProps) {
+  const { value, today: todayProp, onSelectDate } = props;
+
+  const today = React.useMemo(() => {
+    if (todayProp === undefined) {
+      return new Date();
+    }
+    return todayProp;
+  }, [todayProp]);
+
   /** The currently selected date in the calendar */
   const [selectedDate, setSelectedDate] = useControllableState({
     defaultState: today,

--- a/packages/react/src/components/Calendar/Calendar.base.tsx
+++ b/packages/react/src/components/Calendar/Calendar.base.tsx
@@ -59,7 +59,16 @@ const DEFAULT_PROPS: Partial<ICalendarProps> = {
   allFocusable: false,
 };
 
-function useDateState({ value, today = new Date(), onSelectDate }: ICalendarProps) {
+function useDateState(props: ICalendarProps) {
+  const { value, today: todayProp, onSelectDate } = props;
+
+  const today = React.useMemo(() => {
+    if (todayProp === undefined) {
+      return new Date();
+    }
+    return todayProp;
+  }, [todayProp]);
+
   /** The currently selected date in the calendar */
   const [selectedDate = today, setSelectedDate] = useControllableValue(value, today);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Calendar was applying a default value `new Date()` to today which causes rerenders since it creates a new object each time when today is undefined.

## New Behavior

Calendar now memoizes today in order to avoid rerenders
