### PR TITLE
feat: add useFocusVisible() to exports

### DIFF
--- a/change/@fluentui-react-components-53e298a8-94c2-4760-ad6b-4f62f876b949.json
+++ b/change/@fluentui-react-components-53e298a8-94c2-4760-ad6b-4f62f876b949.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add useFocusVisible() to exports",
+  "packageName": "@fluentui/react-components",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1195,6 +1195,7 @@ import { useFocusableGroup } from '@fluentui/react-tabster';
 import { UseFocusableGroupOptions } from '@fluentui/react-tabster';
 import { useFocusFinders } from '@fluentui/react-tabster';
 import { useFocusObserved } from '@fluentui/react-tabster';
+import { useFocusVisible } from '@fluentui/react-tabster';
 import { useFocusWithin } from '@fluentui/react-tabster';
 import { useHeadlessFlatTree_unstable } from '@fluentui/react-tree';
 import { useId } from '@fluentui/react-utilities';
@@ -3798,6 +3799,8 @@ export { UseFocusableGroupOptions }
 export { useFocusFinders }
 
 export { useFocusObserved }
+
+export { useFocusVisible }
 
 export { useFocusWithin }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -37,6 +37,7 @@ export {
   useArrowNavigationGroup,
   useFocusableGroup,
   useFocusFinders,
+  useFocusVisible,
   useFocusWithin,
   useKeyboardNavAttribute,
   useModalAttributes,


### PR DESCRIPTION
## Previous Behavior

`react-tabster`'s `useFocusVisible()` hook was not re-exported from `react-components`

## New Behavior

`useFocusVisible()` is exported from `react-components`.

## Related Issue(s)

This helps teams using [HeadlessProvider](https://github.com/microsoft/fluentui-contrib/tree/main/packages/react-headless-provider) as they do not need to take a separate dependency on `react-tabster`.


