### PR TITLE
fix: MenuSplitGroup has more height than MenuItem

### DIFF
--- a/change/@fluentui-react-menu-76ecb79c-a3ed-4071-a8ae-7f3988c67bab.json
+++ b/change/@fluentui-react-menu-76ecb79c-a3ed-4071-a8ae-7f3988c67bab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "daniharo:fix-menu-split",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
+++ b/packages/react-components/react-menu/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
       '::before': {
         content: '""',
         width: tokens.strokeWidthThin,
-        height: '24px',
+        height: '20px',
         backgroundColor: tokens.colorNeutralStroke1,
       },
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
The divider bar inside the MenuSplitGroup has a height of 24px while the other elements have 20px, resulting in a different height for the Menu Item overall.
<img width="218" alt="image" src="https://github.com/microsoft/fluentui/assets/47931084/424099a9-fb98-4a6d-bc8f-ffc355917032">

<!-- This is the behavior we have today -->

## New Behavior
The divider bar has a height of 20px, and all menu items have the same height.
<img width="222" alt="image" src="https://github.com/microsoft/fluentui/assets/47931084/c2010ba0-e5ab-4242-9616-c86a017362e1">

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
- Fixes #30958
