### PR TITLE
Adding 'multiple' prop to Nav

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -66,6 +66,7 @@ export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue'
     };
     onRequestNavCategoryItemToggle: EventHandler<OnNavItemSelectData>;
     openCategories: NavItemValue[];
+    multiple: boolean;
 };
 
 // @public
@@ -112,6 +113,7 @@ export type NavProps = ComponentProps<NavSlots> & {
     onNavItemSelect?: EventHandler<OnNavItemSelectData>;
     selectedValue?: NavItemValue;
     selectedCategoryValue?: NavItemValue;
+    multiple?: boolean;
     onNavCategoryItemToggle?: EventHandler<OnNavItemSelectData>;
 };
 

--- a/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
@@ -53,6 +53,12 @@ export type NavProps = ComponentProps<NavSlots> & {
   selectedCategoryValue?: NavItemValue;
 
   /**
+   * Indicates if Nav supports multiple open Categories at the same time.
+   * @default true, indicating that multiple categories can be open at the same time.
+   */
+  multiple?: boolean;
+
+  /**
    * Callback used by NavCategoryItem to request a change on it's own opened state
    */
   onNavCategoryItemToggle?: EventHandler<OnNavItemSelectData>;

--- a/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
@@ -43,8 +43,17 @@ const normalizeValues = (index?: NavItemValue | NavItemValue[]): NavItemValue[] 
  * Updates the list of open indexes based on an index that changes
  * @param value - the index that will change
  * @param previousOpenItems - list of current open indexes
+ * @param multiple - if Nav supports open categories at the same time
  */
-const updateOpenItems = (value: NavItemValue, previousOpenItems: NavItemValue[]) => {
+const updateOpenItems = (value: NavItemValue, previousOpenItems: NavItemValue[], multiple: boolean) => {
+  if (multiple) {
+    if (previousOpenItems.includes(value)) {
+      return previousOpenItems.filter(i => i !== value);
+    } else {
+      return [...previousOpenItems, value];
+    }
+  }
+
   return previousOpenItems[0] === value ? [] : [value];
 };
 
@@ -58,7 +67,7 @@ const updateOpenItems = (value: NavItemValue, previousOpenItems: NavItemValue[])
  * @param ref - reference to root HTMLDivElement of Nav
  */
 export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>): NavState => {
-  const { onNavItemSelect, onNavCategoryItemToggle } = props;
+  const { onNavItemSelect, onNavCategoryItemToggle, multiple = true } = props;
 
   const innerRef = React.useRef<HTMLElement>(null);
 
@@ -70,7 +79,7 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
   });
 
   const onRequestNavCategoryItemToggle: EventHandler<OnNavItemSelectData> = useEventCallback((event, data) => {
-    const nextOpenItems = updateOpenItems(data.value, openCategories);
+    const nextOpenItems = updateOpenItems(data.value, openCategories, multiple);
     onNavCategoryItemToggle?.(event, data);
     setOpenCategories(nextOpenItems);
   });

--- a/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNav.ts
@@ -158,5 +158,6 @@ export const useNav_unstable = (props: NavProps, ref: React.Ref<HTMLDivElement>)
     getRegisteredNavItems,
     onRequestNavCategoryItemToggle,
     openCategories,
+    multiple,
   };
 };

--- a/packages/react-components/react-nav-preview/src/components/NavContext.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavContext.ts
@@ -26,6 +26,12 @@ const navContextDefaultValue: NavContextValue = {
    * The list of opened panels by index
    */
   openCategories: [],
+
+  /**
+   * Indicates if Nav supports multiple open Categories at the same time.
+   * @default true, indicating that multiple categories can be open at the same time.
+   */
+  multiple: true,
 };
 
 const NavContext = React.createContext<NavContextValue | undefined>(undefined);

--- a/packages/react-components/react-nav-preview/src/components/NavContext.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavContext.types.ts
@@ -35,6 +35,12 @@ export type NavContextValue = Pick<
    * The list of opened panels by index
    */
   openCategories: NavItemValue[];
