### PR TITLE
chore: Simplify high contrast visuals for RatingItem, and remove iconOutline from RatingDisplay

### DIFF
--- a/change/@fluentui-react-rating-preview-7d6c17b2-2ab4-4dc4-8448-a2097d3f2698.json
+++ b/change/@fluentui-react-rating-preview-7d6c17b2-2ab4-4dc4-8448-a2097d3f2698.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Simplify high contrast visuals for RatingItem, and remove iconOutline from RatingDisplay",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/etc/react-rating-preview.api.md
+++ b/packages/react-components/react-rating-preview/etc/react-rating-preview.api.md
@@ -42,8 +42,7 @@ export type RatingDisplayProps = ComponentProps<RatingDisplaySlots> & {
     color?: 'brand' | 'marigold' | 'neutral';
     compact?: boolean;
     count?: number;
-    iconFilled?: React_2.ReactElement;
-    iconOutline?: React_2.ReactElement;
+    icon?: React_2.ReactElement;
     max?: number;
     size?: 'small' | 'medium' | 'large' | 'extra-large';
     value?: number;
@@ -57,7 +56,7 @@ export type RatingDisplaySlots = {
 };
 
 // @public
-export type RatingDisplayState = ComponentState<RatingDisplaySlots> & Required<Pick<RatingDisplayProps, 'color' | 'compact' | 'iconFilled' | 'iconOutline' | 'max' | 'size'>> & Pick<RatingDisplayProps, 'value'>;
+export type RatingDisplayState = ComponentState<RatingDisplaySlots> & Required<Pick<RatingDisplayProps, 'color' | 'compact' | 'icon' | 'max' | 'size'>> & Pick<RatingDisplayProps, 'value'>;
 
 // @public
 export const RatingItem: ForwardRefComponent<RatingItemProps>;
@@ -77,8 +76,7 @@ export const RatingItemProvider: React_2.Provider<RatingItemContextValue | undef
 export type RatingItemSlots = {
     root: NonNullable<Slot<'span'>>;
     selectedIcon?: NonNullable<Slot<'div'>>;
-    unselectedFilledIcon?: NonNullable<Slot<'div'>>;
-    unselectedOutlineIcon?: NonNullable<Slot<'div'>>;
+    unselectedIcon?: NonNullable<Slot<'div'>>;
     halfValueInput?: NonNullable<Slot<'input'>>;
     fullValueInput?: NonNullable<Slot<'input'>>;
 };
@@ -86,6 +84,7 @@ export type RatingItemSlots = {
 // @public
 export type RatingItemState = ComponentState<RatingItemSlots> & Required<Pick<RatingItemProps, 'value'>> & Pick<RatingState, 'color' | 'step' | 'size'> & {
     iconFillWidth: number;
+    appearance: 'outline' | 'filled';
 };
 
 // @public

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.types.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/RatingDisplay.types.ts
@@ -28,15 +28,10 @@ export type RatingDisplayProps = ComponentProps<RatingDisplaySlots> & {
    */
   count?: number;
   /**
-   * The icon used for filled rating items.
+   * The icon used for rating items.
    * @default <StarFilled />
    */
-  iconFilled?: React.ReactElement;
-  /**
-   * The icon used for unfilled rating items.
-   * @default <StarRegular />
-   */
-  iconOutline?: React.ReactElement;
+  icon?: React.ReactElement;
   /**
    * The max value of the rating. This controls the number of rating items displayed.
    * Must be a whole number greater than 1.
@@ -58,7 +53,7 @@ export type RatingDisplayProps = ComponentProps<RatingDisplaySlots> & {
  * State used in rendering RatingDisplay
  */
 export type RatingDisplayState = ComponentState<RatingDisplaySlots> &
-  Required<Pick<RatingDisplayProps, 'color' | 'compact' | 'iconFilled' | 'iconOutline' | 'max' | 'size'>> &
+  Required<Pick<RatingDisplayProps, 'color' | 'compact' | 'icon' | 'max' | 'size'>> &
   Pick<RatingDisplayProps, 'value'>;
 
 export type RatingDisplayContextValues = { ratingItem: RatingItemContextValue };

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useId } from '@fluentui/react-utilities';
 import type { RatingDisplayProps, RatingDisplayState } from './RatingDisplay.types';
-import { StarFilled, StarRegular } from '@fluentui/react-icons';
+import { StarFilled } from '@fluentui/react-icons';
 import { RatingItem } from '../RatingItem/RatingItem';
 
 /**
@@ -17,16 +17,7 @@ export const useRatingDisplay_unstable = (
   props: RatingDisplayProps,
   ref: React.Ref<HTMLDivElement>,
 ): RatingDisplayState => {
-  const {
-    color = 'neutral',
-    count,
-    compact = false,
-    iconFilled = <StarFilled />,
-    iconOutline = <StarRegular />,
-    max = 5,
-    size = 'medium',
-    value,
-  } = props;
+  const { color = 'neutral', count, compact = false, icon = <StarFilled />, max = 5, size = 'medium', value } = props;
 
   const valueTextId = useId('rating-value-');
   const countTextId = useId('rating-count-');
@@ -43,8 +34,7 @@ export const useRatingDisplay_unstable = (
   const state: RatingDisplayState = {
     color,
     compact,
-    iconFilled,
-    iconOutline,
+    icon,
     max,
     size,
     value,

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayContextValues.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayContextValues.ts
@@ -3,20 +3,20 @@ import { RatingDisplayContextValues, RatingDisplayState } from './RatingDisplay.
 import { RatingItemContextValue } from '../RatingItem/RatingItem.types';
 
 export const useRatingDisplayContextValues = (state: RatingDisplayState): RatingDisplayContextValues => {
-  const { color, compact, iconFilled, iconOutline, size, value } = state;
+  const { color, compact, icon, size, value } = state;
 
   const ratingItem = React.useMemo<RatingItemContextValue>(
     () => ({
       color,
       compact,
-      iconFilled,
-      iconOutline,
+      iconFilled: icon,
+      iconOutline: icon,
       interactive: false,
       step: 0.5,
       size,
       value,
     }),
-    [color, compact, iconFilled, iconOutline, size, value],
+    [color, compact, icon, size, value],
   );
 
   return { ratingItem };

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/RatingItem.types.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/RatingItem.types.ts
@@ -13,13 +13,9 @@ export type RatingItemSlots = {
    */
   selectedIcon?: NonNullable<Slot<'div'>>;
   /**
-   * Icon displayed when the rating value is less than the item's value, when using 'filled' style.
+   * Icon displayed when the rating value is less than the item's value.
    */
-  unselectedFilledIcon?: NonNullable<Slot<'div'>>;
-  /**
-   * Icon displayed when the rating value is less than the item's value, when using 'outline' style or high contrast.
-   */
-  unselectedOutlineIcon?: NonNullable<Slot<'div'>>;
+  unselectedIcon?: NonNullable<Slot<'div'>>;
   /**
    * Radio input slot used for half star precision
    */
@@ -47,6 +43,7 @@ export type RatingItemState = ComponentState<RatingItemSlots> &
   Required<Pick<RatingItemProps, 'value'>> &
   Pick<RatingState, 'color' | 'step' | 'size'> & {
     iconFillWidth: number;
+    appearance: 'outline' | 'filled';
   };
 
 export type RatingItemContextValue = Partial<Pick<RatingState, 'name' | 'hoveredValue' | 'value'>> &

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/renderRatingItem.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/renderRatingItem.tsx
@@ -14,8 +14,7 @@ export const renderRatingItem_unstable = (state: RatingItemState) => {
     <state.root>
       {state.halfValueInput && <state.halfValueInput />}
       {state.fullValueInput && <state.fullValueInput />}
-      {state.unselectedFilledIcon && <state.unselectedFilledIcon />}
-      {state.unselectedOutlineIcon && <state.unselectedOutlineIcon />}
+      {state.unselectedIcon && <state.unselectedIcon />}
       {state.selectedIcon && <state.selectedIcon />}
     </state.root>
   );

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
@@ -22,6 +22,8 @@ export const useRatingItem_unstable = (props: RatingItemProps, ref: React.Ref<HT
 
   const displayedRatingValue = context.hoveredValue ?? ratingValue;
 
+  const appearance = context.interactive ? 'outline' : 'filled';
+
   let iconFillWidth;
   if (context.compact || displayedRatingValue >= value) {
     iconFillWidth = 1;
@@ -39,24 +41,11 @@ export const useRatingItem_unstable = (props: RatingItemProps, ref: React.Ref<HT
     { elementType: 'span' },
   );
 
-  let unselectedOutlineIcon;
-  // The unselectedOutlineIcon always needs to be rendered when unselected,
-  // even for 'filled' appearance, since high contrast always shows an outline.
+  let unselectedIcon;
   if (iconFillWidth < 1) {
-    unselectedOutlineIcon = slot.always(props.unselectedOutlineIcon, {
+    unselectedIcon = slot.always(props.unselectedIcon, {
       defaultProps: {
-        children: context.iconOutline,
-        'aria-hidden': true,
-      },
-      elementType: 'div',
-    });
-  }
-
-  let unselectedFilledIcon;
-  if (iconFillWidth < 1 && !context.interactive) {
-    unselectedFilledIcon = slot.always(props.unselectedFilledIcon, {
-      defaultProps: {
-        children: context.iconFilled,
+        children: appearance === 'filled' ? context.iconFilled : context.iconOutline,
         'aria-hidden': true,
       },
       elementType: 'div',
@@ -112,6 +101,7 @@ export const useRatingItem_unstable = (props: RatingItemProps, ref: React.Ref<HT
   }
 
   const state: RatingItemState = {
+    appearance,
     color: context.color,
     step: context.step,
     size: context.size,
@@ -120,15 +110,13 @@ export const useRatingItem_unstable = (props: RatingItemProps, ref: React.Ref<HT
     components: {
       root: 'span',
       selectedIcon: 'div',
-      unselectedFilledIcon: 'div',
-      unselectedOutlineIcon: 'div',
+      unselectedIcon: 'div',
       halfValueInput: 'input',
       fullValueInput: 'input',
     },
     root,
     selectedIcon,
-    unselectedFilledIcon,
-    unselectedOutlineIcon,
+    unselectedIcon,
     halfValueInput,
     fullValueInput,
   };

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItemStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItemStyles.styles.ts
@@ -6,8 +6,7 @@ import { tokens } from '@fluentui/react-theme';
 export const ratingItemClassNames: SlotClassNames<RatingItemSlots> = {
   root: 'fui-RatingItem',
   selectedIcon: 'fui-RatingItem__selectedIcon',
-  unselectedFilledIcon: 'fui-RatingItem__unselectedFilledIcon',
-  unselectedOutlineIcon: 'fui-RatingItem__unselectedOutlineIcon',
+  unselectedIcon: 'fui-RatingItem__unselectedIcon',
   halfValueInput: 'fui-RatingItem__halfValueInput',
   fullValueInput: 'fui-RatingItem__fullValueInput',
 };
@@ -90,14 +89,12 @@ const useIndicatorStyles = makeStyles({
   marigold: {
     color: tokens.colorPaletteMarigoldBorderActive,
   },
-  highContrastOnly: {
-    color: tokens.colorTransparentStroke,
-  },
   filled: {
     color: tokens.colorNeutralBackground6,
+    stroke: tokens.colorTransparentStroke,
     '@media (forced-colors: active)': {
-      // In high contrast the 'outline' icon is always visible, so we need to hide the 'filled' icon.
-      display: 'none',
+      color: 'Canvas',
+      stroke: 'CanvasText',
     },
   },
   brandFilled: {
@@ -112,7 +109,7 @@ const useIndicatorStyles = makeStyles({
  * Apply styling to the RatingItem slots based on the state
  */
 export const useRatingItemStyles_unstable = (state: RatingItemState): RatingItemState => {
-  const { color, size, iconFillWidth } = state;
+  const { color, size, iconFillWidth, appearance } = state;
   const styles = useStyles();
   const inputBaseClassName = useInputBaseClassName();
   const inputStyles = useInputStyles();
@@ -139,29 +136,18 @@ export const useRatingItemStyles_unstable = (state: RatingItemState): RatingItem
     );
   }
 
-  if (state.unselectedOutlineIcon) {
-    state.unselectedOutlineIcon.className = mergeClasses(
-      ratingItemClassNames.unselectedOutlineIcon,
+  if (state.unselectedIcon) {
+    state.unselectedIcon.className = mergeClasses(
+      ratingItemClassNames.unselectedIcon,
       indicatorBaseClassName,
-      color === 'brand' && indicatorStyles.brand,
-      color === 'marigold' && indicatorStyles.marigold,
-      // If there is also a filled icon, the outline icon is only visible in high contrast
-      state.unselectedFilledIcon && indicatorStyles.highContrastOnly,
+      appearance === 'filled' && indicatorStyles.filled,
+      color === 'brand' && (appearance === 'filled' ? indicatorStyles.brandFilled : indicatorStyles.brand),
+      color === 'marigold' && (appearance === 'filled' ? indicatorStyles.marigoldFilled : indicatorStyles.marigold),
       iconFillWidth === 0.5 && indicatorStyles.upperHalf,
-      state.unselectedOutlineIcon.className,
+      state.unselectedIcon.className,
     );
   }
-  if (state.unselectedFilledIcon) {
-    state.unselectedFilledIcon.className = mergeClasses(
-      ratingItemClassNames.unselectedFilledIcon,
-      indicatorBaseClassName,
-      indicatorStyles.filled,
-      color === 'brand' && indicatorStyles.brandFilled,
-      color === 'marigold' && indicatorStyles.marigoldFilled,
-      iconFillWidth === 0.5 && indicatorStyles.upperHalf,
-      state.unselectedFilledIcon.className,
-    );
-  }
+
   if (state.selectedIcon) {
     state.selectedIcon.className = mergeClasses(
       ratingItemClassNames.selectedIcon,

--- a/packages/react-components/react-rating-preview/stories/RatingDisplay/RatingDisplayShape.stories.tsx
+++ b/packages/react-components/react-rating-preview/stories/RatingDisplay/RatingDisplayShape.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RatingDisplay } from '@fluentui/react-rating-preview';
-import { CircleFilled, CircleRegular, SquareFilled, SquareRegular } from '@fluentui/react-icons';
+import { CircleFilled, SquareFilled } from '@fluentui/react-icons';
 import { makeStyles, shorthands } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -15,8 +15,8 @@ export const Shape = () => {
   const styles = useStyles();
   return (
     <div className={styles.root}>
-      <RatingDisplay iconFilled={<CircleFilled />} iconOutline={<CircleRegular />} value={3.5} />
-      <RatingDisplay iconFilled={<SquareFilled />} iconOutline={<SquareRegular />} value={3.5} />
+      <RatingDisplay icon={<CircleFilled />} value={3.5} />
+      <RatingDisplay icon={<SquareFilled />} value={3.5} />
     </div>
   );
 };
@@ -24,8 +24,7 @@ export const Shape = () => {
 Shape.parameters = {
   docs: {
     description: {
-      story:
-        'You can pass in custom icons to the Rating component. You can specify the icons with the `iconFilled` and `iconOutline` props.',
+      story: 'You can pass in a custom icon to the RatingDisplay component using the `icon` prop.',
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

RatingDisplay icons didn't show up correctly in Windows high contrast mode. Additionally, the styles for rendering outline versions of the RatingDisplay icons were overly complex, relying on rendering two icons at once; hiding one in normal colors, and hiding the other in high contrast.

## New Behavior

Have RatingItem only render one unselected icon. For non-interactive (RatingDisplay), this will always be the filled icon. In high contrast, use `stroke` to draw an outline around it.

Remove RatingDisplay's `iconOutline` prop as that is no longer needed, and rename its `iconFilled` to just `icon`.

