### PR TITLE
fix: Update Label to use a token for its padding, instead of a hardcoded value

### DIFF
--- a/change/@fluentui-react-label-3d4b817c-0699-45e0-8c11-911b01f6a7b2.json
+++ b/change/@fluentui-react-label-3d4b817c-0699-45e0-8c11-911b01f6a7b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Update Label to use a token for its padding, instead of a hardcoded value",
+  "packageName": "@fluentui/react-label",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-label/src/components/Label/useLabelStyles.styles.ts
+++ b/packages/react-components/react-label/src/components/Label/useLabelStyles.styles.ts
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
 
   required: {
     color: tokens.colorPaletteRedForeground3,
-    paddingLeft: '4px', // TODO: Once spacing tokens are added, change this to Horizontal XS
+    paddingLeft: tokens.spacingHorizontalXS,
   },
 
   requiredDisabled: {


### PR DESCRIPTION
## Previous Behavior

Label used a hardcoded px value for padding, with a TODO comment to replace with a token.

## New Behavior

Replace the hardcoded px value with a token.
