### PR TITLE
chore(react-positioning): bumps @floating-ui/dom version to ^1.5.3

### DIFF
--- a/change/@fluentui-react-positioning-304049a8-2b2a-4fbf-8a94-2cef2af9ab0d.json
+++ b/change/@fluentui-react-positioning-304049a8-2b2a-4fbf-8a94-2cef2af9ab0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bumps @floating-ui/dom version to ^1.5.3",
+  "packageName": "@fluentui/react-positioning",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -29,7 +29,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.2.0",
+    "@floating-ui/dom": "^1.5.3",
     "@fluentui/react-shared-contexts": "^9.13.0",
     "@fluentui/react-theme": "^9.1.16",
     "@fluentui/react-utilities": "^9.15.2",

--- a/packages/react-components/react-positioning/src/middleware/matchTargetSize.test.ts
+++ b/packages/react-components/react-positioning/src/middleware/matchTargetSize.test.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareArguments } from '@floating-ui/dom';
+import type { MiddlewareState } from '@floating-ui/dom';
 import { matchTargetSize } from './matchTargetSize';
 
 describe('matchTargetSize', () => {
@@ -7,7 +7,7 @@ describe('matchTargetSize', () => {
     expect.assertions(3);
     const floatingElement = document.createElement('div');
     const referenceWidth = 100;
-    const middlewareArguments = {
+    const middlewareState = {
       middlewareData: {},
       elements: {
         floating: floatingElement,
@@ -17,9 +17,9 @@ describe('matchTargetSize', () => {
         reference: { width: referenceWidth },
         floating: { width: '1px' },
       },
-    } as unknown as MiddlewareArguments;
+    } as unknown as MiddlewareState;
 
-    const result = await middlewareFn(middlewareArguments);
+    const result = await middlewareFn(middlewareState);
 
     expect(result).toEqual({
       data: {
@@ -37,7 +37,7 @@ describe('matchTargetSize', () => {
     expect.assertions(1);
     const floatingElement = document.createElement('div');
     const referenceWidth = 100;
-    const middlewareArguments = {
+    const middlewareState = {
       middlewareData: {},
       elements: {
         floating: floatingElement,
@@ -47,9 +47,9 @@ describe('matchTargetSize', () => {
         reference: { width: referenceWidth },
         floating: { width: referenceWidth },
       },
-    } as unknown as MiddlewareArguments;
+    } as unknown as MiddlewareState;
 
-    const result = await middlewareFn(middlewareArguments);
+    const result = await middlewareFn(middlewareState);
 
     expect(result).toEqual({});
   });
@@ -58,7 +58,7 @@ describe('matchTargetSize', () => {
     expect.assertions(1);
     const floatingElement = document.createElement('div');
     const referenceWidth = 100;
-    const middlewareArguments = {
+    const middlewareState = {
       middlewareData: { matchTargetSize: { matchTargetSizeAttempt: true } },
       elements: {
         floating: floatingElement,
@@ -68,9 +68,9 @@ describe('matchTargetSize', () => {
         reference: { width: referenceWidth },
         floating: { width: '1px' },
       },
-    } as unknown as MiddlewareArguments;
+    } as unknown as MiddlewareState;
 
-    const result = await middlewareFn(middlewareArguments);
+    const result = await middlewareFn(middlewareState);
 
     expect(result).toEqual({});
   });

--- a/packages/react-components/react-positioning/src/utils/getFloatingUIOffset.test.ts
+++ b/packages/react-components/react-positioning/src/utils/getFloatingUIOffset.test.ts
@@ -1,9 +1,9 @@
-import { MiddlewareArguments } from '@floating-ui/dom';
+import { MiddlewareState } from '@floating-ui/dom';
 import { OffsetFunction } from '../types';
 import { FloatingUIOffsetFunction, getFloatingUIOffset } from './getFloatingUIOffset';
 
 describe('getFloatingUIOffset', () => {
-  const testMiddlewareArgs: MiddlewareArguments = {
+  const testMiddlewareState: MiddlewareState = {
     elements: {
       reference: document.createElement('div'),
       floating: document.createElement('div'),
@@ -59,7 +59,7 @@ describe('getFloatingUIOffset', () => {
     const transformedOffset = getFloatingUIOffset(() => offset) as FloatingUIOffsetFunction;
     expect(
       transformedOffset({
-        ...testMiddlewareArgs,
+        ...testMiddlewareState,
         rects: { floating: dummyRect, reference: dummyRect },
         placement: 'top',
       }),
@@ -78,7 +78,7 @@ describe('getFloatingUIOffset', () => {
     const transformedOffset = getFloatingUIOffset(offsetFn) as FloatingUIOffsetFunction;
     expect(
       transformedOffset({
-        ...testMiddlewareArgs,
+        ...testMiddlewareState,
         rects: { floating: dummyRect, reference: dummyRect },
         placement: 'top-start',
       }),
@@ -97,7 +97,7 @@ describe('getFloatingUIOffset', () => {
     const transformedOffset = getFloatingUIOffset(offsetFn) as FloatingUIOffsetFunction;
     expect(
       transformedOffset({
-        ...testMiddlewareArgs,
+        ...testMiddlewareState,
         rects: { floating: dummyRect, reference: dummyRect },
         placement: 'top-start',
       }),
@@ -116,7 +116,7 @@ describe('getFloatingUIOffset', () => {
     const transformedOffset = getFloatingUIOffset(offsetFn) as FloatingUIOffsetFunction;
     expect(
       transformedOffset({
-        ...testMiddlewareArgs,
+        ...testMiddlewareState,
         rects: { floating: dummyRect, reference: dummyRect },
         placement: 'top-start',
       }),

--- a/packages/react-components/react-positioning/src/utils/getFloatingUIOffset.ts
+++ b/packages/react-components/react-positioning/src/utils/getFloatingUIOffset.ts
@@ -1,5 +1,5 @@
 import type { Offset } from '../types';
-import type { MiddlewareArguments } from '@floating-ui/dom';
+import type { MiddlewareState } from '@floating-ui/dom';
 import { fromFloatingUIPlacement } from './fromFloatingUIPlacement';
 /**
  * Type taken from Floating UI since they are not exported
@@ -30,7 +30,7 @@ export type FloatingUIOffsetValue =
 /**
  * Type taken from Floating UI since they are not exported
  */
-export type FloatingUIOffsetFunction = (args: MiddlewareArguments) => FloatingUIOffsetValue;
+export type FloatingUIOffsetFunction = (state: MiddlewareState) => FloatingUIOffsetValue;
 
 /**
  * Shim to transform offset values from this library to Floating UI

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,17 +1876,25 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@floating-ui/core@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.0.tgz#ae7ae7923d41f3d84cb2fd88740a89436610bbec"
-  integrity sha512-GHUXPEhMEmTpnpIfesFA2KAoMJPb1SPQw964tToQwt+BbGXdhqTCWT1rOb0VURGylsxsYxiGMnseJ3IlclVpVA==
-
-"@floating-ui/dom@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.0.tgz#a60212069cc58961c478037c30eba4b191c75316"
-  integrity sha512-QXzg57o1cjLz3cGETzKXjI3kx1xyS49DW9l7kV2jw2c8Yftd434t2hllX0sVGn2Q8MtcW/4pNm8bfE1/4n6mng==
+"@floating-ui/core@^1.4.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
+  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
   dependencies:
-    "@floating-ui/core" "^1.2.0"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/dom@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
+  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
 "@fluentui/dom-utilities@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
## New Behavior

1. bumps version of `@floating-ui/dom` to ^1.5.3 without introducing any breaking changes
2. follows up on deprecation of `MiddlewareArguments` in favor of `MiddlwareState` equivalent type

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/29938
