### PR TITLE
feat: Update position when target or container dimensions change

### DIFF
--- a/change/@fluentui-react-positioning-29f6eb38-4af2-40f1-a095-6abef76d64f4.json
+++ b/change/@fluentui-react-positioning-29f6eb38-4af2-40f1-a095-6abef76d64f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Update position when target or container dimensions change",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/stories/Concepts/Positioning/MatchTargetSize.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/MatchTargetSize.stories.tsx
@@ -31,6 +31,8 @@ MatchTargetSize.parameters = {
         'The `matchTargetSize` option will automatically style the positioned element so that the chosen dimension',
         'matches that of the target element. This can be useful for autocomplete or combobox input fields where the',
         'popover should match the width of the text input field.',
+        '',
+        '> ⚠️ Make sure that the positioned element use `box-sizing: border-box`',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-components/stories/Concepts/Positioning/MatchTargetSize.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/MatchTargetSize.stories.tsx
@@ -17,7 +17,9 @@ export const MatchTargetSize = () => {
         </Button>
       </PopoverTrigger>
 
-      <PopoverSurface>This popover has the same width as its target anchor</PopoverSurface>
+      <PopoverSurface style={{ boxSizing: 'border-box' }}>
+        This popover has the same width as its target anchor
+      </PopoverSurface>
     </Popover>
   );
 };

--- a/packages/react-components/react-components/stories/Concepts/Positioning/PositioningImperativePositionUpdate.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/PositioningImperativePositionUpdate.stories.tsx
@@ -1,39 +1,49 @@
 import * as React from 'react';
-import { Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
-import type { PopoverProps, PositioningImperativeRef } from '@fluentui/react-components';
+import { Button, Popover, PopoverSurface, PopoverTrigger, Slider, Field, makeStyles } from '@fluentui/react-components';
+import type { PositioningImperativeRef, SliderProps } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  container: {
+    position: 'relative',
+  },
+
+  button: {
+    position: 'absolute',
+  },
+
+  slider: {
+    marginBottom: '10px',
+  },
+});
 
 export const ImperativePositionUpdate = () => {
-  const [loading, setLoading] = React.useState(true);
+  const styles = useStyles();
   const positioningRef = React.useRef<PositioningImperativeRef>(null);
-  const timeoutRef = React.useRef(0);
+  const [value, setValue] = React.useState(0);
 
-  const onOpenChange = React.useCallback<NonNullable<PopoverProps['onOpenChange']>>((e, data) => {
-    if (!data.open) {
-      setLoading(true);
-    } else {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = window.setTimeout(() => setLoading(false), 1000);
-    }
+  const onChange: SliderProps['onChange'] = React.useCallback((e, data) => {
+    setValue(data.value);
   }, []);
 
   React.useEffect(() => {
-    if (!loading) {
-      positioningRef.current?.updatePosition();
-    }
-  }, [loading]);
-
-  React.useEffect(() => {
-    return () => clearTimeout(timeoutRef.current);
-  });
+    positioningRef.current?.updatePosition();
+  }, [value]);
 
   return (
-    <Popover positioning={{ position: 'below', positioningRef }} onOpenChange={onOpenChange}>
-      <PopoverTrigger disableButtonEnhancement>
-        <Button appearance="primary">Click me</Button>
-      </PopoverTrigger>
+    <div className={styles.container}>
+      <Field label="Move the button with the slider">
+        <Slider className={styles.slider} value={value} onChange={onChange} max={80} />
+      </Field>
+      <Popover positioning={{ position: 'below', positioningRef }} open>
+        <PopoverTrigger disableButtonEnhancement>
+          <Button style={{ left: `${value}%` }} className={styles.button} appearance="primary">
+            Popover
+          </Button>
+        </PopoverTrigger>
 
-      <PopoverSurface style={{ minWidth: 100 }}>{loading ? 'Loading 1 second...' : <Placeholder />}</PopoverSurface>
-    </Popover>
+        <PopoverSurface style={{ minWidth: 100 }}>Target</PopoverSurface>
+      </Popover>
+    </div>
   );
 };
 
@@ -43,18 +53,14 @@ ImperativePositionUpdate.parameters = {
     description: {
       story: [
         'The `positioningRef` positioning prop provides an [imperative handle](https://reactjs.org/docs/hooks-reference.html#useimperativehandle)',
-        'to reposition the positioned element. This can be useful for scenarios where content is dynamically loaded.',
+        'to reposition the positioned element.',
+        'In this example the `updatePosition` command is used to reposition the popover when its target button is',
+        'dynamically moved.',
         '',
-        'In this example, you can move your mouse in the red boundary and the tooltip will follow the mouse cursor',
+        '> ⚠️ In later versions of Fluent UI, position updates are triggered once the target or container dimensions',
+        'change. This was previously the main use case for imperative position updates. Please think carefully',
+        'if your scenario needs this pattern in the future.',
       ].join('\n'),
     },
   },
 };
-
-const Placeholder = () => (
-  <div>
-    <h4>Dynamic content</h4>
-
-    <img src="https://fabricweb.azureedge.net/fabric-website/placeholders/400x400.png" />
-  </div>
-);

--- a/packages/react-components/react-menu/stories/Menu/MenuDefault.stories.tsx
+++ b/packages/react-components/react-menu/stories/Menu/MenuDefault.stories.tsx
@@ -2,19 +2,29 @@ import * as React from 'react';
 
 import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 
