### PR TITLE
chore: bump @types/react version to v17.0.55

### DIFF
--- a/change/@fluentui-global-context-d5755d89-4b6c-4317-afd3-914b7893dd3e.json
+++ b/change/@fluentui-global-context-d5755d89-4b6c-4317-afd3-914b7893dd3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/global-context",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-a38d0ec0-aa8e-4cae-9fa8-c488343f5902.json
+++ b/change/@fluentui-react-accordion-a38d0ec0-aa8e-4cae-9fa8-c488343f5902.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-b52dadf8-f1e9-4faa-923f-986ae013ed56.json
+++ b/change/@fluentui-react-alert-b52dadf8-f1e9-4faa-923f-986ae013ed56.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-alert",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-0c155c1e-ea98-4944-8177-530f89b7f887.json
+++ b/change/@fluentui-react-aria-0c155c1e-ea98-4944-8177-530f89b7f887.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-e2d23a1d-d3ee-473b-aa8e-09403ddd9a1f.json
+++ b/change/@fluentui-react-avatar-e2d23a1d-d3ee-473b-aa8e-09403ddd9a1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-avatar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-52d78df7-0e24-4b3a-addf-a2e6f6473352.json
+++ b/change/@fluentui-react-badge-52d78df7-0e24-4b3a-addf-a2e6f6473352.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-badge",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-868cfd8b-bc41-4e59-82e8-a4cbac0fa40c.json
+++ b/change/@fluentui-react-breadcrumb-868cfd8b-bc41-4e59-82e8-a4cbac0fa40c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-3624587e-9f3a-44b3-a88f-5537f25ed562.json
+++ b/change/@fluentui-react-button-3624587e-9f3a-44b3-a88f-5537f25ed562.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-button",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-ee460aac-2692-4299-bffd-f969108560cd.json
+++ b/change/@fluentui-react-card-ee460aac-2692-4299-bffd-f969108560cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-card",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-eee45ad1-caa7-4d4a-9a0c-8eb6c7e27c38.json
+++ b/change/@fluentui-react-checkbox-eee45ad1-caa7-4d4a-9a0c-8eb6c7e27c38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-acc8bfb1-c292-4275-a591-63488c504606.json
+++ b/change/@fluentui-react-combobox-acc8bfb1-c292-4275-a591-63488c504606.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-c2036c4d-3da4-491c-9ddf-d9c856c9215d.json
+++ b/change/@fluentui-react-components-c2036c4d-3da4-491c-9ddf-d9c856c9215d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-griffel-0411a1d0-a3ed-4c5d-9702-a7806a24824b.json
+++ b/change/@fluentui-react-conformance-griffel-0411a1d0-a3ed-4c5d-9702-a7806a24824b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-1a1303ea-f0df-4125-ab84-5f934ff238b4.json
+++ b/change/@fluentui-react-context-selector-1a1303ea-f0df-4125-ab84-5f934ff238b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-d9b19a40-a84a-4f3c-8fc2-fad5dc27a08b.json
+++ b/change/@fluentui-react-datepicker-compat-d9b19a40-a84a-4f3c-8fc2-fad5dc27a08b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-c1b1580a-11f9-4f85-a629-b5c6331c6718.json
+++ b/change/@fluentui-react-dialog-c1b1580a-11f9-4f85-a629-b5c6331c6718.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-af7e5883-e242-4d79-84f1-4020a9f2bc17.json
+++ b/change/@fluentui-react-divider-af7e5883-e242-4d79-84f1-4020a9f2bc17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-divider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-ea1e5218-c114-4b71-a256-2b4a9823fde3.json
+++ b/change/@fluentui-react-drawer-ea1e5218-c114-4b71-a256-2b4a9823fde3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-drawer",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-bfbfb504-ead0-45f6-82c2-61c24e5188ea.json
+++ b/change/@fluentui-react-field-bfbfb504-ead0-45f6-82c2-61c24e5188ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-field",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-6d7d25b5-91c0-46b1-bcc2-f9d9134cd768.json
+++ b/change/@fluentui-react-image-6d7d25b5-91c0-46b1-bcc2-f9d9134cd768.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-image",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infobutton-e89a4f8a-4a48-403c-968a-e47d026646e6.json
+++ b/change/@fluentui-react-infobutton-e89a4f8a-4a48-403c-968a-e47d026646e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-6479cce1-6486-4619-9ebd-6fb39a20d5ec.json
+++ b/change/@fluentui-react-input-6479cce1-6486-4619-9ebd-6fb39a20d5ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-input",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-jsx-runtime-5ff447d9-48c7-4454-935a-f1c52e209653.json
+++ b/change/@fluentui-react-jsx-runtime-5ff447d9-48c7-4454-935a-f1c52e209653.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-2d681468-1733-488f-9267-f64fe98a8f9e.json
+++ b/change/@fluentui-react-label-2d681468-1733-488f-9267-f64fe98a8f9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-label",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-aedb70a6-401b-4c62-a1bc-d05a00239138.json
+++ b/change/@fluentui-react-link-aedb70a6-401b-4c62-a1bc-d05a00239138.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-link",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-579e2598-0b16-4339-be66-5eba1a9f6dbc.json
+++ b/change/@fluentui-react-menu-579e2598-0b16-4339-be66-5eba1a9f6dbc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-00adc06d-a60c-4161-b7ae-151623ae1923.json
+++ b/change/@fluentui-react-migration-v0-v9-00adc06d-a60c-4161-b7ae-151623ae1923.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-d5c5f72e-eb02-4718-8d0c-a37c1da85c7b.json
+++ b/change/@fluentui-react-migration-v8-v9-d5c5f72e-eb02-4718-8d0c-a37c1da85c7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-preview-61de2d1c-b6ec-4328-8d19-db72767a01bf.json
+++ b/change/@fluentui-react-motion-preview-61de2d1c-b6ec-4328-8d19-db72767a01bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-motion-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-bdecb14a-138d-46c9-a944-05c3e4b91669.json
+++ b/change/@fluentui-react-overflow-bdecb14a-138d-46c9-a944-05c3e4b91669.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-overflow",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-a5df3c9a-67b2-4cb6-8da8-b065a43c38c8.json
+++ b/change/@fluentui-react-persona-a5df3c9a-67b2-4cb6-8da8-b065a43c38c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-persona",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-7cd48da1-1ef6-4b5e-b6fe-c9c8bee5cce8.json
+++ b/change/@fluentui-react-popover-7cd48da1-1ef6-4b5e-b6fe-c9c8bee5cce8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-6757fe15-e146-436e-b8db-8c65148ec917.json
+++ b/change/@fluentui-react-portal-6757fe15-e146-436e-b8db-8c65148ec917.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-portal",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-535a3e46-44c1-4b26-88ff-2bf15939e4f0.json
+++ b/change/@fluentui-react-portal-compat-535a3e46-44c1-4b26-88ff-2bf15939e4f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-context-bb5f1d8a-d2fc-4772-b350-e4fc9fcd4985.json
+++ b/change/@fluentui-react-portal-compat-context-bb5f1d8a-d2fc-4772-b350-e4fc9fcd4985.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-df1e3360-a76d-484d-b02a-6fb8c4587f2d.json
+++ b/change/@fluentui-react-positioning-df1e3360-a76d-484d-b02a-6fb8c4587f2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-positioning",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-d5dffcbe-5155-493d-81ad-05aafe642f46.json
+++ b/change/@fluentui-react-progress-d5dffcbe-5155-493d-81ad-05aafe642f46.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-progress",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-b237f142-63a1-4ea4-b39d-11d1d4aa0599.json
+++ b/change/@fluentui-react-provider-b237f142-63a1-4ea4-b39d-11d1d4aa0599.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-provider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-be2d9c9c-49e0-49eb-be48-e79cede5e7d6.json
+++ b/change/@fluentui-react-radio-be2d9c9c-49e0-49eb-be48-e79cede5e7d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-radio",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-preview-6ccf1a73-af4e-46ee-ab73-0a696cbc10af.json
+++ b/change/@fluentui-react-search-preview-6ccf1a73-af4e-46ee-ab73-0a696cbc10af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-search-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-30898110-fd4c-4adf-a9b1-e07e52fb19e3.json
+++ b/change/@fluentui-react-select-30898110-fd4c-4adf-a9b1-e07e52fb19e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-select",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-5e3fc3b9-5674-4732-abb1-654ecbd2f2ff.json
+++ b/change/@fluentui-react-shared-contexts-5e3fc3b9-5674-4732-abb1-654ecbd2f2ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-1cdd9113-3d2b-463d-8990-fa6598156c48.json
+++ b/change/@fluentui-react-skeleton-1cdd9113-3d2b-463d-8990-fa6598156c48.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-cd8ed31d-423d-4873-9af1-dc11543c4089.json
+++ b/change/@fluentui-react-slider-cd8ed31d-423d-4873-9af1-dc11543c4089.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-slider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-8c16ff97-4b13-4dcc-9000-bc371fa64a22.json
+++ b/change/@fluentui-react-spinbutton-8c16ff97-4b13-4dcc-9000-bc371fa64a22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-9a9d576d-3773-4569-82f5-466a28ffb48a.json
+++ b/change/@fluentui-react-spinner-9a9d576d-3773-4569-82f5-466a28ffb48a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-spinner",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-41048e4c-3fe3-4794-8ef2-25038db598ce.json
+++ b/change/@fluentui-react-switch-41048e4c-3fe3-4794-8ef2-25038db598ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-switch",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-52037b35-5e1f-40c2-8a4e-28a664915b11.json
+++ b/change/@fluentui-react-table-52037b35-5e1f-40c2-8a4e-28a664915b11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-table",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-be468c43-a845-49bc-ab57-b831007f778a.json
+++ b/change/@fluentui-react-tabs-be468c43-a845-49bc-ab57-b831007f778a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-tabs",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-480bcec1-5112-4a94-bf1a-c53bd8aced8a.json
+++ b/change/@fluentui-react-tabster-480bcec1-5112-4a94-bf1a-c53bd8aced8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-b68cbc5a-41df-420a-a427-ab4fe8d95766.json
+++ b/change/@fluentui-react-tags-b68cbc5a-41df-420a-a427-ab4fe8d95766.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-tags",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-f09c4422-1b7a-4381-a6f4-4e679ea5de69.json
+++ b/change/@fluentui-react-text-f09c4422-1b7a-4381-a6f4-4e679ea5de69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-text",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-699f4dac-b8da-4525-aa31-e993d7f86333.json
+++ b/change/@fluentui-react-textarea-699f4dac-b8da-4525-aa31-e993d7f86333.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-textarea",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-db6dfdb5-1baa-46dd-af85-ea0632f72ce7.json
+++ b/change/@fluentui-react-toast-db6dfdb5-1baa-46dd-af85-ea0632f72ce7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-toast",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-fc4d81f2-acf7-46f9-94e9-ff11058df6b1.json
+++ b/change/@fluentui-react-toolbar-fc4d81f2-acf7-46f9-94e9-ff11058df6b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-3cb49513-b594-441d-a935-bfef20ef4aa9.json
+++ b/change/@fluentui-react-tooltip-3cb49513-b594-441d-a935-bfef20ef4aa9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-ab4e7354-700d-4ba3-b561-ffd21c934806.json
+++ b/change/@fluentui-react-tree-ab4e7354-700d-4ba3-b561-ffd21c934806.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-8be85532-df55-497a-be8b-661a4f181554.json
+++ b/change/@fluentui-react-utilities-8be85532-df55-497a-be8b-661a4f181554.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-1663578e-14c3-4693-a5eb-308dc0831e0f.json
+++ b/change/@fluentui-react-virtualizer-1663578e-14c3-4693-a5eb-308dc0831e0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: bump @types/react version to latest supported version v17.0.55",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@types/prettier": "2.7.2",
     "@types/progress": "2.0.5",
     "@types/prompts": "2.4.1",
-    "@types/react": "17.0.44",
+    "@types/react": "17.0.53",
     "@types/react-dom": "17.0.15",
     "@types/react-is": "17.0.3",
     "@types/react-test-renderer": "17.0.2",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -38,6 +38,7 @@
     "@types/classnames": "^2.2.9",
     "@types/faker": "^4.1.3",
     "@types/simulant": "^0.2.0",
+    "@types/react": "17.0.53",
     "csstype": "^3.0.2",
     "faker": "^4.1.0",
     "fela-tools": "^10.6.1",

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -37,7 +37,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-accordion/package.json
+++ b/packages/react-components/react-accordion/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-alert/package.json
+++ b/packages/react-components/react-alert/package.json
@@ -44,7 +44,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-aria/package.json
+++ b/packages/react-components/react-aria/package.json
@@ -36,7 +36,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-avatar/package.json
+++ b/packages/react-components/react-avatar/package.json
@@ -51,7 +51,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-badge/package.json
+++ b/packages/react-components/react-badge/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-breadcrumb/package.json
+++ b/packages/react-components/react-breadcrumb/package.json
@@ -48,7 +48,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -46,7 +46,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-card/package.json
+++ b/packages/react-components/react-card/package.json
@@ -47,7 +47,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-checkbox/package.json
+++ b/packages/react-components/react-checkbox/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-colorpicker-compat/package.json
+++ b/packages/react-components/react-colorpicker-compat/package.json
@@ -38,7 +38,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -47,7 +47,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -85,7 +85,7 @@
     "@fluentui/react-breadcrumb": "^9.0.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -26,7 +26,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "typescript": "^4.3.0",
     "@fluentui/react-conformance": "^0.18.3"

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -32,7 +32,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-datepicker-compat/package.json
+++ b/packages/react-components/react-datepicker-compat/package.json
@@ -52,7 +52,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-dialog/package.json
+++ b/packages/react-components/react-dialog/package.json
@@ -51,7 +51,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-divider/package.json
+++ b/packages/react-components/react-divider/package.json
@@ -41,7 +41,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-drawer/package.json
+++ b/packages/react-components/react-drawer/package.json
@@ -46,7 +46,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-field/package.json
+++ b/packages/react-components/react-field/package.json
@@ -43,7 +43,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-image/package.json
+++ b/packages/react-components/react-image/package.json
@@ -41,7 +41,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-infobutton/package.json
+++ b/packages/react-components/react-infobutton/package.json
@@ -46,7 +46,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-input/package.json
+++ b/packages/react-components/react-input/package.json
@@ -43,7 +43,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -36,7 +36,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "react": ">=16.14.0 <19.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-label/package.json
+++ b/packages/react-components/react-label/package.json
@@ -41,7 +41,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-link/package.json
+++ b/packages/react-components/react-link/package.json
@@ -44,7 +44,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-menu/package.json
+++ b/packages/react-components/react-menu/package.json
@@ -51,7 +51,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-migration-v0-v9/package.json
+++ b/packages/react-components/react-migration-v0-v9/package.json
@@ -43,7 +43,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-migration-v8-v9/package.json
+++ b/packages/react-components/react-migration-v8-v9/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-motion-preview/package.json
+++ b/packages/react-components/react-motion-preview/package.json
@@ -38,7 +38,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-nav-preview/package.json
+++ b/packages/react-components/react-nav-preview/package.json
@@ -38,7 +38,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-overflow/package.json
+++ b/packages/react-components/react-overflow/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-persona/package.json
+++ b/packages/react-components/react-persona/package.json
@@ -43,7 +43,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-popover/package.json
+++ b/packages/react-components/react-popover/package.json
@@ -50,7 +50,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -31,7 +31,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "react": ">=16.14.0 <19.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@fluentui/react-components": "^9.40.0",
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "react": ">=16.14.0 <19.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-portal/package.json
+++ b/packages/react-components/react-portal/package.json
@@ -40,7 +40,7 @@
     "use-disposable": "^1.0.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -37,7 +37,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-progress/package.json
