### PR TITLE
fix: v8 Dropdown selected option focus outline has contrast against bg

### DIFF
--- a/change/@fluentui-react-abae2dcb-355d-404a-90a2-df54f9744ba1.json
+++ b/change/@fluentui-react-abae2dcb-355d-404a-90a2-df54f9744ba1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: selected option focus outline has contrast against bg",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react/src/components/Dropdown/Dropdown.styles.ts
@@ -47,6 +47,10 @@ const highContrastItemAndTitleStateMixin: IRawStyle = {
       backgroundColor: 'Highlight',
       borderColor: 'Highlight',
       color: 'HighlightText',
+
+      [`.${IsFocusVisibleClassName} &:focus:after`]: {
+        borderColor: 'HighlightText',
+      },
     },
     ['.ms-Checkbox-checkbox']: {
       [HighContrastSelector]: {

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -434,6 +434,13 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                             border-color: Highlight;
                             color: HighlightText;
                           }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border-color: HighlightText;
+                            bottom: 0px;
+                            left: 0px;
+                            right: 0px;
+                            top: 0px;
+                          }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
@@ -468,12 +475,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active:hover {
                             -ms-high-contrast-adjust: none;
                             forced-color-adjust: none;
-                          }
-                          .ms-Fabric--isFocusVisible &:focus:after {
-                            bottom: 0px;
-                            left: 0px;
-                            right: 0px;
-                            top: 0px;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                             inset: 2px;
@@ -701,6 +702,13 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                           border-color: Highlight;
                           color: HighlightText;
                         }
+                        .ms-Fabric--isFocusVisible &:focus:after {
+                          border-color: HighlightText;
+                          bottom: 0px;
+                          left: 0px;
+                          right: 0px;
+                          top: 0px;
+                        }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:hover {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
@@ -735,12 +743,6 @@ exports[`Dropdown multi-select Renders correctly when open 1`] = `
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active), screen and (-ms-high-contrast: black-on-white), screen and (forced-colors: active) and (prefers-color-scheme: light){&:active:hover {
                           -ms-high-contrast-adjust: none;
                           forced-color-adjust: none;
-                        }
-                        .ms-Fabric--isFocusVisible &:focus:after {
-                          bottom: 0px;
-                          left: 0px;
-                          right: 0px;
-                          top: 0px;
                         }
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
                           inset: 2px;
@@ -1643,6 +1645,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                             border: 0;
                           }
                           .ms-Fabric--isFocusVisible &:focus:after {
+                            border-color: HighlightText;
                             border: 1px solid transparent;
                             bottom: 0px;
                             content: "";
@@ -1831,6 +1834,7 @@ exports[`Dropdown single-select Renders correctly when open 1`] = `
                           border: 0;
                         }
                         .ms-Fabric--isFocusVisible &:focus:after {
+                          border-color: HighlightText;
                           border: 1px solid transparent;
                           bottom: 0px;
                           content: "";


### PR DESCRIPTION
## Previous Behavior

The focus outline color didn't have guaranteed contrast against the selected option bg color in high contrast mode:
![the selected option has a white outline against a light blue background](https://github.com/microsoft/fluentui/assets/3819570/b8050c7e-5195-4c34-af39-29f75258b32c)

## New Behavior

fixed!
![selected option has a black outline against the light blue bg color](https://github.com/microsoft/fluentui/assets/3819570/c2581027-1e62-4284-925a-705f2640100d)

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/16200)
