### PR TITLE
bugfix(react-menu): add system colors on hover

### DIFF
--- a/change/@fluentui-react-menu-7e47016d-d354-4335-bfde-d5815e1184df.json
+++ b/change/@fluentui-react-menu-7e47016d-d354-4335-bfde-d5815e1184df.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: add system colors on hover",
+  "packageName": "@fluentui/react-menu",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -54,6 +54,16 @@ const useRootBaseStyles = makeResetStyles({
     color: tokens.colorNeutralForeground2Pressed,
   },
 
+  // High contrast styles
+  '@media (forced-colors: active)': {
+    ':hover': {
+      backgroundColor: 'Canvas',
+      borderColor: 'Highlight',
+      color: 'Highlight',
+    },
+    ...createFocusOutlineStyle({ style: { outlineColor: 'Highlight' } }),
+  },
+
   userSelect: 'none',
   ...createFocusOutlineStyle(),
 });
@@ -142,12 +152,15 @@ const useStyles = makeStyles({
       color: 'GrayText',
       ':hover': {
         color: 'GrayText',
+        backgroundColor: 'Canvas',
         [`& .${menuItemClassNames.icon}`]: {
           color: 'GrayText',
+          backgroundColor: 'Canvas',
         },
       },
       ':focus': {
         color: 'GrayText',
+        backgroundColor: 'Canvas',
       },
     },
   },


### PR DESCRIPTION
## New Behavior

1. adds proper [system colors](https://drafts.csswg.org/css-color-4/#css-system-colors) on hover if [forced colors](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) is active

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/30069
