### PR TITLE
TeachingPopover: Accessibility updates

### DIFF
--- a/change/@fluentui-react-teaching-popover-preview-5d5a06c5-1916-45c4-bfd2-1d1ff7434363.json
+++ b/change/@fluentui-react-teaching-popover-preview-5d5a06c5-1916-45c4-bfd2-1d1ff7434363.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bug: Fix accessibility labels and roles",
+  "packageName": "@fluentui/react-teaching-popover-preview",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarousel/__snapshots__/TeachingPopoverCarousel.test.tsx.snap
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarousel/__snapshots__/TeachingPopoverCarousel.test.tsx.snap
@@ -18,11 +18,13 @@ exports[`TeachingPopoverCarousel renders a default state 1`] = `
       <div
         class="fui-TeachingPopoverCarouselNav fui-TeachingPopoverCarousel__nav"
         data-tabster="{\\"groupper\\":{\\"tabbability\\":1},\\"focusable\\":{}}"
-        role="list"
+        role="tablist"
         tabindex="0"
       >
         <button
+          aria-label="0 of 1"
           class="fui-TeachingPopoverCarouselNavButton"
+          role="tab"
           type="button"
         />
       </div>

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/__snapshots__/TeachingPopoverCarouselNav.test.tsx.snap
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/__snapshots__/TeachingPopoverCarouselNav.test.tsx.snap
@@ -5,15 +5,19 @@ exports[`TeachingPopoverCarouselNav renders a default state 1`] = `
   <div
     class="fui-TeachingPopoverCarouselNav"
     data-tabster="{\\"groupper\\":{\\"tabbability\\":1},\\"focusable\\":{}}"
-    role="list"
+    role="tablist"
     tabindex="0"
   >
     <button
+      aria-label="0 of 2"
       class="fui-TeachingPopoverCarouselNavButton"
+      role="tab"
       type="button"
     />
     <button
+      aria-label="1 of 2"
       class="fui-TeachingPopoverCarouselNavButton"
+      role="tab"
       type="button"
     />
   </div>

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -36,7 +36,7 @@ export const useTeachingPopoverCarouselNav_unstable = (
     root: slot.always(
       getIntrinsicElementProps('div', {
         ref,
-        role: 'list',
+        role: 'tablist',
         tabIndex: 0,
         ...props,
         children: rootChildren,

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNavButton/__snapshots__/TeachingPopoverCarouselNavButton.test.tsx.snap
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNavButton/__snapshots__/TeachingPopoverCarouselNavButton.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`TeachingPopoverCarouselNavButton renders a default state 1`] = `
 <div>
   <button
+    aria-label="0 of 1"
     class="fui-TeachingPopoverCarouselNavButton"
+    role="tab"
     type="button"
   />
 </div>

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
@@ -25,6 +25,7 @@ export const useTeachingPopoverCarouselNavButton_unstable = (
   const appearance = usePopoverContext_unstable(context => context.appearance);
   const setCurrentPage = useTeachingPopoverCarouselContext_unstable(context => context.setCurrentPage);
   const currentPage = useTeachingPopoverCarouselContext_unstable(context => context.currentPage);
+  const totalPages = useTeachingPopoverCarouselContext_unstable(context => context.totalPages);
   const onPageChange = useTeachingPopoverCarouselContext_unstable(context => context.onPageChange);
   const isSelected = currentPage === index;
 
@@ -49,7 +50,7 @@ export const useTeachingPopoverCarouselNavButton_unstable = (
         ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
         role: 'tab',
         type: 'button',
-        'aria-label': `Page ${index}`,
+        'aria-label': `${index} of ${totalPages}`,
       },
     },
   );

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
@@ -47,7 +47,9 @@ export const useTeachingPopoverCarouselNavButton_unstable = (
       elementType: 'button',
       defaultProps: {
         ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+        role: 'tab',
         type: 'button',
+        'aria-label': `Page ${index}`,
       },
     },
   );

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverHeader/__snapshots__/TeachingPopoverHeader.test.tsx.snap
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverHeader/__snapshots__/TeachingPopoverHeader.test.tsx.snap
@@ -26,8 +26,9 @@ exports[`TeachingPopoverHeader renders a default state 1`] = `
     </div>
     Default TeachingPopoverHeader
     <button
+      aria-label="dismiss"
       class="fui-TeachingPopoverHeader__dismissButton"
-      role="img"
+      role="button"
     >
       <svg
         aria-hidden="true"

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.tsx
@@ -56,7 +56,8 @@ export const useTeachingPopoverHeader_unstable = (
       renderByDefault: true,
       defaultProps: {
         children: <Dismiss12Regular />,
-        role: 'img',
+        role: 'button',
+        'aria-label': 'dismiss',
         onClick: onDismissButtonClick,
       },
       elementType: 'button',

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
@@ -48,6 +48,7 @@ export const useTeachingPopoverTitle_unstable = (
       defaultProps: {
         children: <DismissIcon />,
         onClick: onDismissButtonClick,
+        'aria-label': 'dismiss',
         'aria-hidden': true,
       },
       elementType: 'button',

--- a/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverBranded.stories.tsx
+++ b/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverBranded.stories.tsx
@@ -29,7 +29,7 @@ export const DefaultBrand = (props: TeachingPopoverProps) => (
     </TeachingPopoverTrigger>
     <TeachingPopoverSurface>
       <TeachingPopoverHeader>{'Tips'}</TeachingPopoverHeader>
-      <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+      <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
         <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
         {ExampleContent(1)}
       </TeachingPopoverBody>

--- a/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverCarousel.stories.tsx
+++ b/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverCarousel.stories.tsx
@@ -38,19 +38,19 @@ export const Carousel = (props: TeachingPopoverProps) => (
         }}
       >
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(1)}
         </TeachingPopoverBody>
 
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(2)}
         </TeachingPopoverBody>
 
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(3)}
         </TeachingPopoverBody>

--- a/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverCarouselBranded.stories.tsx
+++ b/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverCarouselBranded.stories.tsx
@@ -38,19 +38,19 @@ export const CarouselBrand = (props: TeachingPopoverProps) => (
         }}
       >
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(1)}
         </TeachingPopoverBody>
 
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(2)}
         </TeachingPopoverBody>
 
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(3)}
         </TeachingPopoverBody>

