### PR TITLE
fix(Dropdown): allow expandIcon to be null

### DIFF
--- a/change/@fluentui-react-combobox-cddae570-a33b-4aa0-a960-7b80d45ee4fc.json
+++ b/change/@fluentui-react-combobox-cddae570-a33b-4aa0-a960-7b80d45ee4fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: allow expandIcon to be null",
+  "packageName": "@fluentui/react-combobox",
+  "email": "yuanboxue@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -80,7 +80,7 @@ export type DropdownProps = ComponentProps<Partial<DropdownSlots>, 'button'> & C
 // @public (undocumented)
 export type DropdownSlots = {
     root: NonNullable<Slot<'div'>>;
-    expandIcon: Slot<'span'>;
+    expandIcon?: Slot<'span'>;
     clearButton?: Slot<'button'>;
     button: NonNullable<Slot<'button'>>;
     listbox?: Slot<typeof Listbox>;

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.types.ts
@@ -13,7 +13,7 @@ export type DropdownSlots = {
   root: NonNullable<Slot<'div'>>;
 
   /* The dropdown arrow icon */
-  expandIcon: Slot<'span'>;
+  expandIcon?: Slot<'span'>;
 
   /* The dropdown clear icon */
   clearButton?: Slot<'button'>;

--- a/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
@@ -18,7 +18,7 @@ export const renderDropdown_unstable = (state: DropdownState, contextValues: Dro
       <ComboboxContext.Provider value={contextValues.combobox}>
         <state.button>
           {state.button.children}
-          <state.expandIcon />
+          {state.expandIcon && <state.expandIcon />}
         </state.button>
         {state.clearButton && <state.clearButton />}
         {state.listbox &&


### PR DESCRIPTION
 
## Previous Behavior
In v9.44.3, `<Dropdown expandIcon={null} />` is allowed. But in v9.44.4 it was broken because #30033 removes the optional condition.

## New Behavior

Allow `<Dropdown expandIcon={null} />` again and change expandIcon to optional type. Because `expandIcon: Slot<'span'>` pretends it can't be Null, but it can
 
