### PR TITLE
DRAFT: demoing custom style hooks for nav

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -8,6 +8,7 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import { CustomStyleHooksContextValue_unstable } from '@fluentui/react-shared-contexts';
 import type { EventData } from '@fluentui/react-utilities';
 import { EventHandler } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
@@ -85,10 +86,14 @@ export const NavDrawer: ForwardRefComponent<NavDrawerProps>;
 export const navDrawerClassNames: SlotClassNames<InlineDrawerSlots>;
 
 // @public
-export type NavDrawerProps = InlineDrawerProps & NavProps;
+export type NavDrawerProps = InlineDrawerProps & NavProps & {
+    customStyleHooks?: CustomStyleHooksContextValue_unstable;
+};
 
 // @public
-export type NavDrawerState = InlineDrawerState & NavContextValue;
+export type NavDrawerState = InlineDrawerState & NavContextValue & {
+    customStyleHooks?: CustomStyleHooksContextValue_unstable;
+};
 
 // @public
 export const NavItem: ForwardRefComponent<NavItemProps>;

--- a/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/navCustomStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/navCustomStyles.styles.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { makeStyles } from '@griffel/react';
+import { CustomStyleHooksContextValue } from '@fluentui/react-shared-contexts/src/CustomStyleHooksContext';
+import { tokens } from '@fluentui/react-theme';
+import { useNavDrawerBodyStyles } from './useDrawerBodyStyles.styles';
+import { useNavDrawerFooterStyles } from './useDrawerFooterStyles.styles';
+import { useNavDrawerHeaderStyles } from './useDrawerHeaderStyles.styles';
+
+export const navCustomStyleHooks: CustomStyleHooksContextValue = {
+  useDrawerBodyStyles_unstable: useNavDrawerBodyStyles,
+  useDrawerFooterStyles_unstable: useNavDrawerFooterStyles,
+  useDrawerHeaderStyles_unstable: useNavDrawerHeaderStyles,
+};
+
+export const useSharedNavBackgroundStyles = makeStyles({
+  base: {
+    backgroundColor: tokens.colorNeutralBackground4,
+  },
+});

--- a/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/useDrawerBodyStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/useDrawerBodyStyles.styles.ts
@@ -1,0 +1,18 @@
+import { DrawerBodyState } from '@fluentui/react-drawer';
+import { makeStyles, mergeClasses } from '@griffel/react';
+import { useSharedNavBackgroundStyles } from './navCustomStyles.styles';
+
+const useBodyStyles = makeStyles({
+  base: {
+    backgroundImage: 'unset', // remove the good hack in default useDrawerBodyStyles_unstable since it adds divider lines we don't want
+  },
+});
+
+export const useNavDrawerBodyStyles = (state: unknown) => {
+  const styles = useSharedNavBackgroundStyles();
+  const bodyStyles = useBodyStyles();
+
+  const drawerBodyState = state as DrawerBodyState;
+
+  drawerBodyState.root.className = mergeClasses(drawerBodyState.root.className, styles.base, bodyStyles.base);
+};

--- a/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/useDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/useDrawerFooterStyles.styles.ts
@@ -1,0 +1,11 @@
+import { DrawerFooterState } from '@fluentui/react-drawer';
+import { mergeClasses } from '@griffel/react';
+import { useSharedNavBackgroundStyles } from './navCustomStyles.styles';
+
+export const useNavDrawerFooterStyles = (state: unknown) => {
+  const styles = useSharedNavBackgroundStyles();
+
+  const drawerFooterState = state as DrawerFooterState;
+
+  drawerFooterState.root.className = mergeClasses(drawerFooterState.root.className, styles.base);
+};

--- a/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/useDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/CustomStyleHooks/useDrawerHeaderStyles.styles.ts
@@ -1,0 +1,11 @@
+import { DrawerHeaderState } from '@fluentui/react-drawer';
+import { mergeClasses } from '@griffel/react';
+import { useSharedNavBackgroundStyles } from './navCustomStyles.styles';
+
+export const useNavDrawerHeaderStyles = (state: unknown) => {
+  const styles = useSharedNavBackgroundStyles();
+
+  const drawerHeaderState = state as DrawerHeaderState;
+
+  drawerHeaderState.root.className = mergeClasses(drawerHeaderState.root.className, styles.base);
+};

--- a/packages/react-components/react-nav-preview/src/components/Nav/Nav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Nav/Nav.tsx
@@ -15,6 +15,7 @@ export const Nav: ForwardRefComponent<NavProps> = React.forwardRef((props, ref) 
   const contextValues = useNavContextValues_unstable(state);
 
   useNavStyles_unstable(state);
+
   return renderNav_unstable(state, contextValues);
 });
 

