### PR TITLE
fix: trigger focus should mount hidden listbox

### DIFF
--- a/change/@fluentui-react-combobox-cea228ea-becc-4f56-b04f-1e6d5b72916d.json
+++ b/change/@fluentui-react-combobox-cea228ea-becc-4f56-b04f-1e6d5b72916d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: trigger focus should mount hidden listbox",
+  "packageName": "@fluentui/react-combobox",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field } from '@fluentui/react-field';
 import { Combobox } from './Combobox';
@@ -49,6 +49,24 @@ describe('Combobox', () => {
       </Combobox>,
     );
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('renders a hidden listbox when trigger is focused', () => {
+    const result = render(
+      <Combobox inlinePopup>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    act(() => {
+      result.getByRole('combobox').focus();
+    });
+
+    const listbox = result.container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    expect(window.getComputedStyle(listbox!).display).toEqual('none');
   });
 
   it('renders the popup under document.body by default', () => {

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -32,7 +32,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
 
   const baseState = useComboboxBaseState({ ...props, editable: true });
-  const { open, selectOption, setOpen, setValue, value } = baseState;
+  const { open, selectOption, setOpen, setValue, value, hasFocus } = baseState;
   const [comboboxPopupRef, comboboxTargetRef] = useComboboxPositioning(props);
   const { disabled, freeform, inlinePopup } = props;
   const comboId = useId('combobox-');
@@ -94,7 +94,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     components: { root: 'div', input: 'input', expandIcon: 'span', listbox: Listbox },
     root: rootSlot,
     input: triggerSlot,
-    listbox: open ? listbox : undefined,
+    listbox: open || hasFocus ? listbox : undefined,
     expandIcon: slot.optional(props.expandIcon, {
       renderByDefault: true,
       defaultProps: {

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field } from '@fluentui/react-field';
 import { Dropdown } from './Dropdown';
@@ -38,6 +38,24 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('renders a hidden listbox when trigger is focused', () => {
+    const result = render(
+      <Dropdown inlinePopup>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>,
+    );
+
+    act(() => {
+      result.getByRole('combobox').focus();
+    });
+
+    const listbox = result.container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    expect(window.getComputedStyle(listbox!).display).toEqual('none');
   });
 
   it('renders an open listbox', () => {

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -23,7 +23,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsSize: true });
 
   const baseState = useComboboxBaseState(props);
-  const { open } = baseState;
+  const { open, hasFocus } = baseState;
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
@@ -66,7 +66,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
     components: { root: 'div', button: 'button', expandIcon: 'span', listbox: Listbox },
     root: rootSlot,
     button: trigger,
-    listbox: open ? listbox : undefined,
+    listbox: open || hasFocus ? listbox : undefined,
     expandIcon: slot.optional(props.expandIcon, {
       renderByDefault: true,
       defaultProps: {

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -83,7 +83,6 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
     focusVisible: boolean;
 
     /**
-     * @deprecated - no longer used internally
      * whether the combobox/dropdown currently has focus
      */
     hasFocus: boolean;
@@ -98,9 +97,6 @@ export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 
 
     setFocusVisible(focusVisible: boolean): void;
 
-    /**
-     * @deprecated - no longer used internally
-     */
     setHasFocus(hasFocus: boolean): void;
 
     setOpen(event: ComboboxBaseOpenEvents, newState: boolean): void;

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -32,6 +32,7 @@ export const useComboboxBaseState = (
   const [focusVisible, setFocusVisible] = React.useState(false);
 
   // track focused state to conditionally render collapsed listbox
+  // when the trigger is focused - the listbox should but hidden until the open state is changed
   const [hasFocus, setHasFocus] = React.useState(false);
 
   const ignoreNextBlur = React.useRef(false);

--- a/packages/react-components/react-combobox/src/utils/useTriggerSlot.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerSlot.ts
@@ -17,6 +17,7 @@ export type UseTriggerSlotState = Pick<
   | 'setOpen'
   | 'multiselect'
   | 'value'
+  | 'setHasFocus'
 >;
 
 type UseTriggerSlotOptions = {
@@ -57,6 +58,7 @@ export function useTriggerSlot(
       setFocusVisible,
       setOpen,
       multiselect,
+      setHasFocus,
     },
     defaultProps,
     elementType,
@@ -80,8 +82,17 @@ export function useTriggerSlot(
   // the trigger should open/close the popup on click or blur
   trigger.onBlur = mergeCallbacks((event: React.FocusEvent<HTMLButtonElement> & React.FocusEvent<HTMLInputElement>) => {
     setOpen(event, false);
+    setHasFocus(false);
   }, trigger.onBlur);
 
+  trigger.onFocus = mergeCallbacks(
+    (event: React.FocusEvent<HTMLButtonElement> & React.FocusEvent<HTMLInputElement>) => {
+      if (event.target === event.currentTarget) {
+        setHasFocus(true);
+      }
+    },
+    trigger.onFocus,
+  );
   trigger.onClick = mergeCallbacks(
     (event: React.MouseEvent<HTMLButtonElement> & React.MouseEvent<HTMLInputElement>) => {
       setOpen(event, !open);


### PR DESCRIPTION
Follow up fix from #30010

Previously `hasFocus` and `setHasFocus` were deprecated incorrectly. This caused a regressions since the Combobox/Dropdown should actually mount a listbox with `display: none` when focused.

Also adds a test and docstring to prevent future regression
