### PR TITLE
fix: Resize heuristic should account for zero dimensions

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -1189,6 +1189,36 @@ const PositioningEndEvent = () => {
   );
 };
 
+const TargetDisplayNone = () => {
+  const positioningRef = React.useRef<PositioningImperativeRef>(null);
+  const { targetRef, containerRef } = usePositioning({
+    positioningRef,
+  });
+
+  const [visible, setVisible] = React.useState(true);
+
+  return (
+    <>
+      <div style={{ display: 'inline-block', width: 120, height: 30, border: '1px dashed green' }}>
+        <button
+          id="target"
+          ref={targetRef}
+          style={{ width: 120, height: 30, display: visible ? undefined : 'none' }}
+          onClick={() => setVisible(false)}
+        >
+          remove me
+        </button>
+      </div>
+      <div
+        ref={containerRef}
+        style={{ border: '2px solid blue', padding: 20, backgroundColor: 'white', boxSizing: 'border-box' }}
+      >
+        Should stay positioned to dashed green box
+      </div>
+    </>
+  );
+};
+
 storiesOf('Positioning', module)
   .addDecorator(story => (
     <div
@@ -1276,6 +1306,11 @@ storiesOf('Positioning', module)
   .addStory('Positioning end', () => (
     <StoryWright steps={new Steps().click('#target').snapshot('updated 2 times').end()}>
       <PositioningEndEvent />
+    </StoryWright>
+  ))
+  .addStory('Target display none', () => (
+    <StoryWright steps={new Steps().click('#target').snapshot('target display: none').end()}>
+      <TargetDisplayNone />
     </StoryWright>
   ));
 

--- a/change/@fluentui-react-positioning-ebe269b8-e0d0-4776-a5a4-994637d87db1.json
+++ b/change/@fluentui-react-positioning-ebe269b8-e0d0-4776-a5a4-994637d87db1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Resize heuristic should account for zero dimensions",
+  "packageName": "@fluentui/react-positioning",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -69,7 +69,19 @@ export function createPositionManager(options: PositionManagerOptions): Position
   }
 
   // When the dimensions of the target or the container change - trigger a position update
-  const resizeObserver = disableUpdateOnResize ? null : createResizeObserver(targetWindow, () => updatePosition());
+  const resizeObserver = disableUpdateOnResize
+    ? null
+    : createResizeObserver(targetWindow, entries => {
+        // If content rect dimensions to go 0 -> very likely that `display: none` is being used to hide the element
+        // In this case don't update and let users update imperatively
+        const shouldUpdateOnResize = entries.every(entry => {
+          return entry.contentRect.width > 0 && entry.contentRect.height > 0;
+        });
+
+        if (shouldUpdateOnResize) {
+          updatePosition();
+        }
+      });
 
   let isFirstUpdate = true;
   const scrollParents: Set<HTMLElement> = new Set<HTMLElement>();


### PR DESCRIPTION
When the dimensions of the content rect becomes 0, this is likely that the observed element has been removed from dom or hidden with `display: none`.

This can happen often with mouse hover behaviours (i.e. element disappears when mouse leaves a parent div). To avoid incorrect positioning without a target, we do nothing in these cases and force the user to update imperatively if necessary
