### PR TITLE
Fix incorrect bar height for y values < 1 in vertical stacked bar chart

### DIFF
--- a/change/@fluentui-react-charting-9ab12c74-9f1c-47a9-9ba1-3e53704f82c9.json
+++ b/change/@fluentui-react-charting-9ab12c74-9f1c-47a9-9ba1-3e53704f82c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix incorrect bar height for y values < 1 in vertical stacked bar chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -833,8 +833,9 @@ export class VerticalStackedBarChartBase extends React.Component<
         };
 
         let barHeight = heightValueScale * point.data;
-        if (barHeight < Math.max(heightValueScale * Math.ceil(this._yMax / 100.0), barMinimumHeight)) {
-          barHeight = Math.max(heightValueScale * Math.ceil(this._yMax / 100.0), barMinimumHeight);
+
+        if (barHeight < Math.max(Math.ceil((heightValueScale * this._yMax) / 100.0), barMinimumHeight)) {
+          barHeight = Math.max(Math.ceil((heightValueScale * this._yMax) / 100.0), barMinimumHeight);
         }
         yPoint = yPoint - barHeight - (index ? gapHeight : 0);
         barTotalValue += point.data;

--- a/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChartRTL.test.tsx.snap
@@ -293,11 +293,11 @@ exports[`Vertical stacked bar chart - Screen resolution Should remain unchanged 
                       opacity: ;
                     }
                 fill="#00188f"
-                height="2.37"
+                height="3"
                 transform="translate(0, 0)"
                 width="16"
                 x="279"
-                y="249.89"
+                y="249.26"
               />
             </g>
             <text
@@ -313,7 +313,7 @@ exports[`Vertical stacked bar chart - Screen resolution Should remain unchanged 
               text-anchor="middle"
               transform="translate(0, 0)"
               x="287"
-              y="243.89"
+              y="243.26"
             >
               2.5
             </text>
@@ -1213,11 +1213,11 @@ exports[`Vertical stacked bar chart - Screen resolution Should remain unchanged 
                       opacity: ;
                     }
                 fill="#00188f"
-                height="2.37"
+                height="3"
                 transform="translate(0, 0)"
                 width="16"
                 x="279"
-                y="249.89"
+                y="249.26"
               />
             </g>
             <text
@@ -1233,7 +1233,7 @@ exports[`Vertical stacked bar chart - Screen resolution Should remain unchanged 
               text-anchor="middle"
               transform="translate(0, 0)"
               x="287"
-              y="243.89"
+              y="243.26"
             >
               2.5
             </text>
@@ -2133,11 +2133,11 @@ exports[`Vertical stacked bar chart - Subcomponent Line Should render the vertic
                       opacity: ;
                     }
                 fill="#00188f"
-                height="2.37"
+                height="3"
                 transform="translate(0, 0)"
                 width="16"
                 x="279"
-                y="249.89"
+                y="249.26"
               />
             </g>
             <text
@@ -2153,7 +2153,7 @@ exports[`Vertical stacked bar chart - Subcomponent Line Should render the vertic
               text-anchor="middle"
               transform="translate(0, 0)"
               x="287"
-              y="243.89"
+              y="243.26"
             >
               2.5
             </text>


### PR DESCRIPTION
## Previous Behavior

![Before](https://github.com/microsoft/fluentui/assets/110246001/7e0d214c-0b03-49aa-9d9d-e67aaaffb124)

## New Behavior

![After](https://github.com/microsoft/fluentui/assets/110246001/e4bcb156-2c60-40d2-a56b-04ae40e95da0)