### PR TITLE
chore(react-tree): stop using old slot API on stories

### DIFF
--- a/packages/react-components/react-tree/stories/Tree/Virtualization.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/Virtualization.stories.tsx
@@ -1,4 +1,10 @@
+// FIXME: for some reason jsxImportSource is not working here,
+// using classic runtime instead
+/** @jsxRuntime classic */
+/** @jsx createElement */
+
 import * as React from 'react';
+import { createElement } from '@fluentui/react-jsx-runtime';
 import {
   FlatTreeProps,
   FlatTreeItem,
@@ -15,7 +21,7 @@ import {
   useHeadlessFlatTree_unstable,
 } from '@fluentui/react-components';
 import { FixedSizeList, FixedSizeListProps, ListChildComponentProps } from 'react-window';
-import { ForwardRefComponent, getSlots } from '@fluentui/react-components';
+import { ForwardRefComponent, assertSlots } from '@fluentui/react-components';
 
 type ItemProps = HeadlessFlatTreeItemProps & { content: string };
 
@@ -51,7 +57,7 @@ const FixedSizeTree: ForwardRefComponent<FixedSizeTreeProps> = React.forwardRef(
   const state = useFlatTree_unstable(props, ref);
   useFlatTreeStyles_unstable(state);
   const contextValues = useFlatTreeContextValues_unstable(state);
-  const { slots, slotProps } = getSlots<FlatTreeSlots>(state);
+  assertSlots<FlatTreeSlots>(state);
   const handleOuterRef = React.useCallback((instance: HTMLElement | null) => {
     if (instance) {
       // This element stays between the tree and treeitem
@@ -61,9 +67,9 @@ const FixedSizeTree: ForwardRefComponent<FixedSizeTreeProps> = React.forwardRef(
   }, []);
   return (
     <TreeProvider value={contextValues.tree}>
-      <slots.root {...slotProps.root}>
+      <state.root>
         <FixedSizeList outerRef={handleOuterRef} {...props.listProps} />
-      </slots.root>
+      </state.root>
     </TreeProvider>
   );
 });


### PR DESCRIPTION

## New Behavior

1. stop using `getSlots` into `Virtualization` documentation, use `assertSlots` instead

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Unblocks https://github.com/microsoft/fluentui/pull/29646