### PR TITLE
Example of negative values use for AreaChart

### DIFF
--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.NegativeValues.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.NegativeValues.Example.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import { AreaChart } from '@fluentui/react-charting';
+import { IAreaChartProps } from '@fluentui/react-charting';
+
+interface IAreaChartNegativeValuesState {
+  width: number;
+  height: number;
+}
+
+export class AreaChartNegativeValuesExample extends React.Component<{}, IAreaChartNegativeValuesState> {
+  constructor(props: IAreaChartProps) {
+    super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._negativeValuesExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _negativeValuesExample(): JSX.Element {
+    const chart1Points = [
+      {
+        x: 20,
+        y: -17000,
+      },
+      {
+        x: 25,
+        y: 9000,
+      },
+      {
+        x: 30,
+        y: 13000,
+      },
+      {
+        x: 35,
+        y: 15000,
+      },
+      {
+        x: 40,
+        y: -11000,
+      },
+      {
+        x: 45,
+        y: -8760,
+      },
+      {
+        x: 50,
+        y: 3500,
+      },
+      {
+        x: 55,
+        y: 25000,
+      },
+      {
+        x: 60,
+        y: 17000,
+      },
+      {
+        x: 65,
+        y: 1000,
+      },
+      {
+        x: 70,
+        y: -12000,
+      },
+      {
+        x: 75,
+        y: -6876,
+      },
+      {
+        x: 80,
+        y: 12000,
+      },
+      {
+        x: 85,
+        y: 7000,
+      },
+      {
+        x: 90,
+        y: 10000,
+      },
+    ];
+
+    const chartPoints = [
+      {
+        legend: 'legend1',
+        data: chart1Points,
+      },
+    ];
+
+    const chartData = {
+      chartTitle: 'Area chart Negative Values example',
+      lineChartData: chartPoints,
+    };
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label htmlFor="changeWidth_NegativeValues">Change Width:</label>
+        <input
+          type="range"
+          value={this.state.width}
+          min={200}
+          max={1000}
+          id="changeWidth_NegativeValues"
+          onChange={this._onWidthChange}
+          aria-valuetext={`ChangeWidthSlider${this.state.width}`}
+        />
+        <label htmlFor="changeHeight_NegativeValues">Change Height:</label>
+        <input
+          type="range"
+          value={this.state.height}
+          min={200}
+          max={1000}
+          id="changeHeight_NegativeValues"
+          onChange={this._onHeightChange}
+          aria-valuetext={`ChangeHeightslider${this.state.height}`}
+        />
+
+        <div style={rootStyle}>
+          <AreaChart
+            culture={window.navigator.language}
+            height={this.state.height}
+            width={this.state.width}
+            data={chartData}
+            enablePerfOptimization={true}
+            enableReflow={true}
+            //Future prop addition to enable negative value support by optional flag
+            supportNegativeValues
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.doc.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.doc.tsx
@@ -7,6 +7,7 @@ import { AreaChartStyledExample } from './AreaChart.Styled.Example';
 import { AreaChartMultipleExample } from './AreaChart.Multiple.Example';
 import { AreaChartCustomAccessibilityExample } from './AreaChart.CustomAccessibility.Example';
 import { AreaChartLargeDataExample } from './AreaChart.LargeData.Example';
+import { AreaChartNegativeValuesExample } from './AreaChart.NegativeValues.Example';
 
 const AreaChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx') as string;
@@ -18,6 +19,8 @@ const AreaChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx') as string;
 const AreaChartLargeDataExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.LargeData.Example.tsx') as string;
+const AreaChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.NegativeValues.Example.tsx') as string;
 
 export const AreaChartPageProps: IDocPageProps = {
   title: 'AreaChart',
@@ -48,6 +51,11 @@ export const AreaChartPageProps: IDocPageProps = {
       title: 'AreaChart large data',
       code: AreaChartLargeDataExampleCode,
       view: <AreaChartLargeDataExample />,
+    },
+    {
+      title: 'AreaChart Negative Values',
+      code: AreaChartNegativeValuesExampleCode,
+      view: <AreaChartNegativeValuesExample />,
     },
   ],
   overview: require<string>('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/docs/AreaChartOverview.md'),

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChartPage.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChartPage.tsx
@@ -14,6 +14,7 @@ import { AreaChartStyledExample } from './AreaChart.Styled.Example';
 import { AreaChartCustomAccessibilityExample } from './AreaChart.CustomAccessibility.Example';
 import { AreaChartLargeDataExample } from './AreaChart.LargeData.Example';
 import { AreaChartDataChangeExample } from './AreaChart.DataChange.Example';
+import { AreaChartNegativeValuesExample } from './AreaChart.NegativeValues.Example';
 
 const AreaChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx') as string;
@@ -27,6 +28,8 @@ const AreaChartLargeDataExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.LargeData.Example.tsx') as string;
 const AreaChartDataChangeExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.DataChange.Example.tsx') as string;
+const AreaChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/AreaChart/AreaChart.NegativeValues.Example.tsx') as string;
 
 export class AreaChart extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -53,6 +56,9 @@ export class AreaChart extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title="Area chart Data Change" code={AreaChartDataChangeExampleCode}>
               <AreaChartDataChangeExample />
+            </ExampleCard>
+            <ExampleCard title="Area chart Negative Values" code={AreaChartNegativeValuesExampleCode}>
+              <AreaChartNegativeValuesExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
No examples existed demonstrating use of negative values in AreaChart and VerticalStackedBarChart


## New Behavior
Example demonstrating use of negative values in AreaChart and VerticalStackedBarChart added for dev storybook and public-docsite
<img width="759" alt="image" src="https://github.com/microsoft/fluentui/assets/35366351/93fec819-26ee-4ca6-bf20-73364d316a42">
<img width="870" alt="image" src="https://github.com/microsoft/fluentui/assets/35366351/2c609307-9414-46b2-a210-6064a701cd07">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
