### PR TITLE
fix(fluentui-publish): remove dist-tag leftover from options as canary was removed

### DIFF
--- a/scripts/fluentui-publish/index.ts
+++ b/scripts/fluentui-publish/index.ts
@@ -6,7 +6,7 @@ import * as yargs from 'yargs';
 
 main();
 
-function fluentuiLernaPublish(bumpType: 'patch' | 'minor', skipConfirm = false, npmTagForCanary = 'beta') {
+function fluentuiLernaPublish(bumpType: 'patch' | 'minor', skipConfirm = false) {
   const fluentRoot = path.resolve(workspaceRoot, 'packages', 'fluentui');
 
   let lernaPublishArgs: string[];
@@ -87,14 +87,14 @@ function main() {
   const command = args._[0];
 
   if (command === 'bump') {
-    const { semverType, yes, distTag, postValidate } = args as unknown as {
+    const { semverType, yes, postValidate } = args as unknown as {
       semverType: 'patch' | 'minor';
       distTag?: string;
       yes: boolean;
       postValidate: boolean;
     };
 
-    fluentuiLernaPublish(semverType, yes, distTag);
+    fluentuiLernaPublish(semverType, yes);
     postValidate && fluentuiPostPublishValidation();
 
     return;
@@ -122,10 +122,6 @@ function processArgs() {
           type: 'boolean',
           default: true,
           description: 'execute validation steps after publish',
-        })
-        .option('dist-tag', {
-          type: 'string',
-          description: 'tag for canary release',
         });
     })
     .demandCommand(1)


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

see pr title + linked PR

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/30202
- Partially implements https://github.com/microsoft/fluentui/issues/30265
