### PR TITLE
fix(react-motions): make params in atoms optional

### DIFF
--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -14,130 +14,130 @@ declare namespace atoms {
 export { atoms }
 
 // @public (undocumented)
-const downEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const downEnterUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const downExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const downExitUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const enterFast: ({ fromValue }: FadeParams) => MotionAtom;
+const enterFast: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterFast_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterFast_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const enterFaster: ({ fromValue }: FadeParams) => MotionAtom;
+const enterFaster: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterFaster_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterFaster_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const enterNormal: ({ fromValue }: FadeParams) => MotionAtom;
+const enterNormal: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterNormal_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterNormal_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const enterSlow: ({ fromValue }: FadeParams) => MotionAtom;
+const enterSlow: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterSlow_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterSlow_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const enterSlower: ({ fromValue }: FadeParams) => MotionAtom;
+const enterSlower: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterSlower_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterSlower_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const enterUltraFast: ({ fromValue }: FadeParams) => MotionAtom;
+const enterUltraFast: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterUltraFast_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterUltraFast_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const enterUltraSlow: ({ fromValue }: FadeParams) => MotionAtom;
+const enterUltraSlow: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const enterUltraSlow_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const enterUltraSlow_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitFast: ({ fromValue }: FadeParams) => MotionAtom;
+const exitFast: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitFast_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitFast_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitFaster: ({ fromValue }: FadeParams) => MotionAtom;
+const exitFaster: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitFaster_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitFaster_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitNormal: ({ fromValue }: FadeParams) => MotionAtom;
+const exitNormal: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitNormal_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitNormal_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitSlow: ({ fromValue }: FadeParams) => MotionAtom;
+const exitSlow: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitSlow_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitSlow_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitSlower: ({ fromValue }: FadeParams) => MotionAtom;
+const exitSlower: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitSlower_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitSlower_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitUltraFast: ({ fromValue }: FadeParams) => MotionAtom;
+const exitUltraFast: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitUltraFast_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitUltraFast_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 // @public (undocumented)
-const exitUltraSlow: ({ fromValue }: FadeParams) => MotionAtom;
+const exitUltraSlow: ({ fromValue }?: FadeParams) => MotionAtom;
 
 // @public (undocumented)
-const exitUltraSlow_2: ({ fromValue }: ScaleParams) => MotionAtom;
+const exitUltraSlow_2: ({ fromValue }?: ScaleParams) => MotionAtom;
 
 declare namespace fade {
     export {
@@ -159,46 +159,46 @@ declare namespace fade {
 }
 
 // @public (undocumented)
-const leftEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const leftEnterUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const leftExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const leftExitUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
 export type MotionAtom = {
@@ -207,46 +207,46 @@ export type MotionAtom = {
 };
 
 // @public (undocumented)
-const rightEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const rightEnterUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const rightExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const rightExitUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 declare namespace scale {
     export {
@@ -329,46 +329,46 @@ declare namespace slide {
 }
 
 // @public (undocumented)
-const upEnterFast: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upEnterFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upEnterNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upEnterSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upEnterSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upEnterUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upEnterUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const upEnterUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitFast: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitFaster: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitFaster: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitNormal: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitNormal: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitSlower: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitSlower: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitUltraFast: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitUltraFast: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // @public (undocumented)
-const upExitUltraSlow: ({ fromValue }: SlideParams) => MotionAtom;
+const upExitUltraSlow: ({ fromValue }?: SlideParams) => MotionAtom;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-motions-preview/src/atoms/fade.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/fade.ts
@@ -18,7 +18,7 @@ type FadeParams = {
 // Fade Ins
 // --------------------------------------------------
 
-export const enterUltraFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterUltraFast = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationUltraFast,
@@ -26,7 +26,7 @@ export const enterUltraFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const enterFaster = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterFaster = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationFaster,
@@ -34,7 +34,7 @@ export const enterFaster = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const enterFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterFast = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationFast,
@@ -42,7 +42,7 @@ export const enterFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const enterNormal = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterNormal = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationNormal,
@@ -50,7 +50,7 @@ export const enterNormal = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const enterSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterSlow = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationSlow,
@@ -58,7 +58,7 @@ export const enterSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const enterSlower = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterSlower = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationSlower,
@@ -66,7 +66,7 @@ export const enterSlower = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const enterUltraSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const enterUltraSlow = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
   options: {
     duration: durationUltraSlow,
@@ -77,7 +77,7 @@ export const enterUltraSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
 // Fade Ins
 // --------------------------------------------------
 
-export const exitUltraFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitUltraFast = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationUltraFast,
@@ -85,7 +85,7 @@ export const exitUltraFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const exitFaster = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitFaster = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationFaster,
@@ -93,7 +93,7 @@ export const exitFaster = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const exitFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitFast = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationFast,
@@ -101,7 +101,7 @@ export const exitFast = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const exitNormal = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitNormal = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationNormal,
@@ -109,7 +109,7 @@ export const exitNormal = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const exitSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitSlow = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationSlow,
@@ -117,7 +117,7 @@ export const exitSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const exitSlower = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitSlower = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationSlower,
@@ -125,7 +125,7 @@ export const exitSlower = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
   },
 });
 
-export const exitUltraSlow = ({ fromValue = 0 }: FadeParams): MotionAtom => ({
+export const exitUltraSlow = ({ fromValue = 0 }: FadeParams = {}): MotionAtom => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
   options: {
     duration: durationUltraSlow,

--- a/packages/react-components/react-motions-preview/src/atoms/scale.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/scale.ts
@@ -18,7 +18,7 @@ type ScaleParams = {
 // Scale Ins
 // --------------------------------------------------
 
-export const enterUltraFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterUltraFast = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -29,7 +29,7 @@ export const enterUltraFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom =>
   },
 });
 
-export const enterFaster = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterFaster = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -40,7 +40,7 @@ export const enterFaster = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const enterFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterFast = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -51,7 +51,7 @@ export const enterFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const enterNormal = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterNormal = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -62,7 +62,7 @@ export const enterNormal = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const enterSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterSlow = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -73,7 +73,7 @@ export const enterSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const enterSlower = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterSlower = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -84,7 +84,7 @@ export const enterSlower = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const enterUltraSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const enterUltraSlow = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
@@ -98,7 +98,7 @@ export const enterUltraSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom =>
 // Scale Outs
 // --------------------------------------------------
 
-export const exitUltraFast = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+export const exitUltraFast = ({ fromValue = 0.9 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
@@ -109,7 +109,7 @@ export const exitUltraFast = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => (
   },
 });
 
-export const exitFaster = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+export const exitFaster = ({ fromValue = 0.9 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
@@ -120,7 +120,7 @@ export const exitFaster = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const exitFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const exitFast = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
@@ -131,7 +131,7 @@ export const exitFast = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const exitNormal = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+export const exitNormal = ({ fromValue = 0.9 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
@@ -142,7 +142,7 @@ export const exitNormal = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const exitSlow = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+export const exitSlow = ({ fromValue = 0.9 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
@@ -153,7 +153,7 @@ export const exitSlow = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const exitSlower = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
+export const exitSlower = ({ fromValue = 0.9 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
@@ -164,7 +164,7 @@ export const exitSlower = ({ fromValue = 0.9 }: ScaleParams): MotionAtom => ({
   },
 });
 
-export const exitUltraSlow = ({ fromValue = 0.88 }: ScaleParams): MotionAtom => ({
+export const exitUltraSlow = ({ fromValue = 0.88 }: ScaleParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },

--- a/packages/react-components/react-motions-preview/src/atoms/slide.ts
+++ b/packages/react-components/react-motions-preview/src/atoms/slide.ts
@@ -18,7 +18,7 @@ type SlideParams = {
 // Slide Down Ins
 // --------------------------------------------------
 
-export const downEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -29,7 +29,7 @@ export const downEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionA
   },
 });
 
-export const downEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -40,7 +40,7 @@ export const downEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const downEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -51,7 +51,7 @@ export const downEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const downEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -62,7 +62,7 @@ export const downEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const downEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -73,7 +73,7 @@ export const downEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const downEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -84,7 +84,7 @@ export const downEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const downEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -98,7 +98,7 @@ export const downEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionA
 // Slide Up Ins
 // --------------------------------------------------
 
-export const upEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -109,7 +109,7 @@ export const upEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAto
   },
 });
 
-export const upEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -120,7 +120,7 @@ export const upEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const upEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -131,7 +131,7 @@ export const upEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => 
   },
 });
 
-export const upEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -142,7 +142,7 @@ export const upEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const upEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -153,7 +153,7 @@ export const upEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => 
   },
 });
 
-export const upEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -164,7 +164,7 @@ export const upEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const upEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
@@ -178,7 +178,7 @@ export const upEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAto
 // Slide Left Ins
 // --------------------------------------------------
 
-export const leftEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -189,7 +189,7 @@ export const leftEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionA
   },
 });
 
-export const leftEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -200,7 +200,7 @@ export const leftEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const leftEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -211,7 +211,7 @@ export const leftEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const leftEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -222,7 +222,7 @@ export const leftEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const leftEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -233,7 +233,7 @@ export const leftEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const leftEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -244,7 +244,7 @@ export const leftEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const leftEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -258,7 +258,7 @@ export const leftEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionA
 // Slide Right Ins
 // --------------------------------------------------
 
-export const rightEnterUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -269,7 +269,7 @@ export const rightEnterUltraFast = ({ fromValue = '20px' }: SlideParams): Motion
   },
 });
 
