### PR TITLE
feat(react-motions): add PresenceGroup

### DIFF
--- a/change/@fluentui-react-motions-preview-806677e6-3564-4fa7-8da6-d3372a84161f.json
+++ b/change/@fluentui-react-motions-preview-806677e6-3564-4fa7-8da6-d3372a84161f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add PresenceGroup component",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -99,6 +99,22 @@ declare namespace motionTokens {
 export { motionTokens }
 
 // @public (undocumented)
+export class PresenceGroup extends React_2.Component<PresenceGroupProps, PresenceGroupState> {
+    constructor(props: PresenceGroupProps, context: unknown);
+    // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
+    componentWillUnmount(): void;
+    // (undocumented)
+    static getDerivedStateFromProps(nextProps: PresenceGroupProps, { childMapping: prevChildMapping, firstRender }: PresenceGroupState): {
+        childMapping: PresenceGroupChildMapping;
+        firstRender: boolean;
+    };
+    // (undocumented)
+    render(): JSX.Element;
+}
+
+// @public (undocumented)
 export type PresenceMotion = {
     enter: AtomMotion;
     exit: AtomMotion;

--- a/packages/react-components/react-motions-preview/src/components/PresenceGroup.test.tsx
+++ b/packages/react-components/react-motions-preview/src/components/PresenceGroup.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { PresenceGroupChildContext, PresenceGroupChildContextValue } from '../contexts/PresenceGroupChildContext';
+import { PresenceGroup } from './PresenceGroup';
+
+const TestComponent: React.FC<{
+  id: string;
+  onRender: (data: { id: string; appear: boolean; visible: boolean }) => void;
+}> = props => {
+  const { id, onRender } = props;
+  const context = React.useContext(PresenceGroupChildContext) as PresenceGroupChildContextValue;
+
+  React.useEffect(() => {
+    onRender({
+      id,
+      appear: context.appear,
+      visible: context.visible,
+    });
+  });
+
+  return <div>{id}</div>;
+};
+
+describe('PresenceGroup', () => {
+  it('renders items an provides context to them', () => {
+    const onItemRender = jest.fn();
+
+    render(
+      <PresenceGroup>
+        <TestComponent id="1" onRender={onItemRender} />
+        <TestComponent id="2" onRender={onItemRender} />
+      </PresenceGroup>,
+    );
+
+    expect(onItemRender).toHaveBeenCalledTimes(2);
+    expect(onItemRender).toHaveBeenNthCalledWith(1, { id: '1', appear: false, visible: true });
+    expect(onItemRender).toHaveBeenNthCalledWith(2, { id: '2', appear: false, visible: true });
+  });
+
+  it('updates context when items are added or removed', () => {
+    const onItemRender = jest.fn();
+
+    const { rerender } = render(
+      <PresenceGroup>
+        <TestComponent key="1" id="1" onRender={onItemRender} />
+        <TestComponent key="2" id="2" onRender={onItemRender} />
+      </PresenceGroup>,
+    );
+
+    expect(onItemRender).toHaveBeenCalledTimes(2);
+    onItemRender.mockClear();
+
+    rerender(
+      <PresenceGroup>
+        <TestComponent key="1" id="1" onRender={onItemRender} />
+        <TestComponent key="3" id="3" onRender={onItemRender} />
+      </PresenceGroup>,
+    );
+
+    expect(onItemRender).toHaveBeenCalledTimes(3);
+    expect(onItemRender).toHaveBeenNthCalledWith(1, { id: '1', appear: false, visible: true });
+    expect(onItemRender).toHaveBeenNthCalledWith(2, { id: '3', appear: true, visible: true });
+    expect(onItemRender).toHaveBeenNthCalledWith(3, { id: '2', appear: false, visible: false });
+  });
+});

--- a/packages/react-components/react-motions-preview/src/components/PresenceGroup.tsx
+++ b/packages/react-components/react-motions-preview/src/components/PresenceGroup.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+
+import { getNextChildMapping } from '../utils/groups/getNextChildMapping';
+import { getChildMapping } from '../utils/groups/getChildMapping';
+import type { PresenceGroupChildMapping } from '../utils/groups/types';
+import { PresenceGroupItemProvider } from './PresenceGroupItemProvider';
+
+type PresenceGroupProps = {
+  children: React.ReactNode;
+};
+
+type PresenceGroupState = {
+  childMapping: PresenceGroupChildMapping;
+  firstRender: boolean;
+};
+
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export class PresenceGroup extends React.Component<PresenceGroupProps, PresenceGroupState> {
+  #mounted: boolean = false;
+
+  static getDerivedStateFromProps(
+    nextProps: PresenceGroupProps,
+    { childMapping: prevChildMapping, firstRender }: PresenceGroupState,
+  ) {
+    const nextChildMapping = getChildMapping(nextProps.children);
+
+    return {
+      childMapping: firstRender ? nextChildMapping : getNextChildMapping(prevChildMapping, nextChildMapping),
+      firstRender: false,
+    };
+  }
+
+  constructor(props: PresenceGroupProps, context: unknown) {
+    super(props, context);
+
+    this.state = {
+      childMapping: {},
+      firstRender: true,
+    };
+  }
+
+  #handleExit(childKey: string) {
+    const currentChildMapping = getChildMapping(this.props.children);
+
+    if (childKey in currentChildMapping) {
+      return;
+    }
+
+    if (this.#mounted) {
+      this.setState(state => {
+        const childMapping = { ...state.childMapping };
+        delete childMapping[childKey];
+
+        return { childMapping };
+      });
+    }
+  }
+
+  componentDidMount() {
+    this.#mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.#mounted = false;
+  }
+
+  render() {
+    return (
+      <>
+        {Object.entries(this.state.childMapping).map(([childKey, childProps]) => (
+          <PresenceGroupItemProvider {...childProps} childKey={childKey} key={childKey} onExit={this.#handleExit}>
+            {childProps.element}
+          </PresenceGroupItemProvider>
+        ))}
+      </>
+    );
+  }
+}

--- a/packages/react-components/react-motions-preview/src/components/PresenceGroupItemProvider.tsx
+++ b/packages/react-components/react-motions-preview/src/components/PresenceGroupItemProvider.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
+import type { PresenceGroupChildContextValue } from '../contexts/PresenceGroupChildContext';
+
+type PresenceGroupItemProviderProps = PresenceGroupChildContextValue & {
+  children: React.ReactElement;
+  childKey: string;
+};
+
+/**
+ * @internal
+ *
+ * Provides context for a single child of a `PresenceGroup`. Exists only to make a stable context value for a child.
+ * Not intended for direct use.
+ */
+export const PresenceGroupItemProvider: React.FC<PresenceGroupItemProviderProps> = props => {
+  const { appear, childKey, onExit, visible, unmountOnExit } = props;
+  const contextValue = React.useMemo(
+    () => ({
+      appear,
+      visible,
+      onExit: () => onExit(childKey),
+      unmountOnExit,
+    }),
+    [appear, childKey, onExit, visible, unmountOnExit],
+  );
+
+  return <PresenceGroupChildContext.Provider value={contextValue}>{props.children}</PresenceGroupChildContext.Provider>;
+};

--- a/packages/react-components/react-motions-preview/src/contexts/PresenceGroupChildContext.ts
+++ b/packages/react-components/react-motions-preview/src/contexts/PresenceGroupChildContext.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+/**
+ * @internal
+ */
+export type PresenceGroupChildContextValue = {
+  appear: boolean;
+  visible: boolean;
+  unmountOnExit: boolean;
+
+  onExit: (childKey: string) => void;
+};
+
+/**
+ * @internal
+ */
+export const PresenceGroupChildContext = React.createContext<PresenceGroupChildContextValue | undefined>(undefined);

--- a/packages/react-components/react-motions-preview/src/index.ts
+++ b/packages/react-components/react-motions-preview/src/index.ts
@@ -3,6 +3,8 @@ import * as motionTokens from './motions/motionTokens';
 export { createMotionComponent } from './factories/createMotionComponent';
 export { createPresenceComponent } from './factories/createPresenceComponent';
 
+export { PresenceGroup } from './components/PresenceGroup';
+
 export { motionTokens };
 
 export type { AtomMotion, AtomMotionFn, PresenceMotion, PresenceMotionFn, MotionImperativeRef } from './types';

--- a/packages/react-components/react-motions-preview/src/utils/groups/getChildMapping.test.tsx
+++ b/packages/react-components/react-motions-preview/src/utils/groups/getChildMapping.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { getChildMapping } from './getChildMapping';
+import { render } from '@testing-library/react';
+
+const TestComponent: React.FC<{
+  children: React.ReactNode;
+  onMapping: (mapping: ReturnType<typeof getChildMapping>) => void;
+}> = props => {
+  React.useEffect(() => {
+    props.onMapping(getChildMapping(props.children));
+  });
+
+  return null;
+};
+
+describe('getChildMapping', () => {
+  it('should return an object mapping key to child', () => {
+    const onMapping = jest.fn();
+
+    render(
+      <TestComponent onMapping={onMapping}>
+        <div>Hello</div>
+        <div>World</div>
+      </TestComponent>,
+    );
+
+    expect(onMapping).toHaveBeenCalledTimes(1);
+    expect(onMapping.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          ".0": Object {
+            "appear": false,
+            "element": <div>
+              Hello
+            </div>,
+            "unmountOnExit": true,
+            "visible": true,
+          },
+          ".1": Object {
+            "appear": false,
+            "element": <div>
+              World
+            </div>,
+            "unmountOnExit": true,
+            "visible": true,
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should return an empty object if children is nullable', () => {
+    expect(getChildMapping(null)).toEqual({});
+    expect(getChildMapping(undefined)).toEqual({});
+  });
+});

--- a/packages/react-components/react-motions-preview/src/utils/groups/getChildMapping.ts
+++ b/packages/react-components/react-motions-preview/src/utils/groups/getChildMapping.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import type { PresenceGroupChildMapping } from './types';
+
+/**
+ * Given `children`, return an object mapping key to child.
+ */
+export function getChildMapping(children: React.ReactNode | undefined) {
+  const childMapping: PresenceGroupChildMapping = {};
+
+  if (children) {
+    React.Children.toArray(children).forEach(child => {
+      if (React.isValidElement(child)) {
+        childMapping[child.key ?? ''] = {
+          appear: false,
+          element: child,
+          visible: true,
+          unmountOnExit: true,
+        };
+      }
+    });
+  }
+
+  return childMapping;
+}

--- a/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.test.tsx
+++ b/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.test.tsx
@@ -93,4 +93,45 @@ describe('getNextChildMapping', () => {
       }
     `);
   });
+
+  it('handles flipping items', () => {
+    const mapping = getNextChildMapping(
+      getChildMapping([<div key="a" />, <div key="b" />]),
+      getChildMapping([<div key="a" />]),
+    );
+
+    expect(mapping).toMatchInlineSnapshot(`
+      Object {
+        ".$a": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$b": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": false,
+        },
+      }
+    `);
+
+    expect(getNextChildMapping(mapping, getChildMapping([<div key="a" />, <div key="b" />]))).toMatchInlineSnapshot(`
+      Object {
+        ".$a": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$b": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+      }
+    `);
+  });
 });

--- a/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.test.tsx
+++ b/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.test.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+
+import { getChildMapping } from './getChildMapping';
+import { getNextChildMapping } from './getNextChildMapping';
+
+describe('getNextChildMapping', () => {
+  it('keeps items in as they are if mappings are the same', () => {
+    const previous = getChildMapping([<div key="a" />, <div key="b" />]);
+    const next = getChildMapping([<div key="a" />, <div key="b" />]);
+
+    expect(getNextChildMapping(previous, next)).toMatchInlineSnapshot(`
+      Object {
+        ".$a": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$b": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+      }
+    `);
+  });
+
+  it('removes items from the mapping', () => {
+    const previous = getChildMapping([<div key="a" />, <div key="b" />, <div key="c" />, <div key="d" />]);
+    const next = getChildMapping([<div key="b" />, <div key="d" />]);
+
+    expect(getNextChildMapping(previous, next)).toMatchInlineSnapshot(`
+      Object {
+        ".$a": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": false,
+        },
+        ".$b": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$c": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": false,
+        },
+        ".$d": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+      }
+    `);
+  });
+
+  it('adds new items into mappings', () => {
+    const previous = getChildMapping([<div key="b" />, <div key="d" />]);
+    const next = getChildMapping([<div key="a" />, <div key="b" />, <div key="c" />, <div key="d" />]);
+
+    expect(getNextChildMapping(previous, next)).toMatchInlineSnapshot(`
+      Object {
+        ".$a": Object {
+          "appear": true,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$b": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$c": Object {
+          "appear": true,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$d": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+      }
+    `);
+  });
+});

--- a/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.ts
+++ b/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.ts
@@ -1,0 +1,44 @@
+import { mergeChildMappings } from './mergeChildMappings';
+import type { PresenceGroupChildMapping } from './types';
+
+export function getNextChildMapping(
+  prevChildMapping: PresenceGroupChildMapping,
+  nextChildMapping: PresenceGroupChildMapping,
+) {
+  const childrenMapping = mergeChildMappings(prevChildMapping, nextChildMapping);
+
+  Object.entries(childrenMapping).forEach(([key, childDefinition]) => {
+    const hasPrev = key in prevChildMapping;
+    const hasNext = key in nextChildMapping;
+
+    const prevChild = prevChildMapping[key];
+    const isLeaving = !prevChild?.visible ?? false;
+
+    // item is new (entering)
+    if (hasNext && (!hasPrev || isLeaving)) {
+      childrenMapping[key] = {
+        ...childDefinition,
+        appear: true,
+        visible: true,
+      };
+      return;
+    }
+
+    // item is old (exiting)
+    if (!hasNext && hasPrev && !isLeaving) {
+      childrenMapping[key] = {
+        ...childDefinition,
+        visible: false,
+      };
+      return;
+    }
+
+    if (hasNext && hasPrev) {
+      // item hasn't changed transition states
+      // copy over the last transition props;
+      childrenMapping[key] = { ...childDefinition };
+    }
+  });
+
+  return childrenMapping;
+}

--- a/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.ts
+++ b/packages/react-components/react-motions-preview/src/utils/groups/getNextChildMapping.ts
@@ -11,11 +11,14 @@ export function getNextChildMapping(
     const hasPrev = key in prevChildMapping;
     const hasNext = key in nextChildMapping;
 
-    const prevChild = prevChildMapping[key];
-    const isLeaving = !prevChild?.visible ?? false;
+    if (hasNext) {
+      // Case 1: item hasn't changed transition states
+      if (hasPrev) {
+        childrenMapping[key] = { ...childDefinition };
+        return;
+      }
 
-    // item is new (entering)
-    if (hasNext && (!hasPrev || isLeaving)) {
+      // Case 2: item is new (entering)
       childrenMapping[key] = {
         ...childDefinition,
         appear: true,
@@ -24,20 +27,11 @@ export function getNextChildMapping(
       return;
     }
 
-    // item is old (exiting)
-    if (!hasNext && hasPrev && !isLeaving) {
-      childrenMapping[key] = {
-        ...childDefinition,
-        visible: false,
-      };
-      return;
-    }
-
-    if (hasNext && hasPrev) {
-      // item hasn't changed transition states
-      // copy over the last transition props;
-      childrenMapping[key] = { ...childDefinition };
-    }
+    // Case 3: item is leaving
+    childrenMapping[key] = {
+      ...childDefinition,
+      visible: false,
+    };
   });
 
   return childrenMapping;

--- a/packages/react-components/react-motions-preview/src/utils/groups/mergeChildMappings.test.tsx
+++ b/packages/react-components/react-motions-preview/src/utils/groups/mergeChildMappings.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { getChildMapping } from './getChildMapping';
+import { mergeChildMappings } from './mergeChildMappings';
+
+describe('mergeChildMappings', () => {
+  it('merges child mappings and keeps order', () => {
+    const previous = getChildMapping([<div key="a" />, <div key="b" />, <div key="c" />, <div key="d" />]);
+    const next = getChildMapping([<div key="b" />, <div key="d" />]);
+
+    expect(mergeChildMappings(previous, next)).toMatchInlineSnapshot(`
+      Object {
+        ".$a": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$b": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$c": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+        ".$d": Object {
+          "appear": false,
+          "element": <div />,
+          "unmountOnExit": true,
+          "visible": true,
+        },
+      }
+    `);
+  });
+});

--- a/packages/react-components/react-motions-preview/src/utils/groups/mergeChildMappings.ts
+++ b/packages/react-components/react-motions-preview/src/utils/groups/mergeChildMappings.ts
@@ -37,10 +37,8 @@ export function mergeChildMappings(
   // eslint-disable-next-line guard-for-in
   for (const nextKey in nextMapping) {
     if (nextKeysPending[nextKey]) {
-      for (let i = 0; i < nextKeysPending[nextKey].length; i++) {
-        const pendingNextKey = nextKeysPending[nextKey][i];
-
-        childMapping[nextKeysPending[nextKey][i]] = getValueForKey(pendingNextKey);
+      for (const pendingNextKey of nextKeysPending[nextKey]) {
+        childMapping[pendingNextKey] = getValueForKey(pendingNextKey);
       }
     }
 
@@ -48,8 +46,8 @@ export function mergeChildMappings(
   }
 
   // Finally, add the keys which didn't appear before any key in `next`
-  for (let i = 0; i < pendingKeys.length; i++) {
-    childMapping[pendingKeys[i]] = getValueForKey(pendingKeys[i]);
+  for (const pendingKey of pendingKeys) {
+    childMapping[pendingKey] = getValueForKey(pendingKey);
   }
 
   return childMapping;

--- a/packages/react-components/react-motions-preview/src/utils/groups/mergeChildMappings.ts
+++ b/packages/react-components/react-motions-preview/src/utils/groups/mergeChildMappings.ts
@@ -1,0 +1,56 @@
+import type { PresenceGroupChildMapping } from './types';
+
+/**
+ * When you're adding or removing children some may be added or removed in the same render pass. We want to show *both*
+ * since we want to simultaneously animate elements in and out. This function takes a previous set of keys and a new set
+ * of keys and merges them with its best guess of the correct ordering.
+ */
+export function mergeChildMappings(
+  prevMapping: PresenceGroupChildMapping,
+  nextMapping: PresenceGroupChildMapping,
+): PresenceGroupChildMapping {
+  function getValueForKey(key: string) {
+    return key in nextMapping ? nextMapping[key] : prevMapping[key];
+  }
+
+  // For each key of `next`, the list of keys to insert before that key in
+  // the combined list
+  const nextKeysPending: Record<string, string[]> = {};
+  let pendingKeys: string[] = [];
+
+  // eslint-disable-next-line guard-for-in
+  for (const prevKey in prevMapping) {
+    if (prevKey in nextMapping) {
+      if (pendingKeys.length) {
+        nextKeysPending[prevKey] = pendingKeys;
+        pendingKeys = [];
+      }
+
+      continue;
+    }
+
+    pendingKeys.push(prevKey);
+  }
+
+  const childMapping: PresenceGroupChildMapping = {};
+
+  // eslint-disable-next-line guard-for-in
+  for (const nextKey in nextMapping) {
+    if (nextKeysPending[nextKey]) {
+      for (let i = 0; i < nextKeysPending[nextKey].length; i++) {
+        const pendingNextKey = nextKeysPending[nextKey][i];
+
+        childMapping[nextKeysPending[nextKey][i]] = getValueForKey(pendingNextKey);
+      }
+    }
+
+    childMapping[nextKey] = getValueForKey(nextKey);
+  }
+
+  // Finally, add the keys which didn't appear before any key in `next`
+  for (let i = 0; i < pendingKeys.length; i++) {
+    childMapping[pendingKeys[i]] = getValueForKey(pendingKeys[i]);
+  }
+
+  return childMapping;
+}

--- a/packages/react-components/react-motions-preview/src/utils/groups/types.ts
+++ b/packages/react-components/react-motions-preview/src/utils/groups/types.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export type PresenceGroupChild = {
+  element: React.ReactElement;
+
+  appear: boolean;
+  visible: boolean;
+  unmountOnExit: boolean;
+};
+
+export type PresenceGroupChildMapping = Record<string, PresenceGroupChild>;

--- a/packages/react-components/react-motions-preview/stories/PresenceGroup/PresenceGroupDefault.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/PresenceGroup/PresenceGroupDefault.stories.tsx
@@ -1,0 +1,236 @@
+import {
+  makeStyles,
+  Button,
+  Persona,
+  shorthands,
+  tokens,
+  MessageBar,
+  MessageBarTitle,
+  MessageBarBody,
+} from '@fluentui/react-components';
+import { AddRegular, DeleteRegular } from '@fluentui/react-icons';
+import { createPresenceComponent, motionTokens, PresenceGroup } from '@fluentui/react-motions-preview';
+import * as React from 'react';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    ...shorthands.gap('10px'),
+
+    ...shorthands.border('3px', 'solid', tokens.colorNeutralForeground3),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    borderTopRightRadius: 0,
+    ...shorthands.padding('10px'),
+  },
+  controls: {
+    display: 'flex',
+
+    ...shorthands.gap('10px'),
+
+    ...shorthands.border('3px', 'solid', tokens.colorNeutralForeground3),
+    ...shorthands.borderBottom('none'),
+    borderTopLeftRadius: tokens.borderRadiusMedium,
+    borderTopRightRadius: tokens.borderRadiusMedium,
+    ...shorthands.padding('10px'),
+
+    alignSelf: 'end',
+  },
+});
+
+const users = [
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/AllanMunger.jpg',
+    name: 'Allan Munger',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/AmandaBrady.jpg',
+    name: 'Amanda Brady',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/AshleyMcCarthy.jpg',
+    name: 'Ashley McCarthy',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/CameronEvans.jpg',
+    name: 'Cameron Evans',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/CarlosSlattery.jpg',
+    name: 'Carlos Slattery',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/CarolePoland.jpg',
+    name: 'Carole Poland',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/CecilFolk.jpg',
+    name: 'Cecil Folk',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/CelesteBurton.jpg',
+    name: 'Celeste Burton',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/CharlotteWaltson.jpg',
+    name: 'Charlotte Waltson',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/ColinBallinger.jpg',
+    name: 'ColinBallinger',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/DaisyPhillips.jpg',
+    name: 'Daisy Phillips',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/ElliotWoodward.jpg',
+    name: 'Elliot Woodward',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/ElviaAtkins.jpg',
+    name: 'Elvia Atkins',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/ErikNason.jpg',
+    name: 'Erik Nason',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/HenryBrill.jpg',
+    name: 'Henry Brill',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/IsaacFielder.jpg',
+    name: 'Isaac Fielder',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/JohnieMcConnell.jpg',
+    name: 'Johnie McConnell',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/KatLarsson.jpg',
+    name: 'Kat Larsson',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/KatriAthokas.jpg',
+    name: 'Katri Athokas',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/KevinSturgis.jpg',
+    name: 'Kevin Sturgis',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/KristinPatterson.jpg',
+    name: 'Kristin Patterson',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/LydiaBauer.jpg',
+    name: 'Lydia Bauer',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/MauricioAugust.jpg',
+    name: 'Mauricio August',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/MiguelGarcia.jpg',
+    name: 'Miguel Garcia',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/MonaKane.jpg',
+    name: 'Mona Kane',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobertTolbert.jpg',
+    name: 'Robert Tolbert',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/RobinCounts.jpg',
+    name: 'Robin Counts',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/TimDeboer.jpg',
+    name: 'Tim Deboer',
+  },
+  {
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/WandaHoward.jpg',
+    name: 'Wanda Howard',
+  },
+];
+
+const ItemMotion = createPresenceComponent({
+  enter: {
+    keyframes: [
+      { opacity: 0, transform: 'scaleY(0) translateX(-30px)', height: 0 },
+      { opacity: 1, transform: 'scaleY(1) translateX(0)', height: '40px' },
+    ],
+    easing: motionTokens.easingEasyEase,
+    duration: motionTokens.durationUltraSlow,
+  },
+  exit: {
+    keyframes: [
+      { opacity: 1, transform: 'scaleY(1) translateX(0)', height: '40px' },
+      { opacity: 0, transform: 'scaleY(0) translateX(-30px)', height: 0 },
+    ],
+    easing: motionTokens.easingEasyEase,
+    duration: motionTokens.durationUltraSlow,
+  },
+});
+
+export const PresenceGroupDefault = () => {
+  const classes = useClasses();
+  const [limit, setLimit] = React.useState(3);
+
+  return (
+    <>
+      <div className={classes.container}>
+        <div className={classes.controls}>
+          <Button
+            appearance="primary"
+            disabled={limit + 1 === users.length}
+            icon={<AddRegular />}
+            onClick={() => setLimit(l => l + 1)}
+            size="small"
+          >
+            Add user
+          </Button>
+          <Button disabled={limit === 0} icon={<DeleteRegular />} onClick={() => setLimit(l => l - 1)} size="small">
+            Remove user
+          </Button>
+        </div>
+
+        <div className={classes.card}>
+          <ItemMotion visible={limit === 0} unmountOnExit>
+            <MessageBar>
+              <MessageBarBody>
+                <MessageBarTitle>No users</MessageBarTitle>
+                Click "Add user" to add a user to the presence group.
+              </MessageBarBody>
+            </MessageBar>
+          </ItemMotion>
+
+          <PresenceGroup>
+            {users.slice(0, limit).map(item => (
+              <ItemMotion key={item.name}>
+                <Persona
+                  avatar={{
+                    image: { src: item.image },
+                  }}
+                  textPosition="after"
+                  name={item.name}
+                  presence={{ status: 'available' }}
+                  secondaryText="Available"
+                  size="extra-large"
+                />
+              </ItemMotion>
+            ))}
+          </PresenceGroup>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/react-components/react-motions-preview/stories/PresenceGroup/PresenceGroupDescription.md
+++ b/packages/react-components/react-motions-preview/stories/PresenceGroup/PresenceGroupDescription.md
@@ -1,0 +1,11 @@
+`PresenceGroup` is a component that manages a set of components created with `createPresenceComponent()` in a list. `PresenceGroup` is a state machine for managing the mounting and unmounting of components over time.
+
+> Note: `PresenceGroup` does not define motions.
+>
+> It only manages the mounting and unmounting of components. You must use `createPresenceComponent()` to define the motions for each component. This allows you to mix and match different motions for different components in the same `PresenceGroup`.
+
+<!-- Don't allow prettier to collapse code block into single line -->
+<!-- prettier-ignore -->
+> **⚠️ Preview packages are considered unstable:**
+> - Features and APIs may change before final release
+> - Please contact us if you intend to use this in your product

--- a/packages/react-components/react-motions-preview/stories/PresenceGroup/index.stories.ts
+++ b/packages/react-components/react-motions-preview/stories/PresenceGroup/index.stories.ts
@@ -1,0 +1,15 @@
+import PresenceGroupDescription from './PresenceGroupDescription.md';
+
+export { PresenceGroupDefault as Default } from './PresenceGroupDefault.stories';
+
+export default {
+  title: 'Utilities/Web Motions (Preview)/PresenceGroup',
+  component: null,
+  parameters: {
+    docs: {
+      description: {
+        component: PresenceGroupDescription,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## New Behavior

### `createPresenceComponent()` 

The factory was updated to store options that should not trigger re-renders in `optionsRef`.

### `PresenceGroup`

This PR adds a new component called `PresenceGroup`:

> `PresenceGroup` is a component that manages a set of components created with `createPresenceComponent()` in a list. `PresenceGroup` is a state machine for managing the mounting and unmounting of components over time.

While code is mostly ported from `react-transition-group`, it has some differences: we don't rely on cloning items and rely on React context instead.

Note: `PresenceGroup` is implemented as a class component to benefit from `getDerivedStateFromProps()`. While it's possible to implement this functionality with React hooks, it will require state management tricks.

## Related Issue(s)

Fixes #30546.
