### PR TITLE
feat(useActiveDescendant): Changing active descendant scrolls into view

### DIFF
--- a/change/@fluentui-react-aria-aa625e96-b6ea-4a15-9d18-ae66a8bf4577.json
+++ b/change/@fluentui-react-aria-aa625e96-b6ea-4a15-9d18-ae66a8bf4577.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(useActiveDescendant): Changing active descendant scrolls into view",
+  "packageName": "@fluentui/react-aria",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
During the change to the next active descendant, check if it needs to be scrolled into view and do so.

Addresses #26652 