### PR TITLE
chore(react-teaching-popover): stop using old slot API

### DIFF
--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverTitle/renderTeachingPopoverTitle.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverTitle/renderTeachingPopoverTitle.tsx
@@ -1,19 +1,19 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 import type { TeachingPopoverTitleState } from './TeachingPopoverTitle.types';
-import { getSlotsNext } from '@fluentui/react-utilities';
+import { assertSlots } from '@fluentui/react-utilities';
 import { TeachingPopoverTitleSlots } from './TeachingPopoverTitle.types';
 
 /**
  * Render the final JSX of TeachingPopoverTitle
  */
 export const renderTeachingPopoverTitle_unstable = (state: TeachingPopoverTitleState) => {
-  const { slots, slotProps } = getSlotsNext<TeachingPopoverTitleSlots>(state);
+  assertSlots<TeachingPopoverTitleSlots>(state);
 
   return (
-    <slots.root {...slotProps.root}>
-      {slotProps.root.children}
-      {slots.dismissButton && <slots.dismissButton {...slotProps.dismissButton} />}
-    </slots.root>
+    <state.root>
+      {state.root.children}
+      {state.dismissButton && <state.dismissButton />}
+    </state.root>
   );
 };


### PR DESCRIPTION
1. Stop using old slot API `getSlotsNext` in favor of new `asserSlots` API

Unblocks https://github.com/microsoft/fluentui/pull/29646