### PR TITLE
feat(eslint-plugin): register @nx plugin internally in order to be able to consume our custom @nx/workspace-* lint rules

### DIFF
--- a/change/@fluentui-eslint-plugin-c8715c3d-52d8-4b79-b0e7-279481b378f0.json
+++ b/change/@fluentui-eslint-plugin-c8715c3d-52d8-4b79-b0e7-279481b378f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(eslint-plugin): register @nx plugin internally in order to be able to consume our custom @nx/workspace-* lint rules",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/eslint-plugin/src/configs/core.js
+++ b/packages/eslint-plugin/src/configs/core.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { __internal } = require('../internal');
 const configHelpers = require('../utils/configHelpers');
 
 /** @type {import("eslint").Linter.Config} */
@@ -13,7 +14,16 @@ const config = {
     'prettier',
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['import', '@fluentui', '@rnx-kit', '@typescript-eslint', 'deprecation', 'jest', 'jsdoc'],
+  plugins: [
+    'import',
+    '@fluentui',
+    '@rnx-kit',
+    '@typescript-eslint',
+    'deprecation',
+    'jest',
+    'jsdoc',
+    ...__internal.plugins,
+  ],
   settings: {
     'import/resolver': {
       // @see https://github.com/alexgorbatchev/eslint-import-resolver-typescript#configuration

--- a/packages/eslint-plugin/src/internal.js
+++ b/packages/eslint-plugin/src/internal.js
@@ -1,0 +1,26 @@
+function shouldRegisterInternal() {
+  try {
+    const hasNxEslintPlugin = require.resolve('@nx/eslint-plugin');
+    return Boolean(hasNxEslintPlugin);
+  } catch (err) {
+    return false;
+  }
+}
+
+const shouldRegister = shouldRegisterInternal();
+
+/**
+ * @internal
+ *
+ * this will be removed after https://github.com/microsoft/fluentui/issues/30332
+ *
+ * expands this with rulesets/overrides that are necessary for specific configs
+ */
+const __internal = {
+  /**
+   * `@nx/eslint-plugin` is necessary in order to register custom lint rules that live within tools/eslint-rules
+   */
+  plugins: shouldRegister ? ['@nx'] : [],
+};
+
+exports.__internal = __internal;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

adding a temporary workaround to register workspace lint rules without bigger eslint configuration overhaul that will be don eventually. See referenced epic for more details

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows: https://github.com/microsoft/fluentui/pull/30335
- Implements partially https://github.com/microsoft/fluentui/issues/30332
