### PR TITLE
fix: Infinite reset loop in matchTargetSize middleware

### DIFF
--- a/change/@fluentui-react-positioning-c9eff939-b458-40c9-b61f-f2017ca21de2.json
+++ b/change/@fluentui-react-positioning-c9eff939-b458-40c9-b61f-f2017ca21de2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Infinite reset loop in matchTargetSize middleware",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/middleware/matchTargetSize.test.ts
+++ b/packages/react-components/react-positioning/src/middleware/matchTargetSize.test.ts
@@ -59,7 +59,7 @@ describe('matchTargetSize', () => {
     const floatingElement = document.createElement('div');
     const referenceWidth = 100;
     const middlewareArguments = {
-      middlewareData: { matchTargetSizeAttempt: true },
+      middlewareData: { matchTargetSize: { matchTargetSizeAttempt: true } },
       elements: {
         floating: floatingElement,
       },

--- a/packages/react-components/react-positioning/src/middleware/matchTargetSize.ts
+++ b/packages/react-components/react-positioning/src/middleware/matchTargetSize.ts
@@ -7,7 +7,7 @@ export function matchTargetSize(): Middleware {
       const {
         rects: { reference: referenceRect, floating: floatingRect },
         elements: { floating: floatingElement },
-        middlewareData: { matchTargetSizeAttempt = false },
+        middlewareData: { matchTargetSize: { matchTargetSizeAttempt = false } = {} },
       } = middlewareArguments;
 
       if (referenceRect.width === floatingRect.width || matchTargetSizeAttempt) {


### PR DESCRIPTION
Floating UI middleware data is only typed for its own middleware and there is also no way to type it with user specific middleare data.

This PR fixes an error with destructuring middleware data so that the flag to avoid infinite reset loop is destructured correctly. Also updates the test to use the correct middleware data.
