### PR TITLE
feat(react-calendar-compat): Add navigationIcons prop to allow customization of Calendar's navigation icons

### DIFF
--- a/apps/vr-tests-react-components/src/stories/CalendarCompat.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/CalendarCompat.stories.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { TestWrapperDecorator } from '../utilities/TestWrapperDecorator';
+import { Steps, StoryWright } from 'storywright';
+import { Calendar as CalendarBase, CalendarProps } from '@fluentui/react-calendar-compat/src/Calendar';
+import { ArrowLeftRegular, ArrowRightRegular, DismissCircleRegular } from '@fluentui/react-icons';
+
+const Calendar = (props: CalendarProps) => {
+  const today = new Date('3/15/2023');
+
+  return <CalendarBase today={today} {...props} />;
+};
+
+storiesOf('Calendar Compat', module)
+  .addDecorator(TestWrapperDecorator)
+  .addDecorator(story => (
+    <StoryWright steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</StoryWright>
+  ))
+  .addStory('Default', () => <Calendar />)
+  .addStory('Custom icons', () => (
+    <Calendar
+      calendarDayProps={{
+        navigationIcons: {
+          upNavigation: <ArrowLeftRegular />,
+          downNavigation: <ArrowRightRegular />,
+          dismiss: <DismissCircleRegular />,
+        },
+      }}
+      calendarMonthProps={{
+        navigationIcons: {
+          upNavigation: <ArrowLeftRegular />,
+          downNavigation: <ArrowRightRegular />,
+          dismiss: <DismissCircleRegular />,
+        },
+      }}
+    />
+  ));

--- a/change/@fluentui-react-calendar-compat-9c98d35b-9766-46e6-9c05-8cf3fb400b2a.json
+++ b/change/@fluentui-react-calendar-compat-9c98d35b-9766-46e6-9c05-8cf3fb400b2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: Add navigationIcons prop to allow customization of Calendar's navigation icons.",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/etc/react-calendar-compat.api.md
+++ b/packages/react-components/react-calendar-compat/etc/react-calendar-compat.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import * as React_2 from 'react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
@@ -115,6 +117,7 @@ export interface CalendarDayProps extends CalendarDayGridProps {
     maxDate?: Date;
     minDate?: Date;
     navigatedDate: Date;
+    navigationIcons: CalendarNavigationIcons;
     onDismiss?: () => void;
     onHeaderSelect?: () => void;
     onNavigateDate: (date: Date, focusOnNavigatedDay: boolean) => void;
@@ -157,6 +160,7 @@ export interface CalendarMonthProps {
     maxDate?: Date;
     minDate?: Date;
     navigatedDate: Date;
+    navigationIcons: CalendarNavigationIcons;
     onHeaderSelect?: () => void;
     onNavigateDate: (date: Date, focusOnNavigatedDay: boolean) => void;
     onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
@@ -309,6 +313,7 @@ export interface CalendarYearProps {
     maxYear?: number;
     minYear?: number;
     navigatedYear?: number;
+    navigationIcons: CalendarNavigationIcons;
     onHeaderSelect?: (focus: boolean) => void;
     onRenderTitle?: (props: CalendarYearHeaderProps) => React_2.ReactNode;
     onRenderYear?: (year: number) => React_2.ReactNode;

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utils';
 import { CalendarDay } from '../CalendarDay/CalendarDay';
 import { CalendarMonth } from '../CalendarMonth/CalendarMonth';
+import { defaultNavigationIcons } from './calendarNavigationIcons';
 import { useCalendarStyles_unstable } from './useCalendarStyles.styles';
 import type { ICalendarDay } from '../CalendarDay/CalendarDay.types';
 import type { ICalendarMonth } from '../CalendarMonth/CalendarMonth.types';
@@ -372,6 +373,7 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
             showSixWeeksByDefault={showSixWeeksByDefault}
             minDate={minDate}
             maxDate={maxDate}
+            navigationIcons={defaultNavigationIcons}
             restrictedDates={restrictedDates}
             workWeekDays={workWeekDays}
             componentRef={dayPicker}
@@ -398,6 +400,7 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
               minDate={minDate}
               maxDate={maxDate}
               componentRef={monthPicker}
+              navigationIcons={defaultNavigationIcons}
               {...calendarMonthProps} // at end of list so consumer's custom functions take precedence
             />
             {renderGoToTodayButton()}

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/calendarNavigationIcons.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/calendarNavigationIcons.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { ArrowDownRegular, ArrowUpRegular, DismissRegular } from '@fluentui/react-icons';
+
+export type CalendarNavigationIcons = {
+  /**
+   * Icon to use for up arrow navigation. Default comes from \@fluentui\/react-icons
+   * @default ArrowUpRegular
+   */
+  upNavigation?: JSX.Element;
+
+  /**
+   * Icon to use for down arrow navigation. Default comes from \@fluentui\/react-icons
+   * @default ArrowDownRegular
+   */
+  downNavigation?: JSX.Element;
+
+  /**
+   * Icon to use for the dissmiss button. Default comes from \@fluentui\/react-icons
+   * @default DismissRegular
+   */
+  dismiss?: JSX.Element;
+};
+
+export const defaultNavigationIcons: CalendarNavigationIcons = {
+  dismiss: <DismissRegular />,
+  downNavigation: <ArrowDownRegular />,
+  upNavigation: <ArrowUpRegular />,
+};

--- a/packages/react-components/react-calendar-compat/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarDay/CalendarDay.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Enter } from '@fluentui/keyboard-keys';
-import { ArrowDownRegular, ArrowUpRegular, DismissRegular } from '@fluentui/react-icons';
 import { useId } from '@fluentui/react-utilities';
 import { mergeClasses } from '@griffel/react';
 import { addMonths, compareDatePart, getMonthEnd, getMonthStart } from '../../utils';
@@ -102,6 +101,7 @@ const CalendarDayNavigationButtons = (props: CalendarDayNavigationButtonsProps):
     minDate,
     maxDate,
     navigatedDate,
+    navigationIcons,
     allFocusable,
     strings,
     showCloseButton,
@@ -139,7 +139,7 @@ const CalendarDayNavigationButtons = (props: CalendarDayNavigationButtonsProps):
         }
         type="button"
       >
-        <ArrowUpRegular />
+        {navigationIcons.upNavigation}
       </button>
       <button
         className={mergeClasses(classNames.headerIconButton, !nextMonthInBounds && classNames.disabledStyle)}
@@ -154,7 +154,7 @@ const CalendarDayNavigationButtons = (props: CalendarDayNavigationButtonsProps):
         }
         type="button"
       >
