### PR TITLE
chore(react-motions): flatten AtomMotion type

### DIFF
--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -18,8 +18,7 @@ export { atom }
 // @public (undocumented)
 export type AtomMotion = {
     keyframes: Keyframe[];
-    options: KeyframeEffectOptions;
-};
+} & KeyframeEffectOptions;
 
 // @public
 export function createAtom(motion: AtomMotion): React_2.FC<AtomProps>;

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
@@ -6,9 +6,8 @@ import { createAtom } from './createAtom';
 
 const motion: AtomMotion = {
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
-  options: {
-    duration: 500,
-  },
+
+  duration: 500,
 };
 
 function createElementMock() {
@@ -42,7 +41,7 @@ describe('createAtom', () => {
     );
 
     expect(animateMock).toHaveBeenCalledWith(motion.keyframes, {
-      ...motion.options,
+      duration: motion.duration,
       fill: 'forwards',
       iterations: 1,
     });

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.ts
@@ -35,10 +35,11 @@ export function createAtom(motion: AtomMotion) {
       const element = elementRef.current;
 
       if (element) {
-        const animation = element.animate(motion.keyframes, {
+        const { keyframes, ...options } = motion;
+        const animation = element.animate(keyframes, {
           fill: 'forwards',
 
-          ...motion.options,
+          ...options,
           iterations,
 
           ...(isReducedMotion() && { duration: 1 }),

--- a/packages/react-components/react-motions-preview/src/factories/createPresence.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createPresence.test.tsx
@@ -4,20 +4,18 @@ import * as React from 'react';
 import type { PresenceMotion } from '../types';
 import { createPresence } from './createPresence';
 
-const presence: PresenceMotion = {
+const motion: PresenceMotion = {
   enter: {
     keyframes: [{ opacity: 0 }, { opacity: 1 }],
-    options: {
-      duration: 500,
-      fill: 'forwards',
-    },
+
+    duration: 500,
+    fill: 'forwards',
   },
   exit: {
     keyframes: [{ opacity: 0 }, { opacity: 1 }],
-    options: {
-      duration: 500,
-      fill: 'forwards',
-    },
+
+    duration: 500,
+    fill: 'forwards',
   },
 };
 
@@ -46,7 +44,7 @@ function createElementMock() {
 describe('createPresence', () => {
   describe('appear', () => {
     it('does not animate by default', () => {
-      const TestAtom = createPresence(presence);
+      const TestAtom = createPresence(motion);
       const { animateMock, ElementMock } = createElementMock();
 
       render(
@@ -59,7 +57,9 @@ describe('createPresence', () => {
     });
 
     it('animates when is "true"', () => {
-      const TestAtom = createPresence(presence);
+      const { keyframes, ...options } = motion.enter;
+      const TestAtom = createPresence(motion);
+
       const { animateMock, ElementMock } = createElementMock();
 
       render(
@@ -68,13 +68,15 @@ describe('createPresence', () => {
         </TestAtom>,
       );
 
-      expect(animateMock).toHaveBeenCalledWith(presence.enter.keyframes, presence.enter.options);
+      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
     });
   });
 
   describe('visible', () => {
     it('animates when state changes', () => {
-      const TestAtom = createPresence(presence);
+      const { keyframes, ...options } = motion.exit;
+      const TestAtom = createPresence(motion);
+
       const { animateMock, ElementMock } = createElementMock();
 
       const { rerender } = render(
@@ -91,13 +93,15 @@ describe('createPresence', () => {
         </TestAtom>,
       );
 
-      expect(animateMock).toHaveBeenCalledWith(presence.exit.keyframes, presence.exit.options);
+      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
     });
   });
 
   describe('unmountOnExit', () => {
     it('unmounts when state changes', () => {
-      const TestAtom = createPresence(presence);
+      const { keyframes, ...options } = motion.enter;
+      const TestAtom = createPresence(motion);
+
       const { animateMock, ElementMock } = createElementMock();
 
       const { rerender, queryByText } = render(
@@ -116,7 +120,7 @@ describe('createPresence', () => {
       );
 
       expect(queryByText('ElementMock')).toBe(null);
-      expect(animateMock).toHaveBeenCalledWith(presence.exit.keyframes, presence.exit.options);
+      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
     });
   });
 });

--- a/packages/react-components/react-motions-preview/src/factories/createPresence.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresence.ts
@@ -46,10 +46,11 @@ export function createPresence(motion: PresenceMotion) {
       }
 
       if (elementRef.current) {
-        const animation = elementRef.current.animate(motion.exit.keyframes, {
+        const { keyframes, ...options } = motion.exit;
+        const animation = elementRef.current.animate(keyframes, {
           fill: 'forwards',
 
-          ...motion.exit.options,
+          ...options,
           ...(isReducedMotion() && { duration: 1 }),
         });
 
@@ -78,10 +79,11 @@ export function createPresence(motion: PresenceMotion) {
       const shouldEnter = isFirstMount.current ? appear && visible : mounted && visible;
 
       if (shouldEnter) {
-        const animation = elementRef.current.animate(motion.enter.keyframes, {
+        const { keyframes, ...options } = motion.enter;
+        const animation = elementRef.current.animate(keyframes, {
           fill: 'forwards',
 
-          ...motion.enter.options,
+          ...options,
           ...(isReducedMotion() && { duration: 1 }),
         });
 

--- a/packages/react-components/react-motions-preview/src/motions/atom/fade.ts
+++ b/packages/react-components/react-motions-preview/src/motions/atom/fade.ts
@@ -20,58 +20,51 @@ export type FadeParams = {
 
 export const enterUltraFast = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationUltraFast,
-    easing: easingLinear,
-  },
+
+  duration: durationUltraFast,
+  easing: easingLinear,
 });
 
 export const enterFaster = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationFaster,
-    easing: easingLinear,
-  },
+
+  duration: durationFaster,
+  easing: easingLinear,
 });
 
 export const enterFast = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationFast,
-    easing: easingLinear,
-  },
+
+  duration: durationFast,
+  easing: easingLinear,
 });
 
 export const enterNormal = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationNormal,
-    easing: easingLinear,
-  },
+
+  duration: durationNormal,
+  easing: easingLinear,
 });
 
 export const enterSlow = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationSlow,
-    easing: easingLinear,
-  },
+
+  duration: durationSlow,
+  easing: easingLinear,
 });
 
 export const enterSlower = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationSlower,
-    easing: easingLinear,
-  },
+
+  duration: durationSlower,
+  easing: easingLinear,
 });
 
 export const enterUltraSlow = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: fromValue }, { opacity: 1 }],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingLinear,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingLinear,
 });
 
 // Fade Outs
@@ -79,56 +72,49 @@ export const enterUltraSlow = ({ fromValue = 0 }: FadeParams = {}): AtomMotion =
 
 export const exitUltraFast = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationUltraFast,
-    easing: easingLinear,
-  },
+
+  duration: durationUltraFast,
+  easing: easingLinear,
 });
 
 export const exitFaster = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationFaster,
-    easing: easingLinear,
-  },
+
+  duration: durationFaster,
+  easing: easingLinear,
 });
 
 export const exitFast = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationFast,
