### PR TITLE
feat(react-combobox): add clearable prop for Combobox & Dropdown

### DIFF
--- a/change/@fluentui-react-combobox-057ab96a-491a-422f-8b6b-ee92954175ce.json
+++ b/change/@fluentui-react-combobox-057ab96a-491a-422f-8b6b-ee92954175ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add \"clearable\" prop to Combobox & Dropdown",
+  "packageName": "@fluentui/react-combobox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-d303579a-543d-44b3-91c9-6902acb99b4e.json
+++ b/change/@fluentui-react-timepicker-compat-d303579a-543d-44b3-91c9-6902acb99b4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update types in styles to exclude \"clearIcon\" slot",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-preview-9339e124-bae0-4824-b7b0-7f9953091164.json
+++ b/change/@fluentui-react-timepicker-compat-preview-9339e124-bae0-4824-b7b0-7f9953091164.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: update types in styles to exclude \"clearIcon\" slot",
-  "packageName": "@fluentui/react-timepicker-compat-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-timepicker-compat-preview-9339e124-bae0-4824-b7b0-7f9953091164.json
+++ b/change/@fluentui-react-timepicker-compat-preview-9339e124-bae0-4824-b7b0-7f9953091164.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update types in styles to exclude \"clearIcon\" slot",
+  "packageName": "@fluentui/react-timepicker-compat-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/config/tests.js
+++ b/packages/react-components/react-combobox/config/tests.js
@@ -1,1 +1,3 @@
 /** Jest test setup file. */
+
+require('@testing-library/jest-dom');

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -49,12 +49,15 @@ export const ComboboxProvider: Provider<ComboboxContextValue> & FC<ProviderProps
 export type ComboboxSlots = {
     root: NonNullable<Slot<'div'>>;
     expandIcon: Slot<'span'>;
+    clearIcon?: Slot<'span'>;
     input: NonNullable<Slot<'input'>>;
     listbox?: Slot<typeof Listbox>;
 };
 
 // @public
-export type ComboboxState = ComponentState<ComboboxSlots> & ComboboxBaseState;
+export type ComboboxState = ComponentState<ComboboxSlots> & ComboboxBaseState & {
+    showClearIcon?: boolean;
+};
 
 // @public
 export const Dropdown: ForwardRefComponent<DropdownProps>;
@@ -78,6 +81,7 @@ export type DropdownProps = ComponentProps<Partial<DropdownSlots>, 'button'> & C
 export type DropdownSlots = {
     root: NonNullable<Slot<'div'>>;
     expandIcon: Slot<'span'>;
+    clearButton?: Slot<'button'>;
     button: NonNullable<Slot<'button'>>;
     listbox?: Slot<typeof Listbox>;
 };
@@ -85,6 +89,7 @@ export type DropdownSlots = {
 // @public
 export type DropdownState = ComponentState<DropdownSlots> & ComboboxBaseState & {
     placeholderVisible: boolean;
+    showClearButton?: boolean;
 };
 
 // @public

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -41,6 +41,7 @@
     "@fluentui/react-portal": "^9.4.7",
     "@fluentui/react-positioning": "^9.12.1",
     "@fluentui/react-shared-contexts": "^9.13.2",
+    "@fluentui/react-tabster": "^9.16.1",
     "@fluentui/react-theme": "^9.1.16",
     "@fluentui/react-utilities": "^9.15.6",
     "@griffel/react": "^1.5.14",

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -41,7 +41,7 @@
     "@fluentui/react-portal": "^9.4.7",
     "@fluentui/react-positioning": "^9.12.1",
     "@fluentui/react-shared-contexts": "^9.13.2",
-    "@fluentui/react-tabster": "^9.16.1",
+    "@fluentui/react-tabster": "^9.17.0",
     "@fluentui/react-theme": "^9.1.16",
     "@fluentui/react-utilities": "^9.15.6",
     "@griffel/react": "^1.5.14",

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { render, act } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field } from '@fluentui/react-field';
 import { Combobox } from './Combobox';
 import { Option } from '../Option/index';
 import { isConformant } from '../../testing/isConformant';
 import { resetIdsForTests } from '@fluentui/react-utilities';
