### PR TITLE
feat: Add `disableUpdateOnResize` positioning option

### DIFF
--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -75,7 +75,7 @@ export type PositioningImperativeRef = {
 };
 
 // @public
-export interface PositioningProps extends Pick<PositioningOptions, 'align' | 'arrowPadding' | 'autoSize' | 'coverTarget' | 'flipBoundary' | 'offset' | 'overflowBoundary' | 'overflowBoundaryPadding' | 'pinned' | 'position' | 'strategy' | 'useTransform' | 'matchTargetSize' | 'onPositioningEnd'> {
+export interface PositioningProps extends Pick<PositioningOptions, 'align' | 'arrowPadding' | 'autoSize' | 'coverTarget' | 'flipBoundary' | 'offset' | 'overflowBoundary' | 'overflowBoundaryPadding' | 'pinned' | 'position' | 'strategy' | 'useTransform' | 'matchTargetSize' | 'onPositioningEnd' | 'disableUpdateOnResize'> {
     positioningRef?: React_2.Ref<PositioningImperativeRef>;
     target?: TargetElement | null;
 }

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -38,6 +38,10 @@ interface PositionManagerOptions {
    * @default true
    */
   useTransform?: boolean;
+  /**
+   * Disables the resize observer that updates position on target or dimension change
+   */
+  disableUpdateOnResize?: boolean;
 }
 
 /**
@@ -46,7 +50,16 @@ interface PositionManagerOptions {
  */
 export function createPositionManager(options: PositionManagerOptions): PositionManager {
   let isDestroyed = false;
-  const { container, target, arrow, strategy, middleware, placement, useTransform = true } = options;
+  const {
+    container,
+    target,
+    arrow,
+    strategy,
+    middleware,
+    placement,
+    useTransform = true,
+    disableUpdateOnResize = false,
+  } = options;
   const targetWindow = container.ownerDocument.defaultView;
   if (!target || !container || !targetWindow) {
     return {
@@ -56,7 +69,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
   }
 
   // When the dimensions of the target or the container change - trigger a position update
-  const resizeObserver = createResizeObserver(targetWindow, () => updatePosition());
+  const resizeObserver = disableUpdateOnResize ? null : createResizeObserver(targetWindow, () => updatePosition());
 
   let isFirstUpdate = true;
   const scrollParents: Set<HTMLElement> = new Set<HTMLElement>();
@@ -82,9 +95,9 @@ export function createPositionManager(options: PositionManagerOptions): Position
         scrollParent.addEventListener('scroll', updatePosition, { passive: true });
       });
 
-      resizeObserver.observe(container);
+      resizeObserver?.observe(container);
       if (isHTMLElement(target)) {
-        resizeObserver.observe(target);
+        resizeObserver?.observe(target);
       }
 
       isFirstUpdate = false;
@@ -142,7 +155,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
     });
     scrollParents.clear();
 
-    resizeObserver.disconnect();
+    resizeObserver?.disconnect();
   };
 
   if (targetWindow) {

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -192,6 +192,11 @@ export interface PositioningOptions {
    * It's also possible to listen to the custom DOM event `fui-positioningend`
    */
   onPositioningEnd?: () => void;
+
+  /**
+   * Disables the resize observer that updates position on target or dimension change
+   */
+  disableUpdateOnResize?: boolean;
 }
 
 /**
@@ -214,6 +219,7 @@ export interface PositioningProps
     | 'useTransform'
     | 'matchTargetSize'
     | 'onPositioningEnd'
+    | 'disableUpdateOnResize'
   > {
   /** An imperative handle to Popper methods. */
   positioningRef?: React.Ref<PositioningImperativeRef>;

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -176,6 +176,7 @@ function usePositioningOptions(options: PositioningOptions) {
     fallbackPositions,
     useTransform,
     matchTargetSize,
+    disableUpdateOnResize = false,
   } = options;
 
   const { dir, targetDocument } = useFluent();
@@ -216,6 +217,7 @@ function usePositioningOptions(options: PositioningOptions) {
         middleware,
         strategy: positionStrategy,
         useTransform,
+        disableUpdateOnResize,
       };
     },
     // Options is missing here, but it's not required
@@ -238,6 +240,7 @@ function usePositioningOptions(options: PositioningOptions) {
       useTransform,
       matchTargetSize,
       targetDocument,
+      disableUpdateOnResize,
     ],
   );
 }


### PR DESCRIPTION
Follow up for #29998 

Adds the `disableUpdateOnResize` option since some scenarios might want to avoid using a resize observer for performance reasons