### PR TITLE
Fix colors for high contrast mode in chart hover card

### DIFF
--- a/change/@fluentui-react-charting-d62e0aee-98a2-4b2f-88e2-4913bde0b1c7.json
+++ b/change/@fluentui-react-charting-d62e0aee-98a2-4b2f-88e2-4913bde0b1c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix colors for high contrast mode in chart hover card",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -254,6 +254,9 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
                     margin-top: unset;
                     padding-left: 8px;
                   }
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <div
                 className=
@@ -266,6 +269,9 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
                       font-size: 12px;
                       font-weight: 400;
                       line-height: 16px;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                      color: rgb(255, 255, 255);
                     }
               >
                 2020/04/30
@@ -281,6 +287,9 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
                       font-size: 28px;
                       font-weight: bold;
                       line-height: 36px;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                      color: rgb(255, 255, 255);
                     }
               >
                 20,000

--- a/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/DonutChart/__snapshots__/DonutChartRTL.test.tsx.snap
@@ -227,6 +227,9 @@ exports[`Donut chart interactions Should hide callout on mouse leave 1`] = `
                       margin-top: unset;
                       padding-left: 8px;
                     }
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <div
                   class=
@@ -239,6 +242,9 @@ exports[`Donut chart interactions Should hide callout on mouse leave 1`] = `
                         font-size: 12px;
                         font-weight: 400;
                         line-height: 16px;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                        color: rgb(255, 255, 255);
                       }
                 >
                   2020/04/30
@@ -254,6 +260,9 @@ exports[`Donut chart interactions Should hide callout on mouse leave 1`] = `
                         font-size: 28px;
                         font-weight: bold;
                         line-height: 36px;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                        color: rgb(255, 255, 255);
                       }
                 >
                   20,000

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -822,6 +822,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
                       margin-top: unset;
                       padding-left: 8px;
                     }
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <div
                   className=
@@ -835,6 +838,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
                         font-weight: 400;
                         line-height: 16px;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                        color: rgb(255, 255, 255);
+                      }
                 />
                 <div
                   className=
@@ -847,6 +853,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
                         font-size: 28px;
                         font-weight: bold;
                         line-height: 36px;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                        color: rgb(255, 255, 255);
                       }
                 >
                   66

--- a/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChartRTL.test.tsx.snap
@@ -4358,6 +4358,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
                       margin-top: unset;
                       padding-left: 8px;
                     }
+                    @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <div
                   className=
@@ -4371,6 +4374,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
                         font-weight: 400;
                         line-height: 16px;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                        color: rgb(255, 255, 255);
+                      }
                 />
                 <div
                   className=
@@ -4383,6 +4389,9 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
                         font-size: 28px;
                         font-weight: bold;
                         line-height: 36px;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                        color: rgb(255, 255, 255);
                       }
                 >
                   66

--- a/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -462,6 +462,9 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
                     margin-top: unset;
                     padding-left: 8px;
                   }
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <div
                 className=
@@ -474,6 +477,9 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
                       font-size: 12px;
                       font-weight: 400;
                       line-height: 16px;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                      color: rgb(255, 255, 255);
                     }
               >
                 2020/04/30
@@ -489,6 +495,9 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
                       font-size: 28px;
                       font-weight: bold;
                       line-height: 36px;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                      color: rgb(255, 255, 255);
                     }
               >
                 19%

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/MultiStackedBarChart.test.tsx.snap
@@ -627,6 +627,9 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
                     margin-top: unset;
                     padding-left: 8px;
                   }
+                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <div
                 className=
@@ -639,6 +642,9 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
                       font-size: 12px;
                       font-weight: 400;
                       line-height: 16px;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                      color: rgb(255, 255, 255);
                     }
               >
                 2020/04/30
@@ -654,6 +660,9 @@ exports[`MultiStackedBarChart - mouse events Should render callout correctly on 
                       font-size: 28px;
                       font-weight: bold;
                       line-height: 36px;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                      color: rgb(255, 255, 255);
                     }
               >
                 40%

