### PR TITLE
refactor: Deprecate ComboboxContext in favour of ListboxContext

### DIFF
--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -10,6 +10,7 @@ import type { ActiveDescendantContextValue } from '@fluentui/react-aria';
 import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import { ContextSelector } from '@fluentui/react-context-selector';
 import { FC } from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { PortalProps } from '@fluentui/react-portal';
@@ -27,7 +28,10 @@ export const Combobox: ForwardRefComponent<ComboboxProps>;
 export const comboboxClassNames: SlotClassNames<ComboboxSlots>;
 
 // @public
-export type ComboboxContextValue = Pick<ComboboxState, 'activeOption' | 'appearance' | 'focusVisible' | 'open' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption' | 'setOpen' | 'size'>;
+export type ComboboxContextValue = Pick<ComboboxState, 'activeOption' | 'appearance' | 'focusVisible' | 'open' | 'registerOption' | 'setActiveOption' | 'setOpen' | 'size'> & {
+    selectedOptions: ComboboxState['selectedOptions'];
+    selectOption: ComboboxState['selectOption'];
+};
 
 // @public (undocumented)
 export type ComboboxContextValues = ComboboxBaseContextValues;
@@ -44,7 +48,7 @@ export type ComboboxProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>
     children?: React_2.ReactNode;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ComboboxProvider: Provider<ComboboxContextValue> & FC<ProviderProps<ComboboxContextValue>>;
 
 // @public (undocumented)
@@ -103,7 +107,9 @@ export const Listbox: ForwardRefComponent<ListboxProps>;
 export const listboxClassNames: SlotClassNames<ListboxSlots>;
 
 // @public
