### PR TITLE
fix(react-positioning): update styles to not flip in RTL

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -48,10 +48,17 @@ const useStyles = makeStyles({
     ...shorthands.border('1px', 'solid', 'blue'),
     backgroundColor: 'white',
   },
+  boxBold: {
+    ...shorthands.borderWidth('3px'),
+  },
 
   arrow: {
-    ...createArrowStyles({ arrowHeight: 8 }),
-    backgroundColor: 'red',
+    ...createArrowStyles({
+      arrowHeight: 12,
+      borderStyle: 'solid',
+      borderColor: 'blue',
+      borderWidth: '3px',
+    }),
   },
 
   seeThrough: {
@@ -415,7 +422,7 @@ const Arrow: React.FC = () => {
   const positionedRefs = positions.reduce<ReturnType<typeof usePositioning>[]>((acc, cur) => {
     // this loop is deterministic
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const positioningRefs = usePositioning({ position: cur[0], align: cur[1] });
+    const positioningRefs = usePositioning({ position: cur[0], align: cur[1], offset: 12, arrowPadding: 12 });
     acc.push(positioningRefs);
     return acc;
   }, []);
@@ -425,7 +432,7 @@ const Arrow: React.FC = () => {
   return (
     <div className={styles.wrapper}>
       {positions.map(([position, align], i) => (
-        <Box key={`${position}-${align}`} ref={positionedRefs[i].containerRef}>
+        <Box className={styles.boxBold} key={`${position}-${align}`} ref={positionedRefs[i].containerRef}>
           <div className={styles.arrow} ref={positionedRefs[i].arrowRef} />
           {`${position}-${align}`}
         </Box>

--- a/change/@fluentui-react-positioning-789c4f31-0af6-4da0-a7e3-0b9d6139defd.json
+++ b/change/@fluentui-react-positioning-789c4f31-0af6-4da0-a7e3-0b9d6139defd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update styles to not flip in RTL",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -91,7 +91,7 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
       ),
       ...shorthands.borderBottom(borderWidth, borderStyle, borderColor),
       borderBottomRightRadius: tokens.borderRadiusSmall,
-      transform: 'rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(45deg)',
+      transform: 'rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(45deg) /* @noflip */',
     },
 
     // Popper sets data-popper-placement on the root element, which is used to align the arrow


### PR DESCRIPTION
## Previous Behavior

<img width="672" alt="image" src="https://github.com/microsoft/fluentui/assets/14183168/f0b34194-60e5-4512-9737-518ccb03459b">

## New Behavior

<img width="677" alt="image" src="https://github.com/microsoft/fluentui/assets/14183168/79959512-fe7d-48b8-8693-3a559f3dc091">

## Details

The fix is similar to #21354. The problem is that after https://github.com/kentcdodds/rtl-css-js/pull/66, `transform` value is also started to flip while it should not.

#### 1.15.0

```json
{"transform":"rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(45deg)"}
```

#### 1.16.1

```json
{"transform":"rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(-45deg)"}
```

## Related Issue(s)

Fixes #29944
