### PR TITLE
perf(scripts-task): turn off path aliases within generate-api task, make isUsingPathAliasesForDx lazy => improve d.ts generation speed by ~60%

### DIFF
--- a/change/@fluentui-react-field-b0fef346-1748-4494-95c1-40003abf4b2f.json
+++ b/change/@fluentui-react-field-b0fef346-1748-4494-95c1-40003abf4b2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: re-genearate api.md as result of perf improvements to generate-api task",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-field/etc/react-field.api.md
+++ b/packages/react-components/react-field/etc/react-field.api.md
@@ -21,7 +21,7 @@ export const Field: ForwardRefComponent<FieldProps>;
 export const fieldClassNames: SlotClassNames<FieldSlots>;
 
 // @public (undocumented)
-export const FieldContextProvider: React_2.Provider<Readonly<Pick<FieldState, "orientation" | "required" | "size" | "validationState" | "generatedControlId"> & {
+export const FieldContextProvider: React_2.Provider<Readonly<Pick<FieldState, "required" | "size" | "orientation" | "validationState" | "generatedControlId"> & {
     labelFor?: string | undefined;
     labelId?: string | undefined;
     validationMessageId?: string | undefined;
@@ -81,7 +81,7 @@ export const renderField_unstable: (state: FieldState, contextValues: FieldConte
 export const useField_unstable: (props: FieldProps, ref: React_2.Ref<HTMLDivElement>) => FieldState;
 
 // @public (undocumented)
-export const useFieldContext_unstable: () => Readonly<Pick<FieldState, "orientation" | "required" | "size" | "validationState" | "generatedControlId"> & {
+export const useFieldContext_unstable: () => Readonly<Pick<FieldState, "required" | "size" | "orientation" | "validationState" | "generatedControlId"> & {
     labelFor?: string | undefined;
     labelId?: string | undefined;
     validationMessageId?: string | undefined;

--- a/scripts/tasks/src/generate-api.ts
+++ b/scripts/tasks/src/generate-api.ts
@@ -10,12 +10,13 @@ export function generateApi() {
 }
 
 function generateTypeDeclarations() {
-  const { isUsingPathAliasesForDx, tsConfigFileForCompilation } = getTsPathAliasesConfigUsedOnlyForDx();
+  const { tsConfigFileForCompilation } = getTsPathAliasesConfigUsedOnlyForDx();
   const cmd = [
     'tsc',
     `-p ./${tsConfigFileForCompilation}`,
     '--emitDeclarationOnly',
-    isUsingPathAliasesForDx ? '--baseUrl .' : null,
+    // turn off path aliases.
+    '--baseUrl .',
   ]
     .filter(Boolean)
     .join(' ');

--- a/scripts/tasks/src/ts.ts
+++ b/scripts/tasks/src/ts.ts
@@ -26,7 +26,7 @@ function prepareTsTaskConfig(options: TscTaskOptions) {
 
   const { isUsingPathAliasesForDx, tsConfigFileForCompilation } = getTsPathAliasesConfigUsedOnlyForDx();
 
-  if (isUsingPathAliasesForDx) {
+  if (isUsingPathAliasesForDx()) {
     logger.info(`📣 TSC: Project is using TS path aliases for DX. Disabling aliases for build.`);
     options.baseUrl = '.';
     options.rootDir = './src';

--- a/scripts/tasks/src/utils.ts
+++ b/scripts/tasks/src/utils.ts
@@ -65,7 +65,6 @@ export function getTsPathAliasesConfig() {
 
 export function getTsPathAliasesConfigUsedOnlyForDx() {
   const tsConfigFilesWithAliases = ['tsconfig.app.json', 'tsconfig.lib.json', 'tsconfig.json'];
-  const tsConfigBaseFilesForDx = ['tsconfig.base.v8.json', 'tsconfig.base.all.json'];
   const cwd = process.cwd();
   const tsConfigPath = path.join(cwd, `./tsconfig.json`);
 
@@ -73,15 +72,19 @@ export function getTsPathAliasesConfigUsedOnlyForDx() {
     throw new Error(`${tsConfigPath} doesn't exist`);
   }
 
-  const tsConfig = JSON.parse(stripJsonComments(fs.readFileSync(tsConfigPath, 'utf-8')));
-  const isUsingPathAliasesForDx =
-    tsConfig.extends && tsConfigBaseFilesForDx.some(relativeFilePath => tsConfig.extends.endsWith(relativeFilePath));
-
   const tsConfigFileForCompilation = tsConfigFilesWithAliases.find(fileName => fs.existsSync(path.join(cwd, fileName)));
 
   if (!tsConfigFileForCompilation) {
     throw new Error(`no tsconfig from one of [${tsConfigFilesWithAliases}] found!`);
   }
+
+  const isUsingPathAliasesForDx = () => {
+    const tsConfigBaseFilesForDx = ['tsconfig.base.v8.json', 'tsconfig.base.all.json'];
+    const tsConfig = JSON.parse(stripJsonComments(fs.readFileSync(tsConfigPath, 'utf-8')));
+    return Boolean(
+      tsConfig.extends && tsConfigBaseFilesForDx.some(relativeFilePath => tsConfig.extends.endsWith(relativeFilePath)),
+    );
+  };
 
   return { isUsingPathAliasesForDx, tsConfigFileForCompilation };
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

### Pre-requirements:

- [x] https://github.com/microsoft/fluentui/pull/30989

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- `isUsingPathAliasesForDx` us not used anymore for v9 packages - refactored to make it lazy for few v0/v8 invocations
- TS path aliases are not used anymore for `d.ts` generation in v9 packages - which yields significant perf boost ( **up to 60%  faster** - based on package )

| command | Before | After |
|--------|--------|--------|
| yarn workspace @fluentui/react-drawer generate-api | 16s | 7s /  **𝚫 56% faster** |


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
