### PR TITLE
feat(swatch-picker): UI changes and spacing

### DIFF
--- a/packages/react-components/react-swatch-picker-preview/etc/react-swatch-picker-preview.api.md
+++ b/packages/react-components/react-swatch-picker-preview/etc/react-swatch-picker-preview.api.md
@@ -76,6 +76,7 @@ export type SwatchPickerProps = ComponentProps<SwatchPickerSlots> & {
     selectedValue?: string;
     size?: 'extraSmall' | 'small' | 'medium' | 'large';
     shape?: 'rounded' | 'square' | 'circular';
+    spacing?: 'small' | 'medium';
 };
 
 // @public (undocumented)
@@ -84,7 +85,7 @@ export type SwatchPickerSlots = {
 };
 
 // @public
-export type SwatchPickerState = ComponentState<SwatchPickerSlots> & SwatchPickerContextValue & Pick<SwatchPickerProps, 'size' | 'shape'>;
+export type SwatchPickerState = ComponentState<SwatchPickerSlots> & SwatchPickerContextValue & Pick<SwatchPickerProps, 'size' | 'shape' | 'spacing'>;
 
 // @public
 export const useColorSwatch_unstable: (props: ColorSwatchProps, ref: React_2.Ref<HTMLButtonElement>) => ColorSwatchState;

--- a/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/ColorSwatch.test.tsx
+++ b/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/ColorSwatch.test.tsx
@@ -26,7 +26,7 @@ describe('ColorSwatch', () => {
     expect(result.container).toMatchInlineSnapshot(`
       <div>
         <div
-          aria-selected="false"
+          aria-checked="false"
           class="fui-ColorSwatch"
           role="radio"
           style="--fui-SwatchPicker--color: #f09;"

--- a/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/ColorSwatch.tsx
+++ b/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/ColorSwatch.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { useColorSwatch_unstable } from './useColorSwatch';
 import { renderColorSwatch_unstable } from './renderColorSwatch';
 import { useColorSwatchStyles_unstable } from './useColorSwatchStyles.styles';

--- a/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/useColorSwatch.ts
+++ b/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/useColorSwatch.ts
@@ -35,7 +35,7 @@ export const useColorSwatch_unstable = (
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'button',
-    excludedPropNames: ['value', 'color'],
+    excludedPropNames: ['value', 'color', 'role'],
   });
 
   const rootVariables = {
@@ -46,7 +46,7 @@ export const useColorSwatch_unstable = (
     defaultProps: {
       ref: useFocusWithin<HTMLDivElement>(),
       role: props.role ?? 'radio',
-      'aria-selected': selected,
+      'aria-checked': selected,
       ...nativeProps.root,
     },
     elementType: 'div',

--- a/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker-preview/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -2,7 +2,7 @@ import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { ColorSwatchSlots, ColorSwatchState } from './ColorSwatch.types';
 import { tokens } from '@fluentui/react-theme';
-import { createFocusOutlineStyle } from '@fluentui/react-tabster';
+import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 
 export const colorSwatchClassNames: SlotClassNames<ColorSwatchSlots> = {
   root: 'fui-ColorSwatch',
@@ -19,46 +19,79 @@ const { color } = swatchCSSVars;
  * Styles for the root slot
  */
 const useStyles = makeResetStyles({
-  position: 'relative',
+  display: 'inline-flex',
   boxSizing: 'border-box',
-  border: 'none',
-  padding: 0,
+  border: `1px solid ${tokens.colorTransparentStroke}`,
   background: `var(${color})`,
+  padding: '0',
   ':hover': {
     cursor: 'pointer',
-    outline: `${tokens.strokeWidthThick} solid ${tokens.colorBrandStroke1}`,
-    border: `${tokens.strokeWidthThin} solid ${tokens.colorBrandBackgroundInverted}`,
+    border: 'none',
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus1}`,
   },
   ':hover:active': {
-    outline: `${tokens.strokeWidthThick} solid ${tokens.colorBrandStroke1}`,
-    border: `${tokens.strokeWidthThick} solid ${tokens.colorBrandBackgroundInverted}`,
+    border: 'none',
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
   },
-  ...createFocusOutlineStyle({ style: {}, selector: 'focus-within' }),
+  ':focus': {
+    outline: 'none',
+  },
+  ':focus-visible': {
+    outline: 'none',
+  },
+  ...createCustomFocusIndicatorStyle({
+    border: 'none',
+    outline: 'none',
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorStrokeFocus2}, inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus1}`,
+  }),
+
+  // High contrast styles
+
+  '@media (forced-colors: active)': {
+    ':focus': {
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
+    },
+
+    ':hover': {
+      backgroundColor: 'HighlightText',
+      borderColor: 'Highlight',
+      color: 'Highlight',
+      forcedColorAdjust: 'none',
+    },
+
+    ':hover:active': {
+      backgroundColor: 'HighlightText',
+      borderColor: 'Highlight',
+      color: 'Highlight',
+      forcedColorAdjust: 'none',
+    },
+  },
 });
 
 const useButtonStyles = makeResetStyles({
-  position: 'absolute',
-  left: 0,
-  top: 0,
   width: '100%',
   height: '100%',
   boxSizing: 'border-box',
-  margin: 0,
   opacity: 0,
+  ':hover': {
+    cursor: 'pointer',
+  },
 });
 
 const useStylesSelected = makeStyles({
   selected: {
-    ...shorthands.outline(tokens.strokeWidthThicker, 'solid', tokens.colorBrandStroke1),
-    ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorBrandBackgroundInverted),
+    ...shorthands.border('none'),
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
+    ...shorthands.borderColor(tokens.colorBrandStroke1),
     ':hover': {
-      ...shorthands.outline(tokens.strokeWidthThicker, 'solid', tokens.colorBrandStroke1),
-      ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorBrandBackgroundInverted),
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
     },
     ':hover:active': {
-      ...shorthands.outline(tokens.strokeWidthThicker, 'solid', tokens.colorBrandStroke1),
-      ...shorthands.border(tokens.strokeWidthThick, 'solid', tokens.colorBrandBackgroundInverted),
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 7px ${tokens.colorStrokeFocus1}`,
     },
+    ...createCustomFocusIndicatorStyle({
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus2}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
+    }),
   },
 });
 
