### PR TITLE
fix: Breadcrumb uses button when no href is present, tooltip labels button

### DIFF
--- a/change/@fluentui-react-breadcrumb-preview-99feac5c-b9dd-4c16-b451-3c2cc099992c.json
+++ b/change/@fluentui-react-breadcrumb-preview-99feac5c-b9dd-4c16-b451-3c2cc099992c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use button when no href is defined",
+  "packageName": "@fluentui/react-breadcrumb-preview",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb-preview/package.json
+++ b/packages/react-components/react-breadcrumb-preview/package.json
@@ -35,6 +35,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
+    "@fluentui/react-aria": "^9.3.44",
     "@fluentui/react-button": "^9.3.54",
     "@fluentui/react-icons": "^2.0.217",
     "@fluentui/react-link": "^9.1.33",

--- a/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -32,12 +32,11 @@ describe('Breadcrumb', () => {
             <li
               class="fui-BreadcrumbItem"
             >
-              <a
+              <button
                 class="fui-Button fui-BreadcrumbButton"
-                tabindex="0"
               >
                 Item 1
-              </a>
+              </button>
             </li>
           </ol>
         </nav>

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
@@ -26,12 +26,11 @@ describe('BreadcrumbButton', () => {
     const result = render(<BreadcrumbButton>Default BreadcrumbButton</BreadcrumbButton>);
     expect(result.container).toMatchInlineSnapshot(`
       <div>
-        <a
+        <button
           class="fui-Button fui-BreadcrumbButton"
-          tabindex="0"
         >
           Default BreadcrumbButton
-        </a>
+        </button>
       </div>
     `);
   });
@@ -42,9 +41,8 @@ describe('BreadcrumbButton', () => {
     );
     expect(result.container).toMatchInlineSnapshot(`
       <div>
-        <a
+        <button
           class="fui-Button fui-BreadcrumbButton"
-          tabindex="0"
         >
           <span
             class="fui-Button__icon"
@@ -65,7 +63,7 @@ describe('BreadcrumbButton', () => {
             </svg>
           </span>
           BreadcrumbButton with icon
-        </a>
+        </button>
       </div>
     `);
   });

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButton.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButton.ts
@@ -19,9 +19,9 @@ export const useBreadcrumbButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): BreadcrumbButtonState => {
   const { size } = useBreadcrumbContext_unstable();
-  const { current = false, ...rest } = props;
+  const { current = false, as, ...rest } = props;
 
-  const as = (props as ARIAButtonProps<'a'>).href ? 'a' : 'button';
+  const controlType = as ?? (props as ARIAButtonProps<'a'>).href ? 'a' : 'button';
 
   return {
     ...useButton_unstable(
@@ -29,7 +29,7 @@ export const useBreadcrumbButton_unstable = (
         appearance: 'subtle',
         role: undefined,
         type: undefined,
-        as,
+        as: controlType,
         iconPosition: 'before',
         'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
         'aria-disabled': current ? props['aria-disabled'] ?? true : undefined,

--- a/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButton.ts
+++ b/packages/react-components/react-breadcrumb-preview/src/components/BreadcrumbButton/useBreadcrumbButton.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ARIAButtonProps } from '@fluentui/react-aria';
 import { useButton_unstable } from '@fluentui/react-button';
 import type { ButtonProps } from '@fluentui/react-button';
 import { useBreadcrumbContext_unstable } from '../Breadcrumb/BreadcrumbContext';
@@ -20,13 +21,15 @@ export const useBreadcrumbButton_unstable = (
   const { size } = useBreadcrumbContext_unstable();
   const { current = false, ...rest } = props;
 
+  const as = (props as ARIAButtonProps<'a'>).href ? 'a' : 'button';
+
   return {
     ...useButton_unstable(
       {
         appearance: 'subtle',
         role: undefined,
         type: undefined,
-        as: 'a' as const,
+        as,
         iconPosition: 'before',
         'aria-current': current ? props['aria-current'] ?? 'page' : undefined,
         'aria-disabled': current ? props['aria-disabled'] ?? true : undefined,

--- a/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithTooltip.stories.tsx
+++ b/packages/react-components/react-breadcrumb-preview/stories/Breadcrumb/BreadcrumbWithTooltip.stories.tsx
@@ -102,11 +102,11 @@ function renderItem(entry: Item, isLastItem: boolean) {
   return (
     <React.Fragment key={`item-${entry.key}`}>
       {isTruncatableBreadcrumbContent(entry.item, 30) ? (
-        <Tooltip withArrow content={truncateBreadcrumLongTooltip(entry.item)} relationship="label">
-          <BreadcrumbItem>
+        <BreadcrumbItem>
+          <Tooltip withArrow content={truncateBreadcrumLongTooltip(entry.item)} relationship="label">
             <BreadcrumbButton current={isLastItem}>{truncateBreadcrumbLongName(entry.item)}</BreadcrumbButton>
-          </BreadcrumbItem>
-        </Tooltip>
+          </Tooltip>
+        </BreadcrumbItem>
       ) : (
         <BreadcrumbItem>
           <BreadcrumbButton current={isLastItem}>{entry.item}</BreadcrumbButton>


### PR DESCRIPTION
## Previous Behavior

We had focusable `<a>` tags with no `href`, which is semantically the same as a `<span>`. We could also potentially add `role=link`, but it seems better to render items with no `href` or explicit `as` as a `<button>`.

This also makes a minor story fix to make `<Tooltip>` directly wrap `<BreadcrumbButton>` so that the `aria-label` is being applied to the correct element.