### PR TITLE
chore: Fix Spinner VR tests to pause correctly, and add Animation test

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   paused: {
     '& *': {
       animationPlayState: 'paused !important',
-      animationDelay: '-1s !important',
+      animationDelay: 'var(--test-animation-delay, -1s) !important',
       animationDuration: '1.5s !important',
     },
     [`& .${spinnerClassNames.spinner}`]: {
@@ -91,4 +91,11 @@ storiesOf('Spinner converged', module)
       includeHighContrast: true,
       includeDarkMode: true,
     },
-  );
+  )
+  .addStory('Animation', () => (
+    <div className={useStyles().paused} style={{ display: 'flex', columnGap: '5px' }}>
+      {Array.from({ length: 15 }).map((_, i) => (
+        <Spinner key={i} style={{ '--test-animation-delay': `-${0.1 * i}s` } as React.CSSProperties} />
+      ))}
+    </div>
+  ));

--- a/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Spinner } from '@fluentui/react-spinner';
+import { Spinner, spinnerClassNames } from '@fluentui/react-spinner';
 import { tokens } from '@fluentui/react-theme';
 import { TestWrapperDecoratorFixedWidth } from '../utilities/TestWrapperDecorator';
 import { StoryWright, Steps } from 'storywright';
@@ -11,6 +11,10 @@ const useStyles = makeStyles({
     '& *': {
       animationPlayState: 'paused !important',
       animationDelay: '-1s !important',
+      animationDuration: '1.5s !important',
+    },
+    [`& .${spinnerClassNames.spinner}`]: {
+      animationDuration: '3s !important',
     },
   },
 });


### PR DESCRIPTION
## Previous Behavior

Spinner VR tests weren't showing the paused state correctly.

## New Behavior

Add an animationDuration override to the tests, so the animation is not affected by the test environment's prefers-reduced-motion setting.

Add an "Animation" story with the spinner paused at 0.1s intervals.