### PR TITLE
fix(react-card): remove slow CSS selector from card styles

### DIFF
--- a/change/@fluentui-react-card-8029d09b-3768-40f2-af72-ea3e8d708553.json
+++ b/change/@fluentui-react-card-8029d09b-3768-40f2-af72-ea3e8d708553.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove slow CSS selector from card styles",
+  "packageName": "@fluentui/react-card",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.styles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.styles.ts
@@ -63,10 +63,6 @@ const useStyles = makeStyles({
     [`> .${cardHeaderClassNames.root}, > .${cardFooterClassNames.root}`]: {
       flexShrink: 0,
     },
-    // Allows non-card components to grow to fill the available space.
-    [`> :not(.${cardPreviewClassNames.root}):not(.${cardHeaderClassNames.root}):not(.${cardFooterClassNames.root})`]: {
-      flexGrow: 1,
-    },
   },
 
   focused: {


### PR DESCRIPTION
Remove a slow CSS selector that was set sane defaults for inner children of cards. Since this "default" is the same as the browser already applies, this selector can be safely removed.

## Related Issue(s)
- Fixes #28281