-    easing: easingLinear,
-  },
+
+  duration: durationFast,
+  easing: easingLinear,
 });
 
 export const exitNormal = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationNormal,
-    easing: easingLinear,
-  },
+
+  duration: durationNormal,
+  easing: easingLinear,
 });
 
 export const exitSlow = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationSlow,
-    easing: easingLinear,
-  },
+
+  duration: durationSlow,
+  easing: easingLinear,
 });
 
 export const exitSlower = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationSlower,
-    easing: easingLinear,
-  },
+
+  duration: durationSlower,
+  easing: easingLinear,
 });
 
 export const exitUltraSlow = ({ fromValue = 0 }: FadeParams = {}): AtomMotion => ({
   keyframes: [{ opacity: 1 }, { opacity: fromValue }],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingLinear,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingLinear,
 });

--- a/packages/react-components/react-motions-preview/src/motions/atom/scale.ts
+++ b/packages/react-components/react-motions-preview/src/motions/atom/scale.ts
@@ -23,10 +23,9 @@ export const enterUltraFast = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMoti
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingDecelerateMax,
 });
 
 export const enterFaster = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -34,10 +33,9 @@ export const enterFaster = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion 
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingDecelerateMax,
 });
 
 export const enterFast = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -45,10 +43,9 @@ export const enterFast = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion =>
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingDecelerateMax,
 });
 
 export const enterNormal = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -56,10 +53,9 @@ export const enterNormal = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion 
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingDecelerateMax,
 });
 
 export const enterSlow = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -67,10 +63,9 @@ export const enterSlow = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion =>
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingDecelerateMax,
 });
 
 export const enterSlower = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -78,10 +73,9 @@ export const enterSlower = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion 
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingDecelerateMax,
 });
 
 export const enterUltraSlow = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -89,10 +83,9 @@ export const enterUltraSlow = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMoti
     { transform: `scale(${fromValue})`, opacity: 0 },
     { transform: 'scale(1)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingDecelerateMax,
 });
 
 // Scale Outs
