### PR TITLE
feat(react-motions): implement createAtom() factory

### DIFF
--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -16,7 +16,7 @@ declare namespace atoms {
 export { atoms }
 
 // @public
-export function createAtom(motion: MotionAtom): (props: AtomProps) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>>;
+export function createAtom(motion: MotionAtom): React_2.FC<AtomProps>;
 
 // @public (undocumented)
 const downEnterFast: ({ fromValue }: SlideParams) => MotionAtom;

--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import * as React_2 from 'react';
+
 declare namespace atoms {
     export {
         fade,
@@ -12,6 +14,9 @@ declare namespace atoms {
     }
 }
 export { atoms }
+
+// @public
+export function createAtom(motion: MotionAtom): (props: AtomProps) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>>;
 
 // @public (undocumented)
 const downEnterFast: ({ fromValue }: SlideParams) => MotionAtom;

--- a/packages/react-components/react-motions-preview/package.json
+++ b/packages/react-components/react-motions-preview/package.json
@@ -37,6 +37,8 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
+    "@fluentui/react-shared-contexts": "^9.12.0",
+    "@fluentui/react-utilities": "^9.15.2",
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import type { MotionAtom } from '../types';
+import { createAtom } from './createAtom';
+
+const motion: MotionAtom = {
+  keyframes: [{ opacity: 0 }, { opacity: 1 }],
+  options: {
+    duration: 500,
+  },
+};
+
+function createElementMock() {
+  const animateMock = jest.fn().mockImplementation(() => ({
+    cancel: jest.fn(),
+  }));
+  const ElementMock = React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      animate: animateMock,
+    }));
+
+    return <div>ElementMock</div>;
+  });
+
+  return {
+    animateMock,
+    ElementMock,
+  };
+}
+
+describe('createAtom', () => {
+  it('creates a motion and plays it', () => {
+    const TestAtom = createAtom(motion);
+    const { animateMock, ElementMock } = createElementMock();
+
+    render(
+      <TestAtom>
+        <ElementMock />
+      </TestAtom>,
+    );
+
+    expect(animateMock).toHaveBeenCalledWith(motion.keyframes, { ...motion.options, iterations: 1 });
+  });
+});

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
@@ -13,6 +13,7 @@ const motion: MotionAtom = {
 
 function createElementMock() {
   const animateMock = jest.fn().mockImplementation(() => ({
+    play: jest.fn(),
     cancel: jest.fn(),
   }));
   const ElementMock = React.forwardRef((props, ref) => {
@@ -40,6 +41,10 @@ describe('createAtom', () => {
       </TestAtom>,
     );
 
-    expect(animateMock).toHaveBeenCalledWith(motion.keyframes, { ...motion.options, iterations: 1 });
+    expect(animateMock).toHaveBeenCalledWith(motion.keyframes, {
+      ...motion.options,
+      fill: 'forwards',
+      iterations: 1,
+    });
   });
 });

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.ts
@@ -17,9 +17,7 @@ export type AtomProps = {
  * @param motion - A motion definition.
  */
 export function createAtom(motion: MotionAtom) {
-  // Return a component that will animate the children
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  return function AtomMotion(props: AtomProps) {
+  const Atom: React.FC<AtomProps> = props => {
     const { children, iterations = 1, playState = 'running' } = props;
 
     const child = React.Children.only(children) as React.ReactElement & { ref: React.Ref<HTMLElement> };
@@ -30,22 +28,12 @@ export function createAtom(motion: MotionAtom) {
     const isReducedMotion = useIsReducedMotion();
 
     useIsomorphicLayoutEffect(() => {
-      if (animationRef.current) {
-        if (playState === 'running') {
-          animationRef.current.play();
-        }
-
-        if (playState === 'paused') {
-          animationRef.current.pause();
-        }
-      }
-    }, [playState]);
-
-    useIsomorphicLayoutEffect(() => {
       const element = elementRef.current;
 
       if (element) {
         const animation = element.animate(motion.keyframes, {
+          fill: 'forwards',
+
           ...motion.options,
           iterations,
 
@@ -60,6 +48,23 @@ export function createAtom(motion: MotionAtom) {
       }
     }, [iterations, isReducedMotion]);
 
+    // TODO: Find a way to avoid this effect/refactor as currently it will call .play() on initial render
+    useIsomorphicLayoutEffect(() => {
+      const animation = animationRef.current;
+
+      if (animation) {
+        if (playState === 'running') {
+          animation.play();
+        }
+
+        if (playState === 'paused') {
+          animation.pause();
+        }
+      }
+    }, [playState]);
+
     return React.cloneElement(children, { ref: useMergedRefs(elementRef, child.ref) });
   };
+
+  return Atom;
 }

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.ts
@@ -1,0 +1,65 @@
+import { useIsomorphicLayoutEffect, useMergedRefs } from '@fluentui/react-utilities';
+import * as React from 'react';
+
+import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
+import type { MotionAtom } from '../types';
+
+export type AtomProps = {
+  children: React.ReactElement;
+
+  iterations?: number;
+  playState?: 'running' | 'paused';
+};
+
+/**
+ * Creates a component that will animate the children using the provided motion.
+ *
+ * @param motion - A motion definition.
+ */
+export function createAtom(motion: MotionAtom) {
+  // Return a component that will animate the children
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  return function AtomMotion(props: AtomProps) {
+    const { children, iterations = 1, playState = 'running' } = props;
+
+    const child = React.Children.only(children) as React.ReactElement & { ref: React.Ref<HTMLElement> };
+
+    const animationRef = React.useRef<Animation | undefined>();
+    const elementRef = React.useRef<HTMLElement>();
+
+    const isReducedMotion = useIsReducedMotion();
+
+    useIsomorphicLayoutEffect(() => {
+      if (animationRef.current) {
+        if (playState === 'running') {
+          animationRef.current.play();
+        }
+
+        if (playState === 'paused') {
+          animationRef.current.pause();
+        }
+      }
+    }, [playState]);
+
+    useIsomorphicLayoutEffect(() => {
+      const element = elementRef.current;
+
+      if (element) {
+        const animation = element.animate(motion.keyframes, {
+          ...motion.options,
+          iterations,
+
+          ...(isReducedMotion() && { duration: 1 }),
+        });
+
+        animationRef.current = animation;
+
+        return () => {
+          animation.cancel();
+        };
+      }
+    }, [iterations, isReducedMotion]);
+
+    return React.cloneElement(children, { ref: useMergedRefs(elementRef, child.ref) });
+  };
+}

--- a/packages/react-components/react-motions-preview/src/hooks/useIsReducedMotion.test.tsx
+++ b/packages/react-components/react-motions-preview/src/hooks/useIsReducedMotion.test.tsx
@@ -1,0 +1,48 @@
+import { Provider_unstable } from '@fluentui/react-shared-contexts';
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+import { useIsReducedMotion } from './useIsReducedMotion';
+
+function createMatchMediaMock(matches: boolean): Window['matchMedia'] {
+  return () =>
+    ({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches,
+    } as unknown as ReturnType<Window['matchMedia']>);
+}
+
+function createDocumentMock(matchMedia: Window['matchMedia'] | undefined): Document {
+  return {
+    defaultView: {
+      matchMedia,
+    } as Document['defaultView'],
+  } as Document;
+}
+
+describe('useIsReducedMotion', () => {
+  it('should return "false" if matchMedia is not supported', () => {
+    const targetDocument = createDocumentMock(undefined);
+    const { result } = renderHook(() => useIsReducedMotion(), {
+      wrapper: ({ children }) => (
+        <Provider_unstable value={{ targetDocument, dir: 'ltr' }}>{children}</Provider_unstable>
+      ),
+    });
+
+    expect(result.current()).toBe(false);
+  });
+
+  it('should return a value if matchMedia is supported', () => {
+    const matchMediaMock = createMatchMediaMock(true);
+    const targetDocument = createDocumentMock(matchMediaMock);
+
+    const { result } = renderHook(() => useIsReducedMotion(), {
+      wrapper: ({ children }) => (
+        <Provider_unstable value={{ targetDocument, dir: 'ltr' }}>{children}</Provider_unstable>
+      ),
+    });
+
+    expect(result.current()).toBe(true);
+  });
+});

--- a/packages/react-components/react-motions-preview/src/hooks/useIsReducedMotion.ts
+++ b/packages/react-components/react-motions-preview/src/hooks/useIsReducedMotion.ts
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+
+const REDUCED_MEDIA_QUERY = 'screen and (prefers-reduced-motion: reduce)';
+
+// TODO: find a better approach there as each hook creates a separate subscription
+
+export function useIsReducedMotion(): () => boolean {
+  const { targetDocument } = useFluent();
+  const targetWindow: Window | null = targetDocument?.defaultView ?? null;
+
+  const queryValue = React.useRef<boolean>(false);
+  const isEnabled = React.useCallback(() => queryValue.current, []);
+
+  React.useEffect(() => {
+    if (targetWindow === null || typeof targetWindow.matchMedia !== 'function') {
+      return;
+    }
+
+    const queryMatch = targetWindow.matchMedia(REDUCED_MEDIA_QUERY);
+
+    if (queryMatch.matches) {
+      queryValue.current = true;
+    }
+
+    const matchListener = (e: MediaQueryListEvent) => {
+      queryValue.current = e.matches;
+    };
+
+    queryMatch.addEventListener('change', matchListener);
+
+    return () => {
+      queryMatch.removeEventListener('change', matchListener);
+    };
+  }, [targetWindow]);
+
+  return isEnabled;
+}

--- a/packages/react-components/react-motions-preview/src/index.ts
+++ b/packages/react-components/react-motions-preview/src/index.ts
@@ -1,4 +1,6 @@
 import * as atoms from './atoms';
 
+export { createAtom } from './factories/createAtom';
+
 export { atoms };
 export type { MotionAtom } from './types';

--- a/packages/react-components/react-motions-preview/stories/CreateAtom/CreateAtom.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreateAtom/CreateAtom.stories.tsx
@@ -1,0 +1,105 @@
+import { makeStyles, shorthands, tokens, Label, Slider, useId } from '@fluentui/react-components';
+import { atoms, createAtom } from '@fluentui/react-motions-preview';
+import * as React from 'react';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    ...shorthands.gap('10px'),
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    ...shorthands.border('3px', 'solid', tokens.colorNeutralForeground3),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.padding('10px'),
+
+    alignItems: 'center',
+  },
+  item: {
+    backgroundColor: tokens.colorBrandBackground,
+    ...shorthands.borderRadius('50%'),
+
+    width: '100px',
+    height: '100px',
+  },
+  description: {
+    ...shorthands.margin('5px'),
+  },
+  controls: {
+    display: 'flex',
+    marginTop: '20px',
+
+    ...shorthands.border('3px', 'solid', tokens.colorNeutralForeground3),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.padding('10px'),
+  },
+  meter: {
+    ...shorthands.padding('4px'),
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralForeground3),
+    fontFamily: tokens.fontFamilyNumeric,
+    backgroundColor: tokens.colorNeutralBackground4,
+  },
+  slider: {
+    width: '250px',
+  },
+  label: {
+    alignSelf: 'center',
+  },
+});
+
+const FadeEnter = createAtom(atoms.fade.enterUltraSlow({}));
+const FadeExit = createAtom(atoms.fade.exitUltraSlow({}));
+
+export const CreateAtom = () => {
+  const classes = useClasses();
+  const sliderId = useId();
+
+  const [playbackRate, setPlaybackRate] = React.useState<number>(30);
+
+  React.useEffect(() => {
+    document.getAnimations().forEach(animation => {
+      animation.playbackRate = playbackRate / 100;
+    });
+  }, [playbackRate]);
+
+  return (
+    <>
+      <div className={classes.container}>
+        <div className={classes.card}>
+          <FadeEnter iterations={Infinity}>
+            <div className={classes.item} />
+          </FadeEnter>
+
+          <code className={classes.description}>fadeEnterUltraSlow</code>
+        </div>
+        <div className={classes.card}>
+          <FadeExit iterations={Infinity}>
+            <div className={classes.item} />
+          </FadeExit>
+
+          <div className={classes.description}>fadeExitUltraSlow</div>
+        </div>
+      </div>
+
+      <div className={classes.controls}>
+        <Label className={classes.label} htmlFor={sliderId}>
+          <code>playbackRate</code>
+        </Label>
+        <Slider
+          className={classes.slider}
+          aria-valuetext={`Value is ${playbackRate}%`}
+          value={playbackRate}
+          onChange={(ev, data) => setPlaybackRate(data.value)}
+          min={0}
+          id={sliderId}
+          max={100}
+          step={10}
+        />
+        <div className={classes.meter}>{playbackRate}%</div>
+      </div>
+    </>
+  );
+};

--- a/packages/react-components/react-motions-preview/stories/CreateAtom/index.stories.ts
+++ b/packages/react-components/react-motions-preview/stories/CreateAtom/index.stories.ts
@@ -1,0 +1,9 @@
+export { CreateAtom as createAtom } from './CreateAtom.stories';
+
+export default {
+  title: 'Utilities/Motions (Preview)',
+  component: null,
+  parameters: {
+    docs: {},
+  },
+};


### PR DESCRIPTION
## New Behavior

Adds `createAtom()` factory to animate motion atoms (static motions) defined for [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).

### Usage

```tsx
import { createAtom } from '@fluentui/react-motions-preview'

const FadeEnter = createAtom(atoms.fade.enterSlow());

function App() {
  return (
    <FadeEnter>
      <div />
    </FadeEnter>
  )
}
```

## Related Issue(s)

Related to #29821.