### PR TITLE
fix(react-utilities): Allow `isSlot` to work with multiple utilities instances

### DIFF
--- a/change/@fluentui-react-utilities-16895967-8569-477b-9445-48da8bfd79a9.json
+++ b/change/@fluentui-react-utilities-16895967-8569-477b-9445-48da8bfd79a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow isSlot to work with multiple react-utilities instances",
+  "packageName": "@fluentui/react-utilities",
+  "email": "36034483+daniel-hauser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/compose/constants.ts
+++ b/packages/react-components/react-utilities/src/compose/constants.ts
@@ -2,9 +2,9 @@
  * @internal
  * Internal reference for the render function
  */
-export const SLOT_RENDER_FUNCTION_SYMBOL = Symbol('fui.slotRenderFunction');
+export const SLOT_RENDER_FUNCTION_SYMBOL = Symbol.for('fui.slotRenderFunction');
 /**
  * @internal
  * Internal reference for the render function
  */
-export const SLOT_ELEMENT_TYPE_SYMBOL = Symbol('fui.slotElementType');
+export const SLOT_ELEMENT_TYPE_SYMBOL = Symbol.for('fui.slotElementType');

--- a/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
@@ -34,4 +34,11 @@ describe('isSlot', () => {
   it('handles actual slot', () => {
     expect(isSlot(slot.optional({}, { elementType: 'div' }))).toEqual(true);
   });
+
+  it('handles slots created with a diffrent instance of react-utilities', async () => {
+    jest.isolateModules(() => {
+      const otherSlot = require('./slot') as typeof slot;
+      expect(isSlot(otherSlot.optional({}, { elementType: 'div' }))).toBeTruthy();
+    })
+  });
 });

--- a/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
@@ -39,6 +39,6 @@ describe('isSlot', () => {
     jest.isolateModules(() => {
       const otherSlot = require('./slot') as typeof slot;
       expect(isSlot(otherSlot.optional({}, { elementType: 'div' }))).toBeTruthy();
-    })
+    });
   });
 });

--- a/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/isSlot.test.tsx
@@ -35,7 +35,7 @@ describe('isSlot', () => {
     expect(isSlot(slot.optional({}, { elementType: 'div' }))).toEqual(true);
   });
 
-  it('handles slots created with a diffrent instance of react-utilities', async () => {
+  it('handles slots created with a different instance of react-utilities', async () => {
     jest.isolateModules(() => {
       const otherSlot = require('./slot') as typeof slot;
       expect(isSlot(otherSlot.optional({}, { elementType: 'div' }))).toBeTruthy();


### PR DESCRIPTION


## Previous Behavior

Some complex projects might end up with multiple instances (not necessarily from different versions) of `react-utilities`.

In that case, `isSlot` will `erroneously` return false, causing react to throw the following error when rendering the slots.
```
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. 
```
#29434 added a warning on cases like this, but in large systems it's not always easy to fix.

As described in that PR, this is due to the fact Symbols are unique and having different instances of `react-utilities` running means having multiple Symbols.

## New Behavior

Moving from `Symbol` to [`Symbol.for`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for) will share the same symbol reference in a runtime-wide registry, fixing the issue and allowing `isSlot` to return the correct answer.

## Related Issue(s)

None
