### PR TITLE
fix(react-tree): Allow overriding aria-selected through props

### DIFF
--- a/change/@fluentui-react-tree-0ebd456e-066d-4057-9b9a-d47dfacfcae0.json
+++ b/change/@fluentui-react-tree-0ebd456e-066d-4057-9b9a-d47dfacfcae0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Allow overriding aria-selected through props.",
+  "packageName": "@fluentui/react-tree",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/src/components/TreeItem/useTreeItem.tsx
@@ -44,6 +44,7 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
     as = 'div',
     itemType = 'leaf',
     'aria-level': level = contextLevel,
+    'aria-selected': ariaSelected,
     ...rest
   } = props;
 
@@ -240,8 +241,8 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
         'aria-level': level,
         'aria-checked': selectionMode === 'multiselect' ? checked : undefined,
         // Casting: when selectionMode is 'single', checked is a boolean
-        'aria-selected': selectionMode === 'single' ? (checked as boolean) : undefined,
-        'aria-expanded': itemType === 'branch' ? open : undefined,
+        'aria-selected': selectionMode === 'single' ? !!checked : undefined,
+        'aria-expanded': ariaSelected !== undefined ? ariaSelected : itemType === 'branch' ? open : undefined,
         onClick: handleClick,
         onKeyDown: handleKeyDown,
         onChange: handleChange,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

It wasn't possible to override the `aria-selected` attribute through the props, even though we encourage doing so in certain cases:
![image](https://github.com/microsoft/fluentui/assets/5953191/e96a0c46-7630-4de3-b356-2329889fd3f8)


## New Behavior

This PR now allows overriding `aria-selected`.