--- a/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/StackedBarChart/__snapshots__/StackedBarChart.test.tsx.snap
@@ -328,6 +328,9 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
                           margin-top: unset;
                           padding-left: 8px;
                         }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                          forced-color-adjust: none;
+                        }
                   >
                     <div
                       className=
@@ -340,6 +343,9 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
                             font-size: 12px;
                             font-weight: 400;
                             line-height: 16px;
+                          }
+                          @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                            color: rgb(255, 255, 255);
                           }
                     >
                       first Lorem ipsum dolor sit amet
@@ -355,6 +361,9 @@ exports[`StackedBarChart - mouse events Should render callout correctly on mouse
                             font-size: 28px;
                             font-weight: bold;
                             line-height: 36px;
+                          }
+                          @media screen and (-ms-high-contrast: white-on-black), screen and (forced-colors: active) and (prefers-color-scheme: dark){& {
+                            color: rgb(255, 255, 255);
                           }
                     >
                       40

--- a/packages/react-charting/src/utilities/ChartHoverCard/ChartHoverCard.styles.ts
+++ b/packages/react-charting/src/utilities/ChartHoverCard/ChartHoverCard.styles.ts
@@ -1,5 +1,5 @@
 import { IChartHoverCardStyles, IChartHoverCardStyleProps } from './ChartHoverCard.types';
-import { FontWeights } from '@fluentui/react/lib/Styling';
+import { FontWeights, HighContrastSelector, HighContrastSelectorBlack } from '@fluentui/react/lib/Styling';
 
 export const getChartHoverCardStyles = (props: IChartHoverCardStyleProps): IChartHoverCardStyles => {
   const { color, XValue, theme, isRatioPresent = false } = props;
@@ -34,6 +34,11 @@ export const getChartHoverCardStyles = (props: IChartHoverCardStyleProps): IChar
         lineHeight: '22px',
         color: theme.semanticColors.bodyText,
         borderLeft: `4px solid ${color}`,
+        selectors: {
+          [HighContrastSelector]: {
+            forcedColorAdjust: 'none',
+          },
+        },
       },
     ],
     calloutlegendText: [
@@ -41,6 +46,11 @@ export const getChartHoverCardStyles = (props: IChartHoverCardStyleProps): IChar
       {
         lineHeight: '16px',
         color: theme.semanticColors.bodyText,
+        selectors: {
+          [HighContrastSelectorBlack]: {
+            color: 'rgb(255, 255, 255)',
+          },
+        },
       },
     ],
     calloutContentY: [
@@ -49,6 +59,11 @@ export const getChartHoverCardStyles = (props: IChartHoverCardStyleProps): IChar
         color: color ? color : theme.semanticColors.bodyText,
         fontWeight: 'bold',
         lineHeight: '36px',
+        selectors: {
+          [HighContrastSelectorBlack]: {
+            color: 'rgb(255, 255, 255)',
+          },
+        },
       },
     ],
     calloutInfoContainer: [


### PR DESCRIPTION
## Previous Behavior

<img src="https://github.com/microsoft/fluentui/assets/110246001/1f14e4c3-53ea-4e8e-98aa-14181e763d7d" alt="Before (1)" width="150" /> <img src="https://github.com/microsoft/fluentui/assets/110246001/82971d68-e7c0-4168-b76a-485fc2ae8d10" alt="Before (2)" width="300" />

## New Behavior

<img src="https://github.com/microsoft/fluentui/assets/110246001/a48f1304-2d76-4b99-ae36-65e79e0e63a7" alt="After (1)" width="150" /> <img src="https://github.com/microsoft/fluentui/assets/110246001/92a989ed-4b4e-446c-a750-fefaf9e9f36e" alt="After (2)" width="300" />