### PR TITLE
fix(react-overflow): cleanup overflow manager on every unmount

### DIFF
--- a/apps/react-18-tests-v9/src/Overflow.cy.tsx
+++ b/apps/react-18-tests-v9/src/Overflow.cy.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import {
+  makeStyles,
+  shorthands,
+  Button,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItem,
+  MenuButton,
+  tokens,
+  mergeClasses,
+  Overflow,
+  OverflowItem,
+  OverflowItemProps,
+  useIsOverflowItemVisible,
+  useOverflowMenu,
+  FluentProvider,
+  teamsLightTheme,
+} from '@fluentui/react-components';
+import { mount as mountBase } from '@cypress/react';
+
+// eslint-disable-next-line @griffel/styles-file
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    minWidth: 0,
+    ...shorthands.overflow('hidden'),
+  },
+
+  resizableArea: {
+    minWidth: '200px',
+    maxWidth: '800px',
+    ...shorthands.border('2px', 'solid', tokens.colorBrandBackground),
+    ...shorthands.padding('20px', '10px', '10px', '10px'),
+    position: 'relative',
+    resize: 'horizontal',
+    '::after': {
+      content: `'Resizable Area'`,
+      position: 'absolute',
+      ...shorthands.padding('1px', '4px', '1px'),
+      top: '-2px',
+      left: '-2px',
+      fontFamily: 'monospace',
+      fontSize: '15px',
+      fontWeight: 900,
+      lineHeight: 1,
+      letterSpacing: '1px',
+      color: tokens.colorNeutralForegroundOnBrand,
+      backgroundColor: tokens.colorBrandBackground,
+    },
+  },
+});
+
+const OverflowMenuItem: React.FC<Pick<OverflowItemProps, 'id'>> = props => {
+  const { id } = props;
+  const isVisible = useIsOverflowItemVisible(id);
+
+  if (isVisible) {
+    return null;
+  }
+
+  // As an union between button props and div props may be conflicting, casting is required
+  return <MenuItem>Item {id}</MenuItem>;
+};
+
+const OverflowMenu: React.FC<{ itemIds: string[] }> = ({ itemIds }) => {
+  const { ref, overflowCount, isOverflowing } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <Menu>
+      <MenuTrigger disableButtonEnhancement>
+        <MenuButton ref={ref}>+{overflowCount} items</MenuButton>
+      </MenuTrigger>
+
+      <MenuPopover>
+        <MenuList>
+          {itemIds.map(i => {
+            return <OverflowMenuItem key={i} id={i} />;
+          })}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+};
+
+const mount = (element: JSX.Element) => {
+  mountBase(
+    <React.StrictMode>
+      <FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>
+    </React.StrictMode>,
+  );
+};
+
+describe('Overflow', () => {
+  const items = new Array(8).fill(0).map((_, i) => i.toString());
+
+  it('should render a Overflow', () => {
+    const Default = () => {
+      const styles = useStyles();
+
+      return (
+        <Overflow>
+          <div className={mergeClasses(styles.container, styles.resizableArea)}>
+            {items.map(i => (
+              <OverflowItem key={i} id={i}>
+                <Button>Item {i}</Button>
+              </OverflowItem>
+            ))}
+            <OverflowMenu itemIds={items} />
+          </div>
+        </Overflow>
+      );
+    };
+
+    mount(<Default />);
+
+    cy.viewport(1000, 1000);
+    cy.get('.fui-Overflow').should('exist').get('[data-overflow-item]').should('have.length', 8);
+    cy.get('.fui-Overflow [data-overflowing]').should('not.exist');
+    cy.get('.fui-Overflow [data-overflow-menu]').should('not.exist');
+    cy.viewport(600, 600);
+    cy.get('.fui-Overflow [data-overflowing]').should('have.length', 4);
+    cy.get('.fui-Overflow [data-overflow-menu]').should('exist');
+  });
+});

--- a/change/@fluentui-react-overflow-29889f83-8543-421f-874f-230bd895e152.json
+++ b/change/@fluentui-react-overflow-29889f83-8543-421f-874f-230bd895e152.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: cleanup overflow manager on every unmount",
+  "packageName": "@fluentui/react-overflow",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-overflow/src/components/Overflow.tsx
+++ b/packages/react-components/react-overflow/src/components/Overflow.tsx
@@ -68,7 +68,7 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
 
   const clonedChild = applyTriggerPropsToChildren(children, {
     ref: useMergedRefs(containerRef, ref),
-    className: mergeClasses(styles.overflowMenu, styles.overflowingItems, children.props.className),
+    className: mergeClasses('fui-Overflow', styles.overflowMenu, styles.overflowingItems, children.props.className),
   });
 
   return (

--- a/packages/react-components/react-overflow/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/src/useOverflowContainer.ts
@@ -74,11 +74,15 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
     const newOverflowManager = createOverflowManager();
     newOverflowManager.observe(containerRef.current, overflowOptions);
     setOverflowManager(newOverflowManager);
-
-    return () => {
-      newOverflowManager.disconnect();
-    };
   }, [overflowOptions, firstMount]);
+
+  /* Clean up overflow manager on unmount */
+  React.useEffect(
+    () => () => {
+      overflowManager?.disconnect();
+    },
+    [overflowManager],
+  );
 
   const registerItem = React.useCallback(
     (item: OverflowItemEntry) => {


### PR DESCRIPTION
This PR make sure to disconnect from `overflowManager` on every unmount, which will ensure its creation on next mount.

## Related Issue(s)
- Fixes #29976
