### PR TITLE
fix(react-spinner): Correct Spinner VR test timing for SVG animation

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
       animationDelay: 'var(--test-animation-delay, -1s) !important',
       animationDuration: '1.5s !important',
     },
-    [`& .${spinnerClassNames.spinner}`]: {
+    [`& .${spinnerClassNames.spinner}, & .fui-Spinner__Progressbar`]: {
       animationDuration: '3s !important',
     },
   },


### PR DESCRIPTION
## Previous Behavior

Previous PR #30592 didn't apply the timing to the correct element, resulting in the wrong animation frames being used in VR tests.

## New Behavior

Apply the animation-duration to the correct element for the SVG animation.
