### PR TITLE
fix(ts-minbar-test-react-components): temporarily resolve keyborg to 2.3.0 which will pass TS check

### DIFF
--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'node:fs/promises';
 import {
   prepareTempDirs,
   log,
@@ -11,6 +12,18 @@ import {
 
 const tsVersion = '3.9';
 const testName = 'ts-minbar-react-components';
+
+/**
+ *
+ * REMOVE after https://github.com/microsoft/keyborg/issues/69 is fixed
+ */
+async function pinKeyborgUntilDtsIsFixed(appRoot: string) {
+  const jsonPath = path.join(appRoot, 'package.json');
+  const jsonContent = await fs.readFile(jsonPath, 'utf-8');
+  const json = JSON.parse(jsonContent);
+  json.resolutions['keyborg'] = '2.3.0';
+  await fs.writeFile(jsonPath, JSON.stringify(json, null, 2));
+}
 
 async function performTest() {
   let tempPaths: TempPaths;
@@ -35,6 +48,8 @@ async function performTest() {
 
     const packedPackages = await packProjectPackages(logger, '@fluentui/react-components');
     await addResolutionPathsForProjectPackages(tempPaths.testApp);
+
+    await pinKeyborgUntilDtsIsFixed(tempPaths.testApp);
 
     await shEcho(`yarn add ${packedPackages['@fluentui/react-components']}`, tempPaths.testApp);
     logger(`✔️ Fluent UI packages were added to dependencies`);


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

every pipeline affecting v9 will fail on TS violation

<img width="908" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/b04dbfc0-97cd-426d-8a56-a7c50e493cc3">

example log: https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=329938&view=logs&j=e51d397b-0a7b-5b89-4b48-0052e021371d&t=88c41216-94ff-5ca8-d686-48ce16c1eefc

## New Behavior

unblocks all our pipelines until this is fixed https://github.com/microsoft/keyborg/issues/69

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
