### PR TITLE
fix(workspace-plugin): don't write changes on disk with `--verify` flag within tsconfig-base-all generator

### DIFF
--- a/tools/workspace-plugin/src/generators/tsconfig-base-all/index.ts
+++ b/tools/workspace-plugin/src/generators/tsconfig-base-all/index.ts
@@ -12,7 +12,14 @@ export default async function (tree: Tree, schema: TsconfigBaseAllGeneratorSchem
 
   const { existingTsConfig, mergedTsConfig, tsConfigAllPath } = createPathAliasesConfig(tree);
 
-  if (normalizedOptions.verify && !isEqual(existingTsConfig, mergedTsConfig)) {
+  if (!normalizedOptions.verify) {
+    writeJson(tree, tsConfigAllPath, mergedTsConfig);
+    await formatFiles(tree);
+
+    return;
+  }
+
+  if (!isEqual(existingTsConfig, mergedTsConfig)) {
     throw new Error(`
       🚨 ${tsConfigAllPath} is out of date.
 
@@ -20,8 +27,7 @@ export default async function (tree: Tree, schema: TsconfigBaseAllGeneratorSchem
     `);
   }
 
-  writeJson(tree, tsConfigAllPath, mergedTsConfig);
-  await formatFiles(tree);
+  console.log('✅ tsconfig.base.all.json is up to date');
 }
 
 function normalizeOptions(tree: Tree, options: TsconfigBaseAllGeneratorSchema) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When executed via `--verify` flag, `tsconfig.base.all.json` file wasn't checked for consistency but instead doing nothing, it always wrote updated file to disk.

Because how lage works (understands project graph), this action resulted in marking every project within monorepo on every PR as affected, thus triggering whole build/test/lint pipeline for everything.

## New Behavior

- `--verify` doesn't write anything to disk
- this **fix speeds up `BuildTestLint` pipeline** from [49min](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=328777&view=logs&j=1e96f989-784f-546f-05bb-8f7d8dfe5399) to [15min](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=328882&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55) /  **~69% FASTER 🚅🚀**
  - > this depends on your changes within your PR, to better illustrate the perf boost -> if you gonna change some v9 package you should get similar perf boost as v0,v8 projects wont be executed 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
