### PR TITLE
fix: Using correct colors when MenuItem is pressed

### DIFF
--- a/change/@fluentui-react-menu-95a114de-8688-4d5e-8c26-30da9afd2e00.json
+++ b/change/@fluentui-react-menu-95a114de-8688-4d5e-8c26-30da9afd2e00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Using correct colors when MenuItem is pressed.",
+  "packageName": "@fluentui/react-menu",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -49,6 +49,11 @@ const useRootBaseStyles = makeResetStyles({
     },
   },
 
+  ':hover:active': {
+    backgroundColor: tokens.colorNeutralBackground1Pressed,
+    color: tokens.colorNeutralForeground2Pressed,
+  },
+
   userSelect: 'none',
   ...createFocusOutlineStyle(),
 });


### PR DESCRIPTION
## Previous Behavior

The correct color were not being used when a `MenuItem` was pressed, as specified by the design spec.

![image](https://github.com/microsoft/fluentui/assets/7798177/15b72ca3-2ad8-49ef-a6b9-f2e7bb00ff4e)

## New Behavior

The correct colors are used when a `MenuItem` is pressed, as specified by the design spec.

![image](https://github.com/microsoft/fluentui/assets/7798177/8ba60251-6a67-4a80-ad9e-5ae5f7c251a1)

## Related Issue(s)

- Fixes #29950
