### PR TITLE
fix: Properly cleaning up document onMouseUp event so that it is not removed before it needs to

### DIFF
--- a/change/@fluentui-react-combobox-e3339a17-7c43-4729-98c1-469127f424ab.json
+++ b/change/@fluentui-react-combobox-e3339a17-7c43-4729-98c1-469127f424ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Properly cleaning up document onMouseUp event so that it is not removed before it needs to.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
@@ -99,8 +99,8 @@ export function useTriggerListboxSlots(
   const documentOnMouseUp = useEventCallback((ev: MouseEvent) => {
     if (!listboxRef.current?.contains(ev.target as HTMLElement)) {
       setOpen(ev as unknown as React.MouseEvent<HTMLElement>, false);
+      targetDocument?.removeEventListener('mouseup', documentOnMouseUp);
     }
-    targetDocument?.removeEventListener('mouseup', documentOnMouseUp);
   });
 
   const listboxOnMouseDown = useEventCallback(


### PR DESCRIPTION
## Previous Behavior

There could be cases where clicking on the `scrollbar` within a `Combobox` `listbox`, could cause an `onMouseUp` event listener attached to the `document` to be removed before it needed to. This in turn meant that the `popover` could not be closed.

![Before](https://github.com/microsoft/fluentui/assets/7798177/0bd20ea6-657d-4577-aeb1-c1901a4e52e0)

## New Behavior

This PR fixes this issue by preventing this hasty removal of the event listener, which allows the `popover` to be able to be closed correctly. We do not need to check for multiple instances of the listener since the [`addEventListener` API](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget-addEventListener) specifies that:

> If multiple identical EventListeners are registered on the same EventTarget with the same parameters the duplicate instances are discarded. They do not cause the EventListener to be called twice and since they are discarded they do not need to be removed with the removeEventListener method.

![After](https://github.com/microsoft/fluentui/assets/7798177/93ed0e9b-c55a-4851-97e8-11fb66094b11)

## Related Issue(s)

- Fixes #29701.