### PR TITLE
chore: add all core teams as owner of rfcs/ folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -323,3 +323,7 @@ packages/react-experiments/src/components/TileList @ThomasMichon
 **/api-extractor.json @microsoft/fluentui-react-build
 **/api-extractor.unstable.json @microsoft/fluentui-react-build
 **/.swcrc @microsoft/fluentui-react-build
+
+## Docs
+rfcs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg
+rfcs/shared/build-system/ @microsoft/fluentui-react-build


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

> Based on tech sync offline discussion

if a new RFC PR is created, all core. teams will be assigned as required to review. this adds github automation and explicit visibility ( all members of teams will get notified ) to any RFC PR.

_New flow:_
- each team needs to assign 1 member to review RFC PR on behalf of owning team within `Reviewers` Pane
- if owning team is not interested to provide any feedback
  - they wont assign anyone within `Reviewers` Pane
  - or they can explicitly provide comment within PR that they wont be reviewing
 
_Merge-ability of PR:_

After CI is green and there is at least 1 approval from 1 of the owning teams, PR can be merged. 
The rule that RFC should get at least 2 members approval still applies 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
