### PR TITLE
fix: fix `borderBottomRightRadius` value casting error

### DIFF
--- a/apps/xplat-v9/stories/Button/ButtonStories.tsx
+++ b/apps/xplat-v9/stories/Button/ButtonStories.tsx
@@ -1,8 +1,7 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
-import * as React from 'react';
-
+import 'react';
 import { Default } from './ButtonDefault';
 import { Shape } from './ButtonShape';
 import { Appearance } from './ButtonAppearance';
@@ -14,8 +13,8 @@ export const ButtonStories = () => (
   <div>
     <h1>Default</h1>
     <Default />
-    {/* <h1>Shape</h1>
-    <Shape /> */}
+    <h1>Shape</h1>
+    <Shape />
     <h1>Appearance</h1>
     <Appearance />
     <h1>Size</h1>

--- a/change/@fluentui-tokens-d29191c2-f70b-4ad6-98da-b2bb00c91007.json
+++ b/change/@fluentui-tokens-d29191c2-f70b-4ad6-98da-b2bb00c91007.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use 0 instead of '0' to better support RSD",
+  "packageName": "@fluentui/tokens",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-platform-adapter-preview/etc/react-platform-adapter-preview.api.md
+++ b/packages/react-components/react-platform-adapter-preview/etc/react-platform-adapter-preview.api.md
@@ -10,7 +10,7 @@ import { makeStyles as makeStylesCore } from '@griffel/core';
 import { mergeClasses } from '@griffel/react';
 import type { PartialTheme } from '@fluentui/react-theme';
 import * as React_2 from 'react';
-import { shorthands } from '@griffel/react';
+import { shorthands } from '@griffel/core';
 import { TextDirectionProvider } from '@griffel/react';
 import type { Theme } from '@fluentui/react-theme';
 import { useRenderer_unstable } from '@griffel/react';

--- a/packages/react-components/react-platform-adapter-preview/src/styling/shorthands.ts
+++ b/packages/react-components/react-platform-adapter-preview/src/styling/shorthands.ts
@@ -1,1 +1,1 @@
-export { shorthands } from '@griffel/react';
+export { shorthands } from '@griffel/core';

--- a/packages/tokens/etc/tokens.api.md
+++ b/packages/tokens/etc/tokens.api.md
@@ -6,7 +6,7 @@
 
 // @public (undocumented)
 export type BorderRadiusTokens = {
-    borderRadiusNone: string;
+    borderRadiusNone: string | 0;
     borderRadiusSmall: string;
     borderRadiusMedium: string;
     borderRadiusLarge: string;

--- a/packages/tokens/src/global/borderRadius.ts
+++ b/packages/tokens/src/global/borderRadius.ts
@@ -1,7 +1,7 @@
 import type { BorderRadiusTokens } from '../types';
 
 export const borderRadius: BorderRadiusTokens = {
-  borderRadiusNone: '0',
+  borderRadiusNone: 0,
   borderRadiusSmall: '2px',
   borderRadiusMedium: '4px',
   borderRadiusLarge: '6px',

--- a/packages/tokens/src/types.ts
+++ b/packages/tokens/src/types.ts
@@ -603,7 +603,7 @@ export type TypographyStyles = {
 };
 
 export type BorderRadiusTokens = {
-  borderRadiusNone: string;
+  borderRadiusNone: string | 0;
   borderRadiusSmall: string;
   borderRadiusMedium: string;
   borderRadiusLarge: string;


### PR DESCRIPTION
> [!NOTE]
> This is being merged into the `xplat` branch, not `master`

## Previous Behavior

Android app crashes when trying to render `<Button shape="square">`

## New Behavior

Android app no longer crashes when trying to render `<Button shape="square">`

![Screenshot_1712740607](https://github.com/microsoft/fluentui/assets/4123478/a0eb1db7-b114-48b4-ba7a-802330fed025)