### PR TITLE
Line-chart-focus-callout-trigger-fix

### DIFF
--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -767,6 +767,9 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                 circleId,
                 xAxisCalloutAccessibilityData,
               )}
+              ref={(e: SVGCircleElement | null) => {
+                this._refCallback(e!, circleId);
+              }}
               onMouseOut={this._handleMouseOut}
               onFocus={() => this._handleFocus(lineId, x1, xAxisCalloutData, circleId, xAxisCalloutAccessibilityData)}
               onBlur={this._handleMouseOut}
@@ -803,6 +806,9 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                   key={lastCircleId}
                   d={path}
                   data-is-focusable={true}
+                  ref={(e: SVGCircleElement | null) => {
+                    this._refCallback(e!, lastCircleId);
+                  }}
                   onMouseOver={this._handleHover.bind(
                     this,
                     x2,
@@ -1190,7 +1196,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         .attr('transform', () => `translate(${_this._xAxisScale(x)}, 0)`)
         .attr('visibility', 'visibility');
       this._refArray.forEach((obj: IRefArrayData) => {
-        if (obj.index === lineId) {
+        if (obj.index === lineId || obj.index === circleId) {
           this.setState({
             isCalloutVisible: true,
             refSelected: obj.refElement,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Callout does not trigger using focus for last point of a segment in LineChart with Gaps

## New Behavior
Callouts work with keyboard focus inpresence of gaps
Here's a demo:
https://jam.dev/c/e70d442c-b1f7-4d94-ae28-72148554bd96

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #25431
