### PR TITLE
Adding .mcworld and .mctemplate filetype icons, updated FabricCDN url.

### DIFF
--- a/packages/react-file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/react-file-type-icons/src/FileTypeIconMap.ts
@@ -306,6 +306,12 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     extensions: ['osts'],
   },
   splist: {},
+  mcworld: {
+    extensions: ['mcworld'],
+  },
+  mctemplate: {
+    extensions: ['mctemplate'],
+  },
   model: {
     extensions: [
       '3ds',
@@ -324,7 +330,6 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
       'layer',
       'layout',
       'max',
-      'mcworld',
       'mtl',
       'obj',
       'off',

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -82,7 +82,7 @@ export { DefaultPalette }
 export const EdgeChromiumHighContrastSelector = "@media screen and (-ms-high-contrast: active), screen and (forced-colors: active)";
 
 // @public (undocumented)
-export const FLUENT_CDN_BASE_URL = "https://res.cdn.office.net/files/fabric-cdn-prod_20231212.002";
+export const FLUENT_CDN_BASE_URL = "https://res.cdn.office.net/files/fabric-cdn-prod_20240129.001";
 
 // @public
 export function focusClear(): IRawStyle;

--- a/packages/style-utilities/src/cdn.ts
+++ b/packages/style-utilities/src/cdn.ts
@@ -1,1 +1,1 @@
-export const FLUENT_CDN_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20231212.002';
+export const FLUENT_CDN_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20240129.001';


### PR DESCRIPTION
- [x] yarn change
- [x] yarn lage update to style-utilities (new CDN url location)
- [x] tested within @fluentui/react-experiments 
