### PR TITLE
feat(TimePicker-compat): stable release 

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -38,7 +38,7 @@
     "@fluentui/react-search-preview": "*",
     "@fluentui/react-motion-preview": "*",
     "@fluentui/react-teaching-popover-preview": "*",
-    "@fluentui/react-timepicker-compat-preview": "*",
+    "@fluentui/react-timepicker-compat": "*",
     "@griffel/react": "^1.5.14",
     "@microsoft/applicationinsights-web": "^3",
     "react": "17.0.2",

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -65,7 +65,7 @@
     "@fluentui/react-text": "*",
     "@fluentui/react-textarea": "*",
     "@fluentui/react-theme": "*",
-    "@fluentui/react-timepicker-compat-preview": "*",
+    "@fluentui/react-timepicker-compat": "*",
     "@fluentui/react-toast": "*",
     "@fluentui/react-tooltip": "*",
     "@fluentui/react-toolbar": "*",

--- a/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/TimePicker.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { Steps, StoryWright } from 'storywright';
-import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
+import { TimePicker } from '@fluentui/react-timepicker-compat';
 
 export default {
   title: 'TimePicker compat',

--- a/change/@fluentui-react-timepicker-compat-44d079da-05f8-4e7e-ad30-fc70601e7267.json
+++ b/change/@fluentui-react-timepicker-compat-44d079da-05f8-4e7e-ad30-fc70601e7267.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Stable release",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-preview-8dca177c-555d-4973-8aa1-5ea98786788c.json
+++ b/change/@fluentui-react-timepicker-compat-preview-8dca177c-555d-4973-8aa1-5ea98786788c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Deprecate preview package. Use @fluentui/react-timepicker-compat instead.",
+  "packageName": "@fluentui/react-timepicker-compat-preview",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-timepicker-compat-preview/etc/react-timepicker-compat-preview.api.md
+++ b/packages/react-components/react-timepicker-compat-preview/etc/react-timepicker-compat-preview.api.md
@@ -13,19 +13,19 @@ import * as React_2 from 'react';
 import type { SelectionEvents } from '@fluentui/react-combobox';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
-// @public
+// @public @deprecated
 export function formatDateToTimeString(date: Date, { hourCycle, showSeconds }?: TimeFormatOptions): string;
 
-// @public
+// @public @deprecated
 export const TimePicker: ForwardRefComponent<TimePickerProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const timePickerClassNames: SlotClassNames<TimePickerSlots>;
 
-// @public
+// @public @deprecated
 export type TimePickerErrorType = 'invalid-input' | 'out-of-bounds' | 'required-input';
 
-// @public
+// @public @deprecated
 export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> & Pick<ComboboxProps, 'appearance' | 'defaultOpen' | 'defaultValue' | 'inlinePopup' | 'onOpenChange' | 'open' | 'placeholder' | 'positioning' | 'size' | 'value' | 'mountNode' | 'freeform'> & TimeFormatOptions & {
     startHour?: Hour;
     endHour?: Hour;
@@ -38,28 +38,28 @@ export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input
     parseTimeStringToDate?: (time: string | undefined) => TimeStringValidationResult;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TimePickerSlots = ComboboxSlots;
 
-// @public
+// @public @deprecated
 export type TimePickerState = ComboboxState & Required<Pick<TimePickerProps, 'freeform' | 'parseTimeStringToDate'>> & {
     submittedText: string | undefined;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TimeSelectionData = {
     selectedTime: Date | null;
     selectedTimeText: string | undefined;
     errorType: TimePickerErrorType | undefined;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TimeSelectionEvents = SelectionEvents | React_2.FocusEvent<HTMLElement>;
 
-// @public
+// @public @deprecated
 export const useTimePicker_unstable: (props: TimePickerProps, ref: React_2.Ref<HTMLInputElement>) => TimePickerState;
 
-// @public
+// @public @deprecated
 export const useTimePickerStyles_unstable: (state: TimePickerState) => TimePickerState;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-components/react-timepicker-compat-preview/package.json
+++ b/packages/react-components/react-timepicker-compat-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-timepicker-compat-preview",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Fluent UI TimePicker Compat Component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-components/react-timepicker-compat-preview/package.json
+++ b/packages/react-components/react-timepicker-compat-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-timepicker-compat-preview",
-  "version": "0.1.10",
+  "version": "0.1.9",
   "description": "Fluent UI TimePicker Compat Component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
@@ -1,4 +1,4 @@
-// eslint-disable deprecation/deprecation
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.cy.tsx
@@ -1,3 +1,4 @@
+// eslint-disable deprecation/deprecation
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
@@ -1,4 +1,4 @@
-// eslint-disable deprecation/deprecation
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable deprecation/deprecation
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.tsx
@@ -8,7 +8,7 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * TimePicker Compat component
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export const TimePicker: ForwardRefComponent<TimePickerProps> = React.forwardRef((props, ref) => {
   const state = useTimePicker_unstable(props, ref);

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useTimePicker_unstable } from './useTimePicker';

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.tsx
@@ -8,6 +8,7 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * TimePicker Compat component
+ * @deprecated
  */
 export const TimePicker: ForwardRefComponent<TimePickerProps> = React.forwardRef((props, ref) => {
   const state = useTimePicker_unstable(props, ref);

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import type { ComboboxSlots, ComboboxState, ComboboxProps, SelectionEvents } from '@fluentui/react-combobox';
 import type { ComponentProps } from '@fluentui/react-utilities';

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -51,7 +51,7 @@ export type TimePickerOption = {
 
 /**
  * Error types returned by the `onValidationResult` callback.
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export type TimePickerErrorType = 'invalid-input' | 'out-of-bounds' | 'required-input';
 
@@ -61,16 +61,16 @@ export type TimeStringValidationResult = {
 };
 
 /**
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export type TimePickerSlots = ComboboxSlots;
 
 /**
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export type TimeSelectionEvents = SelectionEvents | React.FocusEvent<HTMLElement>;
 /**
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export type TimeSelectionData = {
   /**
@@ -104,7 +104,7 @@ export type TimeFormatOptions = {
 
 /**
  * TimePicker Props
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> &
   Pick<
@@ -171,7 +171,7 @@ export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input
 
 /**
  * State used in rendering TimePicker
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export type TimePickerState = ComboboxState &
   Required<Pick<TimePickerProps, 'freeform' | 'parseTimeStringToDate'>> & {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/TimePicker.types.ts
@@ -51,6 +51,7 @@ export type TimePickerOption = {
 
 /**
  * Error types returned by the `onValidationResult` callback.
+ * @deprecated
  */
 export type TimePickerErrorType = 'invalid-input' | 'out-of-bounds' | 'required-input';
 
@@ -59,9 +60,18 @@ export type TimeStringValidationResult = {
   errorType?: TimePickerErrorType;
 };
 
+/**
+ * @deprecated
+ */
 export type TimePickerSlots = ComboboxSlots;
 
+/**
+ * @deprecated
+ */
 export type TimeSelectionEvents = SelectionEvents | React.FocusEvent<HTMLElement>;
+/**
+ * @deprecated
+ */
 export type TimeSelectionData = {
   /**
    * The Date object associated with the selected option. For freeform TimePicker it can also be the Date object parsed from the user input.
@@ -94,6 +104,7 @@ export type TimeFormatOptions = {
 
 /**
  * TimePicker Props
+ * @deprecated
  */
 export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> &
   Pick<
@@ -160,6 +171,7 @@ export type TimePickerProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input
 
 /**
  * State used in rendering TimePicker
+ * @deprecated
  */
 export type TimePickerState = ComboboxState &
   Required<Pick<TimePickerProps, 'freeform' | 'parseTimeStringToDate'>> & {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/index.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/index.ts
@@ -2,4 +2,5 @@ export * from './TimePicker';
 export * from './TimePicker.types';
 export * from './useTimePicker';
 export * from './useTimePickerStyles.styles';
+// eslint-disable-next-line deprecation/deprecation
 export { formatDateToTimeString } from './timeMath';

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.test.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import {
   dateToKey,
   keyToDate,

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.ts
@@ -43,6 +43,8 @@ export function keyToDate(key: string): Date | null {
  * formatDateToTimeString(date);                         // Returns "23:45" in CET
  * formatDateToTimeString(date, \{ showSeconds: true \});  // Returns "23:45:12" in CET
  * formatDateToTimeString(date, \{ hourCycle: 'h12', showSeconds: true \}); // Returns "11:45:12 PM" in CET
+ *
+ * @deprecated
  */
 export function formatDateToTimeString(date: Date, { hourCycle, showSeconds }: TimeFormatOptions = {}): string {
   return date.toLocaleTimeString(undefined, {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/timeMath.ts
@@ -44,7 +44,7 @@ export function keyToDate(key: string): Date | null {
  * formatDateToTimeString(date, \{ showSeconds: true \});  // Returns "23:45:12" in CET
  * formatDateToTimeString(date, \{ hourCycle: 'h12', showSeconds: true \}); // Returns "11:45:12 PM" in CET
  *
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export function formatDateToTimeString(date: Date, { hourCycle, showSeconds }: TimeFormatOptions = {}): string {
   return date.toLocaleTimeString(undefined, {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import {
   elementContains,

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -30,7 +30,7 @@ import {
  * @param props - props from this instance of TimePicker
  * @param ref - reference to root HTMLElement of TimePicker
  *
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HTMLInputElement>): TimePickerState => {
   const {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePicker.tsx
@@ -29,6 +29,8 @@ import {
  *
  * @param props - props from this instance of TimePicker
  * @param ref - reference to root HTMLElement of TimePicker
+ *
+ * @deprecated
  */
 export const useTimePicker_unstable = (props: TimePickerProps, ref: React.Ref<HTMLInputElement>): TimePickerState => {
   const {

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TimePickerSlots, TimePickerState } from './TimePicker.types';

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -4,7 +4,7 @@ import type { TimePickerSlots, TimePickerState } from './TimePicker.types';
 import { useComboboxStyles_unstable } from '@fluentui/react-combobox';
 
 /**
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export const timePickerClassNames: SlotClassNames<TimePickerSlots> = {
   root: 'fui-TimePicker',
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the TimePicker slots based on the state
- * @deprecated
+ * @deprecated use \@fluentui/react-timepicker-compat
  */
 export const useTimePickerStyles_unstable = (state: TimePickerState): TimePickerState => {
   const styles = useStyles();

--- a/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -3,6 +3,9 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TimePickerSlots, TimePickerState } from './TimePicker.types';
 import { useComboboxStyles_unstable } from '@fluentui/react-combobox';
 
+/**
+ * @deprecated
+ */
 export const timePickerClassNames: SlotClassNames<TimePickerSlots> = {
   root: 'fui-TimePicker',
   input: 'fui-TimePicker__input',
@@ -18,6 +21,7 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the TimePicker slots based on the state
+ * @deprecated
  */
 export const useTimePickerStyles_unstable = (state: TimePickerState): TimePickerState => {
   const styles = useStyles();

--- a/packages/react-components/react-timepicker-compat-preview/src/index.ts
+++ b/packages/react-components/react-timepicker-compat-preview/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 export {
   TimePicker,
   timePickerClassNames,

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerControlled.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerControlled.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { Field, makeStyles } from '@fluentui/react-components';
 import { TimePicker, TimePickerProps, formatDateToTimeString } from '@fluentui/react-timepicker-compat-preview';

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerDefault.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerDefault.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { Field, makeStyles } from '@fluentui/react-components';
 import { TimePicker, TimePickerProps } from '@fluentui/react-timepicker-compat-preview';

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerFreeformCustomParsing.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerFreeformCustomParsing.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { Field, makeStyles } from '@fluentui/react-components';
 import { TimePicker, TimePickerProps } from '@fluentui/react-timepicker-compat-preview';

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerFreeformWithErrorHandling.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerFreeformWithErrorHandling.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { Field, FieldProps, makeStyles } from '@fluentui/react-components';
 import { TimePicker, TimePickerErrorType, TimePickerProps } from '@fluentui/react-timepicker-compat-preview';

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerWithDatePicker.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/TimePickerWithDatePicker.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { Field, makeStyles } from '@fluentui/react-components';
 import { DatePicker, DatePickerProps } from '@fluentui/react-datepicker-compat';

--- a/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/index.stories.tsx
+++ b/packages/react-components/react-timepicker-compat-preview/stories/TimePicker/index.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { TimePicker } from '@fluentui/react-timepicker-compat-preview';
 
 import descriptionMd from './TimePickerDescription.md';

--- a/packages/react-components/react-timepicker-compat/package.json
+++ b/packages/react-components/react-timepicker-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-timepicker-compat",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Fluent UI TimePicker Compat Component",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
Step 3 of #30198
After this PR, triggering a release will make react-timepicker-compat bump to 0.1.0, and show up on docsite as:
<img width="246" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/174a5d0f-bc98-441b-bef9-0bcbc22bd5e3">