-export type ListboxContextValue = Pick<ListboxState, 'activeOption' | 'focusVisible' | 'multiselect' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption'>;
+export type ListboxContextValue = Pick<ListboxState, 'activeOption' | 'focusVisible' | 'multiselect' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption'> & {
+    onOptionClick: (e: React_2.MouseEvent<HTMLElement>) => void;
+};
 
 // @public (undocumented)
 export type ListboxContextValues = {
@@ -115,7 +121,7 @@ export type ListboxContextValues = {
 export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps;
 
 // @public (undocumented)
-export const ListboxProvider: Provider<ListboxContextValue> & FC<ProviderProps<ListboxContextValue>>;
+export const ListboxProvider: React_2.Provider<ListboxContextValue | undefined> & React_2.FC<React_2.ProviderProps<ListboxContextValue | undefined>>;
 
 // @public (undocumented)
 export type ListboxSlots = {
@@ -211,9 +217,7 @@ export type SelectionEvents = React_2.ChangeEvent<HTMLElement> | React_2.Keyboar
 export const useCombobox_unstable: (props: ComboboxProps, ref: React_2.Ref<HTMLInputElement>) => ComboboxState;
 
 // @public (undocumented)
-export function useComboboxContextValues(state: ComboboxBaseState & {
-    activeDescendantController: ActiveDescendantImperativeRef;
-}): ComboboxBaseContextValues;
+export function useComboboxContextValues(state: ComboboxBaseState & Pick<ComboboxState, 'activeDescendantController'>): ComboboxBaseContextValues;
 
 // @public (undocumented)
 export function useComboboxFilter<T extends {
@@ -232,6 +236,9 @@ export const useDropdownStyles_unstable: (state: DropdownState) => DropdownState
 
 // @public
 export const useListbox_unstable: (props: ListboxProps, ref: React_2.Ref<HTMLElement>) => ListboxState;
+
+// @public (undocumented)
+export const useListboxContext_unstable: <T>(selector: ContextSelector<ListboxContextValue, T>) => T;
 
 // @public (undocumented)
 export function useListboxContextValues(state: ListboxState): ListboxContextValues;

--- a/packages/react-components/react-combobox/package.json
+++ b/packages/react-components/react-combobox/package.json
@@ -33,8 +33,8 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-aria": "^9.8.2",
     "@fluentui/keyboard-keys": "^9.0.7",
+    "@fluentui/react-aria": "^9.8.2",
     "@fluentui/react-context-selector": "^9.1.51",
     "@fluentui/react-field": "^9.1.53",
     "@fluentui/react-icons": "^2.0.224",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
+    "@types/react-dom": ">=16.14.0 <19.0.0",
     "react": ">=16.14.0 <19.0.0",
     "react-dom": ">=16.14.0 <19.0.0",
     "scheduler": "^0.19.0 || ^0.20.0"

--- a/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
@@ -6,6 +6,7 @@ import { ActiveDescendantContextProvider } from '@fluentui/react-aria';
 import { assertSlots } from '@fluentui/react-utilities';
 import { ComboboxContext } from '../../contexts/ComboboxContext';
 import type { ComboboxContextValues, ComboboxState, ComboboxSlots } from './Combobox.types';
+import { ListboxProvider } from '../../contexts/ListboxContext';
 
 /**
  * Render the final JSX of Combobox
@@ -16,19 +17,23 @@ export const renderCombobox_unstable = (state: ComboboxState, contextValues: Com
   return (
     <state.root>
       <ActiveDescendantContextProvider value={contextValues.activeDescendant}>
-        <ComboboxContext.Provider value={contextValues.combobox}>
-          <state.input />
-          {state.clearIcon && <state.clearIcon />}
-          <state.expandIcon />
-          {state.listbox &&
-            (state.inlinePopup ? (
-              <state.listbox />
-            ) : (
-              <Portal mountNode={state.mountNode}>
+        <ListboxProvider value={contextValues.listbox}>
+          {/*eslint-disable-next-line deprecation/deprecation*/}
+          <ComboboxContext.Provider value={contextValues.combobox}>
+            <state.input />
+            {state.clearIcon && <state.clearIcon />}
+            <state.expandIcon />
+            {state.listbox &&
+              (state.inlinePopup ? (
                 <state.listbox />
-              </Portal>
-            ))}
-        </ComboboxContext.Provider>
+              ) : (
+                <Portal mountNode={state.mountNode}>
+                  <state.listbox />
+                </Portal>
+              ))}
+            {/*eslint-disable-next-line deprecation/deprecation*/}
+          </ComboboxContext.Provider>
+        </ListboxProvider>
       </ActiveDescendantContextProvider>
     </state.root>
   );

--- a/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
+++ b/packages/react-components/react-combobox/src/components/Dropdown/renderDropdown.tsx
@@ -7,6 +7,7 @@ import { assertSlots } from '@fluentui/react-utilities';
 import { ActiveDescendantContextProvider } from '@fluentui/react-aria';
 import { ComboboxContext } from '../../contexts/ComboboxContext';
 import type { DropdownContextValues, DropdownState, DropdownSlots } from './Dropdown.types';
+import { ListboxContext } from '../../contexts/ListboxContext';
 
 /**
  * Render the final JSX of Dropdown
@@ -17,21 +18,25 @@ export const renderDropdown_unstable = (state: DropdownState, contextValues: Dro
   return (
     <state.root>
       <ActiveDescendantContextProvider value={contextValues.activeDescendant}>
-        <ComboboxContext.Provider value={contextValues.combobox}>
-          <state.button>
-            {state.button.children}
-            {state.expandIcon && <state.expandIcon />}
-          </state.button>
-          {state.clearButton && <state.clearButton />}
-          {state.listbox &&
-            (state.inlinePopup ? (
-              <state.listbox />
-            ) : (
-              <Portal mountNode={state.mountNode}>
+        <ListboxContext.Provider value={contextValues.listbox}>
+          {/*eslint-disable-next-line deprecation/deprecation*/}
+          <ComboboxContext.Provider value={contextValues.combobox}>
+            <state.button>
+              {state.button.children}
+              {state.expandIcon && <state.expandIcon />}
+            </state.button>
+            {state.clearButton && <state.clearButton />}
+            {state.listbox &&
+              (state.inlinePopup ? (
                 <state.listbox />
-              </Portal>
-            ))}
-        </ComboboxContext.Provider>
+              ) : (
+                <Portal mountNode={state.mountNode}>
+                  <state.listbox />
+                </Portal>
+              ))}
+            {/*eslint-disable-next-line deprecation/deprecation*/}
+          </ComboboxContext.Provider>
+        </ListboxContext.Provider>
       </ActiveDescendantContextProvider>
     </state.root>
   );

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -3,21 +3,21 @@ import {
   getIntrinsicElementProps,
   mergeCallbacks,
   useEventCallback,
-  useMergedRefs,
   slot,
+  useMergedRefs,
 } from '@fluentui/react-utilities';
