### PR TITLE
(fix): Close InfoLabel on clicking the icon when open.

### DIFF
--- a/change/@fluentui-react-infolabel-f5ed7770-84ee-4f6f-acea-e20b55ad48c2.json
+++ b/change/@fluentui-react-infolabel-f5ed7770-84ee-4f6f-acea-e20b55ad48c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Close InfoLabel on clicking the icon when open.",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "santoshsrisai36@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infolabel/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infolabel/src/components/InfoButton/useInfoButton.tsx
@@ -75,13 +75,12 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
     }),
   };
 
-  const [popoverOpen, setPopoverOpen] = useControllableState({
+  const [, setPopoverOpen] = useControllableState({
     state: state.popover.open,
     defaultState: state.popover.defaultOpen,
     initialState: false,
   });
 
-  state.popover.open = popoverOpen;
   state.popover.onOpenChange = mergeCallbacks(state.popover.onOpenChange, (e, data) => setPopoverOpen(data.open));
 
   const focusOutRef = React.useCallback(


### PR DESCRIPTION
## Previous Behavior

In Chrome/Edge/Firefox, when InfoLabel's popover is open, the popover doesn't close when the user clicks on the icon again. This issue doesn't occur in Safari.

## New Behavior

In Chrome/Edge/Firefox, when InfoLabel's popover is open, the popover closes when the user clicks on the icon again.

## Related Issue(s)
- Fixes #30725 
