### PR TITLE
Fix Focus styling for AreaChart Basic Example in docsite

### DIFF
--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -36,16 +36,16 @@
   }
 
   // Remove dotted outline added by MWF's main.css
-  body [contentEditable=true]:focus,
-  body [tabindex]:focus,
-  body area[href]:focus,
-  body button:focus,
-  body iframe:focus,
-  body input:focus,
-  body select:focus,
-  body textarea:focus {
-    outline: none;
-  }
+  // body [contentEditable=true]:focus,
+  // body [tabindex]:focus,
+  // body area[href]:focus,
+  // body button:focus,
+  // body iframe:focus,
+  // body input:focus,
+  // body select:focus,
+  // body textarea:focus {
+  //   outline: none;
+  // }
 
   // Remove link focus outline from all links but the UHF ones unless you're in high contrast mode
   @media (forced-colors: none) {

--- a/apps/public-docsite/src/styles/_base.scss
+++ b/apps/public-docsite/src/styles/_base.scss
@@ -36,16 +36,16 @@
   }
 
   // Remove dotted outline added by MWF's main.css
-  // body [contentEditable=true]:focus,
-  // body [tabindex]:focus,
-  // body area[href]:focus,
-  // body button:focus,
-  // body iframe:focus,
-  // body input:focus,
-  // body select:focus,
-  // body textarea:focus {
-  //   outline: none;
-  // }
+  body [contentEditable=true]:focus,
+  body [tabindex]:focus,
+  body area[href]:focus,
+  body button:focus,
+  body iframe:focus,
+  body input:focus,
+  body select:focus,
+  body textarea:focus {
+    outline: none;
+  }
 
   // Remove link focus outline from all links but the UHF ones unless you're in high contrast mode
   @media (forced-colors: none) {

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -29,14 +29,14 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
   public componentDidMount(): void {
     const style = document.createElement('style');
     const focusStylingCSS = `
-    .rootDiv [contentEditable=true]:focus,
-    .rootDiv [tabindex]:focus,
-    .rootDiv area[href]:focus,
-    .rootDiv button:focus,
-    .rootDiv iframe:focus,
-    .rootDiv input:focus,
-    .rootDiv select:focus,
-    .rootDiv textarea:focus {
+    .containerDiv [contentEditable=true]:focus,
+    .containerDiv [tabindex]:focus,
+    .containerDiv area[href]:focus,
+    .containerDiv button:focus,
+    .containerDiv iframe:focus,
+    .containerDiv input:focus,
+    .containerDiv select:focus,
+    .containerDiv textarea:focus {
       outline: -webkit-focus-ring-color auto 5px;
     }
     `;
@@ -45,7 +45,7 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
   }
 
   public render(): JSX.Element {
-    return <div className="rootDiv">{this._basicExample()}</div>;
+    return <div className="containerDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -9,8 +9,6 @@ interface IAreaChartBasicState {
   height: number;
   isCalloutselected: boolean;
   showAxisTitles: boolean;
-  isHeightSliderFocused: boolean;
-  isWidthSliderFocused: boolean;
 }
 
 const options: IChoiceGroupOption[] = [
@@ -26,13 +24,28 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
       height: 300,
       isCalloutselected: false,
       showAxisTitles: true,
-      isHeightSliderFocused: false,
-      isWidthSliderFocused: false,
     };
+  }
+  public componentDidMount(): void {
+    const style = document.createElement('style');
+    const focusStylingCSS = `
+    .rootDiv [contentEditable=true]:focus,
+    .rootDiv [tabindex]:focus,
+    .rootDiv area[href]:focus,
+    .rootDiv button:focus,
+    .rootDiv iframe:focus,
+    .rootDiv input:focus,
+    .rootDiv select:focus,
+    .rootDiv textarea:focus {
+      outline: -webkit-focus-ring-color auto 5px;
+    }
+    `;
+    style.appendChild(document.createTextNode(focusStylingCSS));
+    document.head.appendChild(style);
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return <div className="rootDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -174,9 +187,6 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
           id="changeWidth_Basic"
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
-          style={this.state.isWidthSliderFocused ? { outline: '-webkit-focus-ring-color auto 5px' } : {}}
-          onFocus={() => this.setState({ isWidthSliderFocused: true })}
-          onBlur={() => this.setState({ isWidthSliderFocused: false })}
         />
         <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
@@ -187,9 +197,6 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
           id="changeHeight_Basic"
           onChange={this._onHeightChange}
           aria-valuetext={`ChangeHeightslider${this.state.height}`}
-          style={this.state.isHeightSliderFocused ? { outline: '-webkit-focus-ring-color auto 5px' } : {}}
-          onFocus={() => this.setState({ isHeightSliderFocused: true })}
-          onBlur={() => this.setState({ isHeightSliderFocused: false })}
         />
 
         <ChoiceGroup options={options} defaultSelectedKey="basicExample" onChange={this._onChange} label="Pick one" />

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -9,6 +9,8 @@ interface IAreaChartBasicState {
   height: number;
   isCalloutselected: boolean;
   showAxisTitles: boolean;
+  isHeightSliderFocused: boolean;
+  isWidthSliderFocused: boolean;
 }
 
 const options: IChoiceGroupOption[] = [
@@ -24,6 +26,8 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
       height: 300,
       isCalloutselected: false,
       showAxisTitles: true,
+      isHeightSliderFocused: false,
+      isWidthSliderFocused: false,
     };
   }
 
@@ -170,6 +174,9 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
           id="changeWidth_Basic"
           onChange={this._onWidthChange}
           aria-valuetext={`ChangeWidthSlider${this.state.width}`}
+          style={this.state.isWidthSliderFocused ? { outline: '-webkit-focus-ring-color auto 5px' } : {}}
+          onFocus={() => this.setState({ isWidthSliderFocused: true })}
+          onBlur={() => this.setState({ isWidthSliderFocused: false })}
         />
         <label htmlFor="changeHeight_Basic">Change Height:</label>
         <input
@@ -180,6 +187,9 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
           id="changeHeight_Basic"
           onChange={this._onHeightChange}
           aria-valuetext={`ChangeHeightslider${this.state.height}`}
+          style={this.state.isHeightSliderFocused ? { outline: '-webkit-focus-ring-color auto 5px' } : {}}
+          onFocus={() => this.setState({ isHeightSliderFocused: true })}
+          onBlur={() => this.setState({ isHeightSliderFocused: false })}
         />
 
         <ChoiceGroup options={options} defaultSelectedKey="basicExample" onChange={this._onChange} label="Pick one" />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Focus styling for AreaChart Basic example was not working (overridden by global styling)

## New Behavior
Focus styling fixed by custom styling.
![image](https://github.com/microsoft/fluentui/assets/35366351/c7347034-90bf-47de-a317-42b50809a18a)
![image](https://github.com/microsoft/fluentui/assets/35366351/a4c3f4ac-6df3-4d4f-a58a-e28aa69de12e)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30853
