### PR TITLE
feat(react-tag-picker): `TagPickerInput` input positioning

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-eedaf17a-87ce-42a2-99a0-73612124120c.json
+++ b/change/@fluentui-react-tag-picker-preview-eedaf17a-87ce-42a2-99a0-73612124120c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: TagPickerInput input positioning",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
@@ -21,7 +21,7 @@ import { useComboboxBaseState, ComboboxBaseState } from '@fluentui/react-combobo
  */
 export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => {
   const popoverId = useId('picker-listbox');
-  const triggerInnerRef = React.useRef<HTMLInputElement>(null);
+  const triggerInnerRef = React.useRef<HTMLInputElement | HTMLButtonElement>(null);
   const secondaryActionRef = React.useRef<HTMLSpanElement>(null);
   const tagPickerGroupRef = React.useRef<HTMLDivElement>(null);
   const { positioning, size = 'medium', inline = false } = props;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -30,6 +30,8 @@ export const useTagPickerButton_unstable = (
     popoverId,
     hasSelectedOption,
   } = usePickerContext();
+  // casting is required here as triggerRef can either be button or input,
+  // but in this case we can assure it's a button
   const root = useButtonTriggerSlot(props, triggerRef as React.RefObject<HTMLButtonElement>, {
     activeDescendantController,
     defaultProps: {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
@@ -1,36 +1,44 @@
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { typographyStyles, tokens } from '@fluentui/react-theme';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TagPickerInputSlots, TagPickerInputState } from './TagPickerInput.types';
-
-// TODO reuse input and icon styles from root
+import { tagPickerInputTokens } from '../../utils/tokens';
 
 export const tagPickerInputClassNames: SlotClassNames<TagPickerInputSlots> = {
   root: 'fui-TagPickerInput',
 };
 
+const useBaseStyle = makeResetStyles({
+  backgroundColor: tokens.colorTransparentBackground,
+  color: tokens.colorNeutralForeground1,
+  fontFamily: tokens.fontFamilyBase,
+  boxSizing: 'border-box',
+
+  '&:focus': {
+    outlineStyle: 'none',
+  },
+  '&::placeholder': {
+    color: tokens.colorNeutralForeground4,
+    opacity: 1,
+  },
+  '&::after': {
+    visibility: 'hidden',
+    whiteSpace: 'pre-wrap',
+  },
+  ...shorthands.border('0'),
+  minWidth: '24px',
+  maxWidth: '100%',
+  // by default width is 0,
+  // it will be calculated based on the requirement of stretching the component to 100% width
+  // see setTagPickerInputStretchStyle method for more details
+  width: tagPickerInputTokens.width,
+  flexGrow: 1,
+});
+
 /**
  * Styles for the root slot
  */
 const useStyles = makeStyles({
-  root: {
-    backgroundColor: tokens.colorTransparentBackground,
-    ...shorthands.border('0'),
-    color: tokens.colorNeutralForeground1,
-    fontFamily: tokens.fontFamilyBase,
-    flexGrow: 1,
-    boxSizing: 'border-box',
-
-    '&:focus': {
-      outlineStyle: 'none',
-    },
-
-    '&::placeholder': {
-      color: tokens.colorNeutralForeground4,
-      opacity: 1,
-    },
-  },
-
   // size variants
   medium: {
     ...typographyStyles.body1,
@@ -58,10 +66,11 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerInput slots based on the state
  */
 export const useTagPickerInputStyles_unstable = (state: TagPickerInputState): TagPickerInputState => {
+  const baseStyle = useBaseStyle();
   const styles = useStyles();
   state.root.className = mergeClasses(
     tagPickerInputClassNames.root,
-    styles.root,
+    baseStyle,
     styles[state.size],
     state.disabled && styles.disabled,
     state.root.className,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerList.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerList.ts
@@ -19,7 +19,9 @@ export const useTagPickerList_unstable = (
   ref: React.Ref<HTMLDivElement>,
 ): TagPickerListState => {
   const multiselect = useTagPickerContext_unstable(ctx => ctx.multiselect);
-  const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
+  const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef) as
+    | React.RefObject<HTMLInputElement>
+    | React.RefObject<HTMLButtonElement>;
   const popoverRef = useTagPickerContext_unstable(ctx => ctx.popoverRef);
   const popoverId = useTagPickerContext_unstable(ctx => ctx.popoverId);
   const open = useTagPickerContext_unstable(ctx => ctx.open);

--- a/packages/react-components/react-tag-picker-preview/src/contexts/TagPickerContext.ts
+++ b/packages/react-components/react-tag-picker-preview/src/contexts/TagPickerContext.ts
@@ -21,7 +21,7 @@ export interface TagPickerContextValue
     | 'disabled'
     | 'freeform'
   > {
-  triggerRef: React.RefObject<HTMLInputElement>;
+  triggerRef: React.RefObject<HTMLInputElement | HTMLButtonElement>;
   popoverRef: React.RefObject<HTMLDivElement>;
   popoverId: string;
   targetRef: React.RefObject<HTMLDivElement>;

--- a/packages/react-components/react-tag-picker-preview/src/utils/tokens.ts
+++ b/packages/react-components/react-tag-picker-preview/src/utils/tokens.ts
@@ -1,0 +1,11 @@
+export type TagPickerInputTokens = {
+  width: string;
+};
+
+export const tagPickerInputCSSRules: { [Key in keyof TagPickerInputTokens]: `--fluent-TagPickerInput__${Key}` } = {
+  width: '--fluent-TagPickerInput__width',
+};
+
+export const tagPickerInputTokens: Record<keyof TagPickerInputTokens, string> = {
+  width: `var(${tagPickerInputCSSRules.width}, 0)`,
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Previously the `input` would always occupy the next line

## New Behavior


1. Ensures `TagPickerInput` `input` slot is properly positioned, according to design. The input should grow/shrink its size based on the amount of characters.

It should occupy a minimal space of `24px`:
![image](https://github.com/microsoft/fluentui/assets/5483269/6dd45639-7d31-417f-8dc0-d62500c67ee0)

But if the text content is bigger than `24px` then the input should grow to occupy the next line

![image](https://github.com/microsoft/fluentui/assets/5483269/216f1ae9-ebda-437d-8f8e-cc1d5f79b857)

