### PR TITLE
Corrected link to Button.types.ts

### DIFF
--- a/packages/react-components/react-button/docs/SPEC.md
+++ b/packages/react-components/react-button/docs/SPEC.md
@@ -69,7 +69,7 @@ The `Button` component supports different sizing with at least three different s
 
 ### Props
 
-See API at [Button.types.ts](packages/react-components/react-button/src/components/Button/Button.types.ts).
+See API at [Button.types.ts](../src/components/Button/Button.types.ts).
 
 ## Structure
 

--- a/packages/react-components/react-button/docs/SPEC.md
+++ b/packages/react-components/react-button/docs/SPEC.md
@@ -69,7 +69,7 @@ The `Button` component supports different sizing with at least three different s
 
 ### Props
 
-See API at [Button.types.ts](./Button.types.ts).
+See API at [Button.types.ts](packages/react-components/react-button/src/components/Button/Button.types.ts).
 
 ## Structure
 


### PR DESCRIPTION
## Previous Behavior

Link to `Button.types.ts` was leading to 404.

## New Behavior

Now it's leading to `Button.types.ts` file.