### PR TITLE
Update Next.js appDir docs to prevent duplicate style renders

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/SSR/NextJSAppDir.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/NextJSAppDir.stories.mdx
@@ -39,8 +39,13 @@ import { useServerInsertedHTML } from 'next/navigation';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [renderer] = React.useState(() => createDOMRenderer());
+  const didRenderRef = useRef(false);
 
   useServerInsertedHTML(() => {
+    if (didRenderRef.current) {
+      return;
+    }
+    didRenderRef.current = true;
     return <>{renderToStyleElements(renderer)}</>;
   });
 

--- a/apps/public-docsite-v9/src/Concepts/SSR/NextJSAppDir.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/NextJSAppDir.stories.mdx
@@ -39,7 +39,7 @@ import { useServerInsertedHTML } from 'next/navigation';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [renderer] = React.useState(() => createDOMRenderer());
-  const didRenderRef = useRef(false);
+  const didRenderRef = React.useRef(false);
 
   useServerInsertedHTML(() => {
     if (didRenderRef.current) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

The existing Next.js documentation for app router results in behavior where styles are rendered multiple times (once in the bottom of the `<head>` and then an arbitrary number of times in the bottom of `<body>`):

![image](https://github.com/microsoft/fluentui/assets/2302043/68bb0ede-db23-4d82-a149-48c5c4fc5789)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Update the documentation to ensure that the styles are rendered only once:

![image](https://github.com/microsoft/fluentui/assets/2302043/b1645d6c-ea5c-45b6-a892-22f3fffee7ce)

The solution itself was suggested in [this discussion](https://github.com/vercel/next.js/discussions/49354#discussioncomment-6279917) in Next.js repo.

This should be removed once the underlying issue is uncovered and resolved (either in this library or upstream in Next.js).

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
