### PR TITLE
Add narratable status for button actions in dynamic chart examples

### DIFF
--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
@@ -88,6 +88,7 @@ export class DonutChartDynamicExample extends React.Component<IDonutChartProps, 
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
         <div aria-live="polite" aria-atomic="true">
+          {/* Change the key so that React treats it as an update even if the message is same */}
           <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
             {this.state.statusMessage}
           </p>

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
@@ -19,6 +19,7 @@ export interface IExampleState {
   statusMessage: string;
 }
 
+/** This style is commonly used to visually hide text that is still available for the screen reader to announce. */
 const screenReaderOnlyStyle: React.CSSProperties = {
   position: 'absolute',
   width: '1px',

--- a/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/DonutChart/DonutChart.Dynamic.Example.tsx
@@ -15,7 +15,20 @@ export interface IExampleState {
   hideLabels: boolean;
   showLabelsInPercent: boolean;
   innerRadius: number;
+  statusKey: number;
+  statusMessage: string;
 }
+
+const screenReaderOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  border: 0,
+};
 
 export class DonutChartDynamicExample extends React.Component<IDonutChartProps, IExampleState> {
   private _colors = [
@@ -37,6 +50,8 @@ export class DonutChartDynamicExample extends React.Component<IDonutChartProps, 
       hideLabels: false,
       showLabelsInPercent: false,
       innerRadius: 35,
+      statusKey: 0,
+      statusMessage: '',
     };
 
     this._changeData = this._changeData.bind(this);
@@ -72,30 +87,39 @@ export class DonutChartDynamicExample extends React.Component<IDonutChartProps, 
         />
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
+        <div aria-live="polite" aria-atomic="true">
+          <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
+            {this.state.statusMessage}
+          </p>
+        </div>
       </div>
     );
   }
 
   private _changeData(): void {
-    this.setState({
+    this.setState(prevState => ({
       dynamicData: [
         { legend: 'first', data: this._randomY(), color: getColorFromToken(DataVizPalette.color1) },
         { legend: 'second', data: this._randomY(), color: getColorFromToken(DataVizPalette.color2) },
         { legend: 'third', data: this._randomY(), color: getColorFromToken(DataVizPalette.color3) },
         { legend: 'fourth', data: this._randomY(), color: getColorFromToken(DataVizPalette.color4) },
       ],
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Donut chart data changed',
+    }));
   }
 
   private _changeColors(): void {
-    this.setState({
+    this.setState(prevState => ({
       dynamicData: [
         { legend: 'first', data: 40, color: this._randomColor(0) },
         { legend: 'second', data: 20, color: this._randomColor(1) },
         { legend: 'third', data: 30, color: this._randomColor(2) },
         { legend: 'fourth', data: 10, color: this._randomColor(3) },
       ],
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Donut chart colors changed',
+    }));
   }
 
   private _randomY(max = 300): number {

--- a/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
@@ -8,7 +8,20 @@ export interface IExampleState {
   colors: string[];
   width: number;
   height: number;
+  statusKey: number;
+  statusMessage: string;
 }
+
+const screenReaderOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  border: 0,
+};
 
 export class PieChartDynamicExample extends React.Component<IPieChartProps, IExampleState> {
   private _colors = [
@@ -30,6 +43,8 @@ export class PieChartDynamicExample extends React.Component<IPieChartProps, IExa
       colors: this._colors[0],
       width: 600,
       height: 350,
+      statusKey: 0,
+      statusMessage: '',
     };
 
     this._changeData = this._changeData.bind(this);
@@ -74,6 +89,11 @@ export class PieChartDynamicExample extends React.Component<IPieChartProps, IExa
         />
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
+        <div aria-live="polite" aria-atomic="true">
+          <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
+            {this.state.statusMessage}
+          </p>
+        </div>
       </div>
     );
   }
@@ -84,20 +104,24 @@ export class PieChartDynamicExample extends React.Component<IPieChartProps, IExa
     const c = this._randomY(100 - a - b - 10);
     const d = 100 - a - b - c;
 
-    this.setState({
+    this.setState(prevState => ({
       dynamicData: [
         { x: 'A', y: a },
         { x: 'B', y: b },
         { x: 'C', y: c },
         { x: 'D', y: d },
       ],
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Pie chart data changed',
+    }));
   }
 
   private _changeColors(): void {
-    this.setState({
+    this.setState(prevState => ({
       colors: [this._randomColor(0), this._randomColor(1), this._randomColor(2), this._randomColor(3)],
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Pie chart colors changed',
+    }));
   }
 
   private _randomY(max: number): number {

--- a/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
@@ -12,6 +12,7 @@ export interface IExampleState {
   statusMessage: string;
 }
 
+/** This style is commonly used to visually hide text that is still available for the screen reader to announce. */
 const screenReaderOnlyStyle: React.CSSProperties = {
   position: 'absolute',
   width: '1px',

--- a/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/PieChart/PieChart.Dynamic.Example.tsx
@@ -90,6 +90,7 @@ export class PieChartDynamicExample extends React.Component<IPieChartProps, IExa
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
         <div aria-live="polite" aria-atomic="true">
+          {/* Change the key so that React treats it as an update even if the message is same */}
           <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
             {this.state.statusMessage}
           </p>

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
@@ -15,6 +15,7 @@ export interface IExampleState {
   statusMessage: string;
 }
 
+/** This style is commonly used to visually hide text that is still available for the screen reader to announce. */
 const screenReaderOnlyStyle: React.CSSProperties = {
   position: 'absolute',
   width: '1px',

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
@@ -11,7 +11,20 @@ import { DefaultButton } from '@fluentui/react/lib/Button';
 
 export interface IExampleState {
   dynamicData: IChartProps;
+  statusKey: number;
+  statusMessage: string;
 }
+
+const screenReaderOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  border: 0,
+};
 
 export class StackedBarChartDynamicExample extends React.Component<{}, IExampleState> {
   private _colors = [
@@ -62,6 +75,8 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
           { legend: 'fourth', data: 87, color: DefaultPalette.greenLight },
         ],
       },
+      statusKey: 0,
+      statusMessage: '',
     };
 
     this._changeData = this._changeData.bind(this);
@@ -86,12 +101,17 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
         />
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
+        <div aria-live="polite" aria-atomic="true">
+          <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
+            {this.state.statusMessage}
+          </p>
+        </div>
       </div>
     );
   }
 
   private _changeData(): void {
-    this.setState({
+    this.setState(prevState => ({
       dynamicData: {
         chartTitle: 'Stacked Bar chart',
         chartData: [
@@ -101,11 +121,13 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
           { legend: 'fourth', data: this._randomY() },
         ],
       },
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Stacked bar chart data changed',
+    }));
   }
 
   private _changeColors(): void {
-    this.setState({
+    this.setState(prevState => ({
       dynamicData: {
         chartTitle: 'Stacked Bar chart',
         chartData: [
@@ -115,7 +137,9 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
           { legend: 'fourth', data: 87, color: this._randomColor(3) },
         ],
       },
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Stacked bar chart colors changed',
+    }));
   }
 
   private _randomY(): number {

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
@@ -102,6 +102,7 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
         <div aria-live="polite" aria-atomic="true">
+          {/* Change the key so that React treats it as an update even if the message is same */}
           <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
             {this.state.statusMessage}
           </p>

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -10,6 +10,7 @@ export interface IExampleState {
   statusMessage: string;
 }
 
+/** This style is commonly used to visually hide text that is still available for the screen reader to announce. */
 const screenReaderOnlyStyle: React.CSSProperties = {
   position: 'absolute',
   width: '1px',

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -6,7 +6,20 @@ import { DefaultButton } from '@fluentui/react/lib/Button';
 export interface IExampleState {
   dynamicData: IDataPoint[];
   colors: string[];
+  statusKey: number;
+  statusMessage: string;
 }
+
+const screenReaderOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  border: 0,
+};
 
 export class VerticalBarChartDynamicExample extends React.Component<IVerticalBarChartProps, IExampleState> {
   private _colors = [
@@ -34,6 +47,8 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
         { x: 100, y: 19 },
       ],
       colors: this._colors[0],
+      statusKey: 0,
+      statusMessage: '',
     };
 
     this._changeData = this._changeData.bind(this);
@@ -58,12 +73,17 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
 
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
+        <div aria-live="polite" aria-atomic="true">
+          <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
+            {this.state.statusMessage}
+          </p>
+        </div>
       </div>
     );
   }
 
   private _changeData(): void {
-    this.setState({
+    this.setState(prevState => ({
       dynamicData: [
         { x: 0, y: this._randomY() },
         { x: 12, y: this._randomY() },
@@ -77,12 +97,18 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
         { x: 90, y: this._randomY() },
         { x: 100, y: this._randomY() },
       ],
-    });
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Vertical bar chart data changed',
+    }));
   }
 
   private _changeColors(): void {
     this._colorIndex = (this._colorIndex + 1) % this._colors.length;
-    this.setState({ colors: this._colors[this._colorIndex] });
+    this.setState(prevState => ({
+      colors: this._colors[this._colorIndex],
+      statusKey: prevState.statusKey + 1,
+      statusMessage: 'Vertical bar chart colors changed',
+    }));
   }
 
   private _randomY(): number {

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Dynamic.Example.tsx
@@ -74,6 +74,7 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
         <DefaultButton text="Change data" onClick={this._changeData} />
         <DefaultButton text="Change colors" onClick={this._changeColors} />
         <div aria-live="polite" aria-atomic="true">
+          {/* Change the key so that React treats it as an update even if the message is same */}
           <p key={this.state.statusKey} style={screenReaderOnlyStyle}>
             {this.state.statusMessage}
           </p>


### PR DESCRIPTION
Two solutions:
1. `alert` role: This role makes screen readers announce an element immediately after its addition to the DOM (using JavaScript). While this works in most browsers and screen readers, it must be used with extreme caution as it interrupts the screen reader's current output. It is used to communicate an important and usually time-sensitive message to the user. Alerts are assertive live regions. Setting `role="alert"` is equivalent to setting `aria-live="assertive"` and `aria-atomic="true"`. For reference: [ARIA: alert role - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role)

2. `aria-live` attribute (_implemented_): This attribute marks specific areas of the HTML as live regions, informing screen readers to announce dynamic content changes. The `polite` value indicates that these changes should be announced at the next convenient time without interrupting the current announcement. Setting `aria-atomic="true"` signals to screen readers that they should announce the entire content rather than announcing only the changes. For reference: [How to announce new content after 'Show more' button is clicked? - Stack Overflow](https://stackoverflow.com/questions/69737344/how-to-announce-new-content-after-show-more-button-is-clicked)

Note:
> But in contrast to `role="alert"`, these live regions are not supported in a homogenous way by browsers and screen readers, so in our experience, they are very tricky to implement.

For reference: [Noticing screen readers using alert role - ADG](https://www.accessibility-developer-guide.com/examples/sensible-aria-usage/alert/)

## Previous Behavior

Screen reader doesn't announce any information when the 'Change data' or 'Change colors' button is clicked.

## New Behavior

Screen reader announces the status when the 'Change data' or 'Change colors' button is clicked.