### PR TITLE
Remove collapsible option for Nav

### DIFF
--- a/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
@@ -43,10 +43,9 @@ const normalizeValues = (index?: NavItemValue | NavItemValue[]): NavItemValue[] 
  * Updates the list of open indexes based on an index that changes
  * @param value - the index that will change
  * @param previousOpenItems - list of current open indexes
- * @param collapsible - if Nav support multiple SubItemGroups closed at the same time
  */
-const updateOpenItems = (value: NavItemValue, previousOpenItems: NavItemValue[], collapsible: boolean) => {
-  return previousOpenItems[0] === value && collapsible ? [] : [value];
+const updateOpenItems = (value: NavItemValue, previousOpenItems: NavItemValue[]) => {
+  return previousOpenItems[0] === value ? [] : [value];
 };
 
 /**
@@ -71,7 +70,7 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
   });
 
   const onRequestNavCategoryItemToggle: EventHandler<OnNavItemSelectData> = useEventCallback((event, data) => {
-    const nextOpenItems = updateOpenItems(data.value, openCategories, false);
+    const nextOpenItems = updateOpenItems(data.value, openCategories);
     onNavCategoryItemToggle?.(event, data);
     setOpenCategories(nextOpenItems);
   });


### PR DESCRIPTION
Accordion has a 'collapsible' prop, which dictates if all its items are ever allowed to be collapsible.

Previous implementation was the default behavior from accordion, which we don't want.

This PR removes all traces of the prop and updates the default behavior to make everything always collapsible.

Before:
https://github.com/microsoft/fluentui/assets/17346018/bee31740-a62c-40fb-a236-8cdbfc6e9867


After:
https://github.com/microsoft/fluentui/assets/17346018/45cac80f-e83a-471d-bc1f-72507cda2ffe


