### PR TITLE
bugfix(react-dialog): ensures non-modal Dialog returns focus to trigger when closed

### DIFF
--- a/change/@fluentui-react-dialog-52adabb2-b975-409b-8bc7-3747eddbd061.json
+++ b/change/@fluentui-react-dialog-52adabb2-b975-409b-8bc7-3747eddbd061.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensures non-modal Dialog returns focus to trigger when closed",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -1,3 +1,5 @@
+/// <reference types="cypress-real-events" />
+
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 
@@ -394,7 +396,7 @@ describe('Dialog', () => {
     });
   });
   describe('modalType = non-modal', () => {
-    it('should close with escape keydown', () => {
+    it('should close with escape keydown and return focus to trigger', () => {
       mount(
         <Dialog modalType="non-modal">
           <DialogTrigger disableButtonEnhancement>
@@ -423,6 +425,7 @@ describe('Dialog', () => {
       cy.get(dialogTriggerOpenSelector).realClick();
       cy.focused().realType('{esc}');
       cy.get(dialogSurfaceSelector).should('not.exist');
+      cy.get(dialogTriggerOpenSelector).should('be.focused');
     });
     it('should not lock body scroll when dialog open', () => {
       mount(

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -64,7 +64,7 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     dialogTitleId: useId('dialog-title-'),
     isNestedDialog: useHasParentContext(DialogContext),
     dialogRef: focusRef,
-    modalAttributes: modalType !== 'non-modal' ? modalAttributes : undefined,
+    modalAttributes,
     triggerAttributes,
   };
 };


### PR DESCRIPTION
## Actual Behavior

On keyboard navigation, when closing the non-modal `Dialog` the focus goes to `body`

## Expected Behavior

The focus should go back to the `DialogTrigger` that opened the non-modal `Dialog`

1. Adds proper tabster modal attributes on `non-modal` dialog
2. adds e2e test to ensure this behaviour

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/30627
