### PR TITLE
fix(deps): fix dependencies post merge commit

### DIFF
--- a/apps/xplat-v9/README.md
+++ b/apps/xplat-v9/README.md
@@ -77,3 +77,5 @@ npx yarn-deduplicate --strategy fewer
 yarn install
 
 ```
+
+After doing so, before commiting any post-merge-commit fixes, make sure to also run `npx syncpack list-mismatches`. It is likely that the `xplat` branch is going to be somewhat out of sync with other changes from core, so make sure to address them before proceeding. Here's an example of a PR doing so.

--- a/packages/react-components/babel-preset-global-context/package.json
+++ b/packages/react-components/babel-preset-global-context/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/core": "^7.10.4",
     "@babel/generator": "^7.12.13",
-    "@babel/types": "7.23.6",
+    "@babel/types": "7.24.0",
     "@babel/helper-plugin-utils": "^7.12.13",
     "@babel/template": "^7.12.13",
     "@babel/traverse": "^7.12.13",

--- a/packages/react-components/react-platform-adapter-preview/package.json
+++ b/packages/react-components/react-platform-adapter-preview/package.json
@@ -34,9 +34,9 @@
     "@stylexjs/stylex": "^0.5.1"
   },
   "dependencies": {
-    "@fluentui/react-shared-contexts": "^9.15.0",
-    "@fluentui/react-theme": "^9.1.17",
-    "@fluentui/react-utilities": "^9.18.3",
+    "@fluentui/react-shared-contexts": "^9.15.2",
+    "@fluentui/react-theme": "^9.1.19",
+    "@fluentui/react-utilities": "^9.18.5",
     "@griffel/core": "^1.14.1",
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,15 +1542,6 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.6.tgz#be33fdb151e1f5a56877d704492c240fc71c7ccd"
-  integrity sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==
-  dependencies:
-    "@babel/helper-string-parser" "^7.23.4"
-    "@babel/helper-validator-identifier" "^7.22.20"
-    to-fast-properties "^2.0.0"
-
 "@babel/types@7.24.0", "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.4", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.20.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.24.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"


### PR DESCRIPTION
ℹ️ Note: This is being merged into the `xplat` branch, not `master`

## Previous Behavior

After the latest merge-commit, some dependencies went out of sync and syncpack started ❌

This PR addressed that, accounting for recent changes from these commits:
* https://github.com/microsoft/fluentui/commit/6a3e6bbbf140f0b87f1fe98a8b27fd813c16aec2
* https://github.com/microsoft/fluentui/commit/d785f27214ba60429d6273db31872fabe56916d5

This is necessary 'cause `react-platform-adapter-preview` is not present in `main` branch and the babel types in `babel-preset-global-context` were added in this `xplat`-only [commit](https://github.com/microsoft/fluentui/commit/756b683a1f6d4520c3d20a0582bfb14864459d1d).

## New Behavior

syncpack is green again.

And added a note to the Readme of xplat-v9 about this part of the keeping up with main branch process.

## Related Issue(s)

N/A
