### PR TITLE
feat(react-motions): add support for functions to be definitions

### DIFF
--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -20,11 +20,14 @@ export type AtomMotion = {
     keyframes: Keyframe[];
 } & KeyframeEffectOptions;
 
+// @public (undocumented)
+export type AtomMotionFn = (element: HTMLElement) => AtomMotion;
+
 // @public
-export function createAtom(motion: AtomMotion): React_2.FC<AtomProps>;
+export function createAtom(motion: AtomMotion | AtomMotionFn): React_2.FC<AtomProps>;
 
 // @public (undocumented)
-export function createPresence(motion: PresenceMotion): React_2.FC<PresenceProps>;
+export function createPresence(motion: PresenceMotion | PresenceMotionFn): React_2.FC<PresenceProps>;
 
 // @public (undocumented)
 const downEnterFast: ({ fromValue }?: SlideParams) => AtomMotion;
@@ -311,6 +314,9 @@ export type PresenceMotion = {
     enter: AtomMotion;
     exit: AtomMotion;
 };
+
+// @public (undocumented)
+export type PresenceMotionFn = (element: HTMLElement) => PresenceMotion;
 
 // @public (undocumented)
 const rightEnterFast: ({ fromValue }?: SlideParams) => AtomMotion;

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.test.tsx
@@ -46,4 +46,22 @@ describe('createAtom', () => {
       iterations: 1,
     });
   });
