### PR TITLE
feat: Release react-teaching-popover-preview package

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -36,6 +36,7 @@
     "@fluentui/theme-designer": "*",
     "@fluentui/react-search-preview": "*",
     "@fluentui/react-motion-preview": "*",
+    "@fluentui/react-teaching-popover-preview": "*",
     "@fluentui/react-timepicker-compat-preview": "*",
     "@griffel/react": "^1.5.14",
     "@microsoft/applicationinsights-web": "^3",

--- a/change/@fluentui-react-teaching-popover-preview-7c3a0833-d4f9-4b31-bc9f-e526c7c40c83.json
+++ b/change/@fluentui-react-teaching-popover-preview-7c3a0833-d4f9-4b31-bc9f-e526c7c40c83.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Release TeachingPopover preview package",
+  "packageName": "@fluentui/react-teaching-popover-preview",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-preview-7c3a0833-d4f9-4b31-bc9f-e526c7c40c83.json
+++ b/change/@fluentui-react-teaching-popover-preview-7c3a0833-d4f9-4b31-bc9f-e526c7c40c83.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: Release TeachingPopover preview package",
+  "comment": "feat: Release react-teaching-popover-preview package",
   "packageName": "@fluentui/react-teaching-popover-preview",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-teaching-popover-preview/package.json
+++ b/packages/react-components/react-teaching-popover-preview/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-teaching-popover-preview",
   "version": "0.0.0",
-  "private": true,
   "description": "New fluentui react package",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
## Previous Behavior

The `@fluentui/react-teaching-popover-preview` package was not published.

## New Behavior

Publish the preview package using the command:
```
yarn nx generate prepare-initial-release --project @fluentui/react-teaching-popover-preview --phase=preview
```

## Related Issue(s)

- #26639
