### PR TITLE
docs(react-menu): add subcomponents to props table

### DIFF
--- a/packages/react-components/react-menu/stories/Menu/index.stories.tsx
+++ b/packages/react-components/react-menu/stories/Menu/index.stories.tsx
@@ -1,4 +1,17 @@
-import { Menu } from '@fluentui/react-components';
+import {
+  Menu,
+  MenuDivider,
+  MenuGroup,
+  MenuGroupHeader,
+  MenuItem,
+  MenuItemCheckbox,
+  MenuItemLink,
+  MenuItemRadio,
+  MenuList,
+  MenuPopover,
+  MenuSplitGroup,
+  MenuTrigger,
+} from '@fluentui/react-components';
 
 import descriptionMd from './MenuDescription.md';
 import bestPracticesMd from './MenuBestPractices.md';
@@ -30,6 +43,19 @@ export { MenuTriggerWithTooltip } from './MenuTriggerWithTooltip.stories';
 export default {
   title: 'Components/Menu/Menu',
   component: Menu,
+  subcomponents: {
+    MenuDivider,
+    MenuGroup,
+    MenuGroupHeader,
+    MenuItem,
+    MenuItemCheckbox,
+    MenuItemLink,
+    MenuItemRadio,
+    MenuList,
+    MenuPopover,
+    MenuSplitGroup,
+    MenuTrigger,
+  },
   parameters: {
     docs: {
       description: {

--- a/packages/react-components/react-menu/stories/MenuList/index.stories.tsx
+++ b/packages/react-components/react-menu/stories/MenuList/index.stories.tsx
@@ -1,4 +1,14 @@
-import { MenuList } from '@fluentui/react-components';
+import {
+  MenuDivider,
+  MenuGroup,
+  MenuGroupHeader,
+  MenuItem,
+  MenuItemCheckbox,
+  MenuItemLink,
+  MenuItemRadio,
+  MenuList,
+  MenuSplitGroup,
+} from '@fluentui/react-components';
 import descriptionMd from './MenuListDescription.md';
 
 export { Default } from './MenuListDefault.stories';
@@ -11,6 +21,16 @@ export { ControlledRadioItems } from './MenuListControlledRadioItems.stories';
 export default {
   title: 'Components/Menu/MenuList',
   component: MenuList,
+  subcomponents: {
+    MenuDivider,
+    MenuGroup,
+    MenuGroupHeader,
+    MenuItem,
+    MenuItemCheckbox,
+    MenuItemLink,
+    MenuItemRadio,
+    MenuSplitGroup,
+  },
   parameters: {
     docs: {
       description: {


### PR DESCRIPTION
## New Behavior

Adds `Menu` subcomponents to props table:

<img width="1015" alt="image" src="https://github.com/microsoft/fluentui/assets/14183168/2e41db59-d7e1-4f67-9ab5-d869682df84f">

## Related Issue(s)

Fixes #29309
