### PR TITLE
chore(xplat readme): fix missing link

### DIFF
--- a/apps/xplat-v9/README.md
+++ b/apps/xplat-v9/README.md
@@ -78,4 +78,4 @@ yarn install
 
 ```
 
-After doing so, before commiting any post-merge-commit fixes, make sure to also run `npx syncpack list-mismatches`. It is likely that the `xplat` branch is going to be somewhat out of sync with other changes from core, so make sure to address them before proceeding. Here's an example of a PR doing so.
+After doing so, before commiting any post-merge-commit fixes, make sure to also run `npx syncpack list-mismatches`. It is likely that the `xplat` branch is going to be somewhat out of sync with other changes from core, so make sure to address them before proceeding. Here's [an example of a PR](https://github.com/microsoft/fluentui/pull/30876) doing so.


### PR DESCRIPTION
ℹ️ Note: This is being merged into the `xplat` branch, not `master`

Quick PR to add a missing link to the README that I forgot from [previous PR](https://github.com/microsoft/fluentui/pull/30876).
