### PR TITLE
fix: Virtual parent cannot be the DOM child of mount node

### DIFF
--- a/change/@fluentui-react-portal-757b09a6-46f6-4e6f-beca-09f6c25b1022.json
+++ b/change/@fluentui-react-portal-757b09a6-46f6-4e6f-beca-09f6c25b1022.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Virtual parent cannot be the DOM child of mount node",
+  "packageName": "@fluentui/react-portal",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-portal/src/components/Portal/Portal.test.tsx
+++ b/packages/react-components/react-portal/src/components/Portal/Portal.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { FluentProvider } from '@fluentui/react-provider';
+import { getParent } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { Portal } from './Portal';
@@ -39,5 +40,23 @@ describe('Portal', () => {
     expect(element).toHaveStyle({
       zIndex: 1000000,
     });
+  });
+
+  it('should not set virtual parent if mount node contains virtual parent', () => {
+    const Test = () => {
+      const [el, setEl] = React.useState<HTMLDivElement | null>(null);
+      return (
+        <div id="parent">
+          <div id="container" ref={setEl}>
+            <Portal mountNode={el}>Foo</Portal>
+          </div>
+        </div>
+      );
+    };
+
+    const { container } = render(<Test />);
+
+    const mountNode = container.querySelector<HTMLSpanElement>('#container');
+    expect((getParent(mountNode) as HTMLElement).id).toBe('parent');
   });
 });

--- a/packages/react-components/react-portal/src/components/Portal/usePortal.ts
+++ b/packages/react-components/react-portal/src/components/Portal/usePortal.ts
@@ -25,15 +25,16 @@ export const usePortal_unstable = (props: PortalProps): PortalState => {
   };
 
   React.useEffect(() => {
-    if (state.virtualParentRootRef.current && state.mountNode) {
-      setVirtualParent(state.mountNode, state.virtualParentRootRef.current);
+    const virtualParent = virtualParentRootRef.current;
+    if (virtualParent && state.mountNode && !state.mountNode.contains(virtualParent)) {
+      setVirtualParent(state.mountNode, virtualParent);
+      return () => {
+        if (state.mountNode) {
+          setVirtualParent(state.mountNode, undefined);
+        }
+      };
     }
-    return () => {
-      if (state.mountNode) {
-        setVirtualParent(state.mountNode, undefined);
-      }
-    };
-  }, [state.virtualParentRootRef, state.mountNode]);
+  }, [virtualParentRootRef, state.mountNode]);
 
   return state;
 };


### PR DESCRIPTION
Currently a portal can be mounted in a DOM parent of its virtual parent span. This PR does a validation of this case and when it happens - does not set the virtual parent.

Fixes #29991