### PR TITLE
Local Codepen Config for react-charting package

### DIFF
--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -20,6 +20,7 @@
     "test": "just-scripts test",
     "just": "just-scripts",
     "clean": "just-scripts clean",
+    "codepen": "node ../../scripts/executors/local-codepen.js",
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev:storybook",
     "start:legacy": "just-scripts dev",

--- a/packages/react-charting/webpack.codepen.config.js
+++ b/packages/react-charting/webpack.codepen.config.js
@@ -1,0 +1,20 @@
+const { getResolveAlias, resources } = require('@fluentui/scripts-webpack');
+
+module.exports = resources.createServeConfig({
+  entry: './src/index.ts',
+
+  output: {
+    filename: 'react-charting.js',
+    libraryTarget: 'var',
+    library: 'FluentUIReactCharting',
+  },
+
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  },
+
+  resolve: {
+    alias: getResolveAlias(),
+  },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Local codepen testing was not configured for react-charting library

## New Behavior
Using command '**yarn codepen**' in react-charting package directory, developers can test out their development build in codepen playground.
Requisites:
ngrok account: The dev must set up an ngrok account and activate his/her authToken. A file named **.codepen_auth** is to be created in react-charting package and the dev can simply paste his/her authToken in it.
<img width="960" alt="image" src="https://github.com/microsoft/fluentui/assets/35366351/9be70c4c-5755-4a0a-b8a4-c3c144f5fd47">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
