### PR TITLE
fix(react-datepicker, react-calendar): Apply correct navigation type for month and year pickers and ariaHidden to input's afterContent slot in datepicker

### DIFF
--- a/change/@fluentui-react-calendar-compat-32f67f10-9c9e-4876-82cd-dab716bb4f8c.json
+++ b/change/@fluentui-react-calendar-compat-32f67f10-9c9e-4876-82cd-dab716bb4f8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Update year and month pickers to use the correct keyboard navigation type and apply requested focus indicator width from design for day picker.",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-936540a7-8e89-4120-8f39-23df60b535e5.json
+++ b/change/@fluentui-react-datepicker-compat-936540a7-8e89-4120-8f39-23df60b535e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Apply aria-disabled to DatePicker's contentAfter slot to avoid confusion when using screen readers.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
@@ -5,6 +5,7 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import {
   addMonths,
   addYears,
+  compareDates,
   DateRangeType,
   DayOfWeek,
   DEFAULT_CALENDAR_STRINGS,
@@ -173,10 +174,22 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       showSixWeeksByDefault = false,
       showWeekNumbers = false,
       strings = DEFAULT_CALENDAR_STRINGS,
-      today = new Date(),
+      today: providedToday,
       value,
       workWeekDays = defaultWorkWeekDays,
     } = props;
