### PR TITLE
[xplat] Add CODEOWNERS for xplat-v9 app and react-platform-adapter package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,7 +130,7 @@ apps/stress-test @microsoft/cxe-red @spmonahan @micahgodbolt
 apps/react-18-tests-v8 @microsoft/cxe-red @micahgodbolt
 apps/react-18-tests-v9 @microsoft/cxe-red @micahgodbolt
 apps/recipes-react-components @microsoft/cxe-red @microsoft/fluentui-react @sopranopillow
-apps/xplat-v9 @behowell @JasonVMo @kelset @tido64
+apps/xplat-v9 @microsoft/fluentui-xplat
 
 #### Packages
 packages/azure-themes @Jacqueline-ms @robtaft-ms
@@ -253,7 +253,7 @@ packages/react-components/react-teaching-popover-preview @microsoft/xc-uxe @Mitc
 packages/react-components/react-timepicker-compat @microsoft/teams-prg
 packages/react-components/react-icons-compat @microsoft/cxe-red @tomi-msft
 packages/react-components/react-tag-picker-preview @microsoft/teams-prg
-packages/react-components/react-platform-adapter @behowell @JasonVMo @kelset @tido64
+packages/react-components/react-platform-adapter @microsoft/fluentui-xplat
 # <%= NX-CODEOWNER-PLACEHOLDER %>
 
 ## Components

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,6 +130,7 @@ apps/stress-test @microsoft/cxe-red @spmonahan @micahgodbolt
 apps/react-18-tests-v8 @microsoft/cxe-red @micahgodbolt
 apps/react-18-tests-v9 @microsoft/cxe-red @micahgodbolt
 apps/recipes-react-components @microsoft/cxe-red @microsoft/fluentui-react @sopranopillow
+apps/xplat-v9 @behowell @JasonVMo @kelset @tido64
 
 #### Packages
 packages/azure-themes @Jacqueline-ms @robtaft-ms
@@ -252,6 +253,7 @@ packages/react-components/react-teaching-popover-preview @microsoft/xc-uxe @Mitc
 packages/react-components/react-timepicker-compat @microsoft/teams-prg
 packages/react-components/react-icons-compat @microsoft/cxe-red @tomi-msft
 packages/react-components/react-tag-picker-preview @microsoft/teams-prg
+packages/react-components/react-platform-adapter @behowell @JasonVMo @kelset @tido64
 # <%= NX-CODEOWNER-PLACEHOLDER %>
 
 ## Components


### PR DESCRIPTION
Add codeowners for `apps/xplat-v9` and `react-platform-adapter` package.

This is for the cross-platform react prototype work being done on the `xplat` branch. This branch won't be merged to `master` in the near future. However, we are using PRs for work on the `xplat` branch, and need appropriate codeowners set.