### PR TITLE
fix: User-provided props win over defined defaults in Link component

### DIFF
--- a/change/@fluentui-react-link-0346db3c-ee8d-4d9e-b3a9-0c785ab3c830.json
+++ b/change/@fluentui-react-link-0346db3c-ee8d-4d9e-b3a9-0c785ab3c830.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: User-provided props win over defined defaults in Link component.",
+  "packageName": "@fluentui/react-link",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/src/components/Link/Link.test.tsx
+++ b/packages/react-components/react-link/src/components/Link/Link.test.tsx
@@ -76,6 +76,16 @@ describe('Link', () => {
 
       expect(link.getAttribute('tabIndex')).toBe('-1');
     });
+
+    it('allows overriding "role"', () => {
+      const result = render(
+        <Link href="https://www.bing.com" role="button">
+          This is a link
+        </Link>,
+      );
+      expect(result.queryAllByRole('link')).toHaveLength(0);
+      expect(result.queryAllByRole('button')).toHaveLength(1);
+    });
   });
 
   describe('when rendered as a button', () => {
@@ -119,6 +129,16 @@ describe('Link', () => {
       const button = result.getByRole('button');
 
       expect(button.getAttribute('tabIndex')).toBe('-1');
+    });
+
+    it('allows overriding "role"', () => {
+      const result = render(
+        <Link href="https://www.bing.com" role="presentation">
+          This is a link
+        </Link>,
+      );
+      expect(result.queryAllByRole('link')).toHaveLength(0);
+      expect(result.queryAllByRole('presentation')).toHaveLength(1);
     });
   });
 });

--- a/packages/react-components/react-link/src/components/Link/useLink.ts
+++ b/packages/react-components/react-link/src/components/Link/useLink.ts
@@ -20,10 +20,10 @@ export const useLink_unstable = (
 
   // Casting is required here as `as` prop would break the union between `a`, `button` and `span` types
   const propsWithAssignedAs = {
-    ...props,
-    as: elementType,
     role: elementType === 'span' ? 'button' : undefined,
     type: elementType === 'button' ? 'button' : undefined,
+    ...props,
+    as: elementType,
   } as LinkProps;
 
   const state: LinkState = {


### PR DESCRIPTION
## Previous Behavior

User-provided `role` and `type` props would not be respected and would instead be overridden by the specified defaults.

## New Behavior

All user-provided props are now respected, and unit tests have been added so that this behavior does not regress in the future.

## Related Issue(s)

- Fixes #30052
