### PR TITLE
fix: focus outline should have `Highlight` colour in high contrast

### DIFF
--- a/change/@fluentui-react-tabster-c2d3df02-d2f4-4671-a204-7585b3e81fff.json
+++ b/change/@fluentui-react-tabster-c2d3df02-d2f4-4671-a204-7585b3e81fff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: focus outline should have `Highlight` colour in high contrast",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/focus/createFocusOutlineStyle.ts
+++ b/packages/react-components/react-tabster/src/focus/createFocusOutlineStyle.ts
@@ -59,6 +59,11 @@ const getFocusOutlineStyles = (options: FocusOutlineStyleOptions): GriffelStyle 
 
   return {
     ...shorthands.borderColor('transparent'),
+    '@media (forced-colors: active)': {
+      '::after': {
+        ...shorthands.borderColor('Highlight'),
+      },
+    },
     '::after': {
       content: '""',
       position: 'absolute',


### PR DESCRIPTION
Sets the border colour to be `Highlight` for the standard pseudoselector based focus outline.

Before
![image](https://github.com/microsoft/fluentui/assets/20744592/822c4760-a339-4149-8826-a357226e8db0)
![image](https://github.com/microsoft/fluentui/assets/20744592/2a75d874-e0de-4a1a-854e-2382fd92eeff)


After

![image](https://github.com/microsoft/fluentui/assets/20744592/a19c3442-293b-435e-ba5f-110389b1dff4)
![image](https://github.com/microsoft/fluentui/assets/20744592/c1291583-782c-4856-935a-48ade5255c3b)
