### PR TITLE
Fix: Add wrap to Rating and RatingDisplay

### DIFF
--- a/change/@fluentui-react-rating-preview-d2b46b99-f2b6-48df-87e9-0fba20df0cd2.json
+++ b/change/@fluentui-react-rating-preview-d2b46b99-f2b6-48df-87e9-0fba20df0cd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add flex wrap to Rating and RatingDisplay",
+  "packageName": "@fluentui/react-rating-preview",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-rating-preview/src/components/Rating/useRatingStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/Rating/useRatingStyles.styles.ts
@@ -12,6 +12,7 @@ export const ratingClassNames: SlotClassNames<RatingSlots> = {
 
 const useRootClassName = makeResetStyles({
   display: 'flex',
+  flexWrap: 'wrap',
 });
 
 /**

--- a/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating-preview/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -15,6 +15,7 @@ export const ratingDisplayClassNames: SlotClassNames<RatingDisplaySlots> = {
 
 const useRootClassName = makeResetStyles({
   display: 'flex',
+  flexWrap: 'wrap',
   alignItems: 'center',
 });
 


### PR DESCRIPTION
Currently content wrap is not supported for `Rating` and `RatingDisplay`, so if the screen is resized, both components lose a lot of functionality. This adds a flex wrap around the `Rating` and `RatingDisplay`.