@@ -103,10 +96,9 @@ export const exitUltraFast = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingAccelerateMax,
 });
 
 export const exitFaster = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion => ({
@@ -114,10 +106,9 @@ export const exitFaster = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion =>
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const exitFast = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -125,10 +116,9 @@ export const exitFast = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => 
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingAccelerateMax,
 });
 
 export const exitNormal = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion => ({
@@ -136,10 +126,9 @@ export const exitNormal = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion =>
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingAccelerateMax,
 });
 
 export const exitSlow = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion => ({
@@ -147,10 +136,9 @@ export const exitSlow = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion => (
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingAccelerateMax,
 });
 
 export const exitSlower = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion => ({
@@ -158,10 +146,9 @@ export const exitSlower = ({ fromValue = 0.9 }: ScaleParams = {}): AtomMotion =>
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingAccelerateMax,
 });
 
 export const exitUltraSlow = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotion => ({
@@ -169,8 +156,7 @@ export const exitUltraSlow = ({ fromValue = 0.88 }: ScaleParams = {}): AtomMotio
     { transform: 'scale(1)', opacity: 1 },
     { transform: `scale(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingAccelerateMax,
 });

--- a/packages/react-components/react-motions-preview/src/motions/atom/slide.ts
+++ b/packages/react-components/react-motions-preview/src/motions/atom/slide.ts
@@ -23,10 +23,9 @@ export const downEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): At
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingDecelerateMax,
 });
 
 export const downEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -34,10 +33,9 @@ export const downEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingDecelerateMax,
 });
 
 export const downEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -45,10 +43,9 @@ export const downEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingDecelerateMax,
 });
 
 export const downEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -56,10 +53,9 @@ export const downEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingDecelerateMax,
 });
 
 export const downEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -67,10 +63,9 @@ export const downEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingDecelerateMax,
 });
 
 export const downEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -78,10 +73,9 @@ export const downEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingDecelerateMax,
 });
 
 export const downEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -89,10 +83,9 @@ export const downEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): At
     { transform: `translateY(-${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingDecelerateMax,
 });
 
 // Slide Up Ins
@@ -103,10 +96,9 @@ export const upEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): Atom
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingDecelerateMax,
 });
 
 export const upEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -114,10 +106,9 @@ export const upEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingDecelerateMax,
 });
 
 export const upEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -125,10 +116,9 @@ export const upEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotio
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingDecelerateMax,
 });
 
 export const upEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -136,10 +126,9 @@ export const upEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingDecelerateMax,
 });
 
 export const upEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -147,10 +136,9 @@ export const upEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotio
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingDecelerateMax,
 });
 
 export const upEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -158,10 +146,9 @@ export const upEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingDecelerateMax,
 });
 
 export const upEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -169,10 +156,9 @@ export const upEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): Atom
     { transform: `translateY(${fromValue})`, opacity: 0 },
     { transform: 'translateY(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingDecelerateMax,
 });
 
 // Slide Left Ins