-import { useContextSelector, useHasParentContext } from '@fluentui/react-context-selector';
+import { useHasParentContext } from '@fluentui/react-context-selector';
 import {
   useActiveDescendant,
   useActiveDescendantContext,
   useHasParentActiveDescendantContext,
 } from '@fluentui/react-aria';
+import type { ListboxProps, ListboxState } from './Listbox.types';
 import { getDropdownActionFromKey } from '../../utils/dropdownKeyActions';
 import { useOptionCollection } from '../../utils/useOptionCollection';
 import { useSelection } from '../../utils/useSelection';
-import { ComboboxContext } from '../../contexts/ComboboxContext';
 import { optionClassNames } from '../Option/useOptionStyles.styles';
-import type { ListboxProps, ListboxState } from './Listbox.types';
+import { ListboxContext, useListboxContext_unstable } from '../../contexts/ListboxContext';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const UNSAFE_noLongerUsed = {
@@ -91,15 +91,15 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   };
 
   // get state from parent combobox, if it exists
-  const hasComboboxContext = useHasParentContext(ComboboxContext);
-  const comboboxSelectedOptions = useContextSelector(ComboboxContext, ctx => ctx.selectedOptions);
-  const comboboxSelectOption = useContextSelector(ComboboxContext, ctx => ctx.selectOption);
+  const hasListboxContent = useHasParentContext(ListboxContext);
+  const contextSelectedOptions = useListboxContext_unstable(ctx => ctx.selectedOptions);
+  const contextSelectOption = useListboxContext_unstable(ctx => ctx.selectOption);
 
   // without a parent combobox context, provide values directly from Listbox
