### PR TITLE
feat(react-utilities): helper type DistributiveOmit

### DIFF
--- a/change/@fluentui-react-aria-17668947-ca6a-43f9-b1b1-c3bcb189a4fd.json
+++ b/change/@fluentui-react-aria-17668947-ca6a-43f9-b1b1-c3bcb189a4fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: import UnionToIntersection from react-utilities instead of redeclaring it locally",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-bb23b6c0-5f20-4520-a037-7a9c5f2e4b65.json
+++ b/change/@fluentui-react-tree-bb23b6c0-5f20-4520-a037-7a9c5f2e4b65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: import DistributiveOmit from react-utilities instead of redeclaring it locally",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-5a4d435a-6cf7-4e78-a675-6c447ed1df24.json
+++ b/change/@fluentui-react-utilities-5a4d435a-6cf7-4e78-a675-6c447ed1df24.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: helper type DistributiveOmit",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -8,6 +8,7 @@ import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { ResolveShorthandFunction } from '@fluentui/react-utilities';
 import type { Slot } from '@fluentui/react-utilities';
+import type { UnionToIntersection } from '@fluentui/react-utilities';
 
 // @public
 export const ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE = "data-activedescendant-focusvisible";

--- a/packages/react-components/react-aria/src/button/types.ts
+++ b/packages/react-components/react-aria/src/button/types.ts
@@ -1,7 +1,5 @@
-import type { ExtractSlotProps, Slot } from '@fluentui/react-utilities';
+import type { ExtractSlotProps, Slot, UnionToIntersection } from '@fluentui/react-utilities';
 import * as React from 'react';
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
 
 export type ARIAButtonType = 'button' | 'a' | 'div';
 

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -18,6 +18,7 @@ import { CheckboxProps } from '@fluentui/react-checkbox';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import { ContextSelector } from '@fluentui/react-context-selector';
+import type { DistributiveOmit } from '@fluentui/react-utilities';
 import type { End } from '@fluentui/keyboard-keys';
 import type { Enter } from '@fluentui/keyboard-keys';
 import type { ExtractSlotProps } from '@fluentui/react-utilities';
@@ -26,7 +27,7 @@ import type { Home } from '@fluentui/keyboard-keys';
 import { Radio } from '@fluentui/react-radio';
 import { RadioProps } from '@fluentui/react-radio';
 import * as React_2 from 'react';
-import { SelectionMode as SelectionMode_2 } from '@fluentui/react-utilities';
+import type { SelectionMode as SelectionMode_2 } from '@fluentui/react-utilities';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 

--- a/packages/react-components/react-tree/src/contexts/treeContext.ts
+++ b/packages/react-components/react-tree/src/contexts/treeContext.ts
@@ -1,6 +1,6 @@
 import { Context, ContextSelector, createContext, useContextSelector } from '@fluentui/react-context-selector';
 import { TreeItemType, TreeItemValue } from '../TreeItem';
-import { SelectionMode } from '@fluentui/react-utilities';
+import type { SelectionMode, DistributiveOmit } from '@fluentui/react-utilities';
 import { ImmutableSet } from '../utils/ImmutableSet';
 import { ImmutableMap } from '../utils/ImmutableMap';
 import { TreeCheckedChangeData, TreeNavigationData_unstable, TreeOpenChangeData } from '../Tree';
@@ -21,16 +21,10 @@ export type TreeContextValue = {
 };
 
 export type TreeItemRequest = { itemType: TreeItemType } & (
-  | (OmitWithoutExpanding<TreeOpenChangeData, 'open' | 'openItems'> & { requestType: 'open' })
+  | (DistributiveOmit<TreeOpenChangeData, 'open' | 'openItems'> & { requestType: 'open' })
   | (TreeNavigationData_unstable & { requestType: 'navigate' })
-  | (OmitWithoutExpanding<TreeCheckedChangeData, 'selectionMode' | 'checkedItems'> & { requestType: 'selection' })
+  | (DistributiveOmit<TreeCheckedChangeData, 'selectionMode' | 'checkedItems'> & { requestType: 'selection' })
 );
