### PR TITLE
fix(TimePickerCompat): provide default aria-labelledby on chevron icon when it is wrapped in Field

### DIFF
--- a/change/@fluentui-react-timepicker-compat-preview-1e940c43-3126-4f50-ac72-9404932eec88.json
+++ b/change/@fluentui-react-timepicker-compat-preview-1e940c43-3126-4f50-ac72-9404932eec88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: provides a default aria-labelledby for the chevron icon if the TimePicker is wrapped in a Field.",
+  "packageName": "@fluentui/react-timepicker-compat-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-timepicker-compat-preview/package.json
+++ b/packages/react-components/react-timepicker-compat-preview/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",
     "@fluentui/react-combobox": "^9.5.33",
+    "@fluentui/react-field": "^9.1.44",
     "@fluentui/react-jsx-runtime": "^9.0.21",
     "@fluentui/react-shared-contexts": "^9.13.1",
     "@fluentui/react-theme": "^9.1.16",

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Field } from '@fluentui/react-components';
 import { isConformant } from '../../testing/isConformant';
 import { TimePicker } from './TimePicker';
 import { TimePickerProps } from './TimePicker.types';
@@ -63,6 +64,17 @@ describe('TimePicker', () => {
 
     userEvent.click(getAllByRole('option')[10]);
     expect(getByRole('combobox').getAttribute('value')).toBe('10:00');
+  });
+
+  it('when wrapped in Field, sets default aria-labelledby on chevron icon', () => {
+    const { getByRole } = render(
+      <Field label="Coffee time">
+        <TimePicker />
+      </Field>,
+    );
+
+    const chevronIcon = getByRole('button');
+    expect(chevronIcon.getAttribute('aria-labelledby')).not.toBeNull();
   });
 
   describe('freeform', () => {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -4,11 +4,13 @@ import {
   mergeCallbacks,
   useControllableState,
   useEventCallback,
+  useId,
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import { Enter } from '@fluentui/keyboard-keys';
 import type { Hour, TimePickerOption, TimePickerProps, TimePickerState, TimeSelectionData } from './TimePicker.types';
 import { ComboboxProps, useCombobox_unstable, Option } from '@fluentui/react-combobox';
+import { useFieldContext_unstable as useFieldContext } from '@fluentui/react-field';
 import {
   dateToKey,
   keyToDate,
@@ -122,6 +124,7 @@ export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HT
     submittedText,
   };
 
+  useDefaultChevronIconLabel(state);
   useSelectTimeFromValue(state, selectTime);
 
   return state;
@@ -211,4 +214,18 @@ const useSelectTimeFromValue = (state: TimePickerState, callback: TimePickerProp
     }
   });
   state.input.onBlur = mergeCallbacks(handleInputBlur, state.input.onBlur);
+};
+
+/**
+ * Provides a default aria-labelledby for the chevron icon if the TimePicker is wrapped in a Field.
+ */
+const useDefaultChevronIconLabel = (state: TimePickerState) => {
+  const fieldContext = useFieldContext();
+  const chevronDefaultId = useId('timepicker-chevron-');
+  const defaultLabelFromCombobox = 'Open';
+
+  if (fieldContext?.labelId && state.expandIcon?.['aria-label'] === defaultLabelFromCombobox) {
+    const chevronId = state.expandIcon.id ?? chevronDefaultId;
+    state.expandIcon['aria-labelledby'] = `${chevronId} ${fieldContext.labelId}`;
+  }
 };


### PR DESCRIPTION
When `TimePicker` is used in `Field`, it should use Field's label for chevron icon:
<img width="724" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/45a66d5c-d71f-4ee0-ae36-f7954e115ff0">
