### PR TITLE
feat: implement useOverflowVisibility hook

### DIFF
--- a/change/@fluentui-react-components-656db22e-187b-4f9c-824c-b4f38f7d0c88.json
+++ b/change/@fluentui-react-components-656db22e-187b-4f9c-824c-b4f38f7d0c88.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export useOverflowVisibility hook",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-b5541fe4-22bc-4699-a14a-fc7f22039bc4.json
+++ b/change/@fluentui-react-overflow-b5541fe4-22bc-4699-a14a-fc7f22039bc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Implement useOverflowVisibility hook",
+  "packageName": "@fluentui/react-overflow",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1228,6 +1228,7 @@ import { useOptionGroupStyles_unstable } from '@fluentui/react-combobox';
 import { useOptionStyles_unstable } from '@fluentui/react-combobox';
 import { useOverflowCount } from '@fluentui/react-overflow';
 import { useOverflowMenu } from '@fluentui/react-overflow';
+import { useOverflowVisibility } from '@fluentui/react-overflow';
 import { useOverlayDrawer_unstable } from '@fluentui/react-drawer';
 import { useOverlayDrawerStyles_unstable } from '@fluentui/react-drawer';
 import { usePersona_unstable } from '@fluentui/react-persona';
@@ -3810,6 +3811,8 @@ export { useOptionStyles_unstable }
 export { useOverflowCount }
 
 export { useOverflowMenu }
+
+export { useOverflowVisibility }
 
 export { useOverlayDrawer_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -884,6 +884,7 @@ export {
   DATA_OVERFLOW_MENU,
   DATA_OVERFLOW_ITEM,
   DATA_OVERFLOW_DIVIDER,
+  useOverflowVisibility,
 } from '@fluentui/react-overflow';
 
 export type { OverflowProps, OverflowItemProps } from '@fluentui/react-overflow';

--- a/packages/react-components/react-overflow/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/etc/react-overflow.api.md
@@ -81,6 +81,12 @@ export function useOverflowMenu<TElement extends HTMLElement>(id?: string): {
     isOverflowing: boolean;
 };
 
+// @public
+export function useOverflowVisibility(): {
+    itemVisibility: Record<string, boolean>;
+    groupVisibility: Record<string, OverflowGroupState>;
+};
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-overflow/src/index.ts
+++ b/packages/react-components/react-overflow/src/index.ts
@@ -9,6 +9,7 @@ export { useOverflowCount } from './useOverflowCount';
 export { useOverflowItem } from './useOverflowItem';
 export { useOverflowMenu } from './useOverflowMenu';
 export { useOverflowDivider } from './useOverflowDivider';
+export { useOverflowVisibility } from './useOverflowVisibility';
 
 export { useOverflowContext } from './overflowContext';
 

--- a/packages/react-components/react-overflow/src/useOverflowVisibility.test.tsx
+++ b/packages/react-components/react-overflow/src/useOverflowVisibility.test.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useOverflowVisibility } from './useOverflowVisibility';
+import { OverflowContext, OverflowContextValue } from './overflowContext';
+
+describe('useOverflowVisibility', () => {
+  it('should return item and group visiblity', () => {
+    const groupVisibility = {
+      foo: 'hidden',
+      bar: 'overflow',
+      baz: 'visible',
+    } as const;
+
+    const itemVisibility = {
+      foo: true,
+      bar: true,
+      baz: false,
+    } as const;
+    const Wrapper: React.FC = props => {
+      return (
+        <OverflowContext.Provider
+          {...props}
+          value={
+            {
+              groupVisibility,
+              itemVisibility,
+            } as unknown as OverflowContextValue
+          }
+        />
+      );
+    };
+    const { result } = renderHook(useOverflowVisibility, { wrapper: Wrapper });
+    expect(result.current.groupVisibility).toEqual(groupVisibility);
+    expect(result.current.itemVisibility).toEqual(itemVisibility);
+  });
+});

--- a/packages/react-components/react-overflow/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/src/useOverflowVisibility.ts
@@ -2,8 +2,11 @@ import * as React from 'react';
 import { useOverflowContext } from './overflowContext';
 
 /**
- * A hook that returns the visibility status of all items and groups. This hook
- * will cause the component it is in to re-render for every single time an item overflows or becomes
+ * A hook that returns the visibility status of all items and groups.
+ *
+ * ⚠️ Heads up!
+ *
+ * This hook will cause the component it is in to re-render for every single time an item overflows or becomes
  * visible - use with caution
  * @returns visibility status of all items and groups
  */

--- a/packages/react-components/react-overflow/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/src/useOverflowVisibility.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useOverflowContext } from './overflowContext';
 
 /**
@@ -7,5 +8,8 @@ import { useOverflowContext } from './overflowContext';
  * @returns visibility status of all items and groups
  */
 export function useOverflowVisibility() {
-  return useOverflowContext(ctx => ({ itemVisibility: ctx.itemVisibility, groupVisibility: ctx.groupVisibility }));
+  const itemVisibility = useOverflowContext(ctx => ctx.itemVisibility);
+  const groupVisibility = useOverflowContext(ctx => ctx.groupVisibility);
+
+  return React.useMemo(() => ({ itemVisibility, groupVisibility }), [itemVisibility, groupVisibility]);
 }

--- a/packages/react-components/react-overflow/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/src/useOverflowVisibility.ts
@@ -1,0 +1,11 @@
+import { useOverflowContext } from './overflowContext';
+
+/**
+ * A hook that returns the visibility status of all items and groups. This hook
+ * will cause the component it is in to re-render for every single time an item overflows or becomes
+ * visible - use with caution
+ * @returns visibility status of all items and groups
+ */
+export function useOverflowVisibility() {
+  return useOverflowContext(ctx => ({ itemVisibility: ctx.itemVisibility, groupVisibility: ctx.groupVisibility }));
+}


### PR DESCRIPTION
Exports a hook that returns the visibility state of every single overflow item and group. This hook can be useful when the overflow menu does not contain the invidivual items but some other view derived from the state of overflow items

