### PR TITLE
fix: react-tabs: Removed unnecessary zIndex from active tab indicator

### DIFF
--- a/change/@fluentui-react-tabs-a844d153-94fc-48f8-9bbc-e8b518faf357.json
+++ b/change/@fluentui-react-tabs-a844d153-94fc-48f8-9bbc-e8b518faf357.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed unneeded zIndex from tab active indicator",
+  "packageName": "@fluentui/react-tabs",
+  "email": "gcox@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/src/components/Tab/useTabStyles.styles.ts
@@ -279,7 +279,6 @@ const useActiveIndicatorStyles = makeStyles({
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
       content: '""',
       position: 'absolute',
-      zIndex: 1,
     },
   },
   selected: {


### PR DESCRIPTION
## Previous Behavior

active tab indicator had z-index of 1 which caused overlap issues with floating UI like dialogs/menus.

## New Behavior

z-index is removed.

## Related Issue(s)

- Fixes #30343

Note: This PR will replace another PR that is stuck without a change file: https://github.com/microsoft/fluentui/pull/30368