### PR TITLE
docs: add troubleshooting guide for migrating layered elements

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
@@ -43,6 +43,11 @@ function App() {
 }
 ```
 
+## "I tried uing a layered v8 component like Callout in a layered v9 component like Dialog and my Callout appears beneath my Dialog. What's going on?"
+
+Both v9 and v8 layers set a `z-index: 10000` by default, which means the document order will resolve their z-positioning. This can lead to inconsistent behavior because z-positioning depends on the order in which elements are opened.
+To work around this set the `z-index` for one of the layers differently to ensure the correct layering. For example, for a v9 `Dialog` that contains a v8 `Callout` you can set the `Dialog`'s `z-index` to `9999` to ensure it is always beneath the `Callout`.
+
 ## "I managed to get the theme working but the components look different than they did previously, why is that?"
 
 We are modernizing our components in version 9 to adhere to the latest guidelines in the Fluent Design Language. That is the reason for any visual differences you might notice.

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
@@ -45,7 +45,10 @@ function App() {
 
 ## "I tried uing a layered v8 component like Callout in a layered v9 component like Dialog and my Callout appears beneath my Dialog. What's going on?"
 
-Both v9 and v8 layers set a `z-index: 10000` by default, which means the document order will resolve their z-positioning. This can lead to inconsistent behavior because z-positioning depends on the order in which elements are opened.
+Both v9 and v8 layers set the same `z-index` value by default, which means the document order will resolve their z-positioning.
+This can lead to inconsistent behavior because z-positioning depends on the order in which elements appear in the DOM.
+Moreover, v8 `Layer` hosts have a tendency to linger in the DOM even after the element they are hosting is closed, which can add to this inconsistency.
+
 Use `PortalMountNodeProvider` to handle this issue.
 
 ```jsx

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
@@ -46,7 +46,22 @@ function App() {
 ## "I tried uing a layered v8 component like Callout in a layered v9 component like Dialog and my Callout appears beneath my Dialog. What's going on?"
 
 Both v9 and v8 layers set a `z-index: 10000` by default, which means the document order will resolve their z-positioning. This can lead to inconsistent behavior because z-positioning depends on the order in which elements are opened.
-To work around this set the `z-index` for one of the layers differently to ensure the correct layering. For example, for a v9 `Dialog` that contains a v8 `Callout` you can set the `Dialog`'s `z-index` to `9999` to ensure it is always beneath the `Callout`.
+Use `PortalMountNodeProvider` to handle this issue.
+
+```jsx
+import { FluentProvider, PortalMountNodeProvider } from '@fluentui/react-components';
+
+function App() {
+  // Get a reference to the v8 layer host
+  const mountNode = document.getElementById('fluent-default-layer-host');
+
+  return (
+    <FluentProvider>
+      <PortalMountNodeProvider mountNode={mountNode}>{/* your components */}</PortalMountNodeProvider>
+    </FluentProvider>
+  );
+}
+```
 
 ## "I managed to get the theme working but the components look different than they did previously, why is that?"
 
@@ -59,3 +74,7 @@ The styling story in version 9 is very different to what existed in version 8. F
 We are also moving away from `mergeStyles` in favor of `makeStyles` from [`@griffel/react`](https://github.com/microsoft/griffel), a new in-house CSS-in-JS solution that allows for things like atomic classes and build-time optimization of styles.
 
 If you want to learn more, read our [guide on how to style components](?path=/story/concepts-developer-styling-components--page).
+
+```
+
+```


### PR DESCRIPTION
## Previous Behavior

No new behavior.

## New Behavior

When mixing layered v8 components (e.g., `Callout`) with layered v9 components (e.g., `Dialog`) users will often end up with inconsistent z-positioning. This is because all layered elements have `z-index: 10000` which means that document order resolves their z-positioning, which means the visual layering will depend on the order in which layers are opened.

There doesn't seem to be an obvious general case solution to this so we're documenting it to improve discoverability and shareability.

- [Example of the issue](https://[codesandbox.io/p/sandbox/affectionate-merkle-x37zg8?file=%2Fsrc%2Fexample.tsx](https://codesandbox.io/p/sandbox/affectionate-merkle-x37zg8?file=%2Fsrc%2Fexample.tsx))
- [Example of the workaround](https://[codesandbox.io/p/sandbox/black-haze-yfztt5?file=%2Fsrc%2Fexample.tsx%3A61%2C55](https://codesandbox.io/p/sandbox/black-haze-yfztt5?file=%2Fsrc%2Fexample.tsx%3A61%2C55))
