### PR TITLE
fix: CommandBar menu icon is not visually disabled in high contrast mode

### DIFF
--- a/change/@fluentui-react-714fcf34-c6dc-4efb-bc09-1a35babefc19.json
+++ b/change/@fluentui-react-714fcf34-c6dc-4efb-bc09-1a35babefc19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: CommandBar menu icon is not disabled in high contrast mode",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -237,9 +237,6 @@ export const getStyles = memoizeFunction(
 
       menuIcon: {
         color: p.neutralSecondary,
-        [HighContrastSelector]: {
-          color: 'GrayText',
-        },
       },
     };
 

--- a/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -306,9 +306,6 @@ exports[`Button renders CommandBarButton correctly 1`] = `
               margin-top: 0;
               text-align: center;
             }
-            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-              color: GrayText;
-            }
         data-icon-name="ChevronDown"
         style="font-family: \\"FabricMDL2Icons\\";"
       >


### PR DESCRIPTION
## Previous Behavior

![screenshot of the commandbar showing button text in the enabled color, and the icon in the disabled color](https://github.com/microsoft/fluentui/assets/3819570/4f3c5001-64f2-4287-8067-c3a4b56bd4b8)

## New Behavior

![screenshot of the commandbar showing icon color matching button text color](https://github.com/microsoft/fluentui/assets/3819570/9c8b6c3e-2f9a-42e1-8222-a8616ae95b18)

Looks like this was an oversight addition in #14215, where it accidentally added a disabled color to icons for regular/enabled non-split menu items. This change still keeps the icon color disabled when the button is disabled, and does not affect split menu items.

## Related Issue(s)

- Fixes #29982
