### PR TITLE
[1 of N] [Size optimization] Compress charting bundle size by mangling variable names

### DIFF
--- a/change/@fluentui-react-charting-b5125005-397e-427f-b4d8-a674ed300d61.json
+++ b/change/@fluentui-react-charting-b5125005-397e-427f-b4d8-a674ed300d61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding terser plugin options to reduce charting bundle size",
+  "packageName": "@fluentui/react-charting",
+  "email": "srmukher@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/webpack.config.js
+++ b/packages/react-charting/webpack.config.js
@@ -1,9 +1,42 @@
 const { resources } = require('@fluentui/scripts-webpack');
+const TerserPlugin = require('terser-webpack-plugin');
 
+const regex = new RegExp(
+  [
+    '(truncateText|addNodeShapetoSVG|createPathLink|addLinktoSVG|',
+    'createTree|createTreeDataStructure|createTreeChart)$',
+  ].join(''),
+);
 module.exports = [
   // Create a bundle for consumption in the browser
   ...resources.createBundleConfig({
     output: 'FluentUIReactCharting',
+    customConfig: {
+      optimization: {
+        minimizer: [
+          new TerserPlugin({
+            parallel: true,
+            terserOptions: {
+              compress: {
+                passes: 2,
+              },
+              mangle: {
+                keep_classnames: false,
+                keep_fnames: false,
+                toplevel: true,
+                properties: {
+                  regex: regex,
+                  undeclared: true,
+                },
+              },
+              output: {
+                comments: false,
+              },
+            },
+          }),
+        ],
+      },
+    },
   }),
   // Also build the legacy demo app for the PR deploy site
   require('./webpack.serve.config'),


### PR DESCRIPTION
Obfuscating variable names for Tree component in charting library which reduces the packaged bundle size for charting to 462 KiB (2 KiB reduction from master).
This is required for following scenarios:
- showcase the minified bundle size (via react-charting.min.js) of the charting library as published on various external bundle measuring tools like 
https://bundlephobia.com/package/@fluentui/react-charting@5
This is used by potential consumers to choose between our charting library or the other.

We hoped to reduce the size of each component even before bundling, but that did not happen. 

Scenario: Compress, minify and mangle the min.js generated for react-charting components (taking one component at a time).

Approaches: 
1. Enabling mangling for all functions of all components: This resulted in maximum minification of the min.js to 353 KiB from 477 KiB. However, this can be enabled only when it is ensured that enabling mangling individually for each component does not regress anything.
2. Enabling mangling only for Tree Chart Component: This resulted minification of the min.js by 2 KiB. This approach is taken in this PR.

Validations:

Following charts have been validated in an html file pointing to a minified js:
1. TreeChart three layer:
![image](https://github.com/microsoft/fluentui/assets/120183316/69f0c2ac-8b2a-4624-8bf1-3b50b3d0fc38)

2. TreeChart three layer compact:
<img width="467" alt="image" src="https://github.com/microsoft/fluentui/assets/120183316/8213e31e-0300-4182-b22d-747e4ba6f8f1">
