### PR TITLE
chore(react-positioning): move from floating-ui-devtools to @floating-ui/devtools

### DIFF
--- a/change/@fluentui-react-positioning-cfff7233-c764-432c-9a6d-bee9da68142d.json
+++ b/change/@fluentui-react-positioning-cfff7233-c764-432c-9a6d-bee9da68142d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: move from floating-ui-devtools to @floating-ui/devtools",
+  "packageName": "@fluentui/react-positioning",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -30,12 +30,12 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.2.0",
+    "@floating-ui/devtools": "0.0.1",
     "@fluentui/react-shared-contexts": "^9.13.2",
     "@fluentui/react-theme": "^9.1.16",
     "@fluentui/react-utilities": "^9.15.4",
     "@griffel/react": "^1.5.14",
-    "@swc/helpers": "^0.5.1",
-    "floating-ui-devtools": "0.1.2"
+    "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -22,7 +22,7 @@ import {
   matchTargetSize as matchTargetSizeMiddleware,
 } from './middleware';
 import { createPositionManager } from './createPositionManager';
-import { middleware as devtoolsMiddleware } from 'floating-ui-devtools';
+import { devtools } from '@floating-ui/devtools';
 import { devtoolsCallback } from './utils/devtools';
 
 /**
@@ -202,9 +202,7 @@ function usePositioningOptions(options: PositioningOptions) {
         arrow && arrowMiddleware({ element: arrow, padding: arrowPadding }),
         hideMiddleware({ strategy: 'referenceHidden' }),
         hideMiddleware({ strategy: 'escaped' }),
-        process.env.NODE_ENV !== 'production' &&
-          targetDocument &&
-          devtoolsMiddleware(targetDocument, devtoolsCallback(options)),
+        process.env.NODE_ENV !== 'production' && targetDocument && devtools(targetDocument, devtoolsCallback(options)),
       ].filter(Boolean) as Middleware[];
 
       const placement = toFloatingUIPlacement(align, position, isRtl);

--- a/packages/react-components/react-positioning/src/utils/devtools.ts
+++ b/packages/react-components/react-positioning/src/utils/devtools.ts
@@ -1,39 +1,36 @@
-import { MiddlewareArguments } from '@floating-ui/dom';
-import { PositioningOptions } from '../types';
-import { FluentUI } from 'floating-ui-devtools';
+import type { MiddlewareArguments } from '@floating-ui/dom';
+import type { PositioningOptions } from '../types';
 import { isHTMLElement } from '@fluentui/react-utilities';
 import { listScrollParents } from './listScrollParents';
 import { fromFloatingUIPlacement } from './fromFloatingUIPlacement';
 
-export const devtoolsCallback =
-  (options: PositioningOptions) =>
-  (middlewareState: MiddlewareArguments): FluentUI.MiddlewareData => {
-    const {
-      elements: { floating, reference },
-    } = middlewareState;
-    const scrollParentsSet = new Set<HTMLElement>();
-    if (isHTMLElement(reference)) {
-      listScrollParents(reference).forEach(scrollParent => scrollParentsSet.add(scrollParent));
-    }
-    listScrollParents(floating).forEach(scrollParent => scrollParentsSet.add(scrollParent));
-    const flipBoundaries: HTMLElement[] = Array.isArray(options.flipBoundary)
-      ? options.flipBoundary
-      : isHTMLElement(options.flipBoundary)
-      ? [options.flipBoundary]
-      : [];
-    const overflowBoundaries: HTMLElement[] = Array.isArray(options.overflowBoundary)
-      ? options.overflowBoundary
-      : isHTMLElement(options.overflowBoundary)
-      ? [options.overflowBoundary]
-      : [];
-    return {
-      type: 'FluentUIMiddleware',
-      middlewareState,
-      options,
-      initialPlacement: fromFloatingUIPlacement(middlewareState.initialPlacement),
-      placement: fromFloatingUIPlacement(middlewareState.placement),
-      flipBoundaries,
-      overflowBoundaries,
-      scrollParents: Array.from(scrollParentsSet),
-    };
-  };
+export const devtoolsCallback = (options: PositioningOptions) => (middlewareState: MiddlewareArguments) => {
+  const {
+    elements: { floating, reference },
+  } = middlewareState;
+  const scrollParentsSet = new Set<HTMLElement>();
+  if (isHTMLElement(reference)) {
+    listScrollParents(reference).forEach(scrollParent => scrollParentsSet.add(scrollParent));
+  }
+  listScrollParents(floating).forEach(scrollParent => scrollParentsSet.add(scrollParent));
+  const flipBoundaries: HTMLElement[] = Array.isArray(options.flipBoundary)
+    ? options.flipBoundary
+    : isHTMLElement(options.flipBoundary)
+    ? [options.flipBoundary]
+    : [];
+  const overflowBoundaries: HTMLElement[] = Array.isArray(options.overflowBoundary)
+    ? options.overflowBoundary
+    : isHTMLElement(options.overflowBoundary)
+    ? [options.overflowBoundary]
+    : [];
+  return {
+    type: 'FluentUIMiddleware',
+    middlewareState,
+    options,
+    initialPlacement: fromFloatingUIPlacement(middlewareState.initialPlacement),
+    placement: fromFloatingUIPlacement(middlewareState.placement),
+    flipBoundaries,
+    overflowBoundaries,
+    scrollParents: Array.from(scrollParentsSet),
+  } as const;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,6 +1881,11 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.0.tgz#ae7ae7923d41f3d84cb2fd88740a89436610bbec"
   integrity sha512-GHUXPEhMEmTpnpIfesFA2KAoMJPb1SPQw964tToQwt+BbGXdhqTCWT1rOb0VURGylsxsYxiGMnseJ3IlclVpVA==
 
+"@floating-ui/devtools@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/devtools/-/devtools-0.0.1.tgz#98b66755b0ef91fabfb35ec5a737c2c83d41d0a4"
+  integrity sha512-itUtNTkiHPfvRDOrAFKLCYEEZ3PrSIir44El6AoBBl7IbmciAx4CxXVfIWjSCIZdZnHFaeXg6vIfEukqC3Z6bw==
+
 "@floating-ui/dom@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.0.tgz#a60212069cc58961c478037c30eba4b191c75316"
@@ -12937,11 +12942,6 @@ flatted@^3.1.0, flatted@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
-
-floating-ui-devtools@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/floating-ui-devtools/-/floating-ui-devtools-0.1.2.tgz#5d0ab3460daea9dd5dc8de313cd66d89885b66a6"
-  integrity sha512-6QZH99AdZx9by0fJt2AI0axAeOxLpcHgpmaJXYxJWLCblv9iKz7i4lcLKwYvPA9B5brkLwehgjlbi2kI6uq/Eg==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
## New Behavior

Follow up on https://github.com/floating-ui/floating-ui/pull/2653

1. moves from `floating-ui-devtools`, which is based on personal repo  https://github.com/bsunderhus/floating-ui-devtools
2. to `@floating-ui/devtools` which is based in official floating ui repo

<!-- This is the behavior we should expect with the changes in this PR -->

