### PR TITLE
fix: Horizontal chart with axis yaxis same label and truncation fixed

### DIFF
--- a/change/@fluentui-react-charting-8bd430b6-3359-4e93-86ee-92b22540b88c.json
+++ b/change/@fluentui-react-charting-8bd430b6-3359-4e93-86ee-92b22540b88c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix:[HorChartWAxis][RTL] y axis same text and truncation fixed",
+  "packageName": "@fluentui/react-charting",
+  "email": "gautam33776@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -717,7 +717,9 @@ export function createYAxisLabels(
   axisNode.selectAll('.tick text').each(function () {
     const text = d3Select(this);
     const totalWord = text.text();
-    const truncatedWord = `${text.text().slice(0, noOfCharsToTruncate)}...`;
+    const truncatedWord = isRtl
+      ? `...${text.text().slice(0, noOfCharsToTruncate)}`
+      : `${text.text().slice(0, noOfCharsToTruncate)}...`;
     const totalWordLength = text.text().length;
     const padding = truncateLabel ? 1.5 : 1; // ems
     const y = text.attr('y');
@@ -737,7 +739,7 @@ export function createYAxisLabels(
       text
         .append('tspan')
         .attr('id', 'showDots')
-        .attr('x', x)
+        .attr('x', isRtl ? 0 : x)
         .attr('y', y)
         .attr('dy', dy)
         .attr('dx', padding + dx + 'em')
@@ -747,7 +749,7 @@ export function createYAxisLabels(
         .attr('text-align', 'start')
         .append('tspan')
         .attr('id', 'LessLength')
-        .attr('x', isRtl ? xValue : x)
+        .attr('x', isRtl ? 0 : x)
         .attr('y', y)
         .attr('dx', padding + dx + 'em')
         .text(totalWord);


### PR DESCRIPTION

<img width="676" alt="image" src="https://github.com/microsoft/fluentui/assets/33349461/3acafd51-7d58-4134-9da2-a0d3c6ace8e3">

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
1. RTL Mode- Due to width issue yAxis was showing only "String" which appeared same but the other part of the word was hidden.
2.RTL Mode-  Text was trucating in reverse manner
<!-- This is the behavior we have today -->

## New Behavior
1. yAxis same issue fixed
2. text truncation issue fixed
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

#29979 
#29978 
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
