### PR TITLE
CI: remove failing pipeline step as it's no longer needed

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -59,6 +59,6 @@ extends:
               - template: .devops/templates/deployE2E.yml@self
 
               # False positive AV. Wi'l follow up with AV owners. For now to get compliant deleting file before.
-              - script: |
-                  rm apps/pr-deploy-site/dist/public-docsite-v9/storybook/407.*.manager.bundle.js
-                displayName: 'Remove false positive file'
+              # - script: |
+              #     rm apps/pr-deploy-site/dist/public-docsite-v9/storybook/407.*.manager.bundle.js
+              #   displayName: 'Remove false positive file'

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -57,8 +57,3 @@ extends:
                   artifactName: web
             steps:
               - template: .devops/templates/deployE2E.yml@self
-
-              # False positive AV. Wi'l follow up with AV owners. For now to get compliant deleting file before.
-              # - script: |
-              #     rm apps/pr-deploy-site/dist/public-docsite-v9/storybook/407.*.manager.bundle.js
-              #   displayName: 'Remove false positive file'


### PR DESCRIPTION
## Issue:
- CI pipeline is failing 
![image](https://github.com/microsoft/fluentui/assets/8649804/eaa5194c-cfc2-47d7-9ffb-26484d4e5cb3)

## Change:
- removes that step as there's no longer any files triggering a security violation
  - see test[ pipeline run](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=336022&view=results)