### PR TITLE
ci(bundlesize): remove lightrail and azure storage uploads as they dont work anymore

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -27,26 +27,4 @@ jobs:
       - script: yarn bundlesizecollect
         displayName: 'Collate Bundle Size Information'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Bundle Size information to Azure Dev Ops Artifacts'
-        inputs:
-          PathtoPublish: 'apps/test-bundles/dist/bundlesizes.json'
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact dist folder upon build for debug'
-        inputs:
-          PathtoPublish: 'apps/test-bundles/dist'
-          ArtifactName: distdrop
-
       - template: .devops/templates/cleanup.yml
-
-  - job: lightrail
-    pool: server
-    dependsOn: build
-    steps:
-      - task: odefun.odsp-lightrail-tasks-partner.odsp-lightrail-tasks-SizeAuditorWorker.SizeAuditorWorker@0
-        displayName: 'Size Auditor Check on LightRail'
-        inputs:
-          connectedServiceName: lowimpact
-          sourceVersionMessage: '$(Build.SourceVersionMessage)'
-          sourceRepositoryUrl: 'https://github.com/microsoft/fluentui'

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -24,6 +24,10 @@ items.forEach(item => {
 
 fs.writeFileSync(path.join(distRoot, outputFilename), JSON.stringify({ sizes }));
 
+console.log('Bundle size Collect:');
+console.log('====================');
+console.log(sizes);
+
 function getFilesizeInBytes(fileName) {
   return fs.statSync(fileName).size;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- removes non functional SizeAuditor part of bundle size pipeline
- provides output within the pipeline to at least get some raw measurement data
  - <img width="817" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/3fa1a8e1-4f29-4ec0-a354-543e0b0dfa50">
 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/27933
