### PR TITLE
ci: disable false positive step which started to fail master pipeline

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -59,6 +59,6 @@ extends:
               - template: .devops/templates/deployE2E.yml@self
 
               # False positive AV. Wi'l follow up with AV owners. For now to get compliant deleting file before.
-              - script: |
-                  rm apps/pr-deploy-site/dist/public-docsite-v9/storybook/407.13419a99614bf685f100.manager.bundle.js
-                displayName: 'Remove false positive file'
+              # - script: |
+              #     rm apps/pr-deploy-site/dist/public-docsite-v9/storybook/407.13419a99614bf685f100.manager.bundle.js
+              #   displayName: 'Remove false positive file'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

disable manual removal of build assets in order to avoid master pipeline failures https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=332087&view=logs&j=df65131f-49fe-5f4e-72c0-55655bbfd745&t=ca18d1ed-e1a6-5374-a1df-e261f105c601

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
