### PR TITLE
ci: bump devcontainer to node 18

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:1-16-bookworm
+ARG VARIANT=18-bookworm
+# https://github.com/devcontainers/images/tree/main/src/typescript-node
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}
 
 # Cypress linux pre-requisites https://docs.cypress.io/guides/getting-started/installing-cypress#Linux-Prerequisites
 RUN apt-get update && apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -4,7 +4,7 @@ This configuration is based on the base Node container provided by VSCode, it sh
 
 > For more information on how to use/create `development containers` follow the [VSCode Documentation](https://code.visualstudio.com/docs/remote/create-dev-container)
 
-> See here for more information on the base container https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/javascript-node/.devcontainer/base.Dockerfile
+> See here for more information on the base container https://github.com/microsoft/vscode-dev-containers/blob/main/containers/javascript-node/.devcontainer/base.Dockerfile
 
 ## Cypress tests
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
   "name": "Node.js",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "18-bookworm"
+    }
   },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/lage.config.js
+++ b/lage.config.js
@@ -27,6 +27,7 @@ module.exports = {
     'change/**',
     'rfcs/**',
     'README.md',
+    '*.md',
     '.vscode/**',
     '.github/*.yml',
     '.github/*.json',
@@ -35,6 +36,7 @@ module.exports = {
     '.github/MAINTAINERS',
     '.github/ISSUE_TEMPLATE/**',
     '.github/policies/**',
+    '.devcontainer/**',
   ],
 
   // All of these options are sent to `backfill`: https://github.com/microsoft/backfill/blob/master/README.md


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- devcontainer uses node 18 ( used within codespaces )
  - <img width="706" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/b8872101-1cd5-4e66-8387-6f5247849f7d">
 
- updated lage ignore

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #29598 