+
+    const [today, setToday] = React.useState<Date>(providedToday ?? new Date());
+    const syncToday = () => {
+      if (providedToday && !compareDates(providedToday, today)) {
+        setToday(providedToday);
+      }
+
+      const newToday = new Date();
+      if (!compareDates(today, newToday)) {
+        setToday(newToday);
+      }
+    };
 
     const [selectedDate, navigatedDay, navigatedMonth, onDateSelected, navigateDay, navigateMonth] = useDateState({
       onSelectDate,
@@ -258,6 +271,7 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       : undefined;
 
     const onGotoToday = (): void => {
+      syncToday();
       navigateDay(today!);
       focusOnNextUpdate();
     };

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
@@ -5,7 +5,6 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import {
   addMonths,
   addYears,
-  compareDates,
   DateRangeType,
   DayOfWeek,
   DEFAULT_CALENDAR_STRINGS,
@@ -174,22 +173,10 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       showSixWeeksByDefault = false,
       showWeekNumbers = false,
       strings = DEFAULT_CALENDAR_STRINGS,
-      today: providedToday,
+      today = new Date(),
       value,
       workWeekDays = defaultWorkWeekDays,
     } = props;
-
-    const [today, setToday] = React.useState<Date>(providedToday ?? new Date());
-    const syncToday = () => {
-      if (providedToday && !compareDates(providedToday, today)) {
-        setToday(providedToday);
-      }
-
-      const newToday = new Date();
-      if (!compareDates(today, newToday)) {
-        setToday(newToday);
-      }
-    };
 
     const [selectedDate, navigatedDay, navigatedMonth, onDateSelected, navigateDay, navigateMonth] = useDateState({
       onSelectDate,
@@ -271,7 +258,6 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       : undefined;
 
     const onGotoToday = (): void => {
-      syncToday();
       navigateDay(today!);
       focusOnNextUpdate();
     };

--- a/packages/react-components/react-calendar-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
@@ -17,9 +17,9 @@ import {
 } from '../../utils';
 import { AnimationDirection } from '../Calendar/Calendar.types';
 import { weekCornersClassNames } from './useWeekCornerStyles.styles';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { CalendarDayGridStyles, CalendarDayGridStyleProps } from './CalendarDayGrid.types';
-import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 
 /**
  * @internal

--- a/packages/react-components/react-calendar-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
@@ -19,6 +19,7 @@ import { AnimationDirection } from '../Calendar/Calendar.types';
 import { weekCornersClassNames } from './useWeekCornerStyles.styles';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { CalendarDayGridStyles, CalendarDayGridStyleProps } from './CalendarDayGrid.types';
+import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 
 /**
  * @internal
@@ -109,6 +110,12 @@ const useDayCellStyles = makeStyles({
       },
     },
   },
+  focusIndicator: createFocusOutlineStyle({
+    style: {
+      outlineWidth: tokens.strokeWidthThin,
+      ...shorthands.borderWidth(tokens.strokeWidthThin),
+    },
+  }),
 });
 
 const useDaySelectedStyles = makeStyles({
@@ -356,7 +363,12 @@ export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStylePro
       tableStyles.base,
       showWeekNumbers && tableStyles.showWeekNumbers,
     ),
-    dayCell: mergeClasses(calendarDayGridClassNames.dayCell, dayCellStyles.base, cornerBorderAndRadiusStyles.corners),
+    dayCell: mergeClasses(
+      calendarDayGridClassNames.dayCell,
+      dayCellStyles.base,
+      dayCellStyles.focusIndicator,
+      cornerBorderAndRadiusStyles.corners,
+    ),
     daySelected: mergeClasses(calendarDayGridClassNames.daySelected, daySelectedStyles.base),
     weekRow: mergeClasses(
       calendarDayGridClassNames.weekRow,

--- a/packages/react-components/react-calendar-compat/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarMonth/CalendarMonth.tsx
@@ -158,7 +158,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = props 
     animationDirection,
   });
 
-  const arrowNavigationAttributes = useArrowNavigationGroup({ axis: 'both' });
+  const arrowNavigationAttributes = useArrowNavigationGroup({ axis: 'grid' });
 
   if (isYearPickerVisible) {
     const [onRenderYear, yearStrings] = getYearStrings({ dateTimeFormatter, navigatedDate, strings });

--- a/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Enter, Space } from '@fluentui/keyboard-keys';
-import { useArrowNavigationGroup, useFocusableGroup } from '@fluentui/react-tabster';
+import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { mergeClasses } from '@griffel/react';
 import { useCalendarYearStyles_unstable } from './useCalendarYearStyles.styles';
 import type {

--- a/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
@@ -81,8 +81,6 @@ const CalendarYearGridCell: React.FunctionComponent<CalendarYearGridCellProps> =
     highlightSelected: highlightSelectedYear,
   });
 
-  // const gridCellTabsterAttributes = ;
-
   return (
     <button
       className={mergeClasses(classNames.itemButton, selected && classNames.selected, disabled && classNames.disabled)}

--- a/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarYear/CalendarYear.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Enter, Space } from '@fluentui/keyboard-keys';
-import { useArrowNavigationGroup } from '@fluentui/react-tabster';
+import { useArrowNavigationGroup, useFocusableGroup } from '@fluentui/react-tabster';
 import { mergeClasses } from '@griffel/react';
 import { useCalendarYearStyles_unstable } from './useCalendarYearStyles.styles';
 import type {
@@ -80,6 +80,8 @@ const CalendarYearGridCell: React.FunctionComponent<CalendarYearGridCellProps> =
     highlightCurrent: highlightCurrentYear,
     highlightSelected: highlightSelectedYear,
   });
+
+  // const gridCellTabsterAttributes = ;
 
   return (
     <button
@@ -168,19 +170,17 @@ const CalendarYearGrid: React.FunctionComponent<CalendarYearGridProps> = props =
     }
   }
 
-  const arrowNavigationAttributes = useArrowNavigationGroup({ axis: 'both' });
+  const arrowNavigationAttributes = useArrowNavigationGroup({ axis: 'grid' });
 
   return (
-    <div {...arrowNavigationAttributes}>
-      <div className={classNames.gridContainer} role="grid" aria-label={gridAriaLabel}>
-        {cells.map((cellRow: React.ReactNode[], index: number) => {
-          return (
-            <div key={'yearPickerRow_' + index + '_' + fromYear} role="row" className={classNames.buttonRow}>
-              {cellRow}
-            </div>
-          );
-        })}
-      </div>
+    <div {...arrowNavigationAttributes} className={classNames.gridContainer} role="grid" aria-label={gridAriaLabel}>
+      {cells.map((cellRow: React.ReactNode[], index: number) => {
+        return (
+          <div key={'yearPickerRow_' + index + '_' + fromYear} role="row" className={classNames.buttonRow}>
+            {cellRow}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/packages/react-components/react-calendar-compat/stories/Calendar/CalendarSixWeeks.stories.tsx
+++ b/packages/react-components/react-calendar-compat/stories/Calendar/CalendarSixWeeks.stories.tsx
@@ -20,7 +20,7 @@ export const CalendarSixWeeks = () => {
 CalendarSixWeeks.parameters = {
   docs: {
     description: {
-      story: 'A Calendar Compat allows you to set a six day week.',
+      story: 'A Calendar Compat allows you to set a six week month.',
     },
   },
 };

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -18,6 +18,7 @@ Object {
           value=""
         />
         <span
+          aria-hidden="true"
           class="fui-Input__contentAfter"
         >
           <svg
@@ -52,6 +53,7 @@ Object {
         value=""
       />
       <span
+        aria-hidden="true"
         class="fui-Input__contentAfter"
       >
         <svg

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -371,6 +371,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
   const contentAfter = slot.always(props.contentAfter || {}, {
     defaultProps: {
       children: <CalendarMonthRegular />,
+      'aria-hidden': true,
     },
     elementType: 'span',
   });


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- Year and Month picker's grid was not acting as a grid when using keyboard to navigate through it.
- When using screen reader contentAfter's slot was reading out clickable causing confusion.

## New Behavior

- Year and Month picker's grid now have the grid navigation type.
- contentAfter slot is now `aria-hidden` to avoid screen readers to read out "clickable".

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30120 
- Fixes #30036 
