### PR TITLE
Example for Negative Values in VerticalBarChart for dev storybook and public-docsite

### DIFF
--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.NegativeValues.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.NegativeValues.Example.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { VerticalBarChart, IVerticalBarChartProps, IVerticalBarChartDataPoint } from '@fluentui/react-charting';
+
+export class VerticalBarChartNegativeValuesExample extends React.Component<IVerticalBarChartProps> {
+  constructor(props: IVerticalBarChartProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const points: IVerticalBarChartDataPoint[] = [
+      {
+        x: 1,
+        y: 20,
+      },
+      {
+        x: 2,
+        y: -20,
+      },
+      {
+        x: 3,
+        y: -28,
+      },
+      {
+        x: 4,
+        y: 40,
+      },
+      {
+        x: 5,
+        y: 60,
+      },
+      {
+        x: 6,
+        y: -48,
+      },
+      {
+        x: 7,
+        y: -4,
+      },
+      {
+        x: 8,
+        y: 50,
+      },
+    ];
+
+    return (
+      <div style={{ width: '600px', height: '400px' }}>
+        <VerticalBarChart
+          chartTitle="Vertical bar chart Negative Values example "
+          data={points}
+          width={600}
+          height={400}
+          barWidth={20}
+          hideLegend={true}
+          enableReflow={true}
+          supportNegativeYValues={true}
+        />
+      </div>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.doc.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.doc.tsx
@@ -8,6 +8,7 @@ import { VerticalBarChartDynamicExample } from './VerticalBarChart.Dynamic.Examp
 import { VerticalBarChartTooltipExample } from './VerticalBarChart.AxisTooltip.Example';
 import { VerticalBarChartCustomAccessibilityExample } from './VerticalBarChart.CustomAccessibility.Example';
 import { VerticalBarChartRotatedLabelExample } from './VerticalBarChart.RotateLabels.Example';
+import { VerticalBarChartNegativeValuesExample } from './VerticalBarChart.NegativeValues.Example';
 
 const VerticalBarChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx') as string;
@@ -21,6 +22,8 @@ const VerticalBarChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.CustomAccessibility.Example.tsx') as string;
 const VerticalBarChartRotateLabelsExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.RotateLabels.Example.tsx') as string;
+const VerticalBarChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.NegativeValues.Example.tsx') as string;
 
 export const VerticalBarChartPageProps: IDocPageProps = {
   title: 'VerticalBarChart',
@@ -57,6 +60,11 @@ export const VerticalBarChartPageProps: IDocPageProps = {
       title: 'VerticalBarChart rotated labels',
       code: VerticalBarChartRotateLabelsExampleCode,
       view: <VerticalBarChartRotatedLabelExample />,
+    },
+    {
+      title: 'VerticalBarChart Negative Values',
+      code: VerticalBarChartNegativeValuesExampleCode,
+      view: <VerticalBarChartNegativeValuesExample />,
     },
   ],
   overview: require<string>('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/docs/VerticalBarChartOverview.md'),

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChartPage.tsx
@@ -14,6 +14,7 @@ import { VerticalBarChartDynamicExample } from './VerticalBarChart.Dynamic.Examp
 import { VerticalBarChartTooltipExample } from './VerticalBarChart.AxisTooltip.Example';
 import { VerticalBarChartCustomAccessibilityExample } from './VerticalBarChart.CustomAccessibility.Example';
 import { VerticalBarChartRotatedLabelExample } from './VerticalBarChart.RotateLabels.Example';
+import { VerticalBarChartNegativeValuesExample } from './VerticalBarChart.NegativeValues.Example';
 
 const VerticalBarChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx') as string;
@@ -27,6 +28,8 @@ const VerticalBarChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.CustomAccessibility.Example.tsx') as string;
 const VerticalBarChartRotateLabelsExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.RotateLabels.Example.tsx') as string;
+const VerticalBarChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.NegativeValues.Example.tsx') as string;
 
 export class VerticalBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -56,6 +59,9 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
             </ExampleCard>
             <ExampleCard title="VerticalBarChart rotate label" code={VerticalBarChartRotateLabelsExampleCode}>
               <VerticalBarChartRotatedLabelExample />
+            </ExampleCard>
+            <ExampleCard title="VerticalBarChart Negative Values" code={VerticalBarChartNegativeValuesExampleCode}>
+              <VerticalBarChartNegativeValuesExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

No examples regarding negative value use in VerticalBarChart

## New Behavior

Example for negative values added under VerticalBarChart

**public-docsite**
![image](https://github.com/microsoft/fluentui/assets/35366351/17b5f26e-6bd0-45e6-a469-5fed93e75e09)

**dev:storybook**
![image](https://github.com/microsoft/fluentui/assets/35366351/ba1c3a58-6d0f-432f-80bb-f7af4ef76740)



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
