### PR TITLE
fix: add `aria-labelledby` to Infolabel note

### DIFF
--- a/change/@fluentui-react-infolabel-db6aadb8-3d81-4e84-ad8d-a1e7831e4104.json
+++ b/change/@fluentui-react-infolabel-db6aadb8-3d81-4e84-ad8d-a1e7831e4104.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add aria-labelledby to infolabel note",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infolabel/src/components/InfoLabel/useInfoLabel.ts
+++ b/packages/react-components/react-infolabel/src/components/InfoLabel/useInfoLabel.ts
@@ -70,6 +70,7 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
     infoButton.info = slot.optional(infoButton?.info, {
       defaultProps: {
         id: baseId + '__info',
+        'aria-labelledby': baseId + '__info',
       },
       elementType: 'div',
     });

--- a/packages/react-components/react-infolabel/src/components/InfoLabel/useInfoLabel.ts
+++ b/packages/react-components/react-infolabel/src/components/InfoLabel/useInfoLabel.ts
@@ -67,10 +67,11 @@ export const useInfoLabel_unstable = (props: InfoLabelProps, ref: React.Ref<HTML
 
   if (infoButton) {
     infoButton.popover = infoButtonPopover;
+    const infoPopupId = baseId + '__info'; // used as a self-referencing aria-labelledby to name the popup
     infoButton.info = slot.optional(infoButton?.info, {
       defaultProps: {
-        id: baseId + '__info',
-        'aria-labelledby': baseId + '__info',
+        id: infoPopupId,
+        'aria-labelledby': infoPopupId,
       },
       elementType: 'div',
     });


### PR DESCRIPTION
## Previous Behavior

Currently, the popup (an element with `role=note`) got focus, but didn't have an explicit accessible name (it functions as a container role, so the content got read even without it).

## New Behavior

Adds an explicit accName equal to the note's text content, using a self-referencing `aria-labelledby`. I tested to ensure we weren't introducing duplicate reading (i.e. of both the content and accName), and it appears that only partially happens with Talkback. The results are as follows (tested the announcement when opening an infolabel containing text & a link):

- macOS VO + Chrome: no difference with self-referencing label, reads text but not link when opened (i.e. reads first node/swipe target then stops)
- macOS VO + Safari: no difference, same as Chrome
- iOS VO: no difference, same as macOS
- NVDA + Chrome: no difference, reads all text & link for all
- NVDA + FF: no difference, reads all text & link for all
- JAWS + Chrome: no difference, reads all text & link & note role for all.
- Android Talkback + Chrome: without labelledby, reads text (not link) + note role. With labelledby, reads all text + link + note role, then reads text again.
- Narrator + Edge: reads note role without labelledby, reads all text + link + note role with labelledby

The talkback duplicate announcement is very minor, so it seems worth updating for Narrator and general future-proofing. JAWS additionally will read duplicate content when moving the virtual cursor into & out of the named region, but that shouldn't be a common interaction with InfoLabel.

## Related Issue(s)

- Fixes partner ADO issue
