### PR TITLE
Changes NavItems and NavSubItems to be anchors

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -83,7 +83,6 @@ export const navItemClassNames: SlotClassNames<NavItemSlots>;
 // @public
 export type NavItemProps = ComponentProps<Partial<NavItemSlots>> & {
     value: NavItemValue;
-    href?: string;
 };
 
 // @public (undocumented)
@@ -157,7 +156,6 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 // @public
 export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
     value: NavItemValue;
-    href?: string;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -83,6 +83,7 @@ export const navItemClassNames: SlotClassNames<NavItemSlots>;
 // @public
 export type NavItemProps = ComponentProps<Partial<NavItemSlots>> & {
     value: NavItemValue;
+    href?: string;
 };
 
 // @public (undocumented)
@@ -93,7 +94,7 @@ export type NavItemRegisterData = {
 
 // @public (undocumented)
 export type NavItemSlots = {
-    root: Slot<'button'>;
+    root: Slot<'a'>;
     content: NonNullable<Slot<'span'>>;
 };
 
@@ -156,11 +157,12 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 // @public
 export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
     value: NavItemValue;
+    href?: string;
 };
 
 // @public (undocumented)
 export type NavSubItemSlots = {
-    root: Slot<'button'>;
+    root: Slot<'a'>;
     content: NonNullable<Slot<'span'>>;
 };
 
@@ -206,7 +208,7 @@ export const useNavCategoryItemStyles_unstable: (state: NavCategoryItemState) =>
 export const useNavContext_unstable: () => NavContextValue;
 
 // @public
-export const useNavItem_unstable: (props: NavItemProps, ref: React_2.Ref<HTMLButtonElement>) => NavItemState;
+export const useNavItem_unstable: (props: NavItemProps, ref: React_2.Ref<HTMLAnchorElement>) => NavItemState;
 
 // @public
 export const useNavItemStyles_unstable: (state: NavItemState) => NavItemState;
@@ -215,7 +217,7 @@ export const useNavItemStyles_unstable: (state: NavItemState) => NavItemState;
 export const useNavStyles_unstable: (state: NavState) => NavState;
 
 // @public
-export const useNavSubItem_unstable: (props: NavSubItemProps, ref: React_2.Ref<HTMLButtonElement>) => NavSubItemState;
+export const useNavSubItem_unstable: (props: NavSubItemProps, ref: React_2.Ref<HTMLAnchorElement>) => NavSubItemState;
 
 // @public
 export const useNavSubItemGroup_unstable: (props: NavSubItemGroupProps, ref: React_2.Ref<HTMLDivElement>) => NavSubItemGroupState;

--- a/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
@@ -64,7 +64,7 @@ export type NavProps = ComponentProps<NavSlots> & {
   onNavCategoryItemToggle?: EventHandler<OnNavItemSelectData>;
 };
 
