### PR TITLE
fix(react-calendar-compat): Fix build errors in TypeScript 5.3.3

### DIFF
--- a/change/@fluentui-react-calendar-compat-7bc02258-da6a-402e-a98a-a46856c95a7f.json
+++ b/change/@fluentui-react-calendar-compat-7bc02258-da6a-402e-a98a-a46856c95a7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Build errors in TypeScript 5.3",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/etc/react-calendar-compat.api.md
+++ b/packages/react-components/react-calendar-compat/etc/react-calendar-compat.api.md
@@ -357,7 +357,7 @@ export interface CalendarYearStyles extends CalendarPickerStyles {
 }
 
 // @public
-export function compareDatePart(date1: Date, date2: Date): Number;
+export function compareDatePart(date1: Date, date2: Date): number;
 
 // @public
 export function compareDates(date1: Date, date2: Date): boolean;

--- a/packages/react-components/react-calendar-compat/src/utils/dateMath/dateMath.ts
+++ b/packages/react-components/react-calendar-compat/src/utils/dateMath/dateMath.ts
@@ -144,7 +144,7 @@ export function compareDates(date1: Date, date2: Date): boolean {
  * @returns A negative value if date1 is earlier than date2, 0 if the dates are equal, or a positive value
  * if date1 is later than date2.
  */
-export function compareDatePart(date1: Date, date2: Date): Number {
+export function compareDatePart(date1: Date, date2: Date): number {
   return getDatePartHashValue(date1) - getDatePartHashValue(date2);
 }
 


### PR DESCRIPTION
## Previous Behavior

TypeScript 5 introduced some breaking changes to the way that implicit type coercion happens in templates, as well as a few other breaking changes. Although we don't currently use TypeScript 5.3.3 in the repo, experimental work in the `xplat` branch requires building against TypesScript 5+. There are also customers using TypeScript 5+, who are seeing build errors when importing FluentUI.

## New Behavior

Fix build errors seen if the repo is updated to TypeScript 5.3.3.  This is part of a set of PRs intending to fix all build errors when building against TypeScript 5.3.3.

The fixes in this PR are caused by a breaking change in TS 5.0: [Forbidden Implicit Coercions in Relational Operators](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#forbidden-implicit-coercions-in-relational-operators) (effectively: can't use `<=`, `>`, etc. between `Number` and `number` values).

ℹ️ **Note**: This is NOT updating the project to use TypeScript 5.3.3, and an update to the TypeScript version is not planned as part of this change. It is only fixing build errors that would occur if it were built against TypeScript 5.3.3.

## Related Issue(s)

This PR was split out from a draft PR that contains all of the changes. I'm not going to publish the monolith PR, but in case it helps to see all of the changes in one place:

* https://github.com/microsoft/fluentui/pull/30796

Here are all of the split-out PRs:

* https://github.com/microsoft/fluentui/pull/30806
* https://github.com/microsoft/fluentui/pull/30807
* https://github.com/microsoft/fluentui/pull/30808
* https://github.com/microsoft/fluentui/pull/30809
* https://github.com/microsoft/fluentui/pull/30810
* https://github.com/microsoft/fluentui/pull/30811
* https://github.com/microsoft/fluentui/pull/30812
* https://github.com/microsoft/fluentui/pull/30813
* https://github.com/microsoft/fluentui/pull/30814
* https://github.com/microsoft/fluentui/pull/30815
* https://github.com/microsoft/fluentui/pull/30816
* https://github.com/microsoft/fluentui/pull/30817