### PR TITLE
fix: Dialog - scroll the surface on short viewports

### DIFF
--- a/change/@fluentui-react-dialog-774134d8-4643-4d4f-9824-3b87fea71437.json
+++ b/change/@fluentui-react-dialog-774134d8-4643-4d4f-9824-3b87fea71437.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Dialog scrolls the whole surface on small screens",
+  "packageName": "@fluentui/react-dialog",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogBody/useDialogBodyStyles.styles.ts
@@ -1,7 +1,7 @@
 import { makeResetStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { DialogBodySlots, DialogBodyState } from './DialogBody.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import { DIALOG_GAP, MEDIA_QUERY_BREAKPOINT_SELECTOR, SURFACE_PADDING } from '../../contexts';
+import { DIALOG_GAP, MEDIA_QUERY_BREAKPOINT_SELECTOR, MEDIA_QUERY_SHORT_SCREEN, SURFACE_PADDING } from '../../contexts';
 
 export const dialogBodyClassNames: SlotClassNames<DialogBodySlots> = {
   root: 'fui-DialogBody',
@@ -22,6 +22,10 @@ const useResetStyles = makeResetStyles({
   [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
     maxWidth: '100vw',
     gridTemplateRows: 'auto 1fr auto',
+  },
+
+  [MEDIA_QUERY_SHORT_SCREEN]: {
+    maxHeight: 'unset',
   },
 });
 

--- a/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogContent/useDialogContentStyles.styles.ts
@@ -2,6 +2,7 @@ import { makeResetStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { DialogContentSlots, DialogContentState } from './DialogContent.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
+import { MEDIA_QUERY_SHORT_SCREEN } from '../../contexts';
 
 export const dialogContentClassNames: SlotClassNames<DialogContentSlots> = {
   root: 'fui-DialogContent',
@@ -21,6 +22,10 @@ const useStyles = makeResetStyles({
   gridRowEnd: 2,
   gridColumnStart: 1,
   gridColumnEnd: 4,
+
+  [MEDIA_QUERY_SHORT_SCREEN]: {
+    overflowY: 'unset',
+  },
 });
 
 /**

--- a/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -2,7 +2,13 @@ import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
 import { createFocusOutlineStyle } from '@fluentui/react-tabster';
-import { MEDIA_QUERY_BREAKPOINT_SELECTOR, SURFACE_BORDER_WIDTH, SURFACE_PADDING } from '../../contexts';
+import {
+  FULLSCREEN_DIALOG_SCROLLBAR_OFFSET,
+  MEDIA_QUERY_BREAKPOINT_SELECTOR,
+  MEDIA_QUERY_SHORT_SCREEN,
+  SURFACE_BORDER_WIDTH,
+  SURFACE_PADDING,
+} from '../../contexts';
 import type { DialogSurfaceSlots, DialogSurfaceState } from './DialogSurface.types';
 
 export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots> = {
@@ -37,6 +43,16 @@ const useRootBaseStyle = makeResetStyles({
 
   [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
     maxWidth: '100vw',
+  },
+
+  [MEDIA_QUERY_SHORT_SCREEN]: {
+    overflowY: 'auto',
+    // We need to offset the scrollbar by adding transparent borders otherwise
+    // it conflits with the border radius.
+    paddingRight: `calc(${SURFACE_PADDING} - ${FULLSCREEN_DIALOG_SCROLLBAR_OFFSET})`,
+    borderRightWidth: FULLSCREEN_DIALOG_SCROLLBAR_OFFSET,
+    borderTopWidth: FULLSCREEN_DIALOG_SCROLLBAR_OFFSET,
+    borderBottomWidth: FULLSCREEN_DIALOG_SCROLLBAR_OFFSET,
   },
 });
 

--- a/packages/react-components/react-dialog/src/contexts/constants.ts
+++ b/packages/react-components/react-dialog/src/contexts/constants.ts
@@ -1,4 +1,6 @@
 export const MEDIA_QUERY_BREAKPOINT_SELECTOR = '@media screen and (max-width: 480px)';
+export const MEDIA_QUERY_SHORT_SCREEN = '@media screen and (max-height: 359px)';
 export const SURFACE_PADDING = '24px';
 export const DIALOG_GAP = '8px';
 export const SURFACE_BORDER_WIDTH = '1px';
+export const FULLSCREEN_DIALOG_SCROLLBAR_OFFSET = '4px';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously on small screens (height < 360px) the content in the dialog would be difficult to see and scroll, because at that point the scrolling should be on the whole surface.

<img width="321" alt="Screenshot 2024-04-11 at 13 55 05" src="https://github.com/microsoft/fluentui/assets/2070479/d8d49765-5c62-494c-bb0e-dea24b050470">


## New Behavior

New behavior fixes this by moving the overflow from body to surface when screen height is smaller than 360px.

<img width="322" alt="Screenshot 2024-04-11 at 13 55 27" src="https://github.com/microsoft/fluentui/assets/2070479/f1b0b5d4-70f8-4e99-a80a-2029fe303333">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31027
