### PR TITLE
Azure Theme  bug fixes for DetailsList with Link, and ChoiceGroup with Icon/Image

### DIFF
--- a/change/@fluentui-azure-themes-deca1b96-b8f7-45cf-9c2b-c8638dd68357.json
+++ b/change/@fluentui-azure-themes-deca1b96-b8f7-45cf-9c2b-c8638dd68357.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "link in detailslist a11y bug fix and choicegroup with icon/image bug fix",
+  "packageName": "@fluentui/azure-themes",
+  "email": "30805892+Jacqueline-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/src/azure/AzureColors.ts
+++ b/packages/azure-themes/src/azure/AzureColors.ts
@@ -1010,7 +1010,7 @@ export const LightSemanticColors: IAzureSemanticColors = {
     hoveredRowLink: BaseColors.BLUE_106EBE,
     hoveredLink: BaseColors.BLUE_106EBE,
     hoveredBackground: BaseColors.GRAY_F3F2F1,
-    selectedLink: BaseColors.BLUE_106EBE,
+    selectedLink: BaseColors.BLUE_005A9E,
     selectedHoveredLink: BaseColors.BLUE_005A9E,
   },
   radioButton: {

--- a/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ChoiceGroupOptions.styles.ts
@@ -66,10 +66,23 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
               disabled && {
                 borderColor: extendedSemanticColors.controlOutlineDisabled,
               },
+            checked &&
+              (hasIcon || hasImage) && {
+                top: 7,
+                right: 7,
+                left: 'auto',
+              },
           ],
           ':hover': [
             (hasIcon || hasImage) && {
               borderColor: extendedSemanticColors.controlOutlineHovered,
+              selectors: {
+                '::after': {
+                  top: 7,
+                  right: 7,
+                  left: 'auto',
+                },
+              },
             },
             !disabled && {
               selectors: {

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -155,13 +155,13 @@ export const DetailsRowStyles = (props: IDetailsRowStyleProps): Partial<IDetails
             '.ms-Check-check': {
               color: extendedSemanticColors.checkBoxCheck,
             },
-            '.ms-Link': {
+            '.ms-Link, .ms-DetailsRow-cell .ms-Link': {
               color: extendedSemanticColors.listLinkRowSelected,
             },
             ':hover': {
               background: extendedSemanticColors.listItemBackgroundSelectedHovered,
               selectors: {
-                '.ms-Link': {
+                '.ms-Link, .ms-DetailsRow-cell .ms-Link': {
                   color: extendedSemanticColors.listLinkRowSelectedHovered,
                 },
                 '.ms-Check-circle': {

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -42,7 +42,6 @@ import { ChoiceGroupImageExample } from '../components/choiceGroupWithImagesandI
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
     <Stack gap={8} horizontalAlign="center">
-      <ChoiceGroupImageExample />
       <Text>13px body text</Text>
       <Label>MessageBar / InfoBox</Label>
       <MessageBarBasicExample />
@@ -176,6 +175,7 @@ const Example = () => (
       <Label>Misc</Label>
       <ActivityItemBasicExample />
       <ChoiceGroupBasicExample />
+      <ChoiceGroupImageExample />
       <ToggleBasicExample />
       <ColorPickerBasicExample />
       <ContextualMenuDefaultExample />

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -36,6 +36,7 @@ import { DatePickerBasicExample } from '../components/defaultDatePicker';
 import { ProgressIndicatorBasicExample } from '../components/ProgressIndicator.stories';
 import { CalendarInlineMultidayDayViewExample } from '../components/CalendarInlineMultidayDayView.stories';
 import { SpinnerBasicExample } from '../components/spinner.stories';
+import { DetailsListCustomColumnsExample } from '../components/DetailsListCustomColumnsExample.stories';
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
@@ -88,6 +89,7 @@ const Example = () => (
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>
       <Label>DetailsList / Grid</Label>
       <DetailsListCompactExample />
+      <DetailsListCustomColumnsExample />
     </Stack>
 
     <Stack gap={8} horizontalAlign="center" style={{ marginTop: 40 }}>

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -37,10 +37,12 @@ import { ProgressIndicatorBasicExample } from '../components/ProgressIndicator.s
 import { CalendarInlineMultidayDayViewExample } from '../components/CalendarInlineMultidayDayView.stories';
 import { SpinnerBasicExample } from '../components/spinner.stories';
 import { DetailsListCustomColumnsExample } from '../components/DetailsListCustomColumnsExample.stories';
+import { ChoiceGroupImageExample } from '../components/choiceGroupWithImagesandIcons.stories';
 
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
     <Stack gap={8} horizontalAlign="center">
+      <ChoiceGroupImageExample />
       <Text>13px body text</Text>
       <Label>MessageBar / InfoBox</Label>
       <MessageBarBasicExample />

--- a/packages/react-examples/src/azure-themes/stories/components/DetailsListCustomColumnsExample.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/DetailsListCustomColumnsExample.stories.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { createListItems, IExampleItem } from '@fluentui/example-data';
+import { Link } from '@fluentui/react/lib/Link';
+import { DetailsList, buildColumns, IColumn } from '@fluentui/react/lib/DetailsList';
+
+export interface IDetailsListCustomColumnsExampleState {
+  sortedItems: IExampleItem[];
+  columns: IColumn[];
+}
+
+export class DetailsListCustomColumnsExample extends React.Component<{}, IDetailsListCustomColumnsExampleState> {
+  constructor(props: {}) {
+    super(props);
+
+    const items = createListItems(5);
+    this.state = {
+      sortedItems: items,
+      columns: this._buildColumns(items),
+    };
+  }
+
+  public render() {
+    const { sortedItems, columns } = this.state;
+
+    return (
+      <DetailsList
+        items={sortedItems}
+        setKey="set"
+        columns={columns}
+        onRenderItemColumn={_renderItemColumn}
+        onItemInvoked={this._onItemInvoked}
+        onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
+        ariaLabelForSelectionColumn="Toggle selection"
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+        checkButtonAriaLabel="select row"
+      />
+    );
+  }
+
+  private _onColumnClick = (event: React.MouseEvent<HTMLElement>, column: IColumn): void => {
+    const { columns } = this.state;
+    let { sortedItems } = this.state;
+    let isSortedDescending = column.isSortedDescending;
+
+    // If we've sorted this column, flip it.
+    if (column.isSorted) {
+      isSortedDescending = !isSortedDescending;
+    }
+
+    // Sort the items.
+    sortedItems = _copyAndSort(sortedItems, column.fieldName!, isSortedDescending);
+
+    // Reset the items and columns to match the state.
+    this.setState({
+      sortedItems,
+      columns: columns.map(col => {
+        col.isSorted = col.key === column.key;
+
+        if (col.isSorted) {
+          col.isSortedDescending = isSortedDescending;
+        }
+
+        return col;
+      }),
+    });
+  };
+
+  private _buildColumns(items: IExampleItem[]): IColumn[] {
+    const columns = buildColumns(items, false, this._onColumnClick);
+
+    const thumbnailColumn = columns.filter(column => column.name === 'thumbnail')[0];
+
+    // Special case one column's definition.
+    thumbnailColumn.name = '';
+    thumbnailColumn.maxWidth = 50;
+    thumbnailColumn.ariaLabel = 'Thumbnail';
+    thumbnailColumn.onColumnClick = undefined;
+
+    // Indicate that all columns except thumbnail column can be sorted,
+    // and only the description colum should disappear at small screen sizes
+    columns.forEach((column: IColumn) => {
+      if (column.name) {
+        column.showSortIconWhenUnsorted = true;
+        column.isCollapsible = column.name === 'description';
+      }
+    });
+
+    return columns;
+  }
+
+  private _onColumnHeaderContextMenu(column: IColumn | undefined, ev: React.MouseEvent<HTMLElement> | undefined): void {
+    console.log(`column ${column!.key} contextmenu opened.`);
+  }
+
+  private _onItemInvoked(item: any, index: number | undefined): void {
+    alert(`Item ${item.name} at index ${index} has been invoked.`);
+  }
+}
+
+function _renderItemColumn(item: IExampleItem, index: number, column: IColumn) {
+  const fieldContent = item[column.fieldName as keyof IExampleItem] as string;
+
+  switch (column.key) {
+    case 'name':
+      return <Link>{fieldContent}</Link>;
+
+    default:
+      return <span>{fieldContent}</span>;
+  }
+}
+
+function _copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
+  const key = columnKey as keyof T;
+  return items.slice(0).sort((a: T, b: T) => ((isSortedDescending ? a[key] < b[key] : a[key] > b[key]) ? 1 : -1));
+}

--- a/packages/react-examples/src/azure-themes/stories/components/choiceGroupWithImagesandIcons.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/choiceGroupWithImagesandIcons.stories.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
+import { TestImages } from '@fluentui/example-data';
+
+const options: IChoiceGroupOption[] = [
+  {
+    key: 'bar',
+    imageSrc: TestImages.choiceGroupBarUnselected,
+    imageAlt: 'Bar chart',
+    selectedImageSrc: TestImages.choiceGroupBarSelected,
+    imageSize: { width: 32, height: 32 },
+    text: 'Bar',
+  },
+  {
+    key: 'pie',
+    imageSrc: TestImages.choiceGroupPieUnselected,
+    imageAlt: 'Pie chart',
+    selectedImageSrc: TestImages.choiceGroupPieSelected,
+    imageSize: { width: 32, height: 32 },
+    text: 'Pie',
+  },
+  { key: 'month', text: 'Month', iconProps: { iconName: 'Calendar' }, disabled: true },
+  { key: 'day', text: 'Day', iconProps: { iconName: 'CalendarDay' } },
+  { key: 'week', text: 'Week', iconProps: { iconName: 'CalendarWeek' } },
+];
+
+export const ChoiceGroupImageExample: React.FunctionComponent = () => {
+  return (
+    <>
+      <ChoiceGroup label="Pick one image" defaultSelectedKey="bar" options={options} />
+      <p>
+        Warning: this ChoiceGroup option layout restricts the space that label text has to expand and wrap. This can
+        cause issues for accessibility, when zoom and text spacing increase the length of words and lines, and also
+        internationalization, since translated text length will vary.
+      </p>
+      <p>We recommend using the standard layout with an inline image for labels longer than a single short word.</p>
+    </>
+  );
+};


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->
Choicegroup with icon / image bug
<img src="https://github.com/microsoft/fluentui/assets/30805892/73fc8f3c-1169-4734-8c32-dbf90f719f6e" width="300px" />

DetailsList selected and selected+hover link is not passing accessibility 
<img src="https://github.com/microsoft/fluentui/assets/30805892/cdbd25dc-1019-4e03-9eb1-2b34dbf3a9e4" width="500px" />


## New Behavior
<img src="https://github.com/microsoft/fluentui/assets/30805892/482e29be-9ef5-4fbf-9e5f-2a2d54d5ba60" width="500px" />
<img src="https://github.com/microsoft/fluentui/assets/30805892/d47ba79c-0ecb-44b5-8408-1b0dbe2520d6" width="500px" />


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
