### PR TITLE
fix: picker tags only show focus styling when focused

### DIFF
--- a/change/@fluentui-react-4cdfc125-5e0f-4177-b942-d76f800e597f.json
+++ b/change/@fluentui-react-4cdfc125-5e0f-4177-b942-d76f800e597f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: picker tags only show focus styling when focused",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -26,14 +26,19 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
+  const personaRootStyles: IStyle = {
+    color: 'inherit',
+  };
+
+  // set text color to inherit to allow focus styles to control persona text colors
   const personaPrimaryTextStyles: IStyle = [
     selected &&
       !invalid &&
       !disabled && {
-        color: palette.white,
+        color: 'inherit',
         selectors: {
           ':hover': {
-            color: palette.white,
+            color: 'inherit',
           },
           [HighContrastSelector]: {
             color: 'HighlightText',
@@ -41,20 +46,25 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
         },
       },
     ((invalid && !selected) || (invalid && selected && disabled)) && {
-      color: palette.redDark,
-      borderBottom: `2px dotted ${palette.redDark}`,
+      color: 'inherit',
+      borderBottom: `2px dotted currentColor`,
       selectors: {
         [`.${classNames.root}:hover &`]: {
           // override Persona root:hover selector
-          color: palette.redDark,
+          color: 'inherit',
         },
       },
     },
     invalid &&
       selected &&
       !disabled && {
-        color: palette.white,
-        borderBottom: `2px dotted ${palette.white}`,
+        color: 'inherit',
+        borderBottom: `2px dotted currentColor`,
+        selectors: {
+          ':hover': {
+            color: 'inherit',
+          },
+        },
       },
     disabled && {
       selectors: {
@@ -69,10 +79,10 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
     selected &&
       !invalid &&
       !disabled && {
-        color: palette.white,
+        color: 'inherit',
         selectors: {
           ':hover': {
-            color: palette.white,
+            color: 'inherit',
           },
           [HighContrastSelector]: {
             color: 'HighlightText',
@@ -113,8 +123,11 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
         !disabled && [
           classNames.isSelected,
           {
-            background: palette.themePrimary,
             selectors: {
+              ':focus-within': {
+                background: palette.themePrimary,
+                color: palette.white,
+              },
               [HighContrastSelector]: {
                 borderColor: 'HighLight',
                 background: 'Highlight',
@@ -127,8 +140,16 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
       invalid &&
         selected &&
         !disabled && {
-          background: palette.redDark,
+          selectors: {
+            ':focus-within': {
+              background: palette.redDark,
+              color: palette.white,
+            },
+          },
         },
+      ((invalid && !selected) || (invalid && selected && disabled)) && {
+        color: palette.redDark,
+      },
       className,
     ],
     itemContent: [
@@ -166,7 +187,6 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
           borderRadius: PICKER_PERSONA_RADIUS,
         }),
         {
-          color: palette.white,
           selectors: {
             ':hover': {
               color: palette.white,
@@ -176,6 +196,9 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
               color: palette.white,
               background: palette.themeDarker,
             },
+            ':focus': {
+              color: palette.white,
+            },
             [HighContrastSelector]: {
               color: 'HighlightText',
             },
@@ -184,9 +207,11 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
         invalid && {
           selectors: {
             ':hover': {
+              color: palette.white,
               background: palette.red,
             },
             ':active': {
+              color: palette.white,
               background: palette.redDark,
             },
           },
@@ -202,6 +227,7 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
     ],
     subComponentStyles: {
       persona: {
+        root: personaRootStyles,
         primaryText: personaPrimaryTextStyles,
         secondaryText: personaSecondaryTextStyles,
       },

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -140,11 +140,9 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
       invalid &&
         selected &&
         !disabled && {
-          selectors: {
-            ':focus-within': {
-              background: palette.redDark,
-              color: palette.white,
-            },
+          ':focus-within': {
+            background: palette.redDark,
+            color: palette.white,
           },
         },
       ((invalid && !selected) || (invalid && selected && disabled)) && {

--- a/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -312,7 +312,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     align-items: center;
                     box-shadow: none;
                     box-sizing: border-box;
-                    color: #323130;
+                    color: inherit;
                     display: flex;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -69,11 +69,9 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
         !disabled && [
           classNames.isSelected,
           {
-            selectors: {
-              ':focus-within': {
-                background: palette.themePrimary,
-                color: palette.white,
-              },
+            ':focus-within': {
+              background: palette.themePrimary,
+              color: palette.white,
             },
           },
         ],

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -69,8 +69,12 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
         !disabled && [
           classNames.isSelected,
           {
-            background: palette.themePrimary,
-            color: palette.white,
+            selectors: {
+              ':focus-within': {
+                background: palette.themePrimary,
+                color: palette.white,
+              },
+            },
           },
         ],
       className,
@@ -108,7 +112,7 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
             background: palette.neutralQuaternaryAlt,
             color: palette.neutralPrimary,
           },
-          [`.${classNames.isSelected} &, :focus`]: {
+          [`.${classNames.isSelected} &:focus`]: {
             color: palette.white,
             background: palette.themePrimary,
           },

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -143,15 +143,11 @@ exports[`TagItem accepts title override 1`] = `
           border-color: Highlight;
           color: Highlight;
         }
-        &:focus {
-          background: #0078d4;
-          color: #ffffff;
-        }
         &:active {
           background-color: #005a9e;
           color: #ffffff;
         }
-        .is-selected & {
+        .is-selected &:focus {
           background: #0078d4;
           color: #ffffff;
         }
@@ -393,15 +389,11 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           border-color: Highlight;
           color: Highlight;
         }
-        &:focus {
-          background: #0078d4;
-          color: #ffffff;
-        }
         &:active {
           background-color: #005a9e;
           color: #ffffff;
         }
-        .is-selected & {
+        .is-selected &:focus {
           background: #0078d4;
           color: #ffffff;
         }
@@ -619,15 +611,11 @@ exports[`TagItem renders correctly 1`] = `
           border-color: Highlight;
           color: Highlight;
         }
-        &:focus {
-          background: #0078d4;
-          color: #ffffff;
-        }
         &:active {
           background-color: #005a9e;
           color: #ffffff;
         }
-        .is-selected & {
+        .is-selected &:focus {
           background: #0078d4;
           color: #ffffff;
         }

--- a/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -224,15 +224,11 @@ exports[`TagPicker renders correctly 1`] = `
                   border-color: Highlight;
                   color: Highlight;
                 }
-                &:focus {
-                  background: #0078d4;
-                  color: #ffffff;
-                }
                 &:active {
                   background-color: #005a9e;
                   color: #ffffff;
                 }
-                .is-selected & {
+                .is-selected &:focus {
                   background: #0078d4;
                   color: #ffffff;
                 }
@@ -625,15 +621,11 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                   border-color: Highlight;
                   color: Highlight;
                 }
-                &:focus {
-                  background: #0078d4;
-                  color: #ffffff;
-                }
                 &:active {
                   background-color: #005a9e;
                   color: #ffffff;
                 }
-                .is-selected & {
+                .is-selected &:focus {
                   background: #0078d4;
                   color: #ffffff;
                 }


### PR DESCRIPTION
## Previous Behavior

Since focus styling is tied to the `selected` state (from the internal SelectionZone), it wasn't correctly losing the blue bg when focus left the picker:

https://github.com/microsoft/fluentui/assets/3819570/4e561c46-714a-4ad9-ae71-4d4ca64dfac8


## New Behavior

I added a `:focus-within` selector for the tag and `:focus` selector for the remove button to ensure the focus color changes are only shown when the tag actually has keyboard focus:

https://github.com/microsoft/fluentui/assets/3819570/8e270af6-eb1a-4268-8ca1-59282bf78df3

For browsers that don't support `:focus-within` in our support matrix, the tag will still have the black outline styles.

## Related Issue(s)

- Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16818)