+++ b/packages/react-components/react-progress/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-provider/package.json
+++ b/packages/react-components/react-provider/package.json
@@ -44,7 +44,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-radio/package.json
+++ b/packages/react-components/react-radio/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-search-preview/package.json
+++ b/packages/react-components/react-search-preview/package.json
@@ -41,7 +41,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-select/package.json
+++ b/packages/react-components/react-select/package.json
@@ -43,7 +43,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-shared-contexts/package.json
+++ b/packages/react-components/react-shared-contexts/package.json
@@ -32,7 +32,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "react": ">=16.14.0 <19.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-skeleton/package.json
+++ b/packages/react-components/react-skeleton/package.json
@@ -41,7 +41,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-slider/package.json
+++ b/packages/react-components/react-slider/package.json
@@ -44,7 +44,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-spinbutton/package.json
+++ b/packages/react-components/react-spinbutton/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-spinner/package.json
+++ b/packages/react-components/react-spinner/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -35,7 +35,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-switch/package.json
+++ b/packages/react-components/react-switch/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-table/package.json
+++ b/packages/react-components/react-table/package.json
@@ -51,7 +51,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-tabs/package.json
+++ b/packages/react-components/react-tabs/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -40,7 +40,7 @@
     "tabster": "^5.0.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-tags/package.json
