### PR TITLE
Using a memoized Empty Object for StyleTag rendererAttributes prop

### DIFF
--- a/change/@fluentui-react-provider-a18c5467-7dd3-413d-a1ea-e6dc40d0d731.json
+++ b/change/@fluentui-react-provider-a18c5467-7dd3-413d-a1ea-e6dc40d0d731.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Avoid re-inserting Style Element to HEAD when re-rendering FluentProvider",
+  "packageName": "@fluentui/react-provider",
+  "email": "ramyrafik@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -65,7 +65,7 @@ export const useFluentProvider_unstable = (
   const { styleTagId, rule } = useFluentProviderThemeStyleTag({
     theme: mergedTheme,
     targetDocument,
-    rendererAttributes: renderer.styleElementAttributes ?? {},
+    rendererAttributes: renderer.styleElementAttributes ?? EMPTY_OBJECT,
   });
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/src/components/FluentProvider/useFluentProvider.ts
@@ -16,8 +16,9 @@ import * as React from 'react';
 import { useFluentProviderThemeStyleTag } from './useFluentProviderThemeStyleTag';
 import type { FluentProviderProps, FluentProviderState } from './FluentProvider.types';
 
-// Fixes a bug where returning a new object each time would cause unnecessary rerenders.
-const EMPTY_OBJECT = {};
+// Meomizing empty objects to avoid unnecessary rerenders.
+const DEFAULT_STYLE_HOOKS = {};
+const DEFAULT_RENDERER_ATTRIBUTES = {};
 
 /**
  * Create the state required to render FluentProvider.
@@ -36,7 +37,7 @@ export const useFluentProvider_unstable = (
   const parentTheme = useTheme();
   const parentOverrides = useOverrides();
   const parentCustomStyleHooks: CustomStyleHooksContextValue =
-    React.useContext(CustomStyleHooksContext) || EMPTY_OBJECT;
+    React.useContext(CustomStyleHooksContext) || DEFAULT_STYLE_HOOKS;
 
   /**
    * TODO: add merge functions to "dir" merge,
@@ -65,7 +66,7 @@ export const useFluentProvider_unstable = (
   const { styleTagId, rule } = useFluentProviderThemeStyleTag({
     theme: mergedTheme,
     targetDocument,
-    rendererAttributes: renderer.styleElementAttributes ?? EMPTY_OBJECT,
+    rendererAttributes: renderer.styleElementAttributes ?? DEFAULT_RENDERER_ATTRIBUTES,
   });
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Previous Behavior
When a FluentProvider component re-renders, the associated Style element is removed and re-inserted to the HEAD. Aside from the Perf improvement, this can lead to rendering un-styled child Components, if the Browser gets few frames between the Deletion and Insertion of the Style element.

Example, taken from PowerApps bug (No PII, All is debug-data)
Resizing triggers re-rendering of React Tree, including FluentProvider

![5336dad7-879b-47c0-bd90-2f3c480ec218](https://github.com/microsoft/fluentui/assets/20221435/2c7a18fa-c144-4e6e-9b34-3c4500ed65a0)


Adding a "Break on -> Node Removal" to the Style element revealed the cause.

The root cause was passing a new Empty Object in the Props to `useFluentProviderThemeStyleTag` every time the FluentProvider re-renders.

## New Behavior
We are now using a memoized empty Object, similar to the `EMPTY_OBJECT` which was created previously for the same issue.

## Related Issue(s)
N/A- There is an issue on Power Apps  product (Bug # 3824191) due to current behavior. I didn't create an issue on FluentUI repo since the fix is less time consuming.