-
-/**
- * helper type that avoids the expansion of unions while inferring it,
- * should work exactly the same as Omit
- */
-type OmitWithoutExpanding<P, K extends string | number | symbol> = P extends unknown ? Omit<P, K> : P;
 
 /**
  * @internal

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -37,6 +37,9 @@ export type ComponentState<Slots extends SlotPropsRecord> = {
 // @internal (undocumented)
 export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): PriorityQueue<T>;
 
+// @public
+export type DistributiveOmit<T, K extends keyof any> = T extends unknown ? Omit<T, K> : T;
+
 // @internal
 export function elementContains(parent: Node | null, child: Node | null): boolean;
 
@@ -58,7 +61,7 @@ export function getEventClientCoords(event: TouchOrMouseEvent): {
 };
 
 // @public
-export const getIntrinsicElementProps: <Props extends UnknownSlotProps, ExcludedPropKeys extends Extract<keyof Props, string> = never>(tagName: NonNullable<Props["as"]>, props: Props & React_2.RefAttributes<InferredElementRefType<Props>>, excludedPropNames?: ExcludedPropKeys[] | undefined) => OmitWithoutExpanding<Props, ExcludedPropKeys | Exclude<keyof Props, "as" | keyof HTMLAttributes>>;
+export const getIntrinsicElementProps: <Props extends UnknownSlotProps, ExcludedPropKeys extends Extract<keyof Props, string> = never>(tagName: NonNullable<Props["as"]>, props: Props & React_2.RefAttributes<InferredElementRefType<Props>>, excludedPropNames?: ExcludedPropKeys[] | undefined) => DistributiveOmit<Props, ExcludedPropKeys | Exclude<keyof Props, "as" | keyof HTMLAttributes>>;
 
 // @public @deprecated
 export function getNativeElementProps<TAttributes extends React_2.HTMLAttributes<any>>(tagName: string, props: {}, excludedPropNames?: string[]): TAttributes;
@@ -303,6 +306,9 @@ export type TouchOrMouseEvent = NativeTouchOrMouseEvent | ReactTouchOrMouseEvent
 export type TriggerProps<TriggerChildProps = unknown> = {
     children?: React_2.ReactElement | ((props: TriggerChildProps) => React_2.ReactElement | null) | null;
 };
+
+// @public
+export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
 
 // @public
 export type UnknownSlotProps = Pick<React_2.HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'> & {

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlots.ts
@@ -6,11 +6,11 @@ import type {
   ExtractSlotProps,
   SlotPropsRecord,
   SlotRenderFunction,
-  UnionToIntersection,
   UnknownSlotProps,
 } from '../types';
 import { isSlot } from '../isSlot';
 import { SLOT_RENDER_FUNCTION_SYMBOL } from '../constants';
+import { UnionToIntersection } from '../../utils/types';
 
 /**
  * @deprecated - use slot.always or slot.optional combined with assertSlots instead

--- a/packages/react-components/react-utilities/src/compose/getIntrinsicElementProps.ts
+++ b/packages/react-components/react-utilities/src/compose/getIntrinsicElementProps.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getNativeElementProps } from '../utils/getNativeElementProps';
 import type { InferredElementRefType, UnknownSlotProps } from './types';
+import type { DistributiveOmit } from '../utils/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HTMLAttributes = React.HTMLAttributes<any>;
@@ -24,12 +25,6 @@ export const getIntrinsicElementProps = <
 ) => {
   // eslint-disable-next-line deprecation/deprecation
   return getNativeElementProps<
-    OmitWithoutExpanding<Props, Exclude<keyof Props, keyof HTMLAttributes | keyof UnknownSlotProps> | ExcludedPropKeys>
+    DistributiveOmit<Props, Exclude<keyof Props, keyof HTMLAttributes | keyof UnknownSlotProps> | ExcludedPropKeys>
   >(props.as ?? tagName, props, excludedPropNames);
 };
-
-/**
- * helper type that avoids the expansion of unions while inferring it,
- * should work exactly the same as Omit
- */
-type OmitWithoutExpanding<P, K extends string | number | symbol> = P extends unknown ? Omit<P, K> : P;

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
+import { DistributiveOmit, ReplaceNullWithUndefined } from '../utils/types';
 
 export type SlotRenderFunction<Props> = (
   Component: React.ElementType<Props>,
@@ -135,9 +136,13 @@ export type IsSingleton<T extends string> = { [K in T]: Exclude<T, K> extends ne
 export type AsIntrinsicElement<As extends keyof JSX.IntrinsicElements> = { as?: As };
 
 /**
- * Converts a union type (`A | B | C`) to an intersection type (`A & B & C`)
+ * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
+ * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
+ *
+ * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
+ * types, to prevent unions from being expanded.
  */
-export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
+export type PropsWithoutRef<P> = 'ref' extends keyof P ? DistributiveOmit<P, 'ref'> : P;
 
 /**
  * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
@@ -146,16 +151,7 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
  * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
  * types, to prevent unions from being expanded.
  */
-export type PropsWithoutRef<P> = 'ref' extends keyof P ? (P extends unknown ? Omit<P, 'ref'> : P) : P;
-
-/**
- * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
- * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
- *
- * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
- * types, to prevent unions from being expanded.
- */
-export type PropsWithoutChildren<P> = 'children' extends keyof P ? (P extends unknown ? Omit<P, 'children'> : P) : P;
+export type PropsWithoutChildren<P> = 'children' extends keyof P ? DistributiveOmit<P, 'children'> : P;
 
 /**
  * Removes SlotShorthandValue and null from the slot type, extracting just the slot's Props object.
@@ -177,11 +173,6 @@ export type ComponentProps<Slots extends SlotPropsRecord, Primary extends keyof 
 // * Otherwise, don't omit any props: include *both* the Primary and `root` props.
 //   We need both props to allow the user to specify native props for either slot because the `root` slot is
 //   special and always gets className and style props, per RFC https://github.com/microsoft/fluentui/pull/18983
-
-/**
- * If type T includes `null`, remove it and add `undefined` instead.
- */
-export type ReplaceNullWithUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;
 
 /**
  * Defines the State object of a component given its slots.

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -69,6 +69,8 @@ export {
   createPriorityQueue,
 } from './utils/index';
 
+export type { DistributiveOmit, UnionToIntersection } from './utils/types';
+
 export type { PriorityQueue } from './utils/priorityQueue';
 
 export { applyTriggerPropsToChildren, getTriggerChild, isFluentTrigger } from './trigger/index';

--- a/packages/react-components/react-utilities/src/utils/types.ts
+++ b/packages/react-components/react-utilities/src/utils/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Helper type that works similar to Omit,
+ * but when modifying an union type it will distribute the omission to all the union members.
+ *
+ * See [distributive conditional types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) for more information
+ */
+// Traditional Omit is basically equivalent to => Pick<T, Exclude<keyof T, K>>
+//
+// let's say we have Omit<{ a: string } | { b: string }, 'a'>
+// equivalent to: Pick<{ a: string } | { b: string }, Exclude<keyof ({ a: string } | { b: string }), 'a'>>
+// The expected result would be {} | { b: string }, the omission of 'a' from all the union members,
+// but keyof ({ a: string } | { b: string }) is never as they don't share common keys
+// so  Exclude<never, 'a'> is never,
+// and Pick<{ a: string } | { b: string }, never> is {}.
+//
+// With DistributiveOmit on the other hand it becomes like this:
+// DistributiveOmit<{ a: string } | { b: string }, 'a'>
+// equivalent to: Omit<{ a: string }, 'a'> | Omit<{ b: string }, 'a'>
+// Since every single Omit clause in this case is being applied to a single union member there's no conflicts on keyof evaluation and in the second clause Omit<{ b: string }, 'a'> becomes { b: string },
+// so the result is {} | { b: string }, as expected.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DistributiveOmit<T, K extends keyof any> = T extends unknown ? Omit<T, K> : T;
+
+/**
+ * Converts a union type (`A | B | C`) to an intersection type (`A & B & C`)
+ */
+export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
+
+/**
+ * @internal
+ * If type T includes `null`, remove it and add `undefined` instead.
+ */
+export type ReplaceNullWithUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Follow up on https://github.com/microsoft/fluentui/pull/29865#discussion_r1423815777

1. adds a new helper type `DistributiveOmit` which aims to provide a solution for  [Distributive Conditional type](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) problems
2. exports `UnionToIntersection` helper type from `react-utilities`
3. `react-aria` stops redeclaring `UnionToIntersection`, uses the one from `react-utilities` instead
4. `react-tree` stops redeclaring `DistributiveOmit`, uses the one from `react-utilities` instead

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
