### PR TITLE
feat(react-aria): active descendants imperative handle to toggle attribute visibility

### DIFF
--- a/change/@fluentui-react-aria-4f48a105-403c-4fc6-9ebb-5c0c1988a6ca.json
+++ b/change/@fluentui-react-aria-4f48a105-403c-4fc6-9ebb-5c0c1988a6ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: active descendants imperative handle to toggle attribute",
+  "packageName": "@fluentui/react-aria",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/etc/react-aria.api.md
@@ -35,11 +35,15 @@ export interface ActiveDescendantImperativeRef {
     // (undocumented)
     focus: (id: string) => void;
     // (undocumented)
+    hideAttributes: () => void;
+    // (undocumented)
     last: (options?: IteratorOptions) => string | undefined;
     // (undocumented)
     next: (options?: IteratorOptions) => string | undefined;
     // (undocumented)
     prev: (options?: IteratorOptions) => string | undefined;
+    // (undocumented)
+    showAttributes: () => void;
 }
 
 // @public (undocumented)

--- a/packages/react-components/react-aria/src/activedescendant/ActiveDescendantContext.ts
+++ b/packages/react-components/react-aria/src/activedescendant/ActiveDescendantContext.ts
@@ -17,6 +17,8 @@ const activeDescendantContextDefaultValue: ActiveDescendantContextValue = {
     last: noop,
     next: noop,
     prev: noop,
+    showAttributes: noop,
+    hideAttributes: noop,
   },
 };
 

--- a/packages/react-components/react-aria/src/activedescendant/types.ts
+++ b/packages/react-components/react-aria/src/activedescendant/types.ts
@@ -9,6 +9,8 @@ export interface ActiveDescendantImperativeRef {
   blur: () => void;
   active: () => string | undefined;
   focus: (id: string) => void;
+  hideAttributes: () => void;
+  showAttributes: () => void;
 }
 
 export interface ActiveDescendantOptions {

--- a/packages/react-components/react-aria/src/activedescendant/useActivedescendant.test.tsx
+++ b/packages/react-components/react-aria/src/activedescendant/useActivedescendant.test.tsx
@@ -91,6 +91,22 @@ describe('useActivedescendant', () => {
     expect(button).toHaveActiveDescendant(expecetdOption);
   });
 
+  it('should not have aria-activedescendant attribute if hideAttributes invoked', () => {
+    const expecetdOption = 'option-1';
+    const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();
+    const { getByRole } = render(<Test imperativeRef={imperativeRef} />);
+
+    imperativeRef.current?.hideAttributes();
+
+    const res = imperativeRef.current?.first();
+    expect(res).toBe(expecetdOption);
+    const button = getByRole('button');
+    expect(button).not.toHaveActiveDescendant(expecetdOption);
+
+    imperativeRef.current?.showAttributes();
+    expect(button).toHaveActiveDescendant(expecetdOption);
+  });
+
   it('should focus next option', () => {
     const expectedOption = 'option-2';
     const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();


### PR DESCRIPTION
## New Behavior

1. provides `showAttributes` and `hideAttributes` method to `ActiveDescendantImperativeRef`
2. adds test to ensure behaviour

## Related Issue(s)

NVDA and JAWS have bugs that suppress reading the input value text when `aria-activedescendant` is set.
To prevent this, the HTML attribute should be removed when a user presses left/right arrows (https://github.com/microsoft/fluentui/issues/26359#issuecomment-1397759888).

- https://github.com/microsoft/fluentui/issues/26652