### PR TITLE
chore(react-tag-picker): code clean-up

### DIFF
--- a/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
+++ b/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
@@ -19,7 +19,6 @@ import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { Listbox } from '@fluentui/react-combobox';
 import type { ListboxContextValue } from '@fluentui/react-combobox';
-import { OptionProps } from '@fluentui/react-combobox';
 import { OptionSlots } from '@fluentui/react-combobox';
 import { OptionState } from '@fluentui/react-combobox';
 import { PortalProps } from '@fluentui/react-portal';
@@ -165,23 +164,24 @@ export const TagPickerOption: ForwardRefComponent<TagPickerOptionProps>;
 export const tagPickerOptionClassNames: SlotClassNames<TagPickerOptionSlots>;
 
 // @public
-export type TagPickerOptionProps = ComponentProps<TagPickerOptionSlots> & Omit<OptionProps, 'checkIcon' | 'disabled'> & {
+export type TagPickerOptionProps = ComponentProps<TagPickerOptionSlots> & {
     children: React_2.ReactNode;
     text?: string;
     value: string;
 };
 
 // @public (undocumented)
-export type TagPickerOptionSlots = Omit<OptionSlots, 'checkIcon'> & {
+export type TagPickerOptionSlots = Pick<OptionSlots, 'root'> & {
     media?: Slot<'div'>;
     secondaryContent?: Slot<'span'>;
 };
 
 // @public
-export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Omit<OptionState, 'checkIcon'>;
+export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Pick<OptionState, 'components' | 'multiselect' | 'root' | 'selected'>;
 
 // @public
-export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps, 'positioning' | 'disabled'> & Pick<Partial<TagPickerContextValue>, 'size' | 'selectedOptions' | 'appearance'> & {
+export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps, 'positioning' | 'disabled' | 'defaultOpen' | 'selectedOptions' | 'defaultSelectedOptions' | 'open'> & Pick<Partial<TagPickerContextValue>, 'size' | 'appearance'> & {
+    onOpenChange?: EventHandler<TagPickerOnOpenChangeData>;
     onOptionSelect?: EventHandler<TagPickerOnOptionSelectData>;
     children: [JSX.Element, JSX.Element] | JSX.Element;
 };
@@ -190,8 +190,7 @@ export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps
 export type TagPickerSlots = {};
 
 // @public
-export type TagPickerState = ComponentState<TagPickerSlots> & Omit<ComboboxState, 'listbox' | 'root' | 'input' | 'expandIcon' | 'clearIcon' | 'components' | 'size'> & Pick<TagPickerContextValue, 'triggerRef' | 'secondaryActionRef' | 'popoverId' | 'popoverRef' | 'targetRef' | 'size' | 'disabled'> & {
-    positioning?: PositioningShorthand;
+export type TagPickerState = ComponentState<TagPickerSlots> & Pick<ComboboxState, 'open' | 'activeDescendantController' | 'mountNode' | 'onOptionClick' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'multiselect' | 'value' | 'setValue' | 'setOpen' | 'setHasFocus' | 'appearance' | 'clearSelection' | 'getOptionById'> & Pick<TagPickerContextValue, 'triggerRef' | 'secondaryActionRef' | 'popoverId' | 'popoverRef' | 'targetRef' | 'size' | 'disabled'> & {
     trigger: React_2.ReactNode;
     popover?: React_2.ReactNode;
 };

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.types.ts
@@ -1,7 +1,6 @@
 import type * as React from 'react';
 import type { ComponentProps, ComponentState, EventData, EventHandler } from '@fluentui/react-utilities';
 import type { ComboboxProps, ComboboxState, ListboxContextValue } from '@fluentui/react-combobox';
-import type { PositioningShorthand } from '@fluentui/react-positioning';
 import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
 import type { ActiveDescendantContextValue } from '@fluentui/react-aria';
 
@@ -23,13 +22,24 @@ export type TagPickerOnOptionSelectData = {
   | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>
 );
 
+export type TagPickerOnOpenChangeData = { open: boolean } & (
+  | EventData<'click', React.MouseEvent<HTMLDivElement>>
+  | EventData<'change', React.ChangeEvent<HTMLDivElement>>
+  | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>
+);
+
 /**
  * Picker Props
  */
 export type TagPickerProps = ComponentProps<TagPickerSlots> &
-  Pick<ComboboxProps, 'positioning' | 'disabled'> &
-  Pick<Partial<TagPickerContextValue>, 'size' | 'selectedOptions' | 'appearance'> & {
+  Pick<
+    ComboboxProps,
+    'positioning' | 'disabled' | 'defaultOpen' | 'selectedOptions' | 'defaultSelectedOptions' | 'open'
+  > &
+  Pick<Partial<TagPickerContextValue>, 'size' | 'appearance'> & {
+    onOpenChange?: EventHandler<TagPickerOnOpenChangeData>;
     onOptionSelect?: EventHandler<TagPickerOnOptionSelectData>;
+
     /**
      * Can contain two children including a trigger and a popover
      */
@@ -38,21 +48,31 @@ export type TagPickerProps = ComponentProps<TagPickerSlots> &
 
 /**
  * State used in rendering Picker
- * TODO: only pick from ComboboxState
  */
 export type TagPickerState = ComponentState<TagPickerSlots> &
-  Omit<ComboboxState, 'listbox' | 'root' | 'input' | 'expandIcon' | 'clearIcon' | 'components' | 'size'> &
+  Pick<
+    ComboboxState,
+    | 'open'
+    | 'activeDescendantController'
+    | 'mountNode'
+    | 'onOptionClick'
+    | 'registerOption'
+    | 'selectedOptions'
+    | 'selectOption'
+    | 'multiselect'
+    | 'value'
+    | 'setValue'
+    | 'setOpen'
+    | 'setHasFocus'
+    | 'appearance'
+    | 'clearSelection'
+    | 'getOptionById'
+  > &
   Pick<
     TagPickerContextValue,
     'triggerRef' | 'secondaryActionRef' | 'popoverId' | 'popoverRef' | 'targetRef' | 'size' | 'disabled'
   > & {
-    /**
-     * Configures the positioned menu
-     */
-    positioning?: PositioningShorthand;
-
     trigger: React.ReactNode;
-
     popover?: React.ReactNode;
   };
 

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import { isHTMLElement, elementContains, useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
-import type { TagPickerOnOptionSelectData, TagPickerProps, TagPickerState } from './TagPicker.types';
+import type {
+  TagPickerOnOpenChangeData,
+  TagPickerOnOptionSelectData,
+  TagPickerProps,
+  TagPickerState,
+} from './TagPicker.types';
 import { optionClassNames } from '@fluentui/react-combobox';
 import { PositioningShorthandValue, resolvePositioningShorthand, usePositioning } from '@fluentui/react-positioning';
 import { useActiveDescendant } from '@fluentui/react-aria';
 import { useComboboxBaseState } from '../../utils/useComboboxBaseState';
-import { SelectionProps } from '../../utils/Selection.types';
+import { ComboboxBaseState } from '../../utils/ComboboxBase.types';
 
 /**
  * Create the state required to render Picker.
@@ -41,29 +46,31 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     matchOption: el => el.classList.contains(optionClassNames.root),
   });
 
-  const handleOptionSelect: SelectionProps['onOptionSelect'] = useEventCallback((event, data) =>
-    props.onOptionSelect?.(event, {
-      ...data,
-      type: event.type,
-      event,
-    } as TagPickerOnOptionSelectData),
-  );
-
-  const state = useComboboxBaseState({
+  const comboboxState = useComboboxBaseState({
     ...props,
-    onOptionSelect: handleOptionSelect,
+    onOptionSelect: useEventCallback((event, data) =>
+      props.onOptionSelect?.(event, {
+        ...data,
+        type: event.type,
+        event,
+      } as TagPickerOnOptionSelectData),
+    ),
+    onOpenChange: useEventCallback((event, data) =>
+      props.onOpenChange?.(event, {
+        ...data,
+        type: event.type,
+        event,
+      } as TagPickerOnOpenChangeData),
+    ),
     activeDescendantController,
     editable: true,
     multiselect: true,
     size: 'medium',
   });
-  const onOptionClickBase = state.onOptionClick;
-  state.onOptionClick = useEventCallback(event => {
-    onOptionClickBase(event);
-    state.setOpen(event, false);
-  });
-  const setOpenBase = state.setOpen;
-  state.setOpen = useEventCallback((event, newValue) => {
+
+  const { trigger, popover } = childrenToTriggerAndPopover(props.children);
+
+  const setOpen: ComboboxBaseState['setOpen'] = useEventCallback((event, newValue) => {
     // if event comes from secondary action, ignore it
     if (isHTMLElement(event.target) && elementContains(secondaryActionRef.current, event.target)) {
       return;
@@ -71,18 +78,51 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     if (disabled) {
       return;
     }
-    setOpenBase(event, newValue);
+    comboboxState.setOpen(event, newValue);
   });
 
-  const children = React.Children.toArray(props.children) as React.ReactElement[];
+  return {
+    activeDescendantController,
+    components: {},
+    trigger,
+    popover: comboboxState.open || comboboxState.hasFocus ? popover : undefined,
+    popoverId,
+    disabled,
+    triggerRef: useMergedRefs(triggerInnerRef, activeParentRef),
+    popoverRef: useMergedRefs(listboxRef, containerRef),
+    secondaryActionRef,
+    targetRef,
+    size,
+    open: comboboxState.open,
+    mountNode: comboboxState.mountNode,
+    onOptionClick: useEventCallback(event => {
+      comboboxState.onOptionClick(event);
+      setOpen(event, false);
+    }),
+    appearance: comboboxState.appearance,
+    clearSelection: comboboxState.clearSelection,
+    getOptionById: comboboxState.getOptionById,
+    registerOption: comboboxState.registerOption,
+    selectedOptions: comboboxState.selectedOptions,
+    selectOption: comboboxState.selectOption,
+    setHasFocus: comboboxState.setHasFocus,
+    setOpen,
+    setValue: comboboxState.setValue,
+    multiselect: comboboxState.multiselect,
+    value: comboboxState.value,
+  };
+};
+
+const childrenToTriggerAndPopover = (children?: React.ReactNode) => {
+  const childrenArray = React.Children.toArray(children) as React.ReactElement[];
 
   if (process.env.NODE_ENV !== 'production') {
-    if (children.length === 0) {
+    if (childrenArray.length === 0) {
       // eslint-disable-next-line no-console
       console.warn('Picker must contain at least one child');
     }
 
-    if (children.length > 2) {
+    if (childrenArray.length > 2) {
       // eslint-disable-next-line no-console
       console.warn('Picker must contain at most two children');
     }
@@ -90,25 +130,11 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
 
   let trigger: React.ReactElement | undefined = undefined;
   let popover: React.ReactElement | undefined = undefined;
-  if (children.length === 2) {
-    trigger = children[0];
-    popover = children[1];
-  } else if (children.length === 1) {
-    popover = children[0];
+  if (childrenArray.length === 2) {
+    trigger = childrenArray[0];
+    popover = childrenArray[1];
+  } else if (childrenArray.length === 1) {
+    popover = childrenArray[0];
   }
-
-  return {
-    activeDescendantController,
-    components: {},
-    trigger,
-    popover: state.open || state.hasFocus ? popover : undefined,
-    popoverId,
-    disabled,
-    triggerRef: useMergedRefs(triggerInnerRef, activeParentRef),
-    popoverRef: useMergedRefs(listboxRef, containerRef),
-    secondaryActionRef,
-    targetRef,
-    ...state,
-    size,
-  };
+  return { trigger, popover };
 };

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPickerContextValues.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPickerContextValues.ts
@@ -8,12 +8,6 @@ export function useTagPickerContextValues(state: TagPickerState): TagPickerConte
     selectedOptions,
     selectOption,
     multiselect,
-    // eslint-disable-next-line deprecation/deprecation
-    focusVisible,
-    // eslint-disable-next-line deprecation/deprecation
-    setActiveOption,
-    // eslint-disable-next-line deprecation/deprecation
-    activeOption,
     value,
     triggerRef,
     secondaryActionRef,
@@ -41,9 +35,8 @@ export function useTagPickerContextValues(state: TagPickerState): TagPickerConte
       selectedOptions,
       selectOption,
       multiselect,
-      focusVisible,
-      setActiveOption,
-      activeOption,
+      focusVisible: false,
+      setActiveOption: noop,
     },
     picker: {
       value,
@@ -67,3 +60,7 @@ export function useTagPickerContextValues(state: TagPickerState): TagPickerConte
     },
   };
 }
+
+const noop = () => {
+  /** noop */
+};

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/TagPickerOption.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/TagPickerOption.types.ts
@@ -1,8 +1,8 @@
-import { OptionProps, OptionSlots, OptionState } from '@fluentui/react-combobox';
+import { OptionSlots, OptionState } from '@fluentui/react-combobox';
 import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 
-export type TagPickerOptionSlots = Omit<OptionSlots, 'checkIcon'> & {
+export type TagPickerOptionSlots = Pick<OptionSlots, 'root'> & {
   media?: Slot<'div'>;
   secondaryContent?: Slot<'span'>;
 };
@@ -10,14 +10,14 @@ export type TagPickerOptionSlots = Omit<OptionSlots, 'checkIcon'> & {
 /**
  * TagPickerOption Props
  */
-export type TagPickerOptionProps = ComponentProps<TagPickerOptionSlots> &
-  Omit<OptionProps, 'checkIcon' | 'disabled'> & {
-    children: React.ReactNode;
-    text?: string;
-    value: string;
-  };
+export type TagPickerOptionProps = ComponentProps<TagPickerOptionSlots> & {
+  children: React.ReactNode;
+  text?: string;
+  value: string;
+};
 
 /**
  * State used in rendering TagPickerOption
  */
-export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Omit<OptionState, 'checkIcon'>;
+export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> &
+  Pick<OptionState, 'components' | 'multiselect' | 'root' | 'selected'>;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
@@ -16,11 +16,10 @@ export const useTagPickerOption_unstable = (
   props: TagPickerOptionProps,
   ref: React.Ref<HTMLDivElement>,
 ): TagPickerOptionState => {
-  const baseState = useOption_unstable(props as OptionProps, ref);
+  const optionState = useOption_unstable(props as OptionProps, ref);
   const state: TagPickerOptionState = {
-    ...baseState,
     components: {
-      ...baseState.components,
+      ...optionState.components,
       media: 'div',
       secondaryContent: 'span',
     },
@@ -30,6 +29,9 @@ export const useTagPickerOption_unstable = (
     secondaryContent: slot.optional(props.secondaryContent, {
       elementType: 'span',
     }),
+    root: optionState.root,
+    selected: optionState.selected,
+    multiselect: optionState.multiselect,
   };
 
   return state;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -33,7 +33,13 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerOption slots based on the state
  */
 export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): TagPickerOptionState => {
-  useOptionStyles_unstable({ ...state, checkIcon: undefined });
+  useOptionStyles_unstable({
+    ...state,
+    active: false,
+    disabled: false,
+    focusVisible: false,
+    checkIcon: undefined,
+  });
   const styles = useStyles();
 
   state.root.className = mergeClasses(tagPickerOptionClassNames.root, styles.root, state.root.className);


### PR DESCRIPTION
## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds `TagPickerOnOpenChangeData` type to not propagate `onOpenChange` from `ComboboxState` as that one does not follow newest pattern https://github.com/microsoft/fluentui/pull/29296
2. adds `defaultSelectedOptions` support as a valid `prop`
3. opts for `Pick` instead of `Omit` on most of the types signatures, to avoid usage of state spreading.
