### PR TITLE
fix: remove components from prop destructuring

### DIFF
--- a/change/@fluentui-react-rating-preview-098152fc-985c-46de-aee3-2e1e7917e969.json
+++ b/change/@fluentui-react-rating-preview-098152fc-985c-46de-aee3-2e1e7917e969.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove component assignment from prop destructuring",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/src/components/Rating/useRating.tsx
+++ b/packages/react-components/react-rating-preview/src/components/Rating/useRating.tsx
@@ -11,6 +11,9 @@ import type { RatingProps, RatingState } from './Rating.types';
 import { RatingItem } from '../../RatingItem';
 import { StarFilled, StarRegular } from '@fluentui/react-icons';
 
+const defaultIconFilled = <StarFilled />;
+const defaultIconOutline = <StarRegular />;
+
 /**
  * Create the state required to render Rating.
  *
@@ -24,22 +27,14 @@ export const useRating_unstable = (props: RatingProps, ref: React.Ref<HTMLDivEle
   const generatedName = useId('rating-');
   const {
     color = 'neutral',
-    iconFilled: iconFilledProp,
-    iconOutline: iconOutlineProp,
+    iconFilled = defaultIconFilled,
+    iconOutline = defaultIconOutline,
     max = 5,
     name = generatedName,
     onChange,
     step = 1,
     size = 'extra-large',
   } = props;
-
-  const iconFilled = React.useMemo(() => {
-    return iconFilledProp ?? <StarFilled />;
-  }, [iconFilledProp]);
-
-  const iconOutline = React.useMemo(() => {
-    return iconOutlineProp ?? <StarRegular />;
-  }, [iconOutlineProp]);
 
   const [value, setValue] = useControllableState({
     state: props.value,

--- a/packages/react-components/react-rating-preview/src/components/Rating/useRating.tsx
+++ b/packages/react-components/react-rating-preview/src/components/Rating/useRating.tsx
@@ -24,14 +24,22 @@ export const useRating_unstable = (props: RatingProps, ref: React.Ref<HTMLDivEle
   const generatedName = useId('rating-');
   const {
     color = 'neutral',
-    iconFilled = <StarFilled />,
-    iconOutline = <StarRegular />,
+    iconFilled: iconFilledProp,
+    iconOutline: iconOutlineProp,
     max = 5,
     name = generatedName,
     onChange,
     step = 1,
     size = 'extra-large',
   } = props;
+
+  const iconFilled = React.useMemo(() => {
+    return iconFilledProp ?? <StarFilled />;
+  }, [iconFilledProp]);
+
+  const iconOutline = React.useMemo(() => {
+    return iconOutlineProp ?? <StarRegular />;
+  }, [iconOutlineProp]);
 
   const [value, setValue] = useControllableState({
     state: props.value,

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -17,7 +17,11 @@ export const useRatingDisplay_unstable = (
   props: RatingDisplayProps,
   ref: React.Ref<HTMLDivElement>,
 ): RatingDisplayState => {
-  const { color = 'neutral', count, compact = false, icon = <StarFilled />, max = 5, size = 'medium', value } = props;
+  const { color = 'neutral', count, compact = false, icon: iconProp, max = 5, size = 'medium', value } = props;
+
+  const icon = React.useMemo(() => {
+    return iconProp ?? <StarFilled />;
+  }, [iconProp]);
 
   const valueTextId = useId('rating-value-');
   const countTextId = useId('rating-count-');

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -4,6 +4,8 @@ import type { RatingDisplayProps, RatingDisplayState } from './RatingDisplay.typ
 import { StarFilled } from '@fluentui/react-icons';
 import { RatingItem } from '../RatingItem/RatingItem';
 
+const defaultIcon = <StarFilled />;
+
 /**
  * Create the state required to render RatingDisplay.
  *
@@ -17,11 +19,7 @@ export const useRatingDisplay_unstable = (
   props: RatingDisplayProps,
   ref: React.Ref<HTMLDivElement>,
 ): RatingDisplayState => {
-  const { color = 'neutral', count, compact = false, icon: iconProp, max = 5, size = 'medium', value } = props;
-
-  const icon = React.useMemo(() => {
-    return iconProp ?? <StarFilled />;
-  }, [iconProp]);
+  const { color = 'neutral', count, compact = false, icon = defaultIcons, max = 5, size = 'medium', value } = props;
 
   const valueTextId = useId('rating-value-');
   const countTextId = useId('rating-count-');

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -19,7 +19,7 @@ export const useRatingDisplay_unstable = (
   props: RatingDisplayProps,
   ref: React.Ref<HTMLDivElement>,
 ): RatingDisplayState => {
-  const { color = 'neutral', count, compact = false, icon = defaultIcons, max = 5, size = 'medium', value } = props;
+  const { color = 'neutral', count, compact = false, icon = defaultIcon, max = 5, size = 'medium', value } = props;
 
   const valueTextId = useId('rating-value-');
   const countTextId = useId('rating-count-');

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useMergedRefs } from '@fluentui/react-utilities';
 import { useFocusWithin } from '@fluentui/react-tabster';
+import type { RatingProps } from '../Rating/Rating.types';
 import type { RatingItemProps, RatingItemState } from './RatingItem.types';
 import { useRatingItemContextValue_unstable } from '../../contexts/RatingItemContext';
+
+const defaultItemLabel: RatingProps['itemLabel'] = num => num + '';
 
 /**
  * Create the state required to render RatingItem.
@@ -16,7 +19,7 @@ import { useRatingItemContextValue_unstable } from '../../contexts/RatingItemCon
 export const useRatingItem_unstable = (props: RatingItemProps, ref: React.Ref<HTMLSpanElement>): RatingItemState => {
   const context = useRatingItemContextValue_unstable();
   const { value = 0 } = props;
-  const { itemLabel = num => num + '' } = context;
+  const { itemLabel = defaultItemLabel } = context;
 
   const ratingValue = Math.round((context.value || 0) * 2) / 2; // round to the nearest 0.5
 

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useMergedRefs } from '@fluentui/react-utilities';
 import { useFocusWithin } from '@fluentui/react-tabster';
-import type { RatingProps } from '../Rating/Rating.types';
 import type { RatingItemProps, RatingItemState } from './RatingItem.types';
 import { useRatingItemContextValue_unstable } from '../../contexts/RatingItemContext';
 

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItem.tsx
@@ -5,7 +5,7 @@ import type { RatingProps } from '../Rating/Rating.types';
 import type { RatingItemProps, RatingItemState } from './RatingItem.types';
 import { useRatingItemContextValue_unstable } from '../../contexts/RatingItemContext';
 
-const defaultItemLabel: RatingProps['itemLabel'] = num => num + '';
+const defaultItemLabel = (num: number) => num + '';
 
 /**
  * Create the state required to render RatingItem.


### PR DESCRIPTION
## Previous Behavior

Components would be reassigned every render when a value was not provided.

## New Behavior

Components are only assigned as needed.