@@ -84,12 +117,21 @@ const useSizeStyles = makeStyles({
 const useShapeStyles = makeStyles({
   rounded: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...createCustomFocusIndicatorStyle({
+      ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    }),
   },
   circular: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    ...createCustomFocusIndicatorStyle({
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    }),
   },
   square: {
     ...shorthands.borderRadius(tokens.borderRadiusNone),
+    ...createCustomFocusIndicatorStyle({
+      ...shorthands.borderRadius(tokens.borderRadiusNone),
+    }),
   },
 });
 

--- a/packages/react-components/react-swatch-picker-preview/src/components/SwatchPicker/SwatchPicker.types.ts
+++ b/packages/react-components/react-swatch-picker-preview/src/components/SwatchPicker/SwatchPicker.types.ts
@@ -43,6 +43,12 @@ export type SwatchPickerProps = ComponentProps<SwatchPickerSlots> & {
    * @defaultvalue 'square'
    */
   shape?: 'rounded' | 'square' | 'circular';
+
+  /**
+   * Spacing between swatches
+   * @defaultvalue 'medium'
+   */
+  spacing?: 'small' | 'medium';
 };
 
 /**
@@ -50,4 +56,4 @@ export type SwatchPickerProps = ComponentProps<SwatchPickerSlots> & {
  */
 export type SwatchPickerState = ComponentState<SwatchPickerSlots> &
   SwatchPickerContextValue &
-  Pick<SwatchPickerProps, 'size' | 'shape'>;
+  Pick<SwatchPickerProps, 'size' | 'shape' | 'spacing'>;

