### PR TITLE
docs: add text warning to badge color stories

### DIFF
--- a/packages/react-components/react-badge/stories/Badge/BadgeColor.stories.tsx
+++ b/packages/react-components/react-badge/stories/Badge/BadgeColor.stories.tsx
@@ -40,7 +40,9 @@ Color.parameters = {
         'A badge can have different colors.' +
         ' The available colors are `brand`, `danger`, `important`, `informative`, ' +
         '`severe`, `subtle`, `success` or `warning`.' +
-        ' The default is `brand`.',
+        ' The default is `brand`.' +
+        ' Information conveyed by color should also be communicated in another way' +
+        ' to meet [accessibility requirements](https://w3c.github.io/wcag/guidelines/22/#use-of-color).',
     },
   },
 };

--- a/packages/react-components/react-badge/stories/CounterBadge/CounterBadgeColor.stories.tsx
+++ b/packages/react-components/react-badge/stories/CounterBadge/CounterBadgeColor.stories.tsx
@@ -19,7 +19,9 @@ Color.parameters = {
         'A counter badge can be different colors.' +
         ' The available colors are `brand`, `danger`, `important`, `informative`, ' +
         '`severe`, `severe`, `success` or `warning`.' +
-        ' The default is `brand`.',
+        ' The default is `brand`.' +
+        ' Information conveyed by color should also be communicated in another way' +
+        ' to meet [accessibility requirements](https://w3c.github.io/wcag/guidelines/22/#use-of-color).',
     },
   },
 };


### PR DESCRIPTION
Related to an ADO bug.

Our badge and counter badge have stories that show color-only changes, so I added a line of warning to each story about the WCAG Use of Color requirement.
