### PR TITLE
Adds ability for NavSubItem to select it's parent

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -37,7 +37,9 @@ export type NavCategoryItemSlots = {
 };
 
 // @public
-export type NavCategoryItemState = ComponentState<NavCategoryItemSlots> & NavCategoryItemContextValue;
+export type NavCategoryItemState = ComponentState<NavCategoryItemSlots> & NavCategoryItemContextValue & {
+    selected: boolean;
+};
 
 // @public
 export type NavCategoryProps = {
@@ -52,17 +54,18 @@ export type NavCategoryState = NavCategoryContextValue & Required<NavCategoryPro
 export const navClassNames: SlotClassNames<NavSlots>;
 
 // @public (undocumented)
-export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue' | 'reserveSelectedNavItemSpace'> & {
+export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue' | 'selectedCategoryValue' | 'reserveSelectedNavItemSpace'> & {
     onRegister: RegisterNavItemEventHandler;
     onUnregister: RegisterNavItemEventHandler;
     onSelect: EventHandler<OnNavItemSelectData>;
     getRegisteredNavItems: () => {
         selectedValue?: NavItemValue;
+        selectedCategoryValue?: NavItemValue;
         previousSelectedValue?: NavItemValue;
         registeredNavItems: Record<string, NavItemRegisterData>;
     };
     onRequestNavCategoryItemToggle: EventHandler<OnNavItemSelectData>;
-    openItems: NavItemValue[];
+    openCategories: NavItemValue[];
 };
 
 // @public
@@ -105,8 +108,10 @@ export type NavItemValue = unknown;
 export type NavProps = ComponentProps<NavSlots> & {
     reserveSelectedNavItemSpace?: boolean;
     defaultSelectedValue?: NavItemValue;
+    defaultSelectedCategoryValue?: NavItemValue;
     onNavItemSelect?: EventHandler<OnNavItemSelectData>;
     selectedValue?: NavItemValue;
+    selectedCategoryValue?: NavItemValue;
     onNavCategoryItemToggle?: EventHandler<OnNavItemSelectData>;
 };
 
@@ -147,15 +152,20 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 };
 
 // @public
-export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {};
+export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
+    value: NavItemValue;
+};
 
 // @public (undocumented)
 export type NavSubItemSlots = {
-    root: Slot<'div'>;
+    root: Slot<'button'>;
+    content: NonNullable<Slot<'span'>>;
 };
 
 // @public
-export type NavSubItemState = ComponentState<NavSubItemSlots>;
+export type NavSubItemState = ComponentState<NavSubItemSlots> & Pick<NavSubItemProps, 'value'> & {
+    selected: boolean;
+};
 
 // @public (undocumented)
 export type RegisterNavItemEventHandler = (data: NavItemRegisterData) => void;
@@ -203,7 +213,7 @@ export const useNavItemStyles_unstable: (state: NavItemState) => NavItemState;
 export const useNavStyles_unstable: (state: NavState) => NavState;
 
 // @public
-export const useNavSubItem_unstable: (props: NavSubItemProps, ref: React_2.Ref<HTMLDivElement>) => NavSubItemState;
+export const useNavSubItem_unstable: (props: NavSubItemProps, ref: React_2.Ref<HTMLButtonElement>) => NavSubItemState;
 
 // @public
 export const useNavSubItemGroup_unstable: (props: NavSubItemGroupProps, ref: React_2.Ref<HTMLDivElement>) => NavSubItemGroupState;

