### PR TITLE
fix(workspace-plugin): dont use ecma reserved word for star import alias within bundle-size-configuration generator

### DIFF
--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/files/bundle-size/index.fixture.js.template
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/files/bundle-size/index.fixture.js.template
@@ -1,6 +1,6 @@
-import * as package from '<%= packageName %>'
+import * as p from '<%= packageName %>'
 
-console.log(package);
+console.log(p);
 
 export default {
   name: '<%= packageName %> - package',

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
@@ -33,9 +33,9 @@ describe('bundle-size-configuration generator', () => {
     expect(packageJson.scripts['bundle-size']).toEqual('monosize measure');
 
     expect(tree.read(joinPathFragments(config.root, 'bundle-size/index.fixture.js'), 'utf-8')).toMatchInlineSnapshot(`
-      "import * as package from '@proj/react-continental';
+      "import * as p from '@proj/react-continental';
 
-      console.log(package);
+      console.log(p);
 
       export default {
         name: '@proj/react-continental - package',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

current setup creates fixture that will not compile 

<img width="870" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/021fdeba-459f-4cbf-952f-3508ffabf8bd">


## New Behavior

see PR title

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/issues/27933 