--- a/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverCarouselText.stories.tsx
+++ b/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverCarouselText.stories.tsx
@@ -40,19 +40,19 @@ export const CarouselText = (props: TeachingPopoverProps) => (
         }}
       >
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(1)}
         </TeachingPopoverBody>
 
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(2)}
         </TeachingPopoverBody>
 
         {/* Multiple TeachingPopoverBody will be wrapped by a 'TeachingPopoverCarousel'*/}
-        <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+        <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
           <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
           {ExampleContent(3)}
         </TeachingPopoverBody>

--- a/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverDefault.stories.tsx
+++ b/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverDefault.stories.tsx
@@ -29,7 +29,7 @@ export const Default = (props: TeachingPopoverProps) => (
     </TeachingPopoverTrigger>
     <TeachingPopoverSurface>
       <TeachingPopoverHeader>{'Tips'}</TeachingPopoverHeader>
-      <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+      <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
         <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
         {ExampleContent(1)}
       </TeachingPopoverBody>

--- a/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverDefaultBranded.stories.tsx
+++ b/packages/react-components/react-teaching-popover-preview/stories/TeachingPopover/TeachingPopoverDefaultBranded.stories.tsx
@@ -29,7 +29,7 @@ export const DefaultBrand = (props: TeachingPopoverProps) => (
     </TeachingPopoverTrigger>
     <TeachingPopoverSurface>
       <TeachingPopoverHeader>{'Tips'}</TeachingPopoverHeader>
-      <TeachingPopoverBody media={<Image fit={'cover'} src={SwapImage} />}>
+      <TeachingPopoverBody media={<Image alt={'test image'} fit={'cover'} src={SwapImage} />}>
         <TeachingPopoverTitle>{'Teaching Bubble Title'}</TeachingPopoverTitle>
         {ExampleContent(1)}
       </TeachingPopoverBody>


### PR DESCRIPTION
Updates required to pass accessibility checks, some strings in aria-labels for buttons - should we enforce this another way?

## New Behavior
Navigation container is now a tablist role, contains tab items.
Added default aria labels to text-less buttons
Images with alt text in stories

## Related Issue(s)
#30804 
