### PR TITLE
chore: enforce RatingDisplay count value to always be an integer

### DIFF
--- a/change/@fluentui-react-rating-preview-411e2095-b715-42bb-a04d-1073ce139144.json
+++ b/change/@fluentui-react-rating-preview-411e2095-b715-42bb-a04d-1073ce139144.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: enforce integer values for RatingDisplay count prop",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -61,7 +61,11 @@ export const useRatingDisplay_unstable = (
     }),
     countText: slot.optional(props.countText, {
       renderByDefault: count !== undefined,
-      defaultProps: { children: count && Math.round(count).toLocaleString(), id: countTextId, 'aria-hidden': true },
+      defaultProps: {
+        children: count && count >= 0 && Math.round(count).toLocaleString(),
+        id: countTextId,
+        'aria-hidden': true,
+      },
       elementType: 'span',
     }),
   };

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -61,7 +61,7 @@ export const useRatingDisplay_unstable = (
     }),
     countText: slot.optional(props.countText, {
       renderByDefault: count !== undefined,
-      defaultProps: { children: count?.toLocaleString(), id: countTextId, 'aria-hidden': true },
+      defaultProps: { children: count && Math.round(count).toLocaleString(), id: countTextId, 'aria-hidden': true },
       elementType: 'span',
     }),
   };


### PR DESCRIPTION
Current behavior is that `RatingDisplay` value can accept and display an integer. This PR adds a `Math.round()` around the count value, while still maintaining the `toLocaleString()` value. 