### PR TITLE
Revert "fix: Input should start with undefined, same as textarea"

### DIFF
--- a/change/@fluentui-react-input-459f0da7-7e7d-4673-b9d6-e81e93766f2c.json
+++ b/change/@fluentui-react-input-459f0da7-7e7d-4673-b9d6-e81e93766f2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert #30845 \"fix: Input should start with undefined, same as textarea\"",
+  "packageName": "@fluentui/react-input",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/src/components/Input/Input.test.tsx
+++ b/packages/react-components/react-input/src/components/Input/Input.test.tsx
@@ -12,6 +12,7 @@ describe('Input', () => {
   let renderedComponent: RenderResult | undefined;
 
   afterEach(() => {
+    jest.clearAllMocks();
     if (renderedComponent) {
       renderedComponent.unmount();
       renderedComponent = undefined;
@@ -115,5 +116,16 @@ describe('Input', () => {
     expect(input.getAttribute('aria-describedby')).toEqual(message.id);
     expect(input.getAttribute('aria-invalid')).toEqual('true');
     expect(input.required).toBe(true);
+  });
+
+  it('does not emit error when uncontrolled', () => {
+    const spy = jest.spyOn(console, 'error');
+    renderedComponent = render(<Input />);
+
+    const input = renderedComponent.getByRole('textbox') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'foo' } });
+    expect(input.value).toBe('foo');
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/react-input/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/src/components/Input/useInput.ts
@@ -34,7 +34,7 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
   const [value, setValue] = useControllableState({
     state: props.value,
     defaultState: props.defaultValue,
-    initialState: undefined,
+    initialState: '',
   });
 
   const nativeProps = getPartitionedNativeProps({


### PR DESCRIPTION
Reverts microsoft/fluentui#30534

The initial value of the input's controllable state is explicitly an empty string since we pass the `value` in to the native rendered `<input />` always. After the above PR an uncontrolled `Input` component _**always**_ renders a react warning because any user input will output this error in non-production environments

This is a blocking issue for any user who consumes this change and has test failures on console.error. Here's a screen recording 

![input error](https://github.com/microsoft/fluentui/assets/20744592/f1a7e807-5ecc-4e1c-aee1-6d405aaf8107)

If an `undefined` value is necessary as an initial value then we should create an issue to track since the change in non-trivial. We _**always**_ pass the `value` to intrinsic `input` elements and that would need to change first.
