### PR TITLE
fix(react-migration-v0-v9): add northstar to dependencies

### DIFF
--- a/change/@fluentui-react-migration-v0-v9-40c471ac-4687-4fe0-8321-043b79251c80.json
+++ b/change/@fluentui-react-migration-v0-v9-40c471ac-4687-4fe0-8321-043b79251c80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-migration-v0-v9): add northstar to dependencies",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-migration-v0-v9/package.json
+++ b/packages/react-components/react-migration-v0-v9/package.json
@@ -27,7 +27,6 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/react-northstar": "*",
     "@fluentui/scripts-api-extractor": "*",
     "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-storybook": "*"
@@ -35,6 +34,7 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.7.0",
     "@fluentui/react-components": "^9.44.3",
+    "@fluentui/react-northstar": "^0.66.4",
     "@fluentui/react-context-selector": "^9.1.46",
     "@fluentui/react-icons": "^2.0.224",
     "@fluentui/react-jsx-runtime": "^9.0.24",

--- a/packages/react-components/react-migration-v0-v9/package.json
+++ b/packages/react-components/react-migration-v0-v9/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
+    "@fluentui/react-northstar": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
@@ -34,7 +35,6 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.7.0",
     "@fluentui/react-components": "^9.44.3",
-    "@fluentui/react-northstar": "^0.66.4",
     "@fluentui/react-context-selector": "^9.1.46",
     "@fluentui/react-icons": "^2.0.224",
     "@fluentui/react-jsx-runtime": "^9.0.24",
@@ -49,7 +49,8 @@
     "@types/react": ">=16.14.0 <19.0.0",
     "@types/react-dom": ">=16.9.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "react-dom": ">=16.14.0 <19.0.0",
+    "@fluentui/react-northstar": "^0.66.4"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

northstar is specified only as a devDependency but its actually being used in public api surface. (discovered https://github.com/microsoft/fluentui/pull/30251)

## New Behavior

northstar is properly set as dependency

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
