### PR TITLE
feat(react-motions): add atoms defined with WAAPI

### DIFF
--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -4,6 +4,372 @@
 
 ```ts
 
+declare namespace atoms {
+    export {
+        fade,
+        scale,
+        slide
+    }
+}
+export { atoms }
+
+declare namespace fade {
+    export {
+        fadeEnterUltraFast,
+        fadeEnterFaster,
+        fadeEnterFast,
+        fadeEnterNormal,
+        fadeEnterSlow,
+        fadeEnterSlower,
+        fadeEnterUltraSlow,
+        fadeExitUltraFast,
+        fadeExitFaster,
+        fadeExitFast,
+        fadeExitNormal,
+        fadeExitSlow,
+        fadeExitSlower,
+        fadeExitUltraSlow
+    }
+}
+
+// @public (undocumented)
+const fadeEnterFast: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeEnterFaster: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeEnterNormal: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeEnterSlow: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeEnterSlower: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeEnterUltraFast: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeEnterUltraSlow: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitFast: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitFaster: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitNormal: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitSlow: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitSlower: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitUltraFast: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+const fadeExitUltraSlow: ({ fromValue }: FadeParams) => MotionAtom;
+
+// @public (undocumented)
+export type MotionAtom = {
+    keyframes: Keyframe[];
+    options: KeyframeEffectOptions;
+};
+
+declare namespace scale {
+    export {
+        scaleEnterUltraFast,
+        scaleEnterFaster,
+        scaleEnterFast,
+        scaleEnterNormal,
+        scaleEnterSlow,
+        scaleEnterSlower,
+        scaleEnterUltraSlow,
+        scaleExitUltraFast,
+        scaleExitFaster,
+        scaleExitFast,
+        scaleExitNormal,
+        scaleExitSlow,
+        scaleExitSlower,
+        scaleExitUltraSlow
+    }
+}
+
+// @public (undocumented)
+const scaleEnterFast: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleEnterFaster: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleEnterNormal: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleEnterSlow: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleEnterSlower: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleEnterUltraFast: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleEnterUltraSlow: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitFast: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitFaster: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitNormal: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitSlow: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitSlower: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitUltraFast: ({ fromValue }: ScaleParams) => MotionAtom;
+
+// @public (undocumented)
+const scaleExitUltraSlow: ({ fromValue }: ScaleParams) => MotionAtom;
+
+declare namespace slide {
+    export {
+        slideDownEnterUltraFast,
+        slideDownEnterFaster,
+        slideDownEnterFast,
+        slideDownEnterNormal,
+        slideDownEnterSlow,
+        slideDownEnterSlower,
+        slideDownEnterUltraSlow,
+        slideUpEnterUltraFast,
+        slideUpEnterFaster,
+        slideUpEnterFast,
+        slideUpEnterNormal,
+        slideUpEnterSlow,
+        slideUpEnterSlower,
+        slideUpEnterUltraSlow,
+        slideLeftEnterUltraFast,
+        slideLeftEnterFaster,
+        slideLeftEnterFast,
+        slideLeftEnterNormal,
+        slideLeftEnterSlow,
+        slideLeftEnterSlower,
+        slideLeftEnterUltraSlow,
+        slideRightEnterUltraFast,
+        slideRightEnterFaster,
+        slideRightEnterFast,
+        slideRightEnterNormal,
+        slideRightEnterSlow,
+        slideRightEnterSlower,
+        slideRightEnterUltraSlow,
+        slideDownExitUltraFast,
+        slideDownExitFaster,
+        slideDownExitFast,
+        slideDownExitNormal,
+        slideDownExitSlow,
+        slideDownExitSlower,
+        slideDownExitUltraSlow,
+        slideUpExitUltraFast,
+        slideUpExitFaster,
+        slideUpExitFast,
+        slideUpExitNormal,
+        slideUpExitSlow,
+        slideUpExitSlower,
+        slideUpExitUltraSlow,
+        slideRightExitUltraFast,
+        slideRightExitFaster,
+        slideRightExitFast,
+        slideRightExitNormal,
+        slideRightExitSlow,
+        slideRightExitSlower,
+        slideRightExitUltraSlow,
+        slideLeftExitUltraFast,
+        slideLeftExitFaster,
+        slideLeftExitFast,
+        slideLeftExitNormal,
+        slideLeftExitSlow,
+        slideLeftExitSlower,
+        slideLeftExitUltraSlow
+    }
+}
+
+// @public (undocumented)
+const slideDownEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideDownExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideLeftExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideRightExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+
+// @public (undocumented)
+const slideUpExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-motions-preview/src/atoms/fade.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/fade.ts
@@ -1,0 +1,135 @@
+import {
+  durationUltraFast,
+  durationFaster,
+  durationFast,
+  durationNormal,
+  durationSlow,
+  durationSlower,
+  durationUltraSlow,
+  easingLinear,
+} from './tokens';
+
+import type { MotionAtom } from '../types';
+
+type FadeParams = {
+  fromValue?: number;
+};
+
+// Fade Ins
+// --------------------------------------------------
+
+export const fadeEnterUltraFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationUltraFast,
+    easing: easingLinear,
+  },
+});
+
+export const fadeEnterFaster = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationFaster,
+    easing: easingLinear,
+  },
+});
+
+export const fadeEnterFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationFast,
+    easing: easingLinear,
+  },
+});
+
+export const fadeEnterNormal = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationNormal,
+    easing: easingLinear,
+  },
+});
+
+// Basic Fade In Animation --Slow
+export const fadeEnterSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationSlow,
+    easing: easingLinear,
+  },
+});
+
+export const fadeEnterSlower = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationSlower,
+    easing: easingLinear,
+  },
+});
+
+export const fadeEnterUltraSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: fromValue }, { opacity: 1 }],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingLinear,
+  },
+});
+
+// Fade Ins
+// --------------------------------------------------
+
+export const fadeExitUltraFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationUltraFast,
+    easing: easingLinear,
+  },
+});
+
+export const fadeExitFaster = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationFaster,
+    easing: easingLinear,
+  },
+});
+
+export const fadeExitFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationFast,
+    easing: easingLinear,
+  },
+});
+
+export const fadeExitNormal = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationNormal,
+    easing: easingLinear,
+  },
+});
+
+export const fadeExitSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationSlow,
+    easing: easingLinear,
+  },
+});
+
+export const fadeExitSlower = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationSlower,
+    easing: easingLinear,
+  },
+});
+
+export const fadeExitUltraSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+  keyframes: [{ opacity: 1 }, { opacity: fromValue }],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingLinear,
+  },
+});

--- a/packages/react-components/react-motions-preview/src/atoms/index.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/index.ts
@@ -1,0 +1,5 @@
+import * as fade from './fade';
+import * as scale from './scale';
+import * as slide from './slide';
+
+export { fade, scale, slide };

--- a/packages/react-components/react-motions-preview/src/atoms/scale.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/scale.ts
@@ -1,0 +1,176 @@
+import {
+  durationFast,
+  durationFaster,
+  durationNormal,
+  durationSlow,
+  durationSlower,
+  durationUltraFast,
+  durationUltraSlow,
+  easingAccelerateMax,
+  easingDecelerateMax,
+} from './tokens';
+import type { MotionAtom } from '../types';
+
+type ScaleParams = {
+  fromValue?: number;
+};
+
+// Scale Ins
+// --------------------------------------------------
+
+export const scaleEnterUltraFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const scaleEnterFaster = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const scaleEnterFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const scaleEnterNormal = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const scaleEnterSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const scaleEnterSlower = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const scaleEnterUltraSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: `scale(${fromValue})`, opacity: 0 },
+    { transform: 'scale(1)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+// Scale Outs
+// --------------------------------------------------
+
+export const scaleExitUltraFast = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const scaleExitFaster = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const scaleExitFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const scaleExitNormal = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const scaleExitSlow = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const scaleExitSlower = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const scaleExitUltraSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'scale(1)', opacity: 1 },
+    { transform: `scale(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingAccelerateMax,
+  },
+});

