### PR TITLE
Make smallFixedNear and smallFixedFar equal sized

### DIFF
--- a/packages/react/src/components/Panel/Panel.styles.ts
+++ b/packages/react/src/components/Panel/Panel.styles.ts
@@ -240,7 +240,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       type === PanelType.smallFixedNear && {
         left: panelMargin.none,
         right: panelMargin.auto,
-        width: panelWidth.xs,
+        width: panelWidth.sm,
       },
       type === PanelType.customNear && {
         right: 'auto',


### PR DESCRIPTION
Possible fix for https://github.com/microsoft/fluentui/issues/30636

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Panels with type `PanelType.smallFixedFar` renders with `340px` width whereas type `PanelType.smallFixedNear` renders with `272px` width.

## New Behavior

Now both panels render with the same small width as documented.

## Related Issue(s)

- Fixes https://github.com/microsoft/fluentui/issues/30636
