### PR TITLE
fix: set z-index: 1 when rendering DatePickerCompat inline

### DIFF
--- a/apps/vr-tests-react-components/src/stories/DatePickerCompat.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/DatePickerCompat.stories.tsx
@@ -87,4 +87,10 @@ storiesOf('DatePicker Compat', module)
     <Field label="Select a date">
       <DatePicker />
     </Field>
+  ))
+  .addStory('when rendering inline, it should not render behind relatively positioned elements', () => (
+    <Field label="Select a date">
+      <DatePicker open inlinePopup />
+      <input style={{ position: 'relative' }} />
+    </Field>
   ));

--- a/apps/vr-tests-react-components/src/stories/DatePickerCompat.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/DatePickerCompat.stories.tsx
@@ -7,11 +7,13 @@ import { storiesOf } from '@storybook/react';
 import { TestWrapperDecorator } from '../utilities/TestWrapperDecorator';
 import type { DatePickerProps } from '@fluentui/react-datepicker-compat';
 
-const DatePicker = (props: DatePickerProps) => {
+const DatePicker = (props: DatePickerProps & { renderRelativeElement?: boolean }) => {
   const today = new Date('3/15/2023');
+  const { renderRelativeElement, ...restProps } = props;
   return (
     <div style={{ width: '500px', height: '330px', padding: '10px' }}>
-      <DatePickerBase value={today} today={today} {...props} />
+      <DatePickerBase value={today} today={today} {...restProps} />
+      {renderRelativeElement && <input style={{ position: 'relative', display: 'block', width: '100%' }} />}
     </div>
   );
 };
@@ -90,7 +92,6 @@ storiesOf('DatePicker Compat', module)
   ))
   .addStory('when rendering inline, it should not render behind relatively positioned elements', () => (
     <Field label="Select a date">
-      <DatePicker open inlinePopup />
-      <input style={{ position: 'relative' }} />
+      <DatePicker open inlinePopup renderRelativeElement />
     </Field>
   ));

--- a/change/@fluentui-react-datepicker-compat-30448161-6505-496a-926b-0b94582e4f4d.json
+++ b/change/@fluentui-react-datepicker-compat-30448161-6505-496a-926b-0b94582e4f4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: set popup's z-index: 1 when rendering DatePickerCompat inline.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePickerStyles.styles.ts
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePickerStyles.styles.ts
@@ -23,6 +23,11 @@ const useStyles = makeStyles({
       cursor: 'default',
     },
   },
+  inline: {
+    // When rendering inline, the popupSurface will be rendered under relatively positioned elements such as Input.
+    // This is due to the surface being positioned as absolute, therefore zIndex: 1 ensures that won't happen.
+    zIndex: 1,
+  },
 });
 
 const usePopupSurfaceClassName = makeResetStyles({
@@ -43,7 +48,7 @@ const usePopupSurfaceClassName = makeResetStyles({
 export const useDatePickerStyles_unstable = (state: DatePickerState): DatePickerState => {
   const styles = useStyles();
   const popupSurfaceClassName = usePopupSurfaceClassName();
-  const { disabled } = state;
+  const { disabled, inlinePopup } = state;
 
   state.root.className = mergeClasses(
     datePickerClassNames.root,
@@ -57,6 +62,7 @@ export const useDatePickerStyles_unstable = (state: DatePickerState): DatePicker
       datePickerClassNames.popupSurface,
       popupSurfaceClassName,
       state.popupSurface.className,
+      inlinePopup && styles.inline,
     );
   }
 


### PR DESCRIPTION
## Previous Behavior

`DatePicker`'s `Calendar` popup appears behind positioned elements when `inlinePopup={true`}.

## New Behavior

The popup appears above positioned elements when `inlinePopup={true}`.
Adds a VR test to validate the behavior.

## Related Issue(s)

- Related #29185

- Fixes #30280
