### PR TITLE
fix: DataGrid - prevent automatic sort when column resizing finishes

### DIFF
--- a/change/@fluentui-react-table-e925277a-0f22-408e-b547-82d19823c883.json
+++ b/change/@fluentui-react-table-e925277a-0f22-408e-b547-82d19823c883.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: DataGrid - prevent unwanted sort after column resizing (#27803)",
+  "packageName": "@fluentui/react-table",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/useTableColumnResizeMouseHandler.ts
+++ b/packages/react-components/react-table/src/hooks/useTableColumnResizeMouseHandler.ts
@@ -13,6 +13,7 @@ export function useTableColumnResizeMouseHandler(columnResizeState: ColumnResize
   const mouseX = React.useRef(0);
   const currentWidth = React.useRef(0);
   const colId = React.useRef<TableColumnId | undefined>(undefined);
+  const [dragging, setDragging] = React.useState<boolean>(false);
 
   const { targetDocument } = useFluent();
   const globalWin = targetDocument?.defaultView;
@@ -54,6 +55,7 @@ export function useTableColumnResizeMouseHandler(columnResizeState: ColumnResize
         targetDocument?.removeEventListener('touchend', onDragEnd);
         targetDocument?.removeEventListener('touchmove', onDrag);
       }
+      setDragging(false);
     },
     [onDrag, targetDocument],
   );
@@ -73,11 +75,13 @@ export function useTableColumnResizeMouseHandler(columnResizeState: ColumnResize
         }
         targetDocument?.addEventListener('mouseup', onDragEnd);
         targetDocument?.addEventListener('mousemove', onDrag);
+        setDragging(true);
       }
 
       if (isTouchEvent(event)) {
         targetDocument?.addEventListener('touchend', onDragEnd);
         targetDocument?.addEventListener('touchmove', onDrag);
+        setDragging(true);
       }
     },
     [getColumnWidth, onDrag, onDragEnd, targetDocument],
@@ -85,5 +89,6 @@ export function useTableColumnResizeMouseHandler(columnResizeState: ColumnResize
 
   return {
     getOnMouseDown,
+    dragging,
   };
 }

--- a/packages/react-components/react-table/src/hooks/useTableColumnSizing.tsx
+++ b/packages/react-components/react-table/src/hooks/useTableColumnSizing.tsx
@@ -30,7 +30,7 @@ export function useTableColumnSizing_unstable<TItem>(params?: UseTableColumnSizi
   return (tableState: TableFeaturesState<TItem>) => useTableColumnSizingState(tableState, params);
 }
 
-function getColumnStyles(column: ColumnWidthState): React.CSSProperties {
+function getColumnStyles(column: ColumnWidthState, dragging?: boolean): React.CSSProperties {
   const width = column.width;
 
   return {
@@ -39,6 +39,8 @@ function getColumnStyles(column: ColumnWidthState): React.CSSProperties {
     // non-native element styles (flex layout)
     minWidth: width,
     maxWidth: width,
+    // Fixed the unwanted sort: https://github.com/microsoft/fluentui/issues/27803
+    pointerEvents: dragging ? 'none' : 'initial',
   };
 }
 
@@ -68,7 +70,7 @@ function useTableColumnSizingState<TItem>(
   );
 
   const { getColumnById, setColumnWidth, getColumns } = columnResizeState;
-  const { getOnMouseDown } = mouseHandler;
+  const { getOnMouseDown, dragging } = mouseHandler;
   return {
     ...tableState,
     tableRef: measureElementRef,
@@ -101,12 +103,12 @@ function useTableColumnSizingState<TItem>(
 
           return col
             ? {
-                style: getColumnStyles(col),
+                style: getColumnStyles(col, dragging),
                 aside,
               }
             : {};
         },
-        [getColumnById, columns, getKeyboardResizingProps, getOnMouseDown],
+        [getColumnById, columns, dragging, getKeyboardResizingProps, getOnMouseDown],
       ),
       getTableCellProps: React.useCallback(
         (columnId: TableColumnId) => {

--- a/packages/react-components/react-table/src/hooks/useTableColumnSizing.tsx
+++ b/packages/react-components/react-table/src/hooks/useTableColumnSizing.tsx
@@ -40,7 +40,7 @@ function getColumnStyles(column: ColumnWidthState, dragging?: boolean): React.CS
     minWidth: width,
     maxWidth: width,
     // Fixed the unwanted sort: https://github.com/microsoft/fluentui/issues/27803
-    pointerEvents: dragging ? 'none' : 'initial',
+    ...(dragging ? { pointerEvents: 'none' } : {}),
   };
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

See #27803 for details.

Previously when column was resized and minimum width was hit, as the cursor ends up over the column header, it would trigger a click event, resulting in an unwanted sort.

## New Behavior

The sort is not triggered anymore, the pointer events on the header are disabled during the resizing.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #27803
