### PR TITLE
fix(breadcrumb): BreadcrumbButton focus border has incorrent width and transition

### DIFF
--- a/change/@fluentui-react-breadcrumb-65d8fcef-c70f-4b03-ace4-69630ba9af7c.json
+++ b/change/@fluentui-react-breadcrumb-65d8fcef-c70f-4b03-ace4-69630ba9af7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(breadcrumb): BreadcrumbButton focus border has incorrent width and transition",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
@@ -66,7 +66,6 @@ const useStyles = makeStyles({
   root: {
     minWidth: 'unset',
     textWrap: 'nowrap',
-    ...shorthands.border('none'),
   },
   small: {
     height: '24px',


### PR DESCRIPTION
BreadcrumbButton focus had incorrect border width and transition

## Previous Behavior
![image](https://github.com/microsoft/fluentui/assets/11574680/0f546ce2-0e2c-4770-bb24-5c0ddde125e7)

## New Behavior
![image](https://github.com/microsoft/fluentui/assets/11574680/e1f00a62-e61d-47be-9a94-4af87e9cde7a)