### PR TITLE
fix: Update IStyleSet type to fix error when using TypeScript 5.3+

### DIFF
--- a/change/@fluentui-foundation-legacy-7c531b8e-750e-4b07-a50d-489529c3ca8d.json
+++ b/change/@fluentui-foundation-legacy-7c531b8e-750e-4b07-a50d-489529c3ca8d.json
@@ -1,7 +1,7 @@
 {
   "type": "minor",
   "comment": "fix: Update IStyleSet type to fix error when using TypeScript 5.3+",
-  "packageName": "@fluentui/merge-styles",
+  "packageName": "@fluentui/foundation-legacy",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-merge-styles-42f4b3e7-c71a-4db9-9b65-cb0f47039fe6.json
+++ b/change/@fluentui-merge-styles-42f4b3e7-c71a-4db9-9b65-cb0f47039fe6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Update IStyleSet types to avoid TS 5.3 error",
+  "packageName": "@fluentui/merge-styles",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-style-utilities-a3584f92-b448-414f-a190-8fa3995f05aa.json
+++ b/change/@fluentui-style-utilities-a3584f92-b448-414f-a190-8fa3995f05aa.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "fix: Update IStyleSet type to fix error when using TypeScript 5.3+",
-  "packageName": "@fluentui/merge-styles",
+  "packageName": "@fluentui/style-utilities",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-utilities-274e92d1-419a-48a6-8d3c-5174bffe5e4d.json
+++ b/change/@fluentui-utilities-274e92d1-419a-48a6-8d3c-5174bffe5e4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Update IStyleSet types to avoid TS 5.3 error",
+  "packageName": "@fluentui/utilities",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-274e92d1-419a-48a6-8d3c-5174bffe5e4d.json
+++ b/change/@fluentui-utilities-274e92d1-419a-48a6-8d3c-5174bffe5e4d.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "fix: Update IStyleSet types to avoid TS 5.3 error",
+  "comment": "fix: Update IStyleSet type to fix error when using TypeScript 5.3+",
   "packageName": "@fluentui/utilities",
   "email": "behowell@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/foundation-legacy/etc/foundation-legacy.api.md
+++ b/packages/foundation-legacy/etc/foundation-legacy.api.md
@@ -6,13 +6,13 @@
 
 import { ISchemeNames } from '@fluentui/style-utilities';
 import { IStyle } from '@fluentui/style-utilities';
-import { IStyleSet } from '@fluentui/style-utilities';
+import { IStyleSetBase } from '@fluentui/style-utilities';
 import { ITheme } from '@fluentui/style-utilities';
 import { styled as legacyStyled } from '@fluentui/utilities';
 import * as React_2 from 'react';
 
 // @public
-export function createComponent<TComponentProps extends ValidProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps extends TComponentProps = TComponentProps, TStatics = {}>(view: IViewComponent<TViewProps>, options?: IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React_2.FunctionComponent<TComponentProps> & TStatics;
+export function createComponent<TComponentProps extends ValidProps, TTokens, TStyleSet extends IStyleSetBase, TViewProps extends TComponentProps = TComponentProps, TStatics = {}>(view: IViewComponent<TViewProps>, options?: IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React_2.FunctionComponent<TComponentProps> & TStatics;
 
 // @public
 export function createFactory<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never>(DefaultComponent: React_2.ComponentType<TProps>, options?: IFactoryOptions<TProps>): ISlotFactory<TProps, TShorthandProp>;
@@ -30,12 +30,12 @@ export function getControlledDerivedProps<TProps, TProp extends keyof TProps>(pr
 export function getSlots<TComponentProps extends ISlottableProps<TComponentSlots>, TComponentSlots>(userProps: TComponentProps, slots: ISlotDefinition<Required<TComponentSlots>>): ISlots<Required<TComponentSlots>>;
 
 // @public
-export type IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>> & {
+export type IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSetBase, TViewProps = TComponentProps, TStatics = {}> = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>> & {
     view: IViewComponent<TViewProps>;
 };
 
 // @public
-export interface IComponentOptions<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
+export interface IComponentOptions<TComponentProps, TTokens, TStyleSet extends IStyleSetBase, TViewProps = TComponentProps, TStatics = {}> {
     displayName?: string;
     factoryOptions?: IFactoryOptions<TComponentProps>;
     fields?: string[];
@@ -59,7 +59,7 @@ export interface IControlledStateOptions<TProps, TProp extends keyof TProps, TDe
 }
 
 // @public (undocumented)
-export type ICustomizationProps<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> = IStyleableComponentProps<TViewProps, TTokens, TStyleSet> & Required<Pick<IStyleableComponentProps<TViewProps, TTokens, TStyleSet>, 'theme'>>;
+export type ICustomizationProps<TViewProps, TTokens, TStyleSet extends IStyleSetBase> = IStyleableComponentProps<TViewProps, TTokens, TStyleSet> & Required<Pick<IStyleableComponentProps<TViewProps, TTokens, TStyleSet>, 'theme'>>;
 
 // @public
 export interface IDefaultSlotProps<TSlots> {
@@ -145,7 +145,7 @@ export type ISlottableReactType<TProps extends ValidProps, TShorthandProp extend
 export type IStateComponentType<TComponentProps, TViewProps> = (props: Readonly<TComponentProps>) => TViewProps;
 
 // @public
-export interface IStyleableComponentProps<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> {
+export interface IStyleableComponentProps<TViewProps, TTokens, TStyleSet extends IStyleSetBase> {
     // (undocumented)
     className?: string;
     // (undocumented)
@@ -157,10 +157,10 @@ export interface IStyleableComponentProps<TViewProps, TTokens, TStyleSet extends
 }
 
 // @public
-export type IStylesFunction<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> = (props: TViewProps, theme: ITheme, tokens: TTokens) => TStyleSet;
+export type IStylesFunction<TViewProps, TTokens, TStyleSet extends IStyleSetBase> = (props: TViewProps, theme: ITheme, tokens: TTokens) => TStyleSet;
 
 // @public
-export type IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> = IStylesFunction<TViewProps, TTokens, TStyleSet> | TStyleSet;
+export type IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet extends IStyleSetBase> = IStylesFunction<TViewProps, TTokens, TStyleSet> | TStyleSet;
 
 // @public (undocumented)
 export interface IThemeProviderProps {
@@ -205,7 +205,6 @@ export type ValidShorthand = string | number | boolean;
 
 // @public
 export function withSlots<P>(type: ISlot<P> | React_2.FunctionComponent<P> | string, props?: (React_2.Attributes & P) | null, ...children: React_2.ReactNode[]): ReturnType<React_2.FunctionComponent<P>>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/foundation-legacy/src/IComponent.ts
+++ b/packages/foundation-legacy/src/IComponent.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyle, IStyleSet, ITheme } from '@fluentui/style-utilities';
+import { IStyle, IStyleSetBase, ITheme } from '@fluentui/style-utilities';
 
 // TODO: Known TypeScript issue is widening return type checks when using function type declarations.
 //        Effect is that mistyped property keys on returned style objects will not generate errors.
@@ -21,7 +21,7 @@ export type IComponentStyles<TSlots> = { [key in keyof TSlots]?: IStyle };
 /**
  * Function declaration for component styles functions.
  */
-export type IStylesFunction<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> = (
+export type IStylesFunction<TViewProps, TTokens, TStyleSet extends IStyleSetBase> = (
   props: TViewProps,
   theme: ITheme,
   tokens: TTokens,
@@ -30,7 +30,7 @@ export type IStylesFunction<TViewProps, TTokens, TStyleSet extends IStyleSet<TSt
 /**
  * Composite type for component styles functions and objects.
  */
-export type IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> =
+export type IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet extends IStyleSetBase> =
   | IStylesFunction<TViewProps, TTokens, TStyleSet>
   | TStyleSet;
 
@@ -63,14 +63,14 @@ export interface ITokenBaseArray<TViewProps, TTokens> extends Array<IToken<TView
  * Optional props for styleable components. If these props are present, they will automatically be
  * used by Foundation when applying theming and styling.
  */
-export interface IStyleableComponentProps<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> {
+export interface IStyleableComponentProps<TViewProps, TTokens, TStyleSet extends IStyleSetBase> {
   className?: string;
   styles?: IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet>;
   theme?: ITheme;
   tokens?: ITokenFunctionOrObject<TViewProps, TTokens>;
 }
 
-export type ICustomizationProps<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> = IStyleableComponentProps<
+export type ICustomizationProps<TViewProps, TTokens, TStyleSet extends IStyleSetBase> = IStyleableComponentProps<
   TViewProps,
   TTokens,
   TStyleSet
@@ -102,7 +102,7 @@ export type IViewComponent<TViewProps> = (
 export interface IComponentOptions<
   TComponentProps,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps = TComponentProps,
   TStatics = {},
 > {
@@ -143,7 +143,7 @@ export interface IComponentOptions<
 export type IComponent<
   TComponentProps,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps = TComponentProps,
   TStatics = {},
 > = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>> & {

--- a/packages/foundation-legacy/src/createComponent.tsx
+++ b/packages/foundation-legacy/src/createComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { concatStyleSets, IStyleSet, ITheme } from '@fluentui/style-utilities';
+import { concatStyleSets, IStyleSetBase, ITheme } from '@fluentui/style-utilities';
 import { Customizations, CustomizerContext, ICustomizerContext } from '@fluentui/utilities';
 import { createFactory } from './slots';
 import { assign } from './utilities';
@@ -37,7 +37,7 @@ import { IDefaultSlotProps, ISlotCreator, ValidProps } from './ISlots';
 export function createComponent<
   TComponentProps extends ValidProps,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps extends TComponentProps = TComponentProps,
   TStatics = {},
 >(
@@ -107,7 +107,7 @@ export function createComponent<
 /**
  * Resolve all styles functions with both props and tokens and flatten results along with all styles objects.
  */
-function _resolveStyles<TProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>>(
+function _resolveStyles<TProps, TTokens, TStyleSet extends IStyleSetBase>(
   props: TProps,
   theme: ITheme,
   tokens: TTokens,
@@ -156,7 +156,7 @@ function _resolveTokens<TViewProps, TTokens>(
  * @param context React context passed to component containing contextual settings.
  * @param fields Optional list of properties to grab from global store and context.
  */
-function _getCustomizations<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>>(
+function _getCustomizations<TViewProps, TTokens, TStyleSet extends IStyleSetBase>(
   displayName: string | undefined,
   context: ICustomizerContext,
   fields?: string[],

--- a/packages/foundation-legacy/src/next/IComponent.ts
+++ b/packages/foundation-legacy/src/next/IComponent.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyleSet } from '@fluentui/style-utilities';
+import { IStyleSetBase } from '@fluentui/style-utilities';
 import { IComponentOptions as IOldComponentOptions } from '../IComponent';
 import { ISlots, ISlotDefinition, ISlottableProps } from '../ISlots';
 
@@ -39,7 +39,7 @@ export type IPartialSlotComponent<TComponentProps extends ISlottableProps<TCompo
 export interface IComponentOptions<
   TComponentProps extends ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},
@@ -57,7 +57,7 @@ export interface IComponentOptions<
 export interface IRecompositionComponentOptions<
   TComponentProps extends ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},
@@ -78,7 +78,7 @@ export interface IRecompositionComponentOptions<
 export type IComponent<
   TComponentProps extends ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},

--- a/packages/foundation-legacy/src/next/ISlots.ts
+++ b/packages/foundation-legacy/src/next/ISlots.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyleSet } from '@fluentui/style-utilities';
+import { IStyleSetBase } from '@fluentui/style-utilities';
 import { ISlottableProps, ValidProps } from '../ISlots';
 import { IComponentOptions } from './IComponent';
 
@@ -9,7 +9,7 @@ import { IComponentOptions } from './IComponent';
 export interface IFoundationComponent<
   TComponentProps extends ValidProps & ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps extends TComponentProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},

--- a/packages/foundation-legacy/src/next/composed.tsx
+++ b/packages/foundation-legacy/src/next/composed.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { mergeStyles } from '@fluentui/merge-styles';
-import { concatStyleSets, IStyleSet, ITheme } from '@fluentui/style-utilities';
+import { concatStyleSets, IStyleSetBase, ITheme } from '@fluentui/style-utilities';
 import { Customizations, CustomizerContext, ICustomizerContext } from '@fluentui/utilities';
 import { createFactory, getSlots } from '../slots';
 import { assign } from '../utilities';
@@ -48,7 +48,7 @@ const memoizedClassNamesMap: IClassNamesMap = {};
 export function composed<
   TComponentProps extends ValidProps & ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps extends TComponentProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},
@@ -79,7 +79,7 @@ export function composed<
 export function composed<
   TComponentProps extends ValidProps & ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps extends TComponentProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},
@@ -114,7 +114,7 @@ export function composed<
 export function composed<
   TComponentProps extends ValidProps & ISlottableProps<TComponentSlots>,
   TTokens,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSetBase,
   TViewProps extends TComponentProps = TComponentProps,
   TComponentSlots = {},
   TStatics = {},
@@ -315,7 +315,7 @@ export function resolveSlots<TComponentProps extends ISlottableProps<TComponentS
 /**
  * Resolve all styles functions with both props and tokens and flatten results along with all styles objects.
  */
-function _resolveStyles<TProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>>(
+function _resolveStyles<TProps, TTokens, TStyleSet extends IStyleSetBase>(
   props: TProps,
   theme: ITheme,
   tokens: TTokens,
@@ -364,7 +364,7 @@ function _resolveTokens<TViewProps, TTokens>(
  * @param context React context passed to component containing contextual settings.
  * @param fields Optional list of properties to grab from global store and context.
  */
-function _getCustomizations<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>>(
+function _getCustomizations<TViewProps, TTokens, TStyleSet extends IStyleSetBase>(
   displayName: string | undefined,
   context: ICustomizerContext,
   fields?: string[],

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -434,7 +434,7 @@ export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase
 export type IStyleSet<TStyleSet extends IStyleSetBase = {
     [key: string]: any;
 }> = {
-    [P in Exclude<keyof TStyleSet, 'subComponentStyles'>]: IStyle;
+    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
         [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -441,7 +441,7 @@ export type IStyleSet<TStyleSet extends IStyleSetBase = {
     };
 };
 
-// @public (undocumented)
+// @public
 export interface IStyleSetBase {
     // (undocumented)
     [key: string]: any;
@@ -550,7 +550,7 @@ export class Stylesheet {
 
 // Warnings were encountered during analysis:
 //
-// lib/IStyleSet.d.ts:57:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
+// lib/IStyleSet.d.ts:60:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -26,7 +26,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
 export function concatStyleSets(...styleSets: (IStyleSet | false | null | undefined)[]): IConcatenatedStyleSet<any>;
 
 // @public
-export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
+export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
 
 // @public
 export type DeepPartial<T> = {
@@ -37,7 +37,7 @@ export type DeepPartial<T> = {
 export function fontFace(font: IFontFace): void;
 
 // @public
-export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
+export type IConcatenatedStyleSet<TStyleSet extends IStyleSet> = {
     [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
@@ -81,7 +81,7 @@ export const InjectionMode: {
 export type InjectionMode = (typeof InjectionMode)[keyof typeof InjectionMode];
 
 // @public
-export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
+export type IProcessedStyleSet<TStyleSet extends IStyleSet> = {
     [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: string;
 } & {
     subComponentStyles: {
@@ -425,13 +425,15 @@ export interface IStyleBaseArray extends Array<IStyle> {
 }
 
 // @public
-export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = (props: TStylesProps) => DeepPartial<TStyleSet>;
+export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet> = (props: TStylesProps) => DeepPartial<TStyleSet>;
 
 // @public
-export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartial<TStyleSet>;
+export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartial<TStyleSet>;
 
 // @public
-export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet> = {
+export type IStyleSet<TStyleSet extends {
+    [key: string]: any;
+} = {
     [key: string]: any;
 }> = {
     [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
@@ -464,17 +466,17 @@ export function keyframes(timeline: IKeyframes): string;
 export function mergeCss(args: (IStyle | IStyleBaseArray | false | null | undefined) | (IStyle | IStyleBaseArray | false | null | undefined)[], options?: IStyleOptions): string;
 
 // @public
-export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<TStyleSet>;
+export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | false | null | undefined, TStyleSet2 | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<TStyleSet1 & TStyleSet2>;
+export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | false | null | undefined, TStyleSet2 | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSets: [
 TStyleSet1 | false | null | undefined,
 TStyleSet2 | false | null | undefined,
 TStyleSet3 | false | null | undefined
-], options?: IStyleOptions): IProcessedStyleSet<TStyleSet1 & TStyleSet2 & TStyleSet3>;
+], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSets: [
@@ -485,7 +487,7 @@ TStyleSet4 | false | null | undefined
 ], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<TStyleSet>;
+export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
 export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
@@ -542,7 +544,7 @@ export class Stylesheet {
 
 // Warnings were encountered during analysis:
 //
-// lib/IStyleSet.d.ts:53:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
+// lib/IStyleSet.d.ts:55:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -26,7 +26,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
 export function concatStyleSets(...styleSets: (IStyleSet | false | null | undefined)[]): IConcatenatedStyleSet<any>;
 
 // @public
-export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
+export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
 
 // @public
 export type DeepPartial<T> = {
@@ -37,7 +37,7 @@ export type DeepPartial<T> = {
 export function fontFace(font: IFontFace): void;
 
 // @public
-export type IConcatenatedStyleSet<TStyleSet extends IStyleSet> = {
+export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
     [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
@@ -81,7 +81,7 @@ export const InjectionMode: {
 export type InjectionMode = (typeof InjectionMode)[keyof typeof InjectionMode];
 
 // @public
-export type IProcessedStyleSet<TStyleSet extends IStyleSet> = {
+export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
     [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: string;
 } & {
     subComponentStyles: {
@@ -425,23 +425,29 @@ export interface IStyleBaseArray extends Array<IStyle> {
 }
 
 // @public
-export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet> = (props: TStylesProps) => DeepPartial<TStyleSet>;
+export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (props: TStylesProps) => DeepPartial<TStyleSet>;
 
 // @public
-export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartial<TStyleSet>;
+export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartial<TStyleSet>;
 
 // @public
-export type IStyleSet<TStyleSet extends {
-    [key: string]: any;
-} = {
+export type IStyleSet<TStyleSet extends IStyleSetBase = {
     [key: string]: any;
 }> = {
-    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
+    [P in Exclude<keyof TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
         [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;
     };
 };
+
+// @public (undocumented)
+export interface IStyleSetBase {
+    // (undocumented)
+    [key: string]: any;
+    // (undocumented)
+    subComponentStyles?: any;
+}
 
 // @public
 export interface IStyleSheetConfig {
@@ -544,7 +550,7 @@ export class Stylesheet {
 
 // Warnings were encountered during analysis:
 //
-// lib/IStyleSet.d.ts:55:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
+// lib/IStyleSet.d.ts:57:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -5,15 +5,13 @@ import { DeepPartial } from './DeepPartial';
  * A style function takes in styleprops and returns a partial styleset.
  * {@docCategory IStyleFunction}
  */
-export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = (
-  props: TStylesProps,
-) => DeepPartial<TStyleSet>;
+export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet> = (props: TStylesProps) => DeepPartial<TStyleSet>;
 
 /**
  * Represents either a style function that takes in style props and returns a partial styleset,
  * or a partial styleset object.
  * {@docCategory IStyleFunctionOrObject}
  */
-export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> =
+export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet> =
   | IStyleFunction<TStylesProps, TStyleSet>
   | DeepPartial<TStyleSet>;

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -1,17 +1,19 @@
-import { IStyleSet } from './IStyleSet';
+import { IStyleSetBase } from './IStyleSet';
 import { DeepPartial } from './DeepPartial';
 
 /**
  * A style function takes in styleprops and returns a partial styleset.
  * {@docCategory IStyleFunction}
  */
-export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet> = (props: TStylesProps) => DeepPartial<TStyleSet>;
+export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (
+  props: TStylesProps,
+) => DeepPartial<TStyleSet>;
 
 /**
  * Represents either a style function that takes in style props and returns a partial styleset,
  * or a partial styleset object.
  * {@docCategory IStyleFunctionOrObject}
  */
-export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet> =
+export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase> =
   | IStyleFunction<TStylesProps, TStyleSet>
   | DeepPartial<TStyleSet>;

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -36,13 +36,12 @@ export interface IStyleSetBase {
  * It may optionally contain style functions for sub components in the special `subComponentStyles`
  * property.
  */
-export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> =
+export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> = {
   // eslint-disable-next-line deprecation/deprecation
-  { [P in Exclude<keyof TStyleSet, 'subComponentStyles'>]: IStyle } & {
-    subComponentStyles?: {
-      [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;
-    };
-  };
+  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
+} & {
+  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
+};
 
 /**
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -28,7 +28,7 @@ export type __MapToFunctionType<T> = Extract<T, Function> extends never
  * It may optionally contain style functions for sub components in the special `subComponentStyles`
  * property.
  */
-export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet> = { [key: string]: any }> = {
+export type IStyleSet<TStyleSet extends { [key: string]: any } = { [key: string]: any }> = {
   // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
@@ -38,7 +38,7 @@ export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet> = { [key: string]: 
 /**
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.
  */
-export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
+export type IConcatenatedStyleSet<TStyleSet extends IStyleSet> = {
   // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
@@ -49,7 +49,7 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
  * A processed style set is one which the set of styles associated with each area has been converted
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
-export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
+export type IProcessedStyleSet<TStyleSet extends IStyleSet> = {
   // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -23,22 +23,28 @@ export type __MapToFunctionType<T> = Extract<T, Function> extends never
   ? (...args: any[]) => Partial<T>
   : Extract<T, Function>;
 
+export interface IStyleSetBase {
+  [key: string]: any;
+  subComponentStyles?: any;
+}
+
 /**
  * A style set is a dictionary of display areas to IStyle objects.
  * It may optionally contain style functions for sub components in the special `subComponentStyles`
  * property.
  */
-export type IStyleSet<TStyleSet extends { [key: string]: any } = { [key: string]: any }> = {
+export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> =
   // eslint-disable-next-line deprecation/deprecation
-  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
-} & {
-  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
-};
+  { [P in Exclude<keyof TStyleSet, 'subComponentStyles'>]: IStyle } & {
+    subComponentStyles?: {
+      [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;
+    };
+  };
 
 /**
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.
  */
-export type IConcatenatedStyleSet<TStyleSet extends IStyleSet> = {
+export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
   // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
@@ -49,7 +55,7 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet> = {
  * A processed style set is one which the set of styles associated with each area has been converted
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
-export type IProcessedStyleSet<TStyleSet extends IStyleSet> = {
+export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
   // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -23,6 +23,9 @@ export type __MapToFunctionType<T> = Extract<T, Function> extends never
   ? (...args: any[]) => Partial<T>
   : Extract<T, Function>;
 
+/**
+ * Used for 'extends IStyleSetBase' type constraints when an IStyleSet type argument is needed.
+ */
 export interface IStyleSetBase {
   [key: string]: any;
   subComponentStyles?: any;

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -1,5 +1,5 @@
 import { concatStyleSets } from './concatStyleSets';
-import { IStyleSet } from './IStyleSet';
+import { IStyleSetBase } from './IStyleSet';
 import { IStyleFunctionOrObject } from './IStyleFunction';
 import { DeepPartial } from './DeepPartial';
 
@@ -8,7 +8,7 @@ import { DeepPartial } from './DeepPartial';
  * @param styleProps - Props used to resolve functional sets.
  * @param allStyles - Style sets, which can be functions or objects.
  */
-export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet>(
+export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
 ): DeepPartial<TStyleSet> {

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -8,7 +8,7 @@ import { DeepPartial } from './DeepPartial';
  * @param styleProps - Props used to resolve functional sets.
  * @param allStyles - Style sets, which can be functions or objects.
  */
-export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(
+export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
 ): DeepPartial<TStyleSet> {

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -9,7 +9,7 @@ export type { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
 export type { DeepPartial } from './DeepPartial';
 
 // eslint-disable-next-line deprecation/deprecation
-export type { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, Omit } from './IStyleSet';
+export type { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, IStyleSetBase, Omit } from './IStyleSet';
 
 export type {
   ICSSRule,

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -1,6 +1,6 @@
 import { mergeStyleSets } from './mergeStyleSets';
 import { Stylesheet, InjectionMode } from './Stylesheet';
-import { IStyleSet, IStyleSetBase } from './IStyleSet';
+import { IStyleSet } from './IStyleSet';
 import { IStyleFunctionOrObject } from './IStyleFunction';
 import { IStyle } from './IStyle';
 
@@ -165,7 +165,7 @@ describe('mergeStyleSets', () => {
   });
 
   describe('typings tests', () => {
-    interface ISubComponentStyles extends IStyleSetBase {
+    interface ISubComponentStyles extends IStyleSet {
       root: IStyle;
     }
 
@@ -173,7 +173,7 @@ describe('mergeStyleSets', () => {
       isCollapsed: boolean;
     }
 
-    interface IStyles extends IStyleSetBase {
+    interface IStyles extends IStyleSet {
       root: IStyle;
       subComponentStyles: {
         button: IStyleFunctionOrObject<ISubComponentStyleProps, IStyleSet<ISubComponentStyles>>;

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -1,6 +1,6 @@
 import { mergeStyleSets } from './mergeStyleSets';
 import { Stylesheet, InjectionMode } from './Stylesheet';
-import { IStyleSet } from './IStyleSet';
+import { IStyleSet, IStyleSetBase } from './IStyleSet';
 import { IStyleFunctionOrObject } from './IStyleFunction';
 import { IStyle } from './IStyle';
 
@@ -165,7 +165,7 @@ describe('mergeStyleSets', () => {
   });
 
   describe('typings tests', () => {
-    interface ISubComponentStyles extends IStyleSet {
+    interface ISubComponentStyles extends IStyleSetBase {
       root: IStyle;
     }
 
@@ -173,7 +173,7 @@ describe('mergeStyleSets', () => {
       isCollapsed: boolean;
     }
 
-    interface IStyles extends IStyleSet {
+    interface IStyles extends IStyleSetBase {
       root: IStyle;
       subComponentStyles: {
         button: IStyleFunctionOrObject<ISubComponentStyleProps, IStyleSet<ISubComponentStyles>>;

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -103,7 +103,7 @@ export function mergeStyleSets(...styleSets: Array<IStyleSet | undefined | false
 export function mergeCssSets<TStyleSet>(
   styleSets: [TStyleSet | false | null | undefined],
   options?: IStyleOptions,
-): IProcessedStyleSet<TStyleSet>;
+): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 /**
  * Takes in one or more style set objects, each1consisting of a set of areas,
@@ -117,7 +117,7 @@ export function mergeCssSets<TStyleSet>(
 export function mergeCssSets<TStyleSet1, TStyleSet2>(
   styleSets: [TStyleSet1 | false | null | undefined, TStyleSet2 | false | null | undefined],
   options?: IStyleOptions,
-): IProcessedStyleSet<TStyleSet1 & TStyleSet2>;
+): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 /**
  * Takes in one or more style set objects, each1consisting of a set of areas,
@@ -135,7 +135,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
     TStyleSet3 | false | null | undefined,
   ],
   options?: IStyleOptions,
-): IProcessedStyleSet<TStyleSet1 & TStyleSet2 & TStyleSet3>;
+): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 /**
  * Takes in one or more style set objects, each1consisting of a set of areas,
@@ -170,7 +170,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
 export function mergeCssSets<TStyleSet>(
   styleSet: [TStyleSet | false | null | undefined],
   options?: IStyleOptions,
-): IProcessedStyleSet<TStyleSet>;
+): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 /**
  * Takes in one or more style set objects, each1consisting of a set of areas,

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -37,6 +37,7 @@ import { ISemanticTextColors } from '@fluentui/theme';
 import { ISpacing } from '@fluentui/theme';
 import { IStyle } from '@fluentui/merge-styles';
 import { IStyleSet } from '@fluentui/merge-styles';
+import { IStyleSetBase } from '@fluentui/merge-styles';
 import { IStyleSheetConfig } from '@fluentui/merge-styles';
 import { ITheme } from '@fluentui/theme';
 import { keyframes } from '@fluentui/merge-styles';
@@ -247,6 +248,8 @@ export { ISpacing }
 export { IStyle }
 
 export { IStyleSet }
+
+export { IStyleSetBase }
 
 export { IStyleSheetConfig }
 

--- a/packages/style-utilities/src/MergeStyles.ts
+++ b/packages/style-utilities/src/MergeStyles.ts
@@ -14,6 +14,7 @@ export type {
   IRawStyle,
   IStyle,
   IStyleSet,
+  IStyleSetBase,
   IProcessedStyleSet,
   IStyleSheetConfig,
   ICSPSettings,

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -14,7 +14,7 @@ import { getVirtualParent } from '@fluentui/dom-utilities';
 import type { IProcessedStyleSet } from '@fluentui/merge-styles';
 import { IStyleFunction } from '@fluentui/merge-styles';
 import { IStyleFunctionOrObject } from '@fluentui/merge-styles';
-import type { IStyleSet } from '@fluentui/merge-styles';
+import type { IStyleSetBase } from '@fluentui/merge-styles';
 import { isVirtualElement } from '@fluentui/dom-utilities';
 import { IVirtualElement } from '@fluentui/dom-utilities';
 import { Omit as Omit_2 } from '@fluentui/merge-styles';
@@ -129,7 +129,7 @@ export function calculatePrecision(value: number | string): number;
 export function canUseDOM(): boolean;
 
 // @public
-export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet>(options?: IClassNamesFunctionOptions): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet>;
+export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSetBase>(options?: IClassNamesFunctionOptions): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet>;
 
 // @public (undocumented)
 export const colGroupProperties: Record<string, number>;
@@ -671,7 +671,7 @@ export interface IPoint extends Point {
 }
 
 // @public (undocumented)
-export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet> {
+export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSetBase> {
     // (undocumented)
     styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
 }
@@ -1231,13 +1231,13 @@ export function shallowCompare<TA extends any, TB extends any>(a: TA, b: TB): bo
 export function shouldWrapFocus(element: HTMLElement, noWrapDataAttribute: 'data-no-vertical-wrap' | 'data-no-horizontal-wrap', doc?: Document): boolean;
 
 // @public
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.FunctionComponent<TComponentProps>;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSetBase>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.FunctionComponent<TComponentProps>;
 
 // @public (undocumented)
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React_2.RefAttributes<TRef>, TStyleProps, TStyleSet extends IStyleSet, TRef = unknown>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.ForwardRefExoticComponent<React_2.PropsWithoutRef<TComponentProps> & React_2.RefAttributes<TRef>>;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React_2.RefAttributes<TRef>, TStyleProps, TStyleSet extends IStyleSetBase, TRef = unknown>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.ForwardRefExoticComponent<React_2.PropsWithoutRef<TComponentProps> & React_2.RefAttributes<TRef>>;
 
 // @public (undocumented)
-export type StyleFunction<TStyleProps, TStyleSet extends IStyleSet> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
+export type StyleFunction<TStyleProps, TStyleSet extends IStyleSetBase> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
     __cachedInputs__: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[];
     __noStyleOverride__: boolean;
 };

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -129,7 +129,7 @@ export function calculatePrecision(value: number | string): number;
 export function canUseDOM(): boolean;
 
 // @public
-export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet<TStyleSet>>(options?: IClassNamesFunctionOptions): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet>;
+export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet>(options?: IClassNamesFunctionOptions): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet>;
 
 // @public (undocumented)
 export const colGroupProperties: Record<string, number>;
@@ -671,7 +671,7 @@ export interface IPoint extends Point {
 }
 
 // @public (undocumented)
-export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>> {
+export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet> {
     // (undocumented)
     styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
 }
@@ -1231,13 +1231,13 @@ export function shallowCompare<TA extends any, TB extends any>(a: TA, b: TB): bo
 export function shouldWrapFocus(element: HTMLElement, noWrapDataAttribute: 'data-no-vertical-wrap' | 'data-no-horizontal-wrap', doc?: Document): boolean;
 
 // @public
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.FunctionComponent<TComponentProps>;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.FunctionComponent<TComponentProps>;
 
 // @public (undocumented)
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React_2.RefAttributes<TRef>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>, TRef = unknown>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.ForwardRefExoticComponent<React_2.PropsWithoutRef<TComponentProps> & React_2.RefAttributes<TRef>>;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React_2.RefAttributes<TRef>, TStyleProps, TStyleSet extends IStyleSet, TRef = unknown>(Component: React_2.ComponentClass<TComponentProps> | React_2.FunctionComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React_2.ForwardRefExoticComponent<React_2.PropsWithoutRef<TComponentProps> & React_2.RefAttributes<TRef>>;
 
 // @public (undocumented)
-export type StyleFunction<TStyleProps, TStyleSet> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
+export type StyleFunction<TStyleProps, TStyleSet extends IStyleSet> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
     __cachedInputs__: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[];
     __noStyleOverride__: boolean;
 };

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -1,7 +1,7 @@
 import { mergeCssSets, Stylesheet } from '@fluentui/merge-styles';
 import { getRTL } from './rtl';
 import { getWindow } from './dom';
-import type { IStyleSet, IProcessedStyleSet, IStyleFunctionOrObject } from '@fluentui/merge-styles';
+import type { IStyleSet, IStyleSetBase, IProcessedStyleSet, IStyleFunctionOrObject } from '@fluentui/merge-styles';
 import type { StyleFunction } from './styled';
 
 const MAX_CACHE_COUNT = 50;
@@ -54,7 +54,7 @@ export interface IClassNamesFunctionOptions {
  * immutable (numbers, strings, and booleans). This will allow the results to be memoized. Violating
  * these will cause extra recalcs to occur.
  */
-export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet>(
+export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSetBase>(
   options: IClassNamesFunctionOptions = {},
 ): (
   getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined,

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -54,7 +54,7 @@ export interface IClassNamesFunctionOptions {
  * immutable (numbers, strings, and booleans). This will allow the results to be memoized. Violating
  * these will cause extra recalcs to occur.
  */
-export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet<TStyleSet>>(
+export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet>(
   options: IClassNamesFunctionOptions = {},
 ): (
   getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined,

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -4,14 +4,14 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 import { styled } from './styled';
 import * as renderer from 'react-test-renderer';
 import { Customizer } from './customizations/Customizer';
-import { Stylesheet, InjectionMode, mergeStyles, IStyleSet } from '@fluentui/merge-styles';
+import { Stylesheet, InjectionMode, mergeStyles } from '@fluentui/merge-styles';
 import { classNamesFunction } from './classNamesFunction';
 import { Customizations } from './customizations/Customizations';
 import { safeCreate } from '@fluentui/test-utilities';
 import { mount } from 'enzyme';
 import type { IStyle, IStyleFunction, IStyleFunctionOrObject } from '@fluentui/merge-styles';
 
-interface ITestStyles extends IStyleSet {
+interface ITestStyles {
   root: IStyle;
 }
 interface ITestProps {

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -4,14 +4,14 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 import { styled } from './styled';
 import * as renderer from 'react-test-renderer';
 import { Customizer } from './customizations/Customizer';
-import { Stylesheet, InjectionMode, mergeStyles } from '@fluentui/merge-styles';
+import { Stylesheet, InjectionMode, mergeStyles, IStyleSet } from '@fluentui/merge-styles';
 import { classNamesFunction } from './classNamesFunction';
 import { Customizations } from './customizations/Customizations';
 import { safeCreate } from '@fluentui/test-utilities';
 import { mount } from 'enzyme';
 import type { IStyle, IStyleFunction, IStyleFunctionOrObject } from '@fluentui/merge-styles';
 
-interface ITestStyles {
+interface ITestStyles extends IStyleSet {
   root: IStyle;
 }
 interface ITestProps {

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -3,7 +3,7 @@ import { concatStyleSetsWithProps } from '@fluentui/merge-styles';
 import { useCustomizationSettings } from './customizations/useCustomizationSettings';
 import type { IStyleSet, IStyleFunctionOrObject } from '@fluentui/merge-styles';
 
-export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>> {
+export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet> {
   styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
 }
 
@@ -22,7 +22,7 @@ export interface ICustomizableProps {
 
 const DefaultFields = ['theme', 'styles'];
 
-export type StyleFunction<TStyleProps, TStyleSet> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
+export type StyleFunction<TStyleProps, TStyleSet extends IStyleSet> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
   /** Cache for all style functions. */
   __cachedInputs__: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[];
 
@@ -52,7 +52,7 @@ export type StyleFunction<TStyleProps, TStyleSet> = IStyleFunctionOrObject<TStyl
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>,
   TStyleProps,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSet,
 >(
   Component: React.ComponentClass<TComponentProps> | React.FunctionComponent<TComponentProps>,
   baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>,
@@ -63,7 +63,7 @@ export function styled<
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React.RefAttributes<TRef>,
   TStyleProps,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSet,
   TRef = unknown,
 >(
   Component: React.ComponentClass<TComponentProps> | React.FunctionComponent<TComponentProps>,
@@ -75,7 +75,7 @@ export function styled<
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React.RefAttributes<TRef>,
   TStyleProps,
-  TStyleSet extends IStyleSet<TStyleSet>,
+  TStyleSet extends IStyleSet,
   TRef = unknown,
 >(
   Component: React.ComponentClass<TComponentProps> | React.FunctionComponent<TComponentProps>,

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { concatStyleSetsWithProps } from '@fluentui/merge-styles';
 import { useCustomizationSettings } from './customizations/useCustomizationSettings';
-import type { IStyleSet, IStyleFunctionOrObject } from '@fluentui/merge-styles';
+import type { IStyleSetBase, IStyleFunctionOrObject } from '@fluentui/merge-styles';
 
-export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet> {
+export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSetBase> {
   styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
 }
 
@@ -22,7 +22,10 @@ export interface ICustomizableProps {
 
 const DefaultFields = ['theme', 'styles'];
 
-export type StyleFunction<TStyleProps, TStyleSet extends IStyleSet> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
+export type StyleFunction<TStyleProps, TStyleSet extends IStyleSetBase> = IStyleFunctionOrObject<
+  TStyleProps,
+  TStyleSet
+> & {
   /** Cache for all style functions. */
   __cachedInputs__: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[];
 
@@ -52,7 +55,7 @@ export type StyleFunction<TStyleProps, TStyleSet extends IStyleSet> = IStyleFunc
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>,
   TStyleProps,
-  TStyleSet extends IStyleSet,
+  TStyleSet extends IStyleSetBase,
 >(
   Component: React.ComponentClass<TComponentProps> | React.FunctionComponent<TComponentProps>,
   baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>,
@@ -63,7 +66,7 @@ export function styled<
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React.RefAttributes<TRef>,
   TStyleProps,
-  TStyleSet extends IStyleSet,
+  TStyleSet extends IStyleSetBase,
   TRef = unknown,
 >(
   Component: React.ComponentClass<TComponentProps> | React.FunctionComponent<TComponentProps>,
@@ -75,7 +78,7 @@ export function styled<
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet> & React.RefAttributes<TRef>,
   TStyleProps,
-  TStyleSet extends IStyleSet,
+  TStyleSet extends IStyleSetBase,
   TRef = unknown,
 >(
   Component: React.ComponentClass<TComponentProps> | React.FunctionComponent<TComponentProps>,


### PR DESCRIPTION
## Previous Behavior

The type definition of IStyleSet has a circular dependency, which causes an error when used with TypeScript 5.3.

## New Behavior

Create an `IStyleSetBase` type to act as the `extends` constraint for type arguments, and avoid a circular reference.

## Related Issue(s)

- Fixes #30714
