### PR TITLE
fix(test-ssr): do not transform JSX in preparation stage

### DIFF
--- a/packages/react-components/react-tree/stories/Tree/Virtualization.stories.tsx
+++ b/packages/react-components/react-tree/stories/Tree/Virtualization.stories.tsx
@@ -1,10 +1,6 @@
-// FIXME: for some reason jsxImportSource is not working here,
-// using classic runtime instead
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
 import * as React from 'react';
-import { createElement } from '@fluentui/react-jsx-runtime';
 import {
   FlatTreeProps,
   FlatTreeItem,

--- a/scripts/test-ssr/src/commands/main.ts
+++ b/scripts/test-ssr/src/commands/main.ts
@@ -6,11 +6,12 @@ import chalk from 'chalk';
 import * as glob from 'glob';
 import * as match from 'micromatch';
 import type { Browser } from 'puppeteer';
+import * as React from 'react';
 
 import { buildAssets } from '../utils/buildAssets';
 import { CHROME_VERSION } from '../utils/constants';
 import { generateEntryPoints } from '../utils/generateEntryPoints';
-import { hrToSeconds } from '../utils/helpers';
+import { containsAriaDescriptionWarning, hrToSeconds } from '../utils/helpers';
 import { renderToHTML } from '../utils/renderToHTML';
 import { visitPage } from '../utils/visitPage';
 
@@ -26,6 +27,40 @@ const EXCLUDED_STORIES = [
 type MainParams = {
   stories: string;
 };
+
+/**
+ * Intercept console.error() and console.warn() calls during rendering HTML (i.e. SSR) to ensure that no errors and
+ * warnings are thrown during rendering.
+ */
+function interceptConsoleLogs() {
+  const originalConsoleError = console.error;
+  const originalConsoleWarn = console.warn;
+
+  console.error = (...args: unknown[]) => {
+    // Ignoring 'aria-description' warning from React 17 as it's a valid prop
+    // https://github.com/facebook/react/issues/21035
+    if (containsAriaDescriptionWarning(args[0] + ' ' + args[1]) && React.version.startsWith('17')) {
+      return;
+    }
+
+    console.log(chalk.bgRed.whiteBright('❌  A console.error() was thrown during rendering HTML:'));
+    originalConsoleError(...args);
+
+    throw new Error('During rendering a console.error() was thrown');
+  };
+
+  console.warn = (...args: unknown[]) => {
+    console.log(chalk.bgRed.whiteBright('❌  A console.warn() was thrown:'));
+    originalConsoleWarn(...args);
+
+    throw new Error('During rendering a console.warn() was thrown during rendering HTML:');
+  };
+
+  return () => {
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+  };
+}
 
 export async function main(params: MainParams) {
   const distDirectory = path.resolve(process.cwd(), 'node_modules', '.cache', 'ssr-tests');
@@ -116,12 +151,17 @@ export async function main(params: MainParams) {
   // ---
 
   const renderStartTime = process.hrtime();
+  const restoreConsole = interceptConsoleLogs();
 
-  await renderToHTML({
-    cjsOutfile,
-    esmOutfile,
-    htmlOutfile,
-  });
+  try {
+    await renderToHTML({
+      cjsOutfile,
+      esmOutfile,
+      htmlOutfile,
+    });
+  } finally {
+    restoreConsole();
+  }
 
   console.log(chalk.bgGreenBright(`🔥 Render done in ${chalk.bold(hrToSeconds(process.hrtime(renderStartTime)))}`));
 

--- a/scripts/test-ssr/src/utils/getExportFromFile.ts
+++ b/scripts/test-ssr/src/utils/getExportFromFile.ts
@@ -101,8 +101,8 @@ export async function getExportFromFile(distDir: string, filename: string): Prom
 
     filename,
 
-    presets: ['@babel/preset-react', '@babel/preset-typescript'],
-    plugins: [babelPlugin],
+    presets: ['@babel/preset-typescript'],
+    plugins: ['@babel/plugin-syntax-jsx', babelPlugin],
   });
 
   return storyImport;

--- a/scripts/test-ssr/src/utils/visitPage.ts
+++ b/scripts/test-ssr/src/utils/visitPage.ts
@@ -20,7 +20,7 @@ export async function visitPage(browser: Browser, url: string) {
     if (message.type() === 'error') {
       const messageContent = message.text();
 
-      // Ignoring 'aria-description' warning from react 17 as it's a valid prop
+      // Ignoring 'aria-description' warning from React 17 as it's a valid prop
       // https://github.com/facebook/react/issues/21035
       if (containsAriaDescriptionWarning(messageContent) && React.version.startsWith('17')) {
         return;


### PR DESCRIPTION
## New Behavior

Follow up for #30123.

- Updates the part of SSR tests that get stories exports to avoid JSX transforms, so there will be no pragma-related errors
- Fixes the story introduces in #30123
- Adds error intercepting for HTML rendering (aka SSR part)