### PR TITLE
fix(codemods): Fix build errors in TypeScript 5.3.3

### DIFF
--- a/change/@fluentui-codemods-65485060-b665-4208-aed8-3a814d1fb9f7.json
+++ b/change/@fluentui-codemods-65485060-b665-4208-aed8-3a814d1fb9f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Build errors in TypeScript 5.3",
+  "packageName": "@fluentui/codemods",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/codemods/src/helpers/maybe.ts
+++ b/packages/codemods/src/helpers/maybe.ts
@@ -28,7 +28,7 @@ class MB<T> implements MaybeChain<T> {
   public flatten() {
     if (this.something) {
       const val = this.value;
-      if (typeof val === 'object' && '__isMaybe' in val) {
+      if (typeof val === 'object' && val !== null && '__isMaybe' in val) {
         return val as Flattened<T, Maybe<T>>;
       }
     }
@@ -65,7 +65,7 @@ export const Something = <T>(value: NonNullable<T>): Something<T> => {
   });
 };
 
-export const MaybeDictionary = <T>(dictionary: { [key: string]: T }): { [key: string]: Maybe<T> } => {
+export const MaybeDictionary = <T extends {}>(dictionary: { [key: string]: T }): { [key: string]: Maybe<T> } => {
   return new Proxy<{ [key: string]: Maybe<T> }>(dictionary as unknown as { [key: string]: Maybe<T> }, {
     get: (target: { [key: string]: Maybe<T> | T }, name: string): Maybe<T> => {
       const value = target[name];

--- a/packages/codemods/src/helpers/tests/maybe.test.ts
+++ b/packages/codemods/src/helpers/tests/maybe.test.ts
@@ -14,6 +14,7 @@ describe('Maybe', () => {
   it('just will error if you pass it undefined', () => {
     let error = false;
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       Something(undefined as any);
     } catch (_) {
       error = true;

--- a/packages/codemods/src/helpers/tests/maybe.test.ts
+++ b/packages/codemods/src/helpers/tests/maybe.test.ts
@@ -14,7 +14,7 @@ describe('Maybe', () => {
   it('just will error if you pass it undefined', () => {
     let error = false;
     try {
-      Something(undefined as unknown);
+      Something(undefined as any);
     } catch (_) {
       error = true;
     }


### PR DESCRIPTION
## Previous Behavior

TypeScript 5 introduced some breaking changes to the way that implicit type coercion happens in templates, as well as a few other breaking changes. Although we don't currently use TypeScript 5.3.3 in the repo, experimental work in the `xplat` branch requires building against TypesScript 5+. There are also customers using TypeScript 5+, who are seeing build errors when importing FluentUI.

## New Behavior

Fix build errors seen if the repo is updated to TypeScript 5.3.3.  This is part of a set of PRs intending to fix all build errors when building against TypeScript 5.3.3.

ℹ️ **Note**: This is NOT updating the project to use TypeScript 5.3.3, and an update to the TypeScript version is not planned as part of this change. It is only fixing build errors that would occur if it were built against TypeScript 5.3.3.

## Related Issue(s)

This PR was split out from a draft PR that contains all of the changes. I'm not going to publish the monolith PR, but in case it helps to see all of the changes in one place:

* https://github.com/microsoft/fluentui/pull/30796

Here are all of the split-out PRs:

* https://github.com/microsoft/fluentui/pull/30806
* https://github.com/microsoft/fluentui/pull/30807
* https://github.com/microsoft/fluentui/pull/30808
* https://github.com/microsoft/fluentui/pull/30809
* https://github.com/microsoft/fluentui/pull/30810
* https://github.com/microsoft/fluentui/pull/30811
* https://github.com/microsoft/fluentui/pull/30812
* https://github.com/microsoft/fluentui/pull/30813
* https://github.com/microsoft/fluentui/pull/30814
* https://github.com/microsoft/fluentui/pull/30815
* https://github.com/microsoft/fluentui/pull/30816
* https://github.com/microsoft/fluentui/pull/30817