### PR TITLE
feat: adds a context for active descendant

### DIFF
--- a/change/@fluentui-react-aria-98e9bbfd-117c-4485-85de-0e91928c19be.json
+++ b/change/@fluentui-react-aria-98e9bbfd-117c-4485-85de-0e91928c19be.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds a context for active descendant",
+  "packageName": "@fluentui/react-aria",
+  "email": "lingfan.gao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -29,7 +29,7 @@ export interface ActiveDescendantImperativeRef {
     // (undocumented)
     blur: () => void;
     // (undocumented)
-    find: (predicate: (id: string) => boolean, options?: IteratorOptions & FindOptions) => string | undefined;
+    find: (predicate: (id: string) => boolean, options?: IteratorOptions) => string | undefined;
     // (undocumented)
     first: (options?: IteratorOptions) => string | undefined;
     // (undocumented)

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -15,13 +15,21 @@ import type { UnionToIntersection } from '@fluentui/react-utilities';
 export const ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE = "data-activedescendant-focusvisible";
 
 // @public (undocumented)
+export const ActiveDescendantContextProvider: React_2.Provider<ActiveDescendantContextValue | undefined>;
+
+// @public (undocumented)
+export type ActiveDescendantContextValue = {
+    controller: ActiveDescendantImperativeRef;
+};
+
+// @public (undocumented)
 export interface ActiveDescendantImperativeRef {
     // (undocumented)
     active: () => string | undefined;
     // (undocumented)
     blur: () => void;
     // (undocumented)
-    find: (predicate: (id: string) => boolean, options?: IteratorOptions) => string | undefined;
+    find: (predicate: (id: string) => boolean, options?: IteratorOptions & FindOptions) => string | undefined;
     // (undocumented)
     first: (options?: IteratorOptions) => string | undefined;
     // (undocumented)
@@ -85,6 +93,9 @@ export const renderAriaLiveAnnouncer_unstable: (state: AriaLiveAnnouncerState, c
 // @public (undocumented)
 export function useActiveDescendant<TActiveParentElement extends HTMLElement, TListboxElement extends HTMLElement>(options: ActiveDescendantOptions): UseActiveDescendantReturn<TActiveParentElement, TListboxElement>;
 
+// @public (undocumented)
+export const useActiveDescendantContext: () => ActiveDescendantContextValue;
+
 // @internal
 export function useARIAButtonProps<Type extends ARIAButtonType, Props extends ARIAButtonProps<Type>>(type?: Type, props?: Props): ARIAButtonResultProps<Type, Props>;
 
@@ -96,6 +107,9 @@ export const useAriaLiveAnnouncer_unstable: (props: AriaLiveAnnouncerProps) => A
 
 // @public (undocumented)
 export function useAriaLiveAnnouncerContextValues_unstable(state: AriaLiveAnnouncerState): AriaLiveAnnouncerContextValues;
+
+// @public (undocumented)
+export const useHasParentActiveDescendantContext: () => boolean;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -29,7 +29,7 @@ export interface ActiveDescendantImperativeRef {
     // (undocumented)
     blur: () => void;
     // (undocumented)
-    find: (predicate: (id: string) => boolean, options?: IteratorOptions) => string | undefined;
+    find: (predicate: (id: string) => boolean, options?: IteratorOptions & FindOptions) => string | undefined;
     // (undocumented)
     first: (options?: IteratorOptions) => string | undefined;
     // (undocumented)

--- a/packages/react-components/react-aria/src/activedescendant/ActiveDescendantContext.ts
+++ b/packages/react-components/react-aria/src/activedescendant/ActiveDescendantContext.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { ActiveDescendantImperativeRef } from './types';
+
+export type ActiveDescendantContextValue = {
+  controller: ActiveDescendantImperativeRef;
+};
+
+const noop = () => undefined;
+
+const activeDescendantContextDefaultValue: ActiveDescendantContextValue = {
+  controller: {
+    active: noop,
+    blur: noop,
+    find: noop,
+    first: noop,
+    focus: noop,
+    last: noop,
+    next: noop,
+    prev: noop,
+  },
+};
+
+const ActiveDescendantContext = React.createContext<ActiveDescendantContextValue | undefined>(undefined);
+
+export const ActiveDescendantContextProvider = ActiveDescendantContext.Provider;
+export const useActiveDescendantContext = () =>
+  React.useContext(ActiveDescendantContext) ?? activeDescendantContextDefaultValue;
+export const useHasParentActiveDescendantContext = () => !!React.useContext(ActiveDescendantContext);

--- a/packages/react-components/react-aria/src/activedescendant/index.ts
+++ b/packages/react-components/react-aria/src/activedescendant/index.ts
@@ -1,3 +1,4 @@
+export * from './ActiveDescendantContext';
 export * from './useActiveDescendant';
 export * from './constants';
 export * from './types';

--- a/packages/react-components/react-aria/src/activedescendant/types.ts
+++ b/packages/react-components/react-aria/src/activedescendant/types.ts
@@ -5,7 +5,7 @@ export interface ActiveDescendantImperativeRef {
   last: (options?: IteratorOptions) => string | undefined;
   next: (options?: IteratorOptions) => string | undefined;
   prev: (options?: IteratorOptions) => string | undefined;
-  find: (predicate: (id: string) => boolean, options?: IteratorOptions) => string | undefined;
+  find: (predicate: (id: string) => boolean, options?: IteratorOptions & FindOptions) => string | undefined;
   blur: () => void;
   active: () => string | undefined;
   focus: (id: string) => void;
@@ -21,6 +21,13 @@ export interface ActiveDescendantOptions {
    * Forward imperative refs when exposing functionality from a React component
    */
   imperativeRef?: React.RefObject<ActiveDescendantImperativeRef>;
+}
+
+export interface FindOptions {
+  /**
+   * Starts the search from a specific id
+   */
+  startFrom?: string;
 }
 
 export interface UseActiveDescendantReturn<

--- a/packages/react-components/react-aria/src/activedescendant/useActiveDescendant.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useActiveDescendant.ts
@@ -29,7 +29,7 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
   });
 
   const matchOption = useEventCallback(matchOptionUnstable);
-  const listboxRef = React.useRef<TListboxElement | null>(null);
+  const listboxRef = React.useRef<TListboxElement>(null);
   const { optionWalker, listboxCallbackRef } = useOptionWalker<TListboxElement>({ matchOption });
   const getActiveDescendant = React.useCallback(() => {
     return listboxRef.current?.querySelector<HTMLElement>(`#${activeIdRef.current}`);
@@ -131,8 +131,8 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
         }
       },
 
-      find(predicate, { passive } = {}) {
-        const target = optionWalker.find(predicate);
+      find(predicate, { passive, startFrom } = {}) {
+        const target = optionWalker.find(predicate, startFrom);
         if (!passive) {
           focusActiveDescendant(target);
         }

--- a/packages/react-components/react-aria/src/activedescendant/useActiveDescendant.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useActiveDescendant.ts
@@ -29,7 +29,7 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
   });
 
   const matchOption = useEventCallback(matchOptionUnstable);
-  const { listboxRef, optionWalker } = useOptionWalker<TListboxElement>({ matchOption });
+  const { listboxRef, optionWalker, listboxCallbackRef } = useOptionWalker<TListboxElement>({ matchOption });
   const getActiveDescendant = React.useCallback(() => {
     return listboxRef.current?.querySelector<HTMLElement>(`#${activeIdRef.current}`);
   }, [listboxRef]);
@@ -144,5 +144,5 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
 
   React.useImperativeHandle(imperativeRef, () => controller);
 
-  return { listboxRef, activeParentRef, controller };
+  return { listboxRef: listboxCallbackRef, activeParentRef, controller };
 }

--- a/packages/react-components/react-aria/src/activedescendant/useActiveDescendant.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useActiveDescendant.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEventCallback } from '@fluentui/react-utilities';
+import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { useOnKeyboardNavigationChange } from '@fluentui/react-tabster';
 import { useOptionWalker } from './useOptionWalker';
 import type { ActiveDescendantImperativeRef, ActiveDescendantOptions, UseActiveDescendantReturn } from './types';