--- a/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/Nav.types.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import type { ComponentProps, ComponentState, EventData, EventHandler, Slot } from '@fluentui/react-utilities';
 import type { NavContextValue, NavItemValue } from '../NavContext.types';
 

--- a/packages/react-components/react-nav-preview/src/components/Nav/renderNav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Nav/renderNav.tsx
@@ -5,7 +5,6 @@ import { assertSlots } from '@fluentui/react-utilities';
 import { NavProvider } from '../NavContext';
 import type { NavState, NavSlots } from './Nav.types';
 import type { NavContextValues } from '../NavContext.types';
-
 export const renderNav_unstable = (state: NavState, contextValues: NavContextValues) => {
   assertSlots<NavSlots>(state);
 

--- a/packages/react-components/react-nav-preview/src/components/Nav/useNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/Nav/useNavStyles.styles.ts
@@ -4,8 +4,6 @@ import type { NavSlots, NavState } from './Nav.types';
 
 export const navClassNames: SlotClassNames<NavSlots> = {
   root: 'fui-Nav',
-  // TODO: add class names for all slots on NavSlots.
-  // Should be of the form `<slotName>: 'fui-Nav__<slotName>`
 };
 
 /**
@@ -16,8 +14,6 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
   },
-
-  // TODO add additional classes for different states and/or slots
 });
 
 /**
@@ -26,9 +22,6 @@ const useStyles = makeStyles({
 export const useNavStyles_unstable = (state: NavState): NavState => {
   const styles = useStyles();
   state.root.className = mergeClasses(navClassNames.root, styles.root, state.root.className);
-
-  // TODO Add class names to slots, for example:
-  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
 
   return state;
 };

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/NavDrawer.types.ts
@@ -1,13 +1,22 @@
 import { InlineDrawerProps, InlineDrawerState } from '@fluentui/react-drawer';
+import { CustomStyleHooksContextValue_unstable as CustomStyleHooksContextValue } from '@fluentui/react-shared-contexts';
 import { NavProps } from '../Nav/Nav.types';
 import { NavContextValue } from '../NavContext.types';
 
 /**
  * NavDrawer Props
  */
-export type NavDrawerProps = InlineDrawerProps & NavProps;
+export type NavDrawerProps = InlineDrawerProps &
+  NavProps & {
+    /** Sets the hooks for custom styling components. */
+    customStyleHooks?: CustomStyleHooksContextValue;
+  };
 
 /**
  * State used in rendering NavDrawer
  */
-export type NavDrawerState = InlineDrawerState & NavContextValue;
+export type NavDrawerState = InlineDrawerState &
+  NavContextValue & {
+    /** Sets the hooks for custom styling components. */
+    customStyleHooks?: CustomStyleHooksContextValue;
+  };

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/renderNavDrawer.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/renderNavDrawer.tsx
@@ -6,6 +6,7 @@ import type { NavDrawerState } from './NavDrawer.types';
 import { NavContextValues } from '../NavContext.types';
 import { NavProvider } from '../NavContext';
 import { InlineDrawerSlots } from '@fluentui/react-drawer';
+import { CustomStyleHooksContext_unstable as CustomStyleHooksContext } from '@fluentui/react-shared-contexts';
 
 /**
  * Render the final JSX of NavDrawer
@@ -13,10 +14,11 @@ import { InlineDrawerSlots } from '@fluentui/react-drawer';
 export const renderNavDrawer_unstable = (state: NavDrawerState, contextValues: NavContextValues) => {
   assertSlots<InlineDrawerSlots>(state);
 
-  // TODO Add additional slots in the appropriate place
   return (
     <NavProvider value={contextValues.nav}>
-      <state.root />
+      <CustomStyleHooksContext.Provider value={state.customStyleHooks}>
+        <state.root />
+      </CustomStyleHooksContext.Provider>
     </NavProvider>
   );
 };

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawer.ts
@@ -3,6 +3,7 @@ import { useInlineDrawer_unstable } from '@fluentui/react-drawer';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { useNav_unstable } from '../Nav/useNav';
 import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
+import { navCustomStyleHooks } from '../CustomStyleHooks/navCustomStyles.styles';
 
 /**
  * Create the state required to render NavDrawer.
@@ -25,7 +26,13 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     ref,
   );
 
+  const styleHooks = {
+    ...navCustomStyleHooks,
+    ...props.customStyleHooks,
+  };
+
   return {
+    customStyleHooks: styleHooks,
     ...baseDrawerState,
     ...navState,
   };

--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
@@ -25,9 +25,6 @@ export const useNavDrawerStyles_unstable = (state: NavDrawerState): NavDrawerSta
   const styles = useStyles();
   state.root.className = mergeClasses(navDrawerClassNames.root, styles.root, state.root.className);
 
-  // TODO Add class names to slots, for example:
-  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
-
   useInlineDrawerStyles_unstable(state);
   return state;
 };

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerCustomStyleHook.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerCustomStyleHook.stories.tsx
@@ -11,6 +11,7 @@ import {
 import { DrawerBody, DrawerBodyState, DrawerFooter, DrawerHeader, DrawerHeaderTitle } from '@fluentui/react-drawer';
 import { makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 import { CustomStyleHooksContextValue } from '@fluentui/react-shared-contexts/src/CustomStyleHooksContext';
+
 const useStyles = makeStyles({
   root: {
     ...shorthands.overflow('hidden'),
@@ -23,19 +24,19 @@ const useStyles = makeStyles({
 });
 
 // This bit validates that the style hooks can be disagreed with.
-export const useNavDrawerBodyStyles = (state: unknown) => {
+const useNavDrawerBodyStyles = (state: unknown) => {
   const styles = useSharedNavBackgroundStyles();
 
   const drawerBodyState = state as DrawerBodyState;
 
-  drawerBodyState.root.className = mergeClasses(drawerBodyState.root.className, styles.base, bodyStyles.base);
+  drawerBodyState.root.className = mergeClasses(drawerBodyState.root.className, styles.base);
 };
 
-export const navCustomStyleHooks: CustomStyleHooksContextValue = {
+const navCustomStyleHooks: CustomStyleHooksContextValue = {
   useDrawerBodyStyles_unstable: useNavDrawerBodyStyles,
 };
 
-export const useSharedNavBackgroundStyles = makeStyles({
+const useSharedNavBackgroundStyles = makeStyles({
   base: {
     backgroundColor: 'green',
   },

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerCustomStyleHook.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerCustomStyleHook.stories.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {
+  NavCategory,
+  NavCategoryItem,
+  NavDrawer,
+  NavDrawerProps,
+  NavItem,
+  NavSubItem,
+  NavSubItemGroup,
+} from '@fluentui/react-nav-preview';
+import { DrawerBody, DrawerBodyState, DrawerFooter, DrawerHeader, DrawerHeaderTitle } from '@fluentui/react-drawer';
+import { makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
+import { CustomStyleHooksContextValue } from '@fluentui/react-shared-contexts/src/CustomStyleHooksContext';
+const useStyles = makeStyles({
+  root: {
+    ...shorthands.overflow('hidden'),
+    display: 'flex',
+    height: '480px', // arbitrary value, for demo purposes only
+    // arbitrary value, for dramatic effect only
+    // I know this is ugly and wrong, but styling is coming, I promise.
+    backgroundColor: tokens.colorBackgroundOverlay,
+  },
+});
+
+// This bit validates that the style hooks can be disagreed with.
+export const useNavDrawerBodyStyles = (state: unknown) => {
+  const styles = useSharedNavBackgroundStyles();
+
+  const drawerBodyState = state as DrawerBodyState;
+
+  drawerBodyState.root.className = mergeClasses(drawerBodyState.root.className, styles.base, bodyStyles.base);
+};
+
+export const navCustomStyleHooks: CustomStyleHooksContextValue = {
+  useDrawerBodyStyles_unstable: useNavDrawerBodyStyles,
+};
+
+export const useSharedNavBackgroundStyles = makeStyles({
+  base: {
+    backgroundColor: 'green',
+  },
+});
+
+export const NavDrawerCustomStyleHook = (props: Partial<NavDrawerProps>) => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.root}>
+      <NavDrawer
+        defaultSelectedValue={'10'}
+        customStyleHooks={navCustomStyleHooks}
+        defaultSelectedCategoryValue={'8'}
+        size="small"
+        open={true}
+      >
+        <DrawerHeader>
+          <DrawerHeaderTitle>Drawer with title</DrawerHeaderTitle>
+        </DrawerHeader>
+        <DrawerBody>
+          <NavItem href="https://www.bing.com/" value="1">
+            First
+          </NavItem>
+          <NavItem href="https://www.bing.com/" value="2">
+            Second
+          </NavItem>
+          <NavItem href="https://www.bing.com/" value="3">
+            Third
+          </NavItem>
+          <NavCategory value="4">
+            <NavCategoryItem>NavCategoryItem 1</NavCategoryItem>
+            <NavSubItemGroup>
+              <NavSubItem href="https://www.bing.com/" value="5">
+                Five
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="6">
+                Six
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="7">
+                Seven
+              </NavSubItem>
+            </NavSubItemGroup>
+          </NavCategory>
+          <NavCategory value="8">
+            <NavCategoryItem>NavCategoryItem2</NavCategoryItem>
+            <NavSubItemGroup>
+              <NavSubItem href="https://www.bing.com/" value="9">
+                Nine
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="10">
+                Ten
+              </NavSubItem>
+              <NavSubItem href="https://www.bing.com/" value="11">
+                Eleven
+              </NavSubItem>
+            </NavSubItemGroup>
+          </NavCategory>
+        </DrawerBody>
+        <DrawerFooter>I am a footer</DrawerFooter>
+      </NavDrawer>
+    </div>
+  );
+};

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -8,7 +8,13 @@ import {
   NavSubItem,
   NavSubItemGroup,
 } from '@fluentui/react-nav-preview';
-import { DrawerBody } from '@fluentui/react-drawer';
+import {
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerHeaderNavigation,
+  DrawerHeaderTitle,
+} from '@fluentui/react-drawer';
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { Folder20Filled, Folder20Regular, bundleIcon } from '@fluentui/react-icons';
 const useStyles = makeStyles({
@@ -34,6 +40,10 @@ export const Default = (props: Partial<NavDrawerProps>) => {
   return (
     <div className={styles.root}>
       <NavDrawer defaultSelectedValue={'10'} defaultSelectedCategoryValue={'8'} size="small" open={true}>
+        <DrawerHeader>
+          <DrawerHeaderNavigation>I am some navigation</DrawerHeaderNavigation>
+          <DrawerHeaderTitle>Drawer with title</DrawerHeaderTitle>
+        </DrawerHeader>
         <DrawerBody>
           <NavItem icon={<Folder />} target="_blank" onClick={someClickHandler} value="1">
             First
@@ -73,6 +83,7 @@ export const Default = (props: Partial<NavDrawerProps>) => {
             </NavSubItemGroup>
           </NavCategory>
         </DrawerBody>
+        <DrawerFooter>I am a footer</DrawerFooter>
       </NavDrawer>
     </div>
   );

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -41,7 +41,6 @@ export const Default = (props: Partial<NavDrawerProps>) => {
     <div className={styles.root}>
       <NavDrawer defaultSelectedValue={'10'} defaultSelectedCategoryValue={'8'} size="small" open={true}>
         <DrawerHeader>
-          <DrawerHeaderNavigation>I am some navigation</DrawerHeaderNavigation>
           <DrawerHeaderTitle>Drawer with title</DrawerHeaderTitle>
         </DrawerHeader>
         <DrawerBody>

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -8,13 +8,7 @@ import {
   NavSubItem,
   NavSubItemGroup,
 } from '@fluentui/react-nav-preview';
-import {
-  DrawerBody,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerHeaderNavigation,
-  DrawerHeaderTitle,
-} from '@fluentui/react-drawer';
+import { DrawerBody, DrawerFooter, DrawerHeader, DrawerHeaderTitle } from '@fluentui/react-drawer';
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { Folder20Filled, Folder20Regular, bundleIcon } from '@fluentui/react-icons';
 const useStyles = makeStyles({

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/index.stories.tsx
@@ -4,6 +4,7 @@ import descriptionMd from './NavDrawerDescription.md';
 import bestPracticesMd from './NavDrawerBestPractices.md';
 
 export { Default } from './NavDrawerDefault.stories';
+export { NavDrawerCustomStyleHook } from './NavDrawerCustomStyleHook.stories';
 
 export default {
   title: 'Preview Components/NavDrawer',


### PR DESCRIPTION
The design for Nav calls for a slightly gray background, rather than the white page background color. Header, body and footer all need to be touched to create a seamless look.

You can ignore the changes made to "Nav" - those are just cleaning up comments while I had the file open.

FAQ: "Why not just re-export these components with the background color injected?"
Answer: There are likely going to be other components we'll need to touch like buttons or personas or tags that we'll want to have our own styling opinions about. Many consumers won't realize that they'll need to import 'the nav flavor' of a given component.

NavDrawerCustomStyleHook story shows how a consumer might disagree with some of my styling opinions provided by the custom style hooks.