### PR TITLE
perf: exclude cypress test files from tsc Program for `.d.ts` generation and type-checking

### DIFF
--- a/change/@fluentui-react-drawer-ecbe0ab7-6a66-465a-ac31-daf11345c21c.json
+++ b/change/@fluentui-react-drawer-ecbe0ab7-6a66-465a-ac31-daf11345c21c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "perf: speed up tsc by not running on cypress files during .d.ts generation and type-checking",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infobutton-9b9694b6-4898-4726-9013-1cc195c28984.json
+++ b/change/@fluentui-react-infobutton-9b9694b6-4898-4726-9013-1cc195c28984.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "perf: speed up tsc by not running on cypress files during .d.ts generation and type-checking",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infolabel-bff74b1d-1607-4226-9d1d-c9dd3fd6998c.json
+++ b/change/@fluentui-react-infolabel-bff74b1d-1607-4226-9d1d-c9dd3fd6998c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "perf: speed up tsc by not running on cypress files during .d.ts generation and type-checking",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tree-2717028e-e8b4-4198-aa82-71af3425d855.json
+++ b/change/@fluentui-react-tree-2717028e-e8b4-4198-aa82-71af3425d855.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "perf: speed up tsc by not running on cypress files during .d.ts generation and type-checking",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.cy.tsx
+++ b/packages/react-components/react-datepicker-compat/src/components/DatePicker/DatePicker.cy.tsx
@@ -1,4 +1,3 @@
-/// <reference types="cypress-real-events" />
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 

--- a/packages/react-components/react-drawer/tsconfig.lib.json
+++ b/packages/react-components/react-drawer/tsconfig.lib.json
@@ -11,12 +11,15 @@
   },
   "exclude": [
     "./src/testing/**",
+    "./src/e2e/**",
     "**/*.spec.ts",
     "**/*.spec.tsx",
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",
-    "**/*.stories.tsx"
+    "**/*.stories.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
   ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-infobutton/src/components/InfoLabel/InfoLabel.cy.tsx
+++ b/packages/react-components/react-infobutton/src/components/InfoLabel/InfoLabel.cy.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable deprecation/deprecation */
-/// <reference types="cypress-real-events" />
 
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';

--- a/packages/react-components/react-infobutton/tsconfig.lib.json
+++ b/packages/react-components/react-infobutton/tsconfig.lib.json
@@ -16,7 +16,9 @@
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",
-    "**/*.stories.tsx"
+    "**/*.stories.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
   ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-infolabel/src/components/InfoLabel/InfoLabel.cy.tsx
+++ b/packages/react-components/react-infolabel/src/components/InfoLabel/InfoLabel.cy.tsx
@@ -1,5 +1,3 @@
-/// <reference types="cypress-real-events" />
-
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';

--- a/packages/react-components/react-infolabel/tsconfig.json
+++ b/packages/react-components/react-infolabel/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "./.storybook/tsconfig.json"
+    },
+    {
+      "path": "./tsconfig.cy.json"
     }
   ]
 }

--- a/packages/react-components/react-infolabel/tsconfig.lib.json
+++ b/packages/react-components/react-infolabel/tsconfig.lib.json
@@ -16,7 +16,9 @@
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",
-    "**/*.stories.tsx"
+    "**/*.stories.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
   ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-tree/src/components/FlatTree/FlatTree.cy.tsx
+++ b/packages/react-components/react-tree/src/components/FlatTree/FlatTree.cy.tsx
@@ -1,6 +1,3 @@
-/// <reference types="cypress" />
-/// <reference types="cypress-real-events" />
-
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';

--- a/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
@@ -1,6 +1,3 @@
-/// <reference types="cypress" />
-/// <reference types="cypress-real-events" />
-
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';

--- a/packages/react-components/react-tree/tsconfig.json
+++ b/packages/react-components/react-tree/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "./.storybook/tsconfig.json"
+    },
+    {
+      "path": "./tsconfig.cy.json"
     }
   ]
 }

--- a/packages/react-components/react-tree/tsconfig.lib.json
+++ b/packages/react-components/react-tree/tsconfig.lib.json
@@ -16,7 +16,9 @@
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",
-    "**/*.stories.tsx"
+    "**/*.stories.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
   ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
### Pre-requirements

- [x] https://github.com/microsoft/fluentui/pull/30988

## Previous Behavior

- we have invalid setup for Type checking and cypress component tests in various projects ( probably caused by not invoking cy config generator )

## New Behavior

- all projects using cypress are properly configured 
- .d.ts generation now avoids running tsc on cypress file trees which adds some speed boost

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
- Also needed for https://github.com/microsoft/fluentui/pull/30866
