### PR TITLE
chore: Add teams-prg as owners to combobox

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -190,7 +190,7 @@ packages/react-components/react-badge @microsoft/cxe-red @behowell
 packages/react-components/react-button @microsoft/cxe-red @khmakoto
 packages/react-components/react-card @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-checkbox @microsoft/cxe-red @khmakoto
-packages/react-components/react-combobox @microsoft/cxe-red @smhigley
+packages/react-components/react-combobox @microsoft/cxe-red @microsoft/teams-prg @smhigley
 packages/react-components/react-components @microsoft/fluentui-react
 packages/react-components/react-dialog @microsoft/teams-prg
 packages/react-components/react-divider @microsoft/cxe-red


### PR DESCRIPTION
Adding teams-prg to combobox as temporary owners to implement some perf and improved composability changes to the package.

These changes were discussed with @smhigley

Addresses https://github.com/microsoft/fluentui/issues/26652