### PR TITLE
feat: setup verdaccio within monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ dist.stats.json
 bower_components
 node_modules
 temp
+tmp
 lib
 lib-amd
 lib-commonjs

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -1,0 +1,37 @@
+# path to a directory with all packages
+storage: ../tmp/local-registry/storage
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    maxage: 60m
+
+packages:
+  # scoped packages
+  '@*/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to npm registry
+    proxy: npmjs
+
+  '**':
+    # give all users (including non-authenticated users) full access
+    # because it is a local registry
+    access: $all
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to npm registry
+    proxy: npmjs
+
+# log settings
+log:
+  type: stdout
+  format: pretty
+  level: warn
+
+publish:
+  allow_offline: true # set offline to true to allow publish offline

--- a/package.json
+++ b/package.json
@@ -379,5 +379,8 @@
     "swc-loader": "^0.2.3",
     "prettier": "2.8.8",
     "puppeteer": "19.6.0"
+  },
+  "nx": {
+    "includedScripts": []
   }
 }

--- a/project.json
+++ b/project.json
@@ -1,0 +1,18 @@
+{
+  "name": "@fluentui/fluentui-repo",
+  "$schema": "node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "prepare-local-registry": {
+      "command": "node ./tools/workspace-plugin/scripts/install-verdaccio"
+    },
+    "local-registry": {
+      "executor": "@nx/js:verdaccio",
+      "options": {
+        "port": 4873,
+        "config": ".verdaccio/config.yml",
+        "storage": "tmp/local-registry/storage"
+      },
+      "dependsOn": ["prepare-local-registry"]
+    }
+  }
+}

--- a/tools/workspace-plugin/scripts/install-verdaccio.js
+++ b/tools/workspace-plugin/scripts/install-verdaccio.js
@@ -1,0 +1,19 @@
+// @ts-check
+const { output, workspaceRoot } = require('@nx/devkit');
+const { execSync } = require('child_process');
+
+main();
+
+function main() {
+  output.logSingleLine('Preparing verdaccio...');
+
+  try {
+    require.resolve('verdaccio');
+    output.logSingleLine('Verdaccio already installed...✅');
+  } catch {
+    output.logSingleLine('Installing verdaccio...');
+    execSync('yarn add -DW verdaccio@5 --ignore-scripts', { stdio: 'inherit', cwd: workspaceRoot });
+  }
+
+  output.logSingleLine('Verdaccio ready to start');
+}

--- a/tools/workspace-plugin/scripts/install-verdaccio.js
+++ b/tools/workspace-plugin/scripts/install-verdaccio.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { output, workspaceRoot } = require('@nx/devkit');
+const { output, workspaceRoot, getPackageManagerCommand } = require('@nx/devkit');
 const { execSync } = require('child_process');
 
 main();
@@ -12,7 +12,9 @@ function main() {
     output.logSingleLine('Verdaccio already installed...✅');
   } catch {
     output.logSingleLine('Installing verdaccio...');
-    execSync('yarn add -DW verdaccio@5 --ignore-scripts', { stdio: 'inherit', cwd: workspaceRoot });
+    const pm = getPackageManagerCommand();
+    const cmd = `${pm} add -DW verdaccio@5 --ignore-scripts`;
+    execSync(cmd, { stdio: 'inherit', cwd: workspaceRoot });
   }
 
   output.logSingleLine('Verdaccio ready to start');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- setup verdaccio within monorepo in order to easily verify/test publishing our packages.

### Technical Details

- whole setup was generated via `nx g @nx/js:setup-verdaccio` + some manual tweaks
- verdaccio package is installed on-demand 

### Usage

To start local registry run `yarn nx local-registry`

- on initial run we will dynamically install verdaccio in order to no spam our node_modules with deps we dont need for CI

<img width="752" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/ac391ca5-5c59-49ed-a7c5-fe5a0b7820f5">

- on 2nd run install step will be skipped

<img width="911" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/72d8a1ad-4259-4255-a90e-34dcd09a6e9f">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Relates to #30251 
