### PR TITLE
fix: rotating SVG should not cause parent overflow

### DIFF
--- a/change/@fluentui-react-spinner-503d4d53-0c62-4c35-b641-f805615cd2c8.json
+++ b/change/@fluentui-react-spinner-503d4d53-0c62-4c35-b641-f805615cd2c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: rotating SVG should not cause parent overflow",
+  "packageName": "@fluentui/react-spinner",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.styles.ts
+++ b/packages/react-components/react-spinner/src/components/Spinner/useSpinnerStyles.styles.ts
@@ -24,6 +24,7 @@ const useRootBaseClassName = makeResetStyles({
   justifyContent: 'center',
   lineHeight: '0',
   gap: '8px',
+  overflow: 'hidden', // prevents height changes from rotating children
 });
 
 const useRootStyles = makeStyles({


### PR DESCRIPTION

## Previous Behavior

The rotation of the SVG sometimes triggered parent scroll overflow (i.e. when rotated 45deg, the diagonal dimension is longer than the 0deg height).

## New Behavior

Adds an `overflow: hidden` to the span wrapping the SVG

## Related Issue(s)

- Fixes #30610
