### PR TITLE
fix(Dropdown): add `type=button` to `clearButton`

### DIFF
--- a/change/@fluentui-react-combobox-ac328fea-a08a-4799-af99-1900bb3e039f.json
+++ b/change/@fluentui-react-combobox-ac328fea-a08a-4799-af99-1900bb3e039f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Dropdown): add `type=button` to `clearButton`",
+  "packageName": "@fluentui/react-combobox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-components/react-combobox/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Dropdown renders a default state 1`] = `
       aria-label="Clear selection"
       class="fui-Dropdown__clearButton"
       tabindex="0"
+      type="button"
     >
       <svg
         aria-hidden="true"
@@ -91,6 +92,7 @@ exports[`Dropdown renders an open listbox 1`] = `
       aria-label="Clear selection"
       class="fui-Dropdown__clearButton"
       tabindex="0"
+      type="button"
     >
       <svg
         aria-hidden="true"

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdown.tsx
@@ -80,6 +80,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
         children: <DismissIcon />,
         // Safari doesn't allow to focus an element with this
         tabIndex: 0,
+        type: 'button',
       },
       elementType: 'button',
       renderByDefault: true,


### PR DESCRIPTION
## New Behavior

Adds `type=button` to `clearButton` slot in `Dropdown`.

## Related Issue(s)

Fixes #30344.