+
+  /**
+   * Indicates if Nav supports multiple open Categories at the same time.
+   * @default true, indicating that multiple categories can be open at the same time.
+   */
+  multiple: boolean;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
+++ b/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
@@ -24,7 +24,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
       getRegisteredNavItems,
       onRequestNavCategoryItemToggle,
       openCategories,
-      multiple: true,
+      multiple,
     }),
     [
       selectedValue,

--- a/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
+++ b/packages/react-components/react-nav-preview/src/components/useNavContextValues.tsx
@@ -11,6 +11,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
     getRegisteredNavItems,
     onRequestNavCategoryItemToggle,
     openCategories,
+    multiple,
   } = state;
 
   const navContext = React.useMemo<NavContextValue>(
@@ -23,6 +24,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
       getRegisteredNavItems,
       onRequestNavCategoryItemToggle,
       openCategories,
+      multiple: true,
     }),
     [
       selectedValue,
@@ -33,6 +35,7 @@ export function useNavContextValues_unstable(state: NavState): NavContextValues 
       getRegisteredNavItems,
       onRequestNavCategoryItemToggle,
       openCategories,
+      multiple,
     ],
   );
 

--- a/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelection.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelection.stories.tsx
@@ -23,6 +23,22 @@ export const WithNestedSubItemsDefaultSelection = () => {
           <NavSubItem value="11">Eleven</NavSubItem>
         </NavSubItemGroup>
       </NavCategory>
+      <NavCategory value="12">
+        <NavCategoryItem>NavCategoryItem3</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="13">Thirteen</NavSubItem>
+          <NavSubItem value="14">Fourteen</NavSubItem>
+          <NavSubItem value="15">Fifteen</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+      <NavCategory value="16">
+        <NavCategoryItem>NavCategoryItem4</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="17">Seventeen</NavSubItem>
+          <NavSubItem value="18">Eighteen</NavSubItem>
+          <NavSubItem value="19">Nineteen</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
     </Nav>
   );
 };

--- a/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelectionSingleCategory.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelectionSingleCategory.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Nav, NavCategory, NavCategoryItem, NavItem, NavSubItem, NavSubItemGroup } from '@fluentui/react-nav-preview';
+
+export const WithNestedSubItemsWithDefaultSelectionSingleCategory = () => {
+  return (
+    <Nav multiple={false} defaultSelectedValue={'7'} defaultSelectedCategoryValue={'4'}>
+      <NavItem value="1">First</NavItem>
+      <NavItem value="2">Second</NavItem>
+      <NavItem value="3">Third</NavItem>
+      <NavCategory value="4">
+        <NavCategoryItem>NavCategoryItem 1</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="5">Five</NavSubItem>
+          <NavSubItem value="6">Six</NavSubItem>
+          <NavSubItem value="7">Seven</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+      <NavCategory value="8">
+        <NavCategoryItem>NavCategoryItem2</NavCategoryItem>
+        <NavSubItemGroup>
+          <NavSubItem value="9">Nine</NavSubItem>
+          <NavSubItem value="10">Ten</NavSubItem>
+          <NavSubItem value="11">Eleven</NavSubItem>
+        </NavSubItemGroup>
+      </NavCategory>
+    </Nav>
+  );
+};

--- a/packages/react-components/react-nav-preview/stories/Nav/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/index.stories.tsx
@@ -7,6 +7,7 @@ export { Default } from './NavDefault.stories';
 export { WithDefaultSelection } from './NavWithDefaultSelection.stories';
 export { WithNestedSubItems } from './NavWithNestedSubItems.stories';
 export { WithNestedSubItemsDefaultSelection } from './NavWithNestedSubItemsWithDefaultSelection.stories';
+export { WithNestedSubItemsWithDefaultSelectionSingleCategory } from './NavWithNestedSubItemsWithDefaultSelectionSingleCategory.stories';
 
 export default {
   title: 'Preview Components/Nav',


### PR DESCRIPTION
Accordion has a prop 'multiple' that controls if multiple items can be open at the same time.

We want an analogous prop, but our prop will default to true.

Adds an example to demonstrate behavior when this is false.

Recording of two relevant examples:

https://github.com/microsoft/fluentui/assets/17346018/6fe1e86d-d482-4488-b008-6c867479bad7

Child of #26649 