--- a/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
@@ -28,6 +28,13 @@ export type NavProps = ComponentProps<NavSlots> & {
   defaultSelectedValue?: NavItemValue;
 
   /**
+   * The value of the navCategory to be selected by default.
+   * Typically useful when the selectedValue is uncontrolled.
+   *  Mutually exclusive with selectedValue.
+   */
+  defaultSelectedCategoryValue?: NavItemValue;
+
+  /**
    * Raised when a navItem is selected.
    */
   onNavItemSelect?: EventHandler<OnNavItemSelectData>;
@@ -37,6 +44,13 @@ export type NavProps = ComponentProps<NavSlots> & {
    * Mutually exclusive with defaultSelectedValue.
    */
   selectedValue?: NavItemValue;
+
+  /**
+   * Indicates a category that has a selected child
+   * Will show the category as selected if it is closed.
+   * Null otherwise
+   */
+  selectedCategoryValue?: NavItemValue;
 
   /**
    * Callback used by NavCategoryItem to request a change on it's own opened state
@@ -49,6 +63,12 @@ export type OnNavItemSelectData = EventData<'click', React.MouseEvent<HTMLButton
    * The value of the selected navItem.
    */
   value: NavItemValue;
+
+  /**
+   * The parent value of the selected navItem
+   * Null if not a child of a category
+   */
+  categoryValue?: NavItemValue;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
@@ -63,7 +63,7 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
 
   const innerRef = React.useRef<HTMLElement>(null);
 
-  const [openItems, setOpenItems] = useControllableState({
+  const [openCategories, setOpenCategories] = useControllableState({
     // normalizeValues(controlledOpenItems), [controlledOpenItems])
     state: React.useMemo(() => normalizeValues(), []),
     defaultState: () => [], // initializeUncontrolledOpenItems({ defaultOpenItems }),
@@ -71,9 +71,9 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
   });
 
   const onRequestNavCategoryItemToggle: EventHandler<OnNavItemSelectData> = useEventCallback((event, data) => {
-    const nextOpenItems = updateOpenItems(data.value, openItems, false);
+    const nextOpenItems = updateOpenItems(data.value, openCategories, false);
     onNavCategoryItemToggle?.(event, data);
-    setOpenItems(nextOpenItems);
+    setOpenCategories(nextOpenItems);
   });
 
   const [selectedValue, setSelectedValue] = useControllableState({
@@ -133,6 +133,6 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
     onSelect,
     getRegisteredNavItems,
     onRequestNavCategoryItemToggle,
-    openItems,
+    openCategories,
   };
 };

--- a/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
@@ -76,11 +76,17 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
     setOpenCategories(nextOpenItems);
   });
 
+  const [selectedCategoryValue, setSelectedCategoryValue] = useControllableState({
+    state: props.selectedCategoryValue,
+    defaultState: props.defaultSelectedCategoryValue,
+    initialState: undefined,
+  });
   const [selectedValue, setSelectedValue] = useControllableState({
     state: props.selectedValue,
     defaultState: props.defaultSelectedValue,
     initialState: undefined,
   });
+
   // considered usePrevious, but it is sensitive to re-renders
   // this could cause the previous to move to current in the case where the navItem list re-renders.
   // these refs avoid getRegisteredNavItems changing when selectedValue changes and causing
@@ -88,13 +94,20 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
   const currentSelectedValue = React.useRef<NavItemValue | undefined>(undefined);
   const previousSelectedValue = React.useRef<NavItemValue | undefined>(undefined);
 
+  const currentSelectedCategoryValue = React.useRef<NavItemValue | undefined>(undefined);
+  const previousSelectedCategoryValue = React.useRef<NavItemValue | undefined>(undefined);
+
   React.useEffect(() => {
     previousSelectedValue.current = currentSelectedValue.current;
     currentSelectedValue.current = selectedValue;
-  }, [selectedValue]);
+
+    previousSelectedCategoryValue.current = currentSelectedCategoryValue.current;
+    currentSelectedCategoryValue.current = selectedCategoryValue;
+  }, [selectedValue, selectedCategoryValue]);
 
   const onSelect: EventHandler<OnNavItemSelectData> = useEventCallback((event, data) => {
     setSelectedValue(data.value);
+    setSelectedCategoryValue(data.categoryValue);
     onNavItemSelect?.(event, data);
   });
 
@@ -112,6 +125,8 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
     return {
       selectedValue: currentSelectedValue.current,
       previousSelectedValue: previousSelectedValue.current,
+      selectedCategoryValue: currentSelectedCategoryValue.current,
+      previousSelectedCategoryValue: previousSelectedCategoryValue.current,
       registeredNavItems: registeredNavItems.current,
     };
   }, []);
@@ -128,6 +143,7 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
       { elementType: 'div' },
     ),
     selectedValue,
+    selectedCategoryValue,
     onRegister,
     onUnregister,
     onSelect,

--- a/packages/react-components/react-nav-preview/src/components/NavCategory/useNavCategory.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavCategory/useNavCategory.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import type { NavCategoryProps, NavCategoryState } from './NavCategory.types';
 import { useNavContext_unstable } from '../NavContext';
+
+import type { NavCategoryProps, NavCategoryState } from './NavCategory.types';
 
 /**
  * Create the state required to render NavCategory.
@@ -14,9 +15,9 @@ import { useNavContext_unstable } from '../NavContext';
 export const useNavCategory_unstable = (props: NavCategoryProps, ref: React.Ref<HTMLDivElement>): NavCategoryState => {
   const { value, children } = props;
 
-  const { openItems } = useNavContext_unstable();
+  const { openCategories } = useNavContext_unstable();
 
-  const open: boolean = openItems?.includes(value);
+  const open: boolean = openCategories?.includes(value);
 
   return {
     open,

--- a/packages/react-components/react-nav-preview/src/components/NavCategoryItem/NavCategoryItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavCategoryItem/NavCategoryItem.types.ts
@@ -1,5 +1,6 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { NavCategoryItemContextValue } from '../NavCategoryItemContext';
+
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavCategoryItemContextValues = {
   navCategoryItem: NavCategoryItemContextValue;
@@ -33,4 +34,10 @@ export type NavCategoryItemProps = ComponentProps<Partial<NavCategoryItemSlots>>
 /**
  * State used in rendering NavCategoryItem
  */
-export type NavCategoryItemState = ComponentState<NavCategoryItemSlots> & NavCategoryItemContextValue;
+export type NavCategoryItemState = ComponentState<NavCategoryItemSlots> &
+  NavCategoryItemContextValue & {
+    /**
+     * If this navCategoryItem is selected
+     */
+    selected: boolean;
+  };

--- a/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
@@ -27,9 +27,7 @@ const useContentStyles = makeStyles({
   closed: {
     transform: 'rotate(90deg)',
   },
-  selected: {
-    ...typographyStyles.body1Strong,
-  },
+  selected: typographyStyles.body1Strong,
 });
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
@@ -1,8 +1,8 @@
-import type { NavCategoryItemSlots, NavCategoryItemState } from './NavCategoryItem.types';
-
 import { makeResetStyles, mergeClasses, makeStyles } from '@griffel/react';
 import { typographyStyles } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
