### PR TITLE
chore: react-shared-contexts should be included in new package deps

### DIFF
--- a/tools/workspace-plugin/src/generators/react-component/files/component/__componentName__.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/component/__componentName__.tsx__tmpl__
@@ -13,7 +13,6 @@ export const <%= componentName %>: ForwardRefComponent<<%= componentName %>Props
   const state = use<%= componentName %>_unstable(props, ref);
 
   use<%= componentName %>Styles_unstable(state);
-  use<%= componentName %>Styles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   useCustomStyleHook_unstable('use<%= componentName %>Styles_unstable')(state);

--- a/tools/workspace-plugin/src/generators/react-component/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.spec.ts
@@ -75,7 +75,6 @@ describe('react-component generator', () => {
           const state = useMyOne_unstable(props, ref);
 
           useMyOneStyles_unstable(state);
-          useMyOneStyles_unstable(state);
           // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
           // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
           useCustomStyleHook_unstable('useMyOneStyles_unstable')(state);

--- a/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "",
+    "@fluentui/react-shared-contexts": "",
     "@fluentui/react-theme": "",
     "@fluentui/react-utilities": "",
     "@griffel/react": "",

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -23,6 +23,7 @@ describe('react-library generator', () => {
     tree = createLibrary(tree, 'react-jsx-runtime');
     tree = createLibrary(tree, 'react-theme');
     tree = createLibrary(tree, 'react-utilities');
+    tree = createLibrary(tree, 'react-shared-contexts');
 
     writeJson(tree, 'tsconfig.base.v0.json', { compilerOptions: { paths: {} } });
     writeJson(tree, 'tsconfig.base.v8.json', { compilerOptions: { paths: {} } });
@@ -103,6 +104,7 @@ describe('react-library generator', () => {
         version: '0.0.0',
         dependencies: {
           '@fluentui/react-jsx-runtime': '^9.0.0',
+          '@fluentui/react-shared-contexts': '^9.0.0',
           '@fluentui/react-theme': '^9.0.0',
           '@fluentui/react-utilities': '^9.0.0',
           '@griffel/react': '^1.2.3',


### PR DESCRIPTION
Since all components need to support custom style hooks, adds react-shared-contexts package to dependencies during package creation

Also removes duplication of style hook in component generation

Fixes partialy #29775

