### PR TITLE
fix(breadcrumb): overflow count in Breadcrumb stories

### DIFF
--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithOverflow.stories.tsx
@@ -169,6 +169,8 @@ const OverflowMenu = (props: PartitionBreadcrumbItems<Item>) => {
     return null;
   }
 
+  const overflowItemsCount = overflowItems ? overflowItems.length + overflowCount : overflowCount;
+
   return (
     <BreadcrumbItem>
       <Menu hasIcons>
@@ -177,7 +179,7 @@ const OverflowMenu = (props: PartitionBreadcrumbItems<Item>) => {
             appearance="subtle"
             ref={ref}
             icon={<MoreHorizontal />}
-            aria-label={`${overflowCount} more items`}
+            aria-label={`${overflowItemsCount} more items`}
             role="button"
           />
         </MenuTrigger>


### PR DESCRIPTION
## Previous Behavior
- overflow count was incorrect. It showed "0 more items" when there were hidden items

## New Behavior
- overflow count includes all the overflow items