### PR TITLE
feat(eslint-plugin): add triple-slash-reference rule to  ban TS '///' within source code

### DIFF
--- a/change/@fluentui-eslint-plugin-ee7a918a-238e-45f3-8a6b-18eb7ca7e02b.json
+++ b/change/@fluentui-eslint-plugin-ee7a918a-238e-45f3-8a6b-18eb7ca7e02b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(eslint-plugin): add triple-slash-reference rule to  ban TS '///' within source code",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cra-template/.eslintrc.json
+++ b/packages/cra-template/.eslintrc.json
@@ -6,7 +6,9 @@
       "files": ["template/**/*.{ts,tsx}"],
       "rules": {
         // the rule can't understand that the actual list of deps is in template.json
-        "import/no-extraneous-dependencies": "off"
+        "import/no-extraneous-dependencies": "off",
+        // valid in some template files - don't wanna spam consumer with inline eslint-disabled pragmas
+        "@typescript-eslint/triple-slash-reference": "off"
       }
     }
   ]

--- a/packages/eslint-plugin/src/configs/base.js
+++ b/packages/eslint-plugin/src/configs/base.js
@@ -14,6 +14,8 @@ module.exports = {
      */
     ...getNamingConventionRule(),
     '@fluentui/max-len': 'off',
+    // @typescript-eslint rules
+    '@typescript-eslint/triple-slash-reference': ['error', { lib: 'always', path: 'never', types: 'never' }],
   },
   overrides: [
     {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
@@ -1,6 +1,3 @@
-/// <reference types="cypress" />
-/// <reference types="cypress-real-events" />
-
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- see PR title
- adds new lint rule for v9 scope https://github.com/microsoft/fluentui/pull/30989 
  -  using manually references is most of the time a code-smell/antipattern so we should disallow this behaviours

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- [x] Follows/Depends on: https://github.com/microsoft/fluentui/pull/30989
