### PR TITLE
fix: add aria-controls to combo and dropdown

### DIFF
--- a/change/@fluentui-react-combobox-017cd1e8-b560-439c-9ba2-83ce1fe18e3a.json
+++ b/change/@fluentui-react-combobox-017cd1e8-b560-439c-9ba2-83ce1fe18e3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add aria-controls to combobox and dropdown",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -168,7 +168,7 @@ describe('Combobox', () => {
     expect(chevronButton?.getAttribute('aria-labelledby')).toEqual('testId');
   });
 
-  it('adds aria-owns pointing to the popup', () => {
+  it('adds aria-owns and aria-controls pointing to the popup', () => {
     const { getByRole, container } = render(
       <Combobox open className="root">
         <Option>Red</Option>
@@ -178,6 +178,7 @@ describe('Combobox', () => {
     );
     const listboxId = getByRole('listbox').id;
     expect(container.querySelector('.root')?.getAttribute('aria-owns')).toEqual(listboxId);
+    expect(container.querySelector('input')?.getAttribute('aria-controls')).toEqual(listboxId);
   });
 
   /* open/close tests */

--- a/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`Combobox renders an open listbox 1`] = `
   >
     <input
       aria-activedescendant="fluent-option3"
+      aria-controls="fluent-listbox2"
       aria-expanded="true"
       class="fui-Combobox__input"
       role="combobox"

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -88,6 +88,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     defaultProps: {
       type: 'text',
       value: value ?? '',
+      'aria-controls': open ? listbox?.id : undefined,
       ...triggerNativeProps,
     },
   });

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.test.tsx
@@ -100,7 +100,7 @@ describe('Dropdown', () => {
     expect(container.querySelector('[role=listbox]')).not.toBeNull();
   });
 
-  it('adds aria-owns pointing to the popup', () => {
+  it('adds aria-owns and aria-controls pointing to the popup', () => {
     const { getByRole, container } = render(
       <Dropdown open className="root">
         <Option>Red</Option>
@@ -111,6 +111,7 @@ describe('Dropdown', () => {
 
     const listboxId = getByRole('listbox').id;
     expect(container.querySelector('.root')?.getAttribute('aria-owns')).toEqual(listboxId);
+    expect(container.querySelector('button')?.getAttribute('aria-controls')).toEqual(listboxId);
   });
 
   /* open/close tests */

--- a/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`Dropdown renders an open listbox 1`] = `
   >
     <button
       aria-activedescendant="fluent-option2"
+      aria-controls="fluent-listbox1"
       aria-expanded="true"
       class="fui-Dropdown__button"
       role="combobox"

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -54,6 +54,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
       type: 'button',
       tabIndex: 0,
       children: baseState.value || props.placeholder,
+      'aria-controls': open ? listbox?.id : undefined,
       ...triggerNativeProps,
     },
   });


### PR DESCRIPTION
## Previous Behavior

Was missing `aria-controls` (no real-world impact, but potential for impact in the future? `aria-controls` is weird.). Mostly relevant because it fails an automated test without it.

## New Behavior

Added `aria-controls`, defined only when the listbox is open.

- Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18401)
