### PR TITLE
Removing 'getTheme' from BasicList examples

### DIFF
--- a/packages/react-examples/src/react/List/List.Basic.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Basic.Example.tsx
@@ -61,7 +61,7 @@ export const ListBasicExample: React.FunctionComponent = () => {
   const originalItems = useConst(() => createListItems(5000));
   const [items, setItems] = React.useState(originalItems);
   const theme = useTheme();
-  const classNames = React.useMemo(() => generateStyles(theme), []);
+  const classNames = React.useMemo(() => generateStyles(theme), [theme]);
 
   const onRenderCell = React.useCallback(
     (item: IExampleItem, index: number | undefined): JSX.Element => {

--- a/packages/react-examples/src/react/List/List.Basic.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Basic.Example.tsx
@@ -5,80 +5,86 @@ import { TextField } from '@fluentui/react/lib/TextField';
 import { Image, ImageFit } from '@fluentui/react/lib/Image';
 import { Icon } from '@fluentui/react/lib/Icon';
 import { List } from '@fluentui/react/lib/List';
-import { ITheme, mergeStyleSets, getTheme, getFocusStyle } from '@fluentui/react/lib/Styling';
+import { ITheme, mergeStyleSets, getFocusStyle } from '@fluentui/react/lib/Styling';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { useConst } from '@fluentui/react-hooks';
+import { useTheme } from '@fluentui/react/lib/Theme';
 
-const theme: ITheme = getTheme();
-const { palette, semanticColors, fonts } = theme;
-
-const classNames = mergeStyleSets({
-  itemCell: [
-    getFocusStyle(theme, { inset: -1 }),
-    {
-      minHeight: 54,
-      padding: 10,
-      boxSizing: 'border-box',
-      borderBottom: `1px solid ${semanticColors.bodyDivider}`,
-      display: 'flex',
-      selectors: {
-        '&:hover': { background: palette.neutralLight },
+const generateStyles = (theme: ITheme) => {
+  const { palette, semanticColors, fonts } = theme;
+  return mergeStyleSets({
+    itemCell: [
+      getFocusStyle(theme, { inset: -1 }),
+      {
+        minHeight: 54,
+        padding: 10,
+        boxSizing: 'border-box',
+        borderBottom: `1px solid ${semanticColors.bodyDivider}`,
+        display: 'flex',
+        selectors: {
+          '&:hover': { background: palette.neutralLight },
+        },
       },
+    ],
+    itemImage: {
+      flexShrink: 0,
     },
-  ],
-  itemImage: {
-    flexShrink: 0,
-  },
-  itemContent: {
-    marginLeft: 10,
-    overflow: 'hidden',
-    flexGrow: 1,
-  },
-  itemName: [
-    fonts.xLarge,
-    {
-      whiteSpace: 'nowrap',
+    itemContent: {
+      marginLeft: 10,
       overflow: 'hidden',
-      textOverflow: 'ellipsis',
+      flexGrow: 1,
     },
-  ],
-  itemIndex: {
-    fontSize: fonts.small.fontSize,
-    color: palette.neutralTertiary,
-    marginBottom: 10,
-  },
-  chevron: {
-    alignSelf: 'center',
-    marginLeft: 10,
-    color: palette.neutralTertiary,
-    fontSize: fonts.large.fontSize,
-    flexShrink: 0,
-  },
-});
-
-const onRenderCell = (item: IExampleItem, index: number | undefined): JSX.Element => {
-  return (
-    <div className={classNames.itemCell} data-is-focusable={true}>
-      <Image
-        className={classNames.itemImage}
-        src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
-        width={50}
-        height={50}
-        imageFit={ImageFit.cover}
-      />
-      <div className={classNames.itemContent}>
-        <div className={classNames.itemName}>{item.name}</div>
-        <div className={classNames.itemIndex}>{`Item ${index}`}</div>
-        <div>{item.description}</div>
-      </div>
-      <Icon className={classNames.chevron} iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'} />
-    </div>
-  );
+    itemName: [
+      fonts.xLarge,
+      {
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      },
+    ],
+    itemIndex: {
+      fontSize: fonts.small.fontSize,
+      color: palette.neutralTertiary,
+      marginBottom: 10,
+    },
+    chevron: {
+      alignSelf: 'center',
+      marginLeft: 10,
+      color: palette.neutralTertiary,
+      fontSize: fonts.large.fontSize,
+      flexShrink: 0,
+    },
+  });
 };
 
 export const ListBasicExample: React.FunctionComponent = () => {
   const originalItems = useConst(() => createListItems(5000));
   const [items, setItems] = React.useState(originalItems);
+  const theme = useTheme();
+  const classNames = React.useMemo(() => generateStyles(theme), []);
+
+  const onRenderCell = React.useCallback(
+    (item: IExampleItem, index: number | undefined): JSX.Element => {
+      return (
+        <div className={classNames.itemCell} data-is-focusable={true}>
+          <Image
+            className={classNames.itemImage}
+            src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+            width={50}
+            height={50}
+            imageFit={ImageFit.cover}
+          />
+          <div className={classNames.itemContent}>
+            <div className={classNames.itemName}>{item.name}</div>
+            <div className={classNames.itemIndex}>{`Item ${index}`}</div>
+            <div>{item.description}</div>
+          </div>
+          <Icon className={classNames.chevron} iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'} />
+        </div>
+      );
+    },
+    [classNames],
+  );
 
   const resultCountText =
     items.length === originalItems.length ? '' : ` (${items.length} of ${originalItems.length} shown)`;
@@ -94,6 +100,7 @@ export const ListBasicExample: React.FunctionComponent = () => {
         // eslint-disable-next-line react/jsx-no-bind
         onChange={onFilterChanged}
       />
+
       <List items={items} onRenderCell={onRenderCell} />
     </FocusZone>
   );

--- a/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
@@ -2,84 +2,90 @@ import * as React from 'react';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
 import { List } from '@fluentui/react/lib/List';
 import { Image, ImageFit } from '@fluentui/react/lib/Image';
-import { ITheme, mergeStyleSets, getTheme, getFocusStyle } from '@fluentui/react/lib/Styling';
+import { ITheme, mergeStyleSets, getFocusStyle } from '@fluentui/react/lib/Styling';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { useConst } from '@fluentui/react-hooks';
+import { useTheme } from '@fluentui/react/lib/Theme';
 
-const theme: ITheme = getTheme();
-const { palette, semanticColors, fonts } = theme;
-const classNames = mergeStyleSets({
-  container: {
-    overflow: 'auto',
-    maxHeight: 500,
-  },
-  itemCell: [
-    getFocusStyle(theme, { inset: -1 }),
-    {
-      minHeight: 54,
-      padding: 10,
-      boxSizing: 'border-box',
-      borderBottom: `1px solid ${semanticColors.bodyDivider}`,
-      display: 'flex',
-      selectors: {
-        '&:hover': { background: palette.neutralLight },
+const generateStyles = (theme: ITheme) => {
+  return mergeStyleSets({
+    container: {
+      overflow: 'auto',
+      maxHeight: 500,
+    },
+    itemCell: [
+      getFocusStyle(theme, { inset: -1 }),
+      {
+        minHeight: 54,
+        padding: 10,
+        boxSizing: 'border-box',
+        borderBottom: `1px solid ${theme.semanticColors.bodyDivider}`,
+        display: 'flex',
+        selectors: {
+          '&:hover': { background: theme.palette.neutralLight },
+        },
       },
+    ],
+    itemImage: {
+      flexShrink: 0,
     },
-  ],
-  itemImage: {
-    flexShrink: 0,
-  },
-  itemContent: {
-    marginLeft: 10,
-    overflow: 'hidden',
-    flexGrow: 1,
-  },
-  itemName: [
-    fonts.xLarge,
-    {
-      whiteSpace: 'nowrap',
+    itemContent: {
+      marginLeft: 10,
       overflow: 'hidden',
-      textOverflow: 'ellipsis',
+      flexGrow: 1,
     },
-  ],
-  itemIndex: {
-    fontSize: fonts.small.fontSize,
-    color: palette.neutralTertiary,
-    marginBottom: 10,
-  },
-  chevron: {
-    alignSelf: 'center',
-    marginLeft: 10,
-    color: palette.neutralTertiary,
-    fontSize: fonts.large.fontSize,
-    flexShrink: 0,
-  },
-});
-
-const onRenderCell = (item: IExampleItem, index: number, isScrolling: boolean): JSX.Element => {
-  return (
-    <div className={classNames.itemCell} data-is-focusable={true}>
-      <Image
-        className={classNames.itemImage}
-        src={
-          isScrolling
-            ? undefined
-            : 'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
-        }
-        width={50}
-        height={50}
-        imageFit={ImageFit.cover}
-      />
-      <div className={classNames.itemContent}>
-        <div className={classNames.itemName}>{item.name}</div>
-        <div className={classNames.itemIndex}>{`Item ${index}`}</div>
-      </div>
-    </div>
-  );
+    itemName: [
+      theme.fonts.xLarge,
+      {
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      },
+    ],
+    itemIndex: {
+      fontSize: theme.fonts.small.fontSize,
+      color: theme.palette.neutralTertiary,
+      marginBottom: 10,
+    },
+    chevron: {
+      alignSelf: 'center',
+      marginLeft: 10,
+      color: theme.palette.neutralTertiary,
+      fontSize: theme.fonts.large.fontSize,
+      flexShrink: 0,
+    },
+  });
 };
 
 export const ListGhostingExample: React.FunctionComponent = () => {
   const items = useConst(() => createListItems(5000));
+  const theme = useTheme();
+  const classNames = React.useMemo(() => generateStyles(theme), []);
+
+  const onRenderCell = React.useCallback(
+    (item: IExampleItem, index: number, isScrolling: boolean): JSX.Element => {
+      return (
+        <div className={classNames.itemCell} data-is-focusable={true}>
+          <Image
+            className={classNames.itemImage}
+            src={
+              isScrolling
+                ? undefined
+                : 'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
+            }
+            width={50}
+            height={50}
+            imageFit={ImageFit.cover}
+          />
+          <div className={classNames.itemContent}>
+            <div className={classNames.itemName}>{item.name}</div>
+            <div className={classNames.itemIndex}>{`Item ${index}`}</div>
+          </div>
+        </div>
+      );
+    },
+    [classNames],
+  );
 
   return (
     <FocusZone direction={FocusZoneDirection.vertical}>

--- a/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
@@ -60,7 +60,7 @@ const generateStyles = (theme: ITheme) => {
 export const ListGhostingExample: React.FunctionComponent = () => {
   const items = useConst(() => createListItems(5000));
   const theme = useTheme();
-  const classNames = React.useMemo(() => generateStyles(theme), []);
+  const classNames = React.useMemo(() => generateStyles(theme), [theme]);
 
   const onRenderCell = React.useCallback(
     (item: IExampleItem, index: number, isScrolling: boolean): JSX.Element => {

--- a/packages/react-examples/src/react/List/List.Grid.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Grid.Example.tsx
@@ -82,29 +82,32 @@ export const ListGridExample: React.FunctionComponent = () => {
     return columnCount.current * ROWS_PER_PAGE;
   }, []);
 
-  const onRenderCell = React.useCallback((item: IExampleItem, index: number | undefined) => {
-    return (
-      <div
-        className={classNames.listGridExampleTile}
-        data-is-focusable
-        style={{
-          width: 100 / columnCount.current + '%',
-        }}
-      >
-        <div className={classNames.listGridExampleSizer}>
-          <div className={classNames.listGridExamplePadder}>
-            <img
-              src={
-                'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
-              }
-              className={classNames.listGridExampleImage}
-            />
-            <span className={classNames.listGridExampleLabel}>{`item ${index}`}</span>
+  const onRenderCell = React.useCallback(
+    (item: IExampleItem, index: number | undefined) => {
+      return (
+        <div
+          className={classNames.listGridExampleTile}
+          data-is-focusable
+          style={{
+            width: 100 / columnCount.current + '%',
+          }}
+        >
+          <div className={classNames.listGridExampleSizer}>
+            <div className={classNames.listGridExamplePadder}>
+              <img
+                src={
+                  'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
+                }
+                className={classNames.listGridExampleImage}
+              />
+              <span className={classNames.listGridExampleLabel}>{`item ${index}`}</span>
+            </div>
           </div>
         </div>
-      </div>
-    );
-  }, []);
+      );
+    },
+    [classNames],
+  );
 
   const getPageHeight = React.useCallback((): number => {
     return rowHeight.current * ROWS_PER_PAGE;

--- a/packages/react-examples/src/react/List/List.Grid.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Grid.Example.tsx
@@ -2,72 +2,77 @@ import * as React from 'react';
 import { FocusZone } from '@fluentui/react/lib/FocusZone';
 import { List } from '@fluentui/react/lib/List';
 import { IRectangle } from '@fluentui/react/lib/Utilities';
-import { ITheme, getTheme, mergeStyleSets } from '@fluentui/react/lib/Styling';
+import { ITheme, mergeStyleSets } from '@fluentui/react/lib/Styling';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { useConst } from '@fluentui/react-hooks';
+import { useTheme } from '@fluentui/react/lib/Theme';
 
-const theme: ITheme = getTheme();
-const { palette, fonts } = theme;
 const ROWS_PER_PAGE = 3;
 const MAX_ROW_HEIGHT = 250;
-const classNames = mergeStyleSets({
-  listGridExample: {
-    overflow: 'hidden',
-    fontSize: 0,
-    position: 'relative',
-  },
-  listGridExampleTile: {
-    textAlign: 'center',
-    outline: 'none',
-    position: 'relative',
-    float: 'left',
-    background: palette.neutralLighter,
-    selectors: {
-      'focus:after': {
-        content: '',
-        position: 'absolute',
-        left: 2,
-        right: 2,
-        top: 2,
-        bottom: 2,
-        boxSizing: 'border-box',
-        border: `1px solid ${palette.white}`,
+
+const generateStyles = (theme: ITheme) => {
+  const { palette, fonts } = theme;
+  return mergeStyleSets({
+    listGridExample: {
+      overflow: 'hidden',
+      fontSize: 0,
+      position: 'relative',
+    },
+    listGridExampleTile: {
+      textAlign: 'center',
+      outline: 'none',
+      position: 'relative',
+      float: 'left',
+      background: palette.neutralLighter,
+      selectors: {
+        'focus:after': {
+          content: '',
+          position: 'absolute',
+          left: 2,
+          right: 2,
+          top: 2,
+          bottom: 2,
+          boxSizing: 'border-box',
+          border: `1px solid ${palette.white}`,
+        },
       },
     },
-  },
-  listGridExampleSizer: {
-    paddingBottom: '100%',
-  },
-  listGridExamplePadder: {
-    position: 'absolute',
-    left: 2,
-    top: 2,
-    right: 2,
-    bottom: 2,
-  },
-  listGridExampleLabel: {
-    background: 'rgba(0, 0, 0, 0.3)',
-    color: '#FFFFFF',
-    position: 'absolute',
-    padding: 10,
-    bottom: 0,
-    left: 0,
-    width: '100%',
-    fontSize: fonts.small.fontSize,
-    boxSizing: 'border-box',
-  },
-  listGridExampleImage: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    height: '100%',
-    width: '100%',
-  },
-});
+    listGridExampleSizer: {
+      paddingBottom: '100%',
+    },
+    listGridExamplePadder: {
+      position: 'absolute',
+      left: 2,
+      top: 2,
+      right: 2,
+      bottom: 2,
+    },
+    listGridExampleLabel: {
+      background: 'rgba(0, 0, 0, 0.3)',
+      color: palette.white,
+      position: 'absolute',
+      padding: 10,
+      bottom: 0,
+      left: 0,
+      width: '100%',
+      fontSize: fonts.small.fontSize,
+      boxSizing: 'border-box',
+    },
+    listGridExampleImage: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      height: '100%',
+      width: '100%',
+    },
+  });
+};
 
 export const ListGridExample: React.FunctionComponent = () => {
   const columnCount = React.useRef(0);
   const rowHeight = React.useRef(0);
+  const theme = useTheme();
+  const classNames = React.useMemo(() => generateStyles(theme), [theme]);
 
   const getItemCountForPage = React.useCallback((itemIndex: number, surfaceRect: IRectangle) => {
     if (itemIndex === 0) {

--- a/packages/react-examples/src/react/List/List.Scrolling.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Scrolling.Example.tsx
@@ -58,7 +58,7 @@ export const ListScrollingExample: React.FunctionComponent = () => {
   const [scrollToMode, setScrollToMode] = React.useState<ScrollToMode>(ScrollToMode.auto);
   const listRef: React.RefObject<IList> = React.useRef(null);
   const theme = useTheme();
-  const classNames = generateStyles(theme);
+  const classNames = React.useMemo(() => generateStyles(theme), [theme]);
 
   const onRenderCell = React.useCallback(
     (item: IExampleItem, index: number): JSX.Element => {

--- a/packages/react-examples/src/react/List/List.Scrolling.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Scrolling.Example.tsx
@@ -5,13 +5,13 @@ import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 import { List, ScrollToMode, IList } from '@fluentui/react/lib/List';
 import { TextField } from '@fluentui/react/lib/TextField';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
-import { mergeStyleSets, getTheme, normalize } from '@fluentui/react/lib/Styling';
+import { mergeStyleSets, normalize, ITheme } from '@fluentui/react/lib/Styling';
 import { useConst } from '@fluentui/react-hooks';
+import { useTheme } from '@fluentui/react/lib/Theme';
 
 const evenItemHeight = 50;
 const oddItemHeight = 25;
 const numberOfItemsOnPage = 10;
-const theme = getTheme();
 const dropdownOptions = [
   { key: 'auto', text: 'Auto' },
   { key: 'top', text: 'Top' },
@@ -19,45 +19,37 @@ const dropdownOptions = [
   { key: 'center', text: 'Center' },
 ];
 
-const styles = mergeStyleSets({
-  container: {
-    overflow: 'auto',
-    maxHeight: 400,
-    border: '1px solid #CCC',
-    marginTop: 20,
-    selectors: {
-      '.ms-List-cell .odd': {
-        height: oddItemHeight,
-        lineHeight: oddItemHeight,
-      },
-      '.ms-List-cell .even': {
-        height: evenItemHeight,
-        lineHeight: evenItemHeight,
-        background: theme.palette.neutralLighter,
+const generateStyles = (theme: ITheme) => {
+  return mergeStyleSets({
+    container: {
+      overflow: 'auto',
+      maxHeight: 400,
+      border: '1px solid ' + theme.palette.neutralLight,
+      marginTop: 20,
+      selectors: {
+        '.ms-List-cell .odd': {
+          height: oddItemHeight,
+          lineHeight: oddItemHeight,
+        },
+        '.ms-List-cell .even': {
+          height: evenItemHeight,
+          lineHeight: evenItemHeight,
+          background: theme.palette.neutralLighter,
+        },
       },
     },
-  },
-  itemContent: [
-    theme.fonts.medium,
-    normalize,
-    {
-      position: 'relative',
-      boxSizing: 'border-box',
-      display: 'block',
-      borderLeft: '3px solid ' + theme.palette.themePrimary,
-      paddingLeft: 27,
-    },
-  ],
-});
-
-const onRenderCell = (item: IExampleItem, index: number): JSX.Element => {
-  return (
-    <div data-is-focusable className={index % 2 === 0 ? 'even' : 'odd'}>
-      <div className={styles.itemContent}>
-        {index} &nbsp; {item.name}
-      </div>
-    </div>
-  );
+    itemContent: [
+      theme.fonts.medium,
+      normalize,
+      {
+        position: 'relative',
+        boxSizing: 'border-box',
+        display: 'block',
+        borderLeft: '3px solid ' + theme.palette.themePrimary,
+        paddingLeft: 27,
+      },
+    ],
+  });
 };
 
 export const ListScrollingExample: React.FunctionComponent = () => {
@@ -65,6 +57,21 @@ export const ListScrollingExample: React.FunctionComponent = () => {
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   const [scrollToMode, setScrollToMode] = React.useState<ScrollToMode>(ScrollToMode.auto);
   const listRef: React.RefObject<IList> = React.useRef(null);
+  const theme = useTheme();
+  const classNames = generateStyles(theme);
+
+  const onRenderCell = React.useCallback(
+    (item: IExampleItem, index: number): JSX.Element => {
+      return (
+        <div data-is-focusable className={index % 2 === 0 ? 'even' : 'odd'}>
+          <div className={classNames.itemContent}>
+            {index} &nbsp; {item.name}
+          </div>
+        </div>
+      );
+    },
+    [classNames],
+  );
 
   const scroll = (index: number, propScrollToMode: ScrollToMode): void => {
     const updatedSelectedIndex = Math.min(Math.max(index, 0), items.length - 1);
@@ -142,7 +149,7 @@ export const ListScrollingExample: React.FunctionComponent = () => {
           onChange={onChangeText}
         />
       </div>
-      <div className={styles.container} data-is-scrollable>
+      <div className={classNames.container} data-is-scrollable>
         <List
           componentRef={listRef}
           items={items}


### PR DESCRIPTION
The basic list examples all use `getTheme` which does not respond to contextual theme changes, the modern v8 method for theming.

This PR updates them to use the useTheme hook. There's some rearrangement required since the styles are passed into the render functions. Sorry for the load PR.

More generally:
- Move render and style generating function to within the scope of the component.
- Apply useCallback for the renders, useMemo for the style generators.
- Tidy up some styles.

Addresses #30358 
