### PR TITLE
docs(react-tag): allow reset dismiss example when one tag is dismissed

### DIFF
--- a/packages/react-components/react-tags/stories/TagGroup/TagGroupDismiss.stories.tsx
+++ b/packages/react-components/react-tags/stories/TagGroup/TagGroupDismiss.stories.tsx
@@ -78,7 +78,7 @@ const DismissWithTags = () => {
       <Button
         onClick={resetItems}
         ref={resetButtonRef}
-        disabled={visibleTags.length !== initialTags.length}
+        disabled={visibleTags.length === initialTags.length}
         className={styles.resetButton}
         size="small"
       >

--- a/packages/react-components/react-tags/stories/TagGroup/TagGroupDismiss.stories.tsx
+++ b/packages/react-components/react-tags/stories/TagGroup/TagGroupDismiss.stories.tsx
@@ -78,7 +78,7 @@ const DismissWithTags = () => {
       <Button
         onClick={resetItems}
         ref={resetButtonRef}
-        disabled={visibleTags.length !== 0}
+        disabled={visibleTags.length !== initialTags.length}
         className={styles.resetButton}
         size="small"
       >


### PR DESCRIPTION
fix #30920


### Before:
Reset button is disabled when one tag is dismissed:
<img width="271" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/6861d8df-b492-4384-adcd-98e9f9e87a10">
Reset can only be done when all tags are dismissed


### BeforeAfter:
Reset can be done when one tag is dismissed
<img width="289" alt="image" src="https://github.com/microsoft/fluentui/assets/28751745/73c4d5cb-32c0-4d6f-8014-f3d73bb0f812">
