### PR TITLE
Scaffold RatingDisplay

### DIFF
--- a/change/@fluentui-react-rating-preview-ae636206-2459-4510-b711-a7d79c21d554.json
+++ b/change/@fluentui-react-rating-preview-ae636206-2459-4510-b711-a7d79c21d554.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Scaffold RatingDisplay",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/etc/react-rating-preview.api.md
+++ b/packages/react-components/react-rating-preview/etc/react-rating-preview.api.md
@@ -28,6 +28,23 @@ export type RatingContextValues = {
 };
 
 // @public
+export const RatingDisplay: ForwardRefComponent<RatingDisplayProps>;
+
+// @public (undocumented)
+export const ratingDisplayClassNames: SlotClassNames<RatingDisplaySlots>;
+
+// @public
+export type RatingDisplayProps = ComponentProps<RatingDisplaySlots> & {};
+
+// @public (undocumented)
+export type RatingDisplaySlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type RatingDisplayState = ComponentState<RatingDisplaySlots>;
+
+// @public
 export const RatingItem: ForwardRefComponent<RatingItemProps>;
 
 // @public (undocumented)
@@ -92,6 +109,9 @@ export type RatingState = ComponentState<RatingSlots> & Required<Pick<RatingProp
 export const renderRating_unstable: (state: RatingState, contextValues: RatingContextValues) => JSX.Element;
 
 // @public
+export const renderRatingDisplay_unstable: (state: RatingDisplayState) => JSX.Element;
+
+// @public
 export const renderRatingItem_unstable: (state: RatingItemState) => JSX.Element;
 
 // @public
@@ -102,6 +122,12 @@ export const useRatingContextValue_unstable: () => RatingContextValue | undefine
 
 // @public (undocumented)
 export const useRatingContextValues: (state: RatingState) => RatingContextValues;
+
+// @public
+export const useRatingDisplay_unstable: (props: RatingDisplayProps, ref: React_2.Ref<HTMLDivElement>) => RatingDisplayState;
+
+// @public
+export const useRatingDisplayStyles_unstable: (state: RatingDisplayState) => RatingDisplayState;
 
 // @public
 export const useRatingItem_unstable: (props: RatingItemProps, ref: React_2.Ref<HTMLSpanElement>) => RatingItemState;

