### PR TITLE
bugfix(react-tag-picker): removes errouneous combobox imports

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-41407ab4-eb34-417a-b086-f5c149bd0c4d.json
+++ b/change/@fluentui-react-tag-picker-preview-41407ab4-eb34-417a-b086-f5c149bd0c4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: removes errouneous combobox imports",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-tag-picker-preview/src/utils/useComboboxBaseState.ts
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { ComboboxBaseProps, ComboboxBaseState } from './ComboboxBase.types';
+import { ComboboxBaseOpenEvents, ComboboxBaseProps, ComboboxBaseState } from './ComboboxBase.types';
 import { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
-import { useOptionCollection } from '../../../react-combobox/src/utils/useOptionCollection';
-import { useSelection } from '../../../react-combobox/src/utils/useSelection';
 import { useControllableState, useEventCallback, useFirstMount } from '@fluentui/react-utilities';
-import { ComboboxBaseOpenEvents } from '../../../react-combobox/src/utils/ComboboxBase.types';
-import { OptionValue } from '../../../react-combobox/src/utils/OptionCollection.types';
+import { OptionValue } from './OptionCollection.types';
+import { useOptionCollection } from './useOptionCollection';
+import { useSelection } from './useSelection';
 
 /**
  * @internal

--- a/packages/react-components/react-tag-picker-preview/src/utils/useOptionCollection.ts
+++ b/packages/react-components/react-tag-picker-preview/src/utils/useOptionCollection.ts
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import type { OptionCollectionState, OptionValue } from './OptionCollection.types';
+
+/**
+ * A hook for managing a collection of child Options
+ */
+export const useOptionCollection = (): OptionCollectionState => {
+  const optionsById = React.useRef(new Map<string, OptionValue>());
+
+  const collectionAPI = React.useMemo(() => {
+    const getCount = () => optionsById.current.size;
+
+    // index searches are no longer used
+    const getOptionAtIndex = () => undefined;
+    const getIndexOfId = () => -1;
+
+    const getOptionById = (id: string) => {
+      return optionsById.current.get(id);
+    };
+    const getOptionsMatchingText = (matcher: (text: string) => boolean) => {
+      return Array.from(optionsById.current.values()).filter(({ text }) => matcher(text));
+    };
+
+    const getOptionsMatchingValue = (matcher: (value: string) => boolean) => {
+      const matches: OptionValue[] = [];
+      for (const option of optionsById.current.values()) {
+        if (matcher(option.value)) {
+          matches.push(option);
+        }
+      }
+
+      return matches;
+    };
+
+    return {
+      getCount,
+      getOptionAtIndex,
+      getIndexOfId,
+      getOptionById,
+      getOptionsMatchingText,
+      getOptionsMatchingValue,
+    };
+  }, []);
+
+  const registerOption = React.useCallback((option: OptionValue) => {
+    optionsById.current.set(option.id, option);
+
+    return () => optionsById.current.delete(option.id);
+  }, []);
+
+  return {
+    ...collectionAPI,
+    options: Array.from(optionsById.current.values()),
+    registerOption,
+  };
+};

--- a/packages/react-components/react-tag-picker-preview/src/utils/useSelection.ts
+++ b/packages/react-components/react-tag-picker-preview/src/utils/useSelection.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { useControllableState } from '@fluentui/react-utilities';
+import { OptionValue } from './OptionCollection.types';
+import { SelectionEvents, SelectionProps, SelectionState } from './Selection.types';
+
+export const useSelection = (props: SelectionProps): SelectionState => {
+  const { defaultSelectedOptions, multiselect, onOptionSelect } = props;
+
+  const [selectedOptions, setSelectedOptions] = useControllableState({
+    state: props.selectedOptions,
+    defaultState: defaultSelectedOptions,
+    initialState: [],
+  });
+
+  const selectOption = useCallback(
+    (event: SelectionEvents, option: OptionValue) => {
+      // if the option is disabled, do nothing
+      if (option.disabled) {
+        return;
+      }
+
+      // for single-select, always return the selected option
+      let newSelection = [option.value];
+
+      // toggle selected state of the option for multiselect
+      if (multiselect) {
+        const selectedIndex = selectedOptions.findIndex(o => o === option.value);
+        if (selectedIndex > -1) {
+          // deselect option
+          newSelection = [...selectedOptions.slice(0, selectedIndex), ...selectedOptions.slice(selectedIndex + 1)];
+        } else {
+          // select option
+          newSelection = [...selectedOptions, option.value];
+        }
+      }
+
+      setSelectedOptions(newSelection);
+      onOptionSelect?.(event, { optionValue: option.value, optionText: option.text, selectedOptions: newSelection });
+    },
+    [onOptionSelect, multiselect, selectedOptions, setSelectedOptions],
+  );
+
+  const clearSelection = (event: SelectionEvents) => {
+    setSelectedOptions([]);
+    onOptionSelect?.(event, { optionValue: undefined, optionText: undefined, selectedOptions: [] });
+  };
+
+  return { clearSelection, selectOption, selectedOptions };
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Follow up on https://github.com/microsoft/fluentui/issues/26652#issuecomment-2029563676

1. removes erroneous imports from `@fluentui/react-combobox`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
