### PR TITLE
chore(react): setup monosize for measuring bundle size which will replace size-auditor bot

### DIFF
--- a/change/@fluentui-keyboard-key-28df3988-2b7e-4b10-b329-811bebd8bdf3.json
+++ b/change/@fluentui-keyboard-key-28df3988-2b7e-4b10-b329-811bebd8bdf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: setup monosize for measuring bundle size which will replace-size auditor bot",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-270ab580-2994-41ed-9746-83e36224f9a0.json
+++ b/change/@fluentui-react-270ab580-2994-41ed-9746-83e36224f9a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: setup monosize for measuring bundle size which will replace-size auditor bot",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/keyboard-key/.npmignore
+++ b/packages/keyboard-key/.npmignore
@@ -32,6 +32,8 @@ tsd.json
 tslint.json
 typings
 visualtests
+project.json
+
 !lib
 !lib-commonjs
 !lib-amd

--- a/packages/keyboard-key/bundle-size/index.fixture.js
+++ b/packages/keyboard-key/bundle-size/index.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/keyboard-key';
+
+console.log(p);
+
+export default {
+  name: 'keyboard-key package',
+};

--- a/packages/keyboard-key/package.json
+++ b/packages/keyboard-key/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "bundle-size": "monosize measure",
     "build": "just-scripts build",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -11,6 +11,7 @@
 .gitignore
 .vscode
 coverage
