### PR TITLE
fix(react-datepicker-compat): Align arrow down behavior with Combobox

### DIFF
--- a/change/@fluentui-react-datepicker-compat-5f53f78d-4fb4-41a1-b544-4b0cefe19002.json
+++ b/change/@fluentui-react-datepicker-compat-5f53f78d-4fb4-41a1-b544-4b0cefe19002.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Align arrow down behavior with Combobox.",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.cy.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.cy.tsx
@@ -1,3 +1,4 @@
+/// <reference types="cypress-real-events" />
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 
@@ -38,5 +39,10 @@ describe('DatePicker', () => {
     mount(<DatePicker inlinePopup />);
     cy.get(inputSelector).focus().realPress('Enter').realPress('Escape');
     cy.focused().should('have.attr', 'role', 'combobox');
+  });
+
+  it('should open on keydown', () => {
+    mount(<DatePicker inlinePopup />);
+    cy.get(inputSelector).focus().realPress('ArrowDown').get(popoverSelector).should('be.visible');
   });
 });

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/useDatePicker.tsx
@@ -296,7 +296,7 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
 
         case ArrowDown:
           ev.preventDefault();
-          if (ev.altKey && !open) {
+          if (!open) {
             showDatePickerPopup();
           }
           break;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

DatePicker's combobox could only be open with `alt + keydown`. This behavior comes from v8 but does not align with v9's combobox where both `alt+keydown` and `keydown` open the combobox.

## New Behavior

Align with v9 combobox's behavior and open with `keydown` or `alt+keydown`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #30042
