### PR TITLE
fix(eslint-plugin): ignore bundle-size package directory

### DIFF
--- a/change/@fluentui-eslint-plugin-86be988e-5fbf-4544-90e8-7712e918b0cb.json
+++ b/change/@fluentui-eslint-plugin-86be988e-5fbf-4544-90e8-7712e918b0cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(eslint-plugin): ignore bundle-size package directory",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/core.js
+++ b/packages/eslint-plugin/src/configs/core.js
@@ -63,6 +63,7 @@ const config = {
     'lib-commonjs',
     'node_modules',
     'temp',
+    'bundle-size',
     '**/__snapshots__',
     '**/*.scss.ts',
   ],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<img width="1077" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/872475a3-7557-4ef9-a301-79e23d88e1f3">


after `bundle-size` is added via nx generator eslint will explode on commit

## New Behavior

no lint issues after `bundle-size` generator was invoked

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
