### PR TITLE
fix: Card actions adopt custom high contrast mode colors

### DIFF
--- a/change/@fluentui-react-card-c41da4ed-3507-468e-ba27-a40458dd122b.json
+++ b/change/@fluentui-react-card-c41da4ed-3507-468e-ba27-a40458dd122b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Card actions adopt custom high contrast mode colors",
+  "packageName": "@fluentui/react-card",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/src/components/CardFooter/useCardFooterStyles.styles.ts
+++ b/packages/react-components/react-card/src/components/CardFooter/useCardFooterStyles.styles.ts
@@ -18,6 +18,16 @@ const useStyles = makeStyles({
   },
   action: {
     marginLeft: 'auto',
+
+    // when the card is selected or hovered, it has custom high contrast color and background styles
+    // setting this ensures action buttons adopt those colors and are still visible in forced-colors mode
+    '@media (forced-colors: active)': {
+      '& .fui-Button, & .fui-Link': {
+        ...shorthands.borderColor('currentColor'),
+        color: 'currentColor',
+        outlineColor: 'currentColor',
+      },
+    },
   },
 });
 

--- a/packages/react-components/react-card/src/components/CardHeader/useCardHeaderStyles.styles.ts
+++ b/packages/react-components/react-card/src/components/CardHeader/useCardHeaderStyles.styles.ts
@@ -1,5 +1,5 @@
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { CardHeaderSlots, CardHeaderState } from './CardHeader.types';
 
 /**
@@ -47,6 +47,16 @@ const useStyles = makeStyles({
     marginLeft: `var(${cardHeaderCSSVars.cardHeaderGapVar})`,
     gridColumnStart: '3',
     gridRowStart: 'span 2',
+
+    // when the card is selected or hovered, it has custom high contrast color and background styles
+    // setting this ensures action buttons adopt those colors and are still visible in forced-colors mode
+    '@media (forced-colors: active)': {
+      '& .fui-Button, & .fui-Link': {
+        ...shorthands.borderColor('currentColor'),
+        color: 'currentColor',
+        outlineColor: 'currentColor',
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## Previous Behavior

Card action buttons did not adapt to the highlighted bg of hovered or selected cards:
![screenshot of two cards, one is selected, and the action button is not visible](https://github.com/microsoft/fluentui/assets/3819570/451e6fca-1f91-433f-a13b-cf6b890b4162)

## New Behavior

it works!
![screenshot of the same two cards, but the action buttons are both visible](https://github.com/microsoft/fluentui/assets/3819570/fa0da10e-b0a4-4a55-ad1c-86c882a082bf)

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18631)
