### PR TITLE
fix: remove new Date() from prop destructuring

### DIFF
--- a/change/@fluentui-react-calendar-compat-0cf74a20-e5f5-4550-8a3a-5e74795ff1d7.json
+++ b/change/@fluentui-react-calendar-compat-0cf74a20-e5f5-4550-8a3a-5e74795ff1d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove new Date() from prop destructuring",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-a5aa1132-9ed3-4aa4-8287-2c11e3c4f9e1.json
+++ b/change/@fluentui-react-datepicker-compat-a5aa1132-9ed3-4aa4-8287-2c11e3c4f9e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove new Date() from prop destructuring",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
@@ -173,10 +173,14 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
       showSixWeeksByDefault = false,
       showWeekNumbers = false,
       strings = DEFAULT_CALENDAR_STRINGS,
-      today = new Date(),
+      today: todayProp,
       value,
       workWeekDays = defaultWorkWeekDays,
     } = props;
+
+    const today = React.useMemo(() => {
+      return todayProp ?? new Date();
+    }, [todayProp]);
 
     const [selectedDate, navigatedDay, navigatedMonth, onDateSelected, navigateDay, navigateMonth] = useDateState({
       onSelectDate,

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -113,7 +113,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     formatDate = defaultFormatDate,
     highlightCurrentMonth = false,
     highlightSelectedMonth = false,
-    initialPickerDate = new Date(),
+    initialPickerDate: initialPickerDateProp,
     inlinePopup = false,
     isMonthPickerVisible = true,
     maxDate,
@@ -134,6 +134,9 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
     value,
     ...restOfProps
   } = props;
+
+  const initialPickerDate = React.useMemo(() => initialPickerDateProp ?? new Date(), [initialPickerDateProp]);
+
   const calendar = React.useRef<ICalendar>(null);
   const [focus, rootRef, preventFocusOpeningPicker, preventNextFocusOpeningPicker] = useFocusLogic();
   const [selectedDate, formattedDate, setSelectedDate, setFormattedDate] = useSelectedDate({


### PR DESCRIPTION
## Previous Behavior

Every render where a value was not provided would create a new `Date`.

## New Behavior

`Date`s are only created when necessary.
