### PR TITLE
fix: Listbox closes on blur after scrollbar click

### DIFF
--- a/change/@fluentui-react-combobox-1097190e-19df-46b4-a56c-1a9ca1181ca6.json
+++ b/change/@fluentui-react-combobox-1097190e-19df-46b4-a56c-1a9ca1181ca6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: listbox closes on blur after scroll click\"",
+  "comment": "fix: listbox closes on blur after scroll click",
   "packageName": "@fluentui/react-combobox",
   "email": "sarah.higley@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-combobox-1097190e-19df-46b4-a56c-1a9ca1181ca6.json
+++ b/change/@fluentui-react-combobox-1097190e-19df-46b4-a56c-1a9ca1181ca6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: listbox closes on blur after scroll click\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerListboxSlots.ts
@@ -110,11 +110,20 @@ export function useTriggerListboxSlots(
     }, listbox?.onMouseDown),
   );
 
+  const listboxOnMouseUp = useEventCallback(
+    mergeCallbacks((event: React.MouseEvent<HTMLDivElement>) => {
+      // some listbox clicks don't blur the input (e.g. clicking a scrollbar)
+      // this ensures future blurs that occur after the click aren't ignored
+      ignoreNextBlur.current = false;
+    }, listbox?.onMouseUp),
+  );
+
   // listbox is nullable, only add event handlers if it exists
   if (listbox) {
     listbox.onClick = listboxOnClick;
     listbox.onMouseOver = listboxOnMouseOver;
     listbox.onMouseDown = listboxOnMouseDown;
+    listbox.onMouseUp = listboxOnMouseUp;
   }
 
   // the trigger should open/close the popup on click or blur


### PR DESCRIPTION

## Previous Behavior

Combobox/Dropdown would ignore the next blur when the listbox is clicked to prevent it immediately closing while trying to click an option. However, clicking a scrollbar does not blur the input/button, so it would ignore the next blur and prevent it from closing when genuinely clicking outside the listbox.

## New Behavior

IgnoreBlur is set to false on mouseUp, which guarantees it'll only ignore a blur that occurs between a single mousedown/mouseup.

## Related Issue(s)

- Fixes #29701
