### PR TITLE
chore: Integrate Monosize into react-charting for all charts

### DIFF
--- a/packages/react-charting/bundle-size/AreaChart.fixture.js
+++ b/packages/react-charting/bundle-size/AreaChart.fixture.js
@@ -1,9 +1,7 @@
 import { AreaChart } from '@fluentui/react-charting';
 
 console.log(AreaChart);
-// "console.log()" is the easiest way to prevent tree-shaking
 
 export default {
   name: 'AreaChart',
-  // defines a name for story that will be used in output
 };

--- a/packages/react-charting/bundle-size/ChartHoverCard.fixture.js
+++ b/packages/react-charting/bundle-size/ChartHoverCard.fixture.js
@@ -1,0 +1,7 @@
+import { ChartHoverCard } from '@fluentui/react-charting';
+
+console.log(ChartHoverCard);
+
+export default {
+  name: 'ChartHoverCard',
+};

--- a/packages/react-charting/bundle-size/DonutChart.fixture.js
+++ b/packages/react-charting/bundle-size/DonutChart.fixture.js
@@ -1,0 +1,7 @@
+import { DonutChart } from '@fluentui/react-charting';
+
+console.log(DonutChart);
+
+export default {
+  name: 'DonutChart',
+};

--- a/packages/react-charting/bundle-size/GaugeChart.fixture.js
+++ b/packages/react-charting/bundle-size/GaugeChart.fixture.js
@@ -1,0 +1,7 @@
+import { GaugeChart } from '@fluentui/react-charting';
+
+console.log(GaugeChart);
+
+export default {
+  name: 'GaugeChart',
+};

--- a/packages/react-charting/bundle-size/GroupedVerticalBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/GroupedVerticalBarChart.fixture.js
@@ -1,0 +1,7 @@
+import { GroupedVerticalBarChart } from '@fluentui/react-charting';
+
+console.log(GroupedVerticalBarChart);
+
+export default {
+  name: 'GroupedVerticalBarChart',
+};

--- a/packages/react-charting/bundle-size/HeatMapChart.fixture.js
+++ b/packages/react-charting/bundle-size/HeatMapChart.fixture.js
@@ -1,0 +1,7 @@
+import { HeatMapChart } from '@fluentui/react-charting';
+
+console.log(HeatMapChart);
+
+export default {
+  name: 'HeatMapChart',
+};

--- a/packages/react-charting/bundle-size/HorizontalBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/HorizontalBarChart.fixture.js
@@ -1,0 +1,7 @@
+import { HorizontalBarChart } from '@fluentui/react-charting';
+
+console.log(HorizontalBarChart);
+
+export default {
+  name: 'HorizontalBarChart',
+};

--- a/packages/react-charting/bundle-size/HorizontalBarChartWithAxis.fixture.js
+++ b/packages/react-charting/bundle-size/HorizontalBarChartWithAxis.fixture.js
@@ -1,0 +1,7 @@
+import { HorizontalBarChartWithAxis } from '@fluentui/react-charting';
+
+console.log(HorizontalBarChartWithAxis);
+
+export default {
+  name: 'HorizontalBarChartWithAxis',
+};

--- a/packages/react-charting/bundle-size/Legends.fixture.js
+++ b/packages/react-charting/bundle-size/Legends.fixture.js
@@ -1,0 +1,7 @@
+import { Legends } from '@fluentui/react-charting';
+
+console.log(Legends);
+
+export default {
+  name: 'Legends',
+};

--- a/packages/react-charting/bundle-size/LineChart.fixture.js
+++ b/packages/react-charting/bundle-size/LineChart.fixture.js
@@ -1,0 +1,7 @@
+import { LineChart } from '@fluentui/react-charting';
+
+console.log(LineChart);
+
+export default {
+  name: 'LineChart',
+};

--- a/packages/react-charting/bundle-size/MultiStackedBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/MultiStackedBarChart.fixture.js
@@ -1,0 +1,7 @@
+import { MultiStackedBarChart } from '@fluentui/react-charting';
+
+console.log(MultiStackedBarChart);
+
+export default {
+  name: 'MultiStackedBarChart',
+};

--- a/packages/react-charting/bundle-size/PieChart.fixture.js
+++ b/packages/react-charting/bundle-size/PieChart.fixture.js
@@ -1,0 +1,7 @@
+import { PieChart } from '@fluentui/react-charting';
+
+console.log(PieChart);
+
+export default {
+  name: 'PieChart',
+};

--- a/packages/react-charting/bundle-size/SankeyChart.fixture.js
+++ b/packages/react-charting/bundle-size/SankeyChart.fixture.js
@@ -1,0 +1,7 @@
+import { SankeyChart } from '@fluentui/react-charting';
+
+console.log(SankeyChart);
+
+export default {
+  name: 'SankeyChart',
+};

--- a/packages/react-charting/bundle-size/Sparkline.fixture.js
+++ b/packages/react-charting/bundle-size/Sparkline.fixture.js
@@ -1,0 +1,7 @@
+import { Sparkline } from '@fluentui/react-charting';
+
+console.log(Sparkline);
+
+export default {
+  name: 'Sparkline',
+};

--- a/packages/react-charting/bundle-size/StackedBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/StackedBarChart.fixture.js
@@ -1,0 +1,7 @@
+import { StackedBarChart } from '@fluentui/react-charting';
+
+console.log(StackedBarChart);
+
+export default {
+  name: 'StackedBarChart',
+};

--- a/packages/react-charting/bundle-size/TreeChart.fixture.js
+++ b/packages/react-charting/bundle-size/TreeChart.fixture.js
@@ -1,0 +1,7 @@
+import { TreeChart } from '@fluentui/react-charting';
+
+console.log(TreeChart);
+
+export default {
+  name: 'TreeChart',
+};

--- a/packages/react-charting/bundle-size/VerticalBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/VerticalBarChart.fixture.js
@@ -1,9 +1,7 @@
 import { VerticalBarChart } from '@fluentui/react-charting';
 
 console.log(VerticalBarChart);
-// "console.log()" is the easiest way to prevent tree-shaking
 
 export default {
   name: 'VerticalBarChart',
-  // defines a name for story that will be used in output
 };

--- a/packages/react-charting/bundle-size/VerticalStackedBarChart.fixture.js
+++ b/packages/react-charting/bundle-size/VerticalStackedBarChart.fixture.js
@@ -1,0 +1,7 @@
+import { VerticalStackedBarChart } from '@fluentui/react-charting';
+
+console.log(VerticalStackedBarChart);
+
+export default {
+  name: 'VerticalStackedBarChart',
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Monosize fixtures were added only for AreaChart and VerticalBarChart
In order to make measurements, go to react-charting directory and run `yarn monosize measure`

## New Behavior
Monosize fixtures added for all charts
Measurements on time of PR staging:
![image](https://github.com/microsoft/fluentui/assets/35366351/38879a99-99a4-4403-82c8-57e7d32bbc88)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
