### PR TITLE
feat(workspace-plugin): setup storybook barrel file based on package phase(type) within react-component generator

### DIFF
--- a/tools/workspace-plugin/src/generators/react-component/files/story/index.stories.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/story/index.stories.tsx__tmpl__
@@ -6,7 +6,7 @@ import bestPracticesMd from './<%= componentName %>BestPractices.md';
 export { Default } from './<%= componentName %>Default.stories';
 
 export default {
-  title: '<%= componentPhase %> Components/<%= componentName %>',
+  title: '<%= storiesTitle %>',
   component: <%= componentName %>,
   parameters: {
     docs: {

--- a/tools/workspace-plugin/src/generators/react-component/files/story/index.stories.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/story/index.stories.tsx__tmpl__
@@ -6,7 +6,7 @@ import bestPracticesMd from './<%= componentName %>BestPractices.md';
 export { Default } from './<%= componentName %>Default.stories';
 
 export default {
-  title: 'Preview Components/<%= componentName %>',
+  title: '<%= componentPhase %> Components/<%= componentName %>',
   component: <%= componentName %>,
   parameters: {
     docs: {

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -54,11 +54,33 @@ function normalizeOptions(tree: Tree, options: ReactComponentGeneratorSchema) {
   };
 }
 
+function createStoriesTitle(options: NormalizedSchema) {
+  const isCompat = options.projectConfig.tags?.includes('compat');
+  const isPreview = options.projectConfig.name?.endsWith('-preview');
+  const isStable = !isCompat && !isPreview;
+
+  let storiesTitlePrefix;
+  if (isStable) {
+    storiesTitlePrefix = '';
+  }
+  if (isPreview) {
+    storiesTitlePrefix = 'Preview ';
+  }
+  if (isCompat) {
+    storiesTitlePrefix = 'Compat ';
+  }
+
+  const storiesTitle = `${storiesTitlePrefix}Components/${options.componentName}`;
+
+  return storiesTitle;
+}
+
 function addFiles(tree: Tree, options: NormalizedSchema) {
   const sourceRoot = options.projectConfig.sourceRoot as string;
+
   const templateOptions = {
     ...options,
-    componentPhase: options.projectConfig.tags?.includes('compat') ? 'Compat' : 'Preview',
+    storiesTitle: createStoriesTitle(options),
     tmpl: '',
   };
 

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -58,6 +58,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
   const sourceRoot = options.projectConfig.sourceRoot as string;
   const templateOptions = {
     ...options,
+    componentPhase: options.projectConfig.tags?.includes('compat') ? 'Compat' : 'Preview',
     tmpl: '',
   };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`nx g react-component` will always bootstrap `index.stories.tsx` with title `Preview Components/....`

## New Behavior

`index.stories.tsx`  title is created based on package phase(preview or stable or compat)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/30150
