### PR TITLE
fix(react-card): selectable cards should not be focusable

### DIFF
--- a/change/@fluentui-react-card-325187ac-9ed9-4045-bc3d-cab221a5cf74.json
+++ b/change/@fluentui-react-card-325187ac-9ed9-4045-bc3d-cab221a5cf74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: selectable card should not be focusable",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/Card/Card.cy.tsx
+++ b/packages/react-components/react-card/src/components/Card/Card.cy.tsx
@@ -323,6 +323,19 @@ describe('Card', () => {
   });
 
   describe('selectable', () => {
+    it('should not be focusable', () => {
+      mountFluent(<CardSample />);
+
+      cy.get('#before').focus();
+
+      cy.get('#card').should('not.be.focused');
+
+      cy.realPress('Tab');
+
+      cy.get('#card').should('not.be.focused');
+      cy.get('#open-button').should('be.focused');
+    });
+
     it('should not be selectable by default', () => {
       mountFluent(<CardSample />);
 

--- a/packages/react-components/react-card/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/src/components/Card/useCard.ts
@@ -100,7 +100,7 @@ export const useCard_unstable = (props: CardProps, ref: React.Ref<HTMLDivElement
       getIntrinsicElementProps('div', {
         ref: cardRef,
         role: 'group',
-        ...focusAttributes,
+        ...(!selectable ? focusAttributes : null),
         ...props,
         ...selectableCardProps,
       }),

--- a/packages/react-components/react-card/src/components/Card/useCardSelectable.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardSelectable.ts
@@ -5,6 +5,8 @@ import { useFocusFinders } from '@fluentui/react-tabster';
 
 import type { CardContextValue, CardOnSelectionChangeEvent, CardProps, CardSlots } from './Card.types';
 
+type SelectableA11yProps = Pick<CardContextValue['selectableA11yProps'], 'referenceId' | 'referenceLabel'>;
+
 /**
  * @internal
  *
@@ -15,11 +17,11 @@ import type { CardContextValue, CardOnSelectionChangeEvent, CardProps, CardSlots
  *
  * @param props - props from this instance of Card
  * @param a11yProps - accessibility props shared between elements of the card
- * @param ref - reference to the root element of Card
+ * @param cardRef - reference to the root element of Card
  */
 export const useCardSelectable = (
   props: CardProps,
-  { referenceLabel, referenceId }: Pick<CardContextValue['selectableA11yProps'], 'referenceId' | 'referenceLabel'>,
+  { referenceLabel, referenceId }: SelectableA11yProps,
   cardRef: React.RefObject<HTMLDivElement>,
 ) => {
   const { checkbox = {}, onSelectionChange, floatingAction, onClick, onKeyDown } = props;


### PR DESCRIPTION
## Previous Behavior
Selectable cards were receiving focus attributes when `onClick` was provided.

## New Behavior
Selectable cards are now not focusable to keep the focus on the internal selectable checkbox

## Related Issue(s)
- Fixes #30142
