### PR TITLE
Fix `List` rendering at end of `List` and add debug renderer.

### DIFF
--- a/change/@fluentui-react-2053c5af-0a37-49f4-8a7f-a7770d2da5cb.json
+++ b/change/@fluentui-react-2053c5af-0a37-49f4-8a7f-a7770d2da5cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update List to render after scrolling finishes.",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/List/List.Basic.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Basic.Example.tsx
@@ -58,7 +58,7 @@ const generateStyles = (theme: ITheme) => {
 };
 
 export const ListBasicExample: React.FunctionComponent = () => {
-  const originalItems = useConst(() => createListItems(61));
+  const originalItems = useConst(() => createListItems(5000));
   const [items, setItems] = React.useState(originalItems);
   const theme = useTheme();
   const classNames = React.useMemo(() => generateStyles(theme), [theme]);

--- a/packages/react-examples/src/react/List/List.Basic.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Basic.Example.tsx
@@ -58,7 +58,7 @@ const generateStyles = (theme: ITheme) => {
 };
 
 export const ListBasicExample: React.FunctionComponent = () => {
-  const originalItems = useConst(() => createListItems(5000));
+  const originalItems = useConst(() => createListItems(61));
   const [items, setItems] = React.useState(originalItems);
   const theme = useTheme();
   const classNames = React.useMemo(() => generateStyles(theme), [theme]);

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -953,12 +953,6 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       const isPageInRequiredRange =
         !this._requiredRect || (pageBottom >= this._requiredRect.top && pageTop <= this._requiredRect.bottom!);
 
-      const isPagePartiallyInRequiredRange =
-        !isPageInRequiredRange &&
-        this._requiredRect &&
-        ((pageTop < this._requiredRect.top && pageBottom > this._requiredRect.top) ||
-          (pageTop < this._requiredRect.bottom! && pageBottom > this._requiredRect.bottom!));
-
       const isPageVisible =
         (!isFirstRender && (isPageInRequiredRange || (isPageInAllowedRange && isPageRendered))) || !shouldVirtualize;
       const isPageFocused = focusedIndex >= itemIndex && focusedIndex < itemIndex + itemsPerPage;
@@ -990,7 +984,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
         pages.push(newPage);
 
-        if ((isPageInRequiredRange || isPagePartiallyInRequiredRange) && this._allowedRect) {
+        if (isPageInRequiredRange && this._allowedRect) {
           _mergeRect(materializedRect, {
             top: pageTop,
             bottom: pageBottom,

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1144,10 +1144,6 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     const scrollHeight = getScrollHeight(this._scrollElement);
     const scrollTop = getScrollYPosition(this._scrollElement);
 
-    const doUpdate =
-      Math.abs((this._visibleRect?.bottom ?? 0) - (this._materializedRect?.bottom ?? 0)) <
-      this._estimatedPageHeight / 5;
-
     // WARNING: EXPENSIVE CALL! We need to know the surface top relative to the window.
     // This needs to be called to recalculate when new pages should be loaded.
     // We check to see how far we've scrolled and if it's further than a third of a page we run it again.
@@ -1158,7 +1154,6 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
         !this._surfaceRect ||
         !scrollHeight ||
         scrollHeight !== this._scrollHeight ||
-        // doUpdate ||
         Math.abs(this._scrollTop - scrollTop) > this._estimatedPageHeight * SCROLL_RATIO)
     ) {
       surfaceRect = this._surfaceRect = _measureSurfaceRect(this._surface.current);

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -26,7 +26,7 @@ import type {
 } from './List.types';
 import { WindowContext } from '@fluentui/react-window-provider';
 import { getWindowEx } from '../../utilities/dom';
-import { ListDebugRenderer } from './utils/ListDebugRenderer';
+// import { ListDebugRenderer } from './utils/ListDebugRenderer';
 
 const RESIZE_DELAY = 16;
 const MIN_SCROLL_UPDATE_DELAY = 100;
@@ -156,8 +156,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _scrollTop: number;
   private _pageCache: IPageCache<T>;
 
-  private _debugRenderer: ListDebugRenderer;
-  private _debugRafId: number | undefined = undefined;
+  // private _debugRenderer: ListDebugRenderer;
+  // private _debugRafId: number | undefined = undefined;
 
   public static getDerivedStateFromProps<U = any>(
     nextProps: IListProps<U>,
@@ -368,24 +368,24 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       this._events.on(this._scrollElement, 'scroll', this._onAsyncScrollDebounced);
     }
 
-    this._debugRenderer = new ListDebugRenderer();
+    // this._debugRenderer = new ListDebugRenderer();
 
-    const debugRender = () => {
-      this._debugRenderer.render({
-        visibleRect: this._visibleRect,
-        allowedRect: this._allowedRect,
-        requiredRect: this._requiredRect,
-        materializedRect: this._materializedRect,
-        surfaceRect: this._surfaceRect,
-        totalListHeight: this.getTotalListHeight(),
-        pages: this.state.pages,
-        scrollTop: Math.abs(this._scrollTop - getScrollYPosition(this._scrollElement)),
-        estimatedLine: this._estimatedPageHeight * SCROLL_RATIO,
-        scrollY: getScrollYPosition(this._scrollElement),
-      });
-      this._debugRafId = requestAnimationFrame(debugRender);
-    };
-    debugRender();
+    // const debugRender = () => {
+    //   this._debugRenderer.render({
+    //     visibleRect: this._visibleRect,
+    //     allowedRect: this._allowedRect,
+    //     requiredRect: this._requiredRect,
+    //     materializedRect: this._materializedRect,
+    //     surfaceRect: this._surfaceRect,
+    //     totalListHeight: this.getTotalListHeight(),
+    //     pages: this.state.pages,
+    //     scrollTop: Math.abs(this._scrollTop - getScrollYPosition(this._scrollElement)),
+    //     estimatedLine: this._estimatedPageHeight * SCROLL_RATIO,
+    //     scrollY: getScrollYPosition(this._scrollElement),
+    //   });
+    //   this._debugRafId = requestAnimationFrame(debugRender);
+    // };
+    // debugRender();
   }
 
   public componentDidUpdate(previousProps: IListProps, previousState: IListState<T>): void {
@@ -431,11 +431,11 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
     delete this._scrollElement;
 
-    this._debugRenderer.dispose();
-    if (this._debugRafId) {
-      cancelAnimationFrame(this._debugRafId);
-      this._debugRafId = undefined;
-    }
+    // this._debugRenderer.dispose();
+    // if (this._debugRafId) {
+    //   cancelAnimationFrame(this._debugRafId);
+    //   this._debugRafId = undefined;
+    // }
   }
 
   public shouldComponentUpdate(newProps: IListProps<T>, newState: IListState<T>): boolean {
@@ -763,7 +763,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _onScrollingDone(): void {
     if (!this.props.ignoreScrollingState) {
       this.setState({ isScrolling: false });
-      // this._onAsyncIdle();
+      this._onAsyncIdle();
     }
   }
 

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -26,6 +26,7 @@ import type {
 } from './List.types';
 import { WindowContext } from '@fluentui/react-window-provider';
 import { getWindowEx } from '../../utilities/dom';
+import { ListDebugRenderer } from './utils/ListDebugRenderer';
 
 const RESIZE_DELAY = 16;
 const MIN_SCROLL_UPDATE_DELAY = 100;
@@ -39,6 +40,8 @@ const DEFAULT_RENDERED_WINDOWS_BEHIND = 2;
 const DEFAULT_RENDERED_WINDOWS_AHEAD = 2;
 const PAGE_KEY_PREFIX = 'page-';
 const SPACER_KEY_PREFIX = 'spacer-';
+// Fraction of a page to have been scrolled before re-running expensive calculations
+const SCROLL_RATIO = 1 / 3;
 
 export interface IListState<T = any> {
   pages?: IPage<T>[];
@@ -152,6 +155,9 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _scrollHeight?: number;
   private _scrollTop: number;
   private _pageCache: IPageCache<T>;
+
+  private _debugRenderer: ListDebugRenderer;
+  private _debugRafId: number | undefined = undefined;
 
   public static getDerivedStateFromProps<U = any>(
     nextProps: IListProps<U>,
@@ -361,6 +367,25 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       this._events.on(this._scrollElement, 'scroll', this._onScroll);
       this._events.on(this._scrollElement, 'scroll', this._onAsyncScrollDebounced);
     }
+
+    this._debugRenderer = new ListDebugRenderer();
+
+    const debugRender = () => {
+      this._debugRenderer.render({
+        visibleRect: this._visibleRect,
+        allowedRect: this._allowedRect,
+        requiredRect: this._requiredRect,
+        materializedRect: this._materializedRect,
+        surfaceRect: this._surfaceRect,
+        totalListHeight: this.getTotalListHeight(),
+        pages: this.state.pages,
+        scrollTop: Math.abs(this._scrollTop - getScrollYPosition(this._scrollElement)),
+        estimatedLine: this._estimatedPageHeight * SCROLL_RATIO,
+        scrollY: getScrollYPosition(this._scrollElement),
+      });
+      this._debugRafId = requestAnimationFrame(debugRender);
+    };
+    debugRender();
   }
 
   public componentDidUpdate(previousProps: IListProps, previousState: IListState<T>): void {
@@ -405,6 +430,12 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     this._events?.dispose();
 
     delete this._scrollElement;
+
+    this._debugRenderer.dispose();
+    if (this._debugRafId) {
+      cancelAnimationFrame(this._debugRafId);
+      this._debugRafId = undefined;
+    }
   }
 
   public shouldComponentUpdate(newProps: IListProps<T>, newState: IListState<T>): boolean {
@@ -732,6 +763,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   private _onScrollingDone(): void {
     if (!this.props.ignoreScrollingState) {
       this.setState({ isScrolling: false });
+      // this._onAsyncIdle();
     }
   }
 
@@ -920,13 +952,17 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       const isPageInAllowedRange = !allowedRect || (pageBottom >= allowedRect.top && pageTop <= allowedRect.bottom!);
       const isPageInRequiredRange =
         !this._requiredRect || (pageBottom >= this._requiredRect.top && pageTop <= this._requiredRect.bottom!);
+
+      const isPagePartiallyInRequiredRange =
+        !isPageInRequiredRange &&
+        this._requiredRect &&
+        ((pageTop < this._requiredRect.top && pageBottom > this._requiredRect.top) ||
+          (pageTop < this._requiredRect.bottom! && pageBottom > this._requiredRect.bottom!));
+
       const isPageVisible =
         (!isFirstRender && (isPageInRequiredRange || (isPageInAllowedRange && isPageRendered))) || !shouldVirtualize;
       const isPageFocused = focusedIndex >= itemIndex && focusedIndex < itemIndex + itemsPerPage;
       const isFirstPage = itemIndex === startIndex;
-
-      // console.log('building page', itemIndex, 'pageTop: ' + pageTop, 'inAllowed: ' +
-      // isPageInAllowedRange, 'inRequired: ' + isPageInRequiredRange);
 
       // Only render whats visible, focused, or first page,
       // or when running in fast rendering mode (not in virtualized mode), we render all current items in pages
@@ -954,7 +990,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
         pages.push(newPage);
 
-        if (isPageInRequiredRange && this._allowedRect) {
+        if ((isPageInRequiredRange || isPagePartiallyInRequiredRange) && this._allowedRect) {
           _mergeRect(materializedRect, {
             top: pageTop,
             bottom: pageBottom,
@@ -1108,6 +1144,10 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     const scrollHeight = getScrollHeight(this._scrollElement);
     const scrollTop = getScrollYPosition(this._scrollElement);
 
+    const doUpdate =
+      Math.abs((this._visibleRect?.bottom ?? 0) - (this._materializedRect?.bottom ?? 0)) <
+      this._estimatedPageHeight / 5;
+
     // WARNING: EXPENSIVE CALL! We need to know the surface top relative to the window.
     // This needs to be called to recalculate when new pages should be loaded.
     // We check to see how far we've scrolled and if it's further than a third of a page we run it again.
@@ -1118,7 +1158,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
         !this._surfaceRect ||
         !scrollHeight ||
         scrollHeight !== this._scrollHeight ||
-        Math.abs(this._scrollTop - scrollTop) > this._estimatedPageHeight / 3)
+        // doUpdate ||
+        Math.abs(this._scrollTop - scrollTop) > this._estimatedPageHeight * SCROLL_RATIO)
     ) {
       surfaceRect = this._surfaceRect = _measureSurfaceRect(this._surface.current);
       this._scrollTop = scrollTop;

--- a/packages/react/src/components/List/utils/ListDebugRenderer.ts
+++ b/packages/react/src/components/List/utils/ListDebugRenderer.ts
@@ -1,0 +1,158 @@
+import { IRectangle } from '@fluentui/utilities';
+import { IPage } from '../List.types';
+
+export type RenderParams = {
+  visibleRect: IRectangle | undefined;
+  allowedRect: IRectangle | null;
+  requiredRect: IRectangle | null;
+  materializedRect: IRectangle | null;
+  surfaceRect: IRectangle | undefined;
+  totalListHeight: number;
+  pages: IPage[] | undefined;
+  scrollTop: number;
+  estimatedLine: number;
+  scrollY: number;
+};
+
+const RENDER_COLOR_VISIBLE_RECT = 'hotpink';
+const RENDER_COLOR_ALLOWED_RECT = 'green';
+const RENDER_COLOR_REQUIRED_RECT = 'blue';
+const RENDER_COLOR_MATERIALIZED_RECT = 'red';
+const RENDER_COLOR_SURFACE_RECT = 'black';
+const RENDER_COLOR_PAGE = 'purple';
+const RENDER_COLOR_SPACER_PAGE = 'orange';
+
+export class ListDebugRenderer {
+  private _wrapper: HTMLElement;
+  private _renderer: CanvasRenderingContext2D;
+  private _doc: Document;
+
+  constructor(doc?: Document) {
+    // eslint-disable-next-line no-restricted-globals
+    this._doc = doc || document;
+    this._wrapper = this._doc.createElement('div');
+    this._wrapper.style.position = 'fixed';
+    this._wrapper.style.top = '0';
+    this._wrapper.style.right = '0';
+    this._wrapper.style.width = '300px';
+    this._wrapper.style.bottom = '0';
+
+    const canvas = this._doc.createElement('canvas');
+    this._renderer = canvas.getContext('2d') as CanvasRenderingContext2D;
+
+    this._wrapper.appendChild(canvas);
+
+    this._doc.body.appendChild(this._wrapper);
+  }
+
+  public dispose(): void {
+    this._doc.body.removeChild(this._wrapper);
+  }
+
+  public render(params: RenderParams): void {
+    const {
+      visibleRect,
+      allowedRect,
+      requiredRect,
+      materializedRect,
+      surfaceRect,
+      totalListHeight,
+      pages,
+      scrollTop,
+      estimatedLine,
+      scrollY,
+    } = params;
+
+    if (!surfaceRect) {
+      return;
+    }
+
+    const debugRendererHeight = this._wrapper.clientHeight;
+    const scaleFactor = debugRendererHeight / totalListHeight;
+
+    this._renderer.canvas.width = this._wrapper.clientWidth;
+    this._renderer.canvas.height = debugRendererHeight;
+    this._renderer.fillStyle = 'white';
+    this._renderer.fillRect(0, 0, this._wrapper.clientWidth, this._wrapper.clientHeight);
+
+    this._renderRect(
+      { left: 0, top: 0, height: totalListHeight, width: surfaceRect.width },
+      RENDER_COLOR_SURFACE_RECT,
+      scaleFactor,
+    );
+
+    if (visibleRect) {
+      this._renderRect(visibleRect, RENDER_COLOR_VISIBLE_RECT, scaleFactor, 10);
+    }
+
+    if (allowedRect) {
+      this._renderRect(allowedRect, RENDER_COLOR_ALLOWED_RECT, scaleFactor, 20);
+    }
+
+    if (requiredRect) {
+      this._renderRect(requiredRect, RENDER_COLOR_REQUIRED_RECT, scaleFactor, 30);
+    }
+
+    if (materializedRect) {
+      this._renderRect(materializedRect, RENDER_COLOR_MATERIALIZED_RECT, scaleFactor, 40);
+    }
+
+    if (pages) {
+      let top = 0;
+      pages.forEach((page, i) => {
+        const isSpacer = page.key.startsWith('spacer');
+        const t = isSpacer ? top : page.top;
+        this._renderPage(
+          page,
+          isSpacer ? RENDER_COLOR_SPACER_PAGE : RENDER_COLOR_PAGE,
+          scaleFactor,
+          surfaceRect.left,
+          surfaceRect.width,
+          t,
+          50 + i * 10,
+        );
+        top += page.height;
+      });
+    }
+
+    this._renderLine(scrollTop, 'red', surfaceRect.width);
+    this._renderLine(estimatedLine, 'black', surfaceRect.width);
+    this._renderLine(scrollY, 'yellow', surfaceRect.width);
+  }
+
+  private _renderRect(rect: IRectangle, color: string, scaleFactor: number, offset: number = 0): void {
+    this._renderer.strokeStyle = color;
+    this._renderer.strokeRect(
+      rect.left * scaleFactor + offset,
+      rect.top * scaleFactor,
+      rect.width * scaleFactor + offset,
+      rect.height * scaleFactor,
+    );
+  }
+
+  private _renderPage(
+    page: IPage,
+    color: string,
+    scaleFactor: number,
+    left: number,
+    width: number,
+    top: number,
+    offset: number = 0,
+  ): void {
+    this._renderer.strokeStyle = color;
+    this._renderer.strokeRect(
+      left * scaleFactor + offset,
+      top * scaleFactor,
+      width * scaleFactor + offset,
+      page.height * scaleFactor,
+    );
+  }
+
+  private _renderLine(y: number, color: string, width: number): void {
+    this._renderer.strokeStyle = color;
+    this._renderer.beginPath();
+    this._renderer.moveTo(0, y);
+    this._renderer.lineTo(width, y);
+    this._renderer.stroke();
+  }
+}


### PR DESCRIPTION
## Previous Behavior

It was possible to get `List` into a state such that part of the visible list was not materialized. That is, there were blank spots in the list where rows should have been rendered.

In the middle of this `List` this isn't a big problem (though it's still a bug!) because users could continue scrolling to get the rows to materialize. This becomes an issue at the end of the list because there is no action the user can take to resolve the issue -- the last row(s) will never render.

## New Behavior

`List` will force a state update after scrolling completes, ensuring the missing rows will materialize. It is still possible to have temporarily missing rows while scrolling but they will render. This is consistent with existing `List` behavior where rows some times take a few ticks to materialize.

As part of this change I've added `ListDebugRenderer`, which is a visualization of the virtualized state of the `List`. The setup for this remains commented out in the `List` code to aid in future debugging.

## Related Issue(s)

- Fixes #29543
