### PR TITLE
fix: Brand row appearance should be brandBackground2 in pressed state

### DIFF
--- a/change/@fluentui-react-table-dc4edf49-9bab-4948-9b2e-65636d70ef4c.json
+++ b/change/@fluentui-react-table-dc4edf49-9bab-4948-9b2e-65636d70ef4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Brand row appearance should be brandBackground2 in pressed state",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
@@ -90,7 +90,8 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorBrandBackground2,
     ...shorthands.borderColor(tokens.colorTransparentStrokeInteractive),
     ':active': {
-      backgroundColor: tokens.colorBrandBackgroundInvertedSelected,
+      backgroundColor: tokens.colorBrandBackground2,
+      color: tokens.colorNeutralForeground1,
     },
 
     '@media(forced-colors: active)': {


### PR DESCRIPTION
Fixes the background colour of the brand TableRow appearance when pressed.

Before
![image](https://github.com/microsoft/fluentui/assets/20744592/e3a3578b-827d-475a-8576-3c19f91cb86b)
![image](https://github.com/microsoft/fluentui/assets/20744592/3b885c17-be8a-4c36-83b2-bb69895e48a6)
![image](https://github.com/microsoft/fluentui/assets/20744592/3ddf8f07-7023-409a-8ef4-495aa43e55b4)


After
![image](https://github.com/microsoft/fluentui/assets/20744592/5e1db396-7010-4911-9f46-95ca3cd70262)
![image](https://github.com/microsoft/fluentui/assets/20744592/0711624b-7f5f-4973-b33c-bdec74cfa9f7)
![image](https://github.com/microsoft/fluentui/assets/20744592/2d561e61-e3c0-43b2-adf9-e71fba00983d)


Fixes #29445