### PR TITLE
fix: v9 Menuitem does not have pressed styles when disabled

### DIFF
--- a/change/@fluentui-react-menu-dd8988b6-0852-4d75-8547-b751bf978365.json
+++ b/change/@fluentui-react-menu-dd8988b6-0852-4d75-8547-b751bf978365.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: disabled menuitem has no pressed style",
+  "packageName": "@fluentui/react-menu",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -137,6 +137,11 @@ const useStyles = makeStyles({
       },
     },
 
+    ':hover:active': {
+      color: tokens.colorNeutralForegroundDisabled,
+      backgroundColor: tokens.colorNeutralBackground1,
+    },
+
     ':focus': {
       color: tokens.colorNeutralForegroundDisabled,
     },


### PR DESCRIPTION
Fixes #30171

## Previous Behavior

The `:hover:active` styles in `makeResetStyles` were not overridden in the disabled styles block, so clicking a disabled menuitem had non-disabled styles when pressed.

## New Behavior

Fixed!