### PR TITLE
fix: End key should move activeOption in Combobox & related controls

### DIFF
--- a/change/@fluentui-react-aria-d78c8463-7fd5-4354-b184-3f71f64bd3ed.json
+++ b/change/@fluentui-react-aria-d78c8463-7fd5-4354-b184-3f71f64bd3ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: End key should move activeOption ",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-c3631462-01cd-4e7c-be6a-98696c644bf6.json
+++ b/change/@fluentui-react-combobox-c3631462-01cd-4e7c-be6a-98696c644bf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: End key should move activeOption",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
+++ b/packages/react-components/react-aria/src/activedescendant/useOptionWalker.ts
@@ -50,6 +50,7 @@ export function useOptionWalker<TListboxElement extends HTMLElement>(options: Us
           return null;
         }
 
+        treeWalkerRef.current.currentNode = listboxRef.current;
         return treeWalkerRef.current.lastChild() as HTMLElement | null;
       },
       next: () => {

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -837,6 +837,62 @@ describe('Combobox', () => {
     expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Green').id);
   });
 
+  it('should move active option with home and end', () => {
+    const { getByTestId, getByText } = render(
+      <Combobox open data-testid="combobox">
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>,
+    );
+
+    const combobox = getByTestId('combobox');
+
+    userEvent.click(getByText('Green'));
+    userEvent.keyboard('{End}');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Blue').id);
+
+    userEvent.keyboard('{Home}');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Red').id);
+  });
+
+  it('should move active option with page up and page down', () => {
+    const { getByTestId, getByText } = render(
+      <Combobox open data-testid="combobox">
+        <Option>Aqua</Option>
+        <Option>Black</Option>
+        <Option>Blue</Option>
+        <Option>Brown</Option>
+        <Option>Green</Option>
+        <Option>Grey</Option>
+        <Option>Gold</Option>
+        <Option>Indigo</Option>
+        <Option>Orange</Option>
+        <Option>Pink</Option>
+        <Option>Purple</Option>
+        <Option>Red</Option>
+        <Option>Violet</Option>
+        <Option>White</Option>
+        <Option>Yellow</Option>
+      </Combobox>,
+    );
+
+    const combobox = getByTestId('combobox');
+
+    userEvent.click(getByText('Aqua'));
+    userEvent.keyboard('{PageDown}');
+
+    // should move forward 10
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Purple').id);
+
+    userEvent.keyboard('{ArrowDown}');
+    userEvent.keyboard('{PageUp}');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Black').id);
+  });
+
   it('should move active option based on typing', () => {
     const { getByTestId, getByText } = render(
       <Combobox open data-testid="combobox">

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -893,6 +893,31 @@ describe('Combobox', () => {
     expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Black').id);
   });
 
+  it('should move active option with page up and page down with less than 10 options', () => {
+    const { getByTestId, getByText } = render(
+      <Combobox open data-testid="combobox">
+        <Option>Aqua</Option>
+        <Option>Black</Option>
+        <Option>Blue</Option>
+        <Option>Brown</Option>
+        <Option>Green</Option>
+      </Combobox>,
+    );
+
+    const combobox = getByTestId('combobox');
+
+    userEvent.click(getByText('Aqua'));
+    userEvent.keyboard('{PageDown}');
+
+    // should move forward to last option if there are less than 10 options
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Green').id);
+
+    userEvent.keyboard('{ArrowDown}');
+    userEvent.keyboard('{PageUp}');
+
+    expect(combobox.getAttribute('aria-activedescendant')).toEqual(getByText('Aqua').id);
+  });
+
   it('should move active option based on typing', () => {
     const { getByTestId, getByText } = render(
       <Combobox open data-testid="combobox">

--- a/packages/react-components/react-combobox/src/utils/useTriggerSlot.ts
+++ b/packages/react-components/react-combobox/src/utils/useTriggerSlot.ts
@@ -106,6 +106,10 @@ function useTriggerKeydown(
     activeDescendantController.first();
   };
 
+  const last = () => {
+    activeDescendantController.last();
+  };
+
   const next = (activeOption: OptionValue | undefined) => {
     if (activeOption) {
       activeDescendantController.next();
@@ -141,6 +145,7 @@ function useTriggerKeydown(
 
     switch (action) {
       case 'First':
+      case 'Last':
       case 'Next':
       case 'Previous':
       case 'PageDown':
@@ -158,6 +163,9 @@ function useTriggerKeydown(
     switch (action) {
       case 'First':
         first();
+        break;
+      case 'Last':
+        last();
         break;
       case 'Next':
         next(activeOption);


### PR DESCRIPTION
## Previous Behavior

`last()` wasn't implemented in Combobox, and there was a bug in the `useOptionWalker` logic, so the End key didn't correctly move the active option.

## New Behavior

It works now, and added tests.

## Related Issue(s)

- Fixes an ADO a11y bug
