### PR TITLE
fix: Preventing multiple 'Open in CodeSandbox' buttons being added when switching themes

### DIFF
--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
@@ -35,6 +35,14 @@ function addActionButton(container: HTMLElement, config: Data, classList: string
   const files = scaffold[config.bundler](config);
   const action = actionConfig[config.provider];
 
+  // Check if button does not exist already in container
+  for (let i = 0; i < container.children.length; i++) {
+    const child = container.children[i];
+    if (child.tagName === 'BUTTON' && child.textContent === 'Open in CodeSandbox') {
+      return;
+    }
+  }
+
   const button = document.createElement('button');
   button.classList.add(...classList);
   button.textContent = `Open in ${action.label}`;

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
@@ -38,7 +38,7 @@ function addActionButton(container: HTMLElement, config: Data, classList: string
   // Check if button does not exist already in container
   for (let i = 0; i < container.children.length; i++) {
     const child = container.children[i];
-    if (child.tagName === 'BUTTON' && child.textContent === 'Open in CodeSandbox') {
+    if (child.tagName === 'BUTTON' && child.textContent === `Open in ${action.label}`) {
       return;
     }
   }

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
@@ -35,14 +35,6 @@ function addActionButton(container: HTMLElement, config: Data, classList: string
   const files = scaffold[config.bundler](config);
   const action = actionConfig[config.provider];
 
-  // Check if button does not exist already in container
-  for (let i = 0; i < container.children.length; i++) {
-    const child = container.children[i];
-    if (child.tagName === 'BUTTON' && child.textContent === `Open in ${action.label}`) {
-      return;
-    }
-  }
-
   const button = document.createElement('button');
   button.classList.add(...classList);
   button.textContent = `Open in ${action.label}`;

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-utils.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-utils.ts
@@ -30,11 +30,9 @@ export function prepareSandboxContainer(context: StoryContext) {
 
   const classList = (showCodeButton.classList.value + ' with-code-sandbox-button').split(' ');
 
-  // this is needed in dev loop as every hot reload will add new buttons
-  if (process.env.NODE_ENV !== 'production') {
-    const ourButtons = container.querySelectorAll(`.with-code-sandbox-button`);
-    ourButtons.forEach(node => node.remove());
-  }
+  // remove button if it already existed
+  const ourButtons = container.querySelectorAll(`.with-code-sandbox-button`);
+  ourButtons.forEach(node => node.remove());
 
   return {
     container,


### PR DESCRIPTION
## Previous Behavior

Switching between themes would make additional `Open in CodeSandbox` buttons to be prepended to each story container.

![image](https://github.com/microsoft/fluentui/assets/7798177/f77d8524-ccee-4301-8005-ef853522ba06)

## New Behavior

We now make sure that only one `Open in CodeSandbox` button exists at any time in the container.

![image](https://github.com/microsoft/fluentui/assets/7798177/2b868b33-f613-48f7-8796-5b800b7dd844)

## Related Issue(s)

- Fixes #29846