+import { comboboxClassNames } from './useComboboxStyles.styles';
 
 describe('Combobox', () => {
   beforeEach(() => {
@@ -23,6 +24,13 @@ describe('Combobox', () => {
             open: true,
             // Portal messes with the classNames test, so rendering the listbox inline here
             inlinePopup: true,
+          },
+          // Classes are defined manually as there is no way to render "expandIcon" and "clearIcon" and the same time
+          expectedClassNames: {
+            root: comboboxClassNames.root,
+            expandIcon: comboboxClassNames.expandIcon,
+            listbox: comboboxClassNames.listbox,
+            input: comboboxClassNames.input,
           },
         },
       ],
@@ -944,5 +952,49 @@ describe('Combobox', () => {
     expect(combobox.getAttribute('aria-describedby')).toEqual(message.id);
     expect(combobox.getAttribute('aria-invalid')).toEqual('true');
     expect(combobox.required).toBe(true);
+  });
+
+  describe('clearable', () => {
+    it('clears the selection on a button click', () => {
+      const { getByText, getByRole } = render(
+        <Combobox
+          clearable
+          defaultSelectedOptions={['Red']}
+          defaultValue="Red"
+          clearIcon={{ children: 'CLEAR BUTTON' }}
+        >
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+
+      const combobox = getByRole('combobox');
+      const clearButton = getByText('CLEAR BUTTON');
+
+      expect(clearButton).not.toHaveStyle({ display: 'none' });
+      expect(combobox).toHaveValue('Red');
+
+      act(() => {
+        fireEvent.click(clearButton);
+      });
+
+      expect(clearButton).toHaveStyle({ display: 'none' });
+      expect(combobox).toHaveValue('');
+    });
+
+    it('is not visible when there is no selection', () => {
+      const { getByText } = render(
+        <Combobox clearable clearIcon={{ children: 'CLEAR BUTTON' }}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+      const clearButton = getByText('CLEAR BUTTON');
+
+      expect(clearButton).toHaveStyle({ display: 'none' });
+      expect(clearButton).toHaveAttribute('aria-hidden', 'true');
+    });
   });
 });

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -16,6 +16,9 @@ export type ComboboxSlots = {
   /* The dropdown arrow icon */
   expandIcon: Slot<'span'>;
 
+  /* The dropdown clear icon */
+  clearIcon?: Slot<'span'>;
+
   /* The primary slot, an input with role="combobox" */
   input: NonNullable<Slot<'input'>>;
 
@@ -42,7 +45,10 @@ export type ComboboxProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>
 /**
  * State used in rendering Combobox
  */
-export type ComboboxState = ComponentState<ComboboxSlots> & ComboboxBaseState;
+export type ComboboxState = ComponentState<ComboboxSlots> &
+  ComboboxBaseState & {
+    showClearIcon?: boolean;
+  };
 
 /* Export types defined in ComboboxBase */
 export type ComboboxContextValues = ComboboxBaseContextValues;

--- a/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -13,6 +13,25 @@ exports[`Combobox renders a default state 1`] = `
       value=""
     />
     <span
+      aria-hidden="true"
+      class="fui-Combobox__clearIcon"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 20 20"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
       aria-expanded="false"
       aria-label="Open"
       class="fui-Combobox__expandIcon"
@@ -50,6 +69,25 @@ exports[`Combobox renders an open listbox 1`] = `
       type="text"
       value=""
     />
+    <span
+      aria-hidden="true"
+      class="fui-Combobox__clearIcon"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 20 20"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
     <span
       aria-expanded="true"
       aria-label="Open"

--- a/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
@@ -16,7 +16,8 @@ export const renderCombobox_unstable = (state: ComboboxState, contextValues: Com
     <state.root>
       <ComboboxContext.Provider value={contextValues.combobox}>
         <state.input />
-        {state.expandIcon && <state.expandIcon />}
+        {state.clearIcon && <state.clearIcon />}
+        <state.expandIcon />
         {state.listbox &&
           (state.inlinePopup ? (
             <state.listbox />

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
+import { ChevronDownRegular as ChevronDownIcon, DismissRegular as DismissIcon } from '@fluentui/react-icons';
 import {
   getPartitionedNativeProps,
   mergeCallbacks,
@@ -32,7 +32,18 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
 
   const baseState = useComboboxBaseState({ ...props, editable: true });
-  const { open, selectOption, setOpen, setValue, value, hasFocus } = baseState;
+  const {
+    clearable,
+    clearSelection,
+    multiselect,
+    open,
+    selectedOptions,
+    selectOption,
+    setOpen,
+    setValue,
+    value,
+    hasFocus,
+  } = baseState;
   const [comboboxPopupRef, comboboxTargetRef] = useComboboxPositioning(props);
   const { disabled, freeform, inlinePopup } = props;
   const comboId = useId('combobox-');
@@ -90,11 +101,20 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   });
   rootSlot.ref = useMergedRefs(rootSlot.ref, comboboxTargetRef);
 
+  const showClearIcon = selectedOptions.length > 0 && clearable && !multiselect;
   const state: ComboboxState = {
-    components: { root: 'div', input: 'input', expandIcon: 'span', listbox: Listbox },
+    components: { root: 'div', input: 'input', expandIcon: 'span', listbox: Listbox, clearIcon: 'span' },
     root: rootSlot,
     input: triggerSlot,
     listbox: open || hasFocus ? listbox : undefined,
+    clearIcon: slot.optional(props.clearIcon, {
+      defaultProps: {
+        'aria-hidden': 'true',
+        children: <DismissIcon />,
+      },
+      elementType: 'span',
+      renderByDefault: true,
+    }),
     expandIcon: slot.optional(props.expandIcon, {
       renderByDefault: true,
       defaultProps: {
@@ -104,6 +124,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
       },
       elementType: 'span',
     }),
+    showClearIcon,
     ...baseState,
   };
 
@@ -143,6 +164,37 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
         state.expandIcon['aria-label'] = defaultOpenString;
       }
     }
+  }
+
+  const onClearIconMouseDown = useEventCallback(
+    mergeCallbacks(state.clearIcon?.onMouseDown, (ev: React.MouseEvent<HTMLSpanElement>) => {
+      ev.preventDefault();
+    }),
+  );
+  const onClearIconClick = useEventCallback(
+    mergeCallbacks(state.clearIcon?.onClick, (ev: React.MouseEvent<HTMLSpanElement>) => {
+      clearSelection(ev);
+    }),
+  );
+
+  if (state.clearIcon) {
+    state.clearIcon.onMouseDown = onClearIconMouseDown;
+    state.clearIcon.onClick = onClearIconClick;
+  }
+
+  // Heads up! We don't support "clearable" in multiselect mode, so we should never display a slot
+  if (multiselect) {
+    state.clearIcon = undefined;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- "process.env" does not change in runtime
+    React.useEffect(() => {
+      if (clearable && multiselect) {
+        // eslint-disable-next-line no-console
+        console.error(`[@fluentui/react-combobox] "clearable" prop is not supported in multiselect mode.`);
+      }
+    }, [clearable, multiselect]);
   }
 
   return state;

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.styles.ts
@@ -8,6 +8,7 @@ export const comboboxClassNames: SlotClassNames<ComboboxSlots> = {
   root: 'fui-Combobox',
   input: 'fui-Combobox__input',
   expandIcon: 'fui-Combobox__expandIcon',
+  clearIcon: 'fui-Combobox__clearIcon',
   listbox: 'fui-Combobox__listbox',
 };
 
@@ -212,6 +213,9 @@ const useIconStyles = makeStyles({
       display: 'block',
     },
   },
+  hidden: {
+    display: 'none',
+  },
 
   // icon size variants
   small: {
@@ -236,7 +240,7 @@ const useIconStyles = makeStyles({
  * Apply styling to the Combobox slots based on the state
  */
 export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState => {
-  const { appearance, open, size } = state;
+  const { appearance, open, size, showClearIcon } = state;
   const invalid = `${state.input['aria-invalid']}` === 'true';
   const disabled = state.input.disabled;
   const styles = useStyles();
@@ -278,7 +282,19 @@ export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState 
       iconStyles.icon,
       iconStyles[size],
       disabled && iconStyles.disabled,
+      showClearIcon && iconStyles.hidden,
       state.expandIcon.className,
+    );
+  }
+
+  if (state.clearIcon) {
+    state.clearIcon.className = mergeClasses(
+      comboboxClassNames.clearIcon,
+      iconStyles.icon,
+      iconStyles[size],
+      disabled && iconStyles.disabled,
+      !showClearIcon && iconStyles.hidden,
+      state.clearIcon.className,
     );
   }
 

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.styles.ts
@@ -216,6 +216,15 @@ const useIconStyles = makeStyles({
   hidden: {
     display: 'none',
   },
+  visuallyHidden: {
+    clip: 'rect(0px, 0px, 0px, 0px)',
+    height: '1px',
+    ...shorthands.margin('-1px'),
+    ...shorthands.overflow('hidden'),
+    ...shorthands.padding('0px'),
+    width: '1px',
+    position: 'absolute',
+  },
 
   // icon size variants
   small: {
@@ -282,7 +291,7 @@ export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState 
       iconStyles.icon,
       iconStyles[size],
       disabled && iconStyles.disabled,
-      showClearIcon && iconStyles.hidden,
+      showClearIcon && iconStyles.visuallyHidden,
       state.expandIcon.className,
     );
   }

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { fireEvent, render, act } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field } from '@fluentui/react-field';
 import { Dropdown } from './Dropdown';
 import { Option } from '../Option/index';
 import { isConformant } from '../../testing/isConformant';
 import { resetIdsForTests } from '@fluentui/react-utilities';
+import { dropdownClassNames } from './useDropdownStyles.styles';
 
 describe('Dropdown', () => {
   beforeEach(() => {
@@ -23,6 +24,13 @@ describe('Dropdown', () => {
             open: true,
             // Portal messes with the classNames test, so rendering the listbox inline here
             inlinePopup: true,
+          },
+          // Classes are defined manually as there is no way to render "expandIcon" and "clearIcon" and the same time
+          expectedClassNames: {
+            root: dropdownClassNames.root,
+            button: dropdownClassNames.button,
+            expandIcon: dropdownClassNames.expandIcon,
+            listbox: dropdownClassNames.listbox,
           },
         },
       ],
@@ -696,5 +704,43 @@ describe('Dropdown', () => {
     expect(combobox.getAttribute('aria-describedby')).toEqual(message.id);
     expect(combobox.getAttribute('aria-invalid')).toEqual('true');
     expect(combobox.getAttribute('aria-required')).toEqual('true');
+  });
+
+  describe('clearable', () => {
+    it('clears the selection on a button click', () => {
+      const { getByLabelText, getByRole } = render(
+        <Dropdown clearable defaultSelectedOptions={['Red']} defaultValue="Red">
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Dropdown>,
+      );
+
+      const dropdown = getByRole('combobox');
+      const clearButton = getByLabelText('Clear selection');
+
+      expect(clearButton).not.toHaveStyle({ display: 'none' });
+      expect(dropdown).toHaveTextContent('Red');
+
+      act(() => {
+        fireEvent.click(clearButton);
+      });
+
+      expect(clearButton).toHaveStyle({ display: 'none' });
+      expect(dropdown).toHaveTextContent('');
+    });
+
+    it('is not visible when there is no selection', () => {
+      const { getByLabelText } = render(
+        <Dropdown clearable>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Dropdown>,
+      );
+      const clearButton = getByLabelText('Clear selection');
+
+      expect(clearButton).toHaveStyle({ display: 'none' });
+    });
   });
 });

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.types.ts
@@ -15,6 +15,9 @@ export type DropdownSlots = {
   /* The dropdown arrow icon */
   expandIcon: Slot<'span'>;
 
+  /* The dropdown clear icon */
+  clearButton?: Slot<'button'>;
+
   /* The primary slot, the element with role="combobox" */
   button: NonNullable<Slot<'button'>>;
 
@@ -34,6 +37,8 @@ export type DropdownState = ComponentState<DropdownSlots> &
   ComboboxBaseState & {
     /* Whether the placeholder is currently displayed */
     placeholderVisible: boolean;
+
+    showClearButton?: boolean;
   };
 
 /* Export types defined in ComboboxBase */

--- a/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -31,6 +31,26 @@ exports[`Dropdown renders a default state 1`] = `
         </svg>
       </span>
     </button>
+    <button
+      aria-label="Clear selection"
+      class="fui-Dropdown__clearButton"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 20 20"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
   </div>
 </div>
 `;
@@ -66,6 +86,26 @@ exports[`Dropdown renders an open listbox 1`] = `
           />
         </svg>
       </span>
+    </button>
+    <button
+      aria-label="Clear selection"
+      class="fui-Dropdown__clearButton"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=""
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 20 20"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m4.09 4.22.06-.07a.5.5 0 0 1 .63-.06l.07.06L10 9.29l5.15-5.14a.5.5 0 0 1 .63-.06l.07.06c.18.17.2.44.06.63l-.06.07L10.71 10l5.14 5.15c.18.17.2.44.06.63l-.06.07a.5.5 0 0 1-.63.06l-.07-.06L10 10.71l-5.15 5.14a.5.5 0 0 1-.63.06l-.07-.06a.5.5 0 0 1-.06-.63l.06-.07L9.29 10 4.15 4.85a.5.5 0 0 1-.06-.63l.06-.07-.06.07Z"
+          fill="currentColor"
+        />
+      </svg>
     </button>
     <div
       class="fui-Listbox fui-Dropdown__listbox"

--- a/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
@@ -18,8 +18,9 @@ export const renderDropdown_unstable = (state: DropdownState, contextValues: Dro
       <ComboboxContext.Provider value={contextValues.combobox}>
         <state.button>
           {state.button.children}
-          {state.expandIcon && <state.expandIcon />}
+          <state.expandIcon />
         </state.button>
+        {state.clearButton && <state.clearButton />}
         {state.listbox &&
           (state.inlinePopup ? (
             <state.listbox />

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import { ChevronDownRegular as ChevronDownIcon } from '@fluentui/react-icons';
-import { getPartitionedNativeProps, useMergedRefs, slot } from '@fluentui/react-utilities';
+import { ChevronDownRegular as ChevronDownIcon, DismissRegular as DismissIcon } from '@fluentui/react-icons';
+import {
+  getPartitionedNativeProps,
+  mergeCallbacks,
+  useMergedRefs,
+  slot,
+  useEventCallback,
+} from '@fluentui/react-utilities';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
 import { useComboboxPositioning } from '../../utils/useComboboxPositioning';
 import { Listbox } from '../Listbox/Listbox';
@@ -23,7 +29,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsSize: true });
 
   const baseState = useComboboxBaseState(props);
-  const { open, hasFocus } = baseState;
+  const { clearable, clearSelection, hasFocus, multiselect, open, selectedOptions } = baseState;
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
@@ -62,11 +68,22 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   });
   rootSlot.ref = useMergedRefs(rootSlot.ref, comboboxTargetRef);
 
+  const showClearButton = selectedOptions.length > 0 && clearable && !multiselect;
   const state: DropdownState = {
-    components: { root: 'div', button: 'button', expandIcon: 'span', listbox: Listbox },
+    components: { root: 'div', button: 'button', clearButton: 'button', expandIcon: 'span', listbox: Listbox },
     root: rootSlot,
     button: trigger,
     listbox: open || hasFocus ? listbox : undefined,
+    clearButton: slot.optional(props.clearButton, {
+      defaultProps: {
+        'aria-label': 'Clear selection',
+        children: <DismissIcon />,
+        // Safari doesn't allow to focus an element with this
+        tabIndex: 0,
+      },
+      elementType: 'button',
+      renderByDefault: true,
+    }),
     expandIcon: slot.optional(props.expandIcon, {
       renderByDefault: true,
       defaultProps: {
@@ -75,8 +92,35 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
       elementType: 'span',
     }),
     placeholderVisible: !baseState.value && !!props.placeholder,
+    showClearButton,
     ...baseState,
   };
+
+  const onClearButtonClick = useEventCallback(
+    mergeCallbacks(state.clearButton?.onClick, (ev: React.MouseEvent<HTMLButtonElement>) => {
+      clearSelection(ev);
+      triggerRef.current?.focus();
+    }),
+  );
+
+  if (state.clearButton) {
+    state.clearButton.onClick = onClearButtonClick;
+  }
+
+  // Heads up! We don't support "clearable" in multiselect mode, so we should never display a slot
+  if (multiselect) {
+    state.clearButton = undefined;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- "process.env" does not change in runtime
+    React.useEffect(() => {
+      if (clearable && multiselect) {
+        // eslint-disable-next-line no-console
+        console.error(`[@fluentui/react-combobox] "clearable" prop is not supported in multiselect mode.`);
+      }
+    }, [clearable, multiselect]);
+  }
 
   return state;
 };

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -1,12 +1,14 @@
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { iconSizes } from '../../utils/internalTokens';
 import type { DropdownSlots, DropdownState } from './Dropdown.types';
 
 export const dropdownClassNames: SlotClassNames<DropdownSlots> = {
   root: 'fui-Dropdown',
   button: 'fui-Dropdown__button',
+  clearButton: 'fui-Dropdown__clearButton',
   expandIcon: 'fui-Dropdown__expandIcon',
   listbox: 'fui-Dropdown__listbox',
 };
@@ -18,7 +20,7 @@ const useStyles = makeStyles({
   root: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     boxSizing: 'border-box',
-    display: 'inline-block',
+    display: 'inline-flex',
     minWidth: '250px',
     position: 'relative',
 
@@ -65,6 +67,13 @@ const useStyles = makeStyles({
     },
     ':focus-within:active::after': {
       borderBottomColor: tokens.colorCompoundBrandStrokePressed,
+    },
+
+    '@supports selector(:has(*))': {
+      [`:has(.${dropdownClassNames.clearButton}:focus)::after`]: {
+        borderBottomColor: 'initial',
+        transform: 'scaleX(0)',
+      },
     },
   },
 
@@ -186,6 +195,10 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForegroundDisabled,
     cursor: 'not-allowed',
   },
+
+  hidden: {
+    display: 'none',
+  },
 });
 
 const useIconStyles = makeStyles({
@@ -223,15 +236,30 @@ const useIconStyles = makeStyles({
   },
 });
 
+const useBaseClearButtonStyle = makeResetStyles({
+  alignSelf: 'center',
+  backgroundColor: tokens.colorTransparentBackground,
+  border: 'none',
+  cursor: 'pointer',
+  height: 'fit-content',
+  margin: 0,
+  marginRight: tokens.spacingHorizontalMNudge,
+  padding: 0,
+  position: 'relative',
+
+  ...createFocusOutlineStyle(),
+});
+
 /**
  * Apply styling to the Dropdown slots based on the state
  */
 export const useDropdownStyles_unstable = (state: DropdownState): DropdownState => {
-  const { appearance, open, placeholderVisible, size } = state;
+  const { appearance, open, placeholderVisible, showClearButton, size } = state;
   const invalid = `${state.button['aria-invalid']}` === 'true';
   const disabled = state.button.disabled;
   const styles = useStyles();
   const iconStyles = useIconStyles();
+  const clearButtonStyle = useBaseClearButtonStyle();
 
   state.root.className = mergeClasses(
     dropdownClassNames.root,
@@ -268,7 +296,20 @@ export const useDropdownStyles_unstable = (state: DropdownState): DropdownState 
       iconStyles.icon,
       iconStyles[size],
       disabled && iconStyles.disabled,
+      showClearButton && styles.hidden,
       state.expandIcon.className,
+    );
+  }
+
+  if (state.clearButton) {
+    state.clearButton.className = mergeClasses(
+      dropdownClassNames.clearButton,
+      clearButtonStyle,
+      iconStyles.icon,
+      iconStyles[size],
+      disabled && iconStyles.disabled,
+      !showClearButton && styles.hidden,
+      state.clearButton.className,
     );
   }
 

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -18,6 +18,11 @@ export type ComboboxBaseProps = SelectionProps &
     appearance?: 'filled-darker' | 'filled-lighter' | 'outline' | 'underline';
 
     /**
+     * If set, the combobox will show an icon to clear the current value.
+     */
+    clearable?: boolean;
+
+    /**
      * The default open state when open is uncontrolled
      */
     defaultOpen?: boolean;
@@ -72,7 +77,9 @@ export type ComboboxBaseProps = SelectionProps &
 /**
  * State used in rendering Combobox
  */
-export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 'open' | 'inlinePopup' | 'size'>> &
+export type ComboboxBaseState = Required<
+  Pick<ComboboxBaseProps, 'appearance' | 'open' | 'clearable' | 'inlinePopup' | 'size'>
+> &
   Pick<ComboboxBaseProps, 'mountNode' | 'placeholder' | 'value' | 'multiselect'> &
   OptionCollectionState &
   SelectionState & {

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -14,6 +14,7 @@ export const useComboboxBaseState = (
   const {
     appearance = 'outline',
     children,
+    clearable = false,
     editable = false,
     inlinePopup = false,
     mountNode = undefined,
@@ -115,6 +116,7 @@ export const useComboboxBaseState = (
     ...selectionState,
     activeOption,
     appearance,
+    clearable,
     focusVisible,
     hasFocus,
     ignoreNextBlur,

--- a/packages/react-components/react-combobox/stories/Combobox/ComboboxClearable.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/ComboboxClearable.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Combobox, Label, makeStyles, Option, shorthands, useId } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'grid',
+    gridTemplateRows: 'auto auto',
+    justifyItems: 'start',
+    ...shorthands.gap('2px'),
+  },
+});
+
+export const Clearable = () => {
+  const comboboxId = useId('combobox');
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <Label id={comboboxId}>Pick a color</Label>
+      <Combobox clearable aria-labelledby={comboboxId} placeholder="Select a color">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>
+    </div>
+  );
+};
+
+Clearable.parameters = {
+  docs: {
+    description: {
+      story:
+        'A Combobox can be clearable and let users remove their selection. Note: this is not supported in multiselect mode yet.',
+    },
+  },
+};

--- a/packages/react-components/react-combobox/stories/Combobox/index.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Combobox/index.stories.tsx
@@ -8,6 +8,7 @@ export { Default } from './ComboboxDefault.stories';
 export { ComplexOptions } from './ComboboxComplexOptions.stories';
 export { CustomOptions } from './ComboboxCustomOptions.stories';
 export { Controlled } from './ComboboxControlled.stories';
+export { Clearable } from './ComboboxClearable.stories';
 export { Filtering } from './ComboboxFiltering.stories';
 export { Freeform } from './ComboboxFreeform.stories';
 export { Multiselect } from './ComboboxMultiselect.stories';

--- a/packages/react-components/react-combobox/stories/Dropdown/DropdownClearable.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/DropdownClearable.stories.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Dropdown, Label, makeStyles, Option, shorthands, useId } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'grid',
+    gridTemplateRows: 'repeat(1fr)',
+    justifyItems: 'start',
+    ...shorthands.gap('2px'),
+    maxWidth: '400px',
+  },
+});
+
+export const Clearable = () => {
+  const dropdownId = useId('');
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <Label id={dropdownId}>Pick a color</Label>
+      <Dropdown clearable aria-labelledby={dropdownId} placeholder="Select a color">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>
+    </div>
+  );
+};
+
+Clearable.parameters = {
+  docs: {
+    description: {
+      story:
+        'A Dropdown can be clearable and let users remove their selection. Note: this is not supported in multiselect mode yet.',
+    },
+  },
+};

--- a/packages/react-components/react-combobox/stories/Dropdown/index.stories.tsx
+++ b/packages/react-components/react-combobox/stories/Dropdown/index.stories.tsx
@@ -8,6 +8,7 @@ import accessibilityMd from './DropdownAccessibility.md';
 export { Default } from './DropdownDefault.stories';
 export { Appearance } from './DropdownAppearance.stories';
 export { Grouped } from './DropdownGrouped.stories';
+export { Clearable } from './DropdownClearable.stories';
 export { ComplexOptions } from './DropdownComplexOptions.stories';
 export { CustomOptions } from './DropdownCustomOptions.stories';
 export { Controlled } from './DropdownControlled.stories';

--- a/packages/react-components/react-combobox/tsconfig.spec.json
+++ b/packages/react-components/react-combobox/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "dist",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/react-components/react-timepicker-compat/etc/react-timepicker-compat.api.md
+++ b/packages/react-components/react-timepicker-compat/etc/react-timepicker-compat.api.md
@@ -39,7 +39,7 @@ export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input
 };
 
 // @public (undocumented)
-export type TimePickerSlots = ComboboxSlots;
+export type TimePickerSlots = Omit<ComboboxSlots, 'clearIcon'>;
 
 // @public
 export type TimePickerState = ComboboxState & Required<Pick<TimePickerProps, 'freeform' | 'parseTimeStringToDate'>> & {

--- a/packages/react-components/react-timepicker-compat/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat/src/components/TimePicker/TimePicker.types.ts
@@ -59,7 +59,7 @@ export type TimeStringValidationResult = {
   errorType?: TimePickerErrorType;
 };
 
-export type TimePickerSlots = ComboboxSlots;
+export type TimePickerSlots = Omit<ComboboxSlots, 'clearIcon'>;
 
 export type TimeSelectionEvents = SelectionEvents | React.FocusEvent<HTMLElement>;
 export type TimeSelectionData = {


### PR DESCRIPTION
## New Behavior

`Combobox` & `Dropdown` components support `clearable` prop. The functionality is implemented similarly to v0, with some changes:
- **Single select `Dropdown`** - `clearable` adds a separate button that is focusable. When clicked, the value removed and focus is moved to the main dropdown trigger button. Allow setting of `aria-label` (and other props) through slot API
- **Single select `Combobox`** - `clearable` adds an icon that is not focusable and has `aria-hidden=true`. When clicked, removes the value and focus is moved to the input
- no change for `multiselect` `Dropdown` & `Combobox` - the prop is ignored there and produces a warning when is used. Might be implemented later.

## Demo

![dropdown-clear](https://github.com/microsoft/fluentui/assets/14183168/05291cf0-ad3d-4f88-aa36-8772edc12cc7)

## Related Issue(s)

Fixes #30248.
Related to #29399.