@@ -183,10 +169,9 @@ export const leftEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): At
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingDecelerateMax,
 });
 
 export const leftEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -194,10 +179,9 @@ export const leftEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingDecelerateMax,
 });
 
 export const leftEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -205,10 +189,9 @@ export const leftEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingDecelerateMax,
 });
 
 export const leftEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -216,10 +199,9 @@ export const leftEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingDecelerateMax,
 });
 
 export const leftEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -227,10 +209,9 @@ export const leftEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingDecelerateMax,
 });
 
 export const leftEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -238,10 +219,9 @@ export const leftEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingDecelerateMax,
 });
 
 export const leftEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -249,10 +229,9 @@ export const leftEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): At
     { transform: `translateX(${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingDecelerateMax,
 });
 
 // Slide Right Ins
@@ -263,10 +242,9 @@ export const rightEnterUltraFast = ({ fromValue = '20px' }: SlideParams = {}): A
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingDecelerateMax,
 });
 
 export const rightEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -274,10 +252,9 @@ export const rightEnterFaster = ({ fromValue = '20px' }: SlideParams = {}): Atom
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingDecelerateMax,
 });
 
 export const rightEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -285,10 +262,9 @@ export const rightEnterFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationFast,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationFast,
+  easing: easingDecelerateMax,
 });
 
 export const rightEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -296,10 +272,9 @@ export const rightEnterNormal = ({ fromValue = '20px' }: SlideParams = {}): Atom
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingDecelerateMax,
 });
 
 export const rightEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -307,10 +282,9 @@ export const rightEnterSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingDecelerateMax,
 });
 
 export const rightEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -318,10 +292,9 @@ export const rightEnterSlower = ({ fromValue = '20px' }: SlideParams = {}): Atom
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingDecelerateMax,
 });
 
 export const rightEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -329,10 +302,9 @@ export const rightEnterUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): A
     { transform: `translateX(-${fromValue})`, opacity: 0 },
     { transform: 'translateX(0px)', opacity: 1 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingDecelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingDecelerateMax,
 });
 
 // Slide Down Outs
@@ -343,10 +315,9 @@ export const downExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): Ato
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingAccelerateMax,
 });
 
 export const downExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -354,10 +325,9 @@ export const downExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const downExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -365,10 +335,9 @@ export const downExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const downExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -376,10 +345,9 @@ export const downExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingAccelerateMax,
 });
 
 export const downExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -387,10 +355,9 @@ export const downExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingAccelerateMax,
 });
 
 export const downExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -398,10 +365,9 @@ export const downExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingAccelerateMax,
 });
 
 export const downExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -409,10 +375,9 @@ export const downExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): Ato
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingAccelerateMax,
 });
 
 // Slide Up Outs
@@ -423,10 +388,9 @@ export const upExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingAccelerateMax,
 });
 
 export const upExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -434,10 +398,9 @@ export const upExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const upExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -445,10 +408,9 @@ export const upExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const upExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -456,10 +418,9 @@ export const upExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingAccelerateMax,
 });
 
 export const upExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -467,10 +428,9 @@ export const upExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingAccelerateMax,
 });
 
 export const upExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -478,10 +438,9 @@ export const upExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingAccelerateMax,
 });
 
 export const upExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -489,10 +448,9 @@ export const upExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: 'translateY(0px)', opacity: 1 },
     { transform: `translateY(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingAccelerateMax,
 });
 
 // Slide Right Outs
@@ -503,10 +461,9 @@ export const rightExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): At
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingAccelerateMax,
 });
 //
 export const rightExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -514,10 +471,9 @@ export const rightExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const rightExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -525,10 +481,9 @@ export const rightExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const rightExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -536,10 +491,9 @@ export const rightExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingAccelerateMax,
 });
 
 export const rightExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -547,10 +501,9 @@ export const rightExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMot
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingAccelerateMax,
 });
 
 export const rightExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -558,10 +511,9 @@ export const rightExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomM
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingAccelerateMax,
 });
 
 export const rightExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -569,10 +521,9 @@ export const rightExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): At
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingAccelerateMax,
 });
 
 // Slide Left Outs
@@ -583,10 +534,9 @@ export const leftExitUltraFast = ({ fromValue = '20px' }: SlideParams = {}): Ato
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraFast,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraFast,
+  easing: easingAccelerateMax,
 });
 
 export const leftExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -594,10 +544,9 @@ export const leftExitFaster = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const leftExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -605,10 +554,9 @@ export const leftExitFast = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationFaster,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationFaster,
+  easing: easingAccelerateMax,
 });
 
 export const leftExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -616,10 +564,9 @@ export const leftExitNormal = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationNormal,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationNormal,
