### PR TITLE
feat: support numbers as v9 Option values

### DIFF
--- a/change/@fluentui-react-combobox-2a451179-1100-440d-b168-ce688b295f8f.json
+++ b/change/@fluentui-react-combobox-2a451179-1100-440d-b168-ce688b295f8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: support numbers as Option values",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -425,14 +425,14 @@ describe('Combobox', () => {
 
   it('should set selectedOptions based on Option `value`', () => {
     const { getByTestId } = render(
-      <Combobox open multiselect selectedOptions={['a', 'c']}>
+      <Combobox open multiselect selectedOptions={['a', 3]}>
         <Option data-testid="red" value="a">
           Red
         </Option>
         <Option data-testid="green" value="b">
           Green
         </Option>
-        <Option data-testid="blue" value="c">
+        <Option data-testid="blue" value={3}>
           Blue
         </Option>
       </Combobox>,

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.test.tsx
@@ -240,8 +240,8 @@ describe('Listbox', () => {
     const { getByText } = render(
       <Listbox onOptionSelect={onOptionSelect}>
         <Option>Red</Option>
-        <Option>Green</Option>
-        <Option>Blue</Option>
+        <Option value="string">Green</Option>
+        <Option value={42}>Blue</Option>
       </Listbox>,
     );
 
@@ -252,6 +252,24 @@ describe('Listbox', () => {
       optionValue: 'Red',
       optionText: 'Red',
       selectedOptions: ['Red'],
+    });
+
+    fireEvent.click(getByText('Green'));
+
+    expect(onOptionSelect).toHaveBeenCalled();
+    expect(onOptionSelect.mock.calls[1][1]).toEqual({
+      optionValue: 'string',
+      optionText: 'Green',
+      selectedOptions: ['string'],
+    });
+
+    fireEvent.click(getByText('Blue'));
+
+    expect(onOptionSelect).toHaveBeenCalled();
+    expect(onOptionSelect.mock.calls[2][1]).toEqual({
+      optionValue: 42,
+      optionText: 'Blue',
+      selectedOptions: [42],
     });
   });
 

--- a/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/Option.test.tsx
@@ -103,6 +103,18 @@ describe('Option', () => {
     expect(getByText('Option 2').getAttribute('aria-selected')).toEqual('false');
   });
 
+  it('sets aria-selected based on number value', () => {
+    const { getByText } = render(
+      <ListboxContext.Provider value={{ ...defaultContextValues, selectedOptions: [42] }}>
+        <Option value={42}>Option 1</Option>
+        <Option value={'42'}>Option 2</Option>
+      </ListboxContext.Provider>,
+    );
+
+    expect(getByText('Option 1').getAttribute('aria-selected')).toEqual('true');
+    expect(getByText('Option 2').getAttribute('aria-selected')).toEqual('false');
+  });
+
   it('ignores text if value is set', () => {
     const { getByText } = render(
       <ListboxContext.Provider value={{ ...defaultContextValues, selectedOptions: ['Option 1'] }}>

--- a/packages/react-components/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-components/react-combobox/src/components/Option/Option.types.ts
@@ -24,7 +24,7 @@ export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
    * Use this to control selectedOptions, or to get the option value in the onOptionSelect callback.
    * Defaults to `text` if not provided.
    */
-  value?: string;
+  value?: string | number;
 } & (
     | {
         /**

--- a/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
@@ -9,7 +9,7 @@ export type OptionValue = {
   text: string;
 
   /** The value string of the option. */
-  value: string;
+  value: string | number;
 };
 
 export type OptionCollectionState = {
@@ -35,7 +35,7 @@ export type OptionCollectionState = {
   getOptionById(id: string): OptionValue | undefined;
 
   /** Returns an array of options filtered by a value matching function against the option's value string. */
-  getOptionsMatchingValue(matcher: (value: string) => boolean): OptionValue[];
+  getOptionsMatchingValue(matcher: (value: string | number) => boolean): OptionValue[];
 
   /** The unordered option data. */
   options: OptionValue[];

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -6,7 +6,7 @@ export type SelectionProps = {
    * For an uncontrolled component, sets the initial selection.
    * If this is set, the `defaultValue` prop MUST also be set.
    */
-  defaultSelectedOptions?: string[];
+  defaultSelectedOptions?: (string | number)[];
 
   /**
    * Sets the selection type to multiselect.
@@ -25,13 +25,13 @@ export type SelectionProps = {
    * Use this with `onOptionSelect` to directly control the selected option(s)
    * If this is set, the `value` prop MUST also be controlled.
    */
-  selectedOptions?: string[];
+  selectedOptions?: (string | number)[];
 };
 
 /* Values returned by the useSelection hook */
 export type SelectionState = {
   clearSelection: (event: SelectionEvents) => void;
-  selectedOptions: string[];
+  selectedOptions: (string | number)[];
   selectOption: (event: SelectionEvents, option: OptionValue) => void;
 };
 
@@ -40,9 +40,9 @@ export type SelectionState = {
  * `optionValue` and `optionText` will be undefined if multiple options are modified at once.
  */
 export type OptionOnSelectData = {
-  optionValue: string | undefined;
+  optionValue: string | number | undefined;
   optionText: string | undefined;
-  selectedOptions: string[];
+  selectedOptions: (string | number)[];
 };
 
 /* Possible event types for onOptionSelect */

--- a/packages/react-components/react-combobox/src/utils/useOptionCollection.ts
+++ b/packages/react-components/react-combobox/src/utils/useOptionCollection.ts
@@ -21,7 +21,7 @@ export const useOptionCollection = (): OptionCollectionState => {
       return Array.from(optionsById.current.values()).filter(({ text }) => matcher(text));
     };
 
-    const getOptionsMatchingValue = (matcher: (value: string) => boolean) => {
+    const getOptionsMatchingValue = (matcher: (value: string | number) => boolean) => {
       const matches: OptionValue[] = [];
       for (const option of optionsById.current.values()) {
         if (matcher(option.value)) {


### PR DESCRIPTION
## Previous Behavior

The `value` prop on the v9 `<Option>` component only accepted strings. Since this is only used for matching with `selectedOptions` and as data on `onOptionSelect`, we should be able to accept number values as well.

## New Behavior

allows `value` to be `string | number` (and updates associated types & tests)

## Related Issue(s)

- Fixes #30571
