### PR TITLE
Example for Negative Values for LineChart in dev storybook and public-docsite

### DIFF
--- a/packages/react-examples/src/react-charting/LineChart/LineChart.NegativeValues.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.NegativeValues.Example.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react';
+import { IChartProps, ILineChartProps, LineChart } from '@fluentui/react-charting';
+
+interface ILineChartNegativeValuesState {
+  width: number;
+  height: number;
+}
+
+export class LineChartNegativeValuesExample extends React.Component<{}, ILineChartNegativeValuesState> {
+  constructor(props: ILineChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._negativeValuesExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _negativeValuesExample(): JSX.Element {
+    const data: IChartProps = {
+      chartTitle: 'Line Chart',
+      lineChartData: [
+        {
+          legend: 'Line1',
+          data: [
+            {
+              x: 1,
+              y: -7,
+            },
+            {
+              x: 2,
+              y: -4,
+            },
+            {
+              x: 3,
+              y: 11,
+            },
+            {
+              x: 4,
+              y: 2,
+            },
+            {
+              x: 5,
+              y: -5,
+            },
+            {
+              x: 6,
+              y: 4,
+            },
+            {
+              x: 7,
+              y: -1,
+            },
+          ],
+          lineOptions: {
+            lineBorderWidth: '4',
+          },
+        },
+        {
+          legend: 'Line2',
+          data: [
+            {
+              x: 1,
+              y: 7,
+            },
+            {
+              x: 2,
+              y: 14,
+            },
+            {
+              x: 3,
+              y: -11,
+            },
+            {
+              x: 4,
+              y: 12,
+            },
+            {
+              x: 5,
+              y: -2,
+            },
+            {
+              x: 6,
+              y: 14,
+            },
+            {
+              x: 7,
+              y: 1,
+            },
+          ],
+          lineOptions: {
+            lineBorderWidth: '4',
+          },
+        },
+      ],
+    };
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label htmlFor="changeWidth_NegativeValues">Change Width:</label>
+        <input
+          type="range"
+          value={this.state.width}
+          min={200}
+          max={1000}
+          id="changeWidth_NegativeValues"
+          onChange={this._onWidthChange}
+          aria-valuetext={`ChangeWidthSlider${this.state.width}`}
+        />
+        <label htmlFor="changeHeight_NegativeValues">Change Height:</label>
+        <input
+          type="range"
+          value={this.state.height}
+          min={200}
+          max={1000}
+          id="changeHeight_NegativeValues"
+          onChange={this._onHeightChange}
+          aria-valuetext={`ChangeHeightslider${this.state.height}`}
+        />
+        <div style={rootStyle}>
+          <LineChart
+            culture={window.navigator.language}
+            data={data}
+            height={this.state.height}
+            width={this.state.width}
+            supportNegativeValues={true}
+            enablePerfOptimization={true}
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.doc.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.doc.tsx
@@ -9,6 +9,7 @@ import { LineChartEventsExample } from './LineChart.Events.Example';
 import { LineChartCustomAccessibilityExample } from './LineChart.CustomAccessibility.Example';
 import { LineChartGapsExample } from './LineChart.Gaps.Example';
 import { LineChartCustomLocaleDateAxisExample } from './LineChart.CustomLocaleDateAxis.Example';
+import { LineChartNegativeValuesExample } from './LineChart.NegativeValues.Example';
 
 const LineChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx') as string;
@@ -24,6 +25,8 @@ const LineChartGapsExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Gaps.Example.tsx') as string;
 const LineChartCustomLocaleDateAxisExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.CustomLocaleDateAxis.Example.tsx') as string;
+const LineChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.NegativeValues.Example.tsx') as string;
 
 export const LineChartPageProps: IDocPageProps = {
   title: 'LineChart',
@@ -64,6 +67,11 @@ export const LineChartPageProps: IDocPageProps = {
       title: 'LineChart custom date axis locale',
       code: LineChartCustomLocaleDateAxisExampleCode,
       view: <LineChartCustomLocaleDateAxisExample />,
+    },
+    {
+      title: 'LineChart Negative Values',
+      code: LineChartNegativeValuesExampleCode,
+      view: <LineChartNegativeValuesExample />,
     },
   ],
   overview: require<string>('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/docs/LineChartOverview.md'),

--- a/packages/react-examples/src/react-charting/LineChart/LineChartPage.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChartPage.tsx
@@ -16,6 +16,7 @@ import { LineChartCustomAccessibilityExample } from './LineChart.CustomAccessibi
 import { LineChartGapsExample } from './LineChart.Gaps.Example';
 import { LineChartLargeDataExample } from './LineChart.LargeData.Example';
 import { LineChartCustomLocaleDateAxisExample } from './LineChart.CustomLocaleDateAxis.Example';
+import { LineChartNegativeValuesExample } from './LineChart.NegativeValues.Example';
 
 const LineChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.Basic.Example.tsx') as string;
@@ -33,6 +34,8 @@ const LineChartLargeDataExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.LargeData.Example.tsx') as string;
 const LineChartCustomLocaleDateAxisExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.CustomLocaleDateAxis.Example.tsx') as string;
+const LineChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/LineChart/LineChart.NegativeValues.Example.tsx') as string;
 
 // All line charts locale is impacted.
 
@@ -67,6 +70,9 @@ export class LineChartPage extends React.Component<IComponentDemoPageProps, {}> 
             </ExampleCard>
             <ExampleCard title="LineChart custom date axis locale" code={LineChartCustomLocaleDateAxisExampleCode}>
               <LineChartCustomLocaleDateAxisExample />
+            </ExampleCard>
+            <ExampleCard title="LineChart Negative Values" code={LineChartNegativeValuesExampleCode}>
+              <LineChartNegativeValuesExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

No example existed demonstrating use of negative values in LineCharts

## New Behavior

Example added demonstrating use of negative values in LineCharts in dev storybook and public-docsite

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
