### PR TITLE
TeachingPopover: Carousel Arrow Navigation

### DIFF
--- a/change/@fluentui-react-teaching-popover-preview-a56f299e-1e8f-44bc-8435-7708cf4fd4e5.json
+++ b/change/@fluentui-react-teaching-popover-preview-a56f299e-1e8f-44bc-8435-7708cf4fd4e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Enable arrow navigation on nav group",
+  "packageName": "@fluentui/react-teaching-popover-preview",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover-preview/package.json
+++ b/packages/react-components/react-teaching-popover-preview/package.json
@@ -47,7 +47,8 @@
     "@fluentui/react-tabster": "^9.19.5",
     "@fluentui/react-icons": "^2.0.224",
     "@fluentui/react-aria": "^9.10.2",
-    "@fluentui/react-context-selector": "^9.1.56"
+    "@fluentui/react-context-selector": "^9.1.56",
+    "@fluentui/keyboard-keys": "^9.0.7"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <19.0.0",

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -9,7 +9,6 @@ import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from '@fluentui/keyboard-ke
 import { useFocusableGroup } from '@fluentui/react-tabster';
 import { TeachingPopoverCarouselNavButton } from '../TeachingPopoverCarouselNavButton/index';
 import { useTeachingPopoverCarouselContext_unstable } from '../TeachingPopoverCarousel/TeachingPopoverCarouselContext';
