### PR TITLE
fix(react-dialog): set transition status to `undefined` for test environment

### DIFF
--- a/change/@fluentui-react-dialog-6091ac61-07dc-43d4-87d0-90f15c513098.json
+++ b/change/@fluentui-react-dialog-6091ac61-07dc-43d4-87d0-90f15c513098.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: set default DialogTransitionProvider value to `undefined` to remove animation styles from test environment.",
+  "packageName": "@fluentui/react-dialog",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.test.tsx
@@ -3,6 +3,9 @@ import { render } from '@testing-library/react';
 import { Dialog } from './Dialog';
 import { DialogProps } from './Dialog.types';
 import { isConformant } from '../../testing/isConformant';
+import { DialogTrigger } from '../DialogTrigger/DialogTrigger';
+import { makeStyles, mergeClasses } from '@griffel/react';
+import { DialogSurface, DialogSurfaceProps } from '../../DialogSurface';
 
 describe('Dialog', () => {
   isConformant<DialogProps>({
@@ -22,8 +25,6 @@ describe('Dialog', () => {
     ],
   });
 
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
   it('renders a default state', () => {
     const result = render(
       <Dialog>
@@ -31,5 +32,34 @@ describe('Dialog', () => {
       </Dialog>,
     );
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('Testing DialogSurface with toBeVisible works as expected', () => {
+    // eslint-disable-next-line @griffel/styles-file
+    const useStyles = makeStyles({
+      root: {
+        left: '2px',
+      },
+    });
+    const CustomDialogSurface = React.forwardRef<HTMLDivElement, DialogSurfaceProps>((props, ref) => {
+      const styles = useStyles();
+      return <DialogSurface ref={ref} className={mergeClasses(styles.root, props.className)} {...props} />;
+    });
+
+    const result = render(
+      <Dialog>
+        <DialogTrigger disableButtonEnhancement>
+          <button data-testid="trigger">Open dialog</button>
+        </DialogTrigger>
+        <CustomDialogSurface>
+          <div data-testid="surface-content">content in surface</div>
+        </CustomDialogSurface>
+      </Dialog>,
+    );
+
+    result.getByTestId('trigger').click();
+
+    expect(result.getByTestId('surface-content')).toBeInTheDocument();
+    expect(result.getByTestId('surface-content')).toBeVisible();
   });
 });

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -17,7 +17,7 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         {trigger}
         {process.env.NODE_ENV === 'test' ? (
-          state.open && <DialogTransitionProvider value={'entered'}>{content}</DialogTransitionProvider>
+          state.open && <DialogTransitionProvider value={'none'}>{content}</DialogTransitionProvider>
         ) : (
           <Transition
             mountOnEnter

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -17,7 +17,7 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         {trigger}
         {process.env.NODE_ENV === 'test' ? (
-          state.open && <DialogTransitionProvider value={'none'}>{content}</DialogTransitionProvider>
+          state.open && <DialogTransitionProvider value={undefined}>{content}</DialogTransitionProvider>
         ) : (
           <Transition
             mountOnEnter

--- a/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/DialogSurface.types.ts
@@ -35,6 +35,9 @@ export type DialogSurfaceState = ComponentState<DialogSurfaceSlots> &
   // This is only partial to avoid breaking changes, it should be mandatory and in fact it is always defined internally.
   Pick<DialogContextValue, 'isNestedDialog'> &
   Pick<PortalProps, 'mountNode'> & {
-    // This is only optional to avoid breaking changes, it should be mandatory and in fact it is always defined internally.
+    /**
+     * Transition status for animation.
+     * In test environment, this is always `undefined`.
+     */
     transitionStatus?: 'entering' | 'entered' | 'idle' | 'exiting' | 'exited' | 'unmounted';
   };

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -39,18 +39,20 @@ const useRootBaseStyle = makeResetStyles({
   [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
     maxWidth: '100vw',
   },
-
-  // initial style before animation:
-  opacity: 0,
-  transitionDuration: tokens.durationGentle,
-  transitionProperty: 'opacity, transform, box-shadow',
-  // // FIXME: https://github.com/microsoft/fluentui/issues/29473
-  transitionTimingFunction: tokens.curveDecelerateMid,
-  boxShadow: '0px 0px 0px 0px rgba(0, 0, 0, 0.1)',
-  transform: 'scale(0.85) translateZ(0)',
 });
 
 const useRootStyles = makeStyles({
+  none: {},
+  animated: {
+    // initial style before animation:
+    opacity: 0,
+    transitionDuration: tokens.durationGentle,
+    transitionProperty: 'opacity, transform, box-shadow',
+    // // FIXME: https://github.com/microsoft/fluentui/issues/29473
+    transitionTimingFunction: tokens.curveDecelerateMid,
+    boxShadow: '0px 0px 0px 0px rgba(0, 0, 0, 0.1)',
+    transform: 'scale(0.85) translateZ(0)',
+  },
   unmounted: {},
   entering: {},
   entered: {
@@ -82,6 +84,7 @@ const useBackdropBaseStyle = makeResetStyles({
 });
 
 const useBackdropStyles = makeStyles({
+  none: {},
   nestedDialogBackdrop: {
     backgroundColor: tokens.colorTransparentBackground,
   },
@@ -101,7 +104,7 @@ const useBackdropStyles = makeStyles({
  * Apply styling to the DialogSurface slots based on the state
  */
 export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): DialogSurfaceState => {
-  const { isNestedDialog, root, backdrop, transitionStatus = 'unmounted' } = state;
+  const { isNestedDialog, root, backdrop, transitionStatus = 'none' } = state;
 
   const rootBaseStyle = useRootBaseStyle();
   const rootStyles = useRootStyles();
@@ -112,6 +115,7 @@ export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): Dial
   root.className = mergeClasses(
     dialogSurfaceClassNames.root,
     rootBaseStyle,
+    transitionStatus !== 'none' && rootStyles.animated,
     rootStyles[transitionStatus],
     root.className,
   );

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -42,7 +42,6 @@ const useRootBaseStyle = makeResetStyles({
 });
 
 const useRootStyles = makeStyles({
-  none: {},
   animated: {
     // initial style before animation:
     opacity: 0,
@@ -84,7 +83,6 @@ const useBackdropBaseStyle = makeResetStyles({
 });
 
 const useBackdropStyles = makeStyles({
-  none: {},
   nestedDialogBackdrop: {
     backgroundColor: tokens.colorTransparentBackground,
   },
@@ -104,7 +102,7 @@ const useBackdropStyles = makeStyles({
  * Apply styling to the DialogSurface slots based on the state
  */
 export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): DialogSurfaceState => {
-  const { isNestedDialog, root, backdrop, transitionStatus = 'none' } = state;
+  const { isNestedDialog, root, backdrop, transitionStatus } = state;
 
   const rootBaseStyle = useRootBaseStyle();
   const rootStyles = useRootStyles();
@@ -115,8 +113,8 @@ export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): Dial
   root.className = mergeClasses(
     dialogSurfaceClassNames.root,
     rootBaseStyle,
-    transitionStatus !== 'none' && rootStyles.animated,
-    rootStyles[transitionStatus],
+    transitionStatus && rootStyles.animated,
+    transitionStatus && rootStyles[transitionStatus],
     root.className,
   );
 
@@ -125,7 +123,7 @@ export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): Dial
       dialogSurfaceClassNames.backdrop,
       backdropBaseStyle,
       isNestedDialog && backdropStyles.nestedDialogBackdrop,
-      backdropStyles[transitionStatus],
+      transitionStatus && backdropStyles[transitionStatus],
       backdrop.className,
     );
   }

--- a/packages/react-components/react-dialog/src/contexts/dialogTransitionContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogTransitionContext.ts
@@ -4,12 +4,12 @@ import { TransitionStatus } from 'react-transition-group';
 /**
  * @internal
  */
-export type DialogTransitionContextValue = TransitionStatus | 'none';
+export type DialogTransitionContextValue = TransitionStatus | undefined;
 
 /**
  * @internal
  */
-const defaultContextValue: DialogTransitionContextValue = 'none';
+const defaultContextValue: DialogTransitionContextValue = undefined;
 
 // Contexts should default to undefined
 /**

--- a/packages/react-components/react-dialog/src/contexts/dialogTransitionContext.ts
+++ b/packages/react-components/react-dialog/src/contexts/dialogTransitionContext.ts
@@ -4,12 +4,12 @@ import { TransitionStatus } from 'react-transition-group';
 /**
  * @internal
  */
-export type DialogTransitionContextValue = TransitionStatus;
+export type DialogTransitionContextValue = TransitionStatus | 'none';
 
 /**
  * @internal
  */
-const defaultContextValue: DialogTransitionContextValue = 'unmounted';
+const defaultContextValue: DialogTransitionContextValue = 'none';
 
 // Contexts should default to undefined
 /**


### PR DESCRIPTION
## Previous Behavior

`DialogTransitionContext` is always defined and has value `entered` for test environment (#29692). However, `DialogSurface` has base style `opacity: 0`, and when transition status is `entered`, it merges style `opacity: 1`. To apply styles `DialogSurface` uses `makeResetStyles()` & `makeStyles()`, so will get following:

```css
.reset-class {
  /* ... some CSS rules */
  opacity: 0;
}
.atomic-class {
  opacity: 1;
}
```

In this case, tests for `DialogSurface` using `jest-dom` & `.toBeVisible()` can fail. This is a `jsdom` bug - it cannot detect style override with 'opacity' nor 'visibility' (check [Stackblitz](https://stackblitz.com/edit/stackblitz-starters-ugiwec?file=package.json)). This happens because `DialogSurface` has as base style `opacity:0`: `getComputedStyles(DialogSurfaceElement).opacity` in `jsdom` returns `0` and ignores the `opacity:1` style override 💥 

Odd thing is, fix #29692 is good enough for a simple test that asserts something within `DialogSurface` via '.toBeVisible()'. But when a random style override is added to `DialogSurface`, the test can fail with the same reason. This PR added a unit test case for this.

## New Behavior

- `DialogTransitionContext` is `undefined` for test environment.
- `DialogSurface` adds style `opacity:0` only when DialogTransitionContext is defined.

Test is green and animation works as is.

## Discarded solution

I also considered simply moving `opacity:0` from baseStyle to 'unmounted' state's style, but it breaks animation:

https://github.com/microsoft/fluentui/assets/28751745/94b75a9d-c16b-43ad-a48b-f62c81e1641c

note that DialogSurface shows up immediately after open. This is because transition state is `exited` `entering` and then `entered` when Dialog is opened. Adding `opacity:0` based on state is not as safe option compare to not adding it at all for test environment.
