### PR TITLE
chore: Integrate microsoft/monosize in react-charting library for AreaChart and VerticalBarChart

### DIFF
--- a/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
+++ b/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "none",
   "comment": "chore: Integrate microsoft/monosize into react-charting for AreaChart and VerticalBarChart",
   "packageName": "@fluentui/react-charting",
   "email": "shubhabrata08@gmail.com",

--- a/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
+++ b/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Integrate microsoft/monosize into react-charting",
+  "packageName": "@fluentui/react-charting",
+  "email": "shubhabrata08@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
+++ b/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Integrate microsoft/monosize into react-charting",
+  "comment": "chore: Integrate microsoft/monosize into react-charting for AreaChart and VerticalBarChart",
   "packageName": "@fluentui/react-charting",
   "email": "shubhabrata08@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
+++ b/change/@fluentui-react-charting-0091dd21-21f9-4537-8fd9-fbfee2e292e7.json
@@ -3,5 +3,5 @@
   "comment": "chore: Integrate microsoft/monosize into react-charting for AreaChart and VerticalBarChart",
   "packageName": "@fluentui/react-charting",
   "email": "shubhabrata08@gmail.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/react-charting/bundle-size/AreaChart.fixture.js
+++ b/packages/react-charting/bundle-size/AreaChart.fixture.js
@@ -1,9 +1,9 @@
 import { AreaChart } from '@fluentui/react-charting';
 
 console.log(AreaChart);
-// 👆 "console.log()" is the easiest way to prevent tree-shaking
+// "console.log()" is the easiest way to prevent tree-shaking
 
 export default {
   name: 'AreaChart',
-  // 👆 defines a name for story that will be used in output
+  // defines a name for story that will be used in output
 };

--- a/packages/react-charting/bundle-size/AreaChart.fixture.js
+++ b/packages/react-charting/bundle-size/AreaChart.fixture.js
@@ -1,0 +1,9 @@
+import { AreaChart } from '@fluentui/react-charting';
+
+console.log(AreaChart);
+// 👆 "console.log()" is the easiest way to prevent tree-shaking
+
+export default {
+  name: 'AreaChart',
+  // 👆 defines a name for story that will be used in output
+};

--- a/packages/react-charting/bundle-size/VerticalBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/VerticalBarChart.fixture.js
@@ -1,0 +1,9 @@
+import { VerticalBarChart } from '@fluentui/react-charting';
+
+console.log(VerticalBarChart);
+// "console.log()" is the easiest way to prevent tree-shaking
+
+export default {
+  name: 'VerticalBarChart',
+  // defines a name for story that will be used in output
+};

--- a/packages/react-charting/monosize.config.mjs
+++ b/packages/react-charting/monosize.config.mjs
@@ -1,0 +1,11 @@
+// monosize.config.mjs
+import storageAdapter from 'monosize-storage-upstash';
+
+export default {
+  repository: 'https://github.com/microsoft/fluentui',
+  storage: storageAdapter(),
+  webpack: config => {
+    // customize config here
+    return config;
+  },
+};

--- a/packages/react-charting/monosize.config.mjs
+++ b/packages/react-charting/monosize.config.mjs
@@ -1,5 +1,5 @@
 // monosize.config.mjs
