### PR TITLE
fix(workspace-plugin): properly generate project list autocomplete when invoking react-component generator

### DIFF
--- a/tools/workspace-plugin/src/generators/react-component/schema.json
+++ b/tools/workspace-plugin/src/generators/react-component/schema.json
@@ -19,9 +19,7 @@
       "type": "string",
       "description": "The name of the project.",
       "alias": "p",
-      "$default": {
-        "$source": "projectName"
-      },
+      "x-dropdown": "projects",
       "x-prompt": "What is the name of the project for this component?",
       "x-priority": "important"
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Project was not prompted as it uses deprecated/removed nx prompt apis within schema

## New Behavior

Project is properly prompted when not specified

<img width="989" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/9aa8e3c4-51a7-4fe4-a647-bc02b6205237">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
