### PR TITLE
Tiny spelling fix in Slots.stories.mdx

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Slots/Slots.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Slots/Slots.stories.mdx
@@ -54,7 +54,7 @@ Later in this topic, you will find examples covering each of these scenarios.
 Some components conditionally render slots.
 
 For example, Avatar has a `label` slot that only renders when there is no image provided.
-t also defines an `icon` slot that only renders when neither an image nor a name are provided.
+It also defines an `icon` slot that only renders when neither an image nor a name are provided.
 
 ### What about children?
 


### PR DESCRIPTION
Correct spelling in docs

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

No changes to behavior.   Small spelling fix.

<!-- This is the behavior we have today -->

## New Behavior

None

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Not Applicable