### PR TITLE
fix: Correctly calculating height of Callout aligning to the top and covering target.

### DIFF
--- a/change/@fluentui-react-e44f66af-f799-4e82-a59f-9b2056b5edbb.json
+++ b/change/@fluentui-react-e44f66af-f799-4e82-a59f-9b2056b5edbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Correctly calculating height of Callout aligning to the top and covering target.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -495,6 +495,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       backgroundColor,
       calloutMaxHeight,
       onScroll,
+      // eslint-disable-next-line deprecation/deprecation
       shouldRestoreFocus = true,
       target,
       hidden,

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -126,6 +126,7 @@ function useMaxHeight(
     gapSpace,
     beakWidth,
     isBeakVisible,
+    coverTarget,
   }: ICalloutProps,
   getBounds: () => IRectangle | undefined,
   targetRef: React.RefObject<Element | MouseEvent | Point | null>,
@@ -141,9 +142,9 @@ function useMaxHeight(
     let { bottom: bottomBounds } = bounds;
     let calculatedHeight: number | undefined;
 
-    // If aligned to top edge of target, update bottom bounds to the top of the target
-    // (accounting for gap space and beak)
-    if (positions?.targetEdge === RectangleEdge.top && targetRect?.top) {
+    // If aligned to top edge of target and not covering target, update bottom bounds to the
+    // top of the target (accounting for gap space and beak)
+    if (positions?.targetEdge === RectangleEdge.top && targetRect?.top && !coverTarget) {
       bottomBounds = targetRect.top - calculateGapSpace(isBeakVisible, beakWidth, gapSpace);
     }
 
@@ -177,6 +178,7 @@ function useMaxHeight(
     beakWidth,
     isBeakVisible,
     targetRect,
+    coverTarget,
   ]);
 
   return maxHeight;
@@ -493,7 +495,6 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       backgroundColor,
       calloutMaxHeight,
       onScroll,
-      // eslint-disable-next-line deprecation/deprecation
       shouldRestoreFocus = true,
       target,
       hidden,

--- a/packages/react/src/components/Keytip/Keytip.tsx
+++ b/packages/react/src/components/Keytip/Keytip.tsx
@@ -36,9 +36,9 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
       // Set callout to top-left corner, will be further positioned in
       // getCalloutOffsetStyles
       calloutProps = {
-        ...calloutProps,
         coverTarget: true,
         directionalHint: DirectionalHint.topLeftEdge,
+        ...calloutProps,
       };
     }
 


### PR DESCRIPTION
## Previous Behavior

Whenever a top edge alignment was specified as well as covering the target, the `Callout` would make wrong calculations about its height that would cause it to not render properly.

![Screenshot 2024-02-02 172903](https://github.com/microsoft/fluentui/assets/7798177/a3b4eb3c-ef5a-4e71-8c52-54630587fb10)

## New Behavior

The `Callout` now calculates its height correctly under these conditions.

![Screenshot 2024-02-02 173009](https://github.com/microsoft/fluentui/assets/7798177/baa6c5f5-2ff0-42f1-840e-e3a3a4ba4b28)

As part of investigating this issue, we also noticed that `calloutProps` passed to `Keytips` were not always respected, so that is a fix is also included as part of this PR.