### PR TITLE
revert(ts-minbar-test-react-components): temporarily resolve keyborg to 2.3.0 which will pass TS check

### DIFF
--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as fs from 'node:fs/promises';
 import {
   prepareTempDirs,
   log,
@@ -12,18 +11,6 @@ import {
 
 const tsVersion = '3.9';
 const testName = 'ts-minbar-react-components';
-
-/**
- *
- * REMOVE after https://github.com/microsoft/keyborg/issues/69 is fixed
- */
-async function pinKeyborgUntilDtsIsFixed(appRoot: string) {
-  const jsonPath = path.join(appRoot, 'package.json');
-  const jsonContent = await fs.readFile(jsonPath, 'utf-8');
-  const json = JSON.parse(jsonContent);
-  json.resolutions['keyborg'] = '2.3.0';
-  await fs.writeFile(jsonPath, JSON.stringify(json, null, 2));
-}
 
 async function performTest() {
   let tempPaths: TempPaths;
@@ -48,8 +35,6 @@ async function performTest() {
 
     const packedPackages = await packProjectPackages(logger, '@fluentui/react-components');
     await addResolutionPathsForProjectPackages(tempPaths.testApp);
-
-    await pinKeyborgUntilDtsIsFixed(tempPaths.testApp);
 
     await shEcho(`yarn add ${packedPackages['@fluentui/react-components']}`, tempPaths.testApp);
     logger(`✔️ Fluent UI packages were added to dependencies`);


### PR DESCRIPTION
https://github.com/microsoft/keyborg/issues/69 was fixed so we dont need this workaround anymore