### PR TITLE
fix: Anchor to custom target example closes menu

### DIFF
--- a/packages/react-components/react-menu/stories/Menu/MenuAnchorToTarget.stories.tsx
+++ b/packages/react-components/react-menu/stories/Menu/MenuAnchorToTarget.stories.tsx
@@ -5,9 +5,16 @@ import type { MenuProps, PositioningImperativeRef } from '@fluentui/react-compon
 
 export const AnchorToCustomTarget = () => {
   const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const customAnchorRef = React.useRef<HTMLButtonElement>(null);
   const positioningRef = React.useRef<PositioningImperativeRef>(null);
   const [open, setOpen] = React.useState(false);
   const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
+    // do not close menu as an outside click if clicking on the custom trigger/target
+    // this prevents it from closing & immediately re-opening when clicking custom triggers
+    if (data.type === 'clickOutside' && (e.target === customAnchorRef.current || e.target === buttonRef.current)) {
+      return;
+    }
+
     setOpen(data.open);
   };
 
@@ -21,7 +28,7 @@ export const AnchorToCustomTarget = () => {
 
   return (
     <>
-      <Button {...restoreFocusTargetAttribute} onClick={() => setOpen(s => !s)}>
+      <Button {...restoreFocusTargetAttribute} ref={customAnchorRef} onClick={() => setOpen(s => !s)}>
         Open menu
       </Button>
       <Button {...restoreFocusTargetAttribute} ref={buttonRef} onClick={() => setOpen(s => !s)}>


### PR DESCRIPTION
## Previous Behavior

The "anchor to custom target" example has an issue where the menu closes & immediately re-opens when you click either custom trigger while the menu is open. The root cause is it closes on an outside click, then re-opens on the custom trigger click.

## New Behavior

Adds a check to the `onOpenChange` logic to not close as an outside click when clicking the custom trigger.

## Related Issue(s)

Related to #30588, fixes the mentioned issue in our examples
