### PR TITLE
fix: v9 Dropdown in Safari gets focus when clicked

### DIFF
--- a/change/@fluentui-react-combobox-33ead5c4-7eb4-47ca-bc9f-49ba7aaa8db7.json
+++ b/change/@fluentui-react-combobox-33ead5c4-7eb4-47ca-bc9f-49ba7aaa8db7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Dropdown button gets focus in Safari when clicked",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Dropdown renders a default state 1`] = `
       aria-expanded="false"
       class="fui-Dropdown__button"
       role="combobox"
+      tabindex="0"
       type="button"
     >
       <span
@@ -44,6 +45,7 @@ exports[`Dropdown renders an open listbox 1`] = `
       aria-expanded="true"
       class="fui-Dropdown__button"
       role="combobox"
+      tabindex="0"
       type="button"
     >
       <span

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -28,8 +28,6 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   const { activeOption, getIndexOfId, getOptionsMatchingText, open, setActiveOption, setFocusVisible, setOpen } =
     baseState;
 
-  const triggerRef = React.useRef<HTMLButtonElement>(null);
-
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'button',
@@ -99,12 +97,6 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
     }
   };
 
-  const onTriggerPointerUp = (ev: React.PointerEvent<HTMLButtonElement>) => {
-    // Safari does not focus button elements when clicked, so we're calling .focus() manually
-    // This needs to be on pointer up, since blur is called after pointer down
-    triggerRef.current?.focus();
-  };
-
   // resolve button and listbox slot props
   let triggerSlot: Slot<'button'>;
   let listboxSlot: Slot<typeof Listbox> | undefined;
@@ -112,14 +104,13 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   triggerSlot = slot.always(props.button, {
     defaultProps: {
       type: 'button',
+      tabIndex: 0,
       children: baseState.value || props.placeholder,
       ...triggerNativeProps,
     },
     elementType: 'button',
   });
-  triggerSlot.ref = useMergedRefs(triggerSlot.ref, triggerRef);
   triggerSlot.onKeyDown = mergeCallbacks(onTriggerKeyDown, triggerSlot.onKeyDown);
-  triggerSlot.onPointerUp = mergeCallbacks(onTriggerPointerUp, triggerSlot.onPointerUp);
   listboxSlot =
     baseState.open || baseState.hasFocus
       ? slot.optional(props.listbox, {

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -104,7 +104,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   triggerSlot = slot.always(props.button, {
     defaultProps: {
       type: 'button',
-      tabIndex: 0,
+      tabIndex: 0, // Safari doesn't focus the button on click without this
       children: baseState.value || props.placeholder,
       ...triggerNativeProps,
     },

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -28,6 +28,8 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   const { activeOption, getIndexOfId, getOptionsMatchingText, open, setActiveOption, setFocusVisible, setOpen } =
     baseState;
 
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'button',
@@ -97,6 +99,12 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
     }
   };
 
+  const onTriggerPointerUp = (ev: React.PointerEvent<HTMLButtonElement>) => {
+    // Safari does not focus button elements when clicked, so we're calling .focus() manually
+    // This needs to be on pointer up, since blur is called after pointer down
+    triggerRef.current?.focus();
+  };
+
   // resolve button and listbox slot props
   let triggerSlot: Slot<'button'>;
   let listboxSlot: Slot<typeof Listbox> | undefined;
@@ -109,7 +117,9 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
     },
     elementType: 'button',
   });
+  triggerSlot.ref = useMergedRefs(triggerSlot.ref, triggerRef);
   triggerSlot.onKeyDown = mergeCallbacks(onTriggerKeyDown, triggerSlot.onKeyDown);
+  triggerSlot.onPointerUp = mergeCallbacks(onTriggerPointerUp, triggerSlot.onPointerUp);
   listboxSlot =
     baseState.open || baseState.hasFocus
       ? slot.optional(props.listbox, {


### PR DESCRIPTION
## Previous Behavior

Safari has a longstanding behavior where it does not focus links and buttons when they are clicked. For Dropdown, this means that keyboard navigation doesn't work after opening them with a mouse, and that they don't close when clicking outside of the dropdown (since there is no blur event).

## New Behavior

The button has an explicit tabindex, which allows it to get focus when clicked in Safari

## Related Issue(s)

- Fixes #29576
