### PR TITLE
chore: export type EventHandler/EventData from react-utilities for typing callback props

### DIFF
--- a/change/@fluentui-react-utilities-a3ed4257-d715-43f5-8585-72d1a93681d9.json
+++ b/change/@fluentui-react-utilities-a3ed4257-d715-43f5-8585-72d1a93681d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new type EventHandler/EventData for callback props",
+  "packageName": "@fluentui/react-utilities",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -41,6 +41,18 @@ export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): Prio
 export function elementContains(parent: Node | null, child: Node | null): boolean;
 
 // @public
+export type EventData<Type extends string, TEvent> = {
+    type: undefined;
+    event: React_2.SyntheticEvent | Event;
+} | {
+    type: Type;
+    event: TEvent;
+};
+
+// @public
+export type EventHandler<TData extends EventData<string, unknown>> = (ev: React_2.SyntheticEvent | Event, data: TData) => void;
+
+// @public
 export type ExtractSlotProps<S> = Exclude<S, SlotShorthandValue | null | undefined>;
 
 // @internal

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -262,3 +262,34 @@ export type SlotComponentType<Props extends UnknownSlotProps> = Props & {
     | React.ComponentType<Props>
     | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
 };
+
+/**
+ * Data type for event handlers. It makes data a discriminated union, where each object requires `event` and `type` property.
+ * - `event` is the specific event type
+ * - `type` is a string literal. It serves as a clear identifier of the event type that reflects the component's state when the event occurred.
+ *    For example, the Tree component's `onNavigation` event handler has different `type` for different key presses: `{ event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight } | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }`.
+ *    Developers can use the `type` property to identify and filter events of interest.
+ * See RFC event-handlers-event-type.md for more details.
+ *
+ * Example usage:
+ * type OnOpenChangeData = (
+ *   | EventData<'click', React.MouseEvent<MyComponentElement>>
+ *   | EventData<'keydown', React.KeyboardEvent<MyComponentElement>>
+ * ) & { open: boolean; };
+ */
+export type EventData<Type extends string, TEvent> =
+  | { type: undefined; event: React.SyntheticEvent | Event }
+  | { type: Type; event: TEvent };
+
+/**
+ * Type for props that are event handlers.
+ * See RFC event-handlers-event-type.md for more details.
+ *
+ * Example usage:
+ * type OnSomeEventData = EventData<'click', React.MouseEvent<MyComponentElement>> & { open: boolean; };
+ * type SomeProps = { onSomeEvent?: EventHandler<OnSomeEventData>; };
+ */
+export type EventHandler<TData extends EventData<string, unknown>> = (
+  ev: React.SyntheticEvent | Event,
+  data: TData,
+) => void;

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -273,9 +273,9 @@ export type SlotComponentType<Props extends UnknownSlotProps> = Props & {
  *
  * Example usage:
  * type OnOpenChangeData = (
- *   | EventData<'click', React.MouseEvent<MyComponentElement>>
- *   | EventData<'keydown', React.KeyboardEvent<MyComponentElement>>
- * ) & { open: boolean; };
+ *   | EventData\<'click', React.MouseEvent\<MyComponentElement\>\>
+ *   | EventData\<'keydown', React.KeyboardEvent\<MyComponentElement\>\>
+ * ) & \{ open: boolean; \};
  */
 export type EventData<Type extends string, TEvent> =
   | { type: undefined; event: React.SyntheticEvent | Event }
@@ -286,8 +286,8 @@ export type EventData<Type extends string, TEvent> =
  * See RFC event-handlers-event-type.md for more details.
  *
  * Example usage:
- * type OnSomeEventData = EventData<'click', React.MouseEvent<MyComponentElement>> & { open: boolean; };
- * type SomeProps = { onSomeEvent?: EventHandler<OnSomeEventData>; };
+ * type OnSomeEventData = EventData\<'click', React.MouseEvent\<MyComponentElement\>\> & \{ open: boolean; \};
+ * type SomeProps = \{ onSomeEvent?: EventHandler\<OnSomeEventData\>; \};
  */
 export type EventHandler<TData extends EventData<string, unknown>> = (
   ev: React.SyntheticEvent | Event,

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -33,6 +33,8 @@ export type {
   SlotComponentType,
   SlotOptions,
   InferredElementRefType,
+  EventData,
+  EventHandler,
 } from './compose/index';
 
 export {


### PR DESCRIPTION
### Background:

We agreed on new event type for v9 callbacks.

Below types will be exported from react-utilities as helpers:
```ts
export type EventData<Type extends string, TEvent> =
  | { type: undefined; event: React.SyntheticEvent | Event }
  | { type: Type; event: TEvent };

export type EventHandler<TData extends EventData<string, unknown>> = (
  ev: React.SyntheticEvent | Event,
  data: TData,
) => void;
```

And they will be used for typing callbacks:
```ts
type MyComponentElement = HTMLElement;

type OnSomeEventData = (
  | EventData<'click', React.MouseEvent<MyComponentElement>>
  | EventData<'focus', React.FocusEvent<MyComponentElement>>
) & {
  open: boolean;
};

type SomeProps = {
  onSomeEvent?: EventHandler<OnSomeEventData>;
};
```

detailed proposal: https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/event-handlers-event-type.md

### This PR does:
Export the helper types as mentioned above.

To make sure this type is used, PR #30293 adds lint rule to force its usage, and PR #30301 deprecates `consistent-callback-args` test that checks for older callback types.