-  const optionContextValues = hasComboboxContext
+  const optionContextValues = hasListboxContent
     ? {
-        selectedOptions: comboboxSelectedOptions,
-        selectOption: comboboxSelectOption,
+        selectedOptions: contextSelectedOptions,
+        selectOption: contextSelectOption,
         ...UNSAFE_noLongerUsed,
       }
     : {

--- a/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
@@ -6,7 +6,6 @@ import { Option } from './Option';
 import type { OptionProps } from './Option.types';
 import { isConformant } from '../../testing/isConformant';
 import { optionClassNames } from './useOptionStyles.styles';
-import { ActiveDescendantContextProvider, ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 
 describe('Option', () => {
   isConformant<OptionProps>({
@@ -30,6 +29,9 @@ describe('Option', () => {
       // noop
     },
     setActiveOption() {
+      // noop
+    },
+    onOptionClick() {
       // noop
     },
   };
@@ -204,18 +206,15 @@ describe('Option', () => {
     expect(registerOption).toHaveBeenCalledTimes(2);
   });
 
-  it('calls selectOption and set as active on click', () => {
+  // TODO test activeDescendantRef
+  it('calls selectOption on click', () => {
     const selectOption = jest.fn();
-    const testController = { focus: jest.fn() } as unknown as ActiveDescendantImperativeRef;
     const { getByRole } = render(
-      <ActiveDescendantContextProvider value={{ controller: testController }}>
-        <ListboxContext.Provider value={{ ...defaultContextValues, selectOption }}>
-          <Option id="optionId" value="foo">
-            Option 1
-          </Option>
-        </ListboxContext.Provider>
-        ,
-      </ActiveDescendantContextProvider>,
+      <ListboxContext.Provider value={{ ...defaultContextValues, selectOption }}>
+        <Option id="optionId" value="foo">
+          Option 1
+        </Option>
+      </ListboxContext.Provider>,
     );
 
     fireEvent.click(getByRole('option'));
@@ -223,8 +222,6 @@ describe('Option', () => {
 
     expect(selectOption).toHaveBeenCalledTimes(1);
     expect(selectOption).toHaveBeenCalledWith(expect.anything(), optionData);
-    expect(testController.focus).toHaveBeenCalledTimes(1);
-    expect(testController.focus).toHaveBeenCalledWith(optionData.id);
   });
 
   describe('checkIcon slot', () => {

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, useId, useMergedRefs, slot } from '@fluentui/react-utilities';
-import { useContextSelector } from '@fluentui/react-context-selector';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
 import { CheckmarkFilled, Checkmark12Filled } from '@fluentui/react-icons';
-import { ComboboxContext } from '../../contexts/ComboboxContext';
-import { ListboxContext } from '../../contexts/ListboxContext';
+import { useListboxContext_unstable } from '../../contexts/ListboxContext';
 import type { OptionValue } from '../../utils/OptionCollection.types';
 import type { OptionProps, OptionState } from './Option.types';
 
@@ -56,18 +54,17 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
     [id, disabled, optionText, optionValue],
   );
 
-  const { controller: activeDescendantController } = useActiveDescendantContext();
-
   // context values
-  const multiselect = useContextSelector(ListboxContext, ctx => ctx.multiselect);
-  const registerOption = useContextSelector(ListboxContext, ctx => ctx.registerOption);
-  const selected = useContextSelector(ListboxContext, ctx => {
+  const { controller: activeDescendantController } = useActiveDescendantContext();
+  const multiselect = useListboxContext_unstable(ctx => ctx.multiselect);
+  const registerOption = useListboxContext_unstable(ctx => ctx.registerOption);
+  const selected = useListboxContext_unstable(ctx => {
     const selectedOptions = ctx.selectedOptions;
 
     return !!optionValue && !!selectedOptions.find(o => o === optionValue);
   });
-  const selectOption = useContextSelector(ListboxContext, ctx => ctx.selectOption);
-  const setOpen = useContextSelector(ComboboxContext, ctx => ctx.setOpen);
+  const selectOption = useListboxContext_unstable(ctx => ctx.selectOption);
+  const onOptionClick = useListboxContext_unstable(ctx => ctx.onOptionClick);
 
   // check icon
   let CheckIcon: React.ReactNode = <CheckmarkFilled />;
@@ -81,17 +78,12 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
       return;
     }
 
-    // clicked option should always become active option
     activeDescendantController.focus(id);
-
-    // close on option click for single-select options in a combobox
-    if (!multiselect) {
-      setOpen?.(event, false);
-    }
 
     // handle selection change
     selectOption(event, optionData);
 
+    onOptionClick(event);
     props.onClick?.(event);
   };
 

--- a/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
@@ -40,8 +40,6 @@ const useStyles = makeStyles({
   },
 
   active: {
-    // taken from @fluentui/react-tabster
-    // cannot use createFocusIndicatorStyle() directly, since we aren't using the :focus selector
     [`[${ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE}]::after`]: {
       content: '""',
       position: 'absolute',

--- a/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ComboboxContext.ts
@@ -6,18 +6,23 @@ import { ComboboxState } from '../components/Combobox/Combobox.types';
  */
 export type ComboboxContextValue = Pick<
   ComboboxState,
-  | 'activeOption'
-  | 'appearance'
-  | 'focusVisible'
-  | 'open'
-  | 'registerOption'
-  | 'selectedOptions'
-  | 'selectOption'
-  | 'setActiveOption'
-  | 'setOpen'
-  | 'size'
->;
+  'activeOption' | 'appearance' | 'focusVisible' | 'open' | 'registerOption' | 'setActiveOption' | 'setOpen' | 'size'
+> & {
+  /**
+   * @deprecated - no longer used
+   */
+  selectedOptions: ComboboxState['selectedOptions'];
 
+  /**
+   * @deprecated - no longer used
+   */
+  selectOption: ComboboxState['selectOption'];
+};
+
+/**
+ * @deprecated - use ListboxContext instead
+ * @see ListboxContext
+ */
 // eslint-disable-next-line @fluentui/no-context-default-value
 export const ComboboxContext = createContext<ComboboxContextValue>({
   activeOption: undefined,
@@ -40,4 +45,10 @@ export const ComboboxContext = createContext<ComboboxContextValue>({
   size: 'medium',
 });
 
+/**
+ * @deprecated - render ListboxProvider instead
+ * @see ListboxProvider
+ * @see useListboxContext_unstable
+ */
+// eslint-disable-next-line deprecation/deprecation
 export const ComboboxProvider = ComboboxContext.Provider;

--- a/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
+++ b/packages/react-components/react-combobox/src/contexts/ListboxContext.ts
@@ -1,4 +1,5 @@
-import { createContext } from '@fluentui/react-context-selector';
+import * as React from 'react';
+import { ContextSelector, createContext, useContextSelector } from '@fluentui/react-context-selector';
 import { ListboxState } from '../components/Listbox/Listbox.types';
 
 /**
@@ -13,10 +14,11 @@ export type ListboxContextValue = Pick<
   | 'selectedOptions'
   | 'selectOption'
   | 'setActiveOption'
->;
+> & {
+  onOptionClick: (e: React.MouseEvent<HTMLElement>) => void;
+};
 
-// eslint-disable-next-line @fluentui/no-context-default-value
-export const ListboxContext = createContext<ListboxContextValue>({
+const listboxContextDefaultValue = {
   activeOption: undefined,
   focusVisible: false,
   multiselect: false,
@@ -24,12 +26,20 @@ export const ListboxContext = createContext<ListboxContextValue>({
     return () => undefined;
   },
   selectedOptions: [],
+  onOptionClick() {
+    // noop
+  },
   selectOption() {
     // noop
   },
   setActiveOption() {
     // noop
   },
-});
+};
+
+export const ListboxContext = createContext<ListboxContextValue | undefined>(undefined);
+
+export const useListboxContext_unstable = <T>(selector: ContextSelector<ListboxContextValue, T>) =>
+  useContextSelector(ListboxContext, (ctx = listboxContextDefaultValue) => selector(ctx));
 
 export const ListboxProvider = ListboxContext.Provider;

--- a/packages/react-components/react-combobox/src/contexts/useComboboxContextValues.ts
+++ b/packages/react-components/react-combobox/src/contexts/useComboboxContextValues.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
-import type { ComboboxBaseContextValues, ComboboxBaseState } from '../utils/ComboboxBase.types';
+import { ComboboxState } from '../Combobox';
+import { ComboboxBaseContextValues, ComboboxBaseState } from '../utils/ComboboxBase.types';
 
 export function useComboboxContextValues(
-  state: ComboboxBaseState & { activeDescendantController: ActiveDescendantImperativeRef },
+  state: ComboboxBaseState & Pick<ComboboxState, 'activeDescendantController'>,
 ): ComboboxBaseContextValues {
   const {
     appearance,
@@ -14,23 +14,30 @@ export function useComboboxContextValues(
     setOpen,
     size,
     activeDescendantController,
-    // eslint-disable-next-line @typescript-eslint/naming-convention, deprecation/deprecation
-    activeOption: UNSAFE_activeOption,
-    // eslint-disable-next-line @typescript-eslint/naming-convention, deprecation/deprecation
-    setActiveOption: UNSAFE_setActiveOption,
+    onOptionClick,
   } = state;
 
   const combobox = {
-    activeOption: UNSAFE_activeOption,
+    activeOption: undefined,
     appearance,
     focusVisible: false,
     open,
     registerOption,
     selectedOptions,
     selectOption,
-    setActiveOption: UNSAFE_setActiveOption,
+    setActiveOption: () => null,
     setOpen,
     size,
+  };
+
+  const listbox = {
+    activeOption: undefined,
+    focusVisible: false,
+    registerOption,
+    selectedOptions,
+    selectOption,
+    setActiveOption: () => null,
+    onOptionClick,
   };
 
   const activeDescendant = React.useMemo(
@@ -40,5 +47,5 @@ export function useComboboxContextValues(
     [activeDescendantController],
   );
 
-  return { combobox, activeDescendant };
+  return { combobox, activeDescendant, listbox };
 }

--- a/packages/react-components/react-combobox/src/contexts/useListboxContextValues.ts
+++ b/packages/react-components/react-combobox/src/contexts/useListboxContextValues.ts
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import { useContextSelector, useHasParentContext } from '@fluentui/react-context-selector';
+import { useHasParentContext } from '@fluentui/react-context-selector';
 import { ListboxContextValues, ListboxState } from '../components/Listbox/Listbox.types';
-import { ComboboxContext } from './ComboboxContext';
+import { ListboxContext, useListboxContext_unstable } from './ListboxContext';
 
 export function useListboxContextValues(state: ListboxState): ListboxContextValues {
-  const hasComboboxContext = useHasParentContext(ComboboxContext);
+  const hasListboxContext = useHasParentContext(ListboxContext);
   const { multiselect, registerOption, selectedOptions, selectOption, activeDescendantController } = state;
 
   // get register/unregister functions from parent combobox context
-  const comboboxRegisterOption = useContextSelector(ComboboxContext, ctx => ctx.registerOption);
+  const parentRegisterOption = useListboxContext_unstable(ctx => ctx.registerOption);
+  const onOptionClick = useListboxContext_unstable(ctx => ctx.onOptionClick);
 
-  const registerOptionValue = hasComboboxContext ? comboboxRegisterOption : registerOption;
+  const registerOptionValue = hasListboxContext ? parentRegisterOption : registerOption;
 
   const listbox = {
     activeOption: undefined,
@@ -20,6 +21,7 @@ export function useListboxContextValues(state: ListboxState): ListboxContextValu
     selectedOptions,
     selectOption,
     setActiveOption: () => undefined,
+    onOptionClick,
   };
 
   const activeDescendant = React.useMemo(

--- a/packages/react-components/react-combobox/src/index.ts
+++ b/packages/react-components/react-combobox/src/index.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line deprecation/deprecation
 export { ComboboxProvider } from './contexts/ComboboxContext';
 export type { ComboboxContextValue } from './contexts/ComboboxContext';
-export { ListboxProvider } from './contexts/ListboxContext';
+export { ListboxProvider, useListboxContext_unstable } from './contexts/ListboxContext';
 export type { ListboxContextValue } from './contexts/ListboxContext';
 export { useComboboxContextValues } from './contexts/useComboboxContextValues';
 export { useListboxContextValues } from './contexts/useListboxContextValues';

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -5,6 +5,7 @@ import type { ComboboxContextValue } from '../contexts/ComboboxContext';
 import type { OptionValue, OptionCollectionState } from '../utils/OptionCollection.types';
 import { SelectionProps, SelectionState } from '../utils/Selection.types';
 import { PortalProps } from '@fluentui/react-portal';
+import { ListboxContextValue } from '../contexts/ListboxContext';
 
 /**
  * ComboboxBase Props
@@ -87,12 +88,12 @@ export type ComboboxBaseState = Required<
   SelectionState & {
     /**
      * @deprecated - no longer used internally
-     * @see activeDescendantController.active() instead
      */
     activeOption?: OptionValue;
 
     /**
-     * @deprecated - no longer used internally
+     * @deprecated - no longer used internally and handled automatically be activedescendant utilities
+     * @see ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE for writing styles involving focusVisible
      */
     focusVisible: boolean;
 
@@ -104,22 +105,27 @@ export type ComboboxBaseState = Required<
 
     /**
      * @deprecated - no longer used internally
-     * @see activeDescendantController.focus(id) instead
      */
     setActiveOption: React.Dispatch<React.SetStateAction<OptionValue | undefined>>;
+
+    /**
+     * @deprecated - no longer used internally and handled automatically be activedescendant utilities
+     * @see useSetKeyboardNavigation for imperatively setting focus visible state
+     */
+    setFocusVisible(focusVisible: boolean): void;
 
     /**
      * whether the combobox/dropdown currently has focus
      */
     hasFocus: boolean;
 
-    setFocusVisible(focusVisible: boolean): void;
-
     setHasFocus(hasFocus: boolean): void;
 
     setOpen(event: ComboboxBaseOpenEvents, newState: boolean): void;
 
     setValue(newValue: string | undefined): void;
+
+    onOptionClick: (e: React.MouseEvent<HTMLElement>) => void;
   };
 
 /**
@@ -138,4 +144,5 @@ export type ComboboxBaseOpenEvents =
 export type ComboboxBaseContextValues = {
   combobox: ComboboxContextValue;
   activeDescendant: ActiveDescendantContextValue;
+  listbox: ListboxContextValue;
 };

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useControllableState, useFirstMount } from '@fluentui/react-utilities';
-import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
+import { useControllableState, useEventCallback, useFirstMount } from '@fluentui/react-utilities';
+import { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 import { useOptionCollection } from '../utils/useOptionCollection';
 import { OptionValue } from '../utils/OptionCollection.types';
 import { useSelection } from '../utils/useSelection';
@@ -156,11 +156,11 @@ export const useComboboxBaseState = (
     appearance,
     clearable,
     focusVisible,
-    hasFocus,
     ignoreNextBlur,
     inlinePopup,
     mountNode,
     open,
+    hasFocus,
     setActiveOption: UNSAFE_setActiveOption,
     setFocusVisible,
     setHasFocus,
@@ -169,5 +169,10 @@ export const useComboboxBaseState = (
     size,
     value,
     multiselect,
+    onOptionClick: useEventCallback((e: React.MouseEvent<HTMLElement>) => {
+      if (!multiselect) {
+        setOpen(e, false);
+      }
+    }),
   };
 };

--- a/packages/react-components/react-combobox/src/utils/useListboxSlot.ts
+++ b/packages/react-components/react-combobox/src/utils/useListboxSlot.ts
@@ -12,10 +12,10 @@ import type { ComboboxBaseState } from './ComboboxBase.types';
 import { Listbox } from '../Listbox';
 import { ListboxProps } from '../Listbox';
 
-export type UseTriggerSlotState = Pick<ComboboxBaseState, 'multiselect'>;
+export type UseListboxSlotState = Pick<ComboboxBaseState, 'multiselect'>;
 
 type UseListboxSlotOptions = {
-  state: ComboboxBaseState;
+  state: UseListboxSlotState;
   triggerRef: React.RefObject<HTMLInputElement> | React.RefObject<HTMLButtonElement>;
   defaultProps?: Partial<ListboxProps>;
 };


### PR DESCRIPTION
There is only one case where the ComboboxContext does not contain the correct state function - closing the listbox popover when an option is clicked.

In all other cases the ListboxContext contains exactly the same properties as the ComboboxContext for its consumers.
