### PR TITLE
fix: Add a namespace to CSS variables in react-positioning package to avoid potential collisions

### DIFF
--- a/change/@fluentui-react-positioning-d0679179-03e3-47de-b4ff-4810ed017ac3.json
+++ b/change/@fluentui-react-positioning-d0679179-03e3-47de-b4ff-4810ed017ac3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add a namespace to CSS variables in react-positioning package to avoid potential collisions.",
+  "packageName": "@fluentui/react-positioning",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -91,25 +91,25 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
       ),
       ...shorthands.borderBottom(borderWidth, borderStyle, borderColor),
       borderBottomRightRadius: tokens.borderRadiusSmall,
-      transform: 'rotate(var(--angle)) translate(0, 50%) rotate(45deg)',
+      transform: 'rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(45deg)',
     },
 
     // Popper sets data-popper-placement on the root element, which is used to align the arrow
     ':global([data-popper-placement^="top"])': {
       bottom: `-${borderWidth}`,
-      '--angle': '0',
+      '--fui-positioning-angle': '0',
     },
     ':global([data-popper-placement^="right"])': {
       left: `-${borderWidth} /* @noflip */`,
-      '--angle': '90deg',
+      '--fui-positioning-angle': '90deg',
     },
     ':global([data-popper-placement^="bottom"])': {
       top: `-${borderWidth}`,
-      '--angle': '180deg',
+      '--fui-positioning-angle': '180deg',
     },
     ':global([data-popper-placement^="left"])': {
       right: `-${borderWidth} /* @noflip */`,
-      '--angle': '270deg',
+      '--fui-positioning-angle': '270deg',
     },
   };
 }

--- a/packages/react-components/react-positioning/src/createSlideStyles.ts
+++ b/packages/react-components/react-positioning/src/createSlideStyles.ts
@@ -17,8 +17,8 @@ export function createSlideStyles(mainAxis: number): GriffelStyle {
     },
   };
 
-  const slideDistanceVarX = '--slide-distance-x';
-  const slideDistanceVarY = '--slide-distance-y';
+  const slideDistanceVarX = '--fui-positioning-slide-distance-x';
+  const slideDistanceVarY = '--fui-positioning-slide-distance-y';
 
   return {
     animationComposition: 'accumulate',


### PR DESCRIPTION
## Previous Behavior

We found a collision of the use of the `--angle` CSS variable in Fluent AI, as it was being used by both `flair` in Fluent AI and `positioning` in Fluent UI. We proceeded to add a namespace to CSS variables in Fluent AI.

## New Behavior

This PR adds a namespace to CSS variables inside of the `react-positioning` package to avoid potential collisions when used in conjunction with other packages/in custom code.

## Related Issue(s)

- Follow-up from https://github.com/microsoft/fluentai/pull/1268.