### PR TITLE
fix: MenuTrigger should let user override tabster attributes

### DIFF
--- a/change/@fluentui-react-menu-cdcb0ce7-cf9f-4e57-93a7-436d6aaacdca.json
+++ b/change/@fluentui-react-menu-cdcb0ce7-cf9f-4e57-93a7-436d6aaacdca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuTrigger tabster attributes can be overriden by user",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/src/components/MenuTrigger/useMenuTrigger.ts
@@ -125,9 +125,9 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
 
   const contextMenuProps = {
     id: triggerId,
+    ...restoreFocusTargetAttribute,
     ...child?.props,
     ref: useMergedRefs(triggerRef, child?.ref),
-    ...restoreFocusTargetAttribute,
     onMouseEnter: useEventCallback(mergeCallbacks(child?.props.onMouseEnter, onMouseEnter)),
     onMouseLeave: useEventCallback(mergeCallbacks(child?.props.onMouseLeave, onMouseLeave)),
     onContextMenu: useEventCallback(mergeCallbacks(child?.props.onContextMenu, onContextMenu)),


### PR DESCRIPTION
Changes the spread order of tabster attributes so that user tabster attributes win

Fixes #29798

