### PR TITLE
fix: InfoLabel popover dismisses if the InfoButton is clicked when it is already open

### DIFF
--- a/change/@fluentui-react-infolabel-9fb527c6-057b-4966-b5e2-89d75f410b93.json
+++ b/change/@fluentui-react-infolabel-9fb527c6-057b-4966-b5e2-89d75f410b93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: InfoLabel popover dismisses if the InfoButton is clicked when it is already open",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infolabel/cypress.config.ts
+++ b/packages/react-components/react-infolabel/cypress.config.ts
@@ -1,0 +1,3 @@
+import { baseConfig } from '@fluentui/scripts-cypress';
+
+export default baseConfig;

--- a/packages/react-components/react-infolabel/package.json
+++ b/packages/react-components/react-infolabel/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "build": "just-scripts build",
     "clean": "just-scripts clean",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component",
     "generate-api": "just-scripts generate-api",
     "lint": "just-scripts lint",
     "start": "yarn storybook",

--- a/packages/react-components/react-infolabel/src/components/InfoLabel/InfoLabel.cy.tsx
+++ b/packages/react-components/react-infolabel/src/components/InfoLabel/InfoLabel.cy.tsx
@@ -5,6 +5,7 @@ import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';
 import { teamsLightTheme } from '@fluentui/react-theme';
 import { InfoLabel } from '@fluentui/react-infolabel';
+import { infoButtonClassNames } from '../InfoButton/useInfoButtonStyles.styles';
 
 const mount = (element: JSX.Element) => {
   mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
@@ -14,13 +15,21 @@ const surfaceSelector = '[role="note"]';
 
 describe('InfoLabel - close on tab-out', () => {
   const openInfoButton = () => {
-    cy.get('button').focus().realPress('{enter}');
+    return cy.get(`button.${infoButtonClassNames.root}`).focus().realPress('{enter}');
   };
 
   it('no focusable elements', () => {
-    mount(<InfoLabel label="InfoLabel's label" info="Example non-focusable info" />);
+    mount(
+      <>
+        <button>before</button>
+        <InfoLabel label="InfoLabel's label" info="Example non-focusable info" />
+      </>,
+    );
 
-    openInfoButton();
+    openInfoButton().get(surfaceSelector).should('exist');
+    // Shift-tab to InfoButton, the surface should still be visible
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('exist');
+    // Shift-tab again to the 'before' button, surface should be hidden
     cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
     openInfoButton();
     cy.realPress('Tab').get(surfaceSelector).should('not.exist');
@@ -28,55 +37,80 @@ describe('InfoLabel - close on tab-out', () => {
 
   it('single focusable element', () => {
     mount(
-      <InfoLabel
-        label="InfoLabel's label"
-        info={
-          <>
-            Example non-focusable info
-            <button>one</button>
-          </>
-        }
-      />,
+      <>
+        <button>before</button>
+        <InfoLabel
+          label="InfoLabel's label"
+          info={
+            <>
+              Example non-focusable info
+              <button>one</button>
+            </>
+          }
+        />
+      </>,
     );
 
-    openInfoButton();
+    openInfoButton().get(surfaceSelector).should('exist');
+    // Shift-tab to InfoButton, the surface should still be visible
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('exist');
+    // Shift-tab again to the 'before' button, surface should be hidden
     cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
     openInfoButton();
     // moving into the focusable item
     cy.realPress('Tab').get(surfaceSelector).should('exist');
     // tabbing out with shift + tab from the first focusable item should close the surface since
     // the surface is only focusable programmatically
-    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    cy.realPress(['Shift', 'Tab']).realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
     openInfoButton();
     cy.realPress('Tab').realPress('Tab').get(surfaceSelector).should('not.exist');
   });
 
   it('one or more focusable elements', () => {
     mount(
-      <InfoLabel
-        label="InfoLabel's label"
-        info={
-          <>
-            Example non-focusable info
-            <button>one</button>
-            <button>two</button>
-            <button>three</button>
-          </>
-        }
-      />,
+      <>
+        <button>before</button>
+        <InfoLabel
+          label="InfoLabel's label"
+          info={
+            <>
+              Example non-focusable info
+              <button>one</button>
+              <button>two</button>
+              <button>three</button>
+            </>
+          }
+        />
+      </>,
     );
 
-    openInfoButton();
+    openInfoButton().get(surfaceSelector).should('exist');
+    // Shift-tab to InfoButton, the surface should still be visible
+    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('exist');
+    // Shift-tab again to the 'before' button, surface should be hidden
     cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
     openInfoButton();
     // moving into the focusable item
     cy.realPress('Tab').get(surfaceSelector).should('exist');
     // tabbing out with shift + tab from the first focusable item should close the surface since
     // the surface is only focusable programmatically
-    cy.realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
+    cy.realPress(['Shift', 'Tab']).realPress(['Shift', 'Tab']).get(surfaceSelector).should('not.exist');
     openInfoButton();
     // checking that event does not propagate to children
     cy.realPress('Tab').realPress('Tab').realPress(['Shift', 'Tab']).get(surfaceSelector).should('exist');
     cy.realPress('Tab').realPress('Tab').realPress('Tab').get(surfaceSelector).should('not.exist');
+  });
+});
+
+describe('InfoLabel - toggle on click', () => {
+  const clickInfoButton = () => {
+    return cy.get(`button.${infoButtonClassNames.root}`).click();
+  };
+
+  it('toggles on click', () => {
+    mount(<InfoLabel label="InfoLabel's label" info="Example info" />);
+
+    clickInfoButton().get(surfaceSelector).should('exist');
+    clickInfoButton().get(surfaceSelector).should('not.exist');
   });
 });

--- a/packages/react-components/react-infolabel/tsconfig.cy.json
+++ b/packages/react-components/react-infolabel/tsconfig.cy.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
+    "lib": ["ES2019", "dom"]
+  },
+  "include": ["**/*.cy.ts", "**/*.cy.tsx"]
+}


### PR DESCRIPTION
## Previous Behavior

The InfoLabel popover doesn't dismiss if the InfoButton is clicked when the popover is already open. Or more accurately, it dismisses and immediately shows again. This happens because the popover gets dismissed when focus moves outside, which  happens on mouseDown on the button. Subsequently, the button's click event shows the popover again.

## New Behavior

* Don't dismiss the popover if focus moves to the InfoButton that launched it. Instead, the popover is only dismissed when focus moves outside of _both_ the popover _and_ the button.
* Use React's onBlurCapture instead of a native focusout event, to avoid an event listener leak. (The focusout listener was never removed when the ref changed.)

## Related Issue(s)

- Fixes #30725
