### PR TITLE
fix: react-drawer dropped mountNode prop in types

### DIFF
--- a/change/@fluentui-react-drawer-485bb1fe-e874-4cb7-934c-6a0a7dfe36a3.json
+++ b/change/@fluentui-react-drawer-485bb1fe-e874-4cb7-934c-6a0a7dfe36a3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: OverlayDrawer accepts mountNode in types\"",
+  "comment": "fix: OverlayDrawer accepts mountNode in types",
   "packageName": "@fluentui/react-drawer",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-drawer-485bb1fe-e874-4cb7-934c-6a0a7dfe36a3.json
+++ b/change/@fluentui-react-drawer-485bb1fe-e874-4cb7-934c-6a0a7dfe36a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: OverlayDrawer accepts mountNode in types\"",
+  "packageName": "@fluentui/react-drawer",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -9,6 +9,7 @@
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { DialogProps } from '@fluentui/react-dialog';
+import type { DialogSurfaceProps } from '@fluentui/react-dialog';
 import type { DialogSurfaceSlots } from '@fluentui/react-dialog';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import * as React_2 from 'react';

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.test.tsx
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.test.tsx
@@ -40,4 +40,16 @@ describe('OverlayDrawer', () => {
     const result = render(<OverlayDrawer>Default OverlayDrawer</OverlayDrawer>);
     expect(result.container).toMatchInlineSnapshot(`<div />`);
   });
+
+  it('respects the mountNode prop', () => {
+    const mountNode = document.createElement('div');
+    render(
+      <OverlayDrawer id="drawer" mountNode={mountNode} open={true}>
+        Default OverlayDrawer
+      </OverlayDrawer>,
+    );
+
+    const result = mountNode.querySelector('#drawer');
+    expect(result).toBeTruthy();
+  });
 });

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawerSurface/OverlayDrawerSurface.types.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawerSurface/OverlayDrawerSurface.types.ts
@@ -1,5 +1,5 @@
-import type { DialogSurfaceSlots, DialogSurfaceState } from '@fluentui/react-dialog';
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { DialogSurfaceProps, DialogSurfaceSlots, DialogSurfaceState } from '@fluentui/react-dialog';
+import type { ComponentState } from '@fluentui/react-utilities';
 
 /**
  * OverlayDrawerSurface slots
@@ -9,7 +9,7 @@ export type OverlayDrawerSurfaceSlots = DialogSurfaceSlots;
 /**
  * OverlayDrawerSurface Props
  */
-export type OverlayDrawerSurfaceProps = ComponentProps<OverlayDrawerSurfaceSlots>;
+export type OverlayDrawerSurfaceProps = DialogSurfaceProps;
 
 /**
  * State used in rendering OverlayDrawerSurface


### PR DESCRIPTION
## Previous Behavior

this fixes an api regression, and re-adds `moutNode` to `OverlayDrawer` (note: this is a type fix, the functionality was already there)

## New Behavior

re-adds `mountNode` via `DialogSurfaceProps`, and adds a test to prevent future regressions

## Related Issue(s)

- Fixes #29819