+
+  it('supports functions as motion definitions', () => {
+    const fnMotion = jest.fn().mockImplementation(() => motion);
+    const TestAtom = createAtom(fnMotion);
+
+    const { animateMock, ElementMock } = createElementMock();
+
+    render(
+      <TestAtom>
+        <ElementMock />
+      </TestAtom>,
+    );
+
+    expect(fnMotion).toHaveBeenCalledTimes(1);
+    expect(fnMotion).toHaveBeenCalledWith({ animate: animateMock } /* mock of html element */);
+
+    expect(animateMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-components/react-motions-preview/src/factories/createAtom.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createAtom.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
 import { getChildElement } from '../utils/getChildElement';
-import type { AtomMotion, MotionImperativeRef } from '../types';
+import type { AtomMotion, AtomMotionFn, MotionImperativeRef } from '../types';
 
 export type AtomProps = {
   children: React.ReactElement;
@@ -20,7 +20,7 @@ export type AtomProps = {
  *
  * @param motion - A motion definition.
  */
-export function createAtom(motion: AtomMotion) {
+export function createAtom(motion: AtomMotion | AtomMotionFn) {
   const Atom: React.FC<AtomProps> = props => {
     const { children, iterations = 1, imperativeRef } = props;
 
@@ -35,7 +35,9 @@ export function createAtom(motion: AtomMotion) {
       const element = elementRef.current;
 
       if (element) {
-        const { keyframes, ...options } = motion;
+        const definition = typeof motion === 'function' ? motion(element) : motion;
+        const { keyframes, ...options } = definition;
+
         const animation = element.animate(keyframes, {
           fill: 'forwards',
 

--- a/packages/react-components/react-motions-preview/src/factories/createPresence.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createPresence.test.tsx
@@ -22,6 +22,7 @@ const motion: PresenceMotion = {
 function createElementMock() {
   const animateMock = jest.fn().mockImplementation(() => ({
     cancel: jest.fn(),
+    finish: jest.fn(),
     set onfinish(callback: Function) {
       callback();
       return;
@@ -42,6 +43,34 @@ function createElementMock() {
 }
 
 describe('createPresence', () => {
+  describe('definitions', () => {
+    it('supports functions as motion definitions', () => {
+      const { keyframes, ...options } = motion.exit;
+
+      const fnMotion = jest.fn().mockImplementation(() => motion);
+      const TestAtom = createPresence(fnMotion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      const { rerender } = render(
+        <TestAtom visible>
+          <ElementMock />
+        </TestAtom>,
+      );
+      expect(animateMock).not.toHaveBeenCalled();
+
+      rerender(
+        <TestAtom visible={false}>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(fnMotion).toHaveBeenCalledTimes(1);
+      expect(fnMotion).toHaveBeenCalledWith({ animate: animateMock } /* mock of html element */);
+
+      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
+    });
+  });
+
   describe('appear', () => {
     it('does not animate by default', () => {
       const TestAtom = createPresence(motion);

--- a/packages/react-components/react-motions-preview/src/factories/createPresence.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresence.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
 import { getChildElement } from '../utils/getChildElement';
-import type { PresenceMotion, MotionImperativeRef } from '../types';
+import type { PresenceMotion, MotionImperativeRef, PresenceMotionFn } from '../types';
 
 type PresenceProps = {
   children: React.ReactElement;
@@ -18,7 +18,7 @@ type PresenceProps = {
   unmountOnExit?: boolean;
 };
 
-export function createPresence(motion: PresenceMotion) {
+export function createPresence(motion: PresenceMotion | PresenceMotionFn) {
   const Presence: React.FC<PresenceProps> = props => {
     const { appear, children, imperativeRef, visible, unmountOnExit } = props;
 
@@ -46,7 +46,9 @@ export function createPresence(motion: PresenceMotion) {
       }
 
       if (elementRef.current) {
-        const { keyframes, ...options } = motion.exit;
+        const definition = typeof motion === 'function' ? motion(elementRef.current) : motion;
+        const { keyframes, ...options } = definition.exit;
+
         const animation = elementRef.current.animate(keyframes, {
           fill: 'forwards',
 
@@ -79,7 +81,9 @@ export function createPresence(motion: PresenceMotion) {
       const shouldEnter = isFirstMount.current ? appear && visible : mounted && visible;
 
       if (shouldEnter) {
-        const { keyframes, ...options } = motion.enter;
+        const definition = typeof motion === 'function' ? motion(elementRef.current) : motion;
+        const { keyframes, ...options } = definition.enter;
+
         const animation = elementRef.current.animate(keyframes, {
           fill: 'forwards',
 

--- a/packages/react-components/react-motions-preview/src/index.ts
+++ b/packages/react-components/react-motions-preview/src/index.ts
@@ -5,4 +5,4 @@ export { createAtom } from './factories/createAtom';
 export { createPresence } from './factories/createPresence';
 
 export { atom, presence };
-export type { AtomMotion, PresenceMotion, MotionImperativeRef } from './types';
+export type { AtomMotion, AtomMotionFn, PresenceMotion, PresenceMotionFn, MotionImperativeRef } from './types';

--- a/packages/react-components/react-motions-preview/src/types.ts
+++ b/packages/react-components/react-motions-preview/src/types.ts
@@ -5,6 +5,9 @@ export type PresenceMotion = {
   exit: AtomMotion;
 };
 
+export type AtomMotionFn = (element: HTMLElement) => AtomMotion;
+export type PresenceMotionFn = (element: HTMLElement) => PresenceMotion;
+
 export type MotionImperativeRef = {
   /** Sets the playback rate of the animation, where 1 is normal speed. */
   setPlaybackRate: (rate: number) => void;

--- a/packages/react-components/react-motions-preview/stories/Motion/MotionFunctions.stories.md
+++ b/packages/react-components/react-motions-preview/stories/Motion/MotionFunctions.stories.md
@@ -1,0 +1,11 @@
+Atoms and presence definitions can be also defined as functions that accept an animated element as an argument. This allows to define more complex animations that depend on the animated element's properties, for example:
+
+```ts
+const Grow = createAtom(() => ({
+  duration: 300,
+  keyframes: [
+    { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },
+    { opacity: 1, maxHeight: `${element.scrollHeight}px` },
+  ],
+}));
+```

--- a/packages/react-components/react-motions-preview/stories/Motion/MotionFunctions.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/Motion/MotionFunctions.stories.tsx
@@ -1,0 +1,128 @@
+import { Checkbox, Label, makeStyles, shorthands, Slider, tokens, useId } from '@fluentui/react-components';
+import { createPresence, MotionImperativeRef, PresenceMotionFn } from '@fluentui/react-motions-preview';
+import * as React from 'react';
+
+import description from './MotionFunctions.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    ...shorthands.gap('10px'),
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    ...shorthands.border('3px', 'solid', tokens.colorNeutralForeground3),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.padding('10px'),
+
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '200px',
+  },
+  item: {
+    ...shorthands.border('3px', 'solid', tokens.colorBrandBackground),
+    ...shorthands.padding('8px'),
+
+    width: '300px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...shorthands.gridArea('2', '1', '2', '3'),
+
+    marginTop: '20px',
+
+    ...shorthands.border('3px', 'solid', tokens.colorNeutralForeground3),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.padding('10px'),
+  },
+  description: {
+    ...shorthands.margin('5px'),
+  },
+});
+
+const collapseMotion: PresenceMotionFn = element => {
+  const duration = 500;
+  const keyframes = [
+    { opacity: 0, maxHeight: '0px', overflow: 'hidden' },
+    { opacity: 1, maxHeight: `${element.scrollHeight}px`, overflow: 'hidden' },
+  ];
+
+  return {
+    enter: { duration, keyframes },
+    exit: { duration, keyframes: [...keyframes].reverse() },
+  };
+};
+const Collapse = createPresence(collapseMotion);
+
+export const MotionFunctions = () => {
+  const classes = useClasses();
+  const sliderId = useId();
+
+  const motionInRef = React.useRef<MotionImperativeRef>();
+  const motionOutRef = React.useRef<MotionImperativeRef>();
+
+  const [playbackRate, setPlaybackRate] = React.useState<number>(30);
+  const [visible, setVisible] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    motionInRef.current?.setPlaybackRate(playbackRate / 100);
+    motionOutRef.current?.setPlaybackRate(playbackRate / 100);
+  }, [playbackRate, visible]);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.card}>
+        <Collapse imperativeRef={motionInRef} visible={visible}>
+          <div className={classes.item}>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Sed vel lectus. Donec odio tempus molestie,
+            porttitor ut, iaculis quis, sem. Integer vulputate sem a nibh rutrum consequat. Etiam quis quam. Curabitur
+            sagittis hendrerit ante. Duis ante orci, molestie vitae vehicula venenatis, tincidunt ac pede.
+          </div>
+        </Collapse>
+        <div className={classes.description}>normal state</div>
+      </div>
+      <div className={classes.card}>
+        <Collapse imperativeRef={motionOutRef} visible={!visible}>
+          <div className={classes.item}>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Sed vel lectus. Donec odio tempus molestie,
+            porttitor ut, iaculis quis, sem. Integer vulputate sem a nibh rutrum consequat. Etiam quis quam. Curabitur
+            sagittis hendrerit ante. Duis ante orci, molestie vitae vehicula venenatis, tincidunt ac pede.
+          </div>
+        </Collapse>
+        <div className={classes.description}>reversed state</div>
+      </div>
+
+      <div className={classes.controls}>
+        <div>
+          <Checkbox label="Visible?" checked={visible} onChange={() => setVisible(v => !v)} />
+        </div>
+        <div>
+          <Label htmlFor={sliderId}>
+            <code>playbackRate</code>: {playbackRate}%
+          </Label>
+          <Slider
+            aria-valuetext={`Value is ${playbackRate}%`}
+            value={playbackRate}
+            onChange={(ev, data) => setPlaybackRate(data.value)}
+            min={0}
+            id={sliderId}
+            max={100}
+            step={10}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+MotionFunctions.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motions-preview/stories/Motion/index.stories.ts
+++ b/packages/react-components/react-motions-preview/stories/Motion/index.stories.ts
@@ -12,6 +12,7 @@ export { ImperativeRefPlayState as setPlayState } from './ImperativeRefPlayState
 
 export { CustomAtom } from './CustomAtom.stories';
 export { TokensUsage } from './TokensUsage.stories';
+export { MotionFunctions } from './MotionFunctions.stories';
 
 export { MotionLibrary } from './MotionLibrary.stories';
 


### PR DESCRIPTION
## New Behavior

_Inspired by #30113_

This PR add support for motions to be defined as functions, for example the following code defines collapse motion:

```tsx
const collapseMotion: PresenceMotionFn = element => {
  const duration = 500;
  const keyframes = [
    { opacity: 0, maxHeight: '0px', overflow: 'hidden' },
    { opacity: 1, maxHeight: `${element.scrollHeight}px`, overflow: 'hidden' },
  ];

  return {
    enter: { duration, keyframes },
    exit: { duration, keyframes: [...keyframes].reverse() },
  };
};
const Collapse = createPresence(collapseMotion);

```