### PR TITLE
fix:  partitionBreadcrumbItems miscalculated endDisplayedItems

### DIFF
--- a/change/@fluentui-react-breadcrumb-2228ee26-b0d3-42d8-af23-5e24fc4f605d.json
+++ b/change/@fluentui-react-breadcrumb-2228ee26-b0d3-42d8-af23-5e24fc4f605d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "partitionBreadcrumbItems miscalculated endDisplayedItems when endDisplayedItems is incorrect when numberOfItemsToHide <= 0",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "GordonJSmith@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb/src/utils/partitionBreadcrumbItems.test.ts
+++ b/packages/react-components/react-breadcrumb/src/utils/partitionBreadcrumbItems.test.ts
@@ -1,6 +1,9 @@
 import { partitionBreadcrumbItems, PartitionBreadcrumbItemsOptions } from './partitionBreadcrumbItems';
+
+type TestData = [PartitionBreadcrumbItemsOptions<number>, ReturnType<typeof partitionBreadcrumbItems>][];
+
 const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-const testData = [
+const testData: TestData = [
   [
     { items, overflowIndex: 2, maxDisplayedItems: 3 },
     { startDisplayedItems: [0, 1], overflowItems: [2, 3, 4, 5, 6, 7, 8, 9], endDisplayedItems: [10] },
@@ -25,9 +28,21 @@ const testData = [
     { items, maxDisplayedItems: 9, overflowIndex: 9 },
     { startDisplayedItems: [0, 1, 2, 3, 4, 5, 6, 7], overflowItems: [8, 9], endDisplayedItems: [10] },
   ],
+  [
+    { items, maxDisplayedItems: 999, overflowIndex: 999 },
+    { startDisplayedItems: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], overflowItems: undefined, endDisplayedItems: undefined },
+  ],
+  [
+    { items, maxDisplayedItems: 11, overflowIndex: 11 },
+    { startDisplayedItems: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], overflowItems: undefined, endDisplayedItems: undefined },
+  ],
 ];
 
-const maxDisplayedItemsData = [
+const maxDisplayedItemsData: TestData = [
+  [
+    { items, maxDisplayedItems: 999 },
+    { startDisplayedItems: [0], overflowItems: undefined, endDisplayedItems: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+  ],
   [
     { items, maxDisplayedItems: 3 },
     { startDisplayedItems: [0], overflowItems: [1, 2, 3, 4, 5, 6, 7, 8], endDisplayedItems: [9, 10] },
@@ -37,7 +52,19 @@ const maxDisplayedItemsData = [
     { startDisplayedItems: [0], overflowItems: [1, 2, 3, 4, 5, 6, 7, 8, 9], endDisplayedItems: [10] },
   ],
 ];
-const overflowIndexData = [
+const overflowIndexData: TestData = [
+  [
+    { items, overflowIndex: 999 },
+    { startDisplayedItems: [0, 1, 2, 3, 4], overflowItems: [5, 6, 7, 8, 9], endDisplayedItems: [10] },
+  ],
+  [
+    { items, overflowIndex: 10 },
+    { startDisplayedItems: [0, 1, 2, 3, 4], overflowItems: [5, 6, 7, 8, 9], endDisplayedItems: [10] },
+  ],
+  [
+    { items, overflowIndex: 6 },
+    { startDisplayedItems: [0, 1, 2, 3, 4], overflowItems: [5, 6, 7, 8, 9], endDisplayedItems: [10] },
+  ],
   [
     { items, overflowIndex: 2 },
     { startDisplayedItems: [0, 1], overflowItems: [2, 3, 4, 5, 6], endDisplayedItems: [7, 8, 9, 10] },

--- a/packages/react-components/react-breadcrumb/src/utils/partitionBreadcrumbItems.ts
+++ b/packages/react-components/react-breadcrumb/src/utils/partitionBreadcrumbItems.ts
@@ -36,12 +36,16 @@ export const partitionBreadcrumbItems = <T>(
   const numberItemsToHide = itemsCount - maxDisplayedItems;
 
   if (numberItemsToHide > 0) {
-    overflowIndex = overflowIndex === maxDisplayedItems ? overflowIndex - 1 : overflowIndex;
+    overflowIndex = overflowIndex >= maxDisplayedItems ? maxDisplayedItems - 1 : overflowIndex;
     const menuLastItemIdx = overflowIndex + numberItemsToHide;
 
     startDisplayedItems = startDisplayedItems.slice(0, overflowIndex);
     overflowItems = items.slice(overflowIndex, menuLastItemIdx);
-    endDisplayedItems = items.slice(menuLastItemIdx, itemsCount);
+    if (menuLastItemIdx < itemsCount) {
+      endDisplayedItems = items.slice(menuLastItemIdx, itemsCount);
+    }
+  } else if (overflowIndex < itemsCount) {
+    endDisplayedItems = items.slice(overflowIndex, itemsCount);
   }
 
   return {


### PR DESCRIPTION
endDisplayedItems is incorrect when numberOfItemsToHide <= 0

<!--
Thank you for submitting a pull request!

Please verify that:
* [ x ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
