### PR TITLE
fix(27817): VoiceOver announcing dropdown for Timepicker as button

### DIFF
--- a/packages/react-examples/src/react/TimePicker/TimePicker.DateTimePicker.Example.tsx
+++ b/packages/react-examples/src/react/TimePicker/TimePicker.DateTimePicker.Example.tsx
@@ -47,12 +47,18 @@ export const TimePickerDateTimePickerExample: React.FC = () => {
     <Stack tokens={stackTokens} styles={stackStyles}>
       <Label>{'DatePicker and TimePicker combination'}</Label>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gridColumnGap: '3px' }}>
-        <DatePicker placeholder="Select a date..." value={datePickerDate} onSelectDate={onSelectDate} />
+        <DatePicker
+          placeholder="Select a date..."
+          value={datePickerDate}
+          onSelectDate={onSelectDate}
+          ariaLabel="Date picker"
+        />
         <TimePicker
           placeholder="Select a time"
           dateAnchor={datePickerDate}
           value={currentTime}
           onChange={onTimePickerChange}
+          ariaLabel="Time picker"
         />
       </div>
       <Text>{`⚓ Date anchor: ${datePickerDate.toString()}`}</Text>


### PR DESCRIPTION
### Description

Though a label text is visible on screen we cannot use `aria-labelledby` and point to it to resolve the `accessibility` issue. Hence, added `aria-label` for `DatePicker` and `TimePicker` components separately.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

As mentioned in the issue #27817 - when focus moves to button on TimePicker in "TimePicker with DatePicker", the button is announced as "button" with no context of labels or description.

## New Behavior

As also mentioned in the issue #27817 - when focus moves to button on TimePicker in "TimePicker with DatePicker", the button should be announced with context or a description of what the button is/does.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes: #27817 
