### PR TITLE
chore(docs): fix code block rendering in dev-workflow.md

### DIFF
--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -4,11 +4,11 @@
 
 Create a branch from your forked repo for your code changes:
 
-\```
+```
 git checkout master
 git pull upstream master
 git checkout -b my-branch-name
-\```
+```
 
 We strongly recommend using the CLI as your primary interface with git. GUIs are useful for viewing diffs, creating branches and making quick commits. However they often do not correctly merge and sync working branches with master. Mistakes in this step are time consuming to fix.
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Code block was not rendered as code, because of backticks being preceded by a slash.

<!-- This is the behavior we have today -->

## New Behavior

Code block is rendered as code.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

n/a
