### PR TITLE
Fix color tokens to render charts correctly for v9 theme

### DIFF
--- a/change/@fluentui-react-charting-4ff1470e-7359-4539-ac6d-724412f4cd67.json
+++ b/change/@fluentui-react-charting-4ff1470e-7359-4539-ac6d-724412f4cd67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: Fix color tokens to enable charts to render correctly for v9 theme",
+  "packageName": "@fluentui/react-charting",
+  "email": "atisjai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -615,7 +615,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     if (this.state.nearestCircleToHighlight === xDataPoint || this.state.activePoint === circleId) {
       this._highlightedCircleId = circleId;
       if (!this.state.isCircleClicked) {
-        fillColor = this.props.theme!.palette.white;
+        fillColor = this.props.theme!.semanticColors.bodyBackground;
       }
     }
 

--- a/packages/react-charting/src/components/DonutChart/Arc/Arc.styles.ts
+++ b/packages/react-charting/src/components/DonutChart/Arc/Arc.styles.ts
@@ -1,5 +1,5 @@
 import { IArcProps, IArcStyles } from './Arc.types';
-import { DefaultPalette, FontSizes, FontWeights } from '@fluentui/react/lib/Styling';
+import { FontSizes, FontWeights } from '@fluentui/react/lib/Styling';
 
 export const getStyles = (props: IArcProps): IArcStyles => {
   const { color, href, theme } = props;
@@ -7,7 +7,7 @@ export const getStyles = (props: IArcProps): IArcStyles => {
     root: {
       fill: color,
       cursor: href ? 'pointer' : 'default',
-      stroke: DefaultPalette.white,
+      stroke: theme.semanticColors.bodyBackground,
       outline: 'transparent',
       selectors: {
         '::-moz-focus-inner': {

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChartRTL.test.tsx.snap
@@ -653,7 +653,7 @@ exports[`Donut chart interactions Should reflect theme change 1`] = `
                         cursor: default;
                         fill: #E5E5E5;
                         outline: transparent;
-                        stroke: #ffffff;
+                        stroke: #1b1a19;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -675,7 +675,7 @@ exports[`Donut chart interactions Should reflect theme change 1`] = `
                         cursor: default;
                         fill: #0078D4;
                         outline: transparent;
-                        stroke: #ffffff;
+                        stroke: #1b1a19;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -697,7 +697,7 @@ exports[`Donut chart interactions Should reflect theme change 1`] = `
                         cursor: default;
                         fill: #DADADA;
                         outline: transparent;
-                        stroke: #ffffff;
+                        stroke: #1b1a19;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/react-charting/src/components/GaugeChart/GaugeChart.styles.ts
+++ b/packages/react-charting/src/components/GaugeChart/GaugeChart.styles.ts
@@ -41,7 +41,7 @@ export const getStyles = (props: IGaugeChartStyleProps): IGaugeChartStyles => {
 
     needle: {
       fill: theme.palette.black,
-      stroke: theme.palette.white,
+      stroke: theme.semanticColors.bodyBackground,
     },
 
     chartTitle: {

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -407,7 +407,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
 
   private _getColor(title: string, color: string): string {
     const { theme } = this.props;
-    const { palette } = theme!;
     let legendColor = color;
     // if one or more legends are selected
     if (this._isLegendSelected) {
@@ -417,7 +416,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       }
       // if the given legend is unselected
       else {
-        legendColor = palette.white;
+        legendColor = theme!.semanticColors.buttonBackground;
       }
     }
     // if no legend is selected
@@ -429,7 +428,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       }
       // if there is a hovered legend but the given legend is not the one
       else {
-        legendColor = palette.white;
+        legendColor = theme!.semanticColors.buttonBackground;
       }
     }
     return legendColor;

--- a/packages/react-charting/src/components/Legends/Legends.styles.ts
+++ b/packages/react-charting/src/components/Legends/Legends.styles.ts
@@ -39,7 +39,7 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       selectors: {
         [HighContrastSelector]: {
           content: `linear-gradient(to right, ${props.colorOnSelectedState}, ${props.colorOnSelectedState})`,
-          opacity: props.colorOnSelectedState === palette.white ? '0.6' : '',
+          opacity: props.colorOnSelectedState === theme!.semanticColors.buttonBackground ? '0.6' : '',
         },
       },
       width: '12px',
@@ -66,7 +66,12 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       borderTop: '10.4px solid',
       borderTopColor: props.colorOnSelectedState,
       marginRight: '8px',
-      opacity: props.colorOnSelectedState === palette.white ? '0.6' : props.opacity ? props.opacity : '',
+      opacity:
+        props.colorOnSelectedState === theme!.semanticColors.buttonBackground
+          ? '0.6'
+          : props.opacity
+          ? props.opacity
+          : '',
       selectors: {
         [HighContrastSelector]: {
           border: '0px',
@@ -81,12 +86,12 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       ...fonts.small,
       lineHeight: '16px',
       color: theme?.semanticColors.bodyText,
-      opacity: props.colorOnSelectedState === palette.white ? '0.67' : '',
+      opacity: props.colorOnSelectedState === theme!.semanticColors.buttonBackground ? '0.67' : '',
     },
     hoverChange: {
       width: '12px',
       height: '12px',
-      backgroundColor: 'white',
+      backgroundColor: theme!.semanticColors.buttonBackground,
       marginRight: '8px',
       border: '1px solid',
       borderColor: props.borderColor ? props.borderColor : palette.black,

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -525,20 +525,20 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     if (allowMultipleShapesForPoints) {
       if (pointIndex === 1 || isLastPoint) {
         if (activePoint === pointId) {
-          return theme!.palette.white;
+          return theme!.semanticColors.bodyBackground;
         } else {
           return lineColor;
         }
       } else {
         if (activePoint === pointId) {
-          return theme!.palette.white;
+          return theme!.semanticColors.bodyBackground;
         } else {
           return lineColor;
         }
       }
     } else {
       if (activePoint === pointId) {
-        return theme!.palette.white;
+        return theme!.semanticColors.bodyBackground;
       } else {
         return lineColor;
       }
@@ -571,7 +571,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             r={activePoint === circleId ? 5.5 : 3.5}
             cx={this._xAxisScale(x1)}
             cy={this._yAxisScale(y1)}
-            fill={activePoint === circleId ? theme!.palette.white : lineColor}
+            fill={activePoint === circleId ? theme!.semanticColors.bodyBackground : lineColor}
             onMouseOver={this._handleHover.bind(
               this,
               x1,
@@ -649,7 +649,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                 fill="transparent"
                 strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
                 strokeWidth={Number.parseFloat(strokeWidth.toString()) + lineBorderWidth}
-                stroke={this._points[i].lineOptions?.lineBorderColor || theme!.palette.white}
+                stroke={this._points[i].lineOptions?.lineBorderColor || theme!.semanticColors.bodyBackground}
                 opacity={1}
               />,
             );
@@ -705,7 +705,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             r={5.5}
             cx={0}
             cy={0}
-            fill={theme!.palette.white}
+            fill={theme!.semanticColors.bodyBackground}
             strokeWidth={DEFAULT_LINE_STROKE_SIZE}
             stroke={lineColor}
             visibility={isPointHighlighted ? 'visibility' : 'hidden'}
@@ -885,7 +885,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                     y2={this._yAxisScale(y2)}
                     strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
                     strokeWidth={Number.parseFloat(strokeWidth.toString()) + lineBorderWidth}
-                    stroke={this._points[i].lineOptions?.lineBorderColor || theme!.palette.white}
+                    stroke={this._points[i].lineOptions?.lineBorderColor || theme!.semanticColors.bodyBackground}
                     opacity={1}
                   />,
                 );

--- a/packages/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
+++ b/packages/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
@@ -61,7 +61,7 @@ export const LabelLink: React.FunctionComponent<ILabelLinkProps> = props => {
   let text: string;
   const fill: string | undefined = props.textColor
     ? getColorFromToken(props.textColor, props.theme?.isInverted)
-    : props.theme?.palette.black;
+    : props.theme?.semanticColors.messageText;
 
   if (props.labelDef.aggregatedIdx.length === 1) {
     text = props.lineDefs[props.labelDef.aggregatedIdx[0]].event;

--- a/packages/react-charting/src/components/Sparkline/Sparkline.styles.ts
+++ b/packages/react-charting/src/components/Sparkline/Sparkline.styles.ts
@@ -7,7 +7,7 @@ export const getStyles = (props: ISparklineStyleProps): ISparklineStyles => {
     },
     valueText: {
       ...props.theme!.fonts.smallPlus,
-      fill: props.theme!.palette.black,
+      fill: props.theme!.semanticColors.messageText,
     },
   };
 };

--- a/packages/react-charting/src/components/Sparkline/__snapshots__/Sparkline.test.tsx.snap
+++ b/packages/react-charting/src/components/Sparkline/__snapshots__/Sparkline.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`Sparkline snapShot testing renders Sparkline correctly 1`] = `
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              fill: #000000;
+              fill: #323130;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;

--- a/packages/react-charting/src/components/Sparkline/__snapshots__/SparklineRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/Sparkline/__snapshots__/SparklineRTL.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Sparkline snapShot testing renders Sparkline correctly 1`] = `
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              fill: #000000;
+              fill: #323130;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;

--- a/packages/react-charting/src/components/TreeChart/TreeChart.styles.ts
+++ b/packages/react-charting/src/components/TreeChart/TreeChart.styles.ts
@@ -17,24 +17,24 @@ export const getStyles = (props: ITreeStyleProps): ITreeStyles => {
     },
     rectNode: {
       strokeWidth: '2px',
-      fill: 'white',
+      fill: props.theme!.semanticColors.bodyBackground,
       padding: '10px',
       rx: '2px',
     },
     rectText: {
-      fill: 'black',
+      fill: props.theme!.semanticColors.messageText,
       ...props.theme!.fonts.large,
     },
     rectSubText: {
-      fill: '#484644',
+      fill: props.theme!.semanticColors.bodySubtext,
       ...props.theme!.fonts.medium,
     },
     rectBodyText: {
-      fill: '#808080',
+      fill: props.theme!.palette.neutralTertiary,
       ...props.theme!.fonts.xSmall,
     },
     rectMetricText: {
-      fill: '#000000',
+      fill: props.theme!.palette.neutralSecondary,
       ...props.theme!.fonts.xLarge,
     },
   };

--- a/packages/react-charting/src/components/TreeChart/TreeChart.styles.ts
+++ b/packages/react-charting/src/components/TreeChart/TreeChart.styles.ts
@@ -22,19 +22,19 @@ export const getStyles = (props: ITreeStyleProps): ITreeStyles => {
       rx: '2px',
     },
     rectText: {
-      fill: props.theme!.semanticColors.messageText,
+      fill: props.theme!.palette.neutralDark,
       ...props.theme!.fonts.large,
     },
     rectSubText: {
-      fill: props.theme!.semanticColors.bodySubtext,
+      fill: props.theme!.palette.neutralPrimary,
       ...props.theme!.fonts.medium,
     },
     rectBodyText: {
-      fill: props.theme!.palette.neutralTertiary,
+      fill: props.theme!.palette.neutralPrimaryAlt,
       ...props.theme!.fonts.xSmall,
     },
     rectMetricText: {
-      fill: props.theme!.palette.neutralSecondary,
+      fill: props.theme!.palette.neutralDark,
       ...props.theme!.fonts.xLarge,
     },
   };

--- a/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
+++ b/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
@@ -40,7 +40,7 @@ subText subtext Root Node"
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -63,7 +63,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -79,7 +79,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -99,7 +99,7 @@ subText subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -122,7 +122,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #484644;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -138,7 +138,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #000000;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -158,7 +158,7 @@ subText sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -181,7 +181,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -197,7 +197,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -217,7 +217,7 @@ subText undefined Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -240,7 +240,7 @@ subText undefined Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #000000;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -260,7 +260,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -283,7 +283,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -299,7 +299,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -319,7 +319,7 @@ subText sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -342,7 +342,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -358,7 +358,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -378,7 +378,7 @@ subText undefined Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -401,7 +401,7 @@ subText undefined Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #000000;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -421,7 +421,7 @@ subText sub Parent info parentId: 6
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -444,7 +444,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -460,7 +460,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -480,7 +480,7 @@ subText sub Parent info parentId: 6
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -503,7 +503,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -519,7 +519,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -539,7 +539,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -562,7 +562,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -578,7 +578,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -598,7 +598,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -621,7 +621,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -637,7 +637,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -657,7 +657,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -680,7 +680,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -696,7 +696,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -716,7 +716,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -739,7 +739,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -755,7 +755,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -775,7 +775,7 @@ subText subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -798,7 +798,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #484644;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -814,7 +814,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #000000;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -834,7 +834,7 @@ subText sub Parent info parentId: 13
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -857,7 +857,7 @@ subText sub Parent info parentId: 13
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -873,7 +873,7 @@ subText sub Parent info parentId: 13
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -989,7 +989,7 @@ subText subtext Root Node"
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1012,7 +1012,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1028,7 +1028,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1048,7 +1048,7 @@ subText subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1071,7 +1071,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #484644;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -1087,7 +1087,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #000000;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -1107,7 +1107,7 @@ subText sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1130,7 +1130,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1146,7 +1146,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1166,7 +1166,7 @@ subText undefined Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1189,7 +1189,7 @@ subText undefined Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #000000;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -1209,7 +1209,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1232,7 +1232,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1248,7 +1248,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1268,7 +1268,7 @@ subText sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1291,7 +1291,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1307,7 +1307,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1327,7 +1327,7 @@ subText undefined Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1350,7 +1350,7 @@ subText undefined Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #000000;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -1370,7 +1370,7 @@ subText sub Parent info parentId: 6
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1393,7 +1393,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1409,7 +1409,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1429,7 +1429,7 @@ subText sub Parent info parentId: 6
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1452,7 +1452,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1468,7 +1468,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1488,7 +1488,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1511,7 +1511,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1527,7 +1527,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1547,7 +1547,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1570,7 +1570,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1586,7 +1586,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1606,7 +1606,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1629,7 +1629,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1645,7 +1645,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1665,7 +1665,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1688,7 +1688,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1704,7 +1704,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1724,7 +1724,7 @@ subText subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1747,7 +1747,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #484644;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -1763,7 +1763,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #000000;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -1783,7 +1783,7 @@ subText sub Parent info parentId: 13
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1806,7 +1806,7 @@ subText sub Parent info parentId: 13
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1822,7 +1822,7 @@ subText sub Parent info parentId: 13
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1938,7 +1938,7 @@ subText subtext Root Node"
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -1961,7 +1961,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1977,7 +1977,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1997,7 +1997,7 @@ subText subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2020,7 +2020,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #484644;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -2036,7 +2036,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #000000;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -2056,7 +2056,7 @@ subText sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2079,7 +2079,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2095,7 +2095,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2115,7 +2115,7 @@ subText undefined Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2138,7 +2138,7 @@ subText undefined Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #000000;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -2158,7 +2158,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2181,7 +2181,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2197,7 +2197,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2217,7 +2217,7 @@ subText sub Parent info parentId: 1
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2240,7 +2240,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2256,7 +2256,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2276,7 +2276,7 @@ subText undefined Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2299,7 +2299,7 @@ subText undefined Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #000000;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -2319,7 +2319,7 @@ subText sub Parent info parentId: 6
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2342,7 +2342,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2358,7 +2358,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2378,7 +2378,7 @@ subText sub Parent info parentId: 6
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2401,7 +2401,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2417,7 +2417,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2437,7 +2437,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2460,7 +2460,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2476,7 +2476,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2496,7 +2496,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2519,7 +2519,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2535,7 +2535,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2555,7 +2555,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2578,7 +2578,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2594,7 +2594,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2614,7 +2614,7 @@ subText sub Parent info parentId: 9
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2637,7 +2637,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2653,7 +2653,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2673,7 +2673,7 @@ subText subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2696,7 +2696,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #484644;
+                fill: #605e5c;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -2712,7 +2712,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #000000;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -2732,7 +2732,7 @@ subText sub Parent info parentId: 13
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2755,7 +2755,7 @@ subText sub Parent info parentId: 13
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2771,7 +2771,7 @@ subText sub Parent info parentId: 13
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2887,7 +2887,7 @@ subText subtext Root Node"
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2910,7 +2910,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2926,7 +2926,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2946,7 +2946,7 @@ subText Subtext val is subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -2969,7 +2969,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2985,7 +2985,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -3005,7 +3005,7 @@ subText Subtext val is subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -3028,7 +3028,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -3044,7 +3044,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -3064,7 +3064,7 @@ subText Subtext val is subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -3087,7 +3087,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -3103,7 +3103,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -3123,7 +3123,7 @@ subText Subtext val is subtext Parent info parentId: 0
           className=
 
               {
-                fill: white;
+                fill: #ffffff;
                 padding-bottom: 10px;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -3146,7 +3146,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: black;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -3162,7 +3162,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #484644;
+                  fill: #605e5c;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;

--- a/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
+++ b/packages/react-charting/src/components/TreeChart/__snapshots__/TreeChart.test.tsx.snap
@@ -63,7 +63,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -79,7 +79,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -122,7 +122,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -138,7 +138,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #201f1e;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -181,7 +181,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -197,7 +197,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -240,7 +240,7 @@ subText undefined Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -283,7 +283,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -299,7 +299,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -342,7 +342,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -358,7 +358,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -401,7 +401,7 @@ subText undefined Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -444,7 +444,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -460,7 +460,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -503,7 +503,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -519,7 +519,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -562,7 +562,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -578,7 +578,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -621,7 +621,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -637,7 +637,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -680,7 +680,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -696,7 +696,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -739,7 +739,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -755,7 +755,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -798,7 +798,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -814,7 +814,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #201f1e;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -857,7 +857,7 @@ subText sub Parent info parentId: 13
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -873,7 +873,7 @@ subText sub Parent info parentId: 13
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1012,7 +1012,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1028,7 +1028,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1071,7 +1071,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -1087,7 +1087,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #201f1e;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -1130,7 +1130,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1146,7 +1146,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1189,7 +1189,7 @@ subText undefined Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -1232,7 +1232,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1248,7 +1248,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1291,7 +1291,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1307,7 +1307,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1350,7 +1350,7 @@ subText undefined Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -1393,7 +1393,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1409,7 +1409,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1452,7 +1452,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1468,7 +1468,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1511,7 +1511,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1527,7 +1527,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1570,7 +1570,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1586,7 +1586,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1629,7 +1629,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1645,7 +1645,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1688,7 +1688,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1704,7 +1704,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1747,7 +1747,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -1763,7 +1763,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #201f1e;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -1806,7 +1806,7 @@ subText sub Parent info parentId: 13
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1822,7 +1822,7 @@ subText sub Parent info parentId: 13
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -1961,7 +1961,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -1977,7 +1977,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2020,7 +2020,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -2036,7 +2036,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #201f1e;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -2079,7 +2079,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2095,7 +2095,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2138,7 +2138,7 @@ subText undefined Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -2181,7 +2181,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2197,7 +2197,7 @@ subText The subtext is as follows: sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2240,7 +2240,7 @@ subText sub Parent info parentId: 1
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2256,7 +2256,7 @@ subText sub Parent info parentId: 1
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2299,7 +2299,7 @@ subText undefined Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 20px;
                 font-weight: 600;
@@ -2342,7 +2342,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2358,7 +2358,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2401,7 +2401,7 @@ subText sub Parent info parentId: 6
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2417,7 +2417,7 @@ subText sub Parent info parentId: 6
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2460,7 +2460,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2476,7 +2476,7 @@ subText The subtext is as follows: subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2519,7 +2519,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2535,7 +2535,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2578,7 +2578,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2594,7 +2594,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2637,7 +2637,7 @@ subText sub Parent info parentId: 9
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2653,7 +2653,7 @@ subText sub Parent info parentId: 9
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2696,7 +2696,7 @@ subText subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #605e5c;
+                fill: #323130;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
@@ -2712,7 +2712,7 @@ subText subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #201f1e;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 20px;
                   font-weight: 600;
@@ -2755,7 +2755,7 @@ subText sub Parent info parentId: 13
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2771,7 +2771,7 @@ subText sub Parent info parentId: 13
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2910,7 +2910,7 @@ subText subtext Root Node"
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2926,7 +2926,7 @@ subText subtext Root Node"
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -2969,7 +2969,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -2985,7 +2985,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -3028,7 +3028,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -3044,7 +3044,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -3087,7 +3087,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -3103,7 +3103,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -3146,7 +3146,7 @@ subText Subtext val is subtext Parent info parentId: 0
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                fill: #323130;
+                fill: #201f1e;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 18px;
                 font-weight: 400;
@@ -3162,7 +3162,7 @@ subText Subtext val is subtext Parent info parentId: 0
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  fill: #605e5c;
+                  fill: #323130;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;

--- a/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -245,7 +245,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           fill="transparent"
           strokeLinecap="square"
           strokeWidth={3 + lineBorderWidth * 2}
-          stroke={theme!.palette.white}
+          stroke={theme!.semanticColors.bodyBackground}
         />,
       );
     }
@@ -283,7 +283,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
             onMouseOut={this._onBarLeave}
             r={8}
             stroke={lineLegendColor}
-            fill={this.props.theme!.palette.white}
+            fill={this.props.theme!.semanticColors.bodyBackground}
             strokeWidth={3}
             visibility={this.state.activeXdataPoint === item.x ? CircleVisbility.show : CircleVisbility.hide}
             onClick={item.point.lineData?.onClick}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -360,7 +360,7 @@ export class VerticalStackedBarChartBase extends React.Component<
               strokeWidth={3 + lineBorderWidth * 2}
               fill="transparent"
               strokeLinecap="round"
-              stroke={theme!.palette.white}
+              stroke={theme!.semanticColors.bodyBackground}
               transform={`translate(${xScaleBandwidthTranslate}, 0)`}
             />,
           );
@@ -412,7 +412,7 @@ export class VerticalStackedBarChartBase extends React.Component<
             })}
             r={this._getCircleVisibilityAndRadius(circlePoint.xItem.xAxisPoint, circlePoint.legend).radius}
             stroke={circlePoint.color}
-            fill={this.props.theme!.palette.white}
+            fill={this.props.theme!.semanticColors.bodyBackground}
             strokeWidth={3}
             visibility={this._getCircleVisibilityAndRadius(circlePoint.xItem.xAxisPoint, circlePoint.legend).visibility}
             transform={`translate(${xScaleBandwidthTranslate}, 0)`}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
There was usage of non semantic colors like white and black in charting code.
These colors work fine in light mode or ideal scenarios where the foreground/background colors are represented as absolute white and black.
This starts causing an issue with Fluent v9 themes where dark mode background is not absolute black but a shade of grey.
This creates following issues in charting controls.
#30397 
#30396 

<!-- This is the behavior we have today -->

## New Behavior
Updated the tokens to use semantic or neutral colors.
This moves the responsibility of handling color tokens to the theme.
Charts will now work seamlessly across v8 and v9 themes.

Related PR:
https://github.com/microsoft/fluentui/pull/30373
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
