### PR TITLE
fix: ensure package is tree-shakeable

### DIFF
--- a/packages/react-components/react-platform-adapter/.eslintrc.json
+++ b/packages/react-components/react-platform-adapter/.eslintrc.json
@@ -1,4 +1,17 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react"],
-  "root": true
+  "root": true,
+  "overrides": [
+    {
+      "files": "**/*.ts",
+      "rules": {
+        "@rnx-kit/no-export-all": [
+          "error",
+          {
+            "expand": "all"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/react-components/react-platform-adapter/src/XPlatProvider/index.ts
+++ b/packages/react-components/react-platform-adapter/src/XPlatProvider/index.ts
@@ -1,2 +1,0 @@
-export { XPlatProvider, suppressCssVariableInsertion } from './XPlatProvider';
-export { type XPlatProviderProps } from './XPlatProvider.types';

--- a/packages/react-components/react-platform-adapter/src/index.ts
+++ b/packages/react-components/react-platform-adapter/src/index.ts
@@ -1,12 +1,12 @@
-export { XPlatProvider, suppressCssVariableInsertion, type XPlatProviderProps } from './XPlatProvider';
-export { jsxPlatformAdapter } from './jsx';
-export {
-  getStylesFromClassName,
-  makeStyles,
-  makeStylesCore,
-  makeResetStyles,
-  mergeClasses,
-  shorthands,
-  TextDirectionProvider,
-  useRenderer_unstable,
-} from './styling/index';
+export { XPlatProvider, suppressCssVariableInsertion } from './XPlatProvider/XPlatProvider';
+export type { XPlatProviderProps } from './XPlatProvider/XPlatProvider.types';
+export { jsxPlatformAdapter } from './jsx/jsxPlatformAdapter';
+export { getStylesFromClassName } from './styling/classNameMap';
+export { makeResetStyles } from './styling/makeResetStyles';
+export { makeStyles } from './styling/makeStyles';
+export { mergeClasses } from './styling/mergeClasses';
+export { shorthands } from './styling/shorthands';
+
+// re-export some griffel types to have fluent use the griffel adapter instead of griffel directly
+export { useRenderer_unstable, TextDirectionProvider } from '@griffel/react';
+export { makeStyles as makeStylesCore } from '@griffel/core';

--- a/packages/react-components/react-platform-adapter/src/jsx/index.ts
+++ b/packages/react-components/react-platform-adapter/src/jsx/index.ts
@@ -1,1 +1,0 @@
-export * from './jsxPlatformAdapter';

--- a/packages/react-components/react-platform-adapter/src/jsx/jsxPlatformAdapter.native.ts
+++ b/packages/react-components/react-platform-adapter/src/jsx/jsxPlatformAdapter.native.ts
@@ -1,8 +1,7 @@
 import type * as React from 'react';
-
 import { html } from 'react-strict-dom';
-import { getStylesFromClassName } from '../styling/index';
-import { JSXRuntime } from './types';
+import { getStylesFromClassName } from '../styling/classNameMap';
+import type { JSXRuntime } from './types';
 
 const modifyPropsForNative = <P extends {}>(
   props: (P & { children?: React.ReactNode; className?: string; style?: React.CSSProperties }) | null,

--- a/packages/react-components/react-platform-adapter/src/jsx/jsxPlatformAdapter.ts
+++ b/packages/react-components/react-platform-adapter/src/jsx/jsxPlatformAdapter.ts
@@ -1,4 +1,4 @@
-import { JSXRuntime } from './types';
+import type { JSXRuntime } from './types';
 
 export const jsxPlatformAdapter = (reactJsx: JSXRuntime) => {
   return reactJsx;

--- a/packages/react-components/react-platform-adapter/src/styling/index.ts
+++ b/packages/react-components/react-platform-adapter/src/styling/index.ts
@@ -1,8 +1,0 @@
-export * from './classNameMap';
-export * from './makeResetStyles';
-export * from './makeStyles';
-export * from './mergeClasses';
-export * from './shorthands';
-// re-export some griffel types to have fluent use the griffel adapter instead of griffel directly
-export { useRenderer_unstable, TextDirectionProvider } from '@griffel/react';
-export { makeStyles as makeStylesCore } from '@griffel/core';


### PR DESCRIPTION
## Previous Behavior

Use of "barrel" files and `export *` prevent treeshaking when bundling with Metro.

## New Behavior

Barrel files are removed, `@rnx-kit/no-export-all` rule is enabled.

## Related Issue(s)

n/a