### PR TITLE
docs: switch to Stackblitz export

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -41,12 +41,12 @@ export const parameters = {
     },
   },
   exportToSandbox: {
-    provider: 'codesandbox-browser',
-    bundler: 'cra',
+    provider: 'stackblitz-cloud',
+    bundler: 'vite',
     requiredDependencies: {
       // for React
-      react: '^17',
-      'react-dom': '^17',
+      react: '^18',
+      'react-dom': '^18',
       // necessary for FluentProvider:
       '@fluentui/react-components': '^9.0.0',
     },

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.spec.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.spec.ts
@@ -365,7 +365,6 @@ describe(`sabdbox-scaffold`, () => {
           \\"scripts\\": {
             \\"dev\\": \\"vite\\",
             \\"build\\": \\"tsc && vite build\\",
-            \\"lint\\": \\"eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0\\",
             \\"preview\\": \\"vite preview\\"
           },
           \\"dependencies\\": {},
@@ -373,8 +372,8 @@ describe(`sabdbox-scaffold`, () => {
             \\"@types/react\\": \\"^17\\",
             \\"@types/react-dom\\": \\"^17\\",
             \\"typescript\\": \\"~4.7.0\\",
-            \\"@vitejs/plugin-react\\": \\"^4.1.0\\",
-            \\"vite\\": \\"^4.0.0\\"
+            \\"@vitejs/plugin-react\\": \\"^4.2.0\\",
+            \\"vite\\": \\"^5.0.0\\"
           }
         }",
           "src/App.tsx": "import { FluentProvider, webLightTheme } from '@fluentui/react-components';
@@ -490,7 +489,6 @@ describe(`sabdbox-scaffold`, () => {
           \\"scripts\\": {
             \\"dev\\": \\"vite\\",
             \\"build\\": \\"tsc && vite build\\",
-            \\"lint\\": \\"eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0\\",
             \\"preview\\": \\"vite preview\\"
           },
           \\"dependencies\\": {},
@@ -498,8 +496,8 @@ describe(`sabdbox-scaffold`, () => {
             \\"@types/react\\": \\"^17\\",
             \\"@types/react-dom\\": \\"^17\\",
             \\"typescript\\": \\"~4.7.0\\",
-            \\"@vitejs/plugin-react\\": \\"^4.1.0\\",
-            \\"vite\\": \\"^4.0.0\\"
+            \\"@vitejs/plugin-react\\": \\"^4.2.0\\",
+            \\"vite\\": \\"^5.0.0\\"
           }
         }",
           "src/App.tsx": "import { FluentProvider, webLightTheme } from '@fluentui/react-components';

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.ts
@@ -128,7 +128,6 @@ const Vite = {
       scripts: {
         dev: 'vite',
         build: 'tsc && vite build',
-        lint: 'eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0',
         preview: 'vite preview',
       },
       dependencies: {
@@ -136,8 +135,8 @@ const Vite = {
       },
       devDependencies: {
         ...commonDevDeps,
-        '@vitejs/plugin-react': '^4.1.0',
-        vite: '^4.0.0',
+        '@vitejs/plugin-react': '^4.2.0',
+        vite: '^5.0.0',
       },
     });
   },


### PR DESCRIPTION
## Previous Behavior

We used Codesandbox for export.

## New Behavior

We use Stackblitz for export.

Also bumped exports to use Vite 5 & React 18.

### Motivation

CodeSandbox recently changes their policies and now you have **only 10** (private by default) sandboxes, so folks in the crew have this problem:

<img width="486" alt="image" src="https://github.com/microsoft/fluentui/assets/14183168/884b1de7-761f-4af2-9ca7-61ab158d5eeb">

And to avoid it, we have to manually port code to Stackblitz 👎 That's a huge PITA in our workflow.