### PR TITLE
[Fix] Zero values unavailable in DonutChart plot

### DIFF
--- a/change/@fluentui-react-charting-fd6cfadf-25f3-4869-923b-f6ee828c7de1.json
+++ b/change/@fluentui-react-charting-fd6cfadf-25f3-4869-923b-f6ee828c7de1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Filtering data for DonutChart with >=0 instead of >0 to allow zero value cases",
+  "packageName": "@fluentui/react-charting",
+  "email": "shubhabrata08@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -138,7 +138,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 focusedArcId={this.state.focusedArcId || ''}
                 href={this.props.href!}
                 calloutId={this._calloutId}
-                valueInsideDonut={this._toLocaleString(valueInsideDonut?.toString())}
+                valueInsideDonut={this._toLocaleString(valueInsideDonut)}
                 theme={this.props.theme!}
                 showLabelsInPercent={this.props.showLabelsInPercent}
                 hideLabels={this.props.hideLabels}

--- a/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -108,7 +108,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     const donutMarginVertical = this.props.hideLabels ? 0 : 40;
     const outerRadius =
       Math.min(this.state._width! - donutMarginHorizontal, this.state._height! - donutMarginVertical) / 2;
-    const chartData = points.filter((d: IChartDataPoint) => d.data! > 0);
+    const chartData = points.filter((d: IChartDataPoint) => d.data! >= 0);
     const valueInsideDonut = this._valueInsideDonut(this.props.valueInsideDonut!, chartData!);
     return !this._isChartEmpty() ? (
       <div
@@ -138,7 +138,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 focusedArcId={this.state.focusedArcId || ''}
                 href={this.props.href!}
                 calloutId={this._calloutId}
-                valueInsideDonut={this._toLocaleString(valueInsideDonut)}
+                valueInsideDonut={this._toLocaleString(valueInsideDonut?.toString())}
                 theme={this.props.theme!}
                 showLabelsInPercent={this.props.showLabelsInPercent}
                 hideLabels={this.props.hideLabels}

--- a/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
@@ -23,6 +23,21 @@ describe('Unit test to convert data to localized string', () => {
   test('Should return localized 0 when data is numeric 0', () => {
     expect(utils.convertToLocaleString(0)).toBe('0');
   });
+  test('Should return localized 123 when data is string 123', () => {
+    expect(utils.convertToLocaleString('123')).toBe('123');
+  });
+  test('Should return localized 1234 when data is string 1234', () => {
+    expect(utils.convertToLocaleString('1234')).toBe('1,234');
+  });
+  test('Should return localized Hello World when data is string Hello World', () => {
+    expect(utils.convertToLocaleString('Hello World')).toBe('Hello World');
+  });
+  test('Should return empty string when data is empty string', () => {
+    expect(utils.convertToLocaleString('')).toBe('');
+  });
+  test('Should return localized whitespace string when data is single whitespace string', () => {
+    expect(utils.convertToLocaleString(' ')).toBe(' ');
+  });
   test('Should return the localised data in the given culture when input data is a string', () => {
     expect(utils.convertToLocaleString('text', 'en-GB')).toBe('text');
     expect(utils.convertToLocaleString('text', 'ar-SY')).toBe('text');

--- a/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
@@ -33,10 +33,10 @@ describe('Unit test to convert data to localized string', () => {
     expect(utils.convertToLocaleString('Hello World')).toBe('Hello World');
   });
   test('Should return empty string when data is empty string', () => {
-    expect(utils.convertToLocaleString('')).toBe('');
+    expect(utils.convertToLocaleString('')).toBe('0');
   });
   test('Should return localized whitespace string when data is single whitespace string', () => {
-    expect(utils.convertToLocaleString(' ')).toBe(' ');
+    expect(utils.convertToLocaleString(' ')).toBe('0');
   });
   test('Should return the localised data in the given culture when input data is a string', () => {
     expect(utils.convertToLocaleString('text', 'en-GB')).toBe('text');

--- a/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
@@ -32,10 +32,10 @@ describe('Unit test to convert data to localized string', () => {
   test('Should return localized Hello World when data is string Hello World', () => {
     expect(utils.convertToLocaleString('Hello World')).toBe('Hello World');
   });
-  test('Should return empty string when data is empty string', () => {
+  test('Should return 0 as string when data is empty string', () => {
     expect(utils.convertToLocaleString('')).toBe('0');
   });
-  test('Should return localized whitespace string when data is single whitespace string', () => {
+  test('Should return 0 as string when data is single whitespace string', () => {
     expect(utils.convertToLocaleString(' ')).toBe('0');
   });
   test('Should return the localised data in the given culture when input data is a string', () => {

--- a/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/react-charting/src/utilities/UtilityUnitTests.test.ts
@@ -17,7 +17,12 @@ describe('Unit test to convert data to localized string', () => {
   test('Should return undefined when data provided is undefined', () => {
     expect(utils.convertToLocaleString(undefined)).toBeUndefined();
   });
-
+  test('Should return NaN when data is NaN', () => {
+    expect(utils.convertToLocaleString(NaN)).toBeNaN();
+  });
+  test('Should return localized 0 when data is numeric 0', () => {
+    expect(utils.convertToLocaleString(0)).toBe('0');
+  });
   test('Should return the localised data in the given culture when input data is a string', () => {
     expect(utils.convertToLocaleString('text', 'en-GB')).toBe('text');
     expect(utils.convertToLocaleString('text', 'ar-SY')).toBe('text');

--- a/packages/react-charting/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
+++ b/packages/react-charting/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
@@ -532,7 +532,7 @@ exports[`createNumericXAxis should create the x-axis labels correctly for a spec
 Array [
   Array [
     0,
-    0,
+    "0",
   ],
   Array [
     50,

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -1351,7 +1351,7 @@ export const getAccessibleDataObject = (
 
 type LocaleStringDataProps = number | string | Date | undefined;
 export const convertToLocaleString = (data: LocaleStringDataProps, culture?: string): LocaleStringDataProps => {
-  if (!data && data !== 0) {
+  if (data === undefined || data === null || Number.isNaN(data)) {
     return data;
   }
   culture = culture || undefined;

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -1351,7 +1351,7 @@ export const getAccessibleDataObject = (
 
 type LocaleStringDataProps = number | string | Date | undefined;
 export const convertToLocaleString = (data: LocaleStringDataProps, culture?: string): LocaleStringDataProps => {
-  if (!data) {
+  if (!data && data !== 0) {
     return data;
   }
   culture = culture || undefined;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Zero values didn't appear on legend hover inside donut
![image](https://github.com/microsoft/fluentui/assets/35366351/6af8d652-3bef-4a6e-bcca-0b2ab4fdc306)

## New Behavior
Zero values now appear on hovering over legend with data zero. This was primarily due to filtering of data by >0 condition.
![image](https://github.com/microsoft/fluentui/assets/35366351/9e23c0c0-2072-461e-a58d-98b31f9400ee)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30051 