--- a/packages/react-components/react-swatch-picker-preview/src/components/SwatchPicker/useSwatchPicker.ts
+++ b/packages/react-components/react-swatch-picker-preview/src/components/SwatchPicker/useSwatchPicker.ts
@@ -31,7 +31,7 @@ export const useSwatchPicker_unstable = (
   props: SwatchPickerProps,
   ref: React.Ref<HTMLDivElement>,
 ): SwatchPickerState => {
-  const { role, onSelectionChange, size = 'medium', shape, ...rest } = props;
+  const { role, onSelectionChange, size = 'medium', shape, spacing = 'medium', ...rest } = props;
   const focusAttributes = useArrowNavigationGroup({
     circular: true,
     axis: 'both',
@@ -77,7 +77,7 @@ export const useSwatchPicker_unstable = (
   state.root.style = {
     [columnCountGrid]: 3,
     [cellSize]: sizeMap[size],
-    [gridGap]: spacingMap.medium,
+    [gridGap]: spacingMap[spacing],
     ...state.root.style,
   };
 

--- a/packages/react-components/react-swatch-picker-preview/stories/ColorSwatch/ColorSwatchDefault.stories.tsx
+++ b/packages/react-components/react-swatch-picker-preview/stories/ColorSwatch/ColorSwatchDefault.stories.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
 import { ColorSwatch } from '@fluentui/react-swatch-picker-preview';
 
-export const Default = () => <ColorSwatch color="red" value="red-color" />;
+export const Default = () => <ColorSwatch color="red" value="red-color" aria-label="Red" />;

--- a/packages/react-components/react-swatch-picker-preview/stories/SwatchPicker/SwatchPickerDefault.stories.tsx
+++ b/packages/react-components/react-swatch-picker-preview/stories/SwatchPicker/SwatchPickerDefault.stories.tsx
@@ -24,15 +24,15 @@ export const Default = () => {
   return (
     <>
       <SwatchPicker aria-label="SwatchPicker default" selectedValue={selectedValue} onSelectionChange={handleSelect}>
-        <ColorSwatch color="#FF1921" value="FF1921" aria-label="red" role="radio" />
-        <ColorSwatch color="#FFC12E" value="FFC12E" aria-label="orange" role="radio" />
-        <ColorSwatch color="#FEFF37" value="FEFF37" aria-label="yellow" role="radio" />
-        <ColorSwatch color="#90D057" value="90D057" aria-label="light green" role="radio" />
-        <ColorSwatch color="#00B053" value="00B053" aria-label="green" role="radio" />
-        <ColorSwatch color="#00AFED" value="00AFED" aria-label="light blue" role="radio" />
-        <ColorSwatch color="#006EBD" value="006EBD" aria-label="blue" role="radio" />
-        <ColorSwatch color="#011F5E" value="011F5E" aria-label="dark blue" role="radio" />
-        <ColorSwatch color="#712F9E" value="712F9E" aria-label="purple" role="radio" />
+        <ColorSwatch color="#FF1921" value="FF1921" aria-label="red" />
+        <ColorSwatch color="#FFC12E" value="FFC12E" aria-label="orange" />
+        <ColorSwatch color="#FEFF37" value="FEFF37" aria-label="yellow" />
+        <ColorSwatch color="#90D057" value="90D057" aria-label="light green" />
+        <ColorSwatch color="#00B053" value="00B053" aria-label="green" />
+        <ColorSwatch color="#00AFED" value="00AFED" aria-label="light blue" />
+        <ColorSwatch color="#006EBD" value="006EBD" aria-label="blue" />
+        <ColorSwatch color="#011F5E" value="011F5E" aria-label="dark blue" />
+        <ColorSwatch color="#712F9E" value="712F9E" aria-label="purple" />
       </SwatchPicker>
       <div
         className={styles.example}


### PR DESCRIPTION
This UI was tested by a11y team.
This PR includes:
- new `spacing` prop
- Styles for the swatch states
 
![image](https://github.com/microsoft/fluentui/assets/11574680/6f4e9476-c181-48b9-bc85-92693ac0d542)

The following PRs would include:
1. HC for dark theme
2. Stories


