### PR TITLE
fix(Combobox): do not select options on "Space"

### DIFF
--- a/change/@fluentui-react-combobox-95fe889a-80c9-4e56-b2a8-17636f4434f6.json
+++ b/change/@fluentui-react-combobox-95fe889a-80c9-4e56-b2a8-17636f4434f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Combobox): do not select options on \"Space\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -474,7 +474,7 @@ describe('Combobox', () => {
     expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Red');
   });
 
-  it('selects an option on enter and space', () => {
+  it('selects an option on enter', () => {
     const { getByTestId, getByRole } = render(
       <Combobox open data-testid="combobox">
         <Option>Red</Option>
@@ -486,13 +486,25 @@ describe('Combobox', () => {
     const combobox = getByTestId('combobox');
 
     userEvent.type(combobox, '{Enter}');
-
     expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Red');
+  });
 
-    // arrow down + space
-    userEvent.keyboard('{ArrowDown} ');
+  it('allows to input space', () => {
+    const { getByRole, getByText } = render(
+      <Combobox open>
+        <Option>Slice of pizza</Option>
+        <Option>Slice of cake</Option>
+        <Option>Slice of pie</Option>
+      </Combobox>,
+    );
 
-    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Green');
+    const combobox = getByRole('combobox');
+
+    userEvent.type(combobox, 'Slice of pie');
+    userEvent.type(combobox, '{Enter}');
+
+    expect(getByText('Slice of pie').getAttribute('aria-selected')).toEqual('true');
+    expect((combobox as HTMLInputElement).value).toEqual('Slice of pie');
   });
 
   it('does not select a disabled option with the keyboard', () => {
@@ -702,23 +714,6 @@ describe('Combobox', () => {
 
     expect(onOptionSelect).not.toHaveBeenCalled();
     expect((getByRole('combobox') as HTMLInputElement).value).toEqual('re ');
-  });
-
-  it('uses space to select after arrowing through options in a freeform combobox', () => {
-    const onOptionSelect = jest.fn();
-
-    const { getByRole } = render(
-      <Combobox onOptionSelect={onOptionSelect} freeform>
-        <Option>Red</Option>
-        <Option>Green</Option>
-        <Option>Blue</Option>
-      </Combobox>,
-    );
-
-    userEvent.type(getByRole('combobox'), 're{ArrowDown} ');
-
-    expect(onOptionSelect).toHaveBeenCalledTimes(1);
-    expect((getByRole('combobox') as HTMLInputElement).value).toEqual('Green');
   });
 
   it('inserts space character in closed freeform combobox', () => {

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
@@ -293,7 +293,7 @@ describe('Listbox', () => {
     expect(onOptionSelect).toHaveBeenCalled();
   });
 
-  it('should select option with the space key', () => {
+  it('should not select option with the space key', () => {
     const onOptionSelect = jest.fn();
 
     const { getByTestId } = render(
@@ -305,10 +305,10 @@ describe('Listbox', () => {
     );
 
     const listbox = getByTestId('listbox');
+
     fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     fireEvent.keyDown(listbox, { key: ' ' });
 
-    expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
-    expect(onOptionSelect).toHaveBeenCalled();
+    expect(onOptionSelect).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/react-combobox/src/utils/dropdownKeyActions.ts
+++ b/packages/react-components/react-combobox/src/utils/dropdownKeyActions.ts
@@ -21,6 +21,7 @@ export type DropdownActions =
   | 'Type';
 
 export interface DropdownActionOptions {
+  elementType?: 'input' | 'button';
   open?: boolean;
   multiselect?: boolean;
 }
@@ -32,7 +33,7 @@ export function getDropdownActionFromKey(
   e: KeyboardEvent | React.KeyboardEvent,
   options: DropdownActionOptions = {},
 ): DropdownActions {
-  const { open = true, multiselect = false } = options;
+  const { elementType, open = true } = options;
   const code = e.key;
   const { altKey, ctrlKey, key, metaKey } = e;
 
@@ -52,11 +53,8 @@ export function getDropdownActionFromKey(
   }
 
   // select or close actions
-  if ((code === keys.ArrowUp && altKey) || code === keys.Enter || (!multiselect && code === keys.Space)) {
+  if ((code === keys.ArrowUp && altKey) || code === keys.Enter || (code === keys.Space && elementType === 'button')) {
     return 'CloseSelect';
-  }
-  if (multiselect && code === keys.Space) {
-    return 'Select';
   }
   if (code === keys.Escape) {
     return 'Close';

--- a/packages/react-components/react-combobox/src/utils/useTriggerSlot.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerSlot.ts
@@ -103,7 +103,7 @@ export function useTriggerSlot(
   // handle combobox keyboard interaction
   trigger.onKeyDown = mergeCallbacks(
     (event: React.KeyboardEvent<HTMLButtonElement> & React.KeyboardEvent<HTMLInputElement>) => {
-      const action = getDropdownActionFromKey(event, { open, multiselect });
+      const action = getDropdownActionFromKey(event, { elementType, open, multiselect });
       const maxIndex = getCount() - 1;
       const activeIndex = activeOption ? getIndexOfId(activeOption.id) : -1;
       let newIndex = activeIndex;


### PR DESCRIPTION
## Previous Behavior

- `Combobox` selects options on <kbd>Spacebar</kbd>

## New Behavior

- `Combobox` does not select options on <kbd>Spacebar</kbd>

## Related Issue(s)

Fixes #26361.
