### PR TITLE
chore: update tabster version

### DIFF
--- a/change/@fluentui-react-table-5e2f12f4-f83e-4b35-a272-a56faafc8ab2.json
+++ b/change/@fluentui-react-table-5e2f12f4-f83e-4b35-a272-a56faafc8ab2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update tabster and replace deprecated functions",
+  "packageName": "@fluentui/react-table",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-cf1ead79-b4ff-44af-af80-235dc727a658.json
+++ b/change/@fluentui-react-tabster-cf1ead79-b4ff-44af-af80-235dc727a658.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update tabster version",
+  "packageName": "@fluentui/react-tabster",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
+++ b/packages/react-components/react-table/src/hooks/useTableCompositeNavigation.ts
@@ -9,7 +9,7 @@ import {
   useFocusFinders,
 } from '@fluentui/react-tabster';
 import { isHTMLElement } from '@fluentui/react-utilities';
-import { TabsterTypes, dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent } from '@fluentui/react-tabster';
+import { TabsterTypes, TabsterEvents } from '@fluentui/react-tabster';
 
 export function useTableCompositeNavigation(): {
   onTableKeyDown: React.KeyboardEventHandler;
@@ -61,12 +61,13 @@ export function useTableCompositeNavigation(): {
 
       // Escape groupper focus trap before arrow down
       if ((e.key === ArrowDown || e.key === ArrowUp) && isInCell) {
-        dispatchGroupperMoveFocusEvent(activeElement as HTMLElement, TabsterTypes.GroupperMoveFocusActions.Escape);
+        activeElement.dispatchEvent(
+          new TabsterEvents.GroupperMoveFocusEvent({ action: TabsterTypes.GroupperMoveFocusActions.Escape }),
+        );
 
         activeElement = targetDocument.activeElement;
-
         if (activeElement) {
-          dispatchMoverMoveFocusEvent(activeElement as HTMLElement, TabsterTypes.MoverKeys[e.key]);
+          activeElement.dispatchEvent(new TabsterEvents.MoverMoveFocusEvent({ key: TabsterTypes.MoverKeys[e.key] }));
         }
       }
     },

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -12,6 +12,7 @@ import { KeyborgFocusInEvent } from 'keyborg';
 import { makeResetStyles } from '@griffel/react';
 import * as React_2 from 'react';
 import type { RefObject } from 'react';
+import { Events as TabsterEvents } from 'tabster';
 import { Types as TabsterTypes } from 'tabster';
 
 // @internal (undocumented)
@@ -59,6 +60,8 @@ export { KeyborgFocusInEvent }
 
 // @public (undocumented)
 export type TabsterDOMAttribute = TabsterTypes.TabsterDOMAttribute;
+
+export { TabsterEvents }
 
 export { TabsterTypes }
 

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -37,7 +37,7 @@
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",
     "keyborg": "^2.5.0",
-    "tabster": "^6.0.1"
+    "tabster": "^7.0.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -45,5 +45,11 @@ export type { KeyborgFocusInEvent } from 'keyborg';
 export { KEYBORG_FOCUSIN } from 'keyborg';
 
 // @internal (undocumented)
-// eslint-disable-next-line deprecation/deprecation
-export { TabsterTypes, TabsterEvents, dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent };
+export {
+  TabsterTypes,
+  TabsterEvents,
+  // eslint-disable-next-line deprecation/deprecation
+  dispatchGroupperMoveFocusEvent,
+  // eslint-disable-next-line deprecation/deprecation
+  dispatchMoverMoveFocusEvent,
+};

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -32,7 +32,12 @@ export type {
 } from './focus/index';
 
 export { applyFocusVisiblePolyfill } from './focus/index';
-import { Types as TabsterTypes, dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent } from 'tabster';
+import {
+  Types as TabsterTypes,
+  Events as TabsterEvents,
+  dispatchGroupperMoveFocusEvent,
+  dispatchMoverMoveFocusEvent,
+} from 'tabster';
 
 export type TabsterDOMAttribute = TabsterTypes.TabsterDOMAttribute;
 
@@ -40,4 +45,5 @@ export type { KeyborgFocusInEvent } from 'keyborg';
 export { KEYBORG_FOCUSIN } from 'keyborg';
 
 // @internal (undocumented)
-export { TabsterTypes, dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent };
+// eslint-disable-next-line deprecation/deprecation
+export { TabsterTypes, TabsterEvents, dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent };

--- a/yarn.lock
+++ b/yarn.lock
@@ -22891,10 +22891,10 @@ table@^6.0.4, table@^6.0.7:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-6.0.1.tgz#192607dce2789236c5f219b0550921af3141e91b"
-  integrity sha512-cNVYkJmQZ76IvdW7laCuUns9XcAGzscmDkZ0T4JY3huCRsacidBNOa7MJu2+ocW7UKR8xOxeER6OdBsmX1l5XQ==
+tabster@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-7.0.1.tgz#ddddaea1991c513e62921dd8ad53d2a587539b68"
+  integrity sha512-KbaNvh21G0bUOzfmJgwTieq5dnYQXaJsjiskLioElX4FSkHWrL2fmyZqlWWq+3BgSiSx3eZun1/nSGdcuhRz8g==
   dependencies:
     keyborg "2.5.0"
     tslib "^2.3.1"


### PR DESCRIPTION
Updates the version of tabster used in react-tabster to the latest. Needed for Fluent AI behavior & v9 fixes.