### PR TITLE
Fix size small  label vertical stying in RatingDisplay

### DIFF
--- a/change/@fluentui-react-rating-preview-73090623-b968-461d-857f-78ed02671b60.json
+++ b/change/@fluentui-react-rating-preview-73090623-b968-461d-857f-78ed02671b60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update vertical styling for RatingDisplay to fix vertical alignment",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { RatingDisplaySlots, RatingDisplayState } from './RatingDisplay.types';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
@@ -25,9 +25,6 @@ const useLabelClassName = makeResetStyles({
 });
 
 const useLabelStyles = makeStyles({
-  small: {
-    ...shorthands.margin(tokens.spacingVerticalSNudge, '0', '0', tokens.spacingHorizontalXXS),
-  },
   large: {
     fontSize: tokens.fontSizeBase300,
     lineHeight: tokens.lineHeightBase300,
@@ -61,7 +58,6 @@ export const useRatingDisplayStyles_unstable = (state: RatingDisplayState): Rati
       ratingDisplayClassNames.valueText,
       labelClassName,
       labelStyles.strong,
-      size === 'small' && labelStyles.small,
       size === 'large' && labelStyles.large,
       size === 'extra-large' && labelStyles.extraLarge,
       state.valueText.className,

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -26,7 +26,7 @@ const useLabelClassName = makeResetStyles({
 
 const useLabelStyles = makeStyles({
   small: {
-    ...shorthands.margin(tokens.spacingVerticalSNudge, '0', '0', tokens.spacingVerticalSNudge),
+    ...shorthands.margin(tokens.spacingVerticalSNudge, '0', '0', tokens.spacingHorizontalXXS),
   },
   large: {
     fontSize: tokens.fontSizeBase300,

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { RatingDisplaySlots, RatingDisplayState } from './RatingDisplay.types';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
@@ -25,6 +25,9 @@ const useLabelClassName = makeResetStyles({
 });
 
 const useLabelStyles = makeStyles({
+  small: {
+    ...shorthands.margin(tokens.spacingVerticalSNudge, '0', '0', tokens.spacingVerticalSNudge),
+  },
   large: {
     fontSize: tokens.fontSizeBase300,
     lineHeight: tokens.lineHeightBase300,
@@ -58,6 +61,7 @@ export const useRatingDisplayStyles_unstable = (state: RatingDisplayState): Rati
       ratingDisplayClassNames.valueText,
       labelClassName,
       labelStyles.strong,
+      size === 'small' && labelStyles.small,
       size === 'large' && labelStyles.large,
       size === 'extra-large' && labelStyles.extraLarge,
       state.valueText.className,

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItemStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItemStyles.styles.ts
@@ -22,24 +22,28 @@ const useStyles = makeStyles({
     fontSize: '12px',
     width: '12px',
     height: '12px',
+    lineHeight: '12px',
   },
 
   medium: {
     fontSize: '16px',
     width: '16px',
     height: '16px',
+    lineHeight: '16px',
   },
 
   large: {
     fontSize: '20px',
     width: '20px',
     height: '20px',
+    lineHeight: '20px',
   },
 
   'extra-large': {
     fontSize: '28px',
     width: '28px',
     height: '28px',
+    lineHeight: '28px',
   },
 });
 
@@ -73,6 +77,8 @@ const useIndicatorBaseClassName = makeResetStyles({
   position: 'absolute',
   left: 0,
   right: 0,
+  top: 0,
+  bottom: 0,
 });
 
 const useIndicatorStyles = makeStyles({


### PR DESCRIPTION
There is a vertical alignment with the label in `RatingDisplay` when `size` is set to small. This PR adds styling to fix this. 

Before: 
![image](https://github.com/microsoft/fluentui/assets/66456876/3f0c5697-b4a9-48cb-859a-ece72b96d499)


After:
![image](https://github.com/microsoft/fluentui/assets/66456876/be8c6e34-24f7-4202-98d7-0816c228e490)
