### PR TITLE
fix(xplat): Fix FluentProvider, don't render style tag on native

### DIFF
--- a/packages/react-components/react-platform-adapter-preview/etc/react-platform-adapter-preview.api.md
+++ b/packages/react-components/react-platform-adapter-preview/etc/react-platform-adapter-preview.api.md
@@ -21,6 +21,9 @@ export const getStylesFromClassName: (className: string) => {
 }[];
 
 // @public (undocumented)
+export const isReactNative: () => boolean;
+
+// @public (undocumented)
 export const jsxPlatformAdapter: (reactJsx: JSXRuntime) => JSXRuntime;
 
 // @public (undocumented)

--- a/packages/react-components/react-platform-adapter-preview/etc/react-platform-adapter-preview.api.md
+++ b/packages/react-components/react-platform-adapter-preview/etc/react-platform-adapter-preview.api.md
@@ -21,7 +21,7 @@ export const getStylesFromClassName: (className: string) => {
 }[];
 
 // @public (undocumented)
-export const isReactNative: () => boolean;
+export const isReactNative: boolean;
 
 // @public (undocumented)
 export const jsxPlatformAdapter: (reactJsx: JSXRuntime) => JSXRuntime;

--- a/packages/react-components/react-platform-adapter-preview/src/index.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/index.ts
@@ -6,6 +6,7 @@ export { makeResetStyles } from './styling/makeResetStyles';
 export { makeStyles } from './styling/makeStyles';
 export { mergeClasses } from './styling/mergeClasses';
 export { shorthands } from './styling/shorthands';
+export { isReactNative } from './utilities/isReactNative';
 
 // re-export some griffel types to have fluent use the griffel adapter instead of griffel directly
 export { useRenderer_unstable, TextDirectionProvider } from '@griffel/react';

--- a/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.native.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.native.ts
@@ -1,1 +1,1 @@
-export const isReactNative = () => true;
+export const isReactNative = true;

--- a/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.native.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.native.ts
@@ -1,1 +1,1 @@
-export const isReactNative = true;
+export const isReactNative: boolean = true;

--- a/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.native.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.native.ts
@@ -1,0 +1,1 @@
+export const isReactNative = () => true;

--- a/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.ts
@@ -1,1 +1,1 @@
-export const isReactNative = () => false;
+export const isReactNative = false;

--- a/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.ts
@@ -1,0 +1,1 @@
+export const isReactNative = () => false;

--- a/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/utilities/isReactNative.ts
@@ -1,1 +1,1 @@
-export const isReactNative = false;
+export const isReactNative: boolean = false;

--- a/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
@@ -13,7 +13,7 @@ import {
 } from '@fluentui/react-shared-contexts';
 import type { FluentProviderContextValues, FluentProviderState, FluentProviderSlots } from './FluentProvider.types';
 import { IconDirectionContextProvider } from '@fluentui/react-icons';
-import { XPlatProvider } from '@fluentui/react-platform-adapter-preview';
+import { isReactNative, XPlatProvider } from '@fluentui/react-platform-adapter-preview';
 
 /**
  * Render the final JSX of FluentProvider
@@ -41,7 +41,7 @@ export const renderFluentProvider_unstable = (
                   <IconDirectionContextProvider value={contextValues.iconDirection}>
                     <OverridesProvider value={contextValues.overrides_unstable}>
                       <state.root>
-                        {canUseDOM() ? null : (
+                        {canUseDOM() || isReactNative() ? null : (
                           <style
                             // Using dangerous HTML because react can escape characters
                             // which can lead to invalid CSS.

--- a/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
+++ b/packages/react-components/react-provider/src/components/FluentProvider/renderFluentProvider.tsx
@@ -41,7 +41,7 @@ export const renderFluentProvider_unstable = (
                   <IconDirectionContextProvider value={contextValues.iconDirection}>
                     <OverridesProvider value={contextValues.overrides_unstable}>
                       <state.root>
-                        {canUseDOM() || isReactNative() ? null : (
+                        {canUseDOM() || isReactNative ? null : (
                           <style
                             // Using dangerous HTML because react can escape characters
                             // which can lead to invalid CSS.


### PR DESCRIPTION
ℹ️ Note: This being merged into the `xplat` branch, not `master`.

## Previous Behavior

FluentProvider renders a `<style>` tag when rendering in SSR for web. The `canUseDOM()` function to detect this case was incorrectly returning false for react native.

## New Behavior

Add a `isReactNative()` function to explicitly check if on React Native. Update FluentProvider to not render a `<style>` tag on native.
