### PR TITLE
feat(workspace-plugin): scaffold `split-library-in-two` generator

### DIFF
--- a/tools/workspace-plugin/generators.json
+++ b/tools/workspace-plugin/generators.json
@@ -89,6 +89,11 @@
       "factory": "./src/generators/bundle-size-configuration/generator",
       "schema": "./src/generators/bundle-size-configuration/schema.json",
       "description": "bundle-size-configuration generator"
+    },
+    "split-library-in-two": {
+      "factory": "./src/generators/split-library-in-two/generator",
+      "schema": "./src/generators/split-library-in-two/schema.json",
+      "description": "split-library-in-two generator"
     }
   }
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/files/src/index.ts.template
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/files/src/index.ts.template
@@ -1,0 +1,1 @@
+const variable = "<%= name %>";

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -1,0 +1,20 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, readProjectConfiguration } from '@nx/devkit';
+
+import { splitLibraryInTwoGenerator } from './generator';
+import { SplitLibraryInTwoGeneratorSchema } from './schema';
+
+describe('split-library-in-two generator', () => {
+  let tree: Tree;
+  const options: SplitLibraryInTwoGeneratorSchema = { name: 'test' };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should run successfully', async () => {
+    await splitLibraryInTwoGenerator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config).toBeDefined();
+  });
+});

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -1,0 +1,17 @@
+import { addProjectConfiguration, formatFiles, generateFiles, Tree } from '@nx/devkit';
+import * as path from 'path';
+import { SplitLibraryInTwoGeneratorSchema } from './schema';
+
+export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibraryInTwoGeneratorSchema) {
+  const projectRoot = `libs/${options.name}`;
+  addProjectConfiguration(tree, options.name, {
+    root: projectRoot,
+    projectType: 'library',
+    sourceRoot: `${projectRoot}/src`,
+    targets: {},
+  });
+  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
+  await formatFiles(tree);
+}
+
+export default splitLibraryInTwoGenerator;

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
@@ -1,0 +1,3 @@
+export interface SplitLibraryInTwoGeneratorSchema {
+  name: string;
+}

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "SplitLibraryInTwo",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use?"
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

boilerplate via `nx g @nx/plugin:generator`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
