### PR TITLE
Partner feature contribution to add gradient color capability in AreaChart

### DIFF
--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -647,6 +647,12 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     this._stackedData.forEach((singleStackedData: Array<any>, index: number) => {
       graph.push(
         <React.Fragment key={`${index}-graph-${this._uniqueIdForGraph}`}>
+          <defs>
+            <linearGradient id={`gradient_${index}`} x1="0%" x2="0%" y1="0%" y2="100%">
+              <stop offset="0" stop-color={this._colors[index]} />
+              <stop offset="100%" stop-color="transparent" />
+            </linearGradient>
+          </defs>
           <path
             id={`${index}-line-${this._uniqueIdForGraph}`}
             d={line(singleStackedData)!}
@@ -678,7 +684,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
             <path
               id={`${index}-graph-${this._uniqueIdForGraph}`}
               d={area(singleStackedData)!}
-              fill={this._colors[index]}
+              fill={this.props.enableGradient ? `url(#gradient_${index})` : this._colors[index]}
               opacity={this._opacity[index]}
               fillOpacity={this._getOpacity(points[index]!.legend)}
               onMouseMove={this._onRectMouseMove}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.types.ts
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.types.ts
@@ -64,6 +64,12 @@ export interface IAreaChartProps extends ICartesianChartProps {
    * Optimize area chart rendering for large data set.
    */
   optimizeLargeData?: boolean;
+
+  /**
+   * @default false
+   * The prop used to enable gradient fill color for the chart.
+   */
+  enableGradient?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Description of changes
The Viva Amplify team requires the use of the Fluent AreaChart control in our app to create trend charts for our analytics. However, the existing AreaChart does not have the capability to use a gradient color for the fill area.

This PR adds a new prop, `enableGradient`, to the AreaChart control to enable/disable a gradient fade to the fill area of the chart. The default value for this prop is false.

## New Behavior
By setting the new prop in AreaChart, `enableGradient` to `true`, the chart will have a gradient fill color, shown below:
