### PR TITLE
docs(react-dialog): creates story for DialogActions

### DIFF
--- a/packages/react-components/react-dialog/stories/Dialog/DialogActions.md
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogActions.md
@@ -1,0 +1,3 @@
+Dialogs should be used for providing the user with quick prompt options where decisions should be made quickly. They should be used for actions that are not reversible, such as deleting an item.
+
+`DialogActions` should be used to provide the user with a set of actions to choose from. The actions should be clear and concise, and should be used to guide the user to the next step in the process.

--- a/packages/react-components/react-dialog/stories/Dialog/DialogActions.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/DialogActions.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogSurface,
+  DialogTitle,
+  DialogContent,
+  DialogBody,
+  DialogActions,
+  Button,
+  Checkbox,
+  CheckboxOnChangeData,
+} from '@fluentui/react-components';
+import story from './DialogActions.md';
+
+export const Actions = () => {
+  const [checked, setChecked] = React.useState(false);
+  const handleChange = (ev: React.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => {
+    setChecked(Boolean(data.checked));
+  };
+  return (
+    <Dialog modalType="non-modal">
+      <DialogTrigger disableButtonEnhancement>
+        <Button>Open campaign dialog</Button>
+      </DialogTrigger>
+      <DialogSurface aria-describedby={undefined}>
+        <DialogBody>
+          <DialogTitle>Delete this campaign?</DialogTitle>
+          <DialogContent>
+            <p>
+              You're about to delete the campaign group "Campaign name that goes up to two lines". This will also delete
+              all associated campaign resources, including the overview page, files, publications, conversations, and so
+              forth. Please back up any content you need before proceeding.
+            </p>
+            <Checkbox
+              checked={checked}
+              onChange={handleChange}
+              label="Yes, delete this campaign and all its associated resources"
+            />
+          </DialogContent>
+          <DialogActions>
+            <DialogTrigger disableButtonEnhancement>
+              <Button disabled={!checked} appearance="primary">
+                Delete
+              </Button>
+            </DialogTrigger>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary">Cancel</Button>
+            </DialogTrigger>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+Actions.parameters = {
+  docs: {
+    description: {
+      story,
+    },
+  },
+};

--- a/packages/react-components/react-dialog/stories/Dialog/index.stories.tsx
+++ b/packages/react-components/react-dialog/stories/Dialog/index.stories.tsx
@@ -9,6 +9,7 @@ export { Default } from './DialogDefault.stories';
 export { NonModal } from './DialogNonModal.stories';
 export { Alert } from './DialogAlert.stories';
 export { ScrollingLongContent } from './DialogScrollingLongContent.stories';
+export { Actions } from './DialogActions.stories';
 export { FluidActions } from './DialogFluidDialogActions.stories';
 export { NoFocusableElement } from './DialogNoFocusableElement.stories';
 export { ControllingOpenAndClose } from './DialogControllingOpenAndClose.stories';


### PR DESCRIPTION

## New Behavior

1. Adds documentation to describe better why to use `DialogActions`
2. Adds checkbox example to showcase CELA explicit acknowledgement to confirm that the user has reviewed the message (Fixes https://github.com/microsoft/fluentui/issues/30507)
