### PR TITLE
fix: memoize tabster attributes

### DIFF
--- a/change/@fluentui-react-tabster-a5ff55a5-f208-4b37-9982-f6ae86bf92e6.json
+++ b/change/@fluentui-react-tabster-a5ff55a5-f208-4b37-9982-f6ae86bf92e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: memoize tabster attributes",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -16,7 +16,7 @@ export const useMergedTabsterAttributes_unstable: (
     .map(attribute => attribute[Types.TabsterAttributeName])
     .filter(Boolean) as string[];
 
-  const mergedStrigAttribute = React.useMemo(() => {
+  return React.useMemo(() => {
     let attribute = stringAttributes[0];
     attributes.shift();
 
@@ -24,11 +24,9 @@ export const useMergedTabsterAttributes_unstable: (
       attribute = mergeAttributes(attribute, attr);
     }
 
-    return attribute;
+    return { [Types.TabsterAttributeName]: attribute };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, stringAttributes);
-
-  return { [Types.TabsterAttributeName]: mergedStrigAttribute };
 };
 
 function mergeAttributes(a: string, b?: string): string {

--- a/packages/react-components/react-tabster/src/hooks/useTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabsterAttributes.ts
@@ -1,5 +1,6 @@
 import { getTabsterAttribute, Types as TabsterTypes } from 'tabster';
 import { useTabster } from './useTabster';
+import * as React from 'react';
 
 /**
  * @internal
@@ -10,5 +11,11 @@ export const useTabsterAttributes = (props: TabsterTypes.TabsterAttributeProps):
   // but calling the hook will ensure that a tabster instance exists internally and avoids consumers doing the same
   useTabster();
 
-  return getTabsterAttribute(props);
+  const strAttr = getTabsterAttribute(props, true);
+  return React.useMemo(
+    () => ({
+      'data-tabster': strAttr,
+    }),
+    [strAttr],
+  );
 };


### PR DESCRIPTION
Tabster attributes are still strings. This PR memoizes the returned spread object based on the string attribute value.

Fixes partially #29908
