### PR TITLE
feature(react-combobox): export internal hooks and types

### DIFF
--- a/change/@fluentui-react-combobox-4683dd24-621c-4ae8-a961-cedec640fa96.json
+++ b/change/@fluentui-react-combobox-4683dd24-621c-4ae8-a961-cedec640fa96.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: export internal hooks and types",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -7,10 +7,11 @@
 /// <reference types="react" />
 
 import type { ActiveDescendantContextValue } from '@fluentui/react-aria';
-import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
+import { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import { ContextSelector } from '@fluentui/react-context-selector';
+import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import { FC } from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { PortalProps } from '@fluentui/react-portal';
@@ -20,9 +21,24 @@ import { ProviderProps } from 'react';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
+import type { SlotComponentType } from '@fluentui/react-utilities';
 
 // @public
 export const Combobox: ForwardRefComponent<ComboboxProps>;
+
+// @public
+export type ComboboxBaseState = Required<Pick<ComboboxBaseProps, 'appearance' | 'open' | 'clearable' | 'inlinePopup' | 'size'>> & Pick<ComboboxBaseProps, 'mountNode' | 'placeholder' | 'value' | 'multiselect'> & OptionCollectionState & SelectionState & {
+    activeOption?: OptionValue;
+    focusVisible: boolean;
+    ignoreNextBlur: React_2.MutableRefObject<boolean>;
+    setActiveOption: React_2.Dispatch<React_2.SetStateAction<OptionValue | undefined>>;
+    setFocusVisible(focusVisible: boolean): void;
+    hasFocus: boolean;
+    setHasFocus(hasFocus: boolean): void;
+    setOpen(event: ComboboxBaseOpenEvents, newState: boolean): void;
+    setValue(newValue: string | undefined): void;
+    onOptionClick: (e: React_2.MouseEvent<HTMLElement>) => void;
+};
 
 // @public (undocumented)
 export const comboboxClassNames: SlotClassNames<ComboboxSlots>;
@@ -213,13 +229,23 @@ export const renderOptionGroup_unstable: (state: OptionGroupState) => JSX.Elemen
 // @public (undocumented)
 export type SelectionEvents = React_2.ChangeEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.MouseEvent<HTMLElement>;
 
+// @internal
+export function useButtonTriggerSlot(triggerFromProps: NonNullable<Slot<'button'>>, ref: React_2.Ref<HTMLButtonElement>, options: UseButtonTriggerSlotOptions): SlotComponentType<ExtractSlotProps<Slot<'button'>>>;
+
 // @public
 export const useCombobox_unstable: (props: ComboboxProps, ref: React_2.Ref<HTMLInputElement>) => ComboboxState;
+
+// @internal
+export const useComboboxBaseState: (props: ComboboxBaseProps & {
+    children?: React_2.ReactNode;
+    editable?: boolean;
+    activeDescendantController: ActiveDescendantImperativeRef;
+}) => ComboboxBaseState;
 
 // @public (undocumented)
 export function useComboboxContextValues(state: ComboboxBaseState & Pick<ComboboxState, 'activeDescendantController'>): ComboboxBaseContextValues;
 
-// @public (undocumented)
+// @internal (undocumented)
 export function useComboboxFilter<T extends {
     children: React_2.ReactNode;
     value: string;
@@ -234,6 +260,9 @@ export const useDropdown_unstable: (props: DropdownProps, ref: React_2.Ref<HTMLB
 // @public
 export const useDropdownStyles_unstable: (state: DropdownState) => DropdownState;
 
+// @internal
+export function useInputTriggerSlot(triggerFromProps: NonNullable<Slot<'input'>>, ref: React_2.Ref<HTMLInputElement>, options: UseInputTriggerSlotOptions): SlotComponentType<ExtractSlotProps<Slot<'input'>>>;
+
 // @public
 export const useListbox_unstable: (props: ListboxProps, ref: React_2.Ref<HTMLElement>) => ListboxState;
 
@@ -242,6 +271,9 @@ export const useListboxContext_unstable: <T>(selector: ContextSelector<ListboxCo
 
 // @public (undocumented)
 export function useListboxContextValues(state: ListboxState): ListboxContextValues;
+
+// @internal (undocumented)
+export function useListboxSlot(listboxSlotFromProp: Slot<typeof Listbox> | undefined, ref: React_2.Ref<HTMLDivElement>, options: UseListboxSlotOptions): SlotComponentType<ExtractSlotProps<Slot<typeof Listbox>>> | undefined;
 
 // @public
 export const useListboxStyles_unstable: (state: ListboxState) => ListboxState;

--- a/packages/react-components/react-combobox/src/components/Combobox/useInputTriggerSlot.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useInputTriggerSlot.ts
@@ -18,7 +18,8 @@ type UseInputTriggerSlotOptions = {
   activeDescendantController: ActiveDescendantImperativeRef;
 };
 
-/*
+/**
+ * @internal
  * useInputTriggerSlot returns a tuple of trigger/listbox shorthand,
  * with the semantics and event handlers needed for the Combobox and Dropdown components.
  * The element type of the ref should always match the element type used in the trigger shorthand.

--- a/packages/react-components/react-combobox/src/components/Dropdown/useButtonTriggerSlot.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useButtonTriggerSlot.ts
@@ -11,7 +11,8 @@ type UseButtonTriggerSlotOptions = {
   activeDescendantController: ActiveDescendantImperativeRef;
 };
 
-/*
+/**
+ * @internal
  * useButtonTriggerSlot returns a tuple of trigger/listbox shorthand,
  * with the semantics and event handlers needed for the Combobox and Dropdown components.
  * The element type of the ref should always match the element type used in the trigger shorthand.

--- a/packages/react-components/react-combobox/src/hooks/useComboboxFilter.tsx
+++ b/packages/react-components/react-combobox/src/hooks/useComboboxFilter.tsx
@@ -30,6 +30,9 @@ function defaultToString(option: string | { value: string }) {
   return typeof option === 'string' ? option : option.value;
 }
 
+/**
+ * @internal
+ */
 export function useComboboxFilter<T extends { children: React.ReactNode; value: string } | string>(
   query: string,
   options: T[],

--- a/packages/react-components/react-combobox/src/index.ts
+++ b/packages/react-components/react-combobox/src/index.ts
@@ -62,3 +62,8 @@ export type { OptionGroupProps, OptionGroupSlots, OptionGroupState } from './Opt
 export type { OptionOnSelectData, SelectionEvents } from './Selection';
 
 export { useComboboxFilter } from './hooks/useComboboxFilter';
+export { useComboboxBaseState } from './utils/useComboboxBaseState';
+export type { ComboboxBaseState } from './utils/ComboboxBase.types';
+export { useListboxSlot } from './utils/useListboxSlot';
+export { useInputTriggerSlot } from './components/Combobox/useInputTriggerSlot';
+export { useButtonTriggerSlot } from './components/Dropdown/useButtonTriggerSlot';

--- a/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/src/utils/useComboboxBaseState.ts
@@ -7,6 +7,7 @@ import { useSelection } from '../utils/useSelection';
 import type { ComboboxBaseProps, ComboboxBaseOpenEvents, ComboboxBaseState } from './ComboboxBase.types';
 
 /**
+ * @internal
  * State shared between Combobox and Dropdown components
  */
 export const useComboboxBaseState = (

--- a/packages/react-components/react-combobox/src/utils/useListboxSlot.ts
+++ b/packages/react-components/react-combobox/src/utils/useListboxSlot.ts
@@ -21,6 +21,7 @@ type UseListboxSlotOptions = {
 };
 
 /**
+ * @internal
  * @returns  listbox slot with desired behaviour and props
  */
 export function useListboxSlot(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. exports internal hooks from combobox as they'll be required for the `react-tag-picker` package 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
