### PR TITLE
bugfix(react-utilities): omit IntrinsicElement props from ComponentProps that would collide with slot names

### DIFF
--- a/change/@fluentui-react-menu-8c0631de-665f-4cf1-bd1e-32dc87f18cd5.json
+++ b/change/@fluentui-react-menu-8c0631de-665f-4cf1-bd1e-32dc87f18cd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Omit colliding content property from ComponentProps",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-dde10f45-6b17-4c43-9117-9430691bd383.json
+++ b/change/@fluentui-react-table-dde10f45-6b17-4c43-9117-9430691bd383.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Omit colliding content property from ComponentProps",
+  "packageName": "@fluentui/react-table",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-8f2916e4-2744-4e3b-bc11-e326d59ebb73.json
+++ b/change/@fluentui-react-tabs-8f2916e4-2744-4e3b-bc11-e326d59ebb73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Omit colliding content property from ComponentProps",
+  "packageName": "@fluentui/react-tabs",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-8a3c1b4d-7de8-4721-8217-4b7114f3c592.json
+++ b/change/@fluentui-react-toast-8a3c1b4d-7de8-4721-8217-4b7114f3c592.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Omit colliding content property from ComponentProps",
+  "packageName": "@fluentui/react-toast",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/etc/react-menu.api.md
@@ -157,7 +157,7 @@ export type MenuItemLinkSlots = {
 export type MenuItemLinkState = ComponentState<MenuItemLinkSlots>;
 
 // @public (undocumented)
-export type MenuItemProps = ComponentProps<Partial<MenuItemSlots>> & {
+export type MenuItemProps = Omit<ComponentProps<Partial<MenuItemSlots>>, 'content'> & Pick<Partial<MenuItemSlots>, 'content'> & {
     hasSubmenu?: boolean;
     persistOnClick?: boolean;
     disabled?: boolean;

--- a/packages/react-components/react-menu/src/components/MenuItem/MenuItem.types.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/MenuItem.types.ts
@@ -31,28 +31,29 @@ export type MenuItemSlots = {
   secondaryContent?: Slot<'span'>;
 };
 
-export type MenuItemProps = ComponentProps<Partial<MenuItemSlots>> & {
-  /**
-   * If the menu item is a trigger for a submenu
-   *
-   * @default false
-   */
-  hasSubmenu?: boolean;
+export type MenuItemProps = Omit<ComponentProps<Partial<MenuItemSlots>>, 'content'> &
+  Pick<Partial<MenuItemSlots>, 'content'> & {
+    /**
+     * If the menu item is a trigger for a submenu
+     *
+     * @default false
+     */
+    hasSubmenu?: boolean;
 
-  /**
-   * Clicking on the menu item will not dismiss an open menu
-   *
-   * @default false
-   */
-  persistOnClick?: boolean;
+    /**
+     * Clicking on the menu item will not dismiss an open menu
+     *
+     * @default false
+     */
+    persistOnClick?: boolean;
 
-  disabled?: boolean;
-  /**
-   * @deprecated this property does nothing.
-   * disabled focusable is by default by simply using `disabled` property
-   */
-  disabledFocusable?: boolean;
-};
+    disabled?: boolean;
+    /**
+     * @deprecated this property does nothing.
+     * disabled focusable is by default by simply using `disabled` property
+     */
+    disabledFocusable?: boolean;
+  };
 
 export type MenuItemState = ComponentState<MenuItemSlots> &
   Required<Pick<MenuItemProps, 'disabled' | 'hasSubmenu' | 'persistOnClick'>>;

--- a/packages/react-components/react-table/etc/react-table.api.md
+++ b/packages/react-components/react-table/etc/react-table.api.md
@@ -320,7 +320,7 @@ export const TableCellLayout: ForwardRefComponent<TableCellLayoutProps>;
 export const tableCellLayoutClassNames: SlotClassNames<TableCellLayoutSlots>;
 
 // @public
-export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>> & {
+export type TableCellLayoutProps = Omit<ComponentProps<Partial<TableCellLayoutSlots>>, 'content'> & Pick<Partial<TableCellLayoutSlots>, 'content'> & {
     appearance?: 'primary';
     truncate?: boolean;
 };

--- a/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
+++ b/packages/react-components/react-table/src/components/TableCellLayout/TableCellLayout.types.ts
@@ -35,18 +35,19 @@ export type TableCellLayoutSlots = {
 /**
  * TableCellLayout Props
  */
-export type TableCellLayoutProps = ComponentProps<Partial<TableCellLayoutSlots>> & {
-  /**
-   * Renders design variants of the table cell
-   * @default undefined
-   */
-  appearance?: 'primary';
+export type TableCellLayoutProps = Omit<ComponentProps<Partial<TableCellLayoutSlots>>, 'content'> &
+  Pick<Partial<TableCellLayoutSlots>, 'content'> & {
+    /**
+     * Renders design variants of the table cell
+     * @default undefined
+     */
+    appearance?: 'primary';
 
-  /**
-   * Renders content with overflow: hidden and text-overflow: ellipsis
-   */
-  truncate?: boolean;
-};
+    /**
+     * Renders content with overflow: hidden and text-overflow: ellipsis
+     */
+    truncate?: boolean;
+  };
 
 /**
  * State used in rendering TableCellLayout

--- a/packages/react-components/react-tabs/etc/react-tabs.api.md
+++ b/packages/react-components/react-tabs/etc/react-tabs.api.md
@@ -89,7 +89,7 @@ export type TabListSlots = {
 export type TabListState = ComponentState<Required<TabListSlots>> & TabListContextValue;
 
 // @public
-export type TabProps = ComponentProps<Partial<TabSlots>> & {
+export type TabProps = Omit<ComponentProps<Partial<TabSlots>>, 'content'> & Pick<Partial<TabSlots>, 'content'> & {
     disabled?: boolean;
     value: TabValue;
 };

--- a/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/Tab.types.ts
@@ -30,17 +30,18 @@ export type TabInternalSlots = TabSlots & {
 /**
  * Tab Props
  */
-export type TabProps = ComponentProps<Partial<TabSlots>> & {
-  /**
-   * A tab can be set to disable interaction.
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * The value that identifies this tab when selected.
-   */
-  value: TabValue;
-};
+export type TabProps = Omit<ComponentProps<Partial<TabSlots>>, 'content'> &
+  Pick<Partial<TabSlots>, 'content'> & {
+    /**
+     * A tab can be set to disable interaction.
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * The value that identifies this tab when selected.
+     */
+    value: TabValue;
+  };
 
 /**
  * State used in rendering Tab

--- a/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
@@ -17,7 +17,7 @@ export type ToastContainerSlots = {
 /**
  * ToastContainer Props
  */
-export type ToastContainerProps = ComponentProps<Partial<ToastContainerSlots>> &
+export type ToastContainerProps = Omit<ComponentProps<Partial<ToastContainerSlots>>, 'content'> &
   Toast & {
     visible: boolean;
     announce: Announce;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

As https://github.com/microsoft/fluentui/issues/29596 describes, some properties that were declared by `@types/react` were clashing with slot names, most common case would be the one involving the `content` slot.

## New Behavior

1. omits properties declared by `@types/react` in favor of the slot names provided


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29596
