### PR TITLE
feat(react-avatar, react-components): Export missing useAvatarGroupPopoverContextValues hook

### DIFF
--- a/change/@fluentui-react-avatar-a01f51ec-ec7e-4af1-ae1a-41557bd92668.json
+++ b/change/@fluentui-react-avatar-a01f51ec-ec7e-4af1-ae1a-41557bd92668.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Export useAvatarGroupPopovercontextValues hook.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-76af5285-1f9e-46d0-984e-6ebe27c2824f.json
+++ b/change/@fluentui-react-components-76af5285-1f9e-46d0-984e-6ebe27c2824f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Export useAvatarGroupPopovercontextValues hook.",
+  "packageName": "@fluentui/react-components",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-avatar/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/etc/react-avatar.api.md
@@ -219,6 +219,9 @@ export const useAvatarGroupItemStyles_unstable: (state: AvatarGroupItemState) =>
 // @public
 export const useAvatarGroupPopover_unstable: (props: AvatarGroupPopoverProps) => AvatarGroupPopoverState;
 
+// @public (undocumented)
+export const useAvatarGroupPopoverContextValues_unstable: (state: AvatarGroupPopoverState) => AvatarGroupContextValues;
+
 // @public
 export const useAvatarGroupPopoverStyles_unstable: (state: AvatarGroupPopoverState) => AvatarGroupPopoverState;
 

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/AvatarGroupPopover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { renderAvatarGroupPopover_unstable } from './renderAvatarGroupPopover';
-import { useAvatarGroupPopoverContextValues } from './useAvatarGroupPopoverContextValues';
+import { useAvatarGroupPopoverContextValues_unstable } from './useAvatarGroupPopoverContextValues';
 import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { useAvatarGroupPopover_unstable } from './useAvatarGroupPopover';
 import { useAvatarGroupPopoverStyles_unstable } from './useAvatarGroupPopoverStyles.styles';
@@ -11,7 +11,7 @@ import type { AvatarGroupPopoverProps } from './AvatarGroupPopover.types';
  */
 export const AvatarGroupPopover: React.FC<AvatarGroupPopoverProps> = props => {
   const state = useAvatarGroupPopover_unstable(props);
-  const contextValues = useAvatarGroupPopoverContextValues(state);
+  const contextValues = useAvatarGroupPopoverContextValues_unstable(state);
 
   useAvatarGroupPopoverStyles_unstable(state);
 

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/index.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/index.ts
@@ -3,3 +3,4 @@ export * from './AvatarGroupPopover.types';
 export * from './renderAvatarGroupPopover';
 export * from './useAvatarGroupPopover';
 export * from './useAvatarGroupPopoverStyles.styles';
+export * from './useAvatarGroupPopoverContextValues';

--- a/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverContextValues.ts
+++ b/packages/react-components/react-avatar/src/components/AvatarGroupPopover/useAvatarGroupPopoverContextValues.ts
@@ -1,7 +1,9 @@
 import { AvatarGroupContextValue, AvatarGroupContextValues } from '../AvatarGroup/AvatarGroup.types';
 import { AvatarGroupPopoverState } from './AvatarGroupPopover.types';
 
-export const useAvatarGroupPopoverContextValues = (state: AvatarGroupPopoverState): AvatarGroupContextValues => {
+export const useAvatarGroupPopoverContextValues_unstable = (
+  state: AvatarGroupPopoverState,
+): AvatarGroupContextValues => {
   const avatarGroup: AvatarGroupContextValue = {
     isOverflow: true,
     size: 24,

--- a/packages/react-components/react-avatar/src/index.ts
+++ b/packages/react-components/react-avatar/src/index.ts
@@ -44,8 +44,9 @@ export {
   AvatarGroupPopover,
   avatarGroupPopoverClassNames,
   renderAvatarGroupPopover_unstable,
-  useAvatarGroupPopoverStyles_unstable,
   useAvatarGroupPopover_unstable,
+  useAvatarGroupPopoverContextValues_unstable,
+  useAvatarGroupPopoverStyles_unstable,
 } from './AvatarGroupPopover';
 export type { AvatarGroupPopoverProps, AvatarGroupPopoverSlots, AvatarGroupPopoverState } from './AvatarGroupPopover';
 export {

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1095,6 +1095,7 @@ import { useAvatarGroupContextValues } from '@fluentui/react-avatar';
 import { useAvatarGroupItem_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupItemStyles_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupPopover_unstable } from '@fluentui/react-avatar';
+import { useAvatarGroupPopoverContextValues_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupPopoverStyles_unstable } from '@fluentui/react-avatar';
 import { useAvatarGroupStyles_unstable } from '@fluentui/react-avatar';
 import { useAvatarStyles_unstable } from '@fluentui/react-avatar';
@@ -3599,6 +3600,8 @@ export { useAvatarGroupItem_unstable }
 export { useAvatarGroupItemStyles_unstable }
 
 export { useAvatarGroupPopover_unstable }
+
+export { useAvatarGroupPopoverContextValues_unstable }
 
 export { useAvatarGroupPopoverStyles_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -219,6 +219,7 @@ export {
   useAvatarGroupItem_unstable,
   renderAvatarGroupPopover_unstable,
   useAvatarGroupPopoverStyles_unstable,
+  useAvatarGroupPopoverContextValues_unstable,
   useAvatarGroupPopover_unstable,
   useAvatarGroupContext_unstable,
   partitionAvatarGroupItems,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The hook `useAvatarGroupPopoverContextValues` was missing from the exports causing issues when recomposing AvatarGroupPopover.

## New Behavior

The hook is now exported in react-components and react-avatar.

