### PR TITLE
fix(.github): dont apply docs/ rule codeowner on whole monorepo to create false positivie ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -326,6 +326,6 @@ packages/react-experiments/src/components/TileList @ThomasMichon
 **/.swcrc @microsoft/fluentui-react-build
 
 ## Docs
-rfcs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg
-rfcs/shared/build-system/ @microsoft/fluentui-react-build
-docs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg
+/rfcs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg
+/rfcs/shared/build-system/ @microsoft/fluentui-react-build
+/docs/ @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`docs/` is applied on whole repo, which creates false positives on ownership

## New Behavior

see PR title

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Replaces https://github.com/microsoft/fluentui/pull/30678
- Fixes https://github.com/microsoft/fluentui/pull/30483/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7