-export const rightEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -280,7 +280,7 @@ export const rightEnterFaster = ({ fromValue = '20px' }: SlideParams): MotionAto
   },
 });
 
-export const rightEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -291,7 +291,7 @@ export const rightEnterFast = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const rightEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -302,7 +302,7 @@ export const rightEnterNormal = ({ fromValue = '20px' }: SlideParams): MotionAto
   },
 });
 
-export const rightEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -313,7 +313,7 @@ export const rightEnterSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const rightEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -324,7 +324,7 @@ export const rightEnterSlower = ({ fromValue = '20px' }: SlideParams): MotionAto
   },
 });
 
-export const rightEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
@@ -338,7 +338,7 @@ export const rightEnterUltraSlow = ({ fromValue = '20px' }: SlideParams): Motion
 // Slide Down Outs
 // --------------------------------------------------
 
-export const downExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -349,7 +349,7 @@ export const downExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAt
   },
 });
 
-export const downExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -360,7 +360,7 @@ export const downExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const downExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -371,7 +371,7 @@ export const downExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const downExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -382,7 +382,7 @@ export const downExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const downExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -393,7 +393,7 @@ export const downExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const downExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -404,7 +404,7 @@ export const downExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const downExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const downExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
@@ -418,7 +418,7 @@ export const downExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAt
 // Slide Up Outs
 // --------------------------------------------------
 
