### PR TITLE
fix(TimePickerCompat): adjust max-height on listbox

### DIFF
--- a/change/@fluentui-react-timepicker-compat-preview-251d04e7-2406-47f7-bf91-521709b2008d.json
+++ b/change/@fluentui-react-timepicker-compat-preview-251d04e7-2406-47f7-bf91-521709b2008d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add max-height to show 12 items in listbox",
+  "packageName": "@fluentui/react-timepicker-compat-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -12,7 +12,7 @@ export const timePickerClassNames: SlotClassNames<TimePickerSlots> = {
 
 const useStyles = makeStyles({
   listbox: {
-    maxHeight: '416px', // height for 12 items
+    maxHeight: 'min(80vh, 416px)', // height for 12 items or 80vh, whichever is smaller
   },
 });
 

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -1,4 +1,4 @@
-import { mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TimePickerSlots, TimePickerState } from './TimePicker.types';
 import { useComboboxStyles_unstable } from '@fluentui/react-combobox';
@@ -10,11 +10,17 @@ export const timePickerClassNames: SlotClassNames<TimePickerSlots> = {
   listbox: 'fui-TimePicker__listbox',
 };
 
+const useStyles = makeStyles({
+  listbox: {
+    maxHeight: '416px', // height for 12 items
+  },
+});
+
 /**
  * Apply styling to the TimePicker slots based on the state
  */
 export const useTimePickerStyles_unstable = (state: TimePickerState): TimePickerState => {
-  useComboboxStyles_unstable(state);
+  const styles = useStyles();
 
   state.root.className = mergeClasses(timePickerClassNames.root, state.root.className);
 
@@ -25,8 +31,10 @@ export const useTimePickerStyles_unstable = (state: TimePickerState): TimePicker
   }
 
   if (state.listbox) {
-    state.listbox.className = mergeClasses(timePickerClassNames.listbox, state.listbox.className);
+    state.listbox.className = mergeClasses(timePickerClassNames.listbox, styles.listbox, state.listbox.className);
   }
+
+  useComboboxStyles_unstable(state);
 
   return state;
 };


### PR DESCRIPTION
fix #29882 

Combobox by default has 80vh maxHeight for listbox. This PR uses `min(80vh, 416px)` for TimePicker, showing maximum 12 item instead of a long list in large viewport:
<img width="356" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/49ed909a-3f9f-4ca1-bcc7-43129013dfd2">
