### PR TITLE
`merge-styles` `adoptedStylesheets` polyfill

### DIFF
--- a/apps/stress-test/src/renderers/wc/btn/wcBasicButton.ts
+++ b/apps/stress-test/src/renderers/wc/btn/wcBasicButton.ts
@@ -2,13 +2,11 @@ import { DOMSelectorTreeComponentRenderer } from '../../../shared/vanilla/types'
 
 declare global {
   interface Document {
-    // eslint-disable-next-line
-    adoptedStyleSheets: any[];
+    adoptedStyleSheets: CSSStyleSheet[];
   }
 
   interface ShadowRoot {
-    // eslint-disable-next-line
-    adoptedStyleSheets: any[];
+    adoptedStyleSheets: CSSStyleSheet[];
   }
 
   interface CSSStyleSheet {

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public (undocumented)
+export const cloneCSSStyleSheet: (srcSheet: CSSStyleSheet, targetSheet: CSSStyleSheet) => CSSStyleSheet;
+
 // @public
 export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
 
@@ -32,6 +35,11 @@ export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSe
 export type DeepPartial<T> = {
     [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+// Warning: (ae-forgotten-export) The symbol "EventArgs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type EventHandler<T> = (args: EventArgs<T>) => void;
 
 // @public
 export function fontFace(font: IFontFace): void;
@@ -452,8 +460,6 @@ export interface IStyleSheetConfig {
         [key: string]: string;
     };
     cspSettings?: ICSPSettings;
-    // (undocumented)
-    currentStylesheetKey?: string;
     defaultPrefix?: string;
     injectionMode?: InjectionMode;
     // (undocumented)
@@ -461,9 +467,11 @@ export interface IStyleSheetConfig {
     namespace?: string;
     // @deprecated
     onInsertRule?: (rule: string) => void;
-    // (undocumented)
-    ownerWindow?: Window;
     rtl?: boolean;
+    // (undocumented)
+    stylesheetKey?: string;
+    // (undocumented)
+    window?: Window;
 }
 
 // @public
@@ -566,12 +574,16 @@ export class Stylesheet {
     insertedRulesFromClassName(className: string): string[] | undefined;
     insertRule(rule: string, preserve?: boolean): void;
     // (undocumented)
+    makeCSSStyleSheet(win: Window): CSSStyleSheet;
+    // (undocumented)
     offAddConstructableStyleSheet(callback: EventHandler<CSSStyleSheet>): void;
-    // Warning: (ae-forgotten-export) The symbol "EventHandler" needs to be exported by the entry point index.d.ts
-    //
+    // (undocumented)
+    offInsertRuleIntoConstructableStyleSheet(callback: EventHandler<CSSStyleSheet>): void;
     // (undocumented)
     onAddConstructableStyleSheet(callback: EventHandler<CSSStyleSheet>): void;
     onInsertRule(callback: Function): Function;
+    // (undocumented)
+    onInsertRuleIntoConstructableStyleSheet(callback: EventHandler<CSSStyleSheet>): void;
     onReset(callback: Function): Function;
     // (undocumented)
     projectStylesToWindow(targetWindow: Window): void;
@@ -580,6 +592,8 @@ export class Stylesheet {
     resetKeys(): void;
     serialize(): string;
     setConfig(config?: IStyleSheetConfig): void;
+    supportsConstructableStylesheets(): boolean;
+    supportsModifyingAdoptedStyleSheets(): boolean;
 }
 
 // Warnings were encountered during analysis:

--- a/packages/merge-styles/src/EventMap.ts
+++ b/packages/merge-styles/src/EventMap.ts
@@ -1,4 +1,4 @@
-export type EventArgs<T> = { key: string; sheet: T };
+export type EventArgs<T> = { key: string; sheet: T; rule?: string };
 export type EventHandler<T> = (args: EventArgs<T>) => void;
 
 export class EventMap<K, V> {

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -188,7 +188,7 @@ export class Stylesheet {
    */
   public static getInstance(shadowConfig?: ShadowConfig): Stylesheet {
     const { stylesheetKey, inShadow, window: win } = shadowConfig ?? DEFAULT_SHADOW_CONFIG;
-    const global = (win ?? getWindow()) as typeof _global;
+    const global = (win ?? getWindow() ?? {}) as typeof _global;
 
     _stylesheet = global[STYLESHEET_SETTING] as Stylesheet;
 

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -368,7 +368,6 @@ export class Stylesheet {
    * @returns true if the browser supports constructable stylesheets
    */
   public supportsConstructableStylesheets(): boolean {
-    return false;
     return SUPPORTS_CONSTRUCTABLE_STYLESHEETS;
   }
 

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -1,6 +1,7 @@
 import { IStyle } from './IStyle';
 import { DEFAULT_SHADOW_CONFIG, GLOBAL_STYLESHEET_KEY, ShadowConfig } from './shadowConfig';
 import { EventHandler, EventMap } from './EventMap';
+import { cloneCSSStyleSheet } from './cloneCSSStyleSheet';
 
 export const InjectionMode = {
   /**
@@ -77,11 +78,11 @@ export interface IStyleSheetConfig {
    */
   classNameCache?: { [key: string]: string };
 
-  ownerWindow?: Window;
+  window?: Window;
 
   inShadow?: boolean;
 
-  currentStylesheetKey?: string;
+  stylesheetKey?: string;
 }
 
 /**
@@ -103,7 +104,26 @@ const STYLESHEET_SETTING = '__stylesheet__';
  */
 const REUSE_STYLE_NODE = typeof navigator !== 'undefined' && /rv:11.0/.test(navigator.userAgent);
 
-// const SUPPORTS_CONSTRUCTIBLE_STYLESHEETS = typeof window !== 'undefined' && 'CSSStyleSheet' in window;
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Document {
+    adoptedStyleSheets: CSSStyleSheet[];
+  }
+}
+
+const SUPPORTS_CONSTRUCTABLE_STYLESHEETS =
+  typeof document !== 'undefined' && Array.isArray(document.adoptedStyleSheets) && 'replace' in CSSStyleSheet.prototype;
+
+let SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS = false;
+
+if (SUPPORTS_CONSTRUCTABLE_STYLESHEETS) {
+  try {
+    document.adoptedStyleSheets.push();
+    SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS = true;
+  } catch (e) {
+    SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS = false;
+  }
+}
 
 export type AdoptableStylesheet = {
   fluentSheet: Stylesheet;
@@ -132,18 +152,6 @@ let _stylesheet: Stylesheet | undefined;
 
 const _getGlobal = (win?: Window): typeof _global => {
   return (win ?? _global) as typeof _global;
-};
-
-const _makeCSSStyleSheet = (win: Window): CSSStyleSheet => {
-  return new (win as Window & typeof globalThis).CSSStyleSheet();
-};
-
-const _cloneCSSStyleSheet = (srcSheet: CSSStyleSheet, targetSheet: CSSStyleSheet): CSSStyleSheet => {
-  for (let i = 0; i < srcSheet.cssRules.length; i++) {
-    targetSheet.insertRule(srcSheet.cssRules[i].cssText);
-  }
-
-  return targetSheet;
 };
 
 const getDocument = () => {
@@ -180,7 +188,7 @@ export class Stylesheet {
    */
   public static getInstance(shadowConfig?: ShadowConfig): Stylesheet {
     const { stylesheetKey, inShadow, window: win } = shadowConfig ?? DEFAULT_SHADOW_CONFIG;
-    const global = (win ?? _global) as typeof _global;
+    const global = (win ?? getWindow()) as typeof _global;
 
     _stylesheet = global[STYLESHEET_SETTING] as Stylesheet;
 
@@ -199,9 +207,9 @@ export class Stylesheet {
     ) {
       const fabricConfig = global?.FabricConfig || {};
       fabricConfig.mergeStyles = fabricConfig.mergeStyles || {};
-      fabricConfig.mergeStyles.ownerWindow = fabricConfig.mergeStyles.ownerWindow ?? win ?? getWindow();
+      fabricConfig.mergeStyles.window = fabricConfig.mergeStyles.window ?? win ?? getWindow();
       fabricConfig.mergeStyles.inShadow = fabricConfig.mergeStyles.inShadow ?? inShadow;
-      fabricConfig.mergeStyles.currentStylesheetKey = fabricConfig.mergeStyles.currentStylesheetKey ?? stylesheetKey;
+      fabricConfig.mergeStyles.stylesheetKey = fabricConfig.mergeStyles.stylesheetKey ?? stylesheetKey;
 
       let stylesheet: Stylesheet;
       if (oldStylesheetInitializedFirst) {
@@ -215,14 +223,14 @@ export class Stylesheet {
     if (inShadow || stylesheetKey === GLOBAL_STYLESHEET_KEY) {
       const sheetWindow = win ?? getWindow();
       if (sheetWindow) {
-        _stylesheet.addAdoptableStyleSheet(stylesheetKey, _makeCSSStyleSheet(sheetWindow));
+        _stylesheet.addAdoptableStyleSheet(stylesheetKey, _stylesheet.makeCSSStyleSheet(sheetWindow));
       }
     }
 
     _stylesheet.setConfig({
-      ownerWindow: win ?? getWindow(),
+      window: win ?? getWindow(),
       inShadow,
-      currentStylesheetKey: stylesheetKey ?? GLOBAL_STYLESHEET_KEY,
+      stylesheetKey: stylesheetKey ?? GLOBAL_STYLESHEET_KEY,
     });
     global[STYLESHEET_SETTING] = _stylesheet;
 
@@ -257,7 +265,7 @@ export class Stylesheet {
 
     if (!this._adoptableSheets.has(key)) {
       this._adoptableSheets.set(key, sheet);
-      this._config.ownerWindow?.requestAnimationFrame?.(() => {
+      this._config.window?.requestAnimationFrame?.(() => {
         this._adoptableSheets!.raise('add-sheet', { key, sheet });
       });
     }
@@ -271,7 +279,7 @@ export class Stylesheet {
 
     let sheet = this._adoptableSheets.get(key);
     if (!sheet) {
-      sheet = _makeCSSStyleSheet(this._config.ownerWindow ?? window);
+      sheet = this.makeCSSStyleSheet(this._config.window ?? window);
       this.addAdoptableStyleSheet(key, sheet);
     }
 
@@ -302,23 +310,40 @@ export class Stylesheet {
     this._adoptableSheets.off('add-sheet', callback);
   }
 
+  public onInsertRuleIntoConstructableStyleSheet(callback: EventHandler<CSSStyleSheet>): void {
+    if (!this._adoptableSheets) {
+      this._adoptableSheets = new EventMap();
+      // window.__DEBUG_SHEETS__ = this._adoptableSheets;
+    }
+
+    this._adoptableSheets.on('insert-rule', callback);
+  }
+
+  public offInsertRuleIntoConstructableStyleSheet(callback: EventHandler<CSSStyleSheet>): void {
+    if (!this._adoptableSheets) {
+      this._adoptableSheets = new EventMap();
+      // window.__DEBUG_SHEETS__ = this._adoptableSheets;
+    }
+
+    this._adoptableSheets.off('insert-rule', callback);
+  }
+
   public projectStylesToWindow(targetWindow: Window): void {
-    const global = _getGlobal(this._config.ownerWindow);
+    const global = _getGlobal(this._config.window);
 
     const serialized = JSON.parse(this.serialize());
     const targetStylesheet = new Stylesheet(
       {
         injectionMode: this._config.injectionMode,
-        ownerWindow: targetWindow,
+        window: targetWindow,
       },
       serialized,
     );
 
     (targetWindow as typeof _global)[STYLESHEET_SETTING] = targetStylesheet;
 
-    // TODO: add support for <style> tags
     this.forEachAdoptedStyleSheet((srcSheet, key) => {
-      const clonedSheet = _cloneCSSStyleSheet(srcSheet, _makeCSSStyleSheet(targetWindow));
+      const clonedSheet = cloneCSSStyleSheet(srcSheet, this.makeCSSStyleSheet(targetWindow));
       targetStylesheet.addAdoptableStyleSheet(key, clonedSheet);
     });
 
@@ -336,6 +361,25 @@ export class Stylesheet {
         }
       }
     }
+  }
+
+  /**
+   * Helper to test if constructable stylesheets are supported.
+   * @returns true if the browser supports constructable stylesheets
+   */
+  public supportsConstructableStylesheets(): boolean {
+    return false;
+    return SUPPORTS_CONSTRUCTABLE_STYLESHEETS;
+  }
+
+  /**
+   * Helper to test if modifying adopted stylesheets is supported.
+   * Currently the spec allows for modifying the adopted sheets array
+   * but previous versions used fronzen arrays.
+   * @returns true if the browser supports modifying adopted stylesheets
+   */
+  public supportsModifyingAdoptedStyleSheets(): boolean {
+    return SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS;
   }
 
   /**
@@ -456,11 +500,11 @@ export class Stylesheet {
    * @param preserve - Preserves the rule beyond a reset boundary.
    */
   public insertRule(rule: string, preserve?: boolean): void {
-    const { injectionMode, currentStylesheetKey = GLOBAL_STYLESHEET_KEY } = this._config;
+    const { injectionMode, stylesheetKey = GLOBAL_STYLESHEET_KEY } = this._config;
 
     const injectStyles = injectionMode !== InjectionMode.none;
     const addToConstructableStylesheet =
-      currentStylesheetKey === GLOBAL_STYLESHEET_KEY || !!this._adoptableSheets?.has(currentStylesheetKey);
+      stylesheetKey === GLOBAL_STYLESHEET_KEY || !!this._adoptableSheets?.has(stylesheetKey);
 
     let element: HTMLStyleElement | undefined = undefined;
     let constructableSheet: CSSStyleSheet | undefined = undefined;
@@ -471,7 +515,7 @@ export class Stylesheet {
     }
 
     if (injectStyles && addToConstructableStylesheet) {
-      constructableSheet = this.getAdoptableStyleSheet(currentStylesheetKey);
+      constructableSheet = this.getAdoptableStyleSheet(stylesheetKey);
     }
 
     if (preserve) {
@@ -479,18 +523,30 @@ export class Stylesheet {
     }
 
     if (element || constructableSheet) {
+      let inserted = false;
+      const sheet: CSSStyleSheet | null = constructableSheet ?? element?.sheet ?? null;
       switch (injectionMode) {
         case InjectionMode.insertNode:
-          this._insertNode(element, rule);
+          inserted = this._insertNode(element, rule);
           break;
 
         case InjectionMode.appendChild:
-          element && (element as HTMLStyleElement).appendChild(document.createTextNode(rule));
+          if (element) {
+            (element as HTMLStyleElement).appendChild(document.createTextNode(rule));
+          }
           break;
       }
 
       if (constructableSheet) {
-        this._insertRuleIntoSheet(constructableSheet, rule);
+        inserted = this._insertRuleIntoSheet(constructableSheet, rule);
+      }
+
+      if (inserted && sheet) {
+        this._adoptableSheets?.raise('insert-rule', {
+          key: stylesheetKey,
+          sheet: sheet as CSSStyleSheet,
+          rule,
+        });
       }
     } else {
       this._rules.push(rule);
@@ -531,53 +587,56 @@ export class Stylesheet {
     this._keyToClassName = {};
   }
 
-  // public get counter(): number {
-  //   return this._counter;
-  // }
+  public makeCSSStyleSheet(win: Window): CSSStyleSheet {
+    if (!SUPPORTS_CONSTRUCTABLE_STYLESHEETS) {
+      const style = this._createStyleElement(win);
+      return style.sheet as CSSStyleSheet;
+    }
 
-  // private get _counter(): number {
-  //   return this._styleCounter;
-  // }
+    return new (win as Window & typeof globalThis).CSSStyleSheet();
+  }
 
-  // private set _counter(value: number) {
-  //   this._styleCounter = value;
-  // }
-
-  private _insertNode(element: HTMLStyleElement | undefined, rule: string): void {
+  private _insertNode(element: HTMLStyleElement | undefined, rule: string): boolean {
     if (!element) {
-      return;
+      return false;
     }
 
     const { sheet } = element! as HTMLStyleElement;
 
     try {
       (sheet as CSSStyleSheet).insertRule(rule, (sheet as CSSStyleSheet).cssRules.length);
+      return true;
     } catch (e) {
       // The browser will throw exceptions on unsupported rules (such as a moz prefix in webkit.)
       // We need to swallow the exceptions for this scenario, otherwise we'd need to filter
       // which could be slower and bulkier.
     }
+
+    return false;
   }
 
-  private _insertRuleIntoSheet(sheet: CSSStyleSheet | undefined, rule: string): void {
+  private _insertRuleIntoSheet(sheet: CSSStyleSheet | undefined, rule: string): boolean {
     if (!sheet) {
-      return;
+      return false;
     }
 
     try {
       sheet!.insertRule(rule, sheet!.cssRules.length);
+      return true;
     } catch (e) {
       // The browser will throw exceptions on unsupported rules (such as a moz prefix in webkit.)
       // We need to swallow the exceptions for this scenario, otherwise we'd need to filter
       // which could be slower and bulkier.
     }
+
+    return false;
   }
 
-  private _getStyleElement(): HTMLStyleElement | undefined {
-    const win = this._config.ownerWindow ?? window;
+  private _getStyleElement(winArg?: Window): HTMLStyleElement | undefined {
+    const win = winArg ?? this._config.window ?? window;
     const doc = win.document;
     if (!this._styleElement && typeof doc !== 'undefined') {
-      this._styleElement = this._createStyleElement();
+      this._styleElement = this._createStyleElement(winArg);
 
       if (!REUSE_STYLE_NODE) {
         // Reset the style element on the next frame.
@@ -589,15 +648,15 @@ export class Stylesheet {
     return this._styleElement;
   }
 
-  private _createStyleElement(): HTMLStyleElement {
-    const doc = this._config.ownerWindow?.document ?? document;
+  private _createStyleElement(winArg?: Window): HTMLStyleElement {
+    const doc = winArg?.document ?? this._config.window?.document ?? document;
     const head: HTMLHeadElement = doc.head;
     const styleElement = doc.createElement('style');
     let nodeToInsertBefore: Node | null = null;
 
     styleElement.setAttribute('data-merge-styles', 'true');
 
-    if (this._config.currentStylesheetKey === GLOBAL_STYLESHEET_KEY) {
+    if (this._config.stylesheetKey === GLOBAL_STYLESHEET_KEY) {
       styleElement.setAttribute('data-merge-styles-global', 'true');
     }
 
@@ -628,7 +687,7 @@ export class Stylesheet {
   }
 
   private _getCacheKey(key: string): string {
-    const { inShadow = false, currentStylesheetKey = GLOBAL_STYLESHEET_KEY } = this._config;
+    const { inShadow = false, stylesheetKey: currentStylesheetKey = GLOBAL_STYLESHEET_KEY } = this._config;
 
     if (inShadow) {
       return `__${currentStylesheetKey}__${key}`;

--- a/packages/merge-styles/src/cloneCSSStyleSheet.ts
+++ b/packages/merge-styles/src/cloneCSSStyleSheet.ts
@@ -1,0 +1,7 @@
+export const cloneCSSStyleSheet = (srcSheet: CSSStyleSheet, targetSheet: CSSStyleSheet): CSSStyleSheet => {
+  for (let i = 0; i < srcSheet.cssRules.length; i++) {
+    targetSheet.insertRule(srcSheet.cssRules[i].cssText);
+  }
+
+  return targetSheet;
+};

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -42,4 +42,8 @@ export type { ObjectOnly } from './ObjectOnly';
 export { GLOBAL_STYLESHEET_KEY, makeShadowConfig } from './shadowConfig';
 export type { ShadowConfig } from './shadowConfig';
 
+export { cloneCSSStyleSheet } from './cloneCSSStyleSheet';
+
+export type { EventHandler } from './EventMap';
+
 import './version';

--- a/packages/react-charting/src/components/LineChart/__snapshots__/LineChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/LineChart/__snapshots__/LineChartRTL.test.tsx.snap
@@ -430,6 +430,20 @@ exports[`Line chart rendering Should render the Line chart with date x-axis data
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             outline-color: #605e5c;
                           }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            outline-color: #605e5c;
+                          }
                       data-is-focusable="true"
                       role="option"
                       tabindex="0"
@@ -2141,6 +2155,20 @@ exports[`Screen resolution Should remain unchanged on zoom in 1`] = `
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             outline-color: #605e5c;
                           }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            outline-color: #605e5c;
+                          }
                       data-is-focusable="true"
                       role="option"
                       tabindex="0"
@@ -2227,6 +2255,20 @@ exports[`Screen resolution Should remain unchanged on zoom in 1`] = `
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             outline-color: #605e5c;
                           }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            outline-color: #605e5c;
+                          }
                       data-is-focusable="true"
                       role="option"
                       tabindex="-1"
@@ -2311,6 +2353,20 @@ exports[`Screen resolution Should remain unchanged on zoom in 1`] = `
                             z-index: 1;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                            outline-color: #605e5c;
+                          }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
                             outline-color: #605e5c;
                           }
                       data-is-focusable="true"
@@ -2740,6 +2796,20 @@ exports[`Screen resolution Should remain unchanged on zoom out 1`] = `
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             outline-color: #605e5c;
                           }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            outline-color: #605e5c;
+                          }
                       data-is-focusable="true"
                       role="option"
                       tabindex="0"
@@ -2826,6 +2896,20 @@ exports[`Screen resolution Should remain unchanged on zoom out 1`] = `
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             outline-color: #605e5c;
                           }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            outline-color: #605e5c;
+                          }
                       data-is-focusable="true"
                       role="option"
                       tabindex="-1"
@@ -2910,6 +2994,20 @@ exports[`Screen resolution Should remain unchanged on zoom out 1`] = `
                             z-index: 1;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                            outline-color: #605e5c;
+                          }
+                          :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                            border: 1px solid transparent;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
                             outline-color: #605e5c;
                           }
                       data-is-focusable="true"
@@ -3352,6 +3450,20 @@ exports[`Should reflect theme change 1`] = `
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                               outline-color: #a19f9d;
                             }
+                            :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                              border: 1px solid transparent;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #a19f9d;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                              outline-color: #a19f9d;
+                            }
                         data-is-focusable="true"
                         role="option"
                         tabindex="0"
@@ -3438,6 +3550,20 @@ exports[`Should reflect theme change 1`] = `
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                               outline-color: #a19f9d;
                             }
+                            :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                              border: 1px solid transparent;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #a19f9d;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                              outline-color: #a19f9d;
+                            }
                         data-is-focusable="true"
                         role="option"
                         tabindex="-1"
@@ -3522,6 +3648,20 @@ exports[`Should reflect theme change 1`] = `
                               z-index: 1;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                              outline-color: #a19f9d;
+                            }
+                            :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                              border: 1px solid transparent;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #a19f9d;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
                               outline-color: #a19f9d;
                             }
                         data-is-focusable="true"

--- a/packages/react-examples/src/react/ShadowDOM/ShadowHelper.tsx
+++ b/packages/react-examples/src/react/ShadowDOM/ShadowHelper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FocusRectsProvider, MergeStylesRootProvider, MergeStylesShadowRootProvider } from '@fluentui/react';
+import { MergeStylesRootProvider, MergeStylesShadowRootProvider } from '@fluentui/react';
 import root from 'react-shadow';
 
 export type ShadowProps = {
@@ -21,13 +21,9 @@ export const Shadow: React.FC<ShadowProps> = ({ window, children }) => {
 
   return (
     <MergeStylesRootProvider window={window}>
-      <FocusRectsProvider providerRef={ref}>
-        <root.div className="shadow-root" delegatesFocus ref={ref}>
-          <MergeStylesShadowRootProvider shadowRoot={shadowRootEl?.shadowRoot}>
-            {children}
-          </MergeStylesShadowRootProvider>
-        </root.div>
-      </FocusRectsProvider>
+      <root.div className="shadow-root" delegatesFocus ref={ref}>
+        <MergeStylesShadowRootProvider shadowRoot={shadowRootEl?.shadowRoot}>{children}</MergeStylesShadowRootProvider>
+      </root.div>
     </MergeStylesRootProvider>
   );
 };

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@fluentui/dom-utilities": "^2.2.12",
     "@fluentui/merge-styles": "^8.5.13",
+    "@fluentui/react-window-provider": "^2.2.16",
     "@fluentui/set-version": "^8.2.12",
     "tslib": "^2.1.0"
   },

--- a/packages/utilities/src/shadowDom/MergeStylesRootContext.tsx
+++ b/packages/utilities/src/shadowDom/MergeStylesRootContext.tsx
@@ -65,7 +65,7 @@ export const MergeStylesRootProvider: React.FC<MergeStylesRootProviderProps> = (
       return;
     }
 
-    const sheet = Stylesheet.getInstance();
+    const sheet = Stylesheet.getInstance(makeShadowConfig(GLOBAL_STYLESHEET_KEY, false, win));
 
     sheet.onAddConstructableStyleSheet(sheetHandler);
 

--- a/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
+++ b/packages/utilities/src/shadowDom/MergeStylesShadowRootContext.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { GLOBAL_STYLESHEET_KEY, makeShadowConfig } from '@fluentui/merge-styles';
+import {
+  GLOBAL_STYLESHEET_KEY,
+  Stylesheet,
+  makeShadowConfig,
+  cloneCSSStyleSheet,
+  EventHandler,
+} from '@fluentui/merge-styles';
 import { useMergeStylesRootStylesheets } from './MergeStylesRootContext';
+import { useDocument, useWindow } from '@fluentui/react-window-provider';
+
+type PolyfileInsertListeners = Record<string, EventHandler<CSSStyleSheet>>;
 
 export type MergeStylesShadowRootContextValue = {
   /**
@@ -74,6 +83,22 @@ const GlobalStyles: React.FC = props => {
 export const useAdoptedStylesheet = (stylesheetKey: string): boolean => {
   const shadowCtx = useMergeStylesShadowRootContext();
   const rootMergeStyles = useMergeStylesRootStylesheets();
+  const doc = useDocument();
+  const win = useWindow();
+  // console.log(doc?.defaultView.__SENTINAL__);
+  const polyfillInsertListners = React.useRef<PolyfileInsertListeners>({});
+
+  React.useEffect(() => {
+    const polyfillListeners = polyfillInsertListners.current;
+    polyfillInsertListners.current = {};
+
+    return () => {
+      const sheet = Stylesheet.getInstance(makeShadowConfig(stylesheetKey, true, win));
+      Object.keys(polyfillListeners).forEach(key => {
+        sheet.offInsertRuleIntoConstructableStyleSheet(polyfillListeners[key]);
+      });
+    };
+  }, [win, stylesheetKey]);
 
   if (!shadowCtx) {
     return false;
@@ -81,13 +106,61 @@ export const useAdoptedStylesheet = (stylesheetKey: string): boolean => {
 
   if (shadowCtx.shadowRoot && !shadowCtx.stylesheets.has(stylesheetKey)) {
     const adoptableStyleSheet = rootMergeStyles.get(stylesheetKey);
-    if (adoptableStyleSheet) {
-      shadowCtx.stylesheets.set(stylesheetKey, adoptableStyleSheet);
-      shadowCtx.shadowRoot.adoptedStyleSheets = [...shadowCtx.shadowRoot.adoptedStyleSheets, adoptableStyleSheet];
+    if (adoptableStyleSheet && doc) {
+      adoptSheet(shadowCtx, doc, stylesheetKey, adoptableStyleSheet, polyfillInsertListners.current);
     }
   }
 
   return true;
+};
+
+const updatePolyfillSheet = (shadowCtx: MergeStylesShadowRootContextValue, stylesheetKey: string, rule: string) => {
+  const shadowRoot = shadowCtx.shadowRoot!;
+  const style = shadowRoot.querySelector(`[data-merge-styles-stylesheet-key="${stylesheetKey}"]`) as HTMLStyleElement;
+  if (style?.sheet) {
+    style.sheet.insertRule(rule);
+  }
+};
+
+const adoptSheet = (
+  shadowCtx: MergeStylesShadowRootContextValue,
+  doc: Document,
+  stylesheetKey: string,
+  stylesheet: CSSStyleSheet,
+  listenerRef: PolyfileInsertListeners,
+) => {
+  const shadowRoot = shadowCtx.shadowRoot!;
+
+  shadowCtx.stylesheets.set(stylesheetKey, stylesheet);
+  if (Stylesheet.getInstance().supportsConstructableStylesheets()) {
+    shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, stylesheet];
+  } else {
+    const style = doc.createElement('style');
+    style.setAttribute('data-merge-styles-stylesheet-key', stylesheetKey);
+
+    const otherStyles = shadowRoot.querySelectorAll('[data-merge-styles-stylesheet-key]');
+    if (otherStyles.length > 0) {
+      shadowRoot.insertBefore(style, otherStyles[otherStyles.length - 1].nextSibling);
+    } else {
+      shadowRoot.insertBefore(style, shadowRoot.firstChild);
+    }
+
+    if (style.sheet) {
+      cloneCSSStyleSheet(stylesheet, style.sheet);
+      if (!listenerRef[stylesheetKey]) {
+        const onInsert: EventHandler<CSSStyleSheet> = ({ key, rule }) => {
+          if (key === stylesheetKey) {
+            if (shadowCtx && rule) {
+              updatePolyfillSheet(shadowCtx, key, rule);
+            }
+          }
+        };
+        const sheet = Stylesheet.getInstance(makeShadowConfig(stylesheetKey, true, doc.defaultView ?? undefined));
+        sheet.onInsertRuleIntoConstructableStyleSheet(onInsert);
+        listenerRef[stylesheetKey] = onInsert;
+      }
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
## Previous Behavior

Shadow DOM styles would not work for browsers that do not support `adoptedStylesheets`.

## New Behavior

Shadow DOM styling works for all browsers in Fluent's browser support matrix. Additionally, we now prefer the latest version of the `adoptedStylesheets` spec which allows the array to be mutated. Previously a new array had to be set to update `adoptedStylesheets`. [Using this updated spec also works around a Safari bug](https://github.com/microsoft/fast/pull/6703).

For browsers that do not support adoptedStylesheets/constructable stylesheets we implement a polyfill that copies styles into `<style>` tags inside appropriate shadow roots. Effectively, this produces the same result as using adoptedStylesheets as elements within the shadow root are styled correctly and the styles are scoped to the shadow root. However, it requires more memory as styles are copied and bookkeeping as we need to keep track of which styles need to be copied. Fortunately, so far as Fluent's support matrix is concerned, this only applies to Safari < 16.4.

To minimize the amount of extra code and paths through the code, the polyfill relies on the infrastructure for the native adopted/constructable stylesheets and only changes how the styles are rendered into the document.

## Related Issue(s)

- Fixes #29517
