### PR TITLE
Add role='grid' to SparklineChart Example Table

### DIFF
--- a/packages/react-examples/src/react-charting/SparklineChart/SparklineChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/SparklineChart/SparklineChart.Basic.Example.tsx
@@ -338,7 +338,7 @@ export class SparklineChartBasicExample extends React.Component<{}, ISparklineSt
           <br />
           <br />
         </div>
-        <table>
+        <table role="grid">
           <tbody>
             <tr>
               <td style={{ paddingRight: '15px', paddingBottom: '5px', paddingTop: '5px' }}>Row 1</td>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Screen Reader couldn't detect table due to absence of role='grid' attribute

## New Behavior
'grid' role added to table in example

https://github.com/microsoft/fluentui/assets/35366351/9dc1f52f-893e-4706-b1d8-a08c459aad16



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30852
