### PR TITLE
chore: Export missing useDrawerStyles_unstable from react-drawer and react-components

### DIFF
--- a/change/@fluentui-react-components-0cc81826-b8da-4ec9-bd13-7afc5a55f529.json
+++ b/change/@fluentui-react-components-0cc81826-b8da-4ec9-bd13-7afc5a55f529.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Export missing useDrawerStyles_unstable from react-drawer.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-b691c676-caea-4230-b7c4-7c304bcf4b60.json
+++ b/change/@fluentui-react-drawer-b691c676-caea-4230-b7c4-7c304bcf4b60.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Export missing useDrawerStyles_unstable.",
+  "packageName": "@fluentui/react-drawer",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1122,6 +1122,7 @@ import { useDrawerHeaderNavigationStyles_unstable } from '@fluentui/react-drawer
 import { useDrawerHeaderStyles_unstable } from '@fluentui/react-drawer';
 import { useDrawerHeaderTitle_unstable } from '@fluentui/react-drawer';
 import { useDrawerHeaderTitleStyles_unstable } from '@fluentui/react-drawer';
+import { useDrawerStyles_unstable } from '@fluentui/react-drawer';
 import { useDropdown_unstable } from '@fluentui/react-combobox';
 import { useDropdownStyles_unstable } from '@fluentui/react-combobox';
 import { useEventCallback } from '@fluentui/react-utilities';
@@ -3596,6 +3597,8 @@ export { useDrawerHeaderStyles_unstable }
 export { useDrawerHeaderTitle_unstable }
 
 export { useDrawerHeaderTitleStyles_unstable }
+
+export { useDrawerStyles_unstable }
 
 export { useDropdown_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1427,6 +1427,7 @@ export type { InfoLabelProps, InfoLabelSlots, InfoLabelState } from '@fluentui/r
 export {
   Drawer,
   renderDrawer_unstable,
+  useDrawerStyles_unstable,
   useDrawer_unstable,
   OverlayDrawer,
   overlayDrawerClassNames,

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -212,6 +212,9 @@ export const useDrawerHeaderTitle_unstable: (props: DrawerHeaderTitleProps, ref:
 export const useDrawerHeaderTitleStyles_unstable: (state: DrawerHeaderTitleState) => DrawerHeaderTitleState;
 
 // @public
+export const useDrawerStyles_unstable: (state: DrawerState) => DrawerState;
+
+// @public
 export const useInlineDrawer_unstable: (props: InlineDrawerProps, ref: React_2.Ref<HTMLDivElement>) => InlineDrawerState;
 
 // @public

--- a/packages/react-components/react-drawer/src/index.ts
+++ b/packages/react-components/react-drawer/src/index.ts
@@ -1,4 +1,4 @@
-export { Drawer, renderDrawer_unstable, useDrawer_unstable } from './Drawer';
+export { Drawer, renderDrawer_unstable, useDrawerStyles_unstable, useDrawer_unstable } from './Drawer';
 export type { DrawerProps, DrawerSlots, DrawerState } from './Drawer';
 
 export {


### PR DESCRIPTION
## Previous Behavior

The export for `useDrawerStyles_unstable` was missing from the index files in both `react-drawer` and `react-components` packages.

## New Behavior

`useDrawerStyles_unstable` is now exported from both `react-drawer` and `react-components` packages.
