### PR TITLE
fix: MenuPopover should stay open for submenu even when not openOnHover

### DIFF
--- a/change/@fluentui-react-menu-5263c408-028b-430c-aeac-d0dcccf716c6.json
+++ b/change/@fluentui-react-menu-5263c408-028b-430c-aeac-d0dcccf716c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuPopover should stay open for submenu even when not openOnHover",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/src/components/MenuPopover/useMenuPopover.ts
@@ -74,7 +74,7 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
   );
   const { onMouseEnter: onMouseEnterOriginal, onKeyDown: onKeyDownOriginal } = rootProps;
   rootProps.onMouseEnter = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (openOnHover) {
+    if (openOnHover || isSubmenu) {
       setOpen(event, { open: true, keyboard: false, type: 'menuPopoverMouseEnter', event });
     }
     onMouseEnterOriginal?.(event);


### PR DESCRIPTION
Currently submenus will only stay open when the mouse enters the MenuPopover when `openOnHover` is set. The assumption was that all submenus would generally be opened with hover.

Updates the check on mouse enter for the MenuPopover so that if the MenuPopover is part of submenu, it should also stay open on mouse enter.

Fixes #30394