+bundle-size/
 dist/storybook
 dist/*.stats.html
 dist/*.stats.json

--- a/packages/react/bundle-size/ActivityItem.fixture.js
+++ b/packages/react/bundle-size/ActivityItem.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ActivityItem';
+
+console.log(p);
+
+export default {
+  name: 'ActivityItem',
+};

--- a/packages/react/bundle-size/Announced.fixture.js
+++ b/packages/react/bundle-size/Announced.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Announced';
+
+console.log(p);
+
+export default {
+  name: 'Announced',
+};

--- a/packages/react/bundle-size/Autofill.fixture.js
+++ b/packages/react/bundle-size/Autofill.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Autofill';
+
+console.log(p);
+
+export default {
+  name: 'Autofill',
+};

--- a/packages/react/bundle-size/Breadcrumb.fixture.js
+++ b/packages/react/bundle-size/Breadcrumb.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Breadcrumb';
+
+console.log(p);
+
+export default {
+  name: 'Breadcrumb',
+};

--- a/packages/react/bundle-size/Button.fixture.js
+++ b/packages/react/bundle-size/Button.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Button';
+
+console.log(p);
+
+export default {
+  name: 'Button',
+};

--- a/packages/react/bundle-size/ButtonGrid.fixture.js
+++ b/packages/react/bundle-size/ButtonGrid.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ButtonGrid';
+
+console.log(p);
+
+export default {
+  name: 'ButtonGrid',
+};

--- a/packages/react/bundle-size/Calendar.fixture.js
+++ b/packages/react/bundle-size/Calendar.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Calendar';
+
+console.log(p);
+
+export default {
+  name: 'Calendar',
+};

--- a/packages/react/bundle-size/Callout.fixture.js
+++ b/packages/react/bundle-size/Callout.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Callout';
+
+console.log(p);
+
+export default {
+  name: 'Callout',
+};

--- a/packages/react/bundle-size/Check.fixture.js
+++ b/packages/react/bundle-size/Check.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Check';
+
+console.log(p);
+
+export default {
+  name: 'Check',
+};

--- a/packages/react/bundle-size/Checkbox.fixture.js
+++ b/packages/react/bundle-size/Checkbox.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Checkbox';
+
+console.log(p);
+
+export default {
+  name: 'Checkbox',
+};

--- a/packages/react/bundle-size/ChoiceGroup.fixture.js
+++ b/packages/react/bundle-size/ChoiceGroup.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ChoiceGroup';
+
+console.log(p);
+
+export default {
+  name: 'ChoiceGroup',
+};

--- a/packages/react/bundle-size/ChoiceGroupOption.fixture.js
+++ b/packages/react/bundle-size/ChoiceGroupOption.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ChoiceGroupOption';
+
+console.log(p);
+
+export default {
+  name: 'ChoiceGroupOption',
+};

--- a/packages/react/bundle-size/Coachmark.fixture.js
+++ b/packages/react/bundle-size/Coachmark.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Coachmark';
+
+console.log(p);
+
+export default {
+  name: 'Coachmark',
+};

--- a/packages/react/bundle-size/Color.fixture.js
+++ b/packages/react/bundle-size/Color.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Color';
+
+console.log(p);
+
+export default {
+  name: 'Color',
+};

--- a/packages/react/bundle-size/ColorPicker.fixture.js
+++ b/packages/react/bundle-size/ColorPicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ColorPicker';
+
+console.log(p);
+
+export default {
+  name: 'ColorPicker',
+};

--- a/packages/react/bundle-size/ComboBox.fixture.js
+++ b/packages/react/bundle-size/ComboBox.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ComboBox';
+
+console.log(p);
+
+export default {
+  name: 'ComboBox',
+};

--- a/packages/react/bundle-size/CommandBar.fixture.js
+++ b/packages/react/bundle-size/CommandBar.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/CommandBar';
+
+console.log(p);
+
+export default {
+  name: 'CommandBar',
+};

--- a/packages/react/bundle-size/ContextualMenu.fixture.js
+++ b/packages/react/bundle-size/ContextualMenu.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ContextualMenu';
+
+console.log(p);
+
+export default {
+  name: 'ContextualMenu',
+};

--- a/packages/react/bundle-size/DatePicker.fixture.js
+++ b/packages/react/bundle-size/DatePicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/DatePicker';
+
+console.log(p);
+
+export default {
+  name: 'DatePicker',
+};

--- a/packages/react/bundle-size/DateTimeUtilities.fixture.js
+++ b/packages/react/bundle-size/DateTimeUtilities.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/DateTimeUtilities';
+
+console.log(p);
+
+export default {
+  name: 'DateTimeUtilities',
+};

--- a/packages/react/bundle-size/DetailsList.fixture.js
+++ b/packages/react/bundle-size/DetailsList.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/DetailsList';
+
+console.log(p);
+
+export default {
+  name: 'DetailsList',
+};

--- a/packages/react/bundle-size/Dialog.fixture.js
+++ b/packages/react/bundle-size/Dialog.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Dialog';
+
+console.log(p);
+
+export default {
+  name: 'Dialog',
+};

--- a/packages/react/bundle-size/Divider.fixture.js
+++ b/packages/react/bundle-size/Divider.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Divider';
+
+console.log(p);
+
+export default {
+  name: 'Divider',
+};

--- a/packages/react/bundle-size/DocumentCard.fixture.js
+++ b/packages/react/bundle-size/DocumentCard.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/DocumentCard';
+
+console.log(p);
+
+export default {
+  name: 'DocumentCard',
+};

--- a/packages/react/bundle-size/DragDrop.fixture.js
+++ b/packages/react/bundle-size/DragDrop.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/DragDrop';
+
+console.log(p);
+
+export default {
+  name: 'DragDrop',
+};

--- a/packages/react/bundle-size/DraggableZone.fixture.js
+++ b/packages/react/bundle-size/DraggableZone.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/DraggableZone';
+
+console.log(p);
+
+export default {
+  name: 'DraggableZone',
+};

--- a/packages/react/bundle-size/Dropdown.fixture.js
+++ b/packages/react/bundle-size/Dropdown.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Dropdown';
+
+console.log(p);
+
+export default {
+  name: 'Dropdown',
+};

--- a/packages/react/bundle-size/ExtendedPicker.fixture.js
+++ b/packages/react/bundle-size/ExtendedPicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ExtendedPicker';
+
+console.log(p);
+
+export default {
+  name: 'ExtendedPicker',
+};

--- a/packages/react/bundle-size/Fabric.fixture.js
+++ b/packages/react/bundle-size/Fabric.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Fabric';
+
+console.log(p);
+
+export default {
+  name: 'Fabric',
+};

--- a/packages/react/bundle-size/Facepile.fixture.js
+++ b/packages/react/bundle-size/Facepile.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Facepile';
+
+console.log(p);
+
+export default {
+  name: 'Facepile',
+};

--- a/packages/react/bundle-size/FloatingPicker.fixture.js
+++ b/packages/react/bundle-size/FloatingPicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/FloatingPicker';
+
+console.log(p);
+
+export default {
+  name: 'FloatingPicker',
+};

--- a/packages/react/bundle-size/FocusTrapZone.fixture.js
+++ b/packages/react/bundle-size/FocusTrapZone.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/FocusTrapZone';
+
+console.log(p);
+
+export default {
+  name: 'FocusTrapZone',
+};

--- a/packages/react/bundle-size/FocusZone.fixture.js
+++ b/packages/react/bundle-size/FocusZone.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/FocusZone';
+
+console.log(p);
+
+export default {
+  name: 'FocusZone',
+};

--- a/packages/react/bundle-size/Grid.fixture.js
+++ b/packages/react/bundle-size/Grid.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Grid';
+
+console.log(p);
+
+export default {
+  name: 'Grid',
+};

--- a/packages/react/bundle-size/GroupedList.fixture.js
+++ b/packages/react/bundle-size/GroupedList.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/GroupedList';
+
+console.log(p);
+
+export default {
+  name: 'GroupedList',
+};

--- a/packages/react/bundle-size/GroupedListV2.fixture.js
+++ b/packages/react/bundle-size/GroupedListV2.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/GroupedListV2';
+
+console.log(p);
+
+export default {
+  name: 'GroupedListV2',
+};

--- a/packages/react/bundle-size/HoverCard.fixture.js
+++ b/packages/react/bundle-size/HoverCard.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/HoverCard';
+
+console.log(p);
+
+export default {
+  name: 'HoverCard',
+};

--- a/packages/react/bundle-size/Icon.fixture.js
+++ b/packages/react/bundle-size/Icon.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Icon';
+
+console.log(p);
+
+export default {
+  name: 'Icon',
+};

--- a/packages/react/bundle-size/Icons.fixture.js
+++ b/packages/react/bundle-size/Icons.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Icons';
+
+console.log(p);
+
+export default {
+  name: 'Icons',
+};

--- a/packages/react/bundle-size/Image.fixture.js
+++ b/packages/react/bundle-size/Image.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Image';
+
+console.log(p);
+
+export default {
+  name: 'Image',
+};

--- a/packages/react/bundle-size/Keytip.fixture.js
+++ b/packages/react/bundle-size/Keytip.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Keytip';
+
+console.log(p);
+
+export default {
+  name: 'Keytip',
+};

--- a/packages/react/bundle-size/KeytipData.fixture.js
+++ b/packages/react/bundle-size/KeytipData.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/KeytipData';
+
+console.log(p);
+
+export default {
+  name: 'KeytipData',
+};

--- a/packages/react/bundle-size/KeytipLayer.fixture.js
+++ b/packages/react/bundle-size/KeytipLayer.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/KeytipLayer';
+
+console.log(p);
+
+export default {
+  name: 'KeytipLayer',
+};

--- a/packages/react/bundle-size/Keytips.fixture.js
+++ b/packages/react/bundle-size/Keytips.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Keytips';
+
+console.log(p);
+
+export default {
+  name: 'Keytips',
+};

--- a/packages/react/bundle-size/Label.fixture.js
+++ b/packages/react/bundle-size/Label.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Label';
+
+console.log(p);
+
+export default {
+  name: 'Label',
+};

--- a/packages/react/bundle-size/Layer.fixture.js
+++ b/packages/react/bundle-size/Layer.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Layer';
+
+console.log(p);
+
+export default {
+  name: 'Layer',
+};

--- a/packages/react/bundle-size/Link.fixture.js
+++ b/packages/react/bundle-size/Link.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Link';
+
+console.log(p);
+
+export default {
+  name: 'Link',
+};

--- a/packages/react/bundle-size/List.fixture.js
+++ b/packages/react/bundle-size/List.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/List';
+
+console.log(p);
+
+export default {
+  name: 'List',
+};

--- a/packages/react/bundle-size/MarqueeSelection.fixture.js
+++ b/packages/react/bundle-size/MarqueeSelection.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/MarqueeSelection';
+
+console.log(p);
+
+export default {
+  name: 'MarqueeSelection',
+};

--- a/packages/react/bundle-size/MessageBar.fixture.js
+++ b/packages/react/bundle-size/MessageBar.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/MessageBar';
+
+console.log(p);
+
+export default {
+  name: 'MessageBar',
+};

--- a/packages/react/bundle-size/Modal.fixture.js
+++ b/packages/react/bundle-size/Modal.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Modal';
+
+console.log(p);
+
+export default {
+  name: 'Modal',
+};

--- a/packages/react/bundle-size/Nav.fixture.js
+++ b/packages/react/bundle-size/Nav.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Nav';
+
+console.log(p);
+
+export default {
+  name: 'Nav',
+};

--- a/packages/react/bundle-size/OverflowSet.fixture.js
+++ b/packages/react/bundle-size/OverflowSet.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/OverflowSet';
+
+console.log(p);
+
+export default {
+  name: 'OverflowSet',
+};

--- a/packages/react/bundle-size/Overlay.fixture.js
+++ b/packages/react/bundle-size/Overlay.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Overlay';
+
+console.log(p);
+
+export default {
+  name: 'Overlay',
+};

--- a/packages/react/bundle-size/Panel.fixture.js
+++ b/packages/react/bundle-size/Panel.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Panel';
+
+console.log(p);
+
+export default {
+  name: 'Panel',
+};

--- a/packages/react/bundle-size/Persona.fixture.js
+++ b/packages/react/bundle-size/Persona.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Persona';
+
+console.log(p);
+
+export default {
+  name: 'Persona',
+};

--- a/packages/react/bundle-size/PersonaCoin.fixture.js
+++ b/packages/react/bundle-size/PersonaCoin.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/PersonaCoin';
+
+console.log(p);
+
+export default {
+  name: 'PersonaCoin',
+};

--- a/packages/react/bundle-size/PersonaPresence.fixture.js
+++ b/packages/react/bundle-size/PersonaPresence.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/PersonaPresence';
+
+console.log(p);
+
+export default {
+  name: 'PersonaPresence',
+};

--- a/packages/react/bundle-size/Pickers.fixture.js
+++ b/packages/react/bundle-size/Pickers.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Pickers';
+
+console.log(p);
+
+export default {
+  name: 'Pickers',
+};

--- a/packages/react/bundle-size/Pivot.fixture.js
+++ b/packages/react/bundle-size/Pivot.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Pivot';
+
+console.log(p);
+
+export default {
+  name: 'Pivot',
+};

--- a/packages/react/bundle-size/Popup.fixture.js
+++ b/packages/react/bundle-size/Popup.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Popup';
+
+console.log(p);
+
+export default {
+  name: 'Popup',
+};

--- a/packages/react/bundle-size/Positioning.fixture.js
+++ b/packages/react/bundle-size/Positioning.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Positioning';
+
+console.log(p);
+
+export default {
+  name: 'Positioning',
+};

--- a/packages/react/bundle-size/PositioningContainer.fixture.js
+++ b/packages/react/bundle-size/PositioningContainer.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/PositioningContainer';
+
+console.log(p);
+
+export default {
+  name: 'PositioningContainer',
+};

--- a/packages/react/bundle-size/ProgressIndicator.fixture.js
+++ b/packages/react/bundle-size/ProgressIndicator.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ProgressIndicator';
+
+console.log(p);
+
+export default {
+  name: 'ProgressIndicator',
+};

--- a/packages/react/bundle-size/Rating.fixture.js
+++ b/packages/react/bundle-size/Rating.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Rating';
+
+console.log(p);
+
+export default {
+  name: 'Rating',
+};

--- a/packages/react/bundle-size/ResizeGroup.fixture.js
+++ b/packages/react/bundle-size/ResizeGroup.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ResizeGroup';
+
+console.log(p);
+
+export default {
+  name: 'ResizeGroup',
+};

--- a/packages/react/bundle-size/ResponsiveMode.fixture.js
+++ b/packages/react/bundle-size/ResponsiveMode.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ResponsiveMode';
+
+console.log(p);
+
+export default {
+  name: 'ResponsiveMode',
+};

--- a/packages/react/bundle-size/ScrollablePane.fixture.js
+++ b/packages/react/bundle-size/ScrollablePane.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ScrollablePane';
+
+console.log(p);
+
+export default {
+  name: 'ScrollablePane',
+};

--- a/packages/react/bundle-size/SearchBox.fixture.js
+++ b/packages/react/bundle-size/SearchBox.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/SearchBox';
+
+console.log(p);
+
+export default {
+  name: 'SearchBox',
+};

--- a/packages/react/bundle-size/SelectableOption.fixture.js
+++ b/packages/react/bundle-size/SelectableOption.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/SelectableOption';
+
+console.log(p);
+
+export default {
+  name: 'SelectableOption',
+};

--- a/packages/react/bundle-size/SelectedItemsList.fixture.js
+++ b/packages/react/bundle-size/SelectedItemsList.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/SelectedItemsList';
+
+console.log(p);
+
+export default {
+  name: 'SelectedItemsList',
+};

--- a/packages/react/bundle-size/Selection.fixture.js
+++ b/packages/react/bundle-size/Selection.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Selection';
+
+console.log(p);
+
+export default {
+  name: 'Selection',
+};

--- a/packages/react/bundle-size/Separator.fixture.js
+++ b/packages/react/bundle-size/Separator.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Separator';
+
+console.log(p);
+
+export default {
+  name: 'Separator',
+};

--- a/packages/react/bundle-size/Shimmer.fixture.js
+++ b/packages/react/bundle-size/Shimmer.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Shimmer';
+
+console.log(p);
+
+export default {
+  name: 'Shimmer',
+};

--- a/packages/react/bundle-size/ShimmeredDetailsList.fixture.js
+++ b/packages/react/bundle-size/ShimmeredDetailsList.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ShimmeredDetailsList';
+
+console.log(p);
+
+export default {
+  name: 'ShimmeredDetailsList',
+};

--- a/packages/react/bundle-size/Slider.fixture.js
+++ b/packages/react/bundle-size/Slider.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Slider';
+
+console.log(p);
+
+export default {
+  name: 'Slider',
+};

--- a/packages/react/bundle-size/SpinButton.fixture.js
+++ b/packages/react/bundle-size/SpinButton.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/SpinButton';
+
+console.log(p);
+
+export default {
+  name: 'SpinButton',
+};

--- a/packages/react/bundle-size/Spinner.fixture.js
+++ b/packages/react/bundle-size/Spinner.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Spinner';
+
+console.log(p);
+
+export default {
+  name: 'Spinner',
+};

--- a/packages/react/bundle-size/Stack.fixture.js
+++ b/packages/react/bundle-size/Stack.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Stack';
+
+console.log(p);
+
+export default {
+  name: 'Stack',
+};

--- a/packages/react/bundle-size/Sticky.fixture.js
+++ b/packages/react/bundle-size/Sticky.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Sticky';
+
+console.log(p);
+
+export default {
+  name: 'Sticky',
+};

--- a/packages/react/bundle-size/Styling.fixture.js
+++ b/packages/react/bundle-size/Styling.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Styling';
+
+console.log(p);
+
+export default {
+  name: 'Styling',
+};

--- a/packages/react/bundle-size/SwatchColorPicker.fixture.js
+++ b/packages/react/bundle-size/SwatchColorPicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/SwatchColorPicker';
+
+console.log(p);
+
+export default {
+  name: 'SwatchColorPicker',
+};

--- a/packages/react/bundle-size/TeachingBubble.fixture.js
+++ b/packages/react/bundle-size/TeachingBubble.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/TeachingBubble';
+
+console.log(p);
+
+export default {
+  name: 'TeachingBubble',
+};

--- a/packages/react/bundle-size/Text.fixture.js
+++ b/packages/react/bundle-size/Text.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Text';
+
+console.log(p);
+
+export default {
+  name: 'Text',
+};

--- a/packages/react/bundle-size/TextField.fixture.js
+++ b/packages/react/bundle-size/TextField.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/TextField';
+
+console.log(p);
+
+export default {
+  name: 'TextField',
+};

--- a/packages/react/bundle-size/Theme.fixture.js
+++ b/packages/react/bundle-size/Theme.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Theme';
+
+console.log(p);
+
+export default {
+  name: 'Theme',
+};

--- a/packages/react/bundle-size/ThemeGenerator.fixture.js
+++ b/packages/react/bundle-size/ThemeGenerator.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/ThemeGenerator';
+
+console.log(p);
+
+export default {
+  name: 'ThemeGenerator',
+};

--- a/packages/react/bundle-size/TimePicker.fixture.js
+++ b/packages/react/bundle-size/TimePicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/TimePicker';
+
+console.log(p);
+
+export default {
+  name: 'TimePicker',
+};

--- a/packages/react/bundle-size/Toggle.fixture.js
+++ b/packages/react/bundle-size/Toggle.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Toggle';
+
+console.log(p);
+
+export default {
+  name: 'Toggle',
+};

--- a/packages/react/bundle-size/Tooltip.fixture.js
+++ b/packages/react/bundle-size/Tooltip.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Tooltip';
+
+console.log(p);
+
+export default {
+  name: 'Tooltip',
+};

--- a/packages/react/bundle-size/Utilities.fixture.js
+++ b/packages/react/bundle-size/Utilities.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Utilities';
+
+console.log(p);
+
+export default {
+  name: 'Utilities',
+};

--- a/packages/react/bundle-size/Viewport.fixture.js
+++ b/packages/react/bundle-size/Viewport.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/Viewport';
+
+console.log(p);
+
+export default {
+  name: 'Viewport',
+};

--- a/packages/react/bundle-size/WeeklyDayPicker.fixture.js
+++ b/packages/react/bundle-size/WeeklyDayPicker.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/WeeklyDayPicker';
+
+console.log(p);
+
+export default {
+  name: 'WeeklyDayPicker',
+};

--- a/packages/react/bundle-size/WindowProvider.fixture.js
+++ b/packages/react/bundle-size/WindowProvider.fixture.js
@@ -1,0 +1,7 @@
+import * as p from '@fluentui/react/lib/WindowProvider';
+
+console.log(p);
+
+export default {
+  name: 'WindowProvider',
+};

--- a/packages/react/monosize.config.mjs
+++ b/packages/react/monosize.config.mjs
@@ -1,0 +1,26 @@
+// @ts-check
+
+import baseConfig from '../../monosize.config.mjs';
+
+/** @type {import('monosize').MonoSizeConfig} */
+const monosizeConfig = {
+  ...baseConfig,
+  webpack: config => {
+    const normalizedTarget = /** @type {string[]}*/ (Array.isArray(config.target) ? config.target : [config.target]);
+    config.target = [
+      ...normalizedTarget,
+      /**
+       * As of webpack 5, you have to add the `es5` target for IE 11 compatibility.
+       * Otherwise it will output lambdas for smaller bundle size.
+       * @see https://webpack.js.org/migrate/5/#need-to-support-an-older-browser-like-ie-11
+       *
+       * NOTE: IE 11 compat is still needed? for fluentui/react (v8) ?
+       */
+      'es5',
+    ];
+
+    return config;
+  },
+};
+
+export default monosizeConfig;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "just-scripts build",
     "bundle": "just-scripts bundle",
+    "bundle-size": "monosize measure",
     "bundle-size-auditor": "bundle-size-auditor --report-path='../../dist/bundle-size-auditor/react'",
     "build-storybook": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts storybook:build",
     "clean": "just-scripts clean",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

this adds following to react project:

- monosize setup
- create monosize fixtures based on deprecated bundle-size dynamically generated fixuters

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/27933
