### PR TITLE
fix: MessageBar with no actions should have correct spacing

### DIFF
--- a/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
@@ -64,6 +64,27 @@ export const Multiline = () => (
   </div>
 );
 
+export const MultilineNoActions = () => (
+  <div
+    style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 500, padding: 10 }}
+    className="testWrapper"
+  >
+    {intents.map(intent => (
+      <MessageBar layout="multiline" key={intent} intent={intent}>
+        <MessageBarBody>
+          <MessageBarTitle>{intent}</MessageBarTitle>
+          Message providing information to the user with actionable insights. <Link>Link</Link>
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum."
+        </MessageBarBody>
+      </MessageBar>
+    ))}
+  </div>
+);
+
 export const Auto = () => {
   return (
     <div

--- a/change/@fluentui-react-message-bar-bcac357a-71f0-438b-89fe-087e112ab7ec.json
+++ b/change/@fluentui-react-message-bar-bcac357a-71f0-438b-89fe-087e112ab7ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MessageBar with no actions should have correct spacing",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar/etc/react-message-bar.api.md
+++ b/packages/react-components/react-message-bar/etc/react-message-bar.api.md
@@ -104,6 +104,7 @@ export type MessageBarProps = ComponentProps<MessageBarSlots> & Pick<Partial<Mes
 export type MessageBarSlots = {
     root: Slot<'div'>;
     icon?: Slot<'div'>;
+    bottomReflowSpacer?: Slot<'div'>;
 };
 
 // @public

--- a/packages/react-components/react-message-bar/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/react-components/react-message-bar/src/components/MessageBar/MessageBar.test.tsx
@@ -7,6 +7,7 @@ import { MessageBarBody } from '../MessageBarBody/MessageBarBody';
 import { MessageBarTitle } from '../MessageBarTitle/MessageBarTitle';
 import { MessageBarActions } from '../MessageBarActions/MessageBarActions';
 import { resetIdsForTests } from '@fluentui/react-utilities';
+import { MessageBarProps } from './MessageBar.types';
 
 describe('MessageBar', () => {
   beforeAll(() => {
@@ -28,7 +29,7 @@ describe('MessageBar', () => {
     resetIdsForTests();
   });
 
-  isConformant({
+  isConformant<MessageBarProps>({
     Component: MessageBar,
     displayName: 'MessageBar',
     testOptions: {
@@ -36,6 +37,7 @@ describe('MessageBar', () => {
         {
           props: {
             icon: 'Icon',
+            layout: 'multiline',
           },
         },
       ],

--- a/packages/react-components/react-message-bar/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/react-components/react-message-bar/src/components/MessageBar/MessageBar.types.ts
@@ -4,6 +4,15 @@ import type { MessageBarContextValue } from '../../contexts/messageBarContext';
 export type MessageBarSlots = {
   root: Slot<'div'>;
   icon?: Slot<'div'>;
+  /**
+   * Rendered when the component is in multiline layout to guarantee correct spacing even
+   * if no actions are rendered. When actions are rendered, the default actions grid area will render
+   * over this element
+   *
+   * NOTE: If you are using this slot, this probably means that you are using the MessageBar without
+   * actions, this is not recommended from an accesibility point of view
+   */
+  bottomReflowSpacer?: Slot<'div'>;
 };
 
 export type MessageBarContextValues = {

--- a/packages/react-components/react-message-bar/src/components/MessageBar/renderMessageBar.tsx
+++ b/packages/react-components/react-message-bar/src/components/MessageBar/renderMessageBar.tsx
@@ -16,6 +16,7 @@ export const renderMessageBar_unstable = (state: MessageBarState, contexts: Mess
       <state.root>
         {state.icon && <state.icon />}
         {state.root.children}
+        {state.bottomReflowSpacer && <state.bottomReflowSpacer />}
       </state.root>
     </MessageBarContextProvider>
   );

--- a/packages/react-components/react-message-bar/src/components/MessageBar/useMessageBar.ts
+++ b/packages/react-components/react-message-bar/src/components/MessageBar/useMessageBar.ts
@@ -39,6 +39,7 @@ export const useMessageBar_unstable = (props: MessageBarProps, ref: React.Ref<HT
     components: {
       root: 'div',
       icon: 'div',
+      bottomReflowSpacer: 'div',
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
@@ -54,6 +55,10 @@ export const useMessageBar_unstable = (props: MessageBarProps, ref: React.Ref<HT
       renderByDefault: true,
       elementType: 'div',
       defaultProps: { children: getIntentIcon(intent) },
+    }),
+    bottomReflowSpacer: slot.optional(props.bottomReflowSpacer, {
+      renderByDefault: computedLayout === 'multiline',
+      elementType: 'div',
     }),
     layout: computedLayout,
     intent,

--- a/packages/react-components/react-message-bar/src/components/MessageBar/useMessageBarStyles.styles.ts
+++ b/packages/react-components/react-message-bar/src/components/MessageBar/useMessageBarStyles.styles.ts
@@ -6,6 +6,7 @@ import type { MessageBarSlots, MessageBarState } from './MessageBar.types';
 export const messageBarClassNames: SlotClassNames<MessageBarSlots> = {
   root: 'fui-MessageBar',
   icon: 'fui-MessageBar__icon',
+  bottomReflowSpacer: 'fui-MessageBar__bottomReflowSpacer',
 };
 
 const useRootBaseStyles = makeResetStyles({
@@ -30,6 +31,11 @@ const useIconBaseStyles = makeResetStyles({
   color: tokens.colorNeutralForeground3,
   display: 'flex',
   alignItems: 'center',
+});
+
+const useReflowSpacerBaseStyles = makeResetStyles({
+  marginBottom: tokens.spacingVerticalS,
+  gridArea: 'secondaryActions',
 });
 
 const useStyles = makeStyles({
@@ -97,6 +103,7 @@ export const useMessageBarStyles_unstable = (state: MessageBarState): MessageBar
   const iconBaseStyles = useIconBaseStyles();
   const iconIntentStyles = useIconIntentStyles();
   const rootIntentStyles = useRootIntentStyles();
+  const reflowSpacerStyles = useReflowSpacerBaseStyles();
   const styles = useStyles();
 
   state.root.className = mergeClasses(
@@ -116,6 +123,10 @@ export const useMessageBarStyles_unstable = (state: MessageBarState): MessageBar
       iconIntentStyles[state.intent],
       state.icon.className,
     );
+  }
+
+  if (state.bottomReflowSpacer) {
+    state.bottomReflowSpacer.className = mergeClasses(messageBarClassNames.bottomReflowSpacer, reflowSpacerStyles);
   }
 
   return state;


### PR DESCRIPTION
Design guidance has always considered MessageBar to include at least one action for accessibility requirements. However, there are still cases in product where MessageBar is used without any actions.

When no actions are rendered, the default secondary actions slot is no longer rendered (that provides correct spacing). In order to handle this edge case the MessageBar will render a new slot `bottomReflowSpacer` that sets the correct spacing in in the same grid area.

There should be no conflict with current secondary actions since the grid layout will render both in the same area and the spacer is just an empty div

Fixes #30461

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
