### PR TITLE
chore(xplat): Add xplat support to Button

### DIFF
--- a/apps/xplat-v9/StrictDomDemo.tsx
+++ b/apps/xplat-v9/StrictDomDemo.tsx
@@ -1,34 +1,21 @@
 import * as React from 'react';
 
+import { Button } from '@fluentui/react-button';
 import { Label } from '@fluentui/react-label';
-import {
-  getStylesFromClassName,
-  makeResetStyles,
-  makeStyles,
-  mergeClasses,
-  shorthands,
-} from '@fluentui/react-platform-adapter';
-import { html } from 'react-strict-dom';
+import { getStylesFromClassName, makeStyles, shorthands } from '@fluentui/react-platform-adapter';
 import { FluentProvider } from '@fluentui/react-provider';
-import { webLightTheme } from '@fluentui/react-theme';
-
-const useBaseClassName = makeResetStyles({
-  marginBlock: '1rem',
-  padding: '10px',
-});
+import { tokens, webLightTheme } from '@fluentui/react-theme';
+import { html } from 'react-strict-dom';
 
 const useClassNames = makeStyles({
   root: {
     ...shorthands.border('2px', 'solid', 'red'),
-    color: '#222',
-    backgroundColor: '#EEE',
-    ':hover': {
-      color: 'blue',
-      backgroundColor: '#DDD',
-    },
-  },
-  cond: {
-    ...shorthands.borderWidth('5px'),
+    backgroundColor: tokens.colorNeutralBackground2,
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '10px',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -39,10 +26,9 @@ export const StrictDomDemo = (props: { cond?: boolean }) => {
 
   return (
     <FluentProvider theme={webLightTheme}>
-      <html.div
-        style={getStylesFromClassName(mergeClasses(useBaseClassName(), classNames.root, cond && classNames.cond))}
-      >
-        <Label required>This is a label</Label>
+      <html.div style={getStylesFromClassName(classNames.root)}>
+        <Label required>Required label</Label>
+        <Button appearance="primary">Primary button</Button>
       </html.div>
     </FluentProvider>
   );

--- a/packages/react-components/react-button/package.json
+++ b/packages/react-components/react-button/package.json
@@ -38,6 +38,7 @@
     "@fluentui/react-aria": "^9.10.0",
     "@fluentui/react-icons": "^2.0.224",
     "@fluentui/react-jsx-runtime": "^9.0.32",
+    "@fluentui/react-platform-adapter": "^0.0.0",
     "@fluentui/react-shared-contexts": "^9.15.0",
     "@fluentui/react-tabster": "^9.19.3",
     "@fluentui/react-theme": "^9.1.17",

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -1,7 +1,7 @@
 import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
-import { shorthands, makeStyles, makeResetStyles, mergeClasses } from '@griffel/react';
+import { shorthands, makeStyles, makeResetStyles, mergeClasses } from '@fluentui/react-platform-adapter';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { ButtonSlots, ButtonState } from './Button.types';
 
@@ -32,19 +32,19 @@ const useRootBaseClassName = makeResetStyles({
   textDecorationLine: 'none',
   verticalAlign: 'middle',
 
-  margin: 0,
-  overflow: 'hidden',
+  ...shorthands.margin(0),
+  ...shorthands.overflow('hidden'),
 
   backgroundColor: tokens.colorNeutralBackground1,
   color: tokens.colorNeutralForeground1,
-  border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+  ...shorthands.border(tokens.strokeWidthThin, 'solid', tokens.colorNeutralStroke1),
 
   fontFamily: tokens.fontFamilyBase,
   outlineStyle: 'none',
 
   ':hover': {
     backgroundColor: tokens.colorNeutralBackground1Hover,
-    borderColor: tokens.colorNeutralStroke1Hover,
+    ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
     color: tokens.colorNeutralForeground1Hover,
 
     cursor: 'pointer',
@@ -52,15 +52,15 @@ const useRootBaseClassName = makeResetStyles({
 
   ':hover:active': {
     backgroundColor: tokens.colorNeutralBackground1Pressed,
-    borderColor: tokens.colorNeutralStroke1Pressed,
+    ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
     color: tokens.colorNeutralForeground1Pressed,
 
     outlineStyle: 'none',
   },
 
-  padding: `${buttonSpacingMedium} ${tokens.spacingHorizontalM}`,
+  ...shorthands.padding(buttonSpacingMedium, tokens.spacingHorizontalM),
   minWidth: '96px',
-  borderRadius: tokens.borderRadiusMedium,
+  ...shorthands.borderRadius(tokens.borderRadiusMedium),
 
   fontSize: tokens.fontSizeBase300,
   fontWeight: tokens.fontWeightSemibold,
@@ -80,19 +80,19 @@ const useRootBaseClassName = makeResetStyles({
 
   '@media (forced-colors: active)': {
     ':focus': {
-      borderColor: 'ButtonText',
+      ...shorthands.borderColor('ButtonText'),
     },
 
     ':hover': {
       backgroundColor: 'HighlightText',
-      borderColor: 'Highlight',
+      ...shorthands.borderColor('Highlight'),
       color: 'Highlight',
       forcedColorAdjust: 'none',
     },
 
     ':hover:active': {
       backgroundColor: 'HighlightText',
-      borderColor: 'Highlight',
+      ...shorthands.borderColor('Highlight'),
       color: 'Highlight',
       forcedColorAdjust: 'none',
     },
@@ -101,10 +101,10 @@ const useRootBaseClassName = makeResetStyles({
   // Focus styles
 
   ...createCustomFocusIndicatorStyle({
-    borderColor: tokens.colorStrokeFocus2,
-    borderRadius: tokens.borderRadiusMedium,
-    borderWidth: '1px',
-    outline: `${tokens.strokeWidthThick} solid ${tokens.colorTransparentStroke}`,
+    ...shorthands.borderColor(tokens.colorStrokeFocus2),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.borderWidth('1px'),
+    ...shorthands.outline(tokens.strokeWidthThick, 'solid', tokens.colorTransparentStroke),
     boxShadow: `0 0 0 ${tokens.strokeWidthThin} ${tokens.colorStrokeFocus2}
       inset
     `,


### PR DESCRIPTION
ℹ️ Note: This is being merged into the `xplat` branch, not `master`.

## New Behavior

Hook up Button to support cross-platform styles. Cross-plat reset styles don't support shorthands, so need to convert the styles to expand shorthands.
