### PR TITLE
fix: ThemeProvider overrides Customizers scopedSettings

### DIFF
--- a/change/@fluentui-react-4100933e-220c-4705-b8cf-b94f39310d68.json
+++ b/change/@fluentui-react-4100933e-220c-4705-b8cf-b94f39310d68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[BugFix] ThemeProvider will now respect scopeSettings from Customizer",
+  "packageName": "@fluentui/react",
+  "email": "aviellavie@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-9349024b-38e9-4eeb-870f-743f82e759bc.json
+++ b/change/@fluentui-utilities-9349024b-38e9-4eeb-870f-743f82e759bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[BugFix] ThemeProvider will now respect scopeSettings from Customizer",
+  "packageName": "@fluentui/utilities",
+  "email": "aviellavie@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/ThemeProvider/useTheme.ts
+++ b/packages/react/src/utilities/ThemeProvider/useTheme.ts
@@ -8,7 +8,8 @@ import type { ITheme, Theme } from '@fluentui/theme';
  * Get theme from CustomizerContext or Customizations singleton.
  */
 function useCompatTheme(): ITheme | undefined {
-  return useCustomizationSettings(['theme']).theme;
+  const customizationSettings = useCustomizationSettings(['theme', 'scopedSettings']);
+  return { ...customizationSettings.theme, components: customizationSettings.scopedSettings };
 }
 
 /**

--- a/packages/utilities/src/customizations/Customizations.ts
+++ b/packages/utilities/src/customizations/Customizations.ts
@@ -66,6 +66,10 @@ export class Customizations {
     const globalScopedSettings = (scopeName && _allSettings.scopedSettings[scopeName]) || {};
 
     for (let property of properties) {
+      if (property === 'scopedSettings') {
+        settings[property] = localSettings.scopedSettings || _allSettings.scopedSettings;
+      }
+
       settings[property] =
         localScopedSettings[property] ||
         localSettings.settings[property] ||


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

ThemeProvider overrides scopedSettings

## New Behavior

ThemeProvider inherits scopedSettings

## Related Issue(s)

[<!-- Please link the issue being fixed so it gets closed when this is merged. -->
](https://github.com/microsoft/fluentui/issues/29997)

- Fixes #

* useTheme