### PR TITLE
feat(workspace-plugin): add `phase=compat` support to prepare-initial-release generator

### DIFF
--- a/change/@fluentui-react-datepicker-compat-b867d463-16c5-49d2-a28e-ac6dd307c83c.json
+++ b/change/@fluentui-react-datepicker-compat-b867d463-16c5-49d2-a28e-ac6dd307c83c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add 'compat' tag to properly categorize v9 compat package",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-datepicker-compat/project.json
+++ b/packages/react-components/react-datepicker-compat/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react-components/react-datepicker-compat/src",
-  "tags": ["vNext", "platform:web"]
+  "tags": ["vNext", "platform:web", "compat"]
 }

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
@@ -34,7 +34,7 @@ export default async function (tree: Tree, schema: ReleasePackageGeneratorSchema
 
   const tasks: Array<(tree: Tree) => void> = [];
 
-  if (options.phase === 'preview') {
+  if (options.phase === 'preview' || options.phase === 'compat') {
     tasks.push(initialRelease(tree, options));
   }
   if (options.phase === 'stable') {
@@ -61,6 +61,11 @@ function normalizeOptions(tree: Tree, options: ReleasePackageGeneratorSchema) {
 }
 
 function initialRelease(tree: Tree, options: NormalizedSchema) {
+  const phase = options.phase;
+  if (phase === 'stable') {
+    throw new Error('invalid logic for options.phase.');
+  }
+
   updateJson<PackageJson>(tree, options.paths.packageJson, json => {
     delete json.private;
     return json;
@@ -76,7 +81,11 @@ function initialRelease(tree: Tree, options: NormalizedSchema) {
   });
 
   return (_tree: Tree) => {
-    generateChangefileTask(tree, options.project, { message: 'feat: release preview package' });
+    const changeTypes = { preview: 'minor', compat: 'patch' } as const;
+    generateChangefileTask(tree, options.project, {
+      changeType: changeTypes[phase],
+      message: `feat: release ${options.phase} package`,
+    });
   };
 }
 
@@ -241,8 +250,11 @@ async function stableRelease(tree: Tree, options: NormalizedSchema) {
 
   return (_tree: Tree) => {
     installPackagesTask(tree, true);
-    generateChangefileTask(tree, newPackage.name, { message: 'feat: release stable' });
-    generateChangefileTask(tree, suitePackageName, { message: `feat: add ${newPackage.name} to suite` });
+    generateChangefileTask(tree, newPackage.name, { message: 'feat: release stable', changeType: 'minor' });
+    generateChangefileTask(tree, suitePackageName, {
+      message: `feat: add ${newPackage.name} to suite`,
+      changeType: 'minor',
+    });
     generateApiMarkdownTask(tree, suitePackageName);
   };
 }
@@ -283,8 +295,12 @@ async function getProjectThatNeedsToBeUpdated(tree: Tree, options: NormalizedSch
   }
 }
 
-function generateChangefileTask(tree: Tree, projectName: string, options: { message: string }) {
-  const cmd = `yarn change --message '${options.message}' --type minor --package ${projectName}`;
+function generateChangefileTask(
+  tree: Tree,
+  projectName: string,
+  options: { changeType: 'minor' | 'patch'; message: string },
+) {
+  const cmd = `yarn change --message '${options.message}' --type ${options.changeType}  --package ${projectName}`;
   return execSync(cmd, { cwd: workspaceRoot, stdio: 'inherit' });
 }
 
@@ -298,13 +314,14 @@ function assertProject(tree: Tree, options: NormalizedSchema) {
 
   const isVnextPackage = options.projectConfig.tags?.includes('vNext');
   const isPreviewPackage = pkgJson.version.startsWith('0') && pkgJson.name.endsWith('-preview');
+  const isCompatPackage = isVnextPackage && options.projectConfig.tags?.includes('compat');
   const isPreparedForStableAlready = pkgJson.version === '9.0.0-alpha.0';
 
   if (!isVnextPackage) {
     throw new Error(`${options.project} is not a v9 package.`);
   }
 
-  if (isPreviewPackage) {
+  if (isPreviewPackage || isCompatPackage) {
     return;
   }
 

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/schema.json
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/schema.json
@@ -21,6 +21,10 @@
         "type": "list",
         "items": [
           {
+            "value": "compat",
+            "label": "compat - prepare 1st release for compat package (shipping as <package-name>-compat)"
+          },
+          {
             "value": "preview",
             "label": "preview - prepare 1st release for preview phase (shipping as <package-name>-preview)"
           },

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/schema.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/schema.ts
@@ -13,5 +13,5 @@ export interface ReleasePackageGeneratorSchema {
   /**
    * Phase of npm release life cycle for fluent v9 core package
    */
-  phase: 'preview' | 'stable';
+  phase: 'preview' | 'stable' | 'compat';
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

[v9 `compat` family](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-datepicker-compat/README.md#compat-component) of packages have no automation for preparing initial release.

## New Behavior

prepare-initial-release now supports `--phase=compat` which will prepare COMPAT package for initial release ( making it publicly available on our docsite as well )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
