### PR TITLE
Enforce integer y axis ticks for integral datasets

### DIFF
--- a/change/@fluentui-react-charting-35073061-577a-4d9f-a0fd-b90a60995009.json
+++ b/change/@fluentui-react-charting-35073061-577a-4d9f-a0fd-b90a60995009.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for sticking to old ceil logic in case of integral datasets",
+  "packageName": "@fluentui/react-charting",
+  "email": "shubhabrata08@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -160,12 +160,9 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         startFromX: 0,
       });
     }
-    for (let i = 0; i < this.props.points.length; i += 1) {
-      if (this.props.points[i].y - Math.floor(this.props.points[i].y) > 0) {
-        this.isIntegralDataset = false;
-        break;
-      }
-    }
+    this.isIntegralDataset = !this.props.points.some((point: { y: number }) => {
+      return point.y % 1 !== 0;
+    });
   }
 
   public componentWillUnmount(): void {
@@ -217,12 +214,9 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       });
     }
     if (prevProps.points !== this.props.points) {
-      for (let i = 0; i < this.props.points.length; i += 1) {
-        if (this.props.points[i].y - Math.floor(this.props.points[i].y) > 0) {
-          this.isIntegralDataset = false;
-          break;
-        }
-      }
+      this.isIntegralDataset = !this.props.points.some((point: { y: number }) => {
+        return point.y % 1 !== 0;
+      });
     }
   }
 

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -216,10 +216,12 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         startFromX: 0,
       });
     }
-    for (let i = 0; i < this.props.points.length; i += 1) {
-      if (this.props.points[i].y - Math.floor(this.props.points[i].y) > 0) {
-        this.isIntegralDataset = false;
-        break;
+    if (prevProps.points !== this.props.points) {
+      for (let i = 0; i < this.props.points.length; i += 1) {
+        if (this.props.points[i].y - Math.floor(this.props.points[i].y) > 0) {
+          this.isIntegralDataset = false;
+          break;
+        }
       }
     }
   }

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -86,6 +86,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _xScale: any;
+  private isIntegralDataset: boolean = true;
 
   constructor(props: IModifiedCartesianChartProps) {
     super(props);
@@ -159,6 +160,12 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
         startFromX: 0,
       });
     }
+    for (let i = 0; i < this.props.points.length; i += 1) {
+      if (this.props.points[i].y - Math.floor(this.props.points[i].y) > 0) {
+        this.isIntegralDataset = false;
+        break;
+      }
+    }
   }
 
   public componentWillUnmount(): void {
@@ -208,6 +215,12 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       this.setState({
         startFromX: 0,
       });
+    }
+    for (let i = 0; i < this.props.points.length; i += 1) {
+      if (this.props.points[i].y - Math.floor(this.props.points[i].y) > 0) {
+        this.isIntegralDataset = false;
+        break;
+      }
     }
   }
 
@@ -389,10 +402,18 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
             axisData,
             chartType,
             this.props.barwidth!,
+            this.isIntegralDataset,
             true,
           );
         }
-        yScale = createYAxis(YAxisParams, this._isRtl, axisData, chartType, this.props.barwidth!);
+        yScale = createYAxis(
+          YAxisParams,
+          this._isRtl,
+          axisData,
+          chartType,
+          this.props.barwidth!,
+          this.isIntegralDataset,
+        );
       }
 
       /*
@@ -411,7 +432,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
           this._isRtl,
         );
 
-      this.props.getAxisData && this.props.getAxisData(axisData);
+      // this.props.getAxisData && this.props.getAxisData(axisData);
       // Callback function for chart, returns axis
       this._getData(xScale, yScale);
 

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -432,7 +432,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
           this._isRtl,
         );
 
-      // this.props.getAxisData && this.props.getAxisData(axisData);
+      this.props.getAxisData && this.props.getAxisData(axisData);
       // Callback function for chart, returns axis
       this._getData(xScale, yScale);
 

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -311,8 +311,8 @@ export function prepareDatapoints(
   isIntegralDataset: boolean,
 ): number[] {
   const val = isIntegralDataset
-    ? 1
-    : (maxVal - minVal) / splitInto > 1
+    ? Math.ceil((maxVal - minVal) / splitInto)
+    : (maxVal - minVal) / splitInto >= 1
     ? Math.ceil((maxVal - minVal) / splitInto)
     : (maxVal - minVal) / splitInto;
   const dataPointsArray: number[] = [minVal, minVal + val];

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -301,11 +301,20 @@ export function createStringXAxis(
  * @param {number} maxVal
  * @param {number} minVal
  * @param {number} splitInto
+ * @param {boolean} isIntegralDataset
  * @returns {number[]}
  */
