### PR TITLE
Fix always enabled single data point in LineChart

### DIFF
--- a/change/@fluentui-react-charting-10654a2a-99cd-4f2e-9ca6-41b469e88f2f.json
+++ b/change/@fluentui-react-charting-10654a2a-99cd-4f2e-9ca6-41b469e88f2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add isLegendSelected condition for single point data in LineChart",
+  "packageName": "@fluentui/react-charting",
+  "email": "shubhabrata08@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -564,6 +564,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       if (this._points[i].data.length === 1) {
         const { x: x1, y: y1, xAxisCalloutData, xAxisCalloutAccessibilityData } = this._points[i].data[0];
         const circleId = `${this._circleId}_${i}`;
+        const isLegendSelected: boolean =
+          this._legendHighlighted(legendVal) || this._noLegendHighlighted() || this.state.isSelectedLegend;
         pointsForLine.push(
           <circle
             id={circleId}
@@ -572,6 +574,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
             cx={this._xAxisScale(x1)}
             cy={this._yAxisScale(y1)}
             fill={activePoint === circleId ? theme!.semanticColors.bodyBackground : lineColor}
+            opacity={isLegendSelected ? 1 : 0.01}
             onMouseOver={this._handleHover.bind(
               this,
               x1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Single data points in LineChart remain in active state even if their legend is not hovered upon.

## New Behavior

Single data points in LineChart change the opacity state based on the selected legend.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30673
