### PR TITLE
feature(react-text): adds semantic elements (strong, b, em, i) to Text root signature

### DIFF
--- a/change/@fluentui-react-text-77e036bf-9a93-4a5f-989f-554ee88420a1.json
+++ b/change/@fluentui-react-text-77e036bf-9a93-4a5f-989f-554ee88420a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: adds semantic elements (strong, b, em, i) to Text root signature",
+  "packageName": "@fluentui/react-text",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-text/etc/react-text.api.md
+++ b/packages/react-components/react-text/etc/react-text.api.md
@@ -125,7 +125,7 @@ export type TextProps = ComponentProps<TextSlots> & {
 
 // @public
 export type TextSlots = {
-    root: Slot<'span', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre'>;
+    root: Slot<'span', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre' | 'strong' | 'b' | 'em' | 'i'>;
 };
 
 // @public

--- a/packages/react-components/react-text/src/components/Text/Text.types.ts
+++ b/packages/react-components/react-text/src/components/Text/Text.types.ts
@@ -4,7 +4,7 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
  * Text slots
  */
 export type TextSlots = {
-  root: Slot<'span', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre'>;
+  root: Slot<'span', 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre' | 'strong' | 'b' | 'em' | 'i'>;
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`Text` component only supports `'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'pre'`

## New Behavior

1. adds support to `'strong' | 'b' | 'em' | 'i'` to `Text` component

> Note: this is not a breaking change! As the additional elements being added do not modify the current signature, as all those elements signatures (`React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>`) are already included on the current supported one

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29749
