### PR TITLE
Fix vertical stacked bar chart rendering issue when data array is empty

### DIFF
--- a/change/@fluentui-react-charting-57bfdb02-b559-4243-b1be-241d801ae8f4.json
+++ b/change/@fluentui-react-charting-57bfdb02-b559-4243-b1be-241d801ae8f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix vertical stacked bar chart rendering issue when data array is empty",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -125,7 +125,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     this._handleMouseOut = this._handleMouseOut.bind(this);
     this._calloutId = getId('callout');
     this._tooltipId = getId('VSBCTooltipId_');
-    if (this._isChartEmpty()) {
+    if (!this._isChartEmpty()) {
       this._adjustProps();
       this._dataset = this._createDataSetLayer();
     }

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.test.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.test.tsx
@@ -266,3 +266,11 @@ describe('Render empty chart aria label div when chart is empty', () => {
     expect(renderedDOM!.length).toBe(1);
   });
 });
+
+test('should render empty chart div when data array is empty', () => {
+  domAct(() => {
+    wrapper = mount(<VerticalStackedBarChart data={[]} />);
+  });
+  const renderedDOM = wrapper!.findWhere(node => node.prop('aria-label') === 'Graph has no data to display');
+  expect(renderedDOM!.length).toBe(1);
+});


### PR DESCRIPTION
## Previous Behavior

Empty array for data in VerticalStackedBarChart throws the following runtime error:

![Before](https://github.com/microsoft/fluentui/assets/110246001/658a16b8-18cd-48a1-8ba3-085b6bbe5a77)

## New Behavior

VerticalStackedBarChart renders an empty div when data array is empty.

![After](https://github.com/microsoft/fluentui/assets/110246001/ceb31958-d0be-492e-8185-73b5d72caf2e)

## Related Issue(s)

- Fixes #30594
