### PR TITLE
fix(react-experiments): Fix build errors in TypeScript 5.3.3

### DIFF
--- a/change/@fluentui-react-experiments-8f55aad9-faab-465e-b18d-2aef0e760a72.json
+++ b/change/@fluentui-react-experiments-8f55aad9-faab-465e-b18d-2aef0e760a72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Build errors in TypeScript 5.3",
+  "packageName": "@fluentui/react-experiments",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -17,7 +17,7 @@ export interface IFloatingSuggestionsState {
   didBind: boolean;
 }
 
-export class FloatingSuggestions<TItem>
+export class FloatingSuggestions<TItem extends {}>
   extends React.Component<IFloatingSuggestionsProps<TItem>, IFloatingSuggestionsState>
   implements IFloatingSuggestions<TItem>
 {

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
@@ -53,7 +53,10 @@ export class SuggestionsHeaderFooterItem extends React.Component<ISuggestionsHea
 /**
  * Class when used with SuggestionsStore, renders a suggestions control with customizable headers and footers
  */
-export class SuggestionsControl<T> extends React.Component<ISuggestionsControlProps<T>, ISuggestionsControlState<T>> {
+export class SuggestionsControl<T extends {}> extends React.Component<
+  ISuggestionsControlProps<T>,
+  ISuggestionsControlState<T>
+> {
   private _selectedElement = React.createRef<HTMLDivElement>();
   private _suggestions = React.createRef<SuggestionsCore<T>>();
 

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
@@ -22,7 +22,7 @@ function hasKey<T>(i: T): i is T & { key: string | number } {
 /**
  * Class when used with SuggestionsStore, renders a basic suggestions control
  */
-export class SuggestionsCore<T> extends React.Component<ISuggestionsCoreProps<T>, {}> {
+export class SuggestionsCore<T extends {}> extends React.Component<ISuggestionsCoreProps<T>, {}> {
   public currentIndex: number;
   public currentSuggestion: ISuggestionModel<T> | undefined;
   protected _selectedElement = React.createRef<HTMLDivElement>();

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.view.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.view.tsx
@@ -8,6 +8,7 @@ import { hideInitialsWhenImageIsLoaded } from './propHelpers';
 import PersonaCoinSize10 from './PersonaCoinSize10/PersonaCoinSize10';
 import { PersonaCoinInitials } from './PersonaCoinInitials/PersonaCoinInitials';
 import type { IPersonaCoinComponent, IPersonaCoinProps, IPersonaCoinSlots } from './PersonaCoin.types';
+import { PersonaSize } from '@fluentui/react';
 
 export const PersonaCoinView: IPersonaCoinComponent['view'] = props => {
   const coinSize = props.size || DEFAULT_PERSONA_COIN_SIZE;
@@ -43,7 +44,7 @@ export const PersonaCoinView: IPersonaCoinComponent['view'] = props => {
         imageShouldStartVisible={props.imageShouldStartVisible}
         imageAlt={props.imageAlt}
       />
-      <Slots.presence coinSize={coinSize} size={coinSize} />
+      <Slots.presence coinSize={coinSize} size={coinSize as PersonaSize} />
     </Slots.root>
   );
 };


### PR DESCRIPTION
## Previous Behavior

TypeScript 5 introduced some breaking changes to the way that implicit type coercion happens in templates, as well as a few other breaking changes. Although we don't currently use TypeScript 5.3.3 in the repo, experimental work in the `xplat` branch requires building against TypesScript 5+. There are also customers using TypeScript 5+, who are seeing build errors when importing FluentUI.

## New Behavior

Fix build errors seen if the repo is updated to TypeScript 5.3.3.  This is part of a set of PRs intending to fix all build errors when building against TypeScript 5.3.3.

The fixes in this PR are caused by:
1. Breaking change in TS 4.8: [Unconstrained Generics No Longer Assignable to `{}`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#unconstrained-generics-no-longer-assignable-to-).
   * Fixed by adding `extends {}` constraint to template types that previously had no constraint (effectively `extends unknown`). The new constraint disallows `null` and `undefined` as template parameters, which were never valid values for these type parameters anyways.

ℹ️ **Note**: This is NOT updating the project to use TypeScript 5.3.3, and an update to the TypeScript version is not planned as part of this change. It is only fixing build errors that would occur if it were built against TypeScript 5.3.3.

## Related Issue(s)

This PR was split out from a draft PR that contains all of the changes. I'm not going to publish the monolith PR, but in case it helps to see all of the changes in one place:

* https://github.com/microsoft/fluentui/pull/30796

Here are all of the split-out PRs:

* https://github.com/microsoft/fluentui/pull/30806
* https://github.com/microsoft/fluentui/pull/30807
* https://github.com/microsoft/fluentui/pull/30808
* https://github.com/microsoft/fluentui/pull/30809
* https://github.com/microsoft/fluentui/pull/30810
* https://github.com/microsoft/fluentui/pull/30811
* https://github.com/microsoft/fluentui/pull/30812
* https://github.com/microsoft/fluentui/pull/30813
* https://github.com/microsoft/fluentui/pull/30814
* https://github.com/microsoft/fluentui/pull/30815
* https://github.com/microsoft/fluentui/pull/30816
* https://github.com/microsoft/fluentui/pull/30817