### PR TITLE
fix: don't call clearTimeout unnecessarily

### DIFF
--- a/change/@fluentui-react-popover-7e7dacac-aba9-4fb0-b535-98d76936c7b3.json
+++ b/change/@fluentui-react-popover-7e7dacac-aba9-4fb0-b535-98d76936c7b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: don't call clearTimeout unnecessarily",
+  "packageName": "@fluentui/react-popover",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This is a preventative PR to address performance concerns that have been brought up by partners. There's no evidence of perf regression, but it shows up enough in traces that it might be nice to avoid.

Updates the popover state so that the hover delay timeout is only cleared if it **actually exists**.

