### PR TITLE
fix(TextField): Don't use native password reveal for Edge.

### DIFF
--- a/change/@fluentui-react-045e39a2-95f9-4477-a0a9-b53b24eebddd.json
+++ b/change/@fluentui-react-045e39a2-95f9-4477-a0a9-b53b24eebddd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(TextField): Don't use native password reveal for Edge.",
+  "packageName": "@fluentui/react",
+  "email": "tfaller1@gmx.de",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -443,6 +443,9 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -607,6 +610,9 @@ exports[`ColorPicker renders correctly 1`] = `
                               outline: 0px;
                             }
                             &::-ms-clear {
+                              display: none;
+                            }
+                            &::-ms-reveal {
                               display: none;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -775,6 +781,9 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -941,6 +950,9 @@ exports[`ColorPicker renders correctly 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -1105,6 +1117,9 @@ exports[`ColorPicker renders correctly 1`] = `
                               outline: 0px;
                             }
                             &::-ms-clear {
+                              display: none;
+                            }
+                            &::-ms-reveal {
                               display: none;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -1622,6 +1637,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -1786,6 +1804,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               outline: 0px;
                             }
                             &::-ms-clear {
+                              display: none;
+                            }
+                            &::-ms-reveal {
                               display: none;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -1954,6 +1975,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -2120,6 +2144,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -2284,6 +2311,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                               outline: 0px;
                             }
                             &::-ms-clear {
+                              display: none;
+                            }
+                            &::-ms-reveal {
                               display: none;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -2781,6 +2811,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -2945,6 +2978,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               outline: 0px;
                             }
                             &::-ms-clear {
+                              display: none;
+                            }
+                            &::-ms-reveal {
                               display: none;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -3113,6 +3149,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -3279,6 +3318,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                             &::-ms-clear {
                               display: none;
                             }
+                            &::-ms-reveal {
+                              display: none;
+                            }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                               background: Window;
                               color: WindowText;
@@ -3443,6 +3485,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                               outline: 0px;
                             }
                             &::-ms-clear {
+                              display: none;
+                            }
+                            &::-ms-reveal {
                               display: none;
                             }
                             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -132,6 +132,9 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
+                &::-ms-reveal {
+                  display: none;
+                }
                 @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background: Window;
                   color: WindowText;
@@ -363,6 +366,9 @@ exports[`DatePicker renders DatePicker with value correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
+                &::-ms-reveal {
+                  display: none;
+                }
                 @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   background: Window;
                   color: WindowText;
@@ -591,6 +597,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   outline: 0px;
                 }
                 &::-ms-clear {
+                  display: none;
+                }
+                &::-ms-reveal {
                   display: none;
                 }
                 @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {

--- a/packages/react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -131,6 +131,9 @@ exports[`MaskedTextField renders correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
+            &::-ms-reveal {
+              display: none;
+            }
             @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
               background: Window;
               color: WindowText;

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -7,7 +7,6 @@ import {
   DelayedRender,
   getId,
   getNativeProps,
-  getWindow,
   initializeComponentRef,
   inputProperties,
   isControlled,
@@ -675,16 +674,7 @@ let __browserNeedsRevealButton: boolean | undefined;
 
 function _browserNeedsRevealButton() {
   if (typeof __browserNeedsRevealButton !== 'boolean') {
-    const win = getWindow();
-
-    if (win?.navigator) {
-      // Edge, Chromium Edge
-      const isEdge = /Edg/.test(win.navigator.userAgent || '');
-
-      __browserNeedsRevealButton = !(isIE11() || isEdge);
-    } else {
-      __browserNeedsRevealButton = true;
-    }
+    __browserNeedsRevealButton = !isIE11();
   }
   return __browserNeedsRevealButton;
 }

--- a/packages/react/src/components/TextField/TextField.styles.tsx
+++ b/packages/react/src/components/TextField/TextField.styles.tsx
@@ -311,6 +311,9 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           '::-ms-clear': {
             display: 'none',
           },
+          '::-ms-reveal': {
+            display: 'none',
+          },
           [HighContrastSelector]: {
             background: 'Window',
             color: disabled ? 'GrayText' : 'WindowText',

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -134,6 +134,9 @@ exports[`TextField snapshots renders correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
+              &::-ms-reveal {
+                display: none;
+              }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
@@ -348,6 +351,9 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
                 outline: 0px;
               }
               &::-ms-clear {
+                display: none;
+              }
+              &::-ms-reveal {
                 display: none;
               }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -601,6 +607,9 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               &::-ms-clear {
                 display: none;
               }
+              &::-ms-reveal {
+                display: none;
+              }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
@@ -811,6 +820,9 @@ exports[`TextField snapshots renders multiline non resizable correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
+              &::-ms-reveal {
+                display: none;
+              }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
@@ -980,6 +992,9 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
                 outline: 0px;
               }
               &::-ms-clear {
+                display: none;
+              }
+              &::-ms-reveal {
                 display: none;
               }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -1153,6 +1168,9 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
               &::-ms-clear {
                 display: none;
               }
+              &::-ms-reveal {
+                display: none;
+              }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                 background: Window;
                 color: WindowText;
@@ -1287,6 +1305,9 @@ exports[`TextField snapshots renders with reveal password button 1`] = `
                 outline: 0px;
               }
               &::-ms-clear {
+                display: none;
+              }
+              &::-ms-reveal {
                 display: none;
               }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
@@ -1590,6 +1611,9 @@ exports[`TextField snapshots should respect user component and subcomponent styl
                 outline: 0px;
               }
               &::-ms-clear {
+                display: none;
+              }
+              &::-ms-reveal {
                 display: none;
               }
               @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {


### PR DESCRIPTION
## Previous Behavior

#24337 changed that in Edge only the native password reveal is used.  However, this change leads to a different behavior than in other browsers, such as Chrome and Firefox. Edge reveals only, if you have typed in the field yourself and have not left the focus. fluentui always allows to reveal the password. I've noticed it in a production app which can show a stored password. In Edge, it is not possible to reveal this password as in other browsers.

## New Behavior

This PR changes TextField so that Edge behaves exactly like Chrome and Firefox. ```::-ms-reveal``` is used to prevent the [native Edge reveal](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal).
