### PR TITLE
feat(workspace-plugin): add bundle-size-configuration generator

### DIFF
--- a/tools/workspace-plugin/generators.json
+++ b/tools/workspace-plugin/generators.json
@@ -84,6 +84,11 @@
       "factory": "./src/generators/eslint-rule/generator",
       "schema": "./src/generators/eslint-rule/schema.json",
       "description": "eslint-rule generator"
+    },
+    "bundle-size-configuration": {
+      "factory": "./src/generators/bundle-size-configuration/generator",
+      "schema": "./src/generators/bundle-size-configuration/schema.json",
+      "description": "bundle-size-configuration generator"
     }
   }
 }

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/files/bundle-size/index.fixture.js.template
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/files/bundle-size/index.fixture.js.template
@@ -1,0 +1,7 @@
+import * as package from '<%= packageName %>'
+
+console.log(package);
+
+export default {
+  name: '<%= packageName %> - package',
+};

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/files/monosize.config.mjs.template
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/files/monosize.config.mjs.template
@@ -1,0 +1,13 @@
+// @ts-check
+
+import baseConfig from '<%= rootOffset %>monosize.config.mjs';
+
+/** @type {import('monosize').MonoSizeConfig} */
+const monosizeConfig = {
+  ...baseConfig,
+  webpack: config => {
+    return config;
+  },
+};
+
+export default monosizeConfig;

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/files/src/index.ts.template
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/files/src/index.ts.template
@@ -1,0 +1,1 @@
+const variable = "<%= name %>";

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/files/src/index.ts.template
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/files/src/index.ts.template
@@ -1,1 +1,0 @@
-const variable = "<%= name %>";

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
@@ -1,20 +1,101 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import {
+  Tree,
+  readProjectConfiguration,
+  readJson,
+  joinPathFragments,
+  writeJson,
+  addProjectConfiguration,
+  stripIndents,
+} from '@nx/devkit';
 
 import { bundleSizeConfigurationGenerator } from './generator';
 import { BundleSizeConfigurationGeneratorSchema } from './schema';
 
 describe('bundle-size-configuration generator', () => {
   let tree: Tree;
-  const options: BundleSizeConfigurationGeneratorSchema = { name: 'test' };
+  const options: BundleSizeConfigurationGeneratorSchema = { name: '@proj/react-continental' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace();
+
+    createLibrary(tree, 'react-continental');
   });
 
-  it('should run successfully', async () => {
+  it('should add setup bundle size', async () => {
     await bundleSizeConfigurationGenerator(tree, options);
-    const config = readProjectConfiguration(tree, 'test');
-    expect(config).toBeDefined();
+    const config = readProjectConfiguration(tree, options.name);
+
+    const packageJson = readJson(tree, joinPathFragments(config.root, 'package.json'));
+
+    expect(tree.exists(joinPathFragments(config.root, 'monosize.config.mjs'))).toEqual(false);
+
+    expect(packageJson.scripts['bundle-size']).toEqual('monosize measure');
+
+    expect(tree.read(joinPathFragments(config.root, 'bundle-size/index.fixture.js'), 'utf-8')).toMatchInlineSnapshot(`
+      "import * as package from '@proj/react-continental';
+
+      console.log(package);
+
+      export default {
+        name: '@proj/react-continental - package',
+      };
+      "
+    `);
+  });
+
+  it(`should not add index.fixture.js if there are already existing fixtures`, async () => {
+    const config = readProjectConfiguration(tree, options.name);
+
+    tree.write(
+      joinPathFragments(config.root, 'bundle-size/Foo.fixture.js'),
+      stripIndents`
+    import {Foo} from '${options.name}'
+
+    export default {
+      name: 'Foo',
+    };
+    `,
+    );
+
+    await bundleSizeConfigurationGenerator(tree, options);
+
+    expect(tree.exists(joinPathFragments(config.root, 'bundle-size/index.fixture.js'))).toEqual(false);
+  });
+
+  it(`should add monosize config within project if overrideBaseConfig was specified`, async () => {
+    await bundleSizeConfigurationGenerator(tree, { ...options, overrideBaseConfig: true });
+
+    const config = readProjectConfiguration(tree, options.name);
+
+    expect(tree.read(joinPathFragments(config.root, 'monosize.config.mjs'), 'utf-8')).toMatchInlineSnapshot(`
+      "// @ts-check
+
+      import baseConfig from '../../../monosize.config.mjs';
+
+      /** @type {import('monosize').MonoSizeConfig} */
+      const monosizeConfig = {
+        ...baseConfig,
+        webpack: (config) => {
+          return config;
+        },
+      };
+
+      export default monosizeConfig;
+      "
+    `);
   });
 });
+
+function createLibrary(tree: Tree, name: string) {
+  const projectName = '@proj/' + name;
+  const root = `packages/react-components/${name}`;
+  addProjectConfiguration(tree, projectName, { root, tags: ['vNext'] });
+  writeJson(tree, joinPathFragments(root, 'package.json'), {
+    name: projectName,
+    version: '9.0.0',
+    scripts: {},
+  });
+
+  return tree;
+}

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
@@ -1,0 +1,20 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, readProjectConfiguration } from '@nx/devkit';
+
+import { bundleSizeConfigurationGenerator } from './generator';
+import { BundleSizeConfigurationGeneratorSchema } from './schema';
+
+describe('bundle-size-configuration generator', () => {
+  let tree: Tree;
+  const options: BundleSizeConfigurationGeneratorSchema = { name: 'test' };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should run successfully', async () => {
+    await bundleSizeConfigurationGenerator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config).toBeDefined();
+  });
+});

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
@@ -1,0 +1,17 @@
+import { addProjectConfiguration, formatFiles, generateFiles, Tree } from '@nx/devkit';
+import * as path from 'path';
+import { BundleSizeConfigurationGeneratorSchema } from './schema';
+
+export async function bundleSizeConfigurationGenerator(tree: Tree, options: BundleSizeConfigurationGeneratorSchema) {
+  const projectRoot = `libs/${options.name}`;
+  addProjectConfiguration(tree, options.name, {
+    root: projectRoot,
+    projectType: 'library',
+    sourceRoot: `${projectRoot}/src`,
+    targets: {},
+  });
+  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
+  await formatFiles(tree);
+}
+
+export default bundleSizeConfigurationGenerator;

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
@@ -1,17 +1,60 @@
-import { addProjectConfiguration, formatFiles, generateFiles, Tree } from '@nx/devkit';
+import {
+  formatFiles,
+  generateFiles,
+  joinPathFragments,
+  offsetFromRoot,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
 import * as path from 'path';
+import { PackageJson } from '../../types';
 import { BundleSizeConfigurationGeneratorSchema } from './schema';
 
-export async function bundleSizeConfigurationGenerator(tree: Tree, options: BundleSizeConfigurationGeneratorSchema) {
-  const projectRoot = `libs/${options.name}`;
-  addProjectConfiguration(tree, options.name, {
-    root: projectRoot,
-    projectType: 'library',
-    sourceRoot: `${projectRoot}/src`,
-    targets: {},
+export async function bundleSizeConfigurationGenerator(tree: Tree, schema: BundleSizeConfigurationGeneratorSchema) {
+  const options = normalizeOptions(tree, schema);
+
+  const config = readProjectConfiguration(tree, options.name);
+  const configPaths = {
+    bundleSizeRoot: joinPathFragments(config.root, 'bundle-size'),
+    bundleSizeConfig: joinPathFragments(config.root, 'monosize.config.mjs'),
+  };
+
+  generateFiles(tree, path.join(__dirname, 'files'), config.root, {
+    packageName: options.name,
+    rootOffset: offsetFromRoot(config.root),
   });
-  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
+
+  let hasFixtures = false;
+  visitNotIgnoredFiles(tree, configPaths.bundleSizeRoot, filePath => {
+    if (!filePath.endsWith('index.fixture.js') && filePath.endsWith('.fixture.js')) {
+      hasFixtures = true;
+    }
+  });
+
+  if (hasFixtures) {
+    tree.delete(joinPathFragments(configPaths.bundleSizeRoot, 'index.fixture.js'));
+  }
+
+  if (options.overrideBaseConfig === false) {
+    tree.delete(configPaths.bundleSizeConfig);
+  }
+
+  updateJson(tree, joinPathFragments(config.root, 'package.json'), (json: PackageJson) => {
+    json.scripts = json.scripts ?? {};
+    json.scripts['bundle-size'] = 'monosize measure';
+    return json;
+  });
+
   await formatFiles(tree);
+}
+
+function normalizeOptions(tree: Tree, schema: BundleSizeConfigurationGeneratorSchema) {
+  return {
+    overrideBaseConfig: false,
+    ...schema,
+  };
 }
 
 export default bundleSizeConfigurationGenerator;

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.d.ts
@@ -1,3 +1,7 @@
 export interface BundleSizeConfigurationGeneratorSchema {
   name: string;
+  /**
+   * @default false
+   */
+  overrideBaseConfig?: boolean;
 }

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.d.ts
@@ -1,0 +1,3 @@
+export interface BundleSizeConfigurationGeneratorSchema {
+  name: string;
+}

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "BundleSizeConfiguration",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use?"
+    }
+  },
+  "required": ["name"]
+}

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
@@ -6,12 +6,19 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "",
+      "description": "Project for which to generate bundle-size configuration.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use?"
+      "x-prompt": "For which project do you want to generate bundle-size configuration?",
+      "x-dropdown": "projects"
+    },
+    "overrideBaseConfig": {
+      "type": "boolean",
+      "description": "generate monosize config within project in order to add custom bundling overrides",
+      "x-prompt": "Would you like to override monosize bundling config for measurements?",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

adds new generator which setups bundle size measurements for your project

```sh
yarn nx g @fluentui/workspace-plugin:bundle-size-configuration
```

Initial setup 
<img width="837" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/7a5a2d0b-1f36-419f-96b9-fc99c5b37338">

initial/later setup with config override

<img width="832" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/23ce49c8-bb55-462f-9ed4-16792eefcaed">



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/27933
