### PR TITLE
V8 Coachmark - Fix: Enable click to open Coachmark on mobile

### DIFF
--- a/change/@fluentui-react-154ee35d-239e-4e15-8fa2-3fd2bd1104f9.json
+++ b/change/@fluentui-react-154ee35d-239e-4e15-8fa2-3fd2bd1104f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: Enable click events on coachmark for mobile & additional entry points on desktop (currently requires mouse movement only)",
+  "packageName": "@fluentui/react",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/react/src/components/Coachmark/Coachmark.base.tsx
@@ -481,6 +481,10 @@ export const CoachmarkBase: React.FunctionComponent<ICoachmarkProps> = React.for
 
   const finalHeight: number | undefined = isCollapsed ? COACHMARK_HEIGHT : entityInnerHostRect.height;
 
+  const onClickCallout = React.useCallback(() => {
+    openCoachmark();
+  }, [openCoachmark]);
+
   return (
     <PositioningContainer
       target={target}
@@ -510,6 +514,7 @@ export const CoachmarkBase: React.FunctionComponent<ICoachmarkProps> = React.for
                 role="dialog"
                 aria-labelledby={ariaLabelledBy}
                 aria-describedby={ariaDescribedBy}
+                onClick={onClickCallout}
               >
                 {isCollapsed && [
                   ariaLabelledBy && (

--- a/packages/react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/react/src/components/Coachmark/Coachmark.styles.ts
@@ -272,6 +272,9 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
         width: entityHostWidth,
         height: entityHostHeight,
       },
+      isCollapsed && {
+        cursor: 'pointer',
+      },
     ],
     entityInnerHost: [
       {

--- a/packages/react/src/components/Coachmark/__snapshots__/Coachmark.test.tsx.snap
+++ b/packages/react/src/components/Coachmark/__snapshots__/Coachmark.test.tsx.snap
@@ -170,6 +170,7 @@ exports[`Coachmark renders Coachmark (color properties) 1`] = `
                         {
                           background-color: red;
                           border-radius: 32px;
+                          cursor: pointer;
                           outline: none;
                           overflow: hidden;
                           position: relative;
@@ -405,6 +406,7 @@ exports[`Coachmark renders Coachmark (correctly) 1`] = `
                         {
                           background-color: #0078d4;
                           border-radius: 32px;
+                          cursor: pointer;
                           outline: none;
                           overflow: hidden;
                           position: relative;


### PR DESCRIPTION
## Previous Behavior

Callout would only open if a mouse move event occurred near Coachmark, this causes issues on mobile as mouse move events are not uniform. Additionally, if a mouse is already present on top of the Coachmark when it appears, it will not open until the mouse moves again.

Currently, there is no 'onClick' behavior for Coachmark, only mouse movement detection.

## New Behavior

onClick enabled on Coachmark - this click event enables press based entry for mobile, it can also be used on desktop with a pointer style design should the mouse already be hovering over Coachmark when it appears.

## Related Issue(s)

- Fixes #30273 