@@ -29,7 +29,8 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
   });
 
   const matchOption = useEventCallback(matchOptionUnstable);
-  const { listboxRef, optionWalker, listboxCallbackRef } = useOptionWalker<TListboxElement>({ matchOption });
+  const listboxRef = React.useRef<TListboxElement | null>(null);
+  const { optionWalker, listboxCallbackRef } = useOptionWalker<TListboxElement>({ matchOption });
   const getActiveDescendant = React.useCallback(() => {
     return listboxRef.current?.querySelector<HTMLElement>(`#${activeIdRef.current}`);
   }, [listboxRef]);
@@ -144,5 +145,5 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
 
   React.useImperativeHandle(imperativeRef, () => controller);
 
-  return { listboxRef: listboxCallbackRef, activeParentRef, controller };
+  return { listboxRef: useMergedRefs(listboxRef, listboxCallbackRef), activeParentRef, controller };
 }

--- a/packages/react-components/react-aria/src/activedescendant/useActivedescendant.test.tsx
+++ b/packages/react-components/react-aria/src/activedescendant/useActivedescendant.test.tsx
@@ -184,6 +184,18 @@ describe('useActivedescendant', () => {
     expect(getByRole('button')).toHaveActiveDescendant(expectedOption);
   });
 
+  it('should find element and focus it starting from', () => {
+    const expectedOption = 'option-3';
+    const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();
+    const { getByRole } = render(<Test imperativeRef={imperativeRef} />);
+
+    const res = imperativeRef.current?.find(id => document.getElementById(id)?.getAttribute('role') === 'option', {
+      startFrom: 'option-3',
+    });
+    expect(res).toBe(expectedOption);
+    expect(getByRole('button')).toHaveActiveDescendant(expectedOption);
+  });
+
   describe('passive', () => {
     it('should return first option', () => {
       const expecetdOption = 'option-1';
@@ -235,6 +247,20 @@ describe('useActivedescendant', () => {
 
       imperativeRef.current?.first();
       const res = imperativeRef.current?.find(id => id === expectedOption, { passive: true });
+      expect(res).toBe(expectedOption);
+      expect(getByRole('button')).toHaveActiveDescendant('option-1');
+    });
+
+    it('should find element starting from', () => {
+      const expectedOption = 'option-3';
+      const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();
+      const { getByRole } = render(<Test imperativeRef={imperativeRef} />);
+
+      imperativeRef.current?.first();
+      const res = imperativeRef.current?.find(id => document.getElementById(id)?.getAttribute('role') === 'option', {
+        startFrom: 'option-3',
+        passive: true,
+      });
       expect(res).toBe(expectedOption);
       expect(getByRole('button')).toHaveActiveDescendant('option-1');
     });

--- a/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
@@ -93,6 +93,5 @@ export function useOptionWalker<TListboxElement extends HTMLElement>(options: Us
   return {
     optionWalker,
     listboxCallbackRef: setListbox,
-    listboxRef,
   };
 }

--- a/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
@@ -66,12 +66,13 @@ export function useOptionWalker<TListboxElement extends HTMLElement>(options: Us
 
         return treeWalkerRef.current.previousNode() as HTMLElement | null;
       },
-      find: (predicate: (id: string) => boolean) => {
+      find: (predicate: (id: string) => boolean, startFrom?: string) => {
         if (!treeWalkerRef.current || !listboxRef.current) {
           return null;
         }
 
-        treeWalkerRef.current.currentNode = listboxRef.current;
+        const start = startFrom ? targetDocument?.getElementById(startFrom) : null;
+        treeWalkerRef.current.currentNode = start ?? listboxRef.current;
         let cur: HTMLElement | null = treeWalkerRef.current.currentNode as HTMLElement;
         while (cur && !predicate(cur.id)) {
           cur = treeWalkerRef.current.nextNode() as HTMLElement | null;
@@ -87,7 +88,7 @@ export function useOptionWalker<TListboxElement extends HTMLElement>(options: Us
         treeWalkerRef.current.currentNode = el;
       },
     }),
-    [],
+    [targetDocument],
   );
 
   return {

--- a/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import { isHTMLElement, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { isHTMLElement } from '@fluentui/react-utilities';
 
 interface UseOptionWalkerOptions {
   matchOption: (el: HTMLElement) => boolean;
@@ -23,13 +23,17 @@ export function useOptionWalker<TListboxElement extends HTMLElement>(options: Us
     [matchOption],
   );
 
-  useIsomorphicLayoutEffect(() => {
-    if (!targetDocument || !listboxRef.current) {
-      return;
-    }
-
-    treeWalkerRef.current = targetDocument.createTreeWalker(listboxRef.current, NodeFilter.SHOW_ELEMENT, optionFilter);
-  }, [targetDocument, optionFilter]);
+  const setListbox = React.useCallback(
+    (el: TListboxElement) => {
+      if (el && targetDocument) {
+        listboxRef.current = el;
+        treeWalkerRef.current = targetDocument.createTreeWalker(el, NodeFilter.SHOW_ELEMENT, optionFilter);
+      } else {
+        listboxRef.current = null;
+      }
+    },
+    [targetDocument, optionFilter],
+  );
 
   const optionWalker = React.useMemo(
     () => ({
@@ -88,6 +92,7 @@ export function useOptionWalker<TListboxElement extends HTMLElement>(options: Us
 
   return {
     optionWalker,
+    listboxCallbackRef: setListbox,
     listboxRef,
   };
 }

--- a/packages/react-components/react-aria/src/index.ts
+++ b/packages/react-components/react-aria/src/index.ts
@@ -3,8 +3,18 @@ export {
   useARIAButtonShorthand,
   useARIAButtonProps,
 } from './button/index';
-export { useActiveDescendant, ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE } from './activedescendant';
-export type { ActiveDescendantImperativeRef, ActiveDescendantOptions } from './activedescendant';
+export {
+  useActiveDescendant,
+  ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE,
+  ActiveDescendantContextProvider,
+  useActiveDescendantContext,
+  useHasParentActiveDescendantContext,
+} from './activedescendant';
+export type {
+  ActiveDescendantImperativeRef,
+  ActiveDescendantOptions,
+  ActiveDescendantContextValue,
+} from './activedescendant';
 export type {
   ARIAButtonSlotProps,
   ARIAButtonProps,


### PR DESCRIPTION
The active descendant API usage will (most of the time) be passed to children to use for 'focus' operations. Hoisting a context here so that it can be used by multiple controls.
