### PR TITLE
fix: GroupedList initiates FocusRects

### DIFF
--- a/change/@fluentui-react-2d68c9d6-2ee1-490d-96a6-83b91e521f24.json
+++ b/change/@fluentui-react-2d68c9d6-2ee1-490d-96a6-83b91e521f24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: GroupedList initiates FocusRects",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { initializeComponentRef, classNamesFunction, KeyCodes, getRTLSafeKeyCode, css } from '../../Utilities';
+import {
+  initializeComponentRef,
+  classNamesFunction,
+  FocusRects,
+  KeyCodes,
+  getRTLSafeKeyCode,
+  css,
+} from '../../Utilities';
 import { GroupedListSection } from './GroupedListSection';
 import { List, ScrollToMode } from '../../List';
 import { SelectionMode } from '../../Selection';
@@ -154,6 +161,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
         shouldEnterInnerZone={shouldEnterInnerZone}
         className={css(this._classNames.root, focusZoneProps.className)}
       >
+        <FocusRects />
         {!groups ? (
           this._renderGroup(undefined, 0)
         ) : (


### PR DESCRIPTION
## Previous Behavior

GroupedList did not import & use `FocusRects`, so if used on its own, focus is not visible (e.g. in [this codepen](https://codepen.io/sbarrameda/pen/jOXNPvo?editors=0010)).

Note: this uses `<FocusRects>` as a component instead of `useFocusRects`, since GroupedList is still a class component.

## New Behavior

Added FocusRects

## Related Issue(s)

Fixes half of this [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18041)
