### PR TITLE
fix(web-components): Fix build errors in TypeScript 5.3.3

### DIFF
--- a/change/@fluentui-web-components-ab1b33f6-1996-46e9-8cf1-1640d08c5917.json
+++ b/change/@fluentui-web-components-ab1b33f6-1996-46e9-8cf1-1640d08c5917.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Build errors in TypeScript 5.3",
+  "packageName": "@fluentui/web-components",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/design-system-provider/index.ts
+++ b/packages/web-components/src/design-system-provider/index.ts
@@ -115,7 +115,7 @@ const backgroundStyles = css`
   ),
 );
 
-function designToken<T>(token: DesignToken<T>) {
+function designToken<T extends {}>(token: DesignToken<T>) {
   return (source: DesignSystemProvider, key: string) => {
     source[key + 'Changed'] = function (this: DesignSystemProvider, prev: T | undefined, next: T | undefined) {
       if (next !== undefined && next !== null) {

--- a/packages/web-components/src/design-system-provider/index.ts
+++ b/packages/web-components/src/design-system-provider/index.ts
@@ -115,6 +115,7 @@ const backgroundStyles = css`
   ),
 );
 
+// eslint-disable-next-line @typescript-eslint/ban-types -- Fix TypeScript 5.3 error in backward compatible way
 function designToken<T extends {}>(token: DesignToken<T>) {
   return (source: DesignSystemProvider, key: string) => {
     source[key + 'Changed'] = function (this: DesignSystemProvider, prev: T | undefined, next: T | undefined) {

--- a/packages/web-components/src/design-tokens.ts
+++ b/packages/web-components/src/design-tokens.ts
@@ -44,6 +44,7 @@ export interface InteractiveColorRecipe {
 
 const { create } = DesignToken;
 
+// eslint-disable-next-line @typescript-eslint/ban-types -- Fix TypeScript 5.3 error in backward compatible way
 function createNonCss<T extends {}>(name: string): DesignToken<T> {
   return DesignToken.create<T>({ name, cssCustomPropertyName: null });
 }

--- a/packages/web-components/src/design-tokens.ts
+++ b/packages/web-components/src/design-tokens.ts
@@ -44,7 +44,7 @@ export interface InteractiveColorRecipe {
 
 const { create } = DesignToken;
 
-function createNonCss<T>(name: string): DesignToken<T> {
+function createNonCss<T extends {}>(name: string): DesignToken<T> {
   return DesignToken.create<T>({ name, cssCustomPropertyName: null });
 }
 


### PR DESCRIPTION
## Previous Behavior

TypeScript 5 introduced some breaking changes to the way that implicit type coercion happens in templates, as well as a few other breaking changes. Although we don't currently use TypeScript 5.3.3 in the repo, experimental work in the `xplat` branch requires building against TypesScript 5+. There are also customers using TypeScript 5+, who are seeing build errors when importing FluentUI.

## New Behavior

Fix build errors seen if the repo is updated to TypeScript 5.3.3.  This is part of a set of PRs intending to fix all build errors when building against TypeScript 5.3.3.

The fixes in this PR are all caused by:
1. Breaking change in TS 4.8: [Unconstrained Generics No Longer Assignable to `{}`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#unconstrained-generics-no-longer-assignable-to-).
   * Fixed by adding `extends {}` constraint to template types that previously had no constraint (effectively `extends unknown`). The new constraint disallows `null` and `undefined` as template parameters, which were never valid values for these type parameters anyways.

ℹ️ **Note**: This is NOT updating the project to use TypeScript 5.3.3, and an update to the TypeScript version is not planned as part of this change. It is only fixing build errors that would occur if it were built against TypeScript 5.3.3.

## Related Issue(s)

This PR was split out from a monolith PR that contains all of the changes. I'm not going to publish the monolith PR, but in case it helps to see all of the changes in one place:

* https://github.com/microsoft/fluentui/pull/30796

Here are all of the split-out PRs:

* https://github.com/microsoft/fluentui/pull/30806
* https://github.com/microsoft/fluentui/pull/30807
* https://github.com/microsoft/fluentui/pull/30808
* https://github.com/microsoft/fluentui/pull/30809
* https://github.com/microsoft/fluentui/pull/30810
* https://github.com/microsoft/fluentui/pull/30811
* https://github.com/microsoft/fluentui/pull/30812
* https://github.com/microsoft/fluentui/pull/30813
* https://github.com/microsoft/fluentui/pull/30814
* https://github.com/microsoft/fluentui/pull/30815
* https://github.com/microsoft/fluentui/pull/30816
* https://github.com/microsoft/fluentui/pull/30817