### PR TITLE
fix(web-components): remove final dependencies on fast-foundation

### DIFF
--- a/apps/vr-tests-web-components/src/utilities/WCThemeDecorator.tsx
+++ b/apps/vr-tests-web-components/src/utilities/WCThemeDecorator.tsx
@@ -2,11 +2,8 @@ import * as React from 'react';
 import { StoryContext } from '@storybook/addons';
 import { ComponentStory } from '@storybook/react';
 import { FASTElement, customElement, html, attr } from '@microsoft/fast-element';
-import { DesignToken } from '@microsoft/fast-foundation';
 import { teamsLightTheme, teamsDarkTheme, webLightTheme, webDarkTheme } from '@fluentui/tokens';
 import { setThemeFor } from '@fluentui/web-components';
-
-DesignToken.registerDefaultStyleTarget();
 
 const themes = [
   { id: 'web-light', label: 'Web Light', theme: webLightTheme },

--- a/change/@fluentui-web-components-86d45358-8f3e-454f-92b1-96b3ea94e9a0.json
+++ b/change/@fluentui-web-components-86d45358-8f3e-454f-92b1-96b3ea94e9a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(web-components): remove final dependencies on fast-foundation",
+  "packageName": "@fluentui/web-components",
+  "email": "=",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -10,6 +10,8 @@ import { ElementStyles } from '@microsoft/fast-element';
 import { ElementViewTemplate } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
 import { FASTElementDefinition } from '@microsoft/fast-element';
+import type { HostBehavior } from '@microsoft/fast-element';
+import type { HostController } from '@microsoft/fast-element';
 import { HTMLDirective } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { SyntheticViewTemplate } from '@microsoft/fast-element';
@@ -1648,6 +1650,9 @@ export const CounterBadgeStyles: ElementStyles;
 // @public
 export const CounterBadgeTemplate: ElementViewTemplate<CounterBadge>;
 
+// @public
+export type CSSDisplayPropertyValue = 'block' | 'contents' | 'flex' | 'grid' | 'inherit' | 'initial' | 'inline' | 'inline-block' | 'inline-flex' | 'inline-grid' | 'inline-table' | 'list-item' | 'none' | 'run-in' | 'table' | 'table-caption' | 'table-cell' | 'table-column' | 'table-column-group' | 'table-footer-group' | 'table-header-group' | 'table-row' | 'table-row-group';
+
 // @public (undocumented)
 export const curveAccelerateMax = "var(--curveAccelerateMax)";
 
@@ -1674,6 +1679,9 @@ export const curveEasyEaseMax = "var(--curveEasyEaseMax)";
 
 // @public (undocumented)
 export const curveLinear = "var(--curveLinear)";
+
+// @public
+export const darkModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "DelegatesARIAButton" because one of its declarations is marked as @internal
 //
@@ -1740,6 +1748,9 @@ export const DialogStyles: ElementStyles;
 
 // @public
 export const DialogTemplate: ElementViewTemplate<Dialog>;
+
+// @public
+export function display(displayValue: CSSDisplayPropertyValue): string;
 
 // @public
 export class Divider extends FASTElement {
@@ -1881,6 +1892,15 @@ export const fontWeightRegular = "var(--fontWeightRegular)";
 export const fontWeightSemibold = "var(--fontWeightSemibold)";
 
 // @public
+export const forcedColorsStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
+
+// @public
+export const getDirection: (rootNode: HTMLElement) => Direction;
+
+// @public
+export const hidden = ":host([hidden]){display:none}";
+
+// @public
 class Image_2 extends FASTElement {
     block?: boolean;
     bordered?: boolean;
@@ -1940,6 +1960,9 @@ export const LabelStyles: ElementStyles;
 // @public (undocumented)
 export const LabelTemplate: ElementViewTemplate<Label>;
 
+// @public
+export const lightModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
+
 // @public (undocumented)
 export const lineHeightBase100 = "var(--lineHeightBase100)";
 
@@ -1969,6 +1992,29 @@ export const lineHeightHero800 = "var(--lineHeightHero800)";
 
 // @public (undocumented)
 export const lineHeightHero900 = "var(--lineHeightHero900)";
+
+// @public
+export abstract class MatchMediaBehavior implements HostBehavior {
+    constructor(query: MediaQueryList);
+    connectedCallback(controller: HostController): void;
+    protected abstract constructListener(controller: HostController): MediaQueryListListener;
+    disconnectedCallback(controller: HostController): void;
+    readonly query: MediaQueryList;
+}
+
+// @public
+export class MatchMediaStyleSheetBehavior extends MatchMediaBehavior {
+    constructor(query: MediaQueryList, styles: ElementStyles);
+    protected constructListener(controller: HostController): MediaQueryListListener;
+    readonly query: MediaQueryList;
+    // @internal
+    removedCallback(controller: HostController<any>): void;
+    readonly styles: ElementStyles;
+    static with(query: MediaQueryList): (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
+}
+
+// @public
+export type MediaQueryListListener = (this: MediaQueryList, ev?: MediaQueryListEvent) => void;
 
 // @public
 export class Menu extends FASTElement {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -205,9 +205,9 @@
   },
   "dependencies": {
     "@microsoft/fast-element": "2.0.0-beta.26",
-    "@microsoft/fast-foundation": "3.0.0-alpha.31",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@fluentui/tokens": "1.0.0-alpha.2",
+    "tabbable": "^6.2.0",
     "tslib": "^2.1.0"
   },
   "beachball": {

--- a/packages/web-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusMedium,
   borderRadiusSmall,

--- a/packages/web-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/src/accordion/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 
 export const styles = css`
   ${display('flex')}

--- a/packages/web-components/src/avatar/avatar.styles.ts
+++ b/packages/web-components/src/avatar/avatar.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusLarge,

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusLarge,

--- a/packages/web-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/src/checkbox/checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,

--- a/packages/web-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/src/dialog/dialog.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utils/index.js';
 import {
   borderRadiusXLarge,
   colorBackgroundOverlay,

--- a/packages/web-components/src/divider/divider.styles.ts
+++ b/packages/web-components/src/divider/divider.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   colorBrandForeground1,
   colorBrandStroke1,

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -30,3 +30,7 @@ export * from './toggle-button/index.js';
 
 export * from './fluent-design-system.js';
 export * from './theme/index.js';
+
+export * from './utils/direction.js';
+export * from './utils/display.js';
+export * from './utils/behaviors/match-media-stylesheet-behavior.js';

--- a/packages/web-components/src/label/label.styles.ts
+++ b/packages/web-components/src/label/label.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   colorNeutralForeground1,
   colorNeutralForegroundDisabled,

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusMedium,
   colorCompoundBrandForeground1Hover,

--- a/packages/web-components/src/menu-list/menu-list.styles.ts
+++ b/packages/web-components/src/menu-list/menu-list.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusMedium,
   colorNeutralBackground1,

--- a/packages/web-components/src/progress-bar/progress-bar.styles.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusMedium,
   colorBrandBackground2,

--- a/packages/web-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/src/radio-group/radio-group.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   colorNeutralForeground1,
   colorNeutralForegroundDisabled,

--- a/packages/web-components/src/radio/radio.styles.ts
+++ b/packages/web-components/src/radio/radio.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusSmall,

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import { colorBrandStroke1, colorBrandStroke2, colorNeutralStrokeOnBrand2 } from '../theme/design-tokens.js';
 
 export const styles = css`

--- a/packages/web-components/src/styles/partials/badge.partials.ts
+++ b/packages/web-components/src/styles/partials/badge.partials.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../../utils/index.js';
 import {
   borderRadiusCircular,
   colorBrandBackground,

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusCircular,
   colorCompoundBrandBackground,

--- a/packages/web-components/src/tab-panel/tab-panel.styles.ts
+++ b/packages/web-components/src/tab-panel/tab-panel.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import { spacingHorizontalM, spacingHorizontalMNudge } from '../theme/design-tokens.js';
 
 export const styles = css`

--- a/packages/web-components/src/tab/tab.styles.ts
+++ b/packages/web-components/src/tab/tab.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display, forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,

--- a/packages/web-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/src/tabs/tabs.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,

--- a/packages/web-components/src/text-input/text-input.styles.ts
+++ b/packages/web-components/src/text-input/text-input.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   borderRadiusMedium,
   colorCompoundBrandStroke,

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation/utilities.js';
+import { display } from '../utils/index.js';
 import {
   fontFamilyBase,
   fontFamilyMonospace,

--- a/packages/web-components/src/theme/theme.stories.ts
+++ b/packages/web-components/src/theme/theme.stories.ts
@@ -1,7 +1,4 @@
-import { DesignToken } from '@microsoft/fast-foundation/design-token.js';
 import * as tokens from '../theme/design-tokens.js';
-
-DesignToken.registerDefaultStyleTarget();
 
 export default {
   title: 'Theme/Tokens',
@@ -12,13 +9,13 @@ export const Tokens = () => `
   <h3>Theme Tokens</h3>
   <p>Debug story which uses theme tokens to style the element below.</p>
   <div style="
-    font-family: var(${tokens.fontFamilyBase});
-    font-size: var(${tokens.fontSizeBase300});
-    background: var(${tokens.colorBrandBackground});
-    color: var(${tokens.colorNeutralForegroundOnBrand});
-    border: var(${tokens.strokeWidthThicker}) solid var(${tokens.colorNeutralStroke1});
-    padding: var(${tokens.spacingVerticalS}) var(${tokens.spacingHorizontalM});
-    box-shadow: var(${tokens.shadow28});
+    font-family: ${tokens.fontFamilyBase};
+    font-size: ${tokens.fontSizeBase300};
+    background: ${tokens.colorBrandBackground};
+    color: ${tokens.colorNeutralForegroundOnBrand};
+    border: ${tokens.strokeWidthThicker} solid ${tokens.colorNeutralStroke1};
+    padding: ${tokens.spacingVerticalS} ${tokens.spacingHorizontalM};
+    box-shadow: ${tokens.shadow28};
   ">colorNeutralForegroundOnBrand on colorBrandBackground with shadow28</div>
 </div>
 `;

--- a/packages/web-components/src/toggle-button/toggle-button.styles.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { forcedColorsStylesheetBehavior } from '@microsoft/fast-foundation/utilities.js';
+import { forcedColorsStylesheetBehavior } from '../utils/index.js';
 import { styles as ButtonStyles } from '../button/button.styles.js';
 import {
   colorBrandBackgroundHover,

--- a/packages/web-components/src/utils/behaviors/match-media-stylesheet-behavior.ts
+++ b/packages/web-components/src/utils/behaviors/match-media-stylesheet-behavior.ts
@@ -1,0 +1,187 @@
+import type { ElementStyles, HostBehavior, HostController } from '@microsoft/fast-element';
+
+/**
+ * An event listener fired by a {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList | MediaQueryList }.
+ * @public
+ */
+export type MediaQueryListListener = (this: MediaQueryList, ev?: MediaQueryListEvent) => void;
+
+/**
+ * An abstract behavior to react to media queries. Implementations should implement
+ * the `constructListener` method to perform some action based on media query changes.
+ *
+ * @public
+ */
+export abstract class MatchMediaBehavior implements HostBehavior {
+  /**
+   * The behavior needs to operate on element instances but elements might share a behavior instance.
+   * To ensure proper attachment / detachment per instance, we construct a listener for
+   * each bind invocation and cache the listeners by element reference.
+   */
+  private listenerCache = new WeakMap<HostController, MediaQueryListListener>();
+
+  /**
+   * The media query that the behavior operates on.
+   */
+  public readonly query: MediaQueryList;
+
+  /**
+   *
+   * @param query - The media query to operate from.
+   */
+  constructor(query: MediaQueryList) {
+    this.query = query;
+  }
+
+  /**
+   * Constructs a function that will be invoked with the MediaQueryList context
+   * @param controller - The host controller orchestrating this behavior.
+   */
+  protected abstract constructListener(controller: HostController): MediaQueryListListener;
+
+  /**
+   * Binds the behavior to the element.
+   * @param controller - The host controller orchestrating this behavior.
+   */
+  connectedCallback(controller: HostController) {
+    const { query } = this;
+    let listener = this.listenerCache.get(controller);
+
+    if (!listener) {
+      listener = this.constructListener(controller);
+      this.listenerCache.set(controller, listener);
+    }
+
+    // Invoke immediately to add if the query currently matches
+    listener.bind(query)();
+    query.addEventListener('change', listener);
+  }
+
+  /**
+   * Unbinds the behavior from the element.
+   * @param controller - The host controller orchestrating this behavior.
+   */
+  disconnectedCallback(controller: HostController) {
+    const listener = this.listenerCache.get(controller);
+    if (listener) {
+      this.query.removeEventListener('change', listener);
+    }
+  }
+}
+
+/**
+ * A behavior to add or remove a stylesheet from an element based on a media query. The behavior ensures that
+ * styles are applied while the a query matches the environment and that styles are not applied if the query does
+ * not match the environment.
+ *
+ * @public
+ */
+export class MatchMediaStyleSheetBehavior extends MatchMediaBehavior {
+  /**
+   * The media query that the behavior operates on.
+   */
+  public readonly query!: MediaQueryList;
+
+  /**
+   * The styles object to be managed by the behavior.
+   */
+  public readonly styles: ElementStyles;
+
+  /**
+   * Constructs a {@link MatchMediaStyleSheetBehavior} instance.
+   * @param query - The media query to operate from.
+   * @param styles - The styles to coordinate with the query.
+   */
+  constructor(query: MediaQueryList, styles: ElementStyles) {
+    super(query);
+    this.styles = styles;
+  }
+
+  /**
+   * Defines a function to construct {@link MatchMediaStyleSheetBehavior | MatchMediaStyleSheetBehaviors} for
+   * a provided query.
+   * @param query - The media query to operate from.
+   *
+   * @public
+   * @example
+   *
+   * ```ts
+   * import { css } from "@microsoft/fast-element";
+   * import { MatchMediaStyleSheetBehavior } from "@fluentui/web-components";
+   *
+   * const landscapeBehavior = MatchMediaStyleSheetBehavior.with(
+   *   window.matchMedia("(orientation: landscape)")
+   * );
+   *
+   * const styles = css`
+   *   :host {
+   *     width: 200px;
+   *     height: 400px;
+   *   }
+   * `
+   * .withBehaviors(landscapeBehavior(css`
+   *   :host {
+   *     width: 400px;
+   *     height: 200px;
+   *   }
+   * `))
+   * ```
+   */
+  public static with(query: MediaQueryList) {
+    return (styles: ElementStyles) => {
+      return new MatchMediaStyleSheetBehavior(query, styles);
+    };
+  }
+
+  /**
+   * Constructs a match-media listener for a provided element.
+   * @param source - the element for which to attach or detach styles.
+   */
+  protected constructListener(controller: HostController): MediaQueryListListener {
+    let attached = false;
+    const styles = this.styles;
+
+    return function listener(this: { matches: boolean }) {
+      const { matches } = this;
+
+      if (matches && !attached) {
+        controller.addStyles(styles);
+        attached = matches;
+      } else if (!matches && attached) {
+        controller.removeStyles(styles);
+        attached = matches;
+      }
+    };
+  }
+
+  /**
+   * Unbinds the behavior from the element.
+   * @param controller - The host controller orchestrating this behavior.
+   * @internal
+   */
+  public removedCallback(controller: HostController<any>): void {
+    controller.removeStyles(this.styles);
+  }
+}
+
+/**
+ * This can be used to construct a behavior to apply a forced-colors only stylesheet.
+ * @public
+ */
+export const forcedColorsStylesheetBehavior = MatchMediaStyleSheetBehavior.with(window.matchMedia('(forced-colors)'));
+
+/**
+ * This can be used to construct a behavior to apply a prefers color scheme: dark only stylesheet.
+ * @public
+ */
+export const darkModeStylesheetBehavior = MatchMediaStyleSheetBehavior.with(
+  window.matchMedia('(prefers-color-scheme: dark)'),
+);
+
+/**
+ * This can be used to construct a behavior to apply a prefers color scheme: light only stylesheet.
+ * @public
+ */
+export const lightModeStylesheetBehavior = MatchMediaStyleSheetBehavior.with(
+  window.matchMedia('(prefers-color-scheme: light)'),
+);

--- a/packages/web-components/src/utils/display.ts
+++ b/packages/web-components/src/utils/display.ts
@@ -1,0 +1,44 @@
+/**
+ * Define all possible CSS display values.
+ * @public
+ */
+export type CSSDisplayPropertyValue =
+  | 'block'
+  | 'contents'
+  | 'flex'
+  | 'grid'
+  | 'inherit'
+  | 'initial'
+  | 'inline'
+  | 'inline-block'
+  | 'inline-flex'
+  | 'inline-grid'
+  | 'inline-table'
+  | 'list-item'
+  | 'none'
+  | 'run-in'
+  | 'table'
+  | 'table-caption'
+  | 'table-cell'
+  | 'table-column'
+  | 'table-column-group'
+  | 'table-footer-group'
+  | 'table-header-group'
+  | 'table-row'
+  | 'table-row-group';
+
+/**
+ * A CSS fragment to set `display: none;` when the host is hidden using the [hidden] attribute.
+ * @public
+ */
+export const hidden = `:host([hidden]){display:none}`;
+
+/**
+ * Applies a CSS display property.
+ * Also adds CSS rules to not display the element when the [hidden] attribute is applied to the element.
+ * @param display - The CSS display property value
+ * @public
+ */
+export function display(displayValue: CSSDisplayPropertyValue): string {
+  return `${hidden}:host{display:${displayValue}}`;
+}

--- a/packages/web-components/src/utils/index.ts
+++ b/packages/web-components/src/utils/index.ts
@@ -2,3 +2,5 @@ export * from './direction.js';
 export * from './typings.js';
 export * from './template-helpers.js';
 export * from './whitespace-filter.js';
+export * from './display.js';
+export * from './behaviors/match-media-stylesheet-behavior.js';

--- a/packages/web-components/tensile.config.js
+++ b/packages/web-components/tensile.config.js
@@ -8,8 +8,6 @@ const config = {
     '@tensile-perf/web-components': '/node_modules/@tensile-perf/web-components/lib/index.js',
     '@microsoft/fast-element': '/node_modules/@microsoft/fast-element/dist/fast-element.min.js',
     '@microsoft/fast-element/utilities.js': '/node_modules/@microsoft/fast-element/dist/esm/utilities.js',
-    '@microsoft/fast-foundation': '/node_modules/@microsoft/fast-foundation/dist/esm/index.js',
-    '@microsoft/fast-foundation/utilities.js': '/node_modules/@microsoft/fast-foundation/dist/esm/utilities/index.js',
     '@microsoft/fast-web-utilities': '/node_modules/@microsoft/fast-web-utilities/dist/index.js',
     '@fluentui/tokens': '/tensile-assets/benchmark-dependencies/tokens.js',
     '@fluentui/web-components': '/node_modules/@fluentui/web-components/dist/esm/index.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,7 +1650,7 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.0.tgz#ae7ae7923d41f3d84cb2fd88740a89436610bbec"
   integrity sha512-GHUXPEhMEmTpnpIfesFA2KAoMJPb1SPQw964tToQwt+BbGXdhqTCWT1rOb0VURGylsxsYxiGMnseJ3IlclVpVA==
 
-"@floating-ui/dom@^1.0.3", "@floating-ui/dom@^1.2.0":
+"@floating-ui/dom@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.0.tgz#a60212069cc58961c478037c30eba4b191c75316"
   integrity sha512-QXzg57o1cjLz3cGETzKXjI3kx1xyS49DW9l7kV2jw2c8Yftd434t2hllX0sVGn2Q8MtcW/4pNm8bfE1/4n6mng==
@@ -3045,17 +3045,6 @@
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.11.0.tgz#494f6c87057bcbb42406982d68a92887d6b5acb1"
   integrity sha512-VKJYMkS5zgzHHb66sY7AFpYv6IfFhXrjQcAyNgi2ivD65My1XOhtjfKez5ELcLFRJfgZNAxvI8kE69apXERTkw==
-
-"@microsoft/fast-foundation@3.0.0-alpha.31":
-  version "3.0.0-alpha.31"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-3.0.0-alpha.31.tgz#096b143d3f513801899d3a1eac00b09913064c4c"
-  integrity sha512-266JfAlmiz1uGQ0cnGIPtahZZ3WVNS8+6vrjsHmEg46sJTzb+9WfhgFan40y+MzgvWzZGr1Y1mh6GVpwVmKFJA==
-  dependencies:
-    "@floating-ui/dom" "^1.0.3"
-    "@microsoft/fast-element" "2.0.0-beta.26"
-    "@microsoft/fast-web-utilities" "^6.0.0"
-    tabbable "^5.2.0"
-    tslib "^2.4.0"
 
 "@microsoft/fast-web-utilities@^6.0.0":
   version "6.0.0"
@@ -24244,10 +24233,10 @@ systeminformation@^5.3.3:
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.12.3.tgz#1e6dc99070ace7d88b6a1dd465f4f3ce7d63901a"
   integrity sha512-aPyTDzK/VjEheGEODprxFTMahIWTHGyWXxTsh9EOHjeekVltrIWrle4dOZouOlOYgtKM1pDoHkrR+IssgYCK/A==
 
-tabbable@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
-  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
+tabbable@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
 table-layout@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This is the final PR to fully remove the dependency on the fast-foundation project. There are two utilities being moved here (along with some cleanup found while changing/removing imports): the `display` helper and the `match-media-stylesheet` behavior and corresponding code.