### PR TITLE
feat: Adds Tabster to Nav

### DIFF
--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
@@ -15,7 +15,8 @@ import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
  */
 export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTMLDivElement>): NavDrawerState => {
   const focusAttributes = useArrowNavigationGroup({ axis: 'vertical', circular: true });
-  const baseDrawerState = useInlineDrawer_unstable(
+  const baseDrawerState = useInlineDrawer_unstable(props, ref);
+  const navState = useNav_unstable(
     {
       role: 'navigation',
       as: 'div',
@@ -24,10 +25,9 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     },
     ref,
   );
-  const navState = useNav_unstable(props, ref);
 
   return {
-    ...navState,
     ...baseDrawerState,
+    ...navState,
   };
 };

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useInlineDrawer_unstable } from '@fluentui/react-drawer';
 import { useNav_unstable } from '../Nav/useNav';
 import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
+import { getIntrinsicElementProps, slot, useMergedRefs } from '@fluentui/react-utilities';
+import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 
 /**
  * Create the state required to render NavDrawer.
@@ -13,11 +15,20 @@ import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
  * @param ref - reference to root HTMLDivElement of NavDrawer
  */
 export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTMLDivElement>): NavDrawerState => {
-  const inlineDrawerState = useInlineDrawer_unstable(props, ref);
+  const focusAttributes = useArrowNavigationGroup({ axis: 'vertical', circular: true });
+  const baseDrawerState = useInlineDrawer_unstable(
+    {
+      role: 'navigation',
+      as: 'div',
+      ...focusAttributes,
+      ...props,
+    },
+    ref,
+  );
   const navState = useNav_unstable(props, ref);
 
   return {
-    ...inlineDrawerState,
     ...navState,
+    ...baseDrawerState,
   };
 };

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
@@ -19,7 +19,6 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
   const navState = useNav_unstable(
     {
       role: 'navigation',
-      as: 'div',
       ...focusAttributes,
       ...props,
     },
@@ -31,3 +30,4 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     ...navState,
   };
 };
+3;

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { useInlineDrawer_unstable } from '@fluentui/react-drawer';
+import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { useNav_unstable } from '../Nav/useNav';
 import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
-import { getIntrinsicElementProps, slot, useMergedRefs } from '@fluentui/react-utilities';
-import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 
 /**
  * Create the state required to render NavDrawer.

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -28,23 +28,41 @@ export const Default = (props: Partial<NavDrawerProps>) => {
     <div className={styles.root}>
       <NavDrawer defaultSelectedValue={'10'} defaultSelectedCategoryValue={'8'} size="small" open={true}>
         <DrawerBody>
-          <NavItem value="1">First</NavItem>
-          <NavItem value="2">Second</NavItem>
-          <NavItem value="3">Third</NavItem>
+          <NavItem href="https://www.bing.com/" value="1">
+            First
+          </NavItem>
+          <NavItem href="https://www.bing.com/" value="2">
+            Second
+          </NavItem>
+          <NavItem href="https://www.bing.com/" value="3">
+            Third
+          </NavItem>
           <NavCategory value="4">
             <NavCategoryItem>NavCategoryItem 1</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem value="5">Five</NavSubItem>
-              <NavSubItem value="6">Six</NavSubItem>
-              <NavSubItem value="7">Seven</NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="5">
+                Five
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="6">
+                Six
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="7">
+                Seven
+              </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>
           <NavCategory value="8">
             <NavCategoryItem>NavCategoryItem2</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem value="9">Nine</NavSubItem>
-              <NavSubItem value="10">Ten</NavSubItem>
-              <NavSubItem value="11">Eleven</NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="9">
+                Nine
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="10">
+                Ten
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="11">
+                Eleven
+              </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>
         </DrawerBody>


### PR DESCRIPTION
The Nav is likely to have at least 10 items in it, which is too many to expect a keyboard user to tab through before getting to the main content area of the page.

This PR adds tabster with a few defaults of circular and vertical.

Will consumers be able to elegantly disagree with these defaults?

https://github.com/microsoft/fluentui/assets/17346018/f242647a-a2b2-4042-ba88-fdd73bdda833

Chips away at #26649 