-export type OnNavItemSelectData = EventData<'click', React.MouseEvent<HTMLButtonElement>> & {
+export type OnNavItemSelectData = EventData<'click', React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>> & {
   /**
    * The value of the selected navItem.
    */

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -25,11 +25,6 @@ export type NavItemProps = ComponentProps<Partial<NavItemSlots>> & {
    * The value that identifies this navCategoryItem when selected.
    */
   value: NavItemValue;
-
-  /**
-   * Destination URL for the link
-   */
-  href?: string;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -2,7 +2,7 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import { NavItemValue } from '../NavContext.types';
 
 export type NavItemSlots = {
-  root: Slot<'button'>;
+  root: Slot<'a'>;
 
   // TODO - light this up when we get design spec
   // /**
@@ -25,6 +25,11 @@ export type NavItemProps = ComponentProps<Partial<NavItemSlots>> & {
    * The value that identifies this navCategoryItem when selected.
    */
   value: NavItemValue;
+
+  /**
+   * Destination URL for the link
+   */
+  href?: string;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -13,7 +13,7 @@ import type { NavItemProps, NavItemState } from './NavItem.types';
  * @param props - props from this instance of NavItem
  * @param ref - reference to root HTMLDivElement of NavItem
  */
-export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLButtonElement>): NavItemState => {
+export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnchorElement>): NavItemState => {
   const { content, onClick, value } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
@@ -42,16 +42,16 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLButt
   });
 
   return {
-    components: { root: 'button', content: 'span' },
+    components: { root: 'a', content: 'span' },
     root: slot.always(
-      getIntrinsicElementProps('button', {
+      getIntrinsicElementProps('a', {
         ref,
         role: 'nav',
         type: 'navigation',
         ...props,
         onClick: onNavItemClick,
       }),
-      { elementType: 'button' },
+      { elementType: 'a' },
     ),
     content: contentSlot,
     selected,

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -3,7 +3,7 @@ import { NavItemValue } from '../NavContext.types';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavSubItemSlots = {
-  root: Slot<'button'>;
+  root: Slot<'a'>;
 
   /**
    * Component children are placed in this slot
@@ -20,6 +20,11 @@ export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
    * The value that identifies this NavSubItem when selected.
    */
   value: NavItemValue;
+
+  /**
+   * Destination URL for the link
+   */
+  href?: string;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -20,11 +20,6 @@ export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
    * The value that identifies this NavSubItem when selected.
    */
   value: NavItemValue;
-
-  /**
-   * Destination URL for the link
-   */
-  href?: string;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -14,7 +14,7 @@ import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
  * @param props - props from this instance of NavSubItem
  * @param ref - reference to root HTMLButtonElement of NavSubItem
  */
-export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HTMLButtonElement>): NavSubItemState => {
+export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HTMLAnchorElement>): NavSubItemState => {
   const { content, onClick, value: subItemValue } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
@@ -49,18 +49,18 @@ export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HT
 
   return {
     components: {
-      root: 'button',
+      root: 'a',
       content: 'span',
     },
     root: slot.always(
-      getIntrinsicElementProps('button', {
+      getIntrinsicElementProps('a', {
         ref,
         role: 'nav',
         type: 'navigation',
         ...props,
         onClick: onNavSubItemClick,
       }),
-      { elementType: 'button' },
+      { elementType: 'a' },
     ),
     content: contentSlot,
     selected,

--- a/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelection.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Nav/NavWithNestedSubItemsWithDefaultSelection.stories.tsx
@@ -2,15 +2,23 @@ import * as React from 'react';
 import { Nav, NavCategory, NavCategoryItem, NavItem, NavSubItem, NavSubItemGroup } from '@fluentui/react-nav-preview';
 
 export const WithNestedSubItemsDefaultSelection = () => {
+  const someClickHandler = () => {
+    console.log('someClickHandler');
+  };
+
   return (
     <Nav defaultSelectedValue={'7'} defaultSelectedCategoryValue={'4'}>
-      <NavItem value="1">First</NavItem>
+      <NavItem href="https://www.microsoft.com" target="_blank" onClick={someClickHandler} value="1">
+        First
+      </NavItem>
       <NavItem value="2">Second</NavItem>
       <NavItem value="3">Third</NavItem>
       <NavCategory value="4">
         <NavCategoryItem>NavCategoryItem 1</NavCategoryItem>
         <NavSubItemGroup>
-          <NavSubItem value="5">Five</NavSubItem>
+          <NavSubItem href="https://www.microsoft.com" onClick={someClickHandler} target="_blank" value="5">
+            Five
+          </NavSubItem>
           <NavSubItem value="6">Six</NavSubItem>
           <NavSubItem value="7">Seven</NavSubItem>
         </NavSubItemGroup>


### PR DESCRIPTION
Drafting off the MenuItemLink component.

I'm updating the types to be an anchor, instead of a button because these will all take the user somewhere.

Adding to example for testing.

Todo in a follow up PR: styling
Related parent: #26649

https://github.com/microsoft/fluentui/assets/17346018/0d17d1b2-3b18-48db-89da-dc58371c2a31

