### PR TITLE
fix(react-components): mark react-tree apis as deprecated and add Deprecation heading to the /unstable module

### DIFF
--- a/change/@fluentui-react-components-3279ab16-e66a-4caa-8a97-8f0d1aa85514.json
+++ b/change/@fluentui-react-components-3279ab16-e66a-4caa-8a97-8f0d1aa85514.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: mark react-tree apis as deprecated and add Deprecation heading to the /unstable module",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -1,4 +1,11 @@
-// Stub for unstable exports
+// =====================================================================================================
+//                                    ⚠️ IMPORTANT:
+// =====================================================================================================
+// - `/unstable` api is DEPRECATED
+// - adding new API exports to this file is FORBIDDEN ( except `react-virtualizer` )
+// - modifying any existing exports in this file is FORBIDDEN
+// - use/consume `*-preview` packages directly for preview/unstable Fluent UI core controls early access
+// =====================================================================================================
 
 /* eslint-disable deprecation/deprecation */
 export {
@@ -79,67 +86,126 @@ export type {
 } from '@fluentui/react-virtualizer';
 
 export {
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   Tree,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   TreeItem,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   FlatTree,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   TreeProvider,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   TreeItemLayout,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   TreeItemProvider,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   TreeItemPersonaLayout,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeContext_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeContextValues_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemContext_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemContextValues_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useFlatTreeContextValues_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTree_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItem_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemLayout_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemPersonaLayout_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   renderTree_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   renderTreeItem_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   renderTreeItemPersonaLayout_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   renderTreeItemLayout_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeStyles_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemStyles_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemPersonaLayoutStyles_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useTreeItemLayoutStyles_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   treeItemPersonaLayoutClassNames,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   treeItemLevelToken,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   treeItemLayoutClassNames,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   treeItemClassNames,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   treeClassNames,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   flatTreeClassNames,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useFlatTree_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useHeadlessFlatTree_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   useFlatTreeStyles_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   renderFlatTree_unstable,
+  /** @deprecated Tree is currently stable. Import from @fluentui/react-components instead */
   flattenTree_unstable,
 } from '@fluentui/react-tree';
 
 export type {
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeState,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeSlots,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeProps,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeOpenChangeEvent,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeOpenChangeData,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeNavigationEvent_unstable,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeNavigationData_unstable,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemState,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemSlots,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemProps,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemPersonaLayoutState,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemPersonaLayoutSlots,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemPersonaLayoutProps,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemLayoutState,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemLayoutSlots,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeItemLayoutProps,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   TreeContextValue,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   FlatTreeProps,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   FlatTreeSlots,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   FlatTreeState,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   HeadlessFlatTree,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   HeadlessFlatTreeItem,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   HeadlessFlatTreeItemProps,
+  /** @deprecated Tree is stable. Import from @fluentui/react-components instead */
   HeadlessFlatTreeOptions,
 } from '@fluentui/react-tree';
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

See PR title

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/28471
