### PR TITLE
chore: wrap password input in form element to avoid warning in chrome

### DIFF
--- a/packages/react-components/react-input/stories/Input/InputType.stories.tsx
+++ b/packages/react-components/react-input/stories/Input/InputType.stories.tsx
@@ -19,7 +19,7 @@ export const Type = () => {
   const styles = useStyles();
 
   return (
-    <div className={styles.root}>
+    <form noValidate autoComplete="off" className={styles.root}>
       <div>
         <Label htmlFor={emailId}>Email input</Label>
         <Input type="email" id={emailId} />
@@ -34,7 +34,7 @@ export const Type = () => {
         <Label htmlFor={passwordId}>Password input</Label>
         <Input type="password" defaultValue="password" id={passwordId} />
       </div>
-    </div>
+    </form>
   );
 };
 

--- a/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
@@ -12,27 +12,30 @@ const columnProps: Partial<IStackProps> = {
 
 export const TextFieldBasicExample: React.FunctionComponent = () => {
   return (
-    <Stack horizontal tokens={stackTokens} styles={stackStyles}>
-      <Stack {...columnProps}>
-        <TextField label="Standard" />
-        <TextField label="Disabled" disabled defaultValue="I am disabled" />
-        <TextField label="Read-only" readOnly defaultValue="I am read-only" />
-        <TextField label="Required " required />
-        <TextField ariaLabel="Required without visible label" required />
-        <TextField label="With error message" errorMessage="Error message" />
+    <form noValidate autoComplete="off">
+      <Stack horizontal tokens={stackTokens} styles={stackStyles}>
+        <Stack {...columnProps}>
+          <TextField label="Standard" />
+          <TextField label="Disabled" disabled defaultValue="I am disabled" />
+          <TextField label="Read-only" readOnly defaultValue="I am read-only" />
+          <TextField label="Required " required />
+          <TextField ariaLabel="Required without visible label" required />
+          <TextField label="With error message" errorMessage="Error message" />
+        </Stack>
+        <Stack {...columnProps}>
+          <MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" title="A 10 digit number" />
+          <TextField label="With an icon" iconProps={iconProps} />
+          <TextField label="With placeholder" placeholder="Please enter text here" />
+          <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
+          {/* All password fields should be rendered inside of a form */}
+          <TextField
+            label="Password with reveal button"
+            type="password"
+            canRevealPassword
+            revealPasswordAriaLabel="Show password"
+          />
+        </Stack>
       </Stack>
-      <Stack {...columnProps}>
-        <MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" title="A 10 digit number" />
-        <TextField label="With an icon" iconProps={iconProps} />
-        <TextField label="With placeholder" placeholder="Please enter text here" />
-        <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
-        <TextField
-          label="Password with reveal button"
-          type="password"
-          canRevealPassword
-          revealPasswordAriaLabel="Show password"
-        />
-      </Stack>
-    </Stack>
+    </form>
   );
 };


### PR DESCRIPTION
There were some concerns that an input with type password logged a warning in Chrome, and that it displayed the password content. This is a years old behavior by Chrome, and is just meant to recommend users to wrap password fields in a form so that they are easier to fill in with password managers.

Despite the fact that this is not an issue at all on our part [1](https://stackoverflow.com/questions/50796140/ionic-3-form-still-warning-me-password-field-is-not-contained-in-a-form) I'm adding this to avoid future reports, and it does align with how inputs are represented in frameworks like MUI.

https://stackoverflow.microsoft.com/questions/376931