+
+import type { NavCategoryItemSlots, NavCategoryItemState } from './NavCategoryItem.types';
 
 export const navCategoryItemClassNames: SlotClassNames<NavCategoryItemSlots> = {
   root: 'fui-NavCategoryItem',
@@ -17,7 +17,7 @@ const useRootStyles = makeResetStyles({
   ...typographyStyles.body1,
 });
 
-const useExpandIconStyles = makeStyles({
+const useContentStyles = makeStyles({
   icon: {
     display: 'flex',
   },
@@ -27,6 +27,9 @@ const useExpandIconStyles = makeStyles({
   closed: {
     transform: 'rotate(90deg)',
   },
+  selected: {
+    ...typographyStyles.body1Strong,
+  },
 });
 
 /**
@@ -34,14 +37,21 @@ const useExpandIconStyles = makeStyles({
  */
 export const useNavCategoryItemStyles_unstable = (state: NavCategoryItemState): NavCategoryItemState => {
   const defaultRootStyles = useRootStyles();
-  const expandIconStyles = useExpandIconStyles();
+  const contentStyles = useContentStyles();
 
-  state.root.className = mergeClasses(navCategoryItemClassNames.root, defaultRootStyles, state.root.className);
+  const { selected } = state;
+
+  state.root.className = mergeClasses(
+    navCategoryItemClassNames.root,
+    defaultRootStyles,
+    state.root.className,
+    selected && state.open === false && contentStyles.selected,
+  );
 
   state.expandIcon.className = mergeClasses(
     navCategoryItemClassNames.expandIcon,
-    expandIconStyles.icon,
-    state.open ? expandIconStyles.open : expandIconStyles.closed,
+    contentStyles.icon,
+    state.open ? contentStyles.open : contentStyles.closed,
     state.expandIcon.className,
   );
 

--- a/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.tsx
@@ -22,11 +22,13 @@ export const useNavCategoryItem_unstable = (
 
   const { open, value } = useNavCategoryContext_unstable();
 
-  const { onRequestNavCategoryItemToggle } = useNavContext_unstable();
+  const { onRequestNavCategoryItemToggle, selectedCategoryValue } = useNavContext_unstable();
 
   const onNavCategoryItemClick = useEventCallback(
     mergeCallbacks(onClick, event => onRequestNavCategoryItemToggle(event, { type: 'click', event, value })),
   );
+
+  const selected = selectedCategoryValue === value;
 
   // TODO - these are copied from AccordionHeader.
   // We need to figure out if they are applicable to this
@@ -80,6 +82,7 @@ export const useNavCategoryItem_unstable = (
       },
       elementType: 'span',
     }),
+    selected,
     // button: useARIAButtonProps(buttonSlot.as, buttonSlot),
     // button: slot.always(
     //   getIntrinsicElementProps('button', {

--- a/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.tsx
@@ -58,6 +58,7 @@ export const useNavCategoryItem_unstable = (
   return {
     open,
     value,
+    selected,
     // TODO add appropriate props/defaults
     components: {
       root: 'button',
@@ -82,7 +83,6 @@ export const useNavCategoryItem_unstable = (
       },
       elementType: 'span',
     }),
-    selected,
     // button: useARIAButtonProps(buttonSlot.as, buttonSlot),
     // button: slot.always(
     //   getIntrinsicElementProps('button', {

--- a/packages/react-components/react-nav-preview/src/components/NavContext.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavContext.ts
@@ -4,6 +4,7 @@ import { NavContextValue } from './NavContext.types';
 const navContextDefaultValue: NavContextValue = {
   reserveSelectedNavItemSpace: true,
   selectedValue: undefined,
+  selectedCategoryValue: undefined,
   onRegister: () => {
     /* noop */
   },

--- a/packages/react-components/react-nav-preview/src/components/NavContext.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavContext.ts
@@ -24,7 +24,7 @@ const navContextDefaultValue: NavContextValue = {
   /**
    * The list of opened panels by index
    */
-  openItems: [],
+  openCategories: [],
 };
 
 const NavContext = React.createContext<NavContextValue | undefined>(undefined);

--- a/packages/react-components/react-nav-preview/src/components/NavContext.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavContext.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import type { NavProps, OnNavItemSelectData } from './Nav/Nav.types';
 import { EventHandler } from '@fluentui/react-utilities';
+
+import type { NavProps, OnNavItemSelectData } from './Nav/Nav.types';
 
 export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue' | 'reserveSelectedNavItemSpace'> & {
   /** A callback to allow a navItem to register itself with the navItem list. */
@@ -29,7 +30,7 @@ export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue'
   /**
    * The list of opened panels by index
    */
-  openItems: NavItemValue[];
+  openCategories: NavItemValue[];
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavContext.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavContext.types.ts
@@ -3,7 +3,10 @@ import { EventHandler } from '@fluentui/react-utilities';
 
 import type { NavProps, OnNavItemSelectData } from './Nav/Nav.types';
 
-export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue' | 'reserveSelectedNavItemSpace'> & {
+export type NavContextValue = Pick<
+  NavProps,
+  'onNavItemSelect' | 'selectedValue' | 'selectedCategoryValue' | 'reserveSelectedNavItemSpace'
+> & {
   /** A callback to allow a navItem to register itself with the navItem list. */
   onRegister: RegisterNavItemEventHandler;
 
@@ -18,6 +21,7 @@ export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue'
    */
   getRegisteredNavItems: () => {
     selectedValue?: NavItemValue;
+    selectedCategoryValue?: NavItemValue;
     previousSelectedValue?: NavItemValue;
     registeredNavItems: Record<string, NavItemRegisterData>;
   };

--- a/packages/react-components/react-nav-preview/src/components/NavItem/renderNavItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/renderNavItem.tsx
@@ -2,6 +2,7 @@
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
 import { assertSlots } from '@fluentui/react-utilities';
+
 import type { NavItemState, NavItemSlots } from './NavItem.types';
 
 /**
@@ -10,11 +11,8 @@ import type { NavItemState, NavItemSlots } from './NavItem.types';
 export const renderNavItem_unstable = (state: NavItemState) => {
   assertSlots<NavItemSlots>(state);
 
-  // TODO Add additional slots in the appropriate place
   return (
     <state.root>
-      {/* TODO: light this up when we have design spec */}
-      {/* {state.icon && <state.icon />} */}
       <state.content />
     </state.root>
   );

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from '@fluentui/react-utilities';
-import type { NavItemProps, NavItemState } from './NavItem.types';
 import { useNavContext_unstable } from '../NavContext';
+
+import type { NavItemProps, NavItemState } from './NavItem.types';
 
 /**
  * Create the state required to render NavItem.

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -20,9 +20,7 @@ const useStyles = makeResetStyles({
  * Styles for the content slot (children)
  */
 const useContentStyles = makeStyles({
-  selected: {
-    ...typographyStyles.body1Strong,
-  },
+  selected: typographyStyles.body1Strong,
 });
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -17,7 +17,7 @@ export type NavSubItemSlots = {
  */
 export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
   /**
-   * The value that identifies this navCategoryItem when selected.
+   * The value that identifies this NavSubItem when selected.
    */
   value: NavItemValue;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -28,7 +28,7 @@ export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
 export type NavSubItemState = ComponentState<NavSubItemSlots> &
   Pick<NavSubItemProps, 'value'> & {
     /**
-     * If this navCategoryItem is selected
+     * If this NavSubItem is selected
      */
     selected: boolean;
   };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -1,17 +1,34 @@
+import { NavItemValue } from '../NavContext.types';
+
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavSubItemSlots = {
-  root: Slot<'div'>;
+  root: Slot<'button'>;
+
+  /**
+   * Component children are placed in this slot
+   * Avoid using the `children` property in this slot in favour of Component children whenever possible.
+   */
+  content: NonNullable<Slot<'span'>>;
 };
 
 /**
  * NavSubItem Props
  */
-export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {};
+export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
+  /**
+   * The value that identifies this navCategoryItem when selected.
+   */
+  value: NavItemValue;
+};
 
 /**
  * State used in rendering NavSubItem
  */
-export type NavSubItemState = ComponentState<NavSubItemSlots>;
-// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavSubItemProps.
-// & Required<Pick<NavSubItemProps, 'propName'>>
+export type NavSubItemState = ComponentState<NavSubItemSlots> &
+  Pick<NavSubItemProps, 'value'> & {
+    /**
+     * If this navCategoryItem is selected
+     */
+    selected: boolean;
+  };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/renderNavSubItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/renderNavSubItem.tsx
@@ -2,6 +2,7 @@
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
 import { assertSlots } from '@fluentui/react-utilities';
+
 import type { NavSubItemState, NavSubItemSlots } from './NavSubItem.types';
 
 /**
@@ -11,5 +12,9 @@ export const renderNavSubItem_unstable = (state: NavSubItemState) => {
   assertSlots<NavSubItemSlots>(state);
 
   // TODO Add additional slots in the appropriate place
-  return <state.root />;
+  return (
+    <state.root>
+      <state.content />
+    </state.root>
+  );
 };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from '@fluentui/react-utilities';
+import { useNavContext_unstable } from '../NavContext';
+
 import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
 
 /**
@@ -9,23 +11,54 @@ import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
  * before being passed to renderNavSubItem_unstable.
  *
  * @param props - props from this instance of NavSubItem
- * @param ref - reference to root HTMLDivElement of NavSubItem
+ * @param ref - reference to root HTMLButtonElement of NavSubItem
  */
-export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HTMLDivElement>): NavSubItemState => {
+export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HTMLButtonElement>): NavSubItemState => {
+  const { content, onClick, value: subItemValue } = props;
+
+  const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
+
+  const selected = selectedValue === subItemValue;
+
+  const innerRef = React.useRef<HTMLElement>(null);
+
+  const onNavSubItemClick = useEventCallback(
+    mergeCallbacks(onClick, event => onSelect(event, { type: 'click', event, value: subItemValue })),
+  );
+
+  React.useEffect(() => {
+    onRegister({
+      value: subItemValue,
+      ref: innerRef,
+    });
+
+    return () => {
+      onUnregister({ value: subItemValue, ref: innerRef });
+    };
+  }, [onRegister, onUnregister, innerRef, subItemValue]);
+
+  const contentSlot = slot.always(content, {
+    defaultProps: { children: props.children },
+    elementType: 'span',
+  });
+
   return {
-    // TODO add appropriate props/defaults
     components: {
-      // TODO add each slot's element type or component
-      root: 'div',
+      root: 'button',
+      content: 'span',
     },
-    // TODO add appropriate slots, for example:
-    // mySlot: resolveShorthand(props.mySlot),
     root: slot.always(
-      getIntrinsicElementProps('div', {
+      getIntrinsicElementProps('button', {
         ref,
+        role: 'nav',
+        type: 'navigation',
         ...props,
+        onClick: onNavSubItemClick,
       }),
-      { elementType: 'div' },
+      { elementType: 'button' },
     ),
+    content: contentSlot,
+    selected,
+    value: subItemValue,
   };
 };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from '@fluentui/react-utilities';
 import { useNavContext_unstable } from '../NavContext';
+import { useNavCategoryContext_unstable } from '../NavCategoryContext';
 
 import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
 
@@ -18,12 +19,16 @@ export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HT
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
 
+  const { value: parentCategoryValue } = useNavCategoryContext_unstable();
+
   const selected = selectedValue === subItemValue;
 
   const innerRef = React.useRef<HTMLElement>(null);
 
   const onNavSubItemClick = useEventCallback(
-    mergeCallbacks(onClick, event => onSelect(event, { type: 'click', event, value: subItemValue })),
+    mergeCallbacks(onClick, event =>
+      onSelect(event, { type: 'click', event, value: subItemValue, categoryValue: parentCategoryValue }),
+    ),
   );
 
   React.useEffect(() => {

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
@@ -6,7 +6,7 @@ import type { NavSubItemSlots, NavSubItemState } from './NavSubItem.types';
 
 export const navSubItemClassNames: SlotClassNames<NavSubItemSlots> = {
   root: 'fui-NavSubItem',
-  content: 'fui-NavItem__content',
+  content: 'fui-NavSubItem__content',
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
@@ -1,33 +1,54 @@
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { typographyStyles } from '@fluentui/react-theme';
+
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { NavSubItemSlots, NavSubItemState } from './NavSubItem.types';
 
 export const navSubItemClassNames: SlotClassNames<NavSubItemSlots> = {
   root: 'fui-NavSubItem',
-  // TODO: add class names for all slots on NavSubItemSlots.
-  // Should be of the form `<slotName>: 'fui-NavSubItem__<slotName>`
+  content: 'fui-NavItem__content',
 };
 
 /**
  * Styles for the root slot
  */
-const useStyles = makeStyles({
-  root: {
-    // TODO Add default styles for the root element
-  },
+const useStyles = makeResetStyles({
+  display: 'flex',
+  ...typographyStyles.body1,
+});
 
-  // TODO add additional classes for different states and/or slots
+/**
+ * Styles for the content slot (children)
+ */
+const useContentStyles = makeStyles({
+  selected: {
+    ...typographyStyles.body1Strong,
+  },
 });
 
 /**
  * Apply styling to the NavSubItem slots based on the state
  */
 export const useNavSubItemStyles_unstable = (state: NavSubItemState): NavSubItemState => {
-  const styles = useStyles();
-  state.root.className = mergeClasses(navSubItemClassNames.root, styles.root, state.root.className);
+  const rootStyles = useStyles();
+  const contentStyles = useContentStyles();
 
-  // TODO Add class names to slots, for example:
-  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+  const { selected } = state;
+
+  state.root.className = mergeClasses(
+    navSubItemClassNames.root,
+    rootStyles,
+
+    state.root.className,
+  );
+
+  state.content.className = mergeClasses(
+    navSubItemClassNames.content,
+    selected && contentStyles.selected,
+    state.content.className,
+  );
+
+  return state;
 
   return state;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
@@ -49,6 +49,4 @@ export const useNavSubItemStyles_unstable = (state: NavSubItemState): NavSubItem
   );
 
   return state;
-
-  return state;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItemStyles.styles.ts
@@ -21,9 +21,7 @@ const useStyles = makeResetStyles({
  * Styles for the content slot (children)
  */
 const useContentStyles = makeStyles({
-  selected: {
-    ...typographyStyles.body1Strong,
-  },
+  selected: typographyStyles.body1Strong,
 });
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
+++ b/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
@@ -4,6 +4,7 @@ import { NavContextValue, NavContextValues, NavState } from '../Nav';
 export function useNavContextValues_unstable(state: NavState): NavContextValues {
   const {
     selectedValue,
+    selectedCategoryValue,
     onRegister,
     onUnregister,
     onSelect,
@@ -15,6 +16,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
   const navContext = React.useMemo<NavContextValue>(
     () => ({
       selectedValue,
+      selectedCategoryValue,
       onSelect,
       onRegister,
       onUnregister,
@@ -24,6 +26,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
     }),
     [
       selectedValue,
+      selectedCategoryValue,
       onSelect,
       onRegister,
       onUnregister,

--- a/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
+++ b/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
@@ -9,7 +9,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
     onSelect,
     getRegisteredNavItems,
     onRequestNavCategoryItemToggle,
-    openItems,
+    openCategories,
   } = state;
 
   const navContext = React.useMemo<NavContextValue>(
@@ -20,7 +20,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
       onUnregister,
       getRegisteredNavItems,
       onRequestNavCategoryItemToggle,
-      openItems,
+      openCategories,
     }),
     [
       selectedValue,
@@ -29,7 +29,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
       onUnregister,
       getRegisteredNavItems,
       onRequestNavCategoryItemToggle,
-      openItems,
+      openCategories,
     ],
   );
 

--- a/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItems.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItems.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Nav, NavCategory, NavCategoryItem, NavItem, NavSubItem, NavSubItemGroup } from '@fluentui/react-nav-preview';
+
+export const WithNestedSubItems = () => {
+  return (
+    <Nav defaultSelectedValue={'2'}>
+      <NavItem value="1">First</NavItem>
+      <NavItem value="2">Second</NavItem>
+      <NavItem value="3">Third</NavItem>
+      <NavCategory value="4">
+        <NavCategoryItem>NavCategoryItem 1</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="5">Five</NavSubItem>
+          <NavSubItem value="6">Six</NavSubItem>
+          <NavSubItem value="7">Seven</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+      <NavCategory value="8">
+        <NavCategoryItem>NavCategoryItem2</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="9">Nine</NavSubItem>
+          <NavSubItem value="10">Ten</NavSubItem>
+          <NavSubItem value="11">Eleven</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+    </Nav>
+  );
+};

--- a/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelection.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelection.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Nav, NavCategory, NavCategoryItem, NavItem, NavSubItem, NavSubItemGroup } from '@fluentui/react-nav-preview';
+
+export const WithNestedSubItemsDefaultSelection = () => {
+  return (
+    <Nav defaultSelectedValue={'7'} defaultSelectedCategoryValue={'4'}>
+      <NavItem value="1">First</NavItem>
+      <NavItem value="2">Second</NavItem>
+      <NavItem value="3">Third</NavItem>
+      <NavCategory value="4">
+        <NavCategoryItem>NavCategoryItem 1</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="5">Five</NavSubItem>
+          <NavSubItem value="6">Six</NavSubItem>
+          <NavSubItem value="7">Seven</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+      <NavCategory value="8">
+        <NavCategoryItem>NavCategoryItem2</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="9">Nine</NavSubItem>
+          <NavSubItem value="10">Ten</NavSubItem>
+          <NavSubItem value="11">Eleven</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+    </Nav>
+  );
+};

--- a/packages/react-components/react-nav-preview/stories/Nav/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/index.stories.tsx
@@ -6,6 +6,7 @@ import bestPracticesMd from './NavBestPractices.md';
 export { Default } from './NavDefault.stories';
 export { WithDefaultSelection } from './NavWithDefaultSelection.stories';
 export { WithNestedSubItems } from './NavWithNestedSubItems.stories';
+export { WithNestedSubItemsDefaultSelection } from './NavWithNestedSubItemsWithDefaultSelection.stories';
 
 export default {
   title: 'Preview Components/Nav',

--- a/packages/react-components/react-nav-preview/stories/Nav/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/index.stories.tsx
@@ -5,6 +5,7 @@ import bestPracticesMd from './NavBestPractices.md';
 
 export { Default } from './NavDefault.stories';
 export { WithDefaultSelection } from './NavWithDefaultSelection.stories';
+export { WithNestedSubItems } from './NavWithNestedSubItems.stories';
 
 export default {
   title: 'Preview Components/Nav',

--- a/packages/react-components/react-nav-preview/stories/NavSubItem/NavSubItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavSubItem/NavSubItemDefault.stories.tsx
@@ -2,4 +2,4 @@ import * as React from 'react';
 import { NavSubItem } from '@fluentui/react-nav-preview';
 import type { NavSubItemProps } from '@fluentui/react-nav-preview';
 
-export const Default = (props: Partial<NavSubItemProps>) => <NavSubItem {...props} />;
+export const Default = (props: Partial<NavSubItemProps>) => <NavSubItem value={'0'} {...props} />;


### PR DESCRIPTION
The Nav has nesting behavior. This PR implements 2 of those behaviors:
https://github.com/microsoft/fluentui/assets/17346018/97ca8516-8da9-49c1-8107-80a28ad2b808
- Select SubItems nested within categories, and maintain that selection state when categories are opened and closed. I rinsed and repeated the same pattern from NavItem.
- When the parent of a SubItem gets closed, the parent shows as selected indicating a selected child to the user.

Note the spec indicates the CategoryItem's ability to close when it's is clicked. This behavior will come in a future PR as I bring in more props and behaviors from the accordion.

This adds a few new props to the top level nav:
- selectedCategoryValue
- defaultSelectedCategoryValue

Also adds a new optional property to our event data, categoryValue
Updates useNav to handle the additional prop, but should be very analogous to selectedValue
Renames `openItems` to `openCategories` for clarity.
Updates type of NavSubItem from div to button.
Updates NavSubItemStyles to show selection. This is just stubbed code for the time being.

Next major project will be to light up many of the accordion props, as discussed in #30566


https://github.com/microsoft/fluentui/assets/17346018/212ca32d-987a-415d-b33f-1f7ad51081ec

![image](https://github.com/microsoft/fluentui/assets/17346018/6b58031d-ebbe-4547-ab3d-960218730335)