### PR TITLE
chore(react-components): add "wyw-in-js" field for tag processor

### DIFF
--- a/change/@fluentui-react-components-623f5d14-335e-4a2a-aba0-b051b8cdb004.json
+++ b/change/@fluentui-react-components-623f5d14-335e-4a2a-aba0-b051b8cdb004.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add \"wyw-in-js\" field for tag processor",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -117,5 +117,11 @@
     "lib",
     "lib-commonjs",
     "unstable"
-  ]
+  ],
+  "wyw-in-js": {
+    "tags": {
+      "makeStyles": "@griffel/tag-processor/make-styles",
+      "makeResetStyles": "@griffel/tag-processor/make-reset-styles"
+    }
+  }
 }


### PR DESCRIPTION
Adds `wyw-in-js` field to `package.json` to support styles processing with WyW-in-JS compiler (https://wyw-in-js.dev/). The plan is to use this compiler for Vite/esbuild plugins (https://github.com/microsoft/griffel/pull/41) and later switch our Webpack loader to it (https://github.com/microsoft/griffel/pull/414).

The same change in Griffel, https://github.com/microsoft/griffel/pull/475.