### PR TITLE
fix: DataGrid stories should add an accName to the checkbox

### DIFF
--- a/packages/react-components/react-table/stories/DataGrid/CompositeNavigation.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/CompositeNavigation.stories.tsx
@@ -140,13 +140,13 @@ export const CompositeNavigation = () => {
   return (
     <DataGrid selectionMode="multiselect" items={items} columns={columns} focusMode="composite">
       <DataGridHeader>
-        <DataGridRow>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/CustomRowId.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/CustomRowId.stories.tsx
@@ -177,7 +177,7 @@ export const CustomRowId = () => {
         getRowId={item => item.file.label}
       >
         <DataGridHeader>
-          <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+          <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
             {({ renderHeaderCell }: TableColumnDefinition<Item>) => (
               <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
             )}
@@ -185,7 +185,7 @@ export const CustomRowId = () => {
         </DataGridHeader>
         <DataGridBody>
           {({ item, rowId }: TableRowData<Item>) => (
-            <DataGridRow key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+            <DataGridRow key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
               {({ renderCell }: TableColumnDefinition<Item>) => <DataGridCell>{renderCell(item)}</DataGridCell>}
             </DataGridRow>
           )}

--- a/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/Default.stories.tsx
@@ -160,13 +160,13 @@ export const Default = () => {
       focusMode="composite"
     >
       <DataGridHeader>
-        <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/FocusableElementsInCells.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/FocusableElementsInCells.stories.tsx
@@ -149,13 +149,13 @@ export const FocusableElementsInCells = () => {
       onSelectionChange={(e, data) => console.log(data)}
     >
       <DataGridHeader>
-        <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell, columnId }) => (
               <DataGridCell focusMode={getCellFocusMode(columnId)}>{renderCell(item)}</DataGridCell>
             )}

--- a/packages/react-components/react-table/stories/DataGrid/MultipleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/MultipleSelect.stories.tsx
@@ -154,13 +154,13 @@ export const MultipleSelect = () => {
   return (
     <DataGrid items={items} columns={columns} selectionMode="multiselect" defaultSelectedItems={defaultSelectedItems}>
       <DataGridHeader>
-        <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/MultipleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/MultipleSelectControlled.stories.tsx
@@ -165,13 +165,13 @@ export const MultipleSelectControlled = () => {
       onSelectionChange={onSelectionChange}
     >
       <DataGridHeader>
-        <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/ResizableColumns.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/ResizableColumns.stories.tsx
@@ -189,7 +189,7 @@ export const ResizableColumns = () => {
         columnSizingOptions={columnSizingOptions}
       >
         <DataGridHeader>
-          <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+          <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
             {({ renderHeaderCell, columnId }, dataGrid) =>
               dataGrid.resizableColumns ? (
                 <Menu openOnContext>
@@ -214,7 +214,7 @@ export const ResizableColumns = () => {
         </DataGridHeader>
         <DataGridBody<Item>>
           {({ item, rowId }) => (
-            <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+            <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
               {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
             </DataGridRow>
           )}

--- a/packages/react-components/react-table/stories/DataGrid/SelectionAppearance.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SelectionAppearance.stories.tsx
@@ -160,13 +160,13 @@ export const SelectionAppearance = () => {
       defaultSelectedItems={defaultSelectedItems}
     >
       <DataGridHeader>
-        <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/SingleSelect.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SingleSelect.stories.tsx
@@ -160,7 +160,7 @@ export const SingleSelect = () => {
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ radioIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/SingleSelectControlled.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SingleSelectControlled.stories.tsx
@@ -171,7 +171,7 @@ export const SingleSelectControlled = () => {
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ radioIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}

--- a/packages/react-components/react-table/stories/DataGrid/SubtleSelection.stories.tsx
+++ b/packages/react-components/react-table/stories/DataGrid/SubtleSelection.stories.tsx
@@ -160,13 +160,13 @@ export const SubtleSelection = () => {
       defaultSelectedItems={defaultSelectedItems}
     >
       <DataGridHeader>
-        <DataGridRow selectionCell={{ 'aria-label': 'Select all rows' }}>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
           {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ 'aria-label': 'Select row' }}>
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
             {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}


### PR DESCRIPTION
Simple example-only fix.

Eventually, we likely want to auto-add an accName for the checkbox based on the first gridcell's text, but this at least demos how to manually add one in our examples.

## Related Issue(s)

- Fixes an ADO a11y issue
