### PR TITLE
Fix Rating icon layout

### DIFF
--- a/change/@fluentui-react-rating-preview-9f325e30-7f5b-430e-85bc-80a4e03999da.json
+++ b/change/@fluentui-react-rating-preview-9f325e30-7f5b-430e-85bc-80a4e03999da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update RatingItem styling to use flex to align all items properly",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItemStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingItem/useRatingItemStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
@@ -24,28 +24,24 @@ const useStyles = makeStyles({
     fontSize: '12px',
     width: '12px',
     height: '12px',
-    lineHeight: '12px',
   },
 
   medium: {
     fontSize: '16px',
     width: '16px',
     height: '16px',
-    lineHeight: '16px',
   },
 
   large: {
     fontSize: '20px',
     width: '20px',
     height: '20px',
-    lineHeight: '20px',
   },
 
   'extra-large': {
     fontSize: '28px',
     width: '28px',
     height: '28px',
-    lineHeight: '28px',
   },
 });
 
@@ -71,7 +67,7 @@ const useInputStyles = makeStyles({
 });
 
 const useIndicatorBaseClassName = makeResetStyles({
-  display: 'inline-block',
+  display: 'flex',
   overflow: 'hidden',
   color: tokens.colorNeutralForeground1,
   fill: 'currentColor',
@@ -86,6 +82,9 @@ const useIndicatorBaseClassName = makeResetStyles({
 const useIndicatorStyles = makeStyles({
   lowerHalf: {
     right: '50%',
+    '& > svg': {
+      ...shorthands.flex(0, 0, 'auto'),
+    },
   },
   upperHalf: {
     left: '50%',


### PR DESCRIPTION
This PR changes the `display` attribute of the `RatingItem` indicator slot from `inline-block` to `flex` so that all items can be aligned properly. This was originally not done because doing so would mean that the half value input icon would not align properly. This PR fixes that by adding a `flex: 0 0 auto` property to the half value svg so that it takes up the appropriate space.