-export const upExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -429,7 +429,7 @@ export const upExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const upExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -440,7 +440,7 @@ export const upExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const upExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -451,7 +451,7 @@ export const upExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => (
   },
 });
 
-export const upExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -462,7 +462,7 @@ export const upExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const upExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -473,7 +473,7 @@ export const upExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => (
   },
 });
 
-export const upExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -484,7 +484,7 @@ export const upExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const upExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const upExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
@@ -498,7 +498,7 @@ export const upExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom
 // Slide Right Outs
 // --------------------------------------------------
 
-export const rightExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -509,7 +509,7 @@ export const rightExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionA
   },
 });
 //
-export const rightExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -520,7 +520,7 @@ export const rightExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const rightExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -531,7 +531,7 @@ export const rightExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const rightExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -542,7 +542,7 @@ export const rightExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const rightExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -553,7 +553,7 @@ export const rightExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom =
   },
 });
 
-export const rightExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -564,7 +564,7 @@ export const rightExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom
   },
 });
 
-export const rightExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const rightExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
@@ -578,7 +578,7 @@ export const rightExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionA
 // Slide Left Outs
 // --------------------------------------------------
 
-export const leftExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
@@ -589,7 +589,7 @@ export const leftExitUltraFast = ({ fromValue = '20px' }: SlideParams): MotionAt
   },
 });
 
-export const leftExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitFaster = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
@@ -600,7 +600,7 @@ export const leftExitFaster = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const leftExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitFast = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
@@ -611,7 +611,7 @@ export const leftExitFast = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const leftExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitNormal = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
@@ -622,7 +622,7 @@ export const leftExitNormal = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const leftExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
@@ -633,7 +633,7 @@ export const leftExitSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom =>
   },
 });
 
-export const leftExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitSlower = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
@@ -644,7 +644,7 @@ export const leftExitSlower = ({ fromValue = '20px' }: SlideParams): MotionAtom 
   },
 });
 
-export const leftExitUltraSlow = ({ fromValue = '20px' }: SlideParams): MotionAtom => ({
+export const leftExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): MotionAtom => ({
   keyframes: [
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },


### PR DESCRIPTION
## Previous Behavior

To create a motion definition, it's required to pass a param:

```ts
atoms.fade.enterSlow({});
```

## New Behavior

The param is optional:

```ts
atoms.fade.enterSlow();
```


## Related Issue(s)

Related to #29821.
