### PR TITLE
fix(TimePickerCompat): letter key navigation should be case insensitive

### DIFF
--- a/change/@fluentui-react-timepicker-compat-preview-925158c3-8c51-4e6d-b2a0-41d8901dd0fe.json
+++ b/change/@fluentui-react-timepicker-compat-preview-925158c3-8c51-4e6d-b2a0-41d8901dd0fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: letter key navigation in listbox should be case insensitive",
+  "packageName": "@fluentui/react-timepicker-compat-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
@@ -144,6 +144,7 @@ describe('TimePicker with custom parsing', () => {
     const formatDateToTimeString = (date: Date) => {
       const localeTimeString = date.toLocaleTimeString([], {
         hour: 'numeric',
+        hourCycle: 'h23',
         minute: '2-digit',
       });
       if (date.getHours() < 12) {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
@@ -150,6 +150,9 @@ describe('TimePicker with custom parsing', () => {
       if (date.getHours() < 12) {
         return `Morning: ${localeTimeString}`;
       }
+      if (date.getHours() === 12) {
+        return `noon: ${localeTimeString}`;
+      }
       return `Afternoon: ${localeTimeString}`;
     };
 
@@ -174,7 +177,8 @@ describe('TimePicker with custom parsing', () => {
           freeform
           dateAnchor={anchor}
           startHour={9}
-          endHour={13}
+          endHour={14}
+          increment={60}
           formatDateToTimeString={formatDateToTimeString}
           parseTimeStringToDate={parseTimeStringToDate}
           onTimeChange={onTimeChange}
@@ -186,8 +190,13 @@ describe('TimePicker with custom parsing', () => {
   it('letter navigation should be case insensitive and select option on enter', () => {
     mount(<Example />);
     cy.get(inputSelector).click().get(optionSelector(0)).should('be.visible');
+
     cy.get(inputSelector).click().type('a').realPress('Enter');
-    cy.get(inputSelector).should('have.value', 'Afternoon: 12:00');
-    cy.get('#selected-time-text').should('have.text', 'Afternoon: 12:00');
+    cy.get(inputSelector).should('have.value', 'Afternoon: 13:00');
+    cy.get('#selected-time-text').should('have.text', 'Afternoon: 13:00');
+
+    cy.get(inputSelector).clear().click().type('N').realPress('Enter');
+    cy.get(inputSelector).should('have.value', 'noon: 12:00');
+    cy.get('#selected-time-text').should('have.text', 'noon: 12:00');
   });
 });

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
@@ -3,7 +3,7 @@ import { mount as mountBase } from '@cypress/react';
 
 import { FluentProvider } from '@fluentui/react-provider';
 import { teamsLightTheme } from '@fluentui/react-theme';
-import { TimePicker, TimePickerProps, TimeSelectionData } from '@fluentui/react-timepicker-compat-preview';
+import { TimePicker, TimePickerProps } from '@fluentui/react-timepicker-compat-preview';
 
 const mount = (element: JSX.Element) => {
   mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
@@ -145,7 +145,6 @@ describe('TimePicker with custom parsing', () => {
       const localeTimeString = date.toLocaleTimeString([], {
         hour: 'numeric',
         minute: '2-digit',
-        hourCycle: 'h12',
       });
       if (date.getHours() < 12) {
         return `Morning: ${localeTimeString}`;
@@ -159,8 +158,7 @@ describe('TimePicker with custom parsing', () => {
       }
 
       const [hours, minutes] = (time.split(' ')[1].match(/\d+/g) ?? []).map(Number);
-      const adjustedHours = time.includes('Afternoon: ') && hours !== 12 ? hours + 12 : hours;
-      const date = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate(), adjustedHours, minutes);
+      const date = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate(), hours, minutes);
 
       return { date };
     };
@@ -188,7 +186,7 @@ describe('TimePicker with custom parsing', () => {
     mount(<Example />);
     cy.get(inputSelector).click().get(optionSelector(0)).should('be.visible');
     cy.get(inputSelector).click().type('a').realPress('Enter');
-    cy.get(inputSelector).should('have.value', 'Afternoon: 12:00 pm');
-    cy.get('#selected-time-text').should('have.text', 'Afternoon: 12:00 pm');
+    cy.get(inputSelector).should('have.value', 'Afternoon: 12:00');
+    cy.get('#selected-time-text').should('have.text', 'Afternoon: 12:00');
   });
 });

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -164,7 +164,7 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
   React.useEffect(() => {
     if (freeform && value) {
       setActiveOption(prevActiveOption => {
-        if (prevActiveOption?.text?.indexOf(value) === 0) {
+        if (prevActiveOption?.text && prevActiveOption.text.toLowerCase().indexOf(value) === 0) {
           return prevActiveOption;
         }
         return undefined;

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -164,7 +164,7 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
   React.useEffect(() => {
     if (freeform && value) {
       setActiveOption(prevActiveOption => {
-        if (prevActiveOption?.text && prevActiveOption.text.toLowerCase().indexOf(value) === 0) {
+        if (prevActiveOption?.text && prevActiveOption.text.toLowerCase().indexOf(value.toLowerCase()) === 0) {
           return prevActiveOption;
         }
         return undefined;


### PR DESCRIPTION

## Previous Behavior
Press letter key in TimePicker input can navigate among item in listbox, but it is case sensitive.

## New Behavior
The navigation is now case insensitive.

## Related Issue(s)
#29824
