### PR TITLE
chore: allow 0.0.0-alpha version for compat packages in normalize-package-dependencies plugin

### DIFF
--- a/tools/workspace-plugin/src/generators/normalize-package-dependencies/index.ts
+++ b/tools/workspace-plugin/src/generators/normalize-package-dependencies/index.ts
@@ -21,6 +21,7 @@ type ProjectIssues = { [projectName: string]: { [depName: string]: string } };
 
 const NORMALIZED_INNER_WORKSPACE_VERSION = '*';
 const NORMALIZED_PRERELEASE_RANGE_VERSION = '>=9.0.0-alpha';
+const NORMALIZED_COMPAT_PRERELEASE_RANGE_VERSION = '>=0.0.0-alpha';
 const BEACHBALL_UNWANTED_PRERELEASE_RANGE_VERSION_REGEXP = /<9.0.0$/;
 
 export default async function (tree: Tree, schema: NormalizePackageDependenciesGeneratorSchema) {
@@ -114,16 +115,21 @@ function getVersion(tree: Tree, deps: Record<string, string>, packageName: strin
   return { updated, match };
 
   function getUpdatedVersion(currentVersion: string) {
+    const isCompatPackage = packageName.endsWith('-compat');
+
     if (BEACHBALL_UNWANTED_PRERELEASE_RANGE_VERSION_REGEXP.test(current)) {
       return NORMALIZED_PRERELEASE_RANGE_VERSION;
     }
 
-    if (currentVersion === NORMALIZED_PRERELEASE_RANGE_VERSION) {
+    const expectedVersion = isCompatPackage
+      ? NORMALIZED_COMPAT_PRERELEASE_RANGE_VERSION
+      : NORMALIZED_PRERELEASE_RANGE_VERSION;
+    if (currentVersion === expectedVersion) {
       const prereleasePkg = readProjectConfiguration(tree, packageName);
       const prereleasePkgJson = readJson<PackageJson>(tree, joinPathFragments(prereleasePkg.root, 'package.json'));
       const isPrerelease = semver.prerelease(prereleasePkgJson.version) !== null;
 
-      return isPrerelease ? NORMALIZED_PRERELEASE_RANGE_VERSION : NORMALIZED_INNER_WORKSPACE_VERSION;
+      return isPrerelease ? expectedVersion : NORMALIZED_INNER_WORKSPACE_VERSION;
     }
 
     if (semver.prerelease(current)) {


### PR DESCRIPTION
 
 
## Previous Behavior

normalize-package-dependencies plugin allows only "9.0.0-alpha" version for v9 prerelease packages. But compat packages starts with 0.0.0. This means CI will fail when there's usage of prerelease compat packages in public-docsite-v9/package.json or vr-tests-react-components/package.json, which can be the case.

## New Behavior

Allow 0.0.0 if the package name ends with -compat

 