+++ b/packages/react-components/react-tags/package.json
@@ -49,7 +49,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-text/package.json
+++ b/packages/react-components/react-text/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-textarea/package.json
+++ b/packages/react-components/react-textarea/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-toast/package.json
+++ b/packages/react-components/react-toast/package.json
@@ -49,7 +49,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-toolbar/package.json
+++ b/packages/react-components/react-toolbar/package.json
@@ -48,7 +48,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-tooltip/package.json
+++ b/packages/react-components/react-tooltip/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-tree/package.json
+++ b/packages/react-components/react-tree/package.json
@@ -53,7 +53,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -35,7 +35,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "react": ">=16.14.0 <19.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-virtualizer/package.json
+++ b/packages/react-components/react-virtualizer/package.json
@@ -39,7 +39,7 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -45,7 +45,7 @@
     "codesandbox-import-utils": "2.2.3"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <=17.0.55",
     "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,10 +5607,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.44", "@types/react@>=16.9.0", "@types/react@^17":
-  version "17.0.44"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
-  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17", "@types/react@17.0.53":
+  version "17.0.53"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.53.tgz#10d4d5999b8af3d6bc6a9369d7eb953da82442ab"
+  integrity sha512-1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

At the moment every v9 component has it's `@types/react` dependency version pinned to `>=16.14.0 <19.0.0`, unfortunately our API breaks due to name clashing issues from v17.0.56 and forward due to this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64972 that introduces `RDFa` types to `HTMLAttributes` interface.

## New Behavior

We should be pinning  `@types/react` dependency version pinned to `>=16.14.0 <= 17.0.55` as it's the last version we actually support without introducing possible name clashes.

1.  v9 packages  `@types/react` dependency version pinned to `>=16.14.0 <= 17.0.55`
2. `@fluentui/react-northstar` dependency `@types/react` version pinned to `17.0.53` as it would break with anything higher
3. root repo dependency `@types/react` version pinned to `17.0.53`,

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29596
