### PR TITLE
fix: Dialog now transitions in on first render

### DIFF
--- a/change/@fluentui-react-dialog-40d163d8-a0f0-45b2-b2fc-f62d77715206.json
+++ b/change/@fluentui-react-dialog-40d163d8-a0f0-45b2-b2fc-f62d77715206.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Dialog now transitions in on first render",
+  "packageName": "@fluentui/react-dialog",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/renderDialog.tsx
@@ -24,6 +24,7 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
             unmountOnExit
             in={state.open}
             nodeRef={state.dialogRef}
+            appear={true}
             // FIXME: this should not be hardcoded tokens.durationGentle
             timeout={250}
           >


### PR DESCRIPTION


## Previous Behavior
See link: https://codesandbox.io/p/sandbox/recursing-wiles-4llpxn?file=%2Fsrc%2Fexample.tsx%3A47%2C42

Previously if the Dialog was rendered at the same time it was set to open, the transition would not happen.

@layershifter had a hunch that it could be as easy as adding `appear` prop, which turned out to be the case:https://reactcommunity.org/react-transition-group/transition#Transition-prop-appear

## New Behavior

If the Dialog is rendered and opened, the transition/animation happens properly.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30043 
