### PR TITLE
fix(useArrowNavigationGroup): should always memorize last focused element

### DIFF
--- a/change/@fluentui-react-table-40a21599-8cd7-4536-a99e-231b1f7c0c3a.json
+++ b/change/@fluentui-react-table-40a21599-8cd7-4536-a99e-231b1f7c0c3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(useArrowNavigationGroup): should always memorize last focused element",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-741ff8ad-dac0-4784-902b-5b3eb8784832.json
+++ b/change/@fluentui-react-tabster-741ff8ad-dac0-4784-902b-5b3eb8784832.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(useArrowNavigationGroup): should always memorize last focused element",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/packages/react-components/react-menu/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`MenuList renders a default state 1`] = `
 <div
   aria-labelledby=""
   className="fui-MenuList"
-  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Tab\\":false}}}"
+  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1,\\"memorizeCurrent\\":true},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Tab\\":false}}}"
   role="menu"
 >
   Default MenuList

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.cy.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.cy.tsx
@@ -169,8 +169,8 @@ describe('DataGrid', () => {
     cy.focused().should('have.attr', 'role', 'row').realPress('ArrowRight');
     cy.focused().should('have.text', '2-1').should('have.attr', 'role', 'gridcell').realPress('Tab');
     cy.focused().should('have.text', 'After').realPress(['Shift', 'Tab']);
-    cy.focused().should('have.attr', 'role', 'row').realPress('ArrowRight');
-    cy.focused().should('have.text', '7-1').should('have.attr', 'role', 'gridcell').realPress(['Shift', 'Tab']);
+    cy.focused().should('have.text', 'header-2').realPress('ArrowRight');
+    cy.focused().should('have.text', 'header-3').should('have.attr', 'role', 'gridcell').realPress(['Shift', 'Tab']);
     cy.focused().should('have.text', 'Before');
   });
 

--- a/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-components/react-table/src/components/DataGrid/DataGrid.test.tsx
@@ -95,7 +95,7 @@ describe('DataGrid', () => {
     );
 
     expect(result.getByRole('grid').getAttribute('data-tabster')).toMatchInlineSnapshot(
-      `"{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3}}"`,
+      `"{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3,\\"memorizeCurrent\\":true}}"`,
     );
   });
 
@@ -147,7 +147,7 @@ describe('DataGrid', () => {
     );
 
     expect(result.getByRole('grid').getAttribute('data-tabster')).toMatchInlineSnapshot(
-      `"{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3}}"`,
+      `"{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3,\\"memorizeCurrent\\":true}}"`,
     );
   });
 });

--- a/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/packages/react-components/react-table/src/components/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DataGrid renders a default state 1`] = `
 <div>
   <div
     class="fui-DataGrid fui-Table"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":3,\\"memorizeCurrent\\":true}}"
     role="grid"
   >
     <div

--- a/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
+++ b/packages/react-components/react-tabster/src/hooks/useArrowNavigationGroup.ts
@@ -15,6 +15,7 @@ export interface UseArrowNavigationGroupOptions {
   /**
    * Last focused element in the group will be remembered and focused (if still
    * available) when tabbing from outside of the group
+   * @default true
    */
   memorizeCurrent?: boolean;
   /**
@@ -42,7 +43,7 @@ export const useArrowNavigationGroup = (options: UseArrowNavigationGroupOptions 
   const {
     circular,
     axis,
-    memorizeCurrent,
+    memorizeCurrent = true,
     tabbable,
     ignoreDefaultKeydown,
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react-components/react-toolbar/src/components/Toolbar/__snapshots__/Toolbar.test.tsx.snap
+++ b/packages/react-components/react-toolbar/src/components/Toolbar/__snapshots__/Toolbar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Toolbar renders a default state 1`] = `
 <div>
   <div
     class="fui-Toolbar"
-    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":0}}"
+    data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":0,\\"memorizeCurrent\\":true}}"
     role="toolbar"
   >
     Default Toolbar


### PR DESCRIPTION
Sets the `memorizeCurrent` option to be true by default  - after discussion with the team it was agreed that all controls with arrow key navigation should behave this way.

Fixes https://github.com/microsoft/fluentui/issues/30111