### PR TITLE
chore: Remove useless northstar aliases

### DIFF
--- a/packages/fluentui/react-northstar/tsconfig.json
+++ b/packages/fluentui/react-northstar/tsconfig.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist/dts",
-    "types": ["node", "jest", "@testing-library/jest-dom"],
-    "paths": {
-      "src/*": ["packages/fluentui/react-northstar/src/*"],
-      "test/*": ["packages/fluentui/react-northstar/test/*"]
-    }
+    "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": ["src", "test"],
   "references": [


### PR DESCRIPTION
Removes useless northstar aliases - should fix alias resolution for `test-ssr` which is blocking #29975
