### PR TITLE
Fix order of default ownership of docs folder.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,9 @@
 
 /.github/ @microsoft/fluentui-react-build
 
+### Default docs folder ownership. 
+docs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg
+
 #### Build folders
 /.codesandbox @microsoft/fluentui-react-build
 /.devcontainer @microsoft/fluentui-react-build
@@ -328,4 +331,3 @@ packages/react-experiments/src/components/TileList @ThomasMichon
 ## Docs
 rfcs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg
 rfcs/shared/build-system/ @microsoft/fluentui-react-build
-docs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Ownership of docs folder was added recently in this PR https://github.com/microsoft/fluentui/pull/30483
As the scope was added at the bottom of the file, it caused the ownership of all sub directories that contain docs folder to get overridden.
<!-- This is the behavior we have today -->

## New Behavior
Moving the docs folder ownership to the top of CODEOWNERS file. 
So that any existing sub directory ownership scopes do not break.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
