### PR TITLE
fix: GroupedList sets correct focus attributes on List

### DIFF
--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -168,6 +168,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
             usePageCache={usePageCache}
             onShouldVirtualize={onShouldVirtualize}
             version={version}
+            renderEarly={true}
             {...rootListProps}
           />
         )}

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { initializeComponentRef, classNamesFunction, KeyCodes, getRTLSafeKeyCode, css } from '../../Utilities';
+import {
+  initializeComponentRef,
+  classNamesFunction,
+  FocusRects,
+  KeyCodes,
+  getRTLSafeKeyCode,
+  css,
+} from '../../Utilities';
 import { GroupedListSection } from './GroupedListSection';
 import { List, ScrollToMode } from '../../List';
 import { SelectionMode } from '../../Selection';
@@ -154,6 +161,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
         shouldEnterInnerZone={shouldEnterInnerZone}
         className={css(this._classNames.root, focusZoneProps.className)}
       >
+        <FocusRects />
         {!groups ? (
           this._renderGroup(undefined, 0)
         ) : (


### PR DESCRIPTION
## Previous Behavior
Related to #27002

GroupedList internally used List, because of the same bug in the linked issue, the internal FocusZone was not setting focus on the first row in the List.

Instead, focus went to the first tabbable item in the content of the List (usually the checkbox), which meant arrow key interaction and screen reader behavior was not correct.

Additionally, the focus outline was not showing up since GroupedList does not initiate FocusRects itself (this only repros if you create a sandbox with only GroupedList and no other Fluent controls, since other controls will initate FocusRects if included).

## New Behavior

Sets the `renderEarly` flag on List, so FocusZone can set tabIndex on the first row in List. Also adds `FocusRects` to GroupedList.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18041)
