### PR TITLE
fix(react-card): interactive cards not having the focus ring when focused

### DIFF
--- a/change/@fluentui-react-card-45d09ab1-d545-47c9-81ab-cae4186e799f.json
+++ b/change/@fluentui-react-card-45d09ab1-d545-47c9-81ab-cae4186e799f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: interactive cards not having the focus ring when focused",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -48,7 +48,7 @@ const useCardInteractive = ({ focusMode = 'off', ...props }: CardProps) => {
 
   return {
     interactive,
-    focusAttributes: focusMode === 'off' ? null : interactiveFocusAttributes,
+    focusAttributes: !interactive && focusMode === 'off' ? null : interactiveFocusAttributes,
   };
 };
 


### PR DESCRIPTION
This PR fixes a regression with the card component

## Previous Behavior
The focus ring was not visible and keyboard navigation was compromised

## New Behavior
Focus ring is visible when tabbing from one card to the other