+  easing: easingAccelerateMax,
 });
 
 export const leftExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -627,10 +574,9 @@ export const leftExitSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMoti
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlow,
+  easing: easingAccelerateMax,
 });
 
 export const leftExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -638,10 +584,9 @@ export const leftExitSlower = ({ fromValue = '20px' }: SlideParams = {}): AtomMo
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationSlower,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationSlower,
+  easing: easingAccelerateMax,
 });
 
 export const leftExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): AtomMotion => ({
@@ -649,8 +594,7 @@ export const leftExitUltraSlow = ({ fromValue = '20px' }: SlideParams = {}): Ato
     { transform: 'translateX(0px)', opacity: 1 },
     { transform: `translateX(-${fromValue})`, opacity: 0 },
   ],
-  options: {
-    duration: durationUltraSlow,
-    easing: easingAccelerateMax,
-  },
+
+  duration: durationUltraSlow,
+  easing: easingAccelerateMax,
 });

--- a/packages/react-components/react-motions-preview/src/types.ts
+++ b/packages/react-components/react-motions-preview/src/types.ts
@@ -1,7 +1,4 @@
-export type AtomMotion = {
-  keyframes: Keyframe[];
-  options: KeyframeEffectOptions;
-};
+export type AtomMotion = { keyframes: Keyframe[] } & KeyframeEffectOptions;
 
 export type PresenceMotion = {
   enter: AtomMotion;

--- a/packages/react-components/react-motions-preview/stories/Motion/CustomAtom.stories.md
+++ b/packages/react-components/react-motions-preview/stories/Motion/CustomAtom.stories.md
@@ -11,7 +11,7 @@ const AtomMotion: AtomMotion = {
   // opacity will be animated from 0 to 1
   keyframes: { opacity: [0, 1] },
   // duration of the animation will be "1000ms"
-  options: { duration: 1000 },
+  duration: 1000,
 };
 ```
 
@@ -24,14 +24,14 @@ const enterAtom = {
   // opacity will be animated from 0 to 1
   keyframes: { opacity: [0, 1] },
   // duration of the animation will be "1000ms"
-  options: { duration: 1000 },
+  duration: 1000,
 };
 
 const exitAtom = {
   // opacity will be animated from 1 to 0
   keyframes: { opacity: [1, 0] },
   // duration of the animation will be "500ms"
-  options: { duration: 500 },
+  duration: 500,
 };
 
 const presense: PresenceMotion = {

--- a/packages/react-components/react-motions-preview/stories/Motion/CustomAtom.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/Motion/CustomAtom.stories.tsx
@@ -37,7 +37,7 @@ const dropInMotion: AtomMotion = {
     { transform: 'rotate(-30deg) translateY(-100%)', opacity: 0 },
     { transform: 'rotate(0deg) translateY(0%)', opacity: 1 },
   ],
-  options: { duration: 4000 },
+  duration: 4000,
 };
 
 const DropIn = createAtom(dropInMotion);

--- a/packages/react-components/react-motions-preview/stories/Motion/TokensUsage.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/Motion/TokensUsage.stories.tsx
@@ -37,7 +37,7 @@ const dropInMotion: AtomMotion = {
     { backgroundColor: tokens.colorStatusDangerBackground3 },
     { backgroundColor: tokens.colorStatusSuccessBackground3 },
   ],
-  options: { duration: 3000 },
+  duration: 3000,
 };
 
 const BackgroundChange = createAtom(dropInMotion);


### PR DESCRIPTION
## New Behavior

This PR change the signature of `AtomMotion`:

```ts
export type AtomMotion = {
  keyframes: Keyframe[];
  options: KeyframeEffectOptions;
}

// ⬇️⬇️⬇️

export type AtomMotion = { keyframes: Keyframe[] } & KeyframeEffectOptions;
```

This makes overrides easier, for example:

```tsx
const fadeEnterSlow = atom.fade.enterSlow();
const motion = {
  keyframes: fadeEnterSlow.keyframes,
  options: {
    ...fadeEnterSlow.options,
    duration: 3000,
  }
}

// ⬇️⬇️⬇️

const motion = {
  ...atom.fade.enterSlow(),
  duration: 3000,
}
```