### PR TITLE
bugfix(react-nav): slots should be declared with new slot API

### DIFF
--- a/packages/react-components/react-nav-preview/src/components/NavLink/renderNavLink.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavLink/renderNavLink.tsx
@@ -2,15 +2,13 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
 import type { NavLinkState, NavLinkSlots } from './NavLink.types';
+import { assertSlots } from '@fluentui/react-utilities';
 
 /**
  * Render the final JSX of NavLink
  */
 export const renderNavLink_unstable = (state: NavLinkState) => {
-  const { slots, slotProps } = getSlotsNext<NavLinkSlots>(state);
-
-  // TODO Add additional slots in the appropriate place
-  return <slots.root {...slotProps.root} />;
+  assertSlots<NavLinkSlots>(state);
+  return <state.root />;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavLink/useNavLink.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavLink/useNavLink.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getIntrinsicElementProps } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { NavLinkProps, NavLinkState } from './NavLink.types';
 
 /**
@@ -20,9 +20,12 @@ export const useNavLink_unstable = (props: NavLinkProps, ref: React.Ref<HTMLDivE
     },
     // TODO add appropriate slots, for example:
     // mySlot: resolveShorthand(props.mySlot),
-    root: getIntrinsicElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };

--- a/packages/react-components/react-nav-preview/src/components/NavLinkGroup/renderNavLinkGroup.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavLinkGroup/renderNavLinkGroup.tsx
@@ -2,15 +2,15 @@
 /** @jsx createElement */
 
 import { createElement } from '@fluentui/react-jsx-runtime';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import type { NavLinkGroupState, NavLinkGroupSlots } from './NavLinkGroup.types';
 
 /**
  * Render the final JSX of NavLinkGroup
  */
 export const renderNavLinkGroup_unstable = (state: NavLinkGroupState) => {
-  const { slots, slotProps } = getSlotsNext<NavLinkGroupSlots>(state);
+  assertSlots<NavLinkGroupSlots>(state);
 
   // TODO Add additional slots in the appropriate place
-  return <slots.root {...slotProps.root} />;
+  return <state.root />;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavLinkGroup/useNavLinkGroup.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavLinkGroup/useNavLinkGroup.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getIntrinsicElementProps } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { NavLinkGroupProps, NavLinkGroupState } from './NavLinkGroup.types';
 
 /**
@@ -23,9 +23,12 @@ export const useNavLinkGroup_unstable = (
     },
     // TODO add appropriate slots, for example:
     // mySlot: resolveShorthand(props.mySlot),
-    root: getIntrinsicElementProps('div', {
-      ref,
-      ...props,
-    }),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
   };
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`NavLink` and `NavLinkGroup` is using `getSlotsNext`

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Migrate to new slot API as the old one will be deprecated

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