--- a/packages/react-components/react-motions-preview/src/atoms/slide.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/slide.ts
@@ -1,0 +1,656 @@
+import {
+  durationFast,
+  durationFaster,
+  durationNormal,
+  durationSlow,
+  durationSlower,
+  durationUltraFast,
+  durationUltraSlow,
+  easingAccelerateMax,
+  easingDecelerateMax,
+} from './tokens';
+import type { MotionAtom } from '../types';
+
+type SlideParams = {
+  fromValue?: string;
+};
+
+// Slide Down Ins
+// --------------------------------------------------
+
+export const slideDownEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideDownEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideDownEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideDownEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideDownEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideDownEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideDownEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+// Slide Up Ins
+// --------------------------------------------------
+
+export const slideUpEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideUpEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideUpEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideUpEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideUpEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideUpEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideUpEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+    { transform: 'translateY(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+// Slide Left Ins
+// --------------------------------------------------
+
+export const slideLeftEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideLeftEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideLeftEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideLeftEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideLeftEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideLeftEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideLeftEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+// Slide Right Ins
+// --------------------------------------------------
+
+export const slideRightEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideRightEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideRightEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationFast,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideRightEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideRightEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideRightEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingDecelerateMax,
+  },
+});
+
+export const slideRightEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+    { transform: 'translateX(0px)', opacity: 1 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingDecelerateMax,
+  },
+});
+
+// Slide Down Outs
+// --------------------------------------------------
+
+export const slideDownExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideDownExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideDownExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideDownExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideDownExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideDownExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideDownExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+// Slide Up Outs
+// --------------------------------------------------
+
+export const slideUpExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideUpExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideUpExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideUpExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideUpExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideUpExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideUpExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateY(0px)', opacity: 1 },
+    { transform: `translateY(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+// Slide Right Outs
+// --------------------------------------------------
+
+export const slideRightExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingAccelerateMax,
+  },
+});
+//
+export const slideRightExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideRightExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideRightExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideRightExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideRightExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideRightExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+// Slide Left Outs
+// --------------------------------------------------
+
+export const slideLeftExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraFast,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideLeftExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideLeftExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationFaster,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideLeftExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationNormal,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideLeftExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlow,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideLeftExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationSlower,
+    easing: easingAccelerateMax,
+  },
+});
+
+export const slideLeftExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+  keyframes: [
+    { transform: 'translateX(0px)', opacity: 1 },
+    { transform: `translateX(-${fromValue})`, opacity: 0 },
+  ],
+  options: {
+    duration: durationUltraSlow,
+    easing: easingAccelerateMax,
+  },
+});

--- a/packages/react-components/react-motions-preview/src/atoms/tokens.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/tokens.ts
@@ -1,0 +1,17 @@
+export const durationUltraFast = 50;
+export const durationFaster = 100;
+export const durationFast = 150;
+export const durationNormal = 200;
+export const durationSlow = 300;
+export const durationSlower = 400;
+export const durationUltraSlow = 500;
+
+export const easingAccelerateMax = 'cubic-bezier(1,0,1,1)';
+export const easingAccelerateMid = 'cubic-bezier(0.7,0,1,0.5)';
+export const easingAccelerateMin = 'cubic-bezier(0.8,0,1,1)';
+export const easingDecelerateMax = 'cubic-bezier(0,0,0,1)';
+export const easingDecelerateMid = 'cubic-bezier(0.1,0.9,0.2,1)';
+export const easingDecelerateMin = 'cubic-bezier(0.33,0,0.1,1)';
+export const easingMaxEasyEase = 'cubic-bezier(0.8,0,0.1,1)';
+export const easingEasyEase = 'cubic-bezier(0.33,0,0.67,1)';
+export const easingLinear = 'cubic-bezier(0,0,1,1)';

--- a/packages/react-components/react-motions-preview/src/index.ts
+++ b/packages/react-components/react-motions-preview/src/index.ts
@@ -1,1 +1,4 @@
-export {};
+import * as atoms from './atoms';
+
+export { atoms };
+export type { MotionAtom } from './types';

--- a/packages/react-components/react-motions-preview/src/types.ts
+++ b/packages/react-components/react-motions-preview/src/types.ts
@@ -1,0 +1,4 @@
+export type MotionAtom = {
+  keyframes: Keyframe[];
+  options: KeyframeEffectOptions;
+};


### PR DESCRIPTION
## New Behavior

Add motion definitions for "atoms" (naming is WIP and will be discussed) powered by [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).

Definitions are ported from v0 as a boilterplate and might/will change in future.

## Related Issue(s)

Related to #29825.
