### PR TITLE
chore: add StackBlitz starter template

### DIFF
--- a/stackblitz-starter/README.md
+++ b/stackblitz-starter/README.md
@@ -1,0 +1,3 @@
+# Fluent UI StackBlitz Starter
+
+This is a [StackBlitz starter template](https://github.com/stackblitz/starters/tree/main?tab=readme-ov-file#stackblitz-starter-templates) for Fluent UI React.

--- a/stackblitz-starter/package.json
+++ b/stackblitz-starter/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fluent-react-components-starter",
+  "description": "StackBlitz starter template for @fluentui/react-components",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "@fluentui/react-components": "^9.47.2",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "react-scripts": "^5.0.1",
+    "typescript": "^4.9.5"
+  },
+  "browserslist": [
+    "defaults"
+  ]
+}

--- a/stackblitz-starter/public/index.html
+++ b/stackblitz-starter/public/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div>

--- a/stackblitz-starter/src/App.tsx
+++ b/stackblitz-starter/src/App.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Button } from '@fluentui/react-components';
+
+export const App: React.FC = () => {
+  return <Button>Hello, Fluent UI!</Button>;
+};

--- a/stackblitz-starter/src/index.tsx
+++ b/stackblitz-starter/src/index.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+
+import { App } from './App';
+
+const root = createRoot(document.getElementById('app'));
+
+root.render(
+  <StrictMode>
+    <FluentProvider theme={webLightTheme}>
+      <App />
+    </FluentProvider>
+  </StrictMode>,
+);

--- a/stackblitz-starter/tsconfig.json
+++ b/stackblitz-starter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2022"],
+    "moduleResolution": "node",
+    "target": "ES2022"
+  }
+}


### PR DESCRIPTION
## Previous Behavior

Fluent lacks a [StackBlitz starter template](https://github.com/stackblitz/starters/tree/main?tab=readme-ov-file#stackblitz-starter-templates), making it tedious to spin up a demo/repro in StackBlitz.

## New Behavior

Fluent has a StackBlitz starter template that does not require a Vite server. This allows the SB to load faster and work in resource constrained environments like mobile devices.

## Related Issue(s)

This is related to #30702, but not the same thing. A non-Vite template is useful for certain testing scenarios like a11y testing as the experience thus far has been that the Vite-based StackBlitz examples do not load on iOS.
