### PR TITLE
chore(react-tag-picker): removes unused props

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-fd7805bc-8cca-4f4b-b0b1-65f51c89d40d.json
+++ b/change/@fluentui-react-tag-picker-preview-fd7805bc-8cca-4f4b-b0b1-65f51c89d40d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: removes unused props",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
+++ b/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
@@ -73,7 +73,7 @@ export const TagPickerButton: ForwardRefComponent<TagPickerButtonProps>;
 export const tagPickerButtonClassNames: SlotClassNames<TagPickerButtonSlots>;
 
 // @public
-export type TagPickerButtonProps = ComponentProps<TagPickerButtonSlots> & Pick<DropdownProps, 'clearable' | 'size' | 'appearance'> & {
+export type TagPickerButtonProps = ComponentProps<TagPickerButtonSlots> & Pick<DropdownProps, 'size' | 'appearance'> & {
     disabled?: boolean;
 };
 
@@ -185,7 +185,6 @@ export type TagPickerOptionGroupState = OptionGroupState;
 // @public
 export type TagPickerOptionProps = ComponentProps<TagPickerOptionSlots> & {
     children: React_2.ReactNode;
-    text?: string;
     value: string;
 };
 
@@ -196,7 +195,7 @@ export type TagPickerOptionSlots = Pick<OptionSlots, 'root'> & {
 };
 
 // @public
-export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Pick<OptionState, 'components' | 'multiselect' | 'root' | 'selected'>;
+export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Pick<OptionState, 'components' | 'root'>;
 
 // @public
 export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps, 'positioning' | 'disabled' | 'defaultOpen' | 'selectedOptions' | 'defaultSelectedOptions' | 'open' | 'freeform'> & Pick<Partial<TagPickerContextValue>, 'size' | 'appearance'> & {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/TagPickerButton.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/TagPickerButton.types.ts
@@ -10,7 +10,7 @@ export type TagPickerButtonSlots = {
  * PickerButton Props
  */
 export type TagPickerButtonProps = ComponentProps<TagPickerButtonSlots> &
-  Pick<DropdownProps, 'clearable' | 'size' | 'appearance'> & {
+  Pick<DropdownProps, 'size' | 'appearance'> & {
     disabled?: boolean;
   };
 

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/TagPickerControl.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/TagPickerControl.types.ts
@@ -5,6 +5,10 @@ import * as React from 'react';
 
 export type TagPickerControlSlots = {
   root: Slot<ExtractSlotProps<Slot<'div'> & { style?: TagPickerControlCSSProperties }>>;
+  /**
+   * A secondary action should be a button-like element to be rendered right after
+   * the trigger responsible for opening/closing the tag picker popover.
+   */
   secondaryAction: Slot<'span'>;
 } & Pick<ComboboxSlots, 'expandIcon'>;
 

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/TagPickerOption.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/TagPickerOption.types.ts
@@ -12,12 +12,10 @@ export type TagPickerOptionSlots = Pick<OptionSlots, 'root'> & {
  */
 export type TagPickerOptionProps = ComponentProps<TagPickerOptionSlots> & {
   children: React.ReactNode;
-  text?: string;
   value: string;
 };
 
 /**
  * State used in rendering TagPickerOption
  */
-export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> &
-  Pick<OptionState, 'components' | 'multiselect' | 'root' | 'selected'>;
+export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Pick<OptionState, 'components' | 'root'>;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
@@ -30,8 +30,6 @@ export const useTagPickerOption_unstable = (
       elementType: 'span',
     }),
     root: optionState.root,
-    selected: optionState.selected,
-    multiselect: optionState.multiselect,
   };
 
   return state;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -39,6 +39,7 @@ export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): 
     disabled: false,
     focusVisible: false,
     checkIcon: undefined,
+    selected: false,
   });
   const styles = useStyles();
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. removes unused props, like:
   - `clearable` (this property makes no sense in the `TagPicker`, as clear state is delegated to `secondaryAction` responsibility
   - `selected` (this might be introduced again once the selection feature is introduced)
   - `multiselect` (this might be introduced again once multiselection feature is introduced)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
