### PR TITLE
feat(react-nav-preview): Add styles to NavItem and add icon prop

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -108,9 +108,8 @@ export type NavItemRegisterData = {
 
 // @public (undocumented)
 export type NavItemSlots = {
-    root: Slot<'a'>;
-    selectedIcon?: Slot<'span'>;
-    unSelectedIcon?: Slot<'span'>;
+    root: NonNullable<Slot<'a'>>;
+    icon?: Slot<'span'>;
     content: NonNullable<Slot<'span'>>;
 };
 

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -109,6 +109,8 @@ export type NavItemRegisterData = {
 // @public (undocumented)
 export type NavItemSlots = {
     root: Slot<'a'>;
+    selectedIcon?: Slot<'span'>;
+    unSelectedIcon?: Slot<'span'>;
     content: NonNullable<Slot<'span'>>;
 };
 

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
@@ -1,9 +1,22 @@
 import { isConformant } from '../../testing/isConformant';
 import { NavItem } from './NavItem';
+import { navItemClassNames } from './useNavItemStyles.styles';
 
 describe('NavItem', () => {
   isConformant({
     Component: NavItem,
     displayName: 'NavItem',
+    testOptions: {
+      'has-static-classnames': [
+        {
+          props: { selectedIcon: 'Test Icon', content: 'Some Content' },
+          expectedClassNames: {
+            root: navItemClassNames.root,
+            content: navItemClassNames.content,
+            selectedIcon: navItemClassNames.selectedIcon,
+          },
+        },
+      ],
+    },
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
@@ -13,7 +13,7 @@ describe('NavItem', () => {
           expectedClassNames: {
             root: navItemClassNames.root,
             content: navItemClassNames.content,
-            selectedIcon: navItemClassNames.selectedIcon,
+            selectedIcon: navItemClassNames.icon,
           },
         },
       ],

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
@@ -9,11 +9,11 @@ describe('NavItem', () => {
     testOptions: {
       'has-static-classnames': [
         {
-          props: { selectedIcon: 'Test Icon', content: 'Some Content' },
+          props: { icon: 'Test Icon', content: 'Some Content' },
           expectedClassNames: {
             root: navItemClassNames.root,
             content: navItemClassNames.content,
-            selectedIcon: navItemClassNames.icon,
+            icon: navItemClassNames.icon,
           },
         },
       ],

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -2,17 +2,12 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import { NavItemValue } from '../NavContext.types';
 
 export type NavItemSlots = {
-  root: Slot<'a'>;
+  root: NonNullable<Slot<'a'>>;
 
   /**
-   * Icon that renders before the content when the item is selected.
+   * Icon that renders before the content.
    */
-  selectedIcon?: Slot<'span'>;
-
-  /**
-   * Icon that renders before the content when the item is unselected.
-   */
-  unSelectedIcon?: Slot<'span'>;
+  icon?: Slot<'span'>;
 
   /**
    * Component children are placed in this slot

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -4,11 +4,15 @@ import { NavItemValue } from '../NavContext.types';
 export type NavItemSlots = {
   root: Slot<'a'>;
 
-  // TODO - light this up when we get design spec
-  // /**
-  //  * Icon that renders before the content.
-  //  */
-  // icon?: Slot<'span'>;
+  /**
+   * Icon that renders before the content when the item is selected.
+   */
+  selectedIcon?: Slot<'span'>;
+
+  /**
+   * Icon that renders before the content when the item is unselected.
+   */
+  unSelectedIcon?: Slot<'span'>;
 
   /**
    * Component children are placed in this slot

--- a/packages/react-components/react-nav-preview/src/components/NavItem/renderNavItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/renderNavItem.tsx
@@ -13,6 +13,8 @@ export const renderNavItem_unstable = (state: NavItemState) => {
 
   return (
     <state.root>
+      {state.selected && state.selectedIcon && <state.selectedIcon />}
+      {!state.selected && state.unSelectedIcon && <state.unSelectedIcon />}
       <state.content />
     </state.root>
   );

--- a/packages/react-components/react-nav-preview/src/components/NavItem/renderNavItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/renderNavItem.tsx
@@ -13,8 +13,7 @@ export const renderNavItem_unstable = (state: NavItemState) => {
 
   return (
     <state.root>
-      {state.selected && state.selectedIcon && <state.selectedIcon />}
-      {!state.selected && state.unSelectedIcon && <state.unSelectedIcon />}
+      {state.icon && <state.icon />}
       <state.content />
     </state.root>
   );

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -14,7 +14,7 @@ import type { NavItemProps, NavItemState } from './NavItem.types';
  * @param ref - reference to root HTMLDivElement of NavItem
  */
 export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnchorElement>): NavItemState => {
-  const { content, onClick, value, selectedIcon, unSelectedIcon } = props;
+  const { content, onClick, value, icon } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
 
@@ -41,23 +41,8 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
     elementType: 'span',
   });
 
-  const selectedIconSlot = selected
-    ? slot.optional(selectedIcon, {
-        renderByDefault: false,
-        elementType: 'span',
-        defaultProps: { children: selectedIcon },
-      })
-    : undefined;
-  const unSelectedIconSlot = !selected
-    ? slot.optional(unSelectedIcon, {
-        renderByDefault: false,
-        elementType: 'span',
-        defaultProps: { children: unSelectedIcon },
-      })
-    : undefined;
-
   return {
-    components: { root: 'a', content: 'span', selectedIcon: 'span', unSelectedIcon: 'span' },
+    components: { root: 'a', content: 'span', icon: 'span' },
     root: slot.always(
       getIntrinsicElementProps('a', {
         ref,
@@ -68,8 +53,11 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
       }),
       { elementType: 'a' },
     ),
-    selectedIcon: selectedIconSlot,
-    unSelectedIcon: unSelectedIconSlot,
+    icon: slot.optional(icon, {
+      renderByDefault: false,
+      elementType: 'span',
+      defaultProps: { children: icon },
+    }),
     content: contentSlot,
     selected,
     value,

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -11,7 +11,7 @@ import type { NavItemProps, NavItemState } from './NavItem.types';
  * before being passed to renderNavItem_unstable.
  *
  * @param props - props from this instance of NavItem
- * @param ref - reference to root HTMLDivElement of NavItem
+ * @param ref - reference to root HTMLAnchorElement of NavItem
  */
 export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnchorElement>): NavItemState => {
   const { content, onClick, value, icon } = props;
@@ -54,9 +54,7 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
       { elementType: 'a' },
     ),
     icon: slot.optional(icon, {
-      renderByDefault: false,
       elementType: 'span',
-      defaultProps: { children: icon },
     }),
     content: contentSlot,
     selected,

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -14,7 +14,7 @@ import type { NavItemProps, NavItemState } from './NavItem.types';
  * @param ref - reference to root HTMLDivElement of NavItem
  */
 export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnchorElement>): NavItemState => {
-  const { content, onClick, value } = props;
+  const { content, onClick, value, selectedIcon, unSelectedIcon } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
 
@@ -41,8 +41,23 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
     elementType: 'span',
   });
 
+  const selectedIconSlot = selected
+    ? slot.optional(selectedIcon, {
+        renderByDefault: false,
+        elementType: 'span',
+        defaultProps: { children: selectedIcon },
+      })
+    : undefined;
+  const unSelectedIconSlot = !selected
+    ? slot.optional(unSelectedIcon, {
+        renderByDefault: false,
+        elementType: 'span',
+        defaultProps: { children: unSelectedIcon },
+      })
+    : undefined;
+
   return {
-    components: { root: 'a', content: 'span' },
+    components: { root: 'a', content: 'span', selectedIcon: 'span', unSelectedIcon: 'span' },
     root: slot.always(
       getIntrinsicElementProps('a', {
         ref,
@@ -53,6 +68,8 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
       }),
       { elementType: 'a' },
     ),
+    selectedIcon: selectedIconSlot,
+    unSelectedIcon: unSelectedIconSlot,
     content: contentSlot,
     selected,
     value,

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -37,6 +37,8 @@ const useContentStyles = makeStyles({
   selected: typographyStyles.body1Strong,
 });
 
+const indicatorHeight = '20px';
+
 const useIndicatorStyles = makeStyles({
   base: {
     '::after': {
@@ -44,7 +46,7 @@ const useIndicatorStyles = makeStyles({
       transform: 'translateX(-18px)', // per spec
       backgroundColor: tokens.colorNeutralForeground2BrandSelected,
       width: '4px', // No relevant to any design token for these
-      height: '20px',
+      height: indicatorHeight,
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
       content: '""',
     },
@@ -54,6 +56,7 @@ const useIndicatorStyles = makeStyles({
 const useSelectedIconStyles = makeStyles({
   base: {
     color: tokens.colorNeutralForeground2BrandSelected,
+    height: indicatorHeight,
   },
 });
 

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -11,9 +11,9 @@ export const navItemClassNames: SlotClassNames<NavItemSlots> = {
 };
 
 const navItemTokens = {
-  indicatorOffset: '18',
-  indicatorWidth: '4',
-  indicatorHeight: '20',
+  indicatorOffset: 18,
+  indicatorWidth: 4,
+  indicatorHeight: 20,
 };
 
 /**
@@ -45,9 +45,6 @@ const useRootDefaultClassName = makeResetStyles({
 const useContentStyles = makeStyles({
   selected: typographyStyles.body1Strong,
 });
-
-// right: `${navItemTokens.indicatorOffset}px`,
-// width: `${navItemTokens.indicatorWidth}px`,
 
 const useIndicatorStyles = makeStyles({
   base: {

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -21,7 +21,6 @@ const navItemTokens = {
  */
 const useRootDefaultClassName = makeResetStyles({
   display: 'flex',
-  // direction: 'rtl',
   textTransform: 'none',
   position: 'relative',
   justifyContent: 'start',

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -1,19 +1,33 @@
-import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { NavItemSlots, NavItemState } from './NavItem.types';
-import { typographyStyles } from '@fluentui/react-theme';
+import { tokens, typographyStyles } from '@fluentui/react-theme';
 
 export const navItemClassNames: SlotClassNames<NavItemSlots> = {
   root: 'fui-NavItem',
   content: 'fui-NavItem__content',
+  selectedIcon: 'fui-NavItem__selectedIcon',
+  unSelectedIcon: 'fui-NavItem__unSelectedIcon',
 };
 
 /**
  * Styles for the root slot
  */
-const useStyles = makeResetStyles({
+const useRootDefaultStyles = makeResetStyles({
   display: 'flex',
+  gap: tokens.spacingHorizontalL,
+  padding: tokens.spacingVerticalMNudge,
+  backgroundColor: tokens.colorNeutralBackground4,
+  borderRadius: tokens.borderRadiusMedium,
+  color: tokens.colorNeutralForeground2,
+  textDecorationLine: 'none',
   ...typographyStyles.body1,
+  ':hover': {
+    backgroundColor: tokens.colorNeutralBackground4Hover,
+  },
+  ':active': {
+    backgroundColor: tokens.colorNeutralBackground4Pressed,
+  },
 });
 
 /**
@@ -23,20 +37,42 @@ const useContentStyles = makeStyles({
   selected: typographyStyles.body1Strong,
 });
 
+const useIndicatorStyles = makeStyles({
+  base: {
+    '::after': {
+      position: 'absolute',
+      transform: 'translateX(-18px)', // per spec
+      backgroundColor: tokens.colorNeutralForeground2BrandSelected,
+      width: '4px', // No relevant to any design token for these
+      height: '20px',
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+      content: '""',
+    },
+  },
+});
+
+const useSelectedIconStyles = makeStyles({
+  base: {
+    color: tokens.colorNeutralForeground2BrandSelected,
+  },
+});
+
 /**
  * Apply styling to the NavItem slots based on the state
  */
 export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => {
-  const rootStyles = useStyles();
+  const rootDefaultStyles = useRootDefaultStyles();
   const contentStyles = useContentStyles();
+  const indicatorStyles = useIndicatorStyles();
+  const selectedIconStyles = useSelectedIconStyles();
 
   const { selected } = state;
 
   state.root.className = mergeClasses(
     navItemClassNames.root,
-    rootStyles,
-
+    rootDefaultStyles,
     state.root.className,
+    selected && indicatorStyles.base,
   );
 
   state.content.className = mergeClasses(
@@ -44,6 +80,20 @@ export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => 
     selected && contentStyles.selected,
     state.content.className,
   );
+
+  // Only shows in the selected state
+  if (state.selectedIcon) {
+    state.selectedIcon.className = mergeClasses(
+      navItemClassNames.selectedIcon,
+      state.selectedIcon.className,
+      selectedIconStyles.base,
+    );
+  }
+
+  // Only shows in the selected state
+  if (state.unSelectedIcon) {
+    state.unSelectedIcon.className = mergeClasses(navItemClassNames.unSelectedIcon, state.unSelectedIcon.className);
+  }
 
   return state;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -2,6 +2,7 @@ import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { NavItemSlots, NavItemState } from './NavItem.types';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
+import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
 
 export const navItemClassNames: SlotClassNames<NavItemSlots> = {
   root: 'fui-NavItem',
@@ -9,21 +10,22 @@ export const navItemClassNames: SlotClassNames<NavItemSlots> = {
   icon: 'fui-NavItem__icon',
 };
 
-// These should match the constants defined in @fluentui/react-icons
-// This package avoids taking a dependency on the icons package for only the constants.
-const iconClassNames = {
-  filled: 'fui-Icon-filled',
-  regular: 'fui-Icon-regular',
+const navItemTokens = {
+  indicatorOffset: '18',
+  indicatorWidth: '4',
+  indicatorHeight: '20',
 };
-
-const navItemTokens = { indicatorWidth: '4px', indicatorOffset: '-18px', indicatorHeight: '20px' };
 
 /**
  * Styles for the root slot
  */
-const useRootDefaultStyles = makeResetStyles({
+const useRootDefaultClassName = makeResetStyles({
   display: 'flex',
-  gap: tokens.spacingHorizontalL,
+  // direction: 'rtl',
+  textTransform: 'none',
+  position: 'relative',
+  justifyContent: 'start',
+  gap: tokens.spacingVerticalL,
   padding: tokens.spacingVerticalMNudge,
   backgroundColor: tokens.colorNeutralBackground4,
   borderRadius: tokens.borderRadiusMedium,
@@ -45,14 +47,17 @@ const useContentStyles = makeStyles({
   selected: typographyStyles.body1Strong,
 });
 
+// right: `${navItemTokens.indicatorOffset}px`,
+// width: `${navItemTokens.indicatorWidth}px`,
+
 const useIndicatorStyles = makeStyles({
   base: {
     '::after': {
       position: 'absolute',
-      transform: `translateX(${navItemTokens.indicatorOffset})`, // per spec
+      marginInlineStart: `-${navItemTokens.indicatorOffset}px`,
       backgroundColor: tokens.colorNeutralForeground2BrandSelected,
-      width: navItemTokens.indicatorWidth,
-      height: navItemTokens.indicatorHeight,
+      height: `${navItemTokens.indicatorHeight}px`,
+      width: `${navItemTokens.indicatorWidth}px`,
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
       content: '""',
     },
@@ -61,20 +66,25 @@ const useIndicatorStyles = makeStyles({
 
 const useIconStyles = makeStyles({
   base: {
-    height: navItemTokens.indicatorHeight,
-    [`& .${iconClassNames.filled}`]: {
+    minHeight: '20px',
+    minWidth: '20px',
+    alignItems: 'top',
+    display: 'inline-flex',
+    justifyContent: 'center',
+    ...shorthands.overflow('hidden'),
+    [`& .${iconFilledClassName}`]: {
       display: 'none',
     },
-    [`& .${iconClassNames.regular}`]: {
+    [`& .${iconRegularClassName}`]: {
       display: 'inline',
     },
   },
   selected: {
-    [`& .${iconClassNames.filled}`]: {
+    [`& .${iconFilledClassName}`]: {
       display: 'inline',
       color: tokens.colorNeutralForeground2BrandSelected,
     },
-    [`& .${iconClassNames.regular}`]: {
+    [`& .${iconRegularClassName}`]: {
       display: 'none',
     },
   },
@@ -84,7 +94,7 @@ const useIconStyles = makeStyles({
  * Apply styling to the NavItem slots based on the state
  */
 export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => {
-  const rootDefaultStyles = useRootDefaultStyles();
+  const rootDefaultClassName = useRootDefaultClassName();
   const contentStyles = useContentStyles();
   const indicatorStyles = useIndicatorStyles();
   const iconStyles = useIconStyles();
@@ -93,7 +103,7 @@ export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => 
 
   state.root.className = mergeClasses(
     navItemClassNames.root,
-    rootDefaultStyles,
+    rootDefaultClassName,
     selected && indicatorStyles.base,
     state.root.className,
   );

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -71,8 +71,8 @@ export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => 
   state.root.className = mergeClasses(
     navItemClassNames.root,
     rootDefaultStyles,
-    state.root.className,
     selected && indicatorStyles.base,
+    state.root.className,
   );
 
   state.content.className = mergeClasses(
@@ -85,8 +85,8 @@ export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => 
   if (state.selectedIcon) {
     state.selectedIcon.className = mergeClasses(
       navItemClassNames.selectedIcon,
-      state.selectedIcon.className,
       selectedIconStyles.base,
+      state.selectedIcon.className,
     );
   }
 

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItemStyles.styles.ts
@@ -6,9 +6,17 @@ import { tokens, typographyStyles } from '@fluentui/react-theme';
 export const navItemClassNames: SlotClassNames<NavItemSlots> = {
   root: 'fui-NavItem',
   content: 'fui-NavItem__content',
-  selectedIcon: 'fui-NavItem__selectedIcon',
-  unSelectedIcon: 'fui-NavItem__unSelectedIcon',
+  icon: 'fui-NavItem__icon',
 };
+
+// These should match the constants defined in @fluentui/react-icons
+// This package avoids taking a dependency on the icons package for only the constants.
+const iconClassNames = {
+  filled: 'fui-Icon-filled',
+  regular: 'fui-Icon-regular',
+};
+
+const navItemTokens = { indicatorWidth: '4px', indicatorOffset: '-18px', indicatorHeight: '20px' };
 
 /**
  * Styles for the root slot
@@ -37,26 +45,38 @@ const useContentStyles = makeStyles({
   selected: typographyStyles.body1Strong,
 });
 
-const indicatorHeight = '20px';
-
 const useIndicatorStyles = makeStyles({
   base: {
     '::after': {
       position: 'absolute',
-      transform: 'translateX(-18px)', // per spec
+      transform: `translateX(${navItemTokens.indicatorOffset})`, // per spec
       backgroundColor: tokens.colorNeutralForeground2BrandSelected,
-      width: '4px', // No relevant to any design token for these
-      height: indicatorHeight,
+      width: navItemTokens.indicatorWidth,
+      height: navItemTokens.indicatorHeight,
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
       content: '""',
     },
   },
 });
 
-const useSelectedIconStyles = makeStyles({
+const useIconStyles = makeStyles({
   base: {
-    color: tokens.colorNeutralForeground2BrandSelected,
-    height: indicatorHeight,
+    height: navItemTokens.indicatorHeight,
+    [`& .${iconClassNames.filled}`]: {
+      display: 'none',
+    },
+    [`& .${iconClassNames.regular}`]: {
+      display: 'inline',
+    },
+  },
+  selected: {
+    [`& .${iconClassNames.filled}`]: {
+      display: 'inline',
+      color: tokens.colorNeutralForeground2BrandSelected,
+    },
+    [`& .${iconClassNames.regular}`]: {
+      display: 'none',
+    },
   },
 });
 
@@ -67,7 +87,7 @@ export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => 
   const rootDefaultStyles = useRootDefaultStyles();
   const contentStyles = useContentStyles();
   const indicatorStyles = useIndicatorStyles();
-  const selectedIconStyles = useSelectedIconStyles();
+  const iconStyles = useIconStyles();
 
   const { selected } = state;
 
@@ -84,18 +104,13 @@ export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => 
     state.content.className,
   );
 
-  // Only shows in the selected state
-  if (state.selectedIcon) {
-    state.selectedIcon.className = mergeClasses(
-      navItemClassNames.selectedIcon,
-      selectedIconStyles.base,
-      state.selectedIcon.className,
+  if (state.icon) {
+    state.icon.className = mergeClasses(
+      navItemClassNames.icon,
+      iconStyles.base,
+      selected && iconStyles.selected,
+      state.icon.className,
     );
-  }
-
-  // Only shows in the selected state
-  if (state.unSelectedIcon) {
-    state.unSelectedIcon.className = mergeClasses(navItemClassNames.unSelectedIcon, state.unSelectedIcon.className);
   }
 
   return state;

--- a/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Nav, NavItem, NavItemProps } from '@fluentui/react-nav-preview';
 import { Folder20Regular, Folder20Filled, bundleIcon } from '@fluentui/react-icons';
-import { makeStyles, tokens } from '@fluentui/react-components';
+import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 
 const Folder = bundleIcon(Folder20Filled, Folder20Regular);
 
@@ -11,10 +11,7 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     maxWidth: '260px',
     rowGap: '60px',
-    paddingTop: '48px',
-    paddingBottom: '48px',
-    paddingLeft: '48px',
-    paddingRight: '48px',
+    ...shorthands.padding('40px'),
     backgroundColor: tokens.colorNeutralBackground4,
   },
 });

--- a/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
@@ -1,4 +1,50 @@
 import * as React from 'react';
-import { NavItem, NavItemProps } from '@fluentui/react-nav-preview';
+import { Nav, NavItem, NavItemProps } from '@fluentui/react-nav-preview';
+import { Folder20Regular, Folder20Filled } from '@fluentui/react-icons';
 
-export const Default = (props: Partial<NavItemProps>) => <NavItem value={'someValue'} {...props} />;
+import { makeStyles } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  root: { display: 'flex', flexDirection: 'column', rowGap: '60px' },
+});
+
+export const Default = (props: Partial<NavItemProps>) => {
+  const classes = useStyles();
+
+  const someClickHandler = () => {
+    console.log('someClickHandler');
+  };
+
+  return (
+    <div className={classes.root}>
+      <Nav defaultSelectedValue={'2'}>
+        <NavItem value="1" target="_blank" onClick={someClickHandler}>
+          Not Selected, no Icon
+        </NavItem>
+        <NavItem value="2" target="_blank" onClick={someClickHandler}>
+          Selected, no icon
+        </NavItem>
+      </Nav>
+      <Nav defaultSelectedValue={'2'}>
+        <NavItem
+          value="1"
+          selectedIcon={<Folder20Filled />}
+          unSelectedIcon={<Folder20Regular />}
+          target="_blank"
+          onClick={someClickHandler}
+        >
+          Not Selected, icon present
+        </NavItem>
+        <NavItem
+          value="2"
+          selectedIcon={<Folder20Filled />}
+          unSelectedIcon={<Folder20Regular />}
+          target="_blank"
+          onClick={someClickHandler}
+        >
+          Selected, icon present
+        </NavItem>
+      </Nav>
+    </div>
+  );
+};

--- a/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
@@ -2,10 +2,20 @@ import * as React from 'react';
 import { Nav, NavItem, NavItemProps } from '@fluentui/react-nav-preview';
 import { Folder20Regular, Folder20Filled } from '@fluentui/react-icons';
 
-import { makeStyles } from '@fluentui/react-components';
+import { makeStyles, tokens } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
-  root: { display: 'flex', flexDirection: 'column', rowGap: '60px' },
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '260px',
+    rowGap: '60px',
+    paddingTop: '48px',
+    paddingBottom: '48px',
+    paddingLeft: '48px',
+    paddingRight: '48px',
+    backgroundColor: tokens.colorNeutralBackground4,
+  },
 });
 
 export const Default = (props: Partial<NavItemProps>) => {

--- a/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
@@ -25,7 +25,7 @@ export const Default = (props: Partial<NavItemProps>) => {
 
   return (
     <div className={classes.root}>
-      <Nav defaultSelectedValue={'2'}>
+      <Nav defaultSelectedValue="2">
         <NavItem value="1" target="_blank" onClick={someClickHandler}>
           Not Selected, no Icon
         </NavItem>
@@ -33,7 +33,7 @@ export const Default = (props: Partial<NavItemProps>) => {
           Selected, no icon
         </NavItem>
       </Nav>
-      <Nav defaultSelectedValue={'2'}>
+      <Nav defaultSelectedValue="2">
         <NavItem value="1" icon={<Folder />} target="_blank" onClick={someClickHandler}>
           Not Selected, icon present
         </NavItem>

--- a/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavItem/NavItemDefault.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { Nav, NavItem, NavItemProps } from '@fluentui/react-nav-preview';
-import { Folder20Regular, Folder20Filled } from '@fluentui/react-icons';
-
+import { Folder20Regular, Folder20Filled, bundleIcon } from '@fluentui/react-icons';
 import { makeStyles, tokens } from '@fluentui/react-components';
+
+const Folder = bundleIcon(Folder20Filled, Folder20Regular);
 
 const useStyles = makeStyles({
   root: {
@@ -36,22 +37,10 @@ export const Default = (props: Partial<NavItemProps>) => {
         </NavItem>
       </Nav>
       <Nav defaultSelectedValue={'2'}>
-        <NavItem
-          value="1"
-          selectedIcon={<Folder20Filled />}
-          unSelectedIcon={<Folder20Regular />}
-          target="_blank"
-          onClick={someClickHandler}
-        >
+        <NavItem value="1" icon={<Folder />} target="_blank" onClick={someClickHandler}>
           Not Selected, icon present
         </NavItem>
-        <NavItem
-          value="2"
-          selectedIcon={<Folder20Filled />}
-          unSelectedIcon={<Folder20Regular />}
-          target="_blank"
-          onClick={someClickHandler}
-        >
+        <NavItem value="2" icon={<Folder />} target="_blank" onClick={someClickHandler}>
           Selected, icon present
         </NavItem>
       </Nav>


### PR DESCRIPTION
Adds styling for the medium size of the NavItem.
Adds selectedIcon and unSelectedIcon props.

Ladders up to #26649 

Things to check for:
Do the new icon names make sense and match standards?
Is the thing pixel perfect?

Spec:
![image](https://github.com/microsoft/fluentui/assets/17346018/dd6669c0-924e-427b-8b17-4aa547e2e52a)

Result:
![image](https://github.com/microsoft/fluentui/assets/17346018/69864dd7-8c69-40a0-a760-2bb2961dba8f)

https://github.com/microsoft/fluentui/assets/17346018/21d174bb-ca0b-4d84-a780-57a1127ed0eb


