### PR TITLE
bugfix(react-tree-item): regression fix for focus and blur events on TreeItem

### DIFF
--- a/change/@fluentui-react-tree-2d77df3e-24cf-4465-ab45-585ec20e0e7b.json
+++ b/change/@fluentui-react-tree-2d77df3e-24cf-4465-ab45-585ec20e0e7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: regression fix for focus and blur events on TreeItem",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -40,10 +40,6 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
   const {
     onClick,
     onKeyDown,
-    onMouseOver,
-    onFocus,
-    onMouseOut,
-    onBlur,
     onChange,
     as = 'div',
     itemType = 'leaf',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`onFocus` and `onBlur` properties were being ignore from `TreeItem` due to a regression introduced in https://github.com/microsoft/fluentui/pull/29694

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Ensures that `onFocus` and `onBlur` are properly provided to the root element for `TreeItem`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
