### PR TITLE
fix: remove aria-multiselectable from v9 listbox

### DIFF
--- a/change/@fluentui-react-combobox-69ab1141-6687-4347-a900-c2462e72f372.json
+++ b/change/@fluentui-react-combobox-69ab1141-6687-4347-a900-c2462e72f372.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: aria-multiselectable is unnecessary with menu roles",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -101,7 +101,6 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
         ref: ref as React.Ref<HTMLDivElement>,
         role: multiselect ? 'menu' : 'listbox',
         'aria-activedescendant': hasComboboxContext ? undefined : activeOption?.id,
-        'aria-multiselectable': multiselect,
         tabIndex: 0,
         ...props,
       }),


### PR DESCRIPTION
Quick fix -- we don't need `aria-multiselectable` on the Listbox control since we're using `role=menu/menuitemcheckbox` instead of listbox/option.

- Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18400/)
