### PR TITLE
chore(react-combobox): fix `useListBoxSlot` signature to accept more `triggerRef` types

### DIFF
--- a/change/@fluentui-react-combobox-c40b9f22-b188-48c8-80fb-706f1472d62d.json
+++ b/change/@fluentui-react-combobox-c40b9f22-b188-48c8-80fb-706f1472d62d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix useListBoxSlot signature to accept more triggerRef types",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/utils/useListboxSlot.ts
+++ b/packages/react-components/react-combobox/src/utils/useListboxSlot.ts
@@ -16,7 +16,10 @@ export type UseListboxSlotState = Pick<ComboboxBaseState, 'multiselect'>;
 
 type UseListboxSlotOptions = {
   state: UseListboxSlotState;
-  triggerRef: React.RefObject<HTMLInputElement> | React.RefObject<HTMLButtonElement>;
+  triggerRef:
+    | React.RefObject<HTMLInputElement>
+    | React.RefObject<HTMLButtonElement>
+    | React.RefObject<HTMLButtonElement | HTMLInputElement>;
   defaultProps?: Partial<ListboxProps>;
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. updates `useListBoxSlot` signature to accept more use cases of `triggerRef` type to support `TagPicker` types

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