--- a/packages/react-components/react-rating-preview/src/RatingDisplay.ts
+++ b/packages/react-components/react-rating-preview/src/RatingDisplay.ts
@@ -1,0 +1,1 @@
+export * from './components/RatingDisplay/index';

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.test.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { RatingDisplay } from './RatingDisplay';
+
+describe('RatingDisplay', () => {
+  isConformant({
+    Component: RatingDisplay,
+    displayName: 'RatingDisplay',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<RatingDisplay>Default RatingDisplay</RatingDisplay>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useRatingDisplay_unstable } from './useRatingDisplay';
+import { renderRatingDisplay_unstable } from './renderRatingDisplay';
+import { useRatingDisplayStyles_unstable } from './useRatingDisplayStyles.styles';
+import type { RatingDisplayProps } from './RatingDisplay.types';
+
+/**
+ * RatingDisplay component - TODO: add more docs
+ */
+export const RatingDisplay: ForwardRefComponent<RatingDisplayProps> = React.forwardRef((props, ref) => {
+  const state = useRatingDisplay_unstable(props, ref);
+
+  useRatingDisplayStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  useCustomStyleHook_unstable('useRatingDisplayStyles_unstable')(state);
+  return renderRatingDisplay_unstable(state);
+});
+
+RatingDisplay.displayName = 'RatingDisplay';

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { useRatingDisplay_unstable } from './useRatingDisplay';
 import { renderRatingDisplay_unstable } from './renderRatingDisplay';
 import { useRatingDisplayStyles_unstable } from './useRatingDisplayStyles.styles';
@@ -13,9 +12,6 @@ export const RatingDisplay: ForwardRefComponent<RatingDisplayProps> = React.forw
   const state = useRatingDisplay_unstable(props, ref);
 
   useRatingDisplayStyles_unstable(state);
-  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
-  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
-  useCustomStyleHook_unstable('useRatingDisplayStyles_unstable')(state);
   return renderRatingDisplay_unstable(state);
 });
 

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.types.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type RatingDisplaySlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * RatingDisplay Props
+ */
+export type RatingDisplayProps = ComponentProps<RatingDisplaySlots> & {};
+
+/**
+ * State used in rendering RatingDisplay
+ */
+export type RatingDisplayState = ComponentState<RatingDisplaySlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from RatingDisplayProps.
+// & Required<Pick<RatingDisplayProps, 'propName'>>

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/__snapshots__/RatingDisplay.test.tsx.snap
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/__snapshots__/RatingDisplay.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RatingDisplay renders a default state 1`] = `
+<div>
+  <div
+    class="fui-RatingDisplay"
+  >
+    Default RatingDisplay
+  </div>
+</div>
+`;

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/index.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/index.ts
@@ -1,0 +1,5 @@
+export * from './RatingDisplay';
+export * from './RatingDisplay.types';
+export * from './renderRatingDisplay';
+export * from './useRatingDisplay';
+export * from './useRatingDisplayStyles.styles';

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/renderRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/renderRatingDisplay.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { RatingDisplayState, RatingDisplaySlots } from './RatingDisplay.types';
+
+/**
+ * Render the final JSX of RatingDisplay
+ */
+export const renderRatingDisplay_unstable = (state: RatingDisplayState) => {
+  assertSlots<RatingDisplaySlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { RatingDisplayProps, RatingDisplayState } from './RatingDisplay.types';
+
+/**
+ * Create the state required to render RatingDisplay.
+ *
+ * The returned state can be modified with hooks such as useRatingDisplayStyles_unstable,
+ * before being passed to renderRatingDisplay_unstable.
+ *
+ * @param props - props from this instance of RatingDisplay
+ * @param ref - reference to root HTMLDivElement of RatingDisplay
+ */
+export const useRatingDisplay_unstable = (
+  props: RatingDisplayProps,
+  ref: React.Ref<HTMLDivElement>,
+): RatingDisplayState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { RatingDisplaySlots, RatingDisplayState } from './RatingDisplay.types';
+
+export const ratingDisplayClassNames: SlotClassNames<RatingDisplaySlots> = {
+  root: 'fui-RatingDisplay',
+  // TODO: add class names for all slots on RatingDisplaySlots.
+  // Should be of the form `<slotName>: 'fui-RatingDisplay__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the RatingDisplay slots based on the state
+ */
+export const useRatingDisplayStyles_unstable = (state: RatingDisplayState): RatingDisplayState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(ratingDisplayClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-rating-preview/src/index.ts
+++ b/packages/react-components/react-rating-preview/src/index.ts
@@ -22,3 +22,4 @@ export {
 } from './RatingItem';
 export type { RatingItemProps, RatingItemSlots, RatingItemState } from './RatingItem';
 export { RatingProvider, useRatingContextValue_unstable, useRatingContextValues } from './contexts/index';
+export * from './RatingDisplay';

--- a/packages/react-components/react-rating-preview/stories/RatingDisplay/RatingDisplayBestPractices.md
+++ b/packages/react-components/react-rating-preview/stories/RatingDisplay/RatingDisplayBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-rating-preview/stories/RatingDisplay/RatingDisplayDefault.stories.tsx
+++ b/packages/react-components/react-rating-preview/stories/RatingDisplay/RatingDisplayDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { RatingDisplay, RatingDisplayProps } from '@fluentui/react-rating-preview';
+
+export const Default = (props: Partial<RatingDisplayProps>) => <RatingDisplay {...props} />;

--- a/packages/react-components/react-rating-preview/stories/RatingDisplay/index.stories.tsx
+++ b/packages/react-components/react-rating-preview/stories/RatingDisplay/index.stories.tsx
@@ -1,0 +1,18 @@
+import { RatingDisplay } from '@fluentui/react-rating-preview';
+
+import descriptionMd from './RatingDisplayDescription.md';
+import bestPracticesMd from './RatingDisplayBestPractices.md';
+
+export { Default } from './RatingDisplayDefault.stories';
+
+export default {
+  title: 'Preview Components/RatingDisplay',
+  component: RatingDisplay,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};


### PR DESCRIPTION
This PR is to scaffold the `RatingDisplay` component. This is part of the work to split `Rating` into two components.

Fixes #30285 