### PR TITLE
feat(docs): Adding global direction switch to dynamically change between ltr and rtl in storybook

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/DirSwitch.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/DirSwitch.stories.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { makeStyles, Label, Switch, tokens, useId, typographyStyles, shorthands } from '@fluentui/react-components';
+import type { SwitchProps } from '@fluentui/react-components';
+import { DIR_ID } from '@fluentui/react-storybook-addon';
+import addons from '@storybook/addons';
+
+const useStyles = makeStyles({
+  container: {
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalXS,
+    display: 'flex',
+    justifyContent: 'start',
+    ...shorthands.margin(tokens.spacingVerticalS, 0),
+  },
+  label: {
+    ...typographyStyles.subtitle2,
+  },
+});
+
+/**
+ * Dir switch used in the react-components docs header
+ */
+export const DirSwitch: React.FC<{ dir?: 'ltr' | 'rtl' }> = ({ dir }) => {
+  const switchId = useId('dir-switch');
+
+  const styles = useStyles();
+
+  const [currentDir, setCurrentDir] = React.useState(dir);
+  const checked = currentDir === 'rtl';
+
+  const setGlobalDir = (newDir: 'ltr' | 'rtl'): void => {
+    addons.getChannel().emit('updateGlobals', { globals: { [DIR_ID]: newDir } });
+  };
+
+  const onChange = React.useCallback<NonNullable<SwitchProps['onChange']>>((_, data) => {
+    const newDir = data.checked ? 'rtl' : 'ltr';
+    setGlobalDir(newDir);
+    setCurrentDir(newDir);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <Label className={styles.label} htmlFor={currentDir === 'ltr' ? undefined : switchId}>
+        LTR
+      </Label>
+      <Switch checked={checked} id={switchId} onChange={onChange} />
+      <Label className={styles.label} htmlFor={currentDir === 'rtl' ? switchId : undefined}>
+        RTL
+      </Label>
+    </div>
+  );
+};

--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -12,7 +12,8 @@ import {
 } from '@storybook/addon-docs';
 import { makeStyles, shorthands } from '@griffel/react';
 import { Toc, nameToHash } from './Toc.stories';
-import { THEME_ID, themes } from '@fluentui/react-storybook-addon';
+import { DIR_ID, THEME_ID, themes } from '@fluentui/react-storybook-addon';
+import { DirSwitch } from './DirSwitch.stories';
 import { ThemePicker } from './ThemePicker.stories';
 
 const useStyles = makeStyles({
@@ -43,6 +44,7 @@ const useStyles = makeStyles({
 export const FluentDocsPage = () => {
   const context = React.useContext(DocsContext);
 
+  const dir = context.parameters?.dir ?? context.globals?.[DIR_ID] ?? 'ltr';
   const selectedTheme = themes.find(theme => theme.id === context.globals![THEME_ID]);
   const stories = context.componentStories();
   const primaryStory = stories[0];
@@ -66,6 +68,7 @@ export const FluentDocsPage = () => {
       <div className={styles.wrapper}>
         <div className={styles.container}>
           <ThemePicker selectedThemeId={selectedTheme?.id} />
+          <DirSwitch dir={dir} />
           <Subtitle />
           <Description />
           <hr className={styles.divider} />

--- a/packages/react-components/react-storybook-addon/src/constants.ts
+++ b/packages/react-components/react-storybook-addon/src/constants.ts
@@ -1,4 +1,5 @@
 export const ADDON_ID = 'storybook_fluentui-react-addon';
-export const THEME_ID = `${ADDON_ID}_theme` as const;
 
+export const DIR_ID = `${ADDON_ID}_dir` as const;
 export const STRICT_MODE_ID = `${ADDON_ID}_strict-mode` as const;
+export const THEME_ID = `${ADDON_ID}_theme` as const;

--- a/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FluentProvider } from '@fluentui/react-provider';
 import { Theme } from '@fluentui/react-theme';
 import { themes, defaultTheme, ThemeIds } from '../theme';
-import { THEME_ID } from '../constants';
+import { DIR_ID, THEME_ID } from '../constants';
 import { FluentGlobals, FluentStoryContext } from '../hooks';
 
 const findTheme = (themeId?: ThemeIds) => {
@@ -25,12 +25,13 @@ export const withFluentProvider = (StoryFn: () => JSX.Element, context: FluentSt
   const { mode } = parameters;
   const isVrTest = mode === 'vr-test';
 
+  const dir = parameters.dir ?? globals[DIR_ID] ?? 'ltr';
   const globalTheme = getActiveFluentTheme(globals);
   const paramTheme = findTheme(parameters.fluentTheme);
   const { theme } = paramTheme ?? globalTheme;
 
   return (
-    <FluentProvider theme={theme} dir={parameters.dir}>
+    <FluentProvider theme={theme} dir={dir}>
       {isVrTest ? StoryFn() : <FluentExampleContainer theme={theme}>{StoryFn()}</FluentExampleContainer>}
     </FluentProvider>
   );

--- a/packages/react-components/react-storybook-addon/src/hooks.ts
+++ b/packages/react-components/react-storybook-addon/src/hooks.ts
@@ -1,7 +1,7 @@
 import { useGlobals as useStorybookGlobals, Args as StorybookArgs } from '@storybook/api';
 import { StoryContext as StorybookContext, Parameters } from '@storybook/addons';
 
-import { STRICT_MODE_ID, THEME_ID } from './constants';
+import { DIR_ID, STRICT_MODE_ID, THEME_ID } from './constants';
 import type { ThemeIds } from './theme';
 
 export interface FluentStoryContext extends StorybookContext {
@@ -13,6 +13,7 @@ export interface FluentStoryContext extends StorybookContext {
  * Extends the storybook globals object to include fluent specific properties
  */
 export interface FluentGlobals extends StorybookArgs {
+  [DIR_ID]?: 'ltr' | 'rtl';
   [THEME_ID]?: ThemeIds;
   [STRICT_MODE_ID]?: boolean;
 }

--- a/packages/react-components/react-storybook-addon/src/index.ts
+++ b/packages/react-components/react-storybook-addon/src/index.ts
@@ -1,5 +1,5 @@
 export type { FluentGlobals, FluentParameters, FluentStoryContext } from './hooks';
 export type { ThemeIds } from './theme';
 export { themes } from './theme';
-export { THEME_ID } from './constants';
+export { DIR_ID, THEME_ID } from './constants';
 export { parameters } from './hooks';


### PR DESCRIPTION
## PR Description

This PR adds a `Switch` to our storybook header to be able to flip between LTR and RTL direction throughout the docs.

![Dir](https://github.com/microsoft/fluentui/assets/7798177/c96d0d57-8e69-4559-8d00-5c5e66447ae9)

## Related Issue(s)

- Fixes #29946