### PR TITLE
bugfix: onOpenChange inconsistent between Tree and TreeItem

### DIFF
--- a/change/@fluentui-react-tree-92e4762b-6aa9-40b1-9827-f9700472e561.json
+++ b/change/@fluentui-react-tree-92e4762b-6aa9-40b1-9827-f9700472e561.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: onOpenChange inconsistent between Tree and TreeItem",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/Tree/Tree.test.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { Tree } from './Tree';
+import { TreeItem } from '../TreeItem/TreeItem';
 
 describe('Tree', () => {
   isConformant({
@@ -15,5 +16,25 @@ describe('Tree', () => {
   it('renders a default state', () => {
     const result = render(<Tree>Default Tree</Tree>);
     expect(result.container).toMatchSnapshot();
+  });
+  it('should sync open state between Tree and TreeItem onOpenChange callback', () => {
+    const handleOpenChange = jest.fn();
+
+    const result = render(
+      <Tree aria-label="Default" onOpenChange={handleOpenChange}>
+        <TreeItem data-testid="tree-item" itemType="branch" open={true} onOpenChange={handleOpenChange}>
+          parent
+          <Tree>
+            <TreeItem itemType="leaf">leaf</TreeItem>
+          </Tree>
+        </TreeItem>
+      </Tree>,
+    );
+
+    result.getByTestId('tree-item').click();
+
+    expect(handleOpenChange).toHaveBeenNthCalledWith(1, expect.any(Object), expect.objectContaining({ open: false }));
+
+    expect(handleOpenChange).toHaveBeenNthCalledWith(2, expect.any(Object), expect.objectContaining({ open: false }));
   });
 });

--- a/packages/react-components/react-tree/src/components/TreeItem/TreeItem.test.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/TreeItem.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { TreeItem } from './TreeItem';
 import { isConformant } from '../../testing/isConformant';
 import { TreeItemProps } from './TreeItem.types';
 import { treeItemClassNames } from './useTreeItemStyles.styles';
+import { Tree } from '../../Tree';
 
 describe('TreeItem', () => {
   isConformant<TreeItemProps>({
@@ -30,5 +31,18 @@ describe('TreeItem', () => {
   it('renders a default state', () => {
     const result = render(<TreeItem itemType="leaf">Default TreeItem</TreeItem>);
     expect(result.container).toMatchSnapshot();
+  });
+  it('should not update open state when the TreeItem is a leaf', () => {
+    const handleOpenChange = jest.fn();
+    const result = render(
+      <Tree onOpenChange={handleOpenChange}>
+        <TreeItem onOpenChange={handleOpenChange} itemType="leaf">
+          Default TreeItem
+        </TreeItem>
+      </Tree>,
+    );
+    fireEvent.click(result.getByText('Default TreeItem'));
+    expect(handleOpenChange).toHaveBeenNthCalledWith(1, expect.anything(), expect.objectContaining({ open: false }));
+    expect(handleOpenChange).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({ open: false }));
   });
 });

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -59,6 +59,7 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
   const treeItemRef = React.useRef<HTMLDivElement>(null);
 
   const open = useTreeContext_unstable(ctx => props.open ?? ctx.openItems.has(value));
+  const getNextOpen = () => (itemType === 'branch' ? !open : open);
   const selectionMode = useTreeContext_unstable(ctx => ctx.selectionMode);
   const checked = useTreeContext_unstable(ctx => ctx.checkedItems.get(value) ?? false);
 
@@ -85,7 +86,7 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
       const data = {
         event,
         value,
-        open: !open,
+        open: getNextOpen(),
         target: event.currentTarget,
         type: isEventFromExpandIcon ? treeDataTypes.ExpandIconClick : treeDataTypes.Click,
       } as const;
@@ -143,7 +144,7 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
         const data = {
           value,
           event,
-          open: !open,
+          open: getNextOpen(),
           type: event.key,
           target: event.currentTarget,
         } as const;
@@ -165,7 +166,7 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
         const data = {
           value,
           event,
-          open: !open,
+          open: getNextOpen(),
           type: event.key,
           target: event.currentTarget,
         } as const;

--- a/packages/react-components/react-tree/src/contexts/treeContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeContext.ts
@@ -21,7 +21,7 @@ export type TreeContextValue = {
 };
 
 export type TreeItemRequest = { itemType: TreeItemType } & (
-  | (DistributiveOmit<TreeOpenChangeData, 'open' | 'openItems'> & { requestType: 'open' })
+  | (DistributiveOmit<TreeOpenChangeData, 'openItems'> & { requestType: 'open' })
   | (TreeNavigationData_unstable & { requestType: 'navigate' })
   | (DistributiveOmit<TreeCheckedChangeData, 'selectionMode' | 'checkedItems'> & { requestType: 'selection' })
 );

--- a/packages/react-components/react-tree/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/src/hooks/useRootTree.ts
@@ -25,12 +25,9 @@ export function useRootTree(
   const checkedItems = React.useMemo(() => createCheckedItems(props.checkedItems), [props.checkedItems]);
 
   const requestOpenChange = (request: Extract<TreeItemRequest, { requestType: 'open' }>) => {
-    const open = request.itemType === 'branch' && !openItems.has(request.value);
-    const nextOpenItems = createNextOpenItems({ value: request.value, open }, openItems);
     props.onOpenChange?.(request.event, {
       ...request,
-      open,
-      openItems: nextOpenItems.dangerouslyGetInternalSet_unstable(),
+      openItems: createNextOpenItems(request, openItems).dangerouslyGetInternalSet_unstable(),
     });
   };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`onOpenChange` callback from root `Tree` ignores the `open` value from `TreeItem` in favor of it's internal one, this is problematic in scenarios where a `TreeItem` controls its own state

## New Behavior

1. `onOpenChange` callback from root `Tree` ignores internal state in favor of the value provided by the `TreeItem`, it works fine if `TreeItem` is controlled/uncontrolled. If it's controlled then the value is defined by the `TreeItem` itself, if it's uncontrolled the `TreeItem` will just replicate the value provided by the root `Tree`
2. Adds test to ensure both `Tree` and `TreeItem` `onOpenChange` callbacks are synchronized if the `TreeItem` is controlled
3. Adds test to ensure that if a `TreeItem` is a leaf it'll not update it's open state on `onOpenChange`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/30048
