### PR TITLE
fix: Avoid infinite loop when comparing different documents

### DIFF
--- a/change/@fluentui-react-positioning-f5912219-e8d2-403c-9c21-6d6df380e139.json
+++ b/change/@fluentui-react-positioning-f5912219-e8d2-403c-9c21-6d6df380e139.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Avoid infinite loop when comparing different documents",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/utils/getScrollParent.ts
+++ b/packages/react-components/react-positioning/src/utils/getScrollParent.ts
@@ -34,7 +34,7 @@ export const getScrollParent = (node: Document | HTMLElement | null): HTMLElemen
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
   const parentNode = node && getParentNode(node as HTMLElement);
   // eslint-disable-next-line
-  if (!parentNode) return document.body;
+  if (!parentNode) return node?.ownerDocument?.body ?? document.body;
 
   switch (parentNode.nodeName) {
     case 'HTML':

--- a/packages/react-components/react-positioning/src/utils/getScrollParent.ts
+++ b/packages/react-components/react-positioning/src/utils/getScrollParent.ts
@@ -34,7 +34,7 @@ export const getScrollParent = (node: Document | HTMLElement | null): HTMLElemen
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
   const parentNode = node && getParentNode(node as HTMLElement);
   // eslint-disable-next-line
-  if (!parentNode) return node?.ownerDocument?.body ?? document.body;
+  if (!parentNode) return document.body;
 
   switch (parentNode.nodeName) {
     case 'HTML':

--- a/packages/react-components/react-positioning/src/utils/listScrollParents.ts
+++ b/packages/react-components/react-positioning/src/utils/listScrollParents.ts
@@ -12,6 +12,16 @@ export function listScrollParents(node: HTMLElement): HTMLElement[] {
       break;
     }
 
+    if (scrollParent.nodeName === 'BODY' && scrollParent !== node.ownerDocument.body) {
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.error(
+          '@fluentui/react-positioning: You are comparing two different documents! This is an unexpected error, please report this as a bug to the Fluent UI team ',
+        );
+      }
+      break;
+    }
+
     scrollParents.push(scrollParent);
     cur = scrollParent;
   }


### PR DESCRIPTION
An infinite loop can occur in `listScrollParents` because the fallback can default to the `document` keyword.

This has only happened in a very
rare case where the `parentNode` is undefined which is actually a bug in the affected application - it's still a good reason to make this more fool proof.

* short circuit and warn when comparing different documents
* fallback should first try the `ownerDocument` before the `document`

Fixes #30407.