-import storageAdapter from 'monosize-storage-upstash';
+import storageAdapter from 'monosize-storage-azure';
 
 export default {
   repository: 'https://github.com/microsoft/fluentui',

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -36,7 +36,9 @@
     "@fluentui/scripts-jest": "*",
     "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-webpack": "*",
-    "jest-canvas-mock": "2.4.0"
+    "jest-canvas-mock": "2.4.0",
+    "monosize": "0.2.1",
+    "monosize-storage-upstash": "0.0.12"
   },
   "dependencies": {
     "@fluentui/react-focus": "^8.8.40",

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -37,8 +37,7 @@
     "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-webpack": "*",
     "jest-canvas-mock": "2.4.0",
-    "monosize": "0.2.1",
-    "monosize-storage-upstash": "0.0.12"
+    "monosize": "0.2.1"
   },
   "dependencies": {
     "@fluentui/react-focus": "^8.8.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,13 +6193,6 @@
   dependencies:
     tslib "^1.10.0"
 
-"@upstash/redis@^1.18.0":
-  version "1.28.3"
-  resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-1.28.3.tgz#a93f661a3ee0d51f249df2fed312d7c0256f0708"
-  integrity sha512-IduU0zrxVKO0z4D+usJUP/VZRYkbbbSoAdj4WYwgijjhc1nxhRZEtktZ8ueTyXT4dAatJ+gDKIIbVSVIiB1xBw==
-  dependencies:
-    crypto-js "^4.2.0"
-
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz#db046555d3c413f8966ca50a95176a0e2c642e24"
@@ -10000,11 +9993,6 @@ crypto-browserify@^3.11.0, crypto-browserify@^3.12.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-js@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
-  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -18708,15 +18696,6 @@ monosize-storage-azure@0.0.6:
     monosize "^0.2.1"
     node-fetch "^3.3.0"
     picocolors "^1.0.0"
-    tslib "^2.4.1"
-
-monosize-storage-upstash@0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/monosize-storage-upstash/-/monosize-storage-upstash-0.0.12.tgz#cbdf9ae3c203b74e4775ea2db0aa1e00a104a6dc"
-  integrity sha512-3zy5i5ygxtB6Km/gVZltQMmSVhy7RQgSKS4Fou2n00YzBUaej3GpNaMI1KN7/c0eiM3L97R5rW0AGnHCJ0TfBQ==
-  dependencies:
-    "@upstash/redis" "^1.18.0"
-    monosize "^0.2.1"
     tslib "^2.4.1"
 
 monosize@0.2.1, monosize@^0.2.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,6 +6193,13 @@
   dependencies:
     tslib "^1.10.0"
 
+"@upstash/redis@^1.18.0":
+  version "1.28.3"
+  resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-1.28.3.tgz#a93f661a3ee0d51f249df2fed312d7c0256f0708"
+  integrity sha512-IduU0zrxVKO0z4D+usJUP/VZRYkbbbSoAdj4WYwgijjhc1nxhRZEtktZ8ueTyXT4dAatJ+gDKIIbVSVIiB1xBw==
+  dependencies:
+    crypto-js "^4.2.0"
+
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz#db046555d3c413f8966ca50a95176a0e2c642e24"
@@ -9993,6 +10000,11 @@ crypto-browserify@^3.11.0, crypto-browserify@^3.12.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -18696,6 +18708,15 @@ monosize-storage-azure@0.0.6:
     monosize "^0.2.1"
     node-fetch "^3.3.0"
     picocolors "^1.0.0"
+    tslib "^2.4.1"
+
+monosize-storage-upstash@0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/monosize-storage-upstash/-/monosize-storage-upstash-0.0.12.tgz#cbdf9ae3c203b74e4775ea2db0aa1e00a104a6dc"
+  integrity sha512-3zy5i5ygxtB6Km/gVZltQMmSVhy7RQgSKS4Fou2n00YzBUaej3GpNaMI1KN7/c0eiM3L97R5rW0AGnHCJ0TfBQ==
+  dependencies:
+    "@upstash/redis" "^1.18.0"
+    monosize "^0.2.1"
     tslib "^2.4.1"
 
 monosize@0.2.1, monosize@^0.2.1:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Monosize was not integrated for react-charting library

## New Behavior

Integrated monosize (0.2.1) in react-charting  for AreaChart and VerticalBarChart. Using monosize-storage-azure for storage adaptor.
<img width="643" alt="image" src="https://github.com/microsoft/fluentui/assets/35366351/44393c6d-ef7a-4fc4-993e-3a84b646cf34">

### Important note:
yarn monosize measure may not be working due to erroneous ESM URL scheming. Refer this issue for temporary workaround for testing in dev env.
https://github.com/microsoft/monosize/issues/31
## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30480 
