### PR TITLE
fix: Applying correct styles to icon when ToggleButton is checked and has a subtle or transparent appearance

### DIFF
--- a/change/@fluentui-react-button-452be093-2c6e-402a-8a9c-52875d63bfac.json
+++ b/change/@fluentui-react-button-452be093-2c6e-402a-8a9c-52875d63bfac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Applying correct styles to icon when ToggleButton is checked and has a subtle or transparent appearance.",
+  "packageName": "@fluentui/react-button",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/ToggleButton/useToggleButtonStyles.styles.ts
@@ -278,9 +278,8 @@ export const useToggleButtonStyles_unstable = (state: ToggleButtonState): Toggle
   if (state.icon) {
     state.icon.className = mergeClasses(
       toggleButtonClassNames.icon,
-      (appearance === 'subtle' || appearance === 'transparent') &&
-        iconCheckedStyles.subtleOrTransparent &&
-        iconCheckedStyles.highContrast,
+      (appearance === 'subtle' || appearance === 'transparent') && iconCheckedStyles.subtleOrTransparent,
+      iconCheckedStyles.highContrast,
       state.icon.className,
     );
   }


### PR DESCRIPTION
## Previous Behavior

Styles for the `icon` slot of the `ToggleButton` component when it was `checked` and had a `subtle` or `transparent` appearance where not being correctly applied.

## New Behavior

Correct styles are applied to the `icon` slot of the `ToggleButton` component when it is `checked` and has a `subtle` or `transparent` appearance.

## Related Issue(s)

- Fixes #30476
