### PR TITLE
fix: create-milestone workflow works again

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -20,7 +20,7 @@ jobs:
           quarter=$(date +"%q")
           year=$(date +"%Y")
           title="${month} Project Cycle Q${quarter} ${year}"
-          due_on=$(date -v1d -v${month_numeric}m -v-1d +"%Y-%m-%dT%H:%M:%S%z")
+          due_on=$(date -d "$(date -d "next month" +%Y-%m-01) -1 day" +"%Y-%m-%dT%H:%M:%S%z")
           echo "Using title '${title}' and setting due date: '${due-on}'"
           gh api --method POST repos/microsoft/fluentui/milestones -f title="${title} -f due_on="${due_on}"
         env:


### PR DESCRIPTION
## Issue
- Create milestone workflow has been quietly broken all year due to invalid date syntax use: https://github.com/microsoft/fluentui/actions/workflows/create-milestone.yml
  <img width="482" alt="image" src="https://github.com/microsoft/fluentui/assets/8649804/8792ddeb-064f-4b31-bf0c-0174a5a2f541">

<!-- This is the behavior we have today -->

## Change
- the `-v` option used by the `due_on` variable is only available for the MacOS version of the `date` command which is why it kept failing in our github actions workflow which uses Linux. Using comparable `-d` option instead which generates the same expected date (last day of current month) and format.

**Example**: 
<img width="951" alt="image" src="https://github.com/microsoft/fluentui/assets/8649804/cbcf7130-955d-4816-9497-397acc50fb16">


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follow up to #26149
