### PR TITLE
fix(react-charting): Fix build errors in TypeScript 5.3.3

### DIFF
--- a/change/@fluentui-react-charting-719b158e-4752-45fd-991d-4e700d135f10.json
+++ b/change/@fluentui-react-charting-719b158e-4752-45fd-991d-4e700d135f10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Build errors in TypeScript 5.3",
+  "packageName": "@fluentui/react-charting",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -1214,9 +1214,9 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
     x: number | Date,
     y: number | Date,
     lineHeight: number,
-    xAxisCalloutData: string,
+    xAxisCalloutData: string | undefined,
     circleId: string,
-    xAxisCalloutAccessibilityData: IAccessibilityProps,
+    xAxisCalloutAccessibilityData: IAccessibilityProps | undefined,
     mouseEvent: React.MouseEvent<SVGElement>,
   ) => {
     mouseEvent.persist();


### PR DESCRIPTION
## Previous Behavior

TypeScript 5 introduced some breaking changes to the way that implicit type coercion happens in templates, as well as a few other breaking changes. Although we don't currently use TypeScript 5.3.3 in the repo, experimental work in the `xplat` branch requires building against TypesScript 5+. There are also customers using TypeScript 5+, who are seeing build errors when importing FluentUI.

## New Behavior

Fix build errors seen if the repo is updated to TypeScript 5.3.3.  This is part of a set of PRs intending to fix all build errors when building against TypeScript 5.3.3.

ℹ️ **Note**: This is NOT updating the project to use TypeScript 5.3.3, and an update to the TypeScript version is not planned as part of this change. It is only fixing build errors that would occur if it were built against TypeScript 5.3.3.

## Related Issue(s)

This PR was split out from a draft PR that contains all of the changes. I'm not going to publish the monolith PR, but in case it helps to see all of the changes in one place:

* https://github.com/microsoft/fluentui/pull/30796

Here are all of the split-out PRs:

* https://github.com/microsoft/fluentui/pull/30806
* https://github.com/microsoft/fluentui/pull/30807
* https://github.com/microsoft/fluentui/pull/30808
* https://github.com/microsoft/fluentui/pull/30809
* https://github.com/microsoft/fluentui/pull/30810
* https://github.com/microsoft/fluentui/pull/30811
* https://github.com/microsoft/fluentui/pull/30812
* https://github.com/microsoft/fluentui/pull/30813
* https://github.com/microsoft/fluentui/pull/30814
* https://github.com/microsoft/fluentui/pull/30815
* https://github.com/microsoft/fluentui/pull/30816
* https://github.com/microsoft/fluentui/pull/30817