### PR TITLE
feat(scripts-*): speed up all `isConverged`, `getAllPackageInfo` calls/usage by ~95%

### DIFF
--- a/scripts/beachball/utils.ts
+++ b/scripts/beachball/utils.ts
@@ -1,6 +1,4 @@
-import * as path from 'node:path';
-
-import { getWorkspaceProjects, isConvergedPackage, workspaceRoot } from '@fluentui/scripts-monorepo';
+import { getAllPackageInfo, isConvergedPackage } from '@fluentui/scripts-monorepo';
 
 /**
  * Reads package info from the monorepo and generates the scopes for beachball bump and release.
@@ -42,19 +40,8 @@ export function getConfig({ version }: { version: 'v8' | 'vNext' }) {
 }
 
 function getVNextPackagePaths() {
-  const projectPackageJsonPaths: string[] = [];
-  const allProjects = getWorkspaceProjects();
+  const allProjects = getAllPackageInfo(isConvergedPackage);
+  const values = Object.values(allProjects);
 
-  allProjects.forEach(project => {
-    if (
-      isConvergedPackage({
-        packagePathOrJson: path.join(workspaceRoot, project.root, 'package.json'),
-        projects: allProjects,
-      })
-    ) {
-      projectPackageJsonPaths.push(project.root);
-    }
-  });
-
-  return projectPackageJsonPaths;
+  return values.map(project => project.packagePath);
 }

--- a/scripts/executors/runPublished.js
+++ b/scripts/executors/runPublished.js
@@ -77,7 +77,7 @@ function getLageArgs(options) {
   // (which must be built and uploaded with each release). This is similar to "--scope \"!packages/fluentui/*\""
   // in the root package.json's publishing-related scripts and will need to be updated if --scope changes.
   const beachballPackageScopes = Object.values(workspacePackagesMetadata)
-    .filter(({ packageJson, packagePath }) => {
+    .filter(({ packageJson, projectConfig, packagePath }) => {
       const isNorthstar = /[\\/]fluentui[\\/]/.test(packagePath);
       const isWebComponents = packageJson.name === '@fluentui/web-components';
 
@@ -85,7 +85,7 @@ function getLageArgs(options) {
         return false;
       }
 
-      const isConverged = isConvergedPackage({ packagePathOrJson: packageJson });
+      const isConverged = isConvergedPackage({ packageJson, project: projectConfig });
       if (releaseScope === 'v9' && isConverged) {
         return packageJson.private !== true;
       }

--- a/scripts/executors/runPublished.spec.ts
+++ b/scripts/executors/runPublished.spec.ts
@@ -21,18 +21,26 @@ describe(`#runPublished`, () => {
       '@fluentui/web-components': {
         packagePath: 'packages/web-components',
         packageJson: { name: '@fluentui/web-components', version: '1.0.0', main: 'lib/index.js', private: false },
+        projectConfig: { name: '@fluentui/web-components', root: 'packages/web-components', tags: [] },
       },
       '@fluentui/react': {
         packagePath: 'packages/react',
         packageJson: { name: '@fluentui/react', version: '8.0.0', main: 'lib/index.js', private: false },
+        projectConfig: { name: '@fluentui/react', root: 'packages/react', tags: [] },
       },
       '@fluentui/react-northstar': {
         packagePath: 'packages/fluentui/react-northstar',
         packageJson: { name: '@fluentui/react-northstar', version: '0.1.0', main: 'lib/index.js', private: false },
+        projectConfig: { name: '@fluentui/react-northstar', root: 'packages/fluentui/react-northstar', tags: [] },
       },
       '@fluentui/react-components': {
         packagePath: 'packages/react-components/react-components',
         packageJson: { name: '@fluentui/react-components', version: '9.0.0', main: 'lib/index.js', private: false },
+        projectConfig: {
+          name: '@fluentui/react-components',
+          root: 'packages/react-components/react-components',
+          tags: [],
+        },
       },
     };
 

--- a/scripts/executors/tag-react-components.ts
+++ b/scripts/executors/tag-react-components.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'child_process';
-import * as semver from 'semver';
-import yargs from 'yargs';
 
 import { AllPackageInfo, getAllPackageInfo, isConvergedPackage } from '@fluentui/scripts-monorepo';
+import * as semver from 'semver';
+import yargs from 'yargs';
 
 function tagPackages(npmToken: string) {
   const packagesToTag = getPackagesToTag();
@@ -42,10 +42,10 @@ function tagPackage(name: string, version: string, npmToken: string): boolean {
 }
 
 function getPackagesToTag() {
-  const packageInfos: AllPackageInfo = getAllPackageInfo();
+  const packageInfos: AllPackageInfo = getAllPackageInfo(isConvergedPackage);
   return Object.values(packageInfos)
     .map(packageInfo => {
-      if (!packageInfo.packageJson.private && isConvergedPackage({ packagePathOrJson: packageInfo.packageJson })) {
+      if (!packageInfo.packageJson.private) {
         return {
           name: packageInfo.packageJson.name,
           version: packageInfo.packageJson.version,
@@ -67,4 +67,6 @@ function main(argv: yargs.Arguments) {
 
 if (require.main === module && process.env.RELEASE_VNEXT) {
   main(yargs.argv);
+} else {
+  console.log('"RELEASE_VNEXT" not set - skipping');
 }

--- a/scripts/generators/create-package/index.ts
+++ b/scripts/generators/create-package/index.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from 'child_process';
 import * as path from 'path';
 
-import { PackageJson, findGitRoot, flushTreeChanges, getProjectMetadata, tree } from '@fluentui/scripts-monorepo';
-import { addProjectConfiguration } from '@nx/devkit';
+import { PackageJson, findGitRoot, flushTreeChanges, tree } from '@fluentui/scripts-monorepo';
+import { addProjectConfiguration, getProjects } from '@nx/devkit';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
@@ -188,10 +188,14 @@ function replaceVersionsFromReference(
 
   const depTypes = ['dependencies', 'devDependencies', 'peerDependencies'] as const;
 
+  const projects = getProjects(tree);
   // Read the package.json files of the given reference packages and combine into one object.
   // This way if a dep is defined in any of them, it can easily be copied to newPackageJson.
   const packageJsons = referencePackages.map(pkgName => {
-    const metadata = getProjectMetadata(pkgName);
+    const metadata = projects.get(pkgName);
+    if (!metadata) {
+      throw new Error(`Couldn't find metadata for package ${pkgName}`);
+    }
 
     return fs.readJSONSync(path.join(metadata.root, 'package.json'));
   });

--- a/scripts/monorepo/src/getAllPackageInfo.spec.ts
+++ b/scripts/monorepo/src/getAllPackageInfo.spec.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+
 import getAllPackageInfo from './getAllPackageInfo';
 
 describe(`#getAllPackageinfo`, () => {
@@ -9,13 +10,29 @@ describe(`#getAllPackageinfo`, () => {
 
     expect(allPackages['@fluentui/noop']).toBe(undefined);
     expect(packageName).toEqual(expect.stringMatching(/^@fluentui\/[a-z-]+/));
+
     expect(packageMetadata).toEqual({
       packagePath: expect.any(String),
       packageJson: expect.objectContaining({
         name: expect.any(String),
         version: expect.any(String),
       }),
+      projectConfig: expect.objectContaining({
+        $schema: expect.any(String),
+        implicitDependencies: expect.any(Array),
+        name: expect.any(String),
+        projectType: expect.any(String),
+        root: expect.any(String),
+      }),
     });
     expect(path.isAbsolute(packageMetadata.packagePath)).toBe(false);
+  });
+
+  it(`should accept predicate filter function`, () => {
+    const allPackages = getAllPackageInfo(metadata => {
+      return metadata.packageJson.name === '@fluentui/non-existent-package';
+    });
+
+    expect(allPackages).toEqual({});
   });
 });

--- a/scripts/monorepo/src/index.d.ts
+++ b/scripts/monorepo/src/index.d.ts
@@ -3,7 +3,7 @@ export { getDependencies } from './getDependencies';
 export { default as findGitRoot } from './findGitRoot';
 export { default as findRepoDeps } from './findRepoDeps';
 export { default as getAllPackageInfo } from './getAllPackageInfo';
-export { isConvergedPackage, shipsAMD } from './isConvergedPackage';
+export { isConvergedPackage } from './isConvergedPackage';
 export { getAffectedPackages } from './getAffectedPackages';
 export { getDefaultEnvironmentVars } from './getDefaultEnvironmentVars';
 export { getProjectMetadata, workspaceRoot, getUncommittedFiles, getUntrackedFiles } from './utils';

--- a/scripts/monorepo/src/index.d.ts
+++ b/scripts/monorepo/src/index.d.ts
@@ -6,7 +6,7 @@ export { default as getAllPackageInfo } from './getAllPackageInfo';
 export { isConvergedPackage } from './isConvergedPackage';
 export { getAffectedPackages } from './getAffectedPackages';
 export { getDefaultEnvironmentVars } from './getDefaultEnvironmentVars';
-export { getProjectMetadata, workspaceRoot, getUncommittedFiles, getUntrackedFiles } from './utils';
+export { workspaceRoot, getUncommittedFiles, getUntrackedFiles } from './utils';
 export * as eslintConstants from './eslint-constants';
 export { getNthCommit } from './getNthCommit';
 export { tree, flushTreeChanges } from './tree';

--- a/scripts/monorepo/src/isConvergedPackage.js
+++ b/scripts/monorepo/src/isConvergedPackage.js
@@ -1,84 +1,14 @@
-const { readConfig } = require('@fluentui/scripts-utils');
 const semver = require('semver');
 
-const { getProjectMetadata } = require('./utils');
-
 /**
- *  @typedef {string | import('./index').PackageJson}  PathOrPackageJson
- */
-
-/**
- * Determines whether a package is converged, based on its version.
  *
- * @param {Object} [options]
- * @param {PathOrPackageJson} [options.packagePathOrJson] - optional different package path to run in OR previously-read package.json
- * (defaults to reading package.json from `process.cwd()`)
- * @param {'library' | 'application' | 'all'} [options.projectType] - filter for what project types you wanna apply the condition
- * @param {ReturnType<typeof import('@nx/devkit').getProjects>} [options.projects] - pass all workspace projects for significantly faster execution ( useful if you need to run this function multiple times )
- *
- * @returns {boolean} true if it's a converged package (version >= 9)
+ * @param {{project:import('@nx/devkit').ProjectConfiguration;packageJson:import('nx/src/utils/package-json').PackageJson}} metadata
  */
