### PR TITLE
updated color code to stackedBarChart benchmark example data

### DIFF
--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Benchmark.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Benchmark.Example.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
-import { StackedBarChart, IChartProps, IChartDataPoint } from '@fluentui/react-charting';
+import {
+  StackedBarChart,
+  IChartProps,
+  IChartDataPoint,
+  DataVizPalette,
+  getColorFromToken,
+} from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 
 export class StackedBarChartBenchmarkExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     const points: IChartDataPoint[] = [
-      { legend: 'first', data: 10, color: DefaultPalette.redDark },
+      { legend: 'first', data: 10, color: getColorFromToken(DataVizPalette.color7) },
       { legend: 'second', data: 90, color: DefaultPalette.neutralTertiaryAlt, placeHolder: true },
     ];
 


### PR DESCRIPTION
Updated color code in StackedBarChart benchmark example data

Color contrast ratio after code changes.
![8637404](https://github.com/microsoft/fluentui/assets/132879294/28d1df85-6766-49ec-be2b-f6b6609d1e95)
