### PR TITLE
fix(Combobox): make high contrast hover color accessible

### DIFF
--- a/change/@fluentui-react-combobox-0fdf2a9f-1e39-479d-abdb-d49e9a4c836a.json
+++ b/change/@fluentui-react-combobox-0fdf2a9f-1e39-479d-abdb-d49e9a4c836a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: make hover color in contrast theme accessible.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
@@ -25,12 +25,16 @@ const useStyles = makeStyles({
     ...shorthands.padding(tokens.spacingVerticalSNudge, tokens.spacingHorizontalS),
     position: 'relative',
 
-    '&:hover': {
+    ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
+      color: tokens.colorNeutralForeground1Hover,
+      [`& .${optionClassNames.checkIcon}`]: shorthands.borderColor(tokens.colorNeutralForeground1Hover),
     },
 
-    '&:active': {
+    ':active': {
       backgroundColor: tokens.colorNeutralBackground1Pressed,
+      color: tokens.colorNeutralForeground1Pressed,
+      [`& .${optionClassNames.checkIcon}`]: shorthands.borderColor(tokens.colorNeutralForeground1Hover),
     },
   },
 
@@ -58,12 +62,16 @@ const useStyles = makeStyles({
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
 
-    '&:hover': {
+    ':hover': {
       backgroundColor: tokens.colorTransparentBackground,
+      color: tokens.colorNeutralForegroundDisabled,
+      [`& .${optionClassNames.checkIcon}`]: shorthands.borderColor(tokens.colorNeutralForegroundDisabled),
     },
 
-    '&:active': {
+    ':active': {
       backgroundColor: tokens.colorTransparentBackground,
+      color: tokens.colorNeutralForegroundDisabled,
+      [`& .${optionClassNames.checkIcon}`]: shorthands.borderColor(tokens.colorNeutralForegroundDisabled),
     },
 
     '@media (forced-colors: active)': {
@@ -119,6 +127,7 @@ const useStyles = makeStyles({
       color: 'GrayText',
     },
   },
+  multiselectCheckDisabled: shorthands.borderColor(tokens.colorNeutralForegroundDisabled),
 });
 
 /**
@@ -144,6 +153,7 @@ export const useOptionStyles_unstable = (state: OptionState): OptionState => {
       selected && styles.selectedCheck,
       selected && multiselect && styles.selectedMultiselectCheck,
       disabled && styles.checkDisabled,
+      disabled && multiselect && styles.multiselectCheckDisabled,
       state.checkIcon.className,
     );
   }


### PR DESCRIPTION
Fix #29367 - match Combobox high contrast style to figma:

| | before | after |
|----|----|---|
| hover | <img width="321" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/d8bea622-0837-45b0-acca-064cd2038040">| <img width="299" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/574f3442-ac61-4861-accc-2c6b33ff7307">|
|multi-select hover and disabled | <img width="290" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/c42ff4f2-28b2-4622-8a03-1014e2ef3cdf"> | <img width="268" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/9691962a-ddcb-4fde-ab59-fff294d47c7a"> | 
| multi-select hover selected | <img width="275" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/2fea19b5-29f6-4750-898f-f7e72e4482ed"> | <img width="270" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/b590a777-8b2c-4952-b0e6-0f325052a2c5">|