-function isConvergedPackage(options = {}) {
-  const { packagePathOrJson, projectType = 'all', projects } = options;
-  const packageJson =
-    !packagePathOrJson || typeof packagePathOrJson === 'string'
-      ? readConfig('package.json', /** @type {string|undefined} */ (packagePathOrJson))
-      : packagePathOrJson;
-
-  if (!packageJson) {
-    throw new Error(`package.json doesn't exist`);
-  }
-
-  const metadata = getProjectMetadata(packageJson.name, projects);
-
-  if (projectType !== 'all' && metadata.projectType !== projectType) {
-    return false;
-  }
-
-  const hasVNextTag = !!metadata.tags?.includes('vNext');
+function isConvergedPackage(metadata) {
+  const { packageJson, project } = metadata;
+  const hasVNextTag = Boolean(project.tags?.includes('vNext'));
 
   return semver.major(packageJson.version) >= 9 || isNightlyVersion(packageJson.version) || hasVNextTag;
-}
-
-/**
- * @param {Object} [options]
- * @param {PathOrPackageJson} [options.packagePathOrJson] - optional different package path to run in OR previously-read package.json
- * (defaults to reading package.json from `process.cwd()`)
- * @returns
- */
-function shipsAMD(options = {}) {
-  const { packagePathOrJson } = options;
-  const packageJson =
-    !packagePathOrJson || typeof packagePathOrJson === 'string'
-      ? readConfig('package.json', /** @type {string|undefined} */ (packagePathOrJson))
-      : packagePathOrJson;
-
-  if (!packageJson) {
-    throw new Error(`package.json doesn't exist`);
-  }
-
-  const metadata = getProjectMetadata(packageJson.name);
-
-  if (metadata.projectType !== 'library') {
-    return false;
-  }
-
-  const tags = new Set(metadata.tags ?? []);
-  const isV8 = tags.has('v8');
-  const isV9 = tags.has('vNext');
-  const needsAMD = tags.has('ships-amd');
-  const isMixedProject = isV9 && isV8;
-
-  if (needsAMD) {
-    return true;
-  }
-  if (isMixedProject) {
-    return true;
-  }
-  if (isV9) {
-    return false;
-  }
-  return true;
 }
 
 /**
@@ -90,4 +20,3 @@ function isNightlyVersion(version) {
 }
 
 exports.isConvergedPackage = isConvergedPackage;
-exports.shipsAMD = shipsAMD;

--- a/scripts/monorepo/src/isConvergedPackage.js
+++ b/scripts/monorepo/src/isConvergedPackage.js
@@ -14,11 +14,12 @@ const { getProjectMetadata } = require('./utils');
  * @param {PathOrPackageJson} [options.packagePathOrJson] - optional different package path to run in OR previously-read package.json
  * (defaults to reading package.json from `process.cwd()`)
  * @param {'library' | 'application' | 'all'} [options.projectType] - filter for what project types you wanna apply the condition
+ * @param {ReturnType<typeof import('@nx/devkit').getProjects>} [options.projects] - pass all workspace projects for significantly faster execution ( useful if you need to run this function multiple times )
  *
  * @returns {boolean} true if it's a converged package (version >= 9)
  */
 function isConvergedPackage(options = {}) {
-  const { packagePathOrJson, projectType = 'all' } = options;
+  const { packagePathOrJson, projectType = 'all', projects } = options;
   const packageJson =
     !packagePathOrJson || typeof packagePathOrJson === 'string'
       ? readConfig('package.json', /** @type {string|undefined} */ (packagePathOrJson))
@@ -28,7 +29,7 @@ function isConvergedPackage(options = {}) {
     throw new Error(`package.json doesn't exist`);
   }
 
-  const metadata = getProjectMetadata(packageJson.name);
+  const metadata = getProjectMetadata(packageJson.name, projects);
 
   if (projectType !== 'all' && metadata.projectType !== projectType) {
     return false;

--- a/scripts/monorepo/src/isConvergedPackage.spec.ts
+++ b/scripts/monorepo/src/isConvergedPackage.spec.ts
@@ -1,0 +1,39 @@
+import { isConvergedPackage } from './isConvergedPackage';
+
+describe(`#isConverged`, () => {
+  it(`should return true for vNext package`, () => {
+    const actual = isConvergedPackage({
+      packageJson: {
+        name: '@proj/one',
+        version: '9.0.0',
+      },
+      project: { root: 'packages/foo/bar/one', projectType: 'library', tags: ['vNext'] },
+    });
+
+    expect(actual).toBe(true);
+  });
+
+  it(`should return true for vNext nightly package`, () => {
+    const actual = isConvergedPackage({
+      packageJson: {
+        name: '@proj/one',
+        version: '0.0.0-nightly.20210101',
+      },
+      project: { root: 'packages/foo/bar/one', projectType: 'library', tags: ['vNext'] },
+    });
+
+    expect(actual).toBe(true);
+  });
+
+  it(`should return false for non vNext Package`, () => {
+    const actual = isConvergedPackage({
+      packageJson: {
+        name: '@proj/one',
+        version: '8.1.2',
+      },
+      project: { root: 'packages/foo/bar/one', projectType: 'library', tags: ['v8'] },
+    });
+
+    expect(actual).toBe(false);
+  });
+});

--- a/scripts/monorepo/src/types.ts
+++ b/scripts/monorepo/src/types.ts
@@ -17,6 +17,7 @@ export interface PackageInfo {
   packagePath: string;
   /** package.json contents */
   packageJson: PackageJson;
+  projectConfig: import('@nx/devkit').ProjectConfiguration;
 }
 
 /**

--- a/scripts/monorepo/src/utils.js
+++ b/scripts/monorepo/src/utils.js
@@ -1,30 +1,8 @@
 const { execSync } = require('child_process');
 
-const { workspaceRoot, readProjectConfiguration } = require('@nx/devkit');
-
-const { tree } = require('./tree');
+const { workspaceRoot } = require('@nx/devkit');
 
 const TEN_MEGABYTES = 1024 * 10000;
-
-/**
- * Gets nx project metadata
- * @param {string} projectName - package name
- * @param {ReturnType<typeof import('@nx/devkit').getProjects>=} allProjects - all workspace projects
- * @returns {import('@nx/devkit').ProjectConfiguration}
- */
-function getProjectMetadata(projectName, allProjects) {
-  if (allProjects) {
-    const project = allProjects.get(projectName);
-
-    if (!project) {
-      throw new Error(`Project ${projectName} not found in workspace`);
-    }
-
-    return project;
-  }
-
-  return readProjectConfiguration(tree, projectName);
-}
 
 /**
  *
@@ -57,5 +35,4 @@ function getUntrackedFiles() {
 
 exports.getUncommittedFiles = getUncommittedFiles;
 exports.getUntrackedFiles = getUntrackedFiles;
-exports.getProjectMetadata = getProjectMetadata;
 exports.workspaceRoot = workspaceRoot;

--- a/scripts/monorepo/src/utils.js
+++ b/scripts/monorepo/src/utils.js
@@ -9,9 +9,20 @@ const TEN_MEGABYTES = 1024 * 10000;
 /**
  * Gets nx project metadata
  * @param {string} projectName - package name
+ * @param {ReturnType<typeof import('@nx/devkit').getProjects>=} allProjects - all workspace projects
  * @returns {import('@nx/devkit').ProjectConfiguration}
  */
-function getProjectMetadata(projectName) {
+function getProjectMetadata(projectName, allProjects) {
+  if (allProjects) {
+    const project = allProjects.get(projectName);
+
+    if (!project) {
+      throw new Error(`Project ${projectName} not found in workspace`);
+    }
+
+    return project;
+  }
+
   return readProjectConfiguration(tree, projectName);
 }
 

--- a/scripts/tasks/src/babel.ts
+++ b/scripts/tasks/src/babel.ts
@@ -12,10 +12,6 @@ function addSourceMappingUrl(code: string, loc: string): string {
   return code + '\n//# sourceMappingURL=' + path.basename(loc);
 }
 
-export function hasBabel() {
-  return fs.existsSync(path.join(process.cwd(), '.babelrc.json'));
-}
-
 export async function babel() {
   const files = glob.sync('lib/**/*.styles.js');
 

--- a/scripts/tasks/src/metadata-utils.spec.ts
+++ b/scripts/tasks/src/metadata-utils.spec.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs';
+
+import { workspaceRoot } from '@nx/devkit';
+
+import { getRawMetadata } from './metadata-utils';
+
+describe(`metadata-utils`, () => {
+  it(`should fetch packageJson and project.json`, () => {
+    const { root } = setup('react-one');
+    const actual = getRawMetadata(root);
+
+    expect(actual.packageJson).toMatchInlineSnapshot(`
+      Object {
+        "name": "@proj/react-one",
+        "private": true,
+        "version": "0.0.0",
+      }
+    `);
+    expect(actual.project).toEqual({
+      name: '@proj/react-one',
+    });
+
+    expect(actual.hasBabel()).toEqual(false);
+    expect(actual.hasJest()).toEqual(false);
+    expect(actual.hasSass()).toEqual(true);
+  });
+});
+
+function setup(projectRootDirName: string) {
+  function tmpFolder() {
+    return `${workspaceRoot}/tmp`;
+  }
+  function tmpProjPath(path?: string) {
+    return path ? `${tmpFolder()}/__tests__/proj/${path}` : `${tmpFolder()}/nx-e2e/proj`;
+  }
+  function cleanup() {
+    fs.rmSync(tmpProjPath(), { recursive: true, force: true });
+  }
+
+  cleanup();
+
+  const root = tmpProjPath(projectRootDirName);
+  fs.mkdirSync(root, { recursive: true });
+
+  fs.writeFileSync(
+    `${root}/package.json`,
+    JSON.stringify({ name: `@proj/${projectRootDirName}`, version: '0.0.0', private: true }),
+  );
+  fs.writeFileSync(`${root}/project.json`, JSON.stringify({ name: `@proj/${projectRootDirName}` }));
+
+  fs.mkdirSync(`${root}/src/foo`, { recursive: true });
+  fs.writeFileSync(`${root}/src/foo/hello.scss`, 'body { color: red; }', 'utf-8');
+
+  return { root };
+}

--- a/scripts/tasks/src/metadata-utils.ts
+++ b/scripts/tasks/src/metadata-utils.ts
@@ -9,9 +9,10 @@ export function getRawMetadata(projectRoot: string) {
   const packageJsonPath = path.join(root, 'package.json');
   const projectJsonPath = path.join(root, 'project.json');
 
-  /** @type {import('@nx/devkit').ProjectConfiguration} */
-  const project = JSON.parse(fs.readFileSync(projectJsonPath, 'utf-8'));
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  const project: import('@nx/devkit').ProjectConfiguration = JSON.parse(fs.readFileSync(projectJsonPath, 'utf-8'));
+  const packageJson: import('nx/src/utils/package-json').PackageJson = JSON.parse(
+    fs.readFileSync(packageJsonPath, 'utf-8'),
+  );
 
   const metadata = { project, packageJson };
 

--- a/scripts/tasks/src/metadata-utils.ts
+++ b/scripts/tasks/src/metadata-utils.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { isConvergedPackage, workspaceRoot } from '@fluentui/scripts-monorepo';
+import * as glob from 'glob';
+
+export function getRawMetadata(projectRoot: string) {
+  const root = path.resolve(workspaceRoot, projectRoot);
+  const packageJsonPath = path.join(root, 'package.json');
+  const projectJsonPath = path.join(root, 'project.json');
+
+  /** @type {import('@nx/devkit').ProjectConfiguration} */
+  const project = JSON.parse(fs.readFileSync(projectJsonPath, 'utf-8'));
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+  const metadata = { project, packageJson };
+
+  const isConverged = () => isConvergedPackage(metadata);
+
+  function shipsAMD() {
+    if (project.projectType !== 'library') {
+      return false;
+    }
+
+    const tags = new Set(project.tags ?? []);
+
+    const isV8 = tags.has('v8');
+    const isV9 = tags.has('vNext');
+    const needsAMD = tags.has('ships-amd');
+    const isMixedProject = isV9 && isV8;
+
+    if (needsAMD) {
+      return true;
+    }
+    if (isMixedProject) {
+      return true;
+    }
+    if (isV9) {
+      return false;
+    }
+    return true;
+  }
+
+  function hasJest() {
+    return fs.existsSync(path.join(projectRoot, 'jest.config.js'));
+  }
+  function hasBabel() {
+    return fs.existsSync(path.join(projectRoot, '.babelrc.json'));
+  }
+  function hasSass() {
+    return glob.sync(path.join(projectRoot, 'src/**/*.scss')).length > 0;
+  }
+
+  return { ...metadata, isConverged, shipsAMD, hasJest, hasBabel, hasSass };
+}

--- a/scripts/tasks/src/presets.ts
+++ b/scripts/tasks/src/presets.ts
@@ -1,22 +1,22 @@
 import fs from 'fs';
 import path from 'path';
 
-import { isConvergedPackage, shipsAMD } from '@fluentui/scripts-monorepo';
 import { addResolvePath, condition, option, parallel, series, task } from 'just-scripts';
 
 import { apiExtractor } from './api-extractor';
 import { JustArgs, getJustArgv } from './argv';
-import { babel, hasBabel } from './babel';
+import { babel } from './babel';
 import { clean } from './clean';
 import { copy, copyCompiled } from './copy';
 import { eslint } from './eslint';
 import { generateApi } from './generate-api';
 import { jest as jestTask, jestWatch } from './jest';
 import { lintImportTaskAll, lintImportTaskAmdOnly } from './lint-imports';
+import { getRawMetadata } from './metadata-utils';
 import { postprocessTask } from './postprocess';
 import { postprocessAmdTask } from './postprocess-amd';
 import { prettier } from './prettier';
-import { hasSass, sass } from './sass';
+import { sass } from './sass';
 import { buildStorybookTask, startStorybookTask } from './storybook';
 import { swc } from './swc';
 import { ts } from './ts';
@@ -49,6 +49,7 @@ export function preset() {
   basicPreset();
 
   const args = getJustArgv();
+  const metadata = getRawMetadata(process.cwd());
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   task('no-op', () => {}).cached!();
@@ -57,7 +58,7 @@ export function preset() {
   task('copy-compiled', copyCompiled);
   task('jest', jestTask);
   task('jest-watch', jestWatch);
-  task('sass', sass());
+  task('sass', sass(metadata.hasSass()));
   task('ts:postprocess', postprocessTask());
   task('postprocess:amd', postprocessAmdTask);
   task('ts:commonjs', ts.commonjs);
@@ -84,7 +85,7 @@ export function preset() {
       return parallel(
         'ts:commonjs',
         'ts:esm',
-        condition('ts:amd', () => !!args.production && !isConvergedPackage()),
+        condition('ts:amd', () => !!args.production && !metadata.isConverged()),
       );
     }
 
@@ -100,7 +101,7 @@ export function preset() {
       'ts:compile',
       'copy-compiled',
       'ts:postprocess',
-      condition('babel:postprocess', () => hasBabel()),
+      condition('babel:postprocess', () => metadata.hasBabel()),
     );
   });
 
@@ -119,7 +120,7 @@ export function preset() {
     const moduleFlag = args.module;
     return series(
       'swc:esm',
-      condition('babel:postprocess', () => hasBabel()),
+      condition('babel:postprocess', () => metadata.hasBabel()),
       resolveModuleCompilation(moduleFlag),
     );
   });
@@ -139,8 +140,8 @@ export function preset() {
       'sass',
       'ts',
       'api-extractor',
-      condition('lint-imports:all', () => !isConvergedPackage() && shipsAMD()),
-      condition('lint-imports:amd', () => isConvergedPackage() && shipsAMD()),
+      condition('lint-imports:all', () => !metadata.isConverged() && metadata.shipsAMD()),
+      condition('lint-imports:amd', () => metadata.isConverged() && metadata.shipsAMD()),
     ),
   ).cached!();
 
@@ -148,8 +149,9 @@ export function preset() {
     return series(
       'clean',
       'copy',
-      condition('sass', () => hasSass()),
+      condition('sass', () => metadata.hasSass()),
       parallel('swc:compile', 'generate-api'),
+      'swc:compile',
     );
   }).cached!();
 
@@ -163,7 +165,7 @@ export function preset() {
     if (!moduleFlag) {
       return parallel(
         'swc:commonjs',
-        condition('swc:amd', () => !!args.production && !isConvergedPackage()),
+        condition('swc:amd', () => Boolean(args.production) && !metadata.isConverged()),
       );
     }
 

--- a/scripts/tasks/src/presets.ts
+++ b/scripts/tasks/src/presets.ts
@@ -7,7 +7,7 @@ import { apiExtractor } from './api-extractor';
 import { JustArgs, getJustArgv } from './argv';
 import { babel } from './babel';
 import { clean } from './clean';
-import { copy, copyCompiled } from './copy';
+import { copy, copyCompiledFactory } from './copy';
 import { eslint } from './eslint';
 import { generateApi } from './generate-api';
 import { jest as jestTask, jestWatch } from './jest';
@@ -55,7 +55,7 @@ export function preset() {
   task('no-op', () => {}).cached!();
   task('clean', clean);
   task('copy', copy);
-  task('copy-compiled', copyCompiled);
+  task('copy-compiled', copyCompiledFactory(metadata));
   task('jest', jestTask);
   task('jest-watch', jestWatch);
   task('sass', sass(metadata.hasSass()));

--- a/scripts/tasks/src/sass.ts
+++ b/scripts/tasks/src/sass.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import * as glob from 'glob';
 import { sassTask } from 'just-scripts';
 import postcssModules from 'postcss-modules';
 
@@ -38,14 +37,10 @@ function getJSON(cssFileName: string, json: Record<string, string>) {
   _fileNameToClassMap[path.resolve(cssFileName)] = json;
 }
 
-export function hasSass() {
-  return glob.sync(path.join(process.cwd(), 'src/**/*.scss')).length > 0;
-}
-
-export function sass() {
+export function sass(enable: boolean) {
   // small optimization: if there are no sass files, the task does nothing
   // (skip actually calling sassTask which must parse several extra dependencies)
-  if (!hasSass()) {
+  if (!enable) {
     return () => undefined;
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Using `readProjectConfiguration` api for more than 1 call is extremely expensive. This was happening in various parts of our infra:
- isConvergedPackage function
- shipsAmd
- generateConfig ( beachball ) 
- others ( see file changes )

This PR refactores critical API's in our core infra to simplify logic and make  things significantly faster 🚅🚅🚅


| command | Before | After |
|--------|--------|--------|
| yarn workspace @fluentui/scripts-beachball jest  | 31s | 0.2s  / **𝚫 99% FASTER** |
| node -r ./scripts/ts-node/register scripts/executors/tag-react-components.ts  | 22s | 0.8s  / **𝚫 96% FASTER** |
| lage build --to react-migration-v8-v9  | 241.12s | 220.16s  / **𝚫 9% FASTER** |

**running `lage build` (whole monorepo):** 

> **NOTE:**
>
> - not that not every task calls following APIs 4 times
> - these calculations are for non parallel execution ( which doesn't happen on CI - that's why "actuall" speed up gain is "only" 9% )

| api | 1 call | just-scripts 1 call | `lage build` -  200 (count of monorepo projects) runs |
|--------|--------|--------|--------|
| old `isConvergedPackage()` |  380ms | 4 * 380ms = 1520ms | 304s |
| new `metadata.isConverged()`| 1ms  | 4 * 1ms = 4ms | 0.8s / **𝚫99.8% faster** |



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
