### PR TITLE
feat(react-tag-picker): adds inline property

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-53df5fed-1401-407b-a8b2-1b6cdeccd079.json
+++ b/change/@fluentui-react-tag-picker-preview-53df5fed-1401-407b-a8b2-1b6cdeccd079.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds inline property",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
+++ b/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
@@ -202,6 +202,7 @@ export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps
     onOpenChange?: EventHandler<TagPickerOnOpenChangeData>;
     onOptionSelect?: EventHandler<TagPickerOnOptionSelectData>;
     children: [JSX.Element, JSX.Element] | JSX.Element;
+    inline?: boolean;
 };
 
 // @public (undocumented)
@@ -211,6 +212,7 @@ export type TagPickerSlots = {};
 export type TagPickerState = ComponentState<TagPickerSlots> & Pick<ComboboxState, 'open' | 'activeDescendantController' | 'mountNode' | 'onOptionClick' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'multiselect' | 'value' | 'setValue' | 'setOpen' | 'setHasFocus' | 'appearance' | 'clearSelection' | 'getOptionById' | 'freeform' | 'disabled'> & Pick<TagPickerContextValue, 'triggerRef' | 'secondaryActionRef' | 'popoverId' | 'popoverRef' | 'targetRef' | 'tagPickerGroupRef' | 'size'> & {
     trigger: React_2.ReactNode;
     popover?: React_2.ReactNode;
+    inline: boolean;
 };
 
 // @public

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.types.ts
@@ -44,6 +44,13 @@ export type TagPickerProps = ComponentProps<TagPickerSlots> &
      * Can contain two children including a trigger and a popover
      */
     children: [JSX.Element, JSX.Element] | JSX.Element;
+    /**
+     * TagPickers are rendered out of DOM order on `document.body` by default,
+     * use this to render the popover in DOM order
+     *
+     * @default false
+     */
+    inline?: boolean;
   };
 
 /**
@@ -76,6 +83,7 @@ export type TagPickerState = ComponentState<TagPickerSlots> &
   > & {
     trigger: React.ReactNode;
     popover?: React.ReactNode;
+    inline: boolean;
   };
 
 export type TagPickerContextValues = {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/renderTagPicker.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/renderTagPicker.tsx
@@ -16,7 +16,8 @@ export const renderTagPicker_unstable = (state: TagPickerState, contexts: TagPic
       <ActiveDescendantContextProvider value={contexts.activeDescendant}>
         <ListboxProvider value={contexts.listbox}>
           {state.trigger}
-          {state.popover && <Portal mountNode={state.mountNode}>{state.popover}</Portal>}
+          {state.popover &&
+            (state.inline ? state.popover : <Portal mountNode={state.mountNode}>{state.popover}</Portal>)}
         </ListboxProvider>
       </ActiveDescendantContextProvider>
     </TagPickerContextProvider>

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
@@ -24,7 +24,7 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
   const triggerInnerRef = React.useRef<HTMLInputElement>(null);
   const secondaryActionRef = React.useRef<HTMLSpanElement>(null);
   const tagPickerGroupRef = React.useRef<HTMLDivElement>(null);
-  const { positioning, size = 'medium' } = props;
+  const { positioning, size = 'medium', inline = false } = props;
 
   // Set a default set of fallback positions to try if the dropdown does not fit on screen
   const fallbackPositions: PositioningShorthandValue[] = ['above', 'after', 'after-top', 'before', 'before-top'];
@@ -96,6 +96,7 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     tagPickerGroupRef,
     targetRef,
     size,
+    inline,
     open: comboboxState.open,
     mountNode: comboboxState.mountNode,
     onOptionClick: useEventCallback(event => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. adds `inline` property to `TagPicker` to follow on [`Popover`](https://react.fluentui.dev/?path=/docs/components-popover--default) signature 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
