### PR TITLE
fix(scripts-tasks): restore original tsconfig if type-check failed

### DIFF
--- a/scripts/tasks/src/type-check.ts
+++ b/scripts/tasks/src/type-check.ts
@@ -34,6 +34,8 @@ export function typeCheck() {
   return exec(program)
     .catch(err => {
       console.error(err.stdout);
+      // restore original tsconfig.json
+      fs.writeFileSync(configPath, content, 'utf-8');
       process.exit(1);
     })
     .finally(() => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

when `generate-api` fails it leaves project in invalid/modified state

## New Behavior

`process.exit` will not allow failed promise to flow to `finally` thus we need to cleanup within catch

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
