### PR TITLE
bugfix(react-table): add system colors on hover

### DIFF
--- a/change/@fluentui-react-table-5e2f49f6-00d8-4546-a260-5351fbb6a98f.json
+++ b/change/@fluentui-react-table-5e2f49f6-00d8-4546-a260-5351fbb6a98f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: add system colors on hover",
+  "packageName": "@fluentui/react-table",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
+++ b/packages/react-components/react-table/src/components/TableRow/useTableRowStyles.styles.ts
@@ -72,6 +72,13 @@ const useStyles = makeStyles({
         opacity: 1,
       },
     },
+    // High contrast styles
+    '@media (forced-colors: active)': {
+      ':hover': {
+        color: 'Highlight',
+        ...shorthands.borderColor('Highlight'),
+      },
+    },
   },
 
   medium: {


### PR DESCRIPTION
## New Behavior

1. adds proper [system colors](https://drafts.csswg.org/css-color-4/#css-system-colors) on hover if [forced colors](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) is active

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/30070
