### PR TITLE
docs: add React 18 setup to quick start docs

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
@@ -16,6 +16,26 @@ Fluent UI components are styled using CSS in JS. This technique requires a style
 
 Place a `<FluentProvider />` at the root of your app and pass theme as a prop.
 
+### React 18
+
+```jsx
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { FluentProvider, teamsLightTheme } from '@fluentui/react-components';
+
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+
+root.render(
+  <FluentProvider theme={teamsLightTheme}>
+    <App />
+  </FluentProvider>,
+);
+```
+
+### React 17
+
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/QuickStart.stories.mdx
@@ -21,14 +21,14 @@ Place a `<FluentProvider />` at the root of your app and pass theme as a prop.
 ```jsx
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { FluentProvider, teamsLightTheme } from '@fluentui/react-components';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 
 import App from './App';
 
 const root = createRoot(document.getElementById('root'));
 
 root.render(
-  <FluentProvider theme={teamsLightTheme}>
+  <FluentProvider theme={webLightTheme}>
     <App />
   </FluentProvider>,
 );
@@ -39,12 +39,12 @@ root.render(
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { FluentProvider, teamsLightTheme } from '@fluentui/react-components';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 
 import App from './App';
 
 ReactDOM.render(
-  <FluentProvider theme={teamsLightTheme}>
+  <FluentProvider theme={webLightTheme}>
     <App />
   </FluentProvider>,
   document.getElementById('root'),


### PR DESCRIPTION
## Previous Behavior

We didn't now show how to "quick start" Fluent v9 with [React 18 APIs](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis).

## New Behavior

We show how to quick start Fluent v9 with React 18 APIs

## Related Issue(s)

- Fixes #30690
