### PR TITLE
fix(react-drawer): remove circular dependency from cypress test files

### DIFF
--- a/packages/react-components/react-drawer/src/e2e/DrawerShared.tsx
+++ b/packages/react-components/react-drawer/src/e2e/DrawerShared.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { mount } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';
 import { webLightTheme } from '@fluentui/react-theme';
-import { DrawerProps } from '@fluentui/react-components';
+
+import type { DrawerProps } from '../Drawer';
 
 const mountFluent = (element: JSX.Element) => {
   mount(<FluentProvider theme={webLightTheme}>{element}</FluentProvider>);

--- a/scripts/beachball/base.config.json
+++ b/scripts/beachball/base.config.json
@@ -15,6 +15,7 @@
     "**/bundle-size/**",
     "**/common/isConformant.ts",
     "**/src/testing/**",
+    "**/src/e2e/**",
     "**/config/tests.js",
     "**/jest.config.js",
     "**/SPEC*.md",

--- a/scripts/beachball/config.test.ts
+++ b/scripts/beachball/config.test.ts
@@ -24,6 +24,7 @@ describe(`beachball configs`, () => {
         '**/bundle-size/**',
         '**/common/isConformant.ts',
         '**/src/testing/**',
+        '**/src/e2e/**',
         '**/config/tests.js',
         '**/jest.config.js',
         '**/SPEC*.md',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

See PR title

As we undergo stories/ separation into separate package in order to remove circular dependencies and ability to drastically speed up type checking, we need to remove any circular dep issues within tests/e2e files ( if those would be really needed, we need to separate also test/e2e to separate project ) 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows: 
  - https://github.com/microsoft/fluentui/pull/30989
  - https://github.com/microsoft/fluentui/pull/30988
- Mitigates issues that will be caught  https://github.com/microsoft/fluentui/pull/30866/files#diff-3b98f51b6fb208cbbe080331a4ba93f2ad00901a59570442eb765220f13f2e6aR520-R527
- Partially implements https://github.com/microsoft/fluentui/issues/30516