-import { useRef } from 'react';
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  getIntrinsicElementProps,
-  mergeCallbacks,
-  slot,
-  useEventCallback,
-  useMergedRefs,
-} from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from '@fluentui/react-utilities';
 import type {
   TeachingPopoverCarouselNavProps,
   TeachingPopoverCarouselNavState,
@@ -29,8 +23,6 @@ export const useTeachingPopoverCarouselNav_unstable = (
   const totalPages = useTeachingPopoverCarouselContext_unstable(context => context.totalPages);
   const currentPage = useTeachingPopoverCarouselContext_unstable(context => context.currentPage);
   const setCurrentPage = useTeachingPopoverCarouselContext_unstable(context => context.setCurrentPage);
-
-  const localRef = useMergedRefs(ref);
 
   let handleKeyDown = useEventCallback((ev: React.KeyboardEvent<HTMLDivElement>) => {
     if (ev.isDefaultPrevented()) {
@@ -72,7 +64,7 @@ export const useTeachingPopoverCarouselNav_unstable = (
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        ref: localRef,
+        ref,
         role: 'tablist',
         tabIndex: 0,
         ...props,

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from '@fluentui/react-utilities';
 import type {
   TeachingPopoverCarouselNavProps,
   TeachingPopoverCarouselNavState,
 } from './TeachingPopoverCarouselNav.types';
+import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from '@fluentui/keyboard-keys';
 
 import { useFocusableGroup } from '@fluentui/react-tabster';
 import { TeachingPopoverCarouselNavButton } from '../TeachingPopoverCarouselNavButton/index';
 import { useTeachingPopoverCarouselContext_unstable } from '../TeachingPopoverCarousel/TeachingPopoverCarouselContext';
+import { useRef } from 'react';
 
 /**
  * Returns the props and state required to render the component
@@ -21,6 +23,31 @@ export const useTeachingPopoverCarouselNav_unstable = (
   const focusableGroupAttr = useFocusableGroup({ tabBehavior: 'limited' });
   const totalPages = useTeachingPopoverCarouselContext_unstable(context => context.totalPages);
   const currentPage = useTeachingPopoverCarouselContext_unstable(context => context.currentPage);
+  const setCurrentPage = useTeachingPopoverCarouselContext_unstable(context => context.setCurrentPage);
+
+  let handleKeyDown = useEventCallback((ev: React.KeyboardEvent<HTMLDivElement>) => {
+    props.onKeyDown?.(ev);
+
+    if (ev.isDefaultPrevented()) {
+      return;
+    }
+
+    const key = ev.key;
+
+    if (key === ArrowUp || key === ArrowLeft) {
+      let prevPage = Math.max(0, currentPage - 1);
+      setCurrentPage(prevPage);
+    }
+
+    if (key === ArrowDown || key === ArrowRight) {
+      let nextPage = Math.min(totalPages - 1, currentPage + 1);
+      setCurrentPage(nextPage);
+    }
+  });
+
+  if (props.onKeyDown) {
+    handleKeyDown = mergeCallbacks(handleKeyDown, props.onKeyDown);
+  }
 
   // Generate the child TeachingPopoverCarouselNavButton and memoize them to prevent unnecessary re-rendering
   const rootChildren = React.useMemo(() => {
@@ -40,6 +67,7 @@ export const useTeachingPopoverCarouselNav_unstable = (
         tabIndex: 0,
         ...props,
         children: rootChildren,
+        onKeyDown: handleKeyDown,
         ...focusableGroupAttr,
       }),
       { elementType: 'div' },

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -25,28 +25,25 @@ export const useTeachingPopoverCarouselNav_unstable = (
   const setCurrentPage = useTeachingPopoverCarouselContext_unstable(context => context.setCurrentPage);
 
   let handleKeyDown = useEventCallback((ev: React.KeyboardEvent<HTMLDivElement>) => {
-    props.onKeyDown?.(ev);
-
     if (ev.isDefaultPrevented()) {
       return;
     }
 
     const key = ev.key;
+    let _currentPage = currentPage;
 
     if (key === ArrowUp || key === ArrowLeft) {
-      let prevPage = Math.max(0, currentPage - 1);
-      setCurrentPage(prevPage);
+      _currentPage = Math.max(0, currentPage - 1);
+    } else if (key === ArrowDown || key === ArrowRight) {
+      _currentPage = Math.min(totalPages - 1, currentPage + 1);
     }
 
-    if (key === ArrowDown || key === ArrowRight) {
-      let nextPage = Math.min(totalPages - 1, currentPage + 1);
-      setCurrentPage(nextPage);
+    if (_currentPage !== currentPage) {
+      setCurrentPage(_currentPage);
     }
   });
 
-  if (props.onKeyDown) {
-    handleKeyDown = mergeCallbacks(handleKeyDown, props.onKeyDown);
-  }
+  handleKeyDown = mergeCallbacks(handleKeyDown, props.onKeyDown);
 
   // Generate the child TeachingPopoverCarouselNavButton and memoize them to prevent unnecessary re-rendering
   const rootChildren = React.useMemo(() => {

--- a/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover-preview/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from '@fluentui/react-utilities';
+import {
+  getIntrinsicElementProps,
+  mergeCallbacks,
+  slot,
+  useEventCallback,
+  useMergedRefs,
+} from '@fluentui/react-utilities';
 import type {
   TeachingPopoverCarouselNavProps,
   TeachingPopoverCarouselNavState,
@@ -24,8 +30,16 @@ export const useTeachingPopoverCarouselNav_unstable = (
   const currentPage = useTeachingPopoverCarouselContext_unstable(context => context.currentPage);
   const setCurrentPage = useTeachingPopoverCarouselContext_unstable(context => context.setCurrentPage);
 
+  const localRef = useMergedRefs(ref);
+
   let handleKeyDown = useEventCallback((ev: React.KeyboardEvent<HTMLDivElement>) => {
     if (ev.isDefaultPrevented()) {
+      return;
+    }
+
+    let target = ev.target as HTMLDivElement;
+    // We only want this enabled at the tablist level, not within
+    if (target.role !== 'tablist') {
       return;
     }
 
@@ -58,7 +72,7 @@ export const useTeachingPopoverCarouselNav_unstable = (
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        ref,
+        ref: localRef,
         role: 'tablist',
         tabIndex: 0,
         ...props,


### PR DESCRIPTION
## Previous Behavior
Nav group was tabbable group only

## New Behavior
Nav group is still a tab list group (tabster) but it also now enables arrow key exploration.

## Related Issue(s)
TeachingPopover bug bash feature request
