### PR TITLE
fix: Datepicker with input renders semantic button for voice control

### DIFF
--- a/change/@fluentui-react-datepicker-compat-90ecf66d-ad92-4c24-9737-1299a1769080.json
+++ b/change/@fluentui-react-datepicker-compat-90ecf66d-ad92-4c24-9737-1299a1769080.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: DatePicker renders a semantic button for voice control",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-fbfbd480-81b2-4336-9ba2-8318be8c27e3.json
+++ b/change/@fluentui-react-fbfbd480-81b2-4336-9ba2-8318be8c27e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Datepicker with input renders semantic button for voice control",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -12,14 +12,17 @@ Object {
           aria-expanded="false"
           aria-haspopup="dialog"
           class="fui-Input__input"
+          id="datePicker-input1"
           readonly=""
           role="combobox"
           type="text"
           value=""
         />
         <span
-          aria-hidden="true"
+          aria-expanded="false"
+          aria-labelledby="datePicker-input1"
           class="fui-Input__contentAfter"
+          role="button"
         >
           <svg
             aria-hidden="true"
@@ -47,14 +50,17 @@ Object {
         aria-expanded="false"
         aria-haspopup="dialog"
         class="fui-Input__input"
+        id="datePicker-input1"
         readonly=""
         role="combobox"
         type="text"
         value=""
       />
       <span
-        aria-hidden="true"
+        aria-expanded="false"
+        aria-labelledby="datePicker-input1"
         class="fui-Input__contentAfter"
+        role="button"
       >
         <svg
           aria-hidden="true"

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -369,6 +369,8 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
   });
   input.ref = useMergedRefs(input.ref, ref, rootRef);
 
+  // Props to create a semantic but non-focusable button on the element with the click-to-open handler
+  // Used for voice control and touch screen reader accessibility
   const inputLabelledBy = props['aria-labelledby'];
   const inputId = props.id ?? defaultId;
   const iconA11yProps = React.useMemo(

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -144,6 +144,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
   const [open, setOpenState] = usePopupVisibility(props);
   const fieldContext = useFieldContext();
   const required = fieldContext?.required ?? props.required;
+  const defaultId = useId('datePicker-input');
   const popupSurfaceId = useId('datePicker-popupSurface');
 
   const validateTextInput = React.useCallback(
@@ -368,10 +369,21 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
   });
   input.ref = useMergedRefs(input.ref, ref, rootRef);
 
+  const inputLabelledBy = props['aria-labelledby'];
+  const inputId = props.id ?? defaultId;
+  const iconA11yProps = React.useMemo(
+    () => ({
+      role: 'button',
+      'aria-expanded': open,
+      'aria-labelledby': inputLabelledBy ?? inputId,
+    }),
+    [open, inputLabelledBy, inputId],
+  );
+
   const contentAfter = slot.always(props.contentAfter || {}, {
     defaultProps: {
       children: <CalendarMonthRegular />,
-      'aria-hidden': true,
+      ...iconA11yProps,
     },
     elementType: 'span',
   });
@@ -385,6 +397,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
       'aria-haspopup': 'dialog',
       readOnly: !allowTextInput,
       role: 'combobox',
+      id: inputId,
     },
     elementType: Input,
   });

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -478,6 +478,17 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
 
   const dataIsFocusable = (textFieldProps as any)?.['data-is-focusable'] ?? (props as any)['data-is-focusable'] ?? true;
 
+  // Props to create a semantic but non-focusable button when the datepicker has a text input
+  // Used for voice control and touch screen reader accessibility
+  const iconA11yProps: React.HTMLAttributes<HTMLSpanElement> = allowTextInput
+    ? {
+        role: 'button',
+        'aria-expanded': isCalendarShown,
+        'aria-label': ariaLabel ?? label,
+        'aria-labelledby': textFieldProps && textFieldProps['aria-labelledby'],
+      }
+    : {};
+
   return (
     <div {...nativeProps} className={classNames.root} ref={forwardedRef}>
       <div ref={datePickerDiv} aria-owns={isCalendarShown ? calloutId : undefined} className={classNames.wrapper}>
@@ -504,6 +515,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
           className={css(classNames.textField, textFieldProps && textFieldProps.className)}
           iconProps={{
             iconName: 'Calendar',
+            ...iconA11yProps,
             ...iconProps,
             className: css(classNames.icon, iconProps && iconProps.className),
             onClick: onIconClick,

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -173,7 +173,6 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
           />
           <i
             aria-expanded={false}
-            aria-haspopup="dialog"
             aria-hidden={true}
             className=
                 ms-DatePicker-event--without-label

--- a/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -172,6 +172,8 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
             value=""
           />
           <i
+            aria-expanded={false}
+            aria-haspopup="dialog"
             aria-hidden={true}
             className=
                 ms-DatePicker-event--without-label
@@ -198,6 +200,7 @@ exports[`DatePicker renders DatePicker allowing text input correctly 1`] = `
                 }
             data-icon-name="Calendar"
             onClick={[Function]}
+            role="button"
           >
             
           </i>


### PR DESCRIPTION
This is a workaround for an ongoing issue where Voice Access cannot expand a combobox-like popup from a text input. Since there's no clear solution from the Voice Access or Edge side of things, it makes sense to have the Fluent DatePicker render the icon as a semantic button so that it can be activated by voice control to open the calendar popup.

## New Behavior

DatePicker adds button semantics to the calendar icon when the control renders a text input (otherwise it is unnecessary, since the issue only arises when inputs are used as combobox triggers).

## Related Issue(s)

- Fixes multiple ADO issues