-export function prepareDatapoints(maxVal: number, minVal: number, splitInto: number): number[] {
-  const val =
-    (maxVal - minVal) / splitInto > 1 ? Math.ceil((maxVal - minVal) / splitInto) : (maxVal - minVal) / splitInto;
+export function prepareDatapoints(
+  maxVal: number,
+  minVal: number,
+  splitInto: number,
+  isIntegralDataset: boolean,
+): number[] {
+  const val = isIntegralDataset
+    ? 1
+    : (maxVal - minVal) / splitInto > 1
+    ? Math.ceil((maxVal - minVal) / splitInto)
+    : (maxVal - minVal) / splitInto;
   const dataPointsArray: number[] = [minVal, minVal + val];
   while (dataPointsArray[dataPointsArray.length - 1] < maxVal) {
     dataPointsArray.push(dataPointsArray[dataPointsArray.length - 1] + val);
@@ -325,13 +334,14 @@ export function createYAxis(
   axisData: IAxisData,
   chartType: ChartTypes,
   barWidth: number,
+  isIntegralDataset: boolean,
   useSecondaryYScale: boolean = false,
 ) {
   switch (chartType) {
     case ChartTypes.HorizontalBarChartWithAxis:
       return createYAxisForHorizontalBarChartWithAxis(yAxisParams, isRtl, axisData, barWidth!);
     default:
-      return createYAxisForOtherCharts(yAxisParams, isRtl, axisData, useSecondaryYScale);
+      return createYAxisForOtherCharts(yAxisParams, isRtl, axisData, isIntegralDataset, useSecondaryYScale);
   }
 }
 
@@ -372,6 +382,7 @@ export function createYAxisForOtherCharts(
   yAxisParams: IYAxisParams,
   isRtl: boolean,
   axisData: IAxisData,
+  isIntegralDataset: boolean,
   useSecondaryYScale: boolean = false,
 ) {
   const {
@@ -394,7 +405,7 @@ export function createYAxisForOtherCharts(
   const tempVal = maxOfYVal || yMinMaxValues.endValue;
   const finalYmax = tempVal > yMaxValue ? tempVal : yMaxValue!;
   const finalYmin = yMinMaxValues.startValue < yMinValue ? 0 : yMinValue!;
-  const domainValues = prepareDatapoints(finalYmax, finalYmin, yAxisTickCount);
+  const domainValues = prepareDatapoints(finalYmax, finalYmin, yAxisTickCount, isIntegralDataset);
   const yAxisScale = d3ScaleLinear()
     .domain([finalYmin, domainValues[domainValues.length - 1]])
     .range([containerHeight - margins.bottom!, margins.top! + (eventAnnotationProps! ? eventLabelHeight! : 0)]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://github.com/microsoft/fluentui/assets/35366351/67fcffad-b517-43be-9962-b34a7c3018a0)

## New Behavior
Since the dataset consists of integral values only, the y axis ticks should also be constrained to integral values.
![image](https://github.com/microsoft/fluentui/assets/35366351/fe9cb0c2-1dd3-4c5b-8ce5-519f978851f3)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #26383
