### PR TITLE
fix(foundation-legacy): Fix build errors in TypeScript 5.3.3

### DIFF
--- a/change/@fluentui-foundation-legacy-c6b23d62-8aa6-4679-8d5d-780d48c89a89.json
+++ b/change/@fluentui-foundation-legacy-c6b23d62-8aa6-4679-8d5d-780d48c89a89.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Build errors in TypeScript 5.3",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/foundation-legacy/etc/foundation-legacy.api.md
+++ b/packages/foundation-legacy/etc/foundation-legacy.api.md
@@ -204,7 +204,7 @@ export type ValidProps = object;
 export type ValidShorthand = string | number | boolean;
 
 // @public
-export function withSlots<P>(type: ISlot<P> | React_2.FunctionComponent<P> | string, props?: (React_2.Attributes & P) | null, ...children: React_2.ReactNode[]): ReturnType<React_2.FunctionComponent<P>>;
+export function withSlots<P extends {}>(type: ISlot<P> | React_2.FunctionComponent<P> | string, props?: (React_2.Attributes & P) | null, ...children: React_2.ReactNode[]): ReturnType<React_2.FunctionComponent<P>>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/foundation-legacy/src/slots.tsx
+++ b/packages/foundation-legacy/src/slots.tsx
@@ -33,7 +33,7 @@ import {
  */
 // Can't use typeof on React.createElement since it's overloaded. Approximate createElement's signature for now
 // and widen as needed.
-export function withSlots<P>(
+export function withSlots<P extends {}>(
   type: ISlot<P> | React.FunctionComponent<P> | string,
   props?: (React.Attributes & P) | null,
   ...children: React.ReactNode[]


### PR DESCRIPTION
## Previous Behavior

TypeScript 5 introduced some breaking changes to the way that implicit type coercion happens in templates, as well as a few other breaking changes. Although we don't currently use TypeScript 5.3.3 in the repo, experimental work in the `xplat` branch requires building against TypesScript 5+. There are also customers using TypeScript 5+, who are seeing build errors when importing FluentUI.

## New Behavior

Fix build errors seen if the repo is updated to TypeScript 5.3.3.  This is part of a set of PRs intending to fix all build errors when building against TypeScript 5.3.3.

The fixes in this PR are caused by a breaking change in TS 4.8: [Unconstrained Generics No Longer Assignable to `{}`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#unconstrained-generics-no-longer-assignable-to-).
   * Fixed by adding `extends {}` constraint to template types that previously had no constraint (effectively `extends unknown`). The new constraint disallows `null` and `undefined` as template parameters, which were never valid values for these type parameters anyways.

ℹ️ **Note**: This is NOT updating the project to use TypeScript 5.3.3, and an update to the TypeScript version is not planned as part of this change. It is only fixing build errors that would occur if it were built against TypeScript 5.3.3.

## Related Issue(s)

This PR was split out from a draft PR that contains all of the changes. I'm not going to publish the monolith PR, but in case it helps to see all of the changes in one place:

* https://github.com/microsoft/fluentui/pull/30796

Here are all of the split-out PRs:

* https://github.com/microsoft/fluentui/pull/30806
* https://github.com/microsoft/fluentui/pull/30807
* https://github.com/microsoft/fluentui/pull/30808
* https://github.com/microsoft/fluentui/pull/30809
* https://github.com/microsoft/fluentui/pull/30810
* https://github.com/microsoft/fluentui/pull/30811
* https://github.com/microsoft/fluentui/pull/30812
* https://github.com/microsoft/fluentui/pull/30813
* https://github.com/microsoft/fluentui/pull/30814
* https://github.com/microsoft/fluentui/pull/30815
* https://github.com/microsoft/fluentui/pull/30816
* https://github.com/microsoft/fluentui/pull/30817