### PR TITLE
Update ToolbarButton.types.ts to allow 'secondary' in appearance

### DIFF
--- a/change/@fluentui-react-toolbar-694f03cb-529d-4cf1-8923-11ac8f126074.json
+++ b/change/@fluentui-react-toolbar-694f03cb-529d-4cf1-8923-11ac8f126074.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ToolbarButton's appearance to accept 'secondary'",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "ggiunchi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/src/components/ToolbarButton/ToolbarButton.types.ts
+++ b/packages/react-components/react-toolbar/src/components/ToolbarButton/ToolbarButton.types.ts
@@ -6,7 +6,7 @@ import { ButtonProps, ButtonSlots, ButtonState } from '@fluentui/react-button';
  */
 export type ToolbarButtonProps = ComponentProps<ButtonSlots> &
   Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable'>> & {
-    appearance?: 'primary' | 'subtle';
+    appearance?: 'primary' | 'secondary' | 'subtle';
   } & {
     vertical?: boolean;
   };


### PR DESCRIPTION
Fixes:

Toolbarbutton "already" accepts 'secondary' in the appearance property, even though it's not listed as possible value.

With a code like this:

`<ToolbarButton appearance="secondary">Export doc</ToolbarButton>`

the result is like this:

<img width="85" alt="image" src="https://github.com/microsoft/fluentui/assets/22346749/a3258ebb-35f3-4320-bbea-ec2b54db6c34">

This pr would just list the value in the definition