### PR TITLE
feature: scaffold NavDrawer

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -75,6 +75,23 @@ export type NavContextValues = {
 };
 
 // @public
+export const NavDrawer: ForwardRefComponent<NavDrawerProps>;
+
+// @public (undocumented)
+export const navDrawerClassNames: SlotClassNames<NavDrawerSlots>;
+
+// @public
+export type NavDrawerProps = ComponentProps<NavDrawerSlots> & {};
+
+// @public (undocumented)
+export type NavDrawerSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavDrawerState = ComponentState<NavDrawerSlots>;
+
+// @public
 export const NavItem: ForwardRefComponent<NavItemProps>;
 
 // @public (undocumented)
@@ -182,6 +199,9 @@ export const renderNavCategory_unstable: (state: NavCategoryState, contextValues
 export const renderNavCategoryItem_unstable: (state: NavCategoryItemState, contextValues: NavCategoryItemContextValues) => JSX.Element;
 
 // @public
+export const renderNavDrawer_unstable: (state: NavDrawerState) => JSX.Element;
+
+// @public
 export const renderNavItem_unstable: (state: NavItemState) => JSX.Element;
 
 // @public
@@ -204,6 +224,12 @@ export const useNavCategoryItemStyles_unstable: (state: NavCategoryItemState) =>
 
 // @public (undocumented)
 export const useNavContext_unstable: () => NavContextValue;
+
+// @public
+export const useNavDrawer_unstable: (props: NavDrawerProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerState;
+
+// @public
+export const useNavDrawerStyles_unstable: (state: NavDrawerState) => NavDrawerState;
 
 // @public
 export const useNavItem_unstable: (props: NavItemProps, ref: React_2.Ref<HTMLAnchorElement>) => NavItemState;

--- a/packages/react-components/react-nav-preview/src/NavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/NavDrawer.ts
@@ -1,0 +1,1 @@
+export * from './components/NavDrawer/index';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavDrawer } from './NavDrawer';
+
+describe('NavDrawer', () => {
+  isConformant({
+    Component: NavDrawer,
+    displayName: 'NavDrawer',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavDrawer>Default NavDrawer</NavDrawer>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useNavDrawer_unstable } from './useNavDrawer';
+import { renderNavDrawer_unstable } from './renderNavDrawer';
+import { useNavDrawerStyles_unstable } from './useNavDrawerStyles.styles';
+import type { NavDrawerProps } from './NavDrawer.types';
+
+/**
+ * NavDrawer component - TODO: add more docs
+ */
+export const NavDrawer: ForwardRefComponent<NavDrawerProps> = React.forwardRef((props, ref) => {
+  const state = useNavDrawer_unstable(props, ref);
+
+  useNavDrawerStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  useCustomStyleHook_unstable('useNavDrawerStyles_unstable')(state);
+  return renderNavDrawer_unstable(state);
+});
+
+NavDrawer.displayName = 'NavDrawer';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { useNavDrawer_unstable } from './useNavDrawer';
 import { renderNavDrawer_unstable } from './renderNavDrawer';
 import { useNavDrawerStyles_unstable } from './useNavDrawerStyles.styles';
@@ -15,7 +15,7 @@ export const NavDrawer: ForwardRefComponent<NavDrawerProps> = React.forwardRef((
   useNavDrawerStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
-  useCustomStyleHook_unstable('useNavDrawerStyles_unstable')(state);
+  // useCustomStyleHook_unstable('useNavDrawerStyles_unstable')(state);
   return renderNavDrawer_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavDrawerSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavDrawer Props
+ */
+export type NavDrawerProps = ComponentProps<NavDrawerSlots> & {};
+
+/**
+ * State used in rendering NavDrawer
+ */
+export type NavDrawerState = ComponentState<NavDrawerSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavDrawerProps.
+// & Required<Pick<NavDrawerProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/__snapshots__/NavDrawer.test.tsx.snap
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/__snapshots__/NavDrawer.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavDrawer renders a default state 1`] = `
+<div>
+  <div
+    class="fui-NavDrawer"
+  >
+    Default NavDrawer
+  </div>
+</div>
+`;

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/index.ts
@@ -1,0 +1,5 @@
+export * from './NavDrawer';
+export * from './NavDrawer.types';
+export * from './renderNavDrawer';
+export * from './useNavDrawer';
+export * from './useNavDrawerStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/renderNavDrawer.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/renderNavDrawer.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavDrawerState, NavDrawerSlots } from './NavDrawer.types';
+
+/**
+ * Render the final JSX of NavDrawer
+ */
+export const renderNavDrawer_unstable = (state: NavDrawerState) => {
+  assertSlots<NavDrawerSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
+
+/**
+ * Create the state required to render NavDrawer.
+ *
+ * The returned state can be modified with hooks such as useNavDrawerStyles_unstable,
+ * before being passed to renderNavDrawer_unstable.
+ *
+ * @param props - props from this instance of NavDrawer
+ * @param ref - reference to root HTMLDivElement of NavDrawer
+ */
+export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTMLDivElement>): NavDrawerState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavDrawerSlots, NavDrawerState } from './NavDrawer.types';
+
+export const navDrawerClassNames: SlotClassNames<NavDrawerSlots> = {
+  root: 'fui-NavDrawer',
+  // TODO: add class names for all slots on NavDrawerSlots.
+  // Should be of the form `<slotName>: 'fui-NavDrawer__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavDrawer slots based on the state
+ */
+export const useNavDrawerStyles_unstable = (state: NavDrawerState): NavDrawerState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(navDrawerClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/index.ts
+++ b/packages/react-components/react-nav-preview/src/index.ts
@@ -56,3 +56,4 @@ export type {
   NavSubItemGroupProps,
   NavSubItemGroupState,
 } from './components/NavSubItemGroup/index';
+export * from './NavDrawer';

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavDrawer, NavDrawerProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavDrawerProps>) => <NavDrawer {...props} />;

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavDrawer } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavDrawerDescription.md';
+import bestPracticesMd from './NavDrawerBestPractices.md';
+
+export { Default } from './NavDrawerDefault.stories';
+
+export default {
+  title: 'Preview Components/NavDrawer',
+  component: NavDrawer,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};


### PR DESCRIPTION
Nav will live in an inline drawer in 99% of cases.

It will have a drawer component and several nav specific providers built in.

This PR scaffolds it all out.

Result of running:

`yarn create-component`, commenting out the custom style hooks, running `yarn build` to update the API.

Part of #26649 