### PR TITLE
Add dynamic status badge for Test Coverage in package README

### DIFF
--- a/packages/react-charting/README.md
+++ b/packages/react-charting/README.md
@@ -61,7 +61,7 @@ A comprehensive contributor guide is available in our internal [wiki](https://ak
 
 ## Testing
 
-![Static Badge](https://img.shields.io/badge/coverage-87%25-brightgreen)
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Ffluentui-charting-contrib%2Ftest-coverage-artifacts%2FubuntuCoverage.json&query=%24.statementCoverage&label=coverage&color=brightgreen)
 
 The library has a wide variety of tests to ensure quality of the library.
 The tests range from component tests, unit tests, visual regression tests, accessibility tests, integration tests and manual tests.

--- a/packages/react-charting/README.md
+++ b/packages/react-charting/README.md
@@ -61,7 +61,7 @@ A comprehensive contributor guide is available in our internal [wiki](https://ak
 
 ## Testing
 
-![Test Coverage Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Ffluentui-charting-contrib%2Ftest-coverage-artifacts%2FubuntuCoverage.json&query=%24.statementCoverage&label=coverage&color=brightgreen)
+![Test Coverage Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Ffluentui-charting-contrib%2Ftest-coverage-artifacts%2FubuntuCoverage.json&query=%24.statementCoverage&suffix=%25&label=coverage&color=brightgreen)
 
 The library has a wide variety of tests to ensure quality of the library.
 The tests range from component tests, unit tests, visual regression tests, accessibility tests, integration tests and manual tests.

--- a/packages/react-charting/README.md
+++ b/packages/react-charting/README.md
@@ -61,7 +61,7 @@ A comprehensive contributor guide is available in our internal [wiki](https://ak
 
 ## Testing
 
-![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Ffluentui-charting-contrib%2Ftest-coverage-artifacts%2FubuntuCoverage.json&query=%24.statementCoverage&label=coverage&color=brightgreen)
+![Test Coverage Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Ffluentui-charting-contrib%2Ftest-coverage-artifacts%2FubuntuCoverage.json&query=%24.statementCoverage&label=coverage&color=brightgreen)
 
 The library has a wide variety of tests to ensure quality of the library.
 The tests range from component tests, unit tests, visual regression tests, accessibility tests, integration tests and manual tests.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The test coverage badge is a static status badge and needs to updated manually everytime the coverage changes.

## New Behavior

The test coverage badge is now made dynamic as it fetches  the latest coverage status from workflow outputs

## Related Issue(s)

- Fixes #