-export const Default = () => (
-  <Menu>
-    <MenuTrigger disableButtonEnhancement>
-      <Button>Toggle menu</Button>
-    </MenuTrigger>
+export const Default = () => {
+  const [wide, setWide] = React.useState(false);
+  React.useEffect(() => {
+    setTimeout(() => setWide(true), 3000);
+  }, []);
 
-    <MenuPopover>
-      <MenuList>
-        <MenuItem>New </MenuItem>
-        <MenuItem>New Window</MenuItem>
-        <MenuItem disabled>Open File</MenuItem>
-        <MenuItem>Open Folder</MenuItem>
-      </MenuList>
-    </MenuPopover>
-  </Menu>
-);
+  return (
+    <>
+      <div style={{ marginLeft: '200px', display: 'inline-block' }} />
+      <Menu positioning="below">
+        <MenuTrigger disableButtonEnhancement>
+          <Button>Toggle menu</Button>
+        </MenuTrigger>
+
+        <MenuPopover style={{ width: wide ? '200px' : undefined }}>
+          <MenuList>
+            <MenuItem>New </MenuItem>
+            <MenuItem>New Window</MenuItem>
+            <MenuItem disabled>Open File</MenuItem>
+            <MenuItem>Open Folder</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    </>
+  );
+};

--- a/packages/react-components/react-menu/stories/Menu/MenuDefault.stories.tsx
+++ b/packages/react-components/react-menu/stories/Menu/MenuDefault.stories.tsx
@@ -2,29 +2,19 @@ import * as React from 'react';
 
 import { Button, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover } from '@fluentui/react-components';
 
-export const Default = () => {
-  const [wide, setWide] = React.useState(false);
-  React.useEffect(() => {
-    setTimeout(() => setWide(true), 3000);
-  }, []);
+export const Default = () => (
+  <Menu>
+    <MenuTrigger disableButtonEnhancement>
+      <Button>Toggle menu</Button>
+    </MenuTrigger>
 
-  return (
-    <>
-      <div style={{ marginLeft: '200px', display: 'inline-block' }} />
-      <Menu positioning="below">
-        <MenuTrigger disableButtonEnhancement>
-          <Button>Toggle menu</Button>
-        </MenuTrigger>
-
-        <MenuPopover style={{ width: wide ? '200px' : undefined }}>
-          <MenuList>
-            <MenuItem>New </MenuItem>
-            <MenuItem>New Window</MenuItem>
-            <MenuItem disabled>Open File</MenuItem>
-            <MenuItem>Open Folder</MenuItem>
-          </MenuList>
-        </MenuPopover>
-      </Menu>
-    </>
-  );
-};
+    <MenuPopover>
+      <MenuList>
+        <MenuItem>New </MenuItem>
+        <MenuItem>New Window</MenuItem>
+        <MenuItem disabled>Open File</MenuItem>
+        <MenuItem>Open Folder</MenuItem>
+      </MenuList>
+    </MenuPopover>
+  </Menu>
+);

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -4,6 +4,7 @@ import type { PositionManager, TargetElement } from './types';
 import { debounce, writeArrowUpdates, writeContainerUpdates } from './utils';
 import { isHTMLElement } from '@fluentui/react-utilities';
 import { listScrollParents } from './utils/listScrollParents';
+import { createResizeObserver } from './utils/createResizeObserver';
 
 interface PositionManagerOptions {
   /**
@@ -45,7 +46,8 @@ interface PositionManagerOptions {
 export function createPositionManager(options: PositionManagerOptions): PositionManager {
   let isDestroyed = false;
   const { container, target, arrow, strategy, middleware, placement, useTransform = true } = options;
-  if (!target || !container) {
+  const targetWindow = container.ownerDocument.defaultView;
+  if (!target || !container || !targetWindow) {
     return {
       updatePosition: () => undefined,
       dispose: () => undefined,
@@ -53,11 +55,10 @@ export function createPositionManager(options: PositionManagerOptions): Position
   }
 
   // When the dimensions of the target or the container change - trigger a position update
-  const resizeObserver = new ResizeObserver(() => updatePosition());
+  const resizeObserver = createResizeObserver(targetWindow, () => updatePosition());
 
   let isFirstUpdate = true;
   const scrollParents: Set<HTMLElement> = new Set<HTMLElement>();
-  const targetWindow = container.ownerDocument.defaultView;
 
   // When the container is first resolved, set position `fixed` to avoid scroll jumps.
   // Without this scroll jumps can occur when the element is rendered initially and receives focus

--- a/packages/react-components/react-positioning/src/utils/createResizeObserver.ts
+++ b/packages/react-components/react-positioning/src/utils/createResizeObserver.ts
@@ -1,0 +1,19 @@
+export function createResizeObserver(targetWindow: Window & typeof globalThis, callback: ResizeObserverCallback) {
+  // https://github.com/jsdom/jsdom/issues/3368
+  // Add the polyfill here so it is not needed for all unit tests that leverage positioning
+  if (process.env.NODE_ENV === 'test') {
+    targetWindow.ResizeObserver = class ResizeObserver {
+      public observe() {
+        // do nothing
+      }
+      public unobserve() {
+        // do nothing
+      }
+      public disconnect() {
+        // do nothing
+      }
+    };
+  }
+
+  return new targetWindow.ResizeObserver(callback);
+}


### PR DESCRIPTION
Uses a ResizeObserver in the position manager so that a position update is triggered when the dimension of the target or container changes. This should handle most async update scenarios without needing to call `updatePosition` in userland.

The ResizeObserver will only be created when:
* both target and positioned element that refer to HTML elements
* the positionig logic is `enabled`

Practically this means that the ResizeObserver is created only when Popover/Menu/Combobox/Tooltip etc... are open. Just mounting an (unopened) Popover will not create a new ResizeObserver

Fixes #29998