### PR TITLE
Fixing codepen issue for charts not opening

### DIFF
--- a/change/@fluentui-react-charting-e217bea5-7bc5-44cd-a606-027b5c599b2e.json
+++ b/change/@fluentui-react-charting-e217bea5-7bc5-44cd-a606-027b5c599b2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing codepen issue for charts not visible",
+  "packageName": "@fluentui/react-charting",
+  "email": "srmukher@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/webpack.config.js
+++ b/packages/react-charting/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = [
               mangle: {
                 keep_classnames: false,
                 keep_fnames: false,
-                toplevel: true,
                 properties: {
                   regex: regex,
                   undeclared: true,


### PR DESCRIPTION
Issue: The toplevel global variable name of "FluentUIReactCharting" inside window object was getting mangled to "t" when the "toplevel" was set to true and the corresponding chart in codepen was not visible as follows.
<img width="1247" alt="image" src="https://github.com/microsoft/fluentui/assets/120183316/fbf18533-8826-4e9e-b09c-0bac9bf38976">
After removing the toplevel property in mangle options (default value is false) restored the varibale name to "FluentUIReactCharting" without any impact on the generated min js size.
