### PR TITLE
Tabster 6.0.1

### DIFF
--- a/change/@fluentui-react-tabster-d1ecb8a0-803a-4d33-9edd-225c1a12b51a.json
+++ b/change/@fluentui-react-tabster-d1ecb8a0-803a-4d33-9edd-225c1a12b51a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Active modal checks if an element outside of it is a virtual child of a modal before setting aria-hidden.'",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -37,7 +37,7 @@
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",
     "keyborg": "^2.5.0",
-    "tabster": "^6.0.0"
+    "tabster": "^6.0.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24146,10 +24146,10 @@ table@^6.0.4, table@^6.0.7:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-6.0.0.tgz#7fbea44c1e59f636cd3837c63491fdcb60974a2c"
-  integrity sha512-Dvrzv4wG+Qjw9wmC7bKOTVXDn24h8XZLNPmc+XfuEv4pGiTxg+EZ5fp265ccqu00E2om8Wznp9jFftWVu624aQ==
+tabster@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-6.0.1.tgz#192607dce2789236c5f219b0550921af3141e91b"
+  integrity sha512-cNVYkJmQZ76IvdW7laCuUns9XcAGzscmDkZ0T4JY3huCRsacidBNOa7MJu2+ocW7UKR8xOxeER6OdBsmX1l5XQ==
   dependencies:
     keyborg "2.5.0"
     tslib "^2.3.1"


### PR DESCRIPTION
Active modal checks if an element outside of it is a virtual child of a modal before setting aria-hidden.