### PR TITLE
docs: fix links to images in specs

### DIFF
--- a/packages/react-components/react-infobutton/docs/Spec.md
+++ b/packages/react-components/react-infobutton/docs/Spec.md
@@ -10,7 +10,7 @@ Because the Popover isn't always visible, it should not contain information that
 
 ### Anatomy
 
-![Anatomy](./etc/images/anatomy.png)
+![Anatomy](../etc/images/anatomy.png)
 
 ## Prior Art
 

--- a/packages/react-components/react-infolabel/docs/Spec.md
+++ b/packages/react-components/react-infolabel/docs/Spec.md
@@ -10,7 +10,7 @@ Because the Popover isn't always visible, it should not contain information that
 
 ### Anatomy
 
-![Anatomy](./etc/images/anatomy.png)
+![Anatomy](../etc/images/anatomy.png)
 
 ## Prior Art
 

--- a/packages/react-components/react-menu/docs/Spec.md
+++ b/packages/react-components/react-menu/docs/Spec.md
@@ -938,24 +938,24 @@ Below is a set of diagrams that tries to illustrates all the interactions menus 
 > TODO convert these diagrams to excalidraw or smth that is text format
 > TODO add extra descriptions to diagrams
 
-<img src="./etc/images/menu-interactions/Slide1.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide2.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide3.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide4.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide5.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide6.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide7.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide8.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide9.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide10.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide11.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide12.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide13.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide14.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide15.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide16.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide17.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide18.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide1.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide2.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide3.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide4.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide5.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide6.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide7.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide8.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide9.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide10.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide11.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide12.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide13.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide14.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide15.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide16.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide17.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide18.PNG" width="700" />
 
 ### Split button MenuItem submenu
 
@@ -964,10 +964,10 @@ All of the above Mouse events seen previously should apply to the part of the sp
 > TODO convert these diagrams to excalidraw or smth that is text format
 > TODO add extra descriptions to diagrams
 
-<img src="./etc/images/menu-interactions/Slide19.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide20.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide21.PNG" width="700" />
-<img src="./etc/images/menu-interactions/Slide22.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide19.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide20.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide21.PNG" width="700" />
+<img src="../etc/images/menu-interactions/Slide22.PNG" width="700" />
 
 ### MenuItem selection
 
@@ -985,7 +985,7 @@ In the event that the selection method is a radio, the previous selected item mu
 
 When a user sets focus on menu items using keyboard navigation, and then switches to mouse hover there should be one unique 'active' state for menu items. There should not be two different indicators at this point for hover and focus. Below is a GIF of the `ContextualMenu` in v7 that also supports this behaviour.
 
-![Linked keyboard and mouse navigation](./etc/images/linked-keyboard-mouse-navigation.gif)
+![Linked keyboard and mouse navigation](../etc/images/linked-keyboard-mouse-navigation.gif)
 
 ### Positioning
 

--- a/packages/react-components/react-persona/docs/Spec.md
+++ b/packages/react-components/react-persona/docs/Spec.md
@@ -17,7 +17,7 @@ Persona is used in PeoplePicker, Team's left rail and menus, chiclets, and Card.
 
 ## Anatomy
 
-![Anatomy](./etc/images/anatomy.png)
+![Anatomy](../etc/images/anatomy.png)
 
 ### Avatar, PresenceBadge, and Avatar + PresenceBadge
 

--- a/packages/react-components/react-radio/docs/Spec.md
+++ b/packages/react-components/react-radio/docs/Spec.md
@@ -57,31 +57,31 @@ It uses the option's `value` property as the input value and holds the currently
 
 Inline positioning of the inputs and labels.
 
-![Horizontal group](./etc/images/horizontal-group.png)
+![Horizontal group](../etc/images/horizontal-group.png)
 
 #### Horizonal stacked
 
 Positioning the label at the bottom of the radio inputs.
 
-![Horizontal group - stacked](./etc/images/horizontal-group-stacked.png)
+![Horizontal group - stacked](../etc/images/horizontal-group-stacked.png)
 
 #### Vertical
 
 Default vertical positioning of Radio items.
 
-![Vertical group](./etc/images/vertical-group.png)
+![Vertical group](../etc/images/vertical-group.png)
 
 #### Vertical with input
 
 Default positioning of Radio items with an input as its last Radio item.
 
-![Vertical group with input](./etc/images/vertical-group-with-input.png)
+![Vertical group with input](../etc/images/vertical-group-with-input.png)
 
 ### Vertical with dropdown
 
 Default positioning of Radio items with a dropdown as its last Radio item.
 
-![Vertical group with dropdown](./etc/images/vertical-group-with-dropdown.png)
+![Vertical group with dropdown](../etc/images/vertical-group-with-dropdown.png)
 
 ## API
 

--- a/packages/react-components/react-table/docs/Spec.md
+++ b/packages/react-components/react-table/docs/Spec.md
@@ -437,9 +437,9 @@ overriding the default interaction behaviour of the `DataGrid` component is too 
 Table header cells are only focusable when they are sortable. Focus when tabbing into the Table control should
 focus on the first sortable header, if any.
 
-<img src="./etc/images/table-interactions/Slide2.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide3.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide4.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide2.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide3.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide4.PNG" width="700" />
 
 ### Navigation modes
 
@@ -456,11 +456,11 @@ This is the most accessible and screenreader friendly navigation mode. This is w
 [WAI APG examples](https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids). Navigation happsn only
 on the level of the cell in both directions.
 
-<img src="./etc/images/table-interactions/Slide6.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide7.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide8.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide9.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide10.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide6.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide7.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide8.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide9.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide10.PNG" width="700" />
 
 #### row
 
@@ -468,9 +468,9 @@ This navigation mode can cause screen reader issues since tables are not intende
 This mode only navigates the table by row and can be useful when row selection is the only interactive feature of
 the component
 
-<img src="./etc/images/table-interactions/Slide12.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide13.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide14.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide12.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide13.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide14.PNG" width="700" />
 
 ### Nested focusables in cells
 
@@ -480,18 +480,18 @@ When there is a single focusable element inside a cell, users are recommended to
 In this scenario, cells will be focused on navigation, but the focusable
 element inside the cell should be focused if it exists.
 
-<img src="./etc/images/table-interactions/Slide24.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide25.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide24.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide25.PNG" width="700" />
 
 #### Nested focusable
 
 When there are multile focusable elemnts inside a cell, we implement a pattern similar to the [WAI grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/).
 Pressing `Enter` on a cell will move focus and trap focus inside until the user presses `Escape` to revert back to grid navigation.
 
-<img src="./etc/images/table-interactions/Slide27.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide28.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide29.PNG" width="700" />
-<img src="./etc/images/table-interactions/Slide30.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide27.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide28.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide29.PNG" width="700" />
+<img src="../etc/images/table-interactions/Slide30.PNG" width="700" />
 ## Accessibility
 
 The spec aims to use the accessibility section as little as possible and building an accessible component by default.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Images on various spec files are broken:

![image](https://github.com/microsoft/fluentui/assets/19153565/53561afb-6222-4170-8d5c-c9100699ad8e)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Use the correct relative path instead:

![image](https://github.com/microsoft/fluentui/assets/19153565/c3d6d913-128f-411e-be01-cf406c2b86cd)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- ~~Fixes #~~ Haven't found one
