### PR TITLE
Negative Value Example for VerticalStackedBarChart

### DIFF
--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.NegativeValues.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.NegativeValues.Example.tsx
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import { IVSChartDataPoint, IVerticalStackedChartProps, VerticalStackedBarChart } from '@fluentui/react-charting';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+
+interface IVerticalStackedBarState {
+  width: number;
+  height: number;
+  barGapMax: number;
+}
+
+export class VerticalStackedBarChartNegativeValuesExample extends React.Component<{}, IVerticalStackedBarState> {
+  constructor(props: IVerticalStackedChartProps) {
+    super(props);
+    this.state = {
+      width: 650,
+      height: 350,
+      barGapMax: 2,
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div key={'id_VSBC'}>{this._negativeValues()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _negativeValues(): JSX.Element {
+    const firstChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 40,
+        color: DefaultPalette.blue,
+      },
+      {
+        legend: 'Metadata2',
+        data: 5,
+        color: DefaultPalette.blueMid,
+      },
+      {
+        legend: 'Metadata3',
+        data: 20,
+        color: DefaultPalette.blueLight,
+      },
+    ];
+
+    const secondChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: -30,
+        color: DefaultPalette.blue,
+      },
+      {
+        legend: 'Metadata2',
+        data: -20,
+        color: DefaultPalette.blueMid,
+      },
+      {
+        legend: 'Metadata3',
+        data: -40,
+        color: DefaultPalette.blueLight,
+      },
+    ];
+
+    const thirdChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 44,
+        color: DefaultPalette.blue,
+      },
+      {
+        legend: 'Metadata2',
+        data: 28,
+        color: DefaultPalette.blueMid,
+      },
+      {
+        legend: 'Metadata3',
+        data: 30,
+        color: DefaultPalette.blueLight,
+      },
+    ];
+
+    const fourthChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: -88,
+        color: DefaultPalette.blue,
+      },
+      {
+        legend: 'Metadata2',
+        data: -22,
+        color: DefaultPalette.blueMid,
+      },
+      {
+        legend: 'Metadata3',
+        data: -30,
+        color: DefaultPalette.blueLight,
+      },
+    ];
+
+    const data: IVerticalStackedChartProps[] = [
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 0,
+      },
+      {
+        chartData: secondChartPoints,
+        xAxisPoint: 20,
+      },
+      {
+        chartData: thirdChartPoints,
+        xAxisPoint: 40,
+      },
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 60,
+      },
+      {
+        chartData: fourthChartPoints,
+        xAxisPoint: 80,
+      },
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 100,
+      },
+    ];
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label htmlFor="changeWidth_NegativeValues">Change Width:</label>
+        <input
+          type="range"
+          value={this.state.width}
+          min={200}
+          max={1000}
+          id="changeWidth_NegativeValues"
+          onChange={this._onWidthChange}
+          aria-valuetext={`ChangeWidthSlider${this.state.width}`}
+        />
+        <label htmlFor="changeHeight_NegativeValues">Change Height:</label>
+        <input
+          type="range"
+          value={this.state.height}
+          min={200}
+          max={1000}
+          id="changeHeight_NegativeValues"
+          onChange={this._onHeightChange}
+          aria-valuetext={`ChangeHeightslider${this.state.height}`}
+        />
+        <label htmlFor="changeBarGapMax_NegativeValues">BarGapMax:</label>
+        <input
+          type="range"
+          value={this.state.barGapMax}
+          min={0}
+          max={10}
+          id="changeBarGapMax_NegativeValues"
+          onChange={e => this.setState({ barGapMax: +e.target.value })}
+          aria-valuetext={`ChangebarGapMaxSlider${this.state.barGapMax}`}
+        />
+        <div style={rootStyle}>
+          <VerticalStackedBarChart
+            culture={window.navigator.language}
+            chartTitle="Vertical stacked bar chart negative values example"
+            barGapMax={this.state.barGapMax}
+            data={data}
+            height={this.state.height}
+            width={this.state.width}
+            legendProps={{
+              allowFocusOnLegends: true,
+            }}
+            enableReflow={true}
+            supportNegativeValues={true}
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.doc.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.doc.tsx
@@ -7,6 +7,7 @@ import { VerticalStackedBarChartStyledExample } from './VerticalStackedBarChart.
 import { VerticalStackedBarChartCalloutExample } from './VerticalStackedBarChart.Callout.Example';
 import { VerticalStackedBarChartTooltipExample } from './VerticalStackedBarChart.AxisTooltip.Example';
 import { VerticalStackedBarChartCustomAccessibilityExample } from './VerticalStackedBarChart.CustomAccessibility.Example';
