### PR TITLE
fix(react-combobox): Inline Listbox should render on top of relatively positioned elements

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Combobox.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Combobox.stories.tsx
@@ -133,6 +133,16 @@ storiesOf('Combobox Converged', module)
       </Combobox>
     </div>
   ))
+  .addStory('When rendering inline, it should render on top of relatively positioned elements', () => (
+    <div style={{ paddingBottom: '120px' }}>
+      <Combobox open inlinePopup>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Combobox>
+      <button style={{ position: 'relative' }}>sample button</button>
+    </div>
+  ))
   .addStory('Option with long content', () => (
     <div style={{ paddingBottom: '240px' }}>
       <Combobox open>

--- a/apps/vr-tests-react-components/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Dropdown.stories.tsx
@@ -138,6 +138,16 @@ storiesOf('Dropdown Converged', module)
       <Option>Blue</Option>
     </Dropdown>
   ))
+  .addStory('When rendering inline, it should render on top of relatively positioned elements', () => (
+    <>
+      <Dropdown open inlinePopup>
+        <Option>Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Dropdown>
+      <button style={{ position: 'relative' }}>sample button</button>
+    </>
+  ))
   .addStory('Option with long content', () => (
     <Dropdown open>
       <Option>

--- a/change/@fluentui-react-combobox-96629c15-7cd4-4887-b3fb-10a120cb445f.json
+++ b/change/@fluentui-react-combobox-96629c15-7cd4-4887-b3fb-10a120cb445f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Inline Listbox should render on top of relatively positioned elements.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/useComboboxStyles.styles.ts
@@ -91,6 +91,12 @@ const useStyles = makeStyles({
     display: 'none',
   },
 
+  // When rendering inline, the popupSurface will be rendered under relatively positioned elements such as Input.
+  // This is due to the surface being positioned as absolute, therefore zIndex: 1 ensures that won't happen.
+  inlineListbox: {
+    zIndex: 1,
+  },
+
   // size variants
   small: {
     height: fieldHeights.small,
@@ -280,6 +286,7 @@ export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState 
     state.listbox.className = mergeClasses(
       comboboxClassNames.listbox,
       styles.listbox,
+      state.inlinePopup && styles.inlineListbox,
       !open && styles.listboxCollapsed,
       state.listbox.className,
     );

--- a/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -88,6 +88,12 @@ const useStyles = makeStyles({
     display: 'none',
   },
 
+  // When rendering inline, the popupSurface will be rendered under relatively positioned elements such as Input.
+  // This is due to the surface being positioned as absolute, therefore zIndex: 1 ensures that won't happen.
+  inlineListbox: {
+    zIndex: 1,
+  },
+
   button: {
     alignItems: 'center',
     backgroundColor: tokens.colorTransparentBackground,
@@ -285,6 +291,7 @@ export const useDropdownStyles_unstable = (state: DropdownState): DropdownState 
     state.listbox.className = mergeClasses(
       dropdownClassNames.listbox,
       styles.listbox,
+      state.inlinePopup && styles.inlineListbox,
       !open && styles.listboxCollapsed,
       state.listbox.className,
     );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

![image](https://github.com/microsoft/fluentui/assets/5953191/f1e135f0-d5c0-4631-ac4d-18a110d538a9)


## New Behavior

![image](https://github.com/microsoft/fluentui/assets/5953191/61735184-d9a2-4dfe-aa8b-8ca4ccdafaf0)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31021
