### PR TITLE
Detailslist focusable

### DIFF
--- a/change/@fluentui-react-a7c9c9d5-8b9a-4bc0-bf47-e6e0e425816c.json
+++ b/change/@fluentui-react-a7c9c9d5-8b9a-4bc0-bf47-e6e0e425816c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DetailsList inner FocusZone receives focus even if the header is not tabbable",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -494,7 +494,8 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
 
       const rowRole = role === defaultRole ? undefined : 'presentation';
 
-      // add tabindex="0" to first row if no header exists, to ensure the focuszone is in the tab order
+      // add tabindex="0" to first row so if the header isn't rendered or isn't focusable,
+      // the focuszone still has content in the tab order.
       const rowFocusZoneProps = index > 0 ? rowFocusZoneNoTabIndexProps : rowFocusZoneAddTabIndexProps;
 
       const rowProps: IDetailsRowProps = {

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -495,8 +495,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
       const rowRole = role === defaultRole ? undefined : 'presentation';
 
       // add tabindex="0" to first row if no header exists, to ensure the focuszone is in the tab order
-      const rowFocusZoneProps =
-        isHeaderVisible || index > 0 ? rowFocusZoneNoTabIndexProps : rowFocusZoneAddTabIndexProps;
+      const rowFocusZoneProps = index > 0 ? rowFocusZoneNoTabIndexProps : rowFocusZoneAddTabIndexProps;
 
       const rowProps: IDetailsRowProps = {
         item,

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -8187,6 +8187,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 onKeyDown={[Function]}
                                 onMouseDownCapture={[Function]}
                                 role="row"
+                                tabIndex={0}
                               >
                                 <span
                                   className="ms-GroupSpacer"

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
@@ -7637,6 +7637,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                       onKeyDown={[Function]}
                       onMouseDownCapture={[Function]}
                       role="row"
+                      tabIndex={0}
                     >
                       <span
                         className="ms-GroupSpacer"


### PR DESCRIPTION
## Previous Behavior

Related to #25342 -- that PR fixed this same issue for when the header row is entirely absent. The issue still presents when the DetailsList header is present but not focusable (i.e. by disabling both selection and `columnActionsMode`).

## New Behavior

The first row of the DetailsList body is now always in the tab order. When I was taking another look at the earlier fix, I realized that there's no use case when we _wouldn't_ want the first content row to be in the tab order, since the headers are a separate tab stop from the body.

## Related Issue(s)

- Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18499)

