### PR TITLE
fix: focus-visible polyfill should only register in scope

### DIFF
--- a/change/@fluentui-react-tabster-7de2abf6-4ead-4023-b4e3-c7da63220700.json
+++ b/change/@fluentui-react-tabster-7de2abf6-4ead-4023-b4e3-c7da63220700.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: focus-visible polyfill should only register in scope",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
@@ -78,7 +78,9 @@ export function applyFocusVisiblePolyfill(scope: HTMLElement, targetWindow: Wind
   scope.addEventListener('focusout', blurListener);
   (scope as HTMLElementWithFocusVisibleScope).focusVisible = true;
 
-  registerElementIfNavigating(targetWindow.document.activeElement);
+  if (scope.contains(targetWindow.document.activeElement)) {
+    registerElementIfNavigating(targetWindow.document.activeElement);
+  }
 
   // Return disposer
   return () => {

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.cy.tsx
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.cy.tsx
@@ -19,7 +19,7 @@ describe('useFocusVisible', () => {
     };
 
     mount(<Example />);
-    cy.get('#start').focus().realPress('Tab').pause();
+    cy.get('#start').focus().realPress('Tab');
     cy.get('#shadow-host').shadow().find('#end').should('have.attr', FOCUS_VISIBLE_ATTR);
   });
 
@@ -44,5 +44,44 @@ describe('useFocusVisible', () => {
       .shadow()
       .find('#end')
       .should('not.have.attr', FOCUS_VISIBLE_ATTR);
+  });
+
+  it('should not register activeElement if it is outside of scope', () => {
+    const FocusVisible = () => {
+      const ref = useFocusVisible<HTMLDivElement>();
+
+      return (
+        <div ref={ref}>
+          <button>Within scope</button>
+        </div>
+      );
+    };
+
+    const Example = () => {
+      const [mounted, setMounted] = React.useState(false);
+      const ref = useFocusVisible<HTMLDivElement>();
+
+      return (
+        <>
+          <div ref={ref}>
+            <button id="toggle" onClick={() => setMounted(s => !s)}>
+              Toggle mount
+            </button>
+          </div>
+          {mounted && (
+            <div id="portal">
+              <FocusVisible />
+            </div>
+          )}
+        </>
+      );
+    };
+
+    mount(<Example />);
+    cy.get('#toggle').focus().realPress('Tab');
+    cy.get('#toggle').focus().realPress('Enter');
+    cy.get('#toggle').should('have.attr', FOCUS_VISIBLE_ATTR).realPress('Enter');
+    cy.get('#portal').should('not.exist');
+    cy.get('#toggle').should('have.attr', FOCUS_VISIBLE_ATTR);
   });
 });


### PR DESCRIPTION
Previously the polyfill registered any activeElement on the document. This meant that when a polyfill was disposed - it would remove the focus visible attribute from elements outside of its scope.

Adds an extra check to make sure that the activeElement is in scope before registering.