+import { VerticalStackedBarChartNegativeValuesExample } from './VerticalStackedBarChart.NegativeValues.Example';
 
 const VerticalBarChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx') as string;
@@ -18,6 +19,8 @@ const VerticalBarChartTooltipExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx') as string;
 const VerticalBarChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example.tsx') as string;
+const VerticalStackedBarChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.NegativeValues.Example.tsx') as string;
 
 export const VerticalStackedBarChartPageProps: IDocPageProps = {
   title: 'VerticalStackedBarChart',
@@ -49,6 +52,11 @@ export const VerticalStackedBarChartPageProps: IDocPageProps = {
       title: 'VerticalStackedBarChart custom accessibility',
       code: VerticalBarChartCustomAccessibilityExampleCode,
       view: <VerticalStackedBarChartCustomAccessibilityExample />,
+    },
+    {
+      title: 'VerticalStackedBarChart Negative Values',
+      code: VerticalStackedBarChartNegativeValuesExampleCode,
+      view: <VerticalStackedBarChartNegativeValuesExample />,
     },
   ],
   overview: require<string>('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/docs/VerticalStackedBarChartOverview.md'),

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChartPage.tsx
@@ -13,6 +13,7 @@ import { VerticalStackedBarChartStyledExample } from './VerticalStackedBarChart.
 import { VerticalStackedBarChartCalloutExample } from './VerticalStackedBarChart.Callout.Example';
 import { VerticalStackedBarChartTooltipExample } from './VerticalStackedBarChart.AxisTooltip.Example';
 import { VerticalStackedBarChartCustomAccessibilityExample } from './VerticalStackedBarChart.CustomAccessibility.Example';
+import { VerticalStackedBarChartNegativeValuesExample } from './VerticalStackedBarChart.NegativeValues.Example';
 
 const VerticalBarChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx') as string;
@@ -24,6 +25,8 @@ const VerticalBarChartTooltipExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example') as string;
 const VerticalBarChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.CustomAccessibility.Example') as string;
+const VerticalStackedBarChartNegativeValuesExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.NegativeValues.Example') as string;
 
 export class VerticalBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -42,7 +45,7 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
             <ExampleCard title="VerticalStackedBarChart Callout" code={VerticalBarChartCalloutExampleCode}>
               <VerticalStackedBarChartCalloutExample />
             </ExampleCard>
-            <ExampleCard title="VerticalStackedBarChart Callout" code={VerticalBarChartTooltipExampleCode}>
+            <ExampleCard title="VerticalStackedBarChart Tooltip" code={VerticalBarChartTooltipExampleCode}>
               <VerticalStackedBarChartTooltipExample />
             </ExampleCard>
             <ExampleCard
@@ -50,6 +53,12 @@ export class VerticalBarChartPage extends React.Component<IComponentDemoPageProp
               code={VerticalBarChartCustomAccessibilityExampleCode}
             >
               <VerticalStackedBarChartCustomAccessibilityExample />
+            </ExampleCard>
+            <ExampleCard
+              title="VerticalStackedBarChart Negative Values"
+              code={VerticalStackedBarChartNegativeValuesExampleCode}
+            >
+              <VerticalStackedBarChartNegativeValuesExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
No example demonstrating use of negative values for VerticalStackedBarChart

## New Behavior
Negative Values example for VSBC added to dev storybook and public-docsite
<img width="687" alt="image" src="https://github.com/microsoft/fluentui/assets/35366351/135e34de-02c4-4325-9571-fc8c575708ea">
![image](https://github.com/microsoft/fluentui/assets/35366351/bd68d775-32e3-4547-8c17-4abc808995a6)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
