### PR TITLE
fix: Disabled Label should use GrayText in forced-colors mode

### DIFF
--- a/change/@fluentui-react-label-65a884aa-21c2-4ab3-9323-d0910642b5b9.json
+++ b/change/@fluentui-react-label-65a884aa-21c2-4ab3-9323-d0910642b5b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Disabled Label should use GrayText in forced-colors mode",
+  "packageName": "@fluentui/react-label",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-label/src/components/Label/useLabelStyles.styles.ts
+++ b/packages/react-components/react-label/src/components/Label/useLabelStyles.styles.ts
@@ -19,15 +19,14 @@ const useStyles = makeStyles({
 
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+    },
   },
 
   required: {
     color: tokens.colorPaletteRedForeground3,
     paddingLeft: '4px', // TODO: Once spacing tokens are added, change this to Horizontal XS
-  },
-
-  requiredDisabled: {
-    color: tokens.colorNeutralForegroundDisabled,
   },
 
   small: {
@@ -69,7 +68,7 @@ export const useLabelStyles_unstable = (state: LabelState): LabelState => {
     state.required.className = mergeClasses(
       labelClassNames.required,
       styles.required,
-      state.disabled && styles.requiredDisabled,
+      state.disabled && styles.disabled,
       state.required.className,
     );
   }


### PR DESCRIPTION
## Previous Behavior

In forced-colors mode (Windows high contrast), disabled labels don't appear disabled.

## New Behavior

Use `GrayText` for disabled labels in forced-colors mode.
