### PR TITLE
fix(react-storybook-addon-export-to-sandbox): use React v18 APIs

### DIFF
--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.spec.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.spec.ts
@@ -66,14 +66,15 @@ describe(`sabdbox-scaffold`, () => {
                   export const Default = () => <Text>This is an example of the Text component's usage.</Text>;
                 ",
           "src/index.tsx": "import * as React from 'react';
-        import * as ReactDOM from 'react-dom';
+        import { createRoot } from 'react-dom/client';
         import App from './App';
 
-        ReactDOM.render(
+        const root = createRoot(document.getElementById('root') as HTMLElement);
+
+        root.render(
           <React.StrictMode>
             <App />
           </React.StrictMode>,
-          document.getElementById('root') as HTMLElement
         );",
           "tsconfig.json": "{
           \\"include\\": [
@@ -180,14 +181,15 @@ describe(`sabdbox-scaffold`, () => {
                   export const Default = () => <Text>This is an example of the Text component's usage.</Text>;
                 ",
           "src/index.tsx": "import * as React from 'react';
-        import * as ReactDOM from 'react-dom';
+        import { createRoot } from 'react-dom/client';
         import App from './App';
 
-        ReactDOM.render(
+        const root = createRoot(document.getElementById('root') as HTMLElement);
+
+        root.render(
           <React.StrictMode>
             <App />
           </React.StrictMode>,
-          document.getElementById('root') as HTMLElement
         );",
           "tsconfig.json": "{
           \\"include\\": [
@@ -260,14 +262,15 @@ describe(`sabdbox-scaffold`, () => {
                   export const Default = () => <Text>This is an example of the Text component's usage.</Text>;
                 ",
           "src/index.tsx": "import * as React from 'react';
-        import * as ReactDOM from 'react-dom';
+        import { createRoot } from 'react-dom/client';
         import App from './App';
 
-        ReactDOM.render(
+        const root = createRoot(document.getElementById('root') as HTMLElement);
+
+        root.render(
           <React.StrictMode>
             <App />
           </React.StrictMode>,
-          document.getElementById('root') as HTMLElement
         );",
           "tsconfig.json": "{
           \\"include\\": [
@@ -395,14 +398,15 @@ describe(`sabdbox-scaffold`, () => {
                   export const Default = () => <Text>This is an example of the Text component's usage.</Text>;
                 ",
           "src/index.tsx": "import * as React from 'react';
-        import * as ReactDOM from 'react-dom';
+        import { createRoot } from 'react-dom/client';
         import App from './App';
 
-        ReactDOM.render(
+        const root = createRoot(document.getElementById('root') as HTMLElement);
+
+        root.render(
           <React.StrictMode>
             <App />
           </React.StrictMode>,
-          document.getElementById('root') as HTMLElement
         );",
           "tsconfig.json": "{
           \\"compilerOptions\\": {
@@ -519,14 +523,15 @@ describe(`sabdbox-scaffold`, () => {
                   export const Default = () => <Text>This is an example of the Text component's usage.</Text>;
                 ",
           "src/index.tsx": "import * as React from 'react';
-        import * as ReactDOM from 'react-dom';
+        import { createRoot } from 'react-dom/client';
         import App from './App';
 
-        ReactDOM.render(
+        const root = createRoot(document.getElementById('root') as HTMLElement);
+
+        root.render(
           <React.StrictMode>
             <App />
           </React.StrictMode>,
-          document.getElementById('root') as HTMLElement
         );",
           "tsconfig.json": "{
           \\"compilerOptions\\": {

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-scaffold.ts
@@ -232,14 +232,15 @@ function getStackblitzConfig() {
 function getIndex() {
   return dedent`
     import * as React from 'react';
-    import * as ReactDOM from 'react-dom';
+    import { createRoot } from 'react-dom/client';
     import App from './App';
 
-    ReactDOM.render(
+    const root = createRoot(document.getElementById('root') as HTMLElement);
+
+    root.render(
       <React.StrictMode>
         <App />
       </React.StrictMode>,
-      document.getElementById('root') as HTMLElement
     );
   `;
 }


### PR DESCRIPTION
## Previous Behavior

Every exported example on Stackblitz has:

<img width="580" alt="image" src="https://github.com/microsoft/fluentui/assets/14183168/98f37b80-18b7-4ddb-aad2-34ed81044b26">

For context: in #30613 I updated React version to be 18, but we still were using deprecated `ReactDOM.render()` API.

## New Behavior

No errors/warnings about deprecated APIs.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