-        <ArrowDownRegular />
+        {navigationIcons.downNavigation}
       </button>
       {showCloseButton && (
         <button
@@ -164,7 +164,7 @@ const CalendarDayNavigationButtons = (props: CalendarDayNavigationButtonsProps):
           title={strings.closeButtonAriaLabel}
           type="button"
         >
-          <DismissRegular />
+          {navigationIcons.dismiss}
         </button>
       )}
     </div>

--- a/packages/react-components/react-calendar-compat/src/components/CalendarDay/CalendarDay.types.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarDay/CalendarDay.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { CalendarStrings, DateFormatting } from '../../utils';
 import type { CalendarDayGridProps, CalendarDayGridStyleProps } from '../CalendarDayGrid/CalendarDayGrid.types';
+import type { CalendarNavigationIcons } from '../Calendar/calendarNavigationIcons';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ICalendarDay {
@@ -89,6 +90,11 @@ export interface CalendarDayProps extends CalendarDayGridProps {
    * @default false
    */
   allFocusable?: boolean;
+
+  /**
+   * Custom navigation icons.
+   */
+  navigationIcons: CalendarNavigationIcons;
 }
 
 /**

--- a/packages/react-components/react-calendar-compat/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarMonth/CalendarMonth.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Enter } from '@fluentui/keyboard-keys';
-import { ArrowDownRegular, ArrowUpRegular } from '@fluentui/react-icons';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { mergeClasses } from '@griffel/react';
@@ -81,6 +80,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
     maxDate,
     minDate,
     navigatedDate,
+    navigationIcons,
     onHeaderSelect: onUserHeaderSelect,
     onNavigateDate,
     selectedDate,
@@ -178,6 +178,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
           selectedDate ? selectedDate.getFullYear() : navigatedDate ? navigatedDate.getFullYear() : undefined
         }
         navigatedYear={navigatedDate.getFullYear()}
+        navigationIcons={navigationIcons}
         onRenderYear={onRenderYear}
         strings={yearStrings}
         componentRef={calendarYearRef}
@@ -197,6 +198,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
   const headerAriaLabel = strings.monthPickerHeaderAriaLabel
     ? strings.monthPickerHeaderAriaLabel.replace('{0}', yearString)
     : yearString;
+
+  const { upNavigation: upNavigationIcon, downNavigation: downNavigationIcon } = navigationIcons;
 
   return (
     <div className={classNames.root}>
@@ -227,7 +230,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
             }
             type="button"
           >
-            {dir === 'ltr' ? <ArrowUpRegular /> : <ArrowDownRegular />}
+            {dir === 'rtl' ? upNavigationIcon : downNavigationIcon}
           </button>
           <button
             className={mergeClasses(classNames.navigationButton, !isNextYearInBounds && classNames.disabled)}
@@ -242,7 +245,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
             }
             type="button"
           >
-            {dir === 'ltr' ? <ArrowDownRegular /> : <ArrowUpRegular />}
+            {dir === 'rtl' ? downNavigationIcon : upNavigationIcon}
           </button>
         </div>
       </div>

--- a/packages/react-components/react-calendar-compat/src/components/CalendarMonth/CalendarMonth.types.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarMonth/CalendarMonth.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { AnimationDirection } from '../Calendar/Calendar.types';
+import type { CalendarNavigationIcons } from '../Calendar/calendarNavigationIcons';
 import type { CalendarStrings, DateFormatting } from '../../utils';
 import type { CalendarPickerStyleProps, CalendarPickerStyles } from '../CalendarPicker/CalendarPicker.types';
 
@@ -103,6 +104,11 @@ export interface CalendarMonthProps {
    * The cardinal directions for animation to occur during transitions, either horizontal or veritcal
    */
   animationDirection?: AnimationDirection;
+
+  /**
+   * Custom navigation icons.
+   */
+  navigationIcons: CalendarNavigationIcons;
 }
 
 /**

--- a/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Enter, Space } from '@fluentui/keyboard-keys';
-import { ArrowDownRegular, ArrowUpRegular } from '@fluentui/react-icons';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { mergeClasses } from '@griffel/react';
@@ -208,6 +207,7 @@ const CalendarYearNavArrow: React.FunctionComponent<CalendarYearNavArrowProps> =
     toYear,
     maxYear,
     minYear,
+    navigationIcons,
   } = props;
 
   const classNames = useCalendarYearStyles_unstable({
@@ -249,7 +249,7 @@ const CalendarYearNavArrow: React.FunctionComponent<CalendarYearNavArrowProps> =
       title={ariaLabelString}
       disabled={disabled}
     >
-      {isLeftNavigation ? <ArrowUpRegular /> : <ArrowDownRegular />}
+      {isLeftNavigation ? navigationIcons.upNavigation : navigationIcons.downNavigation}
     </button>
   );
 };

--- a/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.types.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { AnimationDirection } from '../Calendar/Calendar.types';
+import type { CalendarNavigationIcons } from '../Calendar/calendarNavigationIcons';
 import type { CalendarPickerStyleProps, CalendarPickerStyles } from '../CalendarPicker/CalendarPicker.types';
 
 /**
@@ -112,6 +113,11 @@ export interface CalendarYearProps {
    * The cardinal directions for animation to occur during transitions, either horizontal or veritcal
    */
   animationDirection?: AnimationDirection;
+
+  /**
+   * Custom navigation icons.
+   */
+  navigationIcons: CalendarNavigationIcons;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

It wasn't possible to customize navigation icons like in v8. This was due to v8 using the Icon component and being able to pass the name of the icon instead of having to pass the whole icon.

## New Behavior

Added navigationIcons prop which aligns with the usage of v8, but instead of passing a string, a JSX element is required that will be the icon itself.


