### PR TITLE
chore(react-aria): adds @fluentui/react-jsx-runtime as dependency

### DIFF
--- a/change/@fluentui-react-aria-4272dc51-3c77-444a-b9d3-1e40a1fc40ee.json
+++ b/change/@fluentui-react-aria-4272dc51-3c77-444a-b9d3-1e40a1fc40ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adds @fluentui/react-jsx-runtime as dependency",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/package.json
+++ b/packages/react-components/react-aria/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",
     "@fluentui/react-shared-contexts": "^9.14.0",
+    "@fluentui/react-jsx-runtime": "^9.0.29",
     "@fluentui/react-tabster": "^9.18.0",
     "@fluentui/react-utilities": "^9.18.0",
     "@swc/helpers": "^0.5.1"


### PR DESCRIPTION
As https://github.com/microsoft/fluentui/pull/30345 Introduces:

https://github.com/microsoft/fluentui/blob/c39e261e7c1f7543c8f0892461597765aaca2970/packages/react-components/react-aria/src/AriaLiveAnnouncer/renderAriaLiveAnnouncer.tsx#L1-L2

`@fluentui/react-aria` required the dependency of `@fluentui/react-jsx-runtime`

<!-- This is the behavior we have today -->

## New Behavior

1 adds `@fluentui/react-jsx-runtime` as a dependency

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/microsoft/fluentui/issues/30400#issuecomment-1928982262
