### PR TITLE
fix: remove border from high contrast mode to make focus more visible

### DIFF
--- a/change/@fluentui-react-accordion-7cc895ca-0a54-47c7-bbf4-7ca1d1553d65.json
+++ b/change/@fluentui-react-accordion-7cc895ca-0a54-47c7-bbf4-7ca1d1553d65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove border from high contrast mode to match styles and make focus more visible",
+  "packageName": "@fluentui/react-accordion",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
+++ b/packages/react-components/react-accordion/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
@@ -42,7 +42,7 @@ const useStyles = makeStyles({
   button: {
     position: 'relative',
     width: '100%',
-    ...shorthands.border('1px', 'solid', 'transparent'),
+    ...shorthands.borderWidth('0'),
     ...shorthands.padding(0, tokens.spacingHorizontalM, 0, tokens.spacingHorizontalMNudge),
     minHeight: '44px',
     display: 'flex',


### PR DESCRIPTION
## Previous Behavior

There was a transparent border on the AccordionHeader button, which showed up in high contrast mode (since the transparent color is overridden). This made the focus outline barely visible (second item is focused):

![screenshot of the docs accordion example in high contrast dark mode, with a slight difference in the outline of the second item](https://github.com/microsoft/fluentui/assets/3819570/2916c9e2-4e2f-42fd-9a2a-9e46217381a5)

## New Behavior

There is no 1px border, so the focus outline in HCM is clearly visible, and the accordion styles match the appearance outside of forced-colors mode. This doesn't change the accordion height, since it already has a `44px` height style.

![screenshot of the same example, with no borders around accordions and a clearly visible focus outline](https://github.com/microsoft/fluentui/assets/3819570/18409540-4b64-4d88-a198-018b07c1c760)

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18624)
