### PR TITLE
Allow inline drawer to be rendered as an aside element

### DIFF
--- a/change/@fluentui-react-drawer-d203c458-f397-4bea-8f11-853ea0af279d.json
+++ b/change/@fluentui-react-drawer-d203c458-f397-4bea-8f11-853ea0af279d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow inline drawer to be rendered as an aside element",
+  "packageName": "@fluentui/react-drawer",
+  "email": "agokhale@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/src/components/InlineDrawer/InlineDrawer.types.ts
+++ b/packages/react-components/react-drawer/src/components/InlineDrawer/InlineDrawer.types.ts
@@ -3,7 +3,7 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import { DrawerBaseProps, DrawerBaseState } from '../../shared/DrawerBase.types';
 
 export type InlineDrawerSlots = {
-  root: Slot<'div'>;
+  root: Slot<'div', 'aside'>;
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
InlineDrawer is only able to be rendered as a 'div'
<!-- This is the behavior we have today -->

## New Behavior
InlineDrawer will still be rendered as a 'div' by default but also allow 'aside'
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30738
