### PR TITLE
fix: export SearchBoxChangeEvent type

### DIFF
--- a/change/@fluentui-react-search-preview-97e1e824-f803-4a7f-8912-3e6b690e70bf.json
+++ b/change/@fluentui-react-search-preview-97e1e824-f803-4a7f-8912-3e6b690e70bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "export SearchBoxChangeEvent type.",
+  "packageName": "@fluentui/react-search-preview",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search-preview/etc/react-search-preview.api.md
+++ b/packages/react-components/react-search-preview/etc/react-search-preview.api.md
@@ -23,6 +23,9 @@ export const renderSearchBox_unstable: (state: SearchBoxState) => JSX.Element;
 // @public
 export const SearchBox: ForwardRefComponent<SearchBoxProps>;
 
+// @public
+export type SearchBoxChangeEvent = React_2.ChangeEvent<HTMLInputElement> | React_2.MouseEvent<HTMLSpanElement>;
+
 // @public (undocumented)
 export const searchBoxClassNames: SlotClassNames<SearchBoxSlots>;
 

--- a/packages/react-components/react-search-preview/src/index.ts
+++ b/packages/react-components/react-search-preview/src/index.ts
@@ -5,4 +5,4 @@ export {
   useSearchBoxStyles_unstable,
   useSearchBox_unstable,
 } from './SearchBox';
-export type { SearchBoxProps, SearchBoxSlots, SearchBoxState } from './SearchBox';
+export type { SearchBoxChangeEvent, SearchBoxProps, SearchBoxSlots, SearchBoxState } from './SearchBox';


### PR DESCRIPTION
## Previous Behavior

The `SearchBoxChangeEvent` type was not exported.

## New Behavior

The `SearchBoxChangeEvent` is exported.

## Related Issue(s)

- Fixes #30869
