### PR TITLE
fix: Remove import cycle between assertSlots.ts and index.ts

### DIFF
--- a/change/@fluentui-react-utilities-f584d831-49de-41c8-95ba-8df7bcf5dbd1.json
+++ b/change/@fluentui-react-utilities-f584d831-49de-41c8-95ba-8df7bcf5dbd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Remove import cycle between assertSlots.ts and index.ts",
+  "packageName": "@fluentui/react-utilities",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SLOT_ELEMENT_TYPE_SYMBOL } from './constants';
 import { isSlot } from './isSlot';
 import { ComponentState, ExtractSlotProps, SlotComponentType, SlotPropsRecord } from './types';
-import { slot } from './index';
+import * as slot from './slot';
 
 type SlotComponents<Slots extends SlotPropsRecord> = {
   [K in keyof Slots]: SlotComponentType<ExtractSlotProps<Slots[K]>>;


### PR DESCRIPTION
## Previous Behavior

The file `assertSlots.ts` imports from `./index`, and `index.ts` exports `*` from `./assertSlots`. This was creating an import cycle and a warning message from `@rnx-kit`:

```log
warn @fluentui\react-utilities\lib-commonjs\compose\index.js
warn └── @fluentui\react-utilities\lib-commonjs\compose\assertSlots.js
warn     └── @fluentui\react-utilities\lib-commonjs\compose\index.js
warn         └── @fluentui\react-utilities\lib-commonjs\index.js

error Import cycles detected.
```

## New Behavior

Have `assertSlots.ts` import directly from `./slot` instead of `./index`.