### PR TITLE
docs: typo on griffel link and code example using compareMediaQueries

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/AdvancedConfiguration.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/AdvancedConfiguration.stories.mdx
@@ -34,7 +34,7 @@ You can check complete example at [CodeSandbox](https://codesandbox.io/s/fluentu
 
 ### Media Queries Sorting
 
-Fluent UI React v9 uses Griffel as CSS-in-JS to apply styles. To provide deterministic behavior, styles applied by Griffel [are sorted]((https://griffel.js.org/react/guides/atomic-css#lvfha-order-of-pseudo-classes), the same applies to media queries. Fluent UI does not provide an opinionated default to sort media queries as the order may vary depending on the specific needs of the application.
+Fluent UI React v9 uses Griffel as CSS-in-JS to apply styles. To provide deterministic behavior, styles applied by Griffel [are sorted](https://griffel.js.org/react/guides/atomic-css#lvfha-order-of-pseudo-classes), the same applies to media queries. Fluent UI does not provide an opinionated default to sort media queries as the order may vary depending on the specific needs of the application.
 
 To configure the sorting behavior, please pass `compareMediaQueries` function with the same signature as sort functions in e.g. `Array.prototype.sort`.
 
@@ -42,7 +42,7 @@ To configure the sorting behavior, please pass `compareMediaQueries` function wi
 import { createDOMRenderer } from '@griffel/react';
 
 const mediaQueryOrder = [
-  'only screen and (min-width: 1366px)',
+  'only screen and (min-width: 1024px)',
   'only screen and (min-width: 1366px)',
   'only screen and (min-width: 1920px)',
 ];
@@ -52,7 +52,7 @@ function sortMediaQueries(a, b) {
 }
 
 const renderer = createDOMRenderer(document, {
-  compareMediaQueries,
+  compareMediaQueries: sortMediaQueries,
 });
 ```
 


### PR DESCRIPTION
## Previous Behavior

(screen shots grabbed from the public docs site (live))

There was a broken link
![image](https://github.com/microsoft/fluentui/assets/1711372/d2e16a83-aa77-46b4-a2d5-c16f46ab5081)

There was also a code example that didn't match the expected
![image](https://github.com/microsoft/fluentui/assets/1711372/6b8baea8-a126-422f-b9d2-c3e365fda860)


## New Behavior

(screen shots grabbed from github preview)

The link is no longer broken
![image](https://github.com/microsoft/fluentui/assets/1711372/8f60800e-6dde-4c4b-a4f7-1c245801ca8b)

The code example matches the output example of properly ordered media queries.
![image](https://github.com/microsoft/fluentui/assets/1711372/c486e47b-2cb4-4e8b-a9f1-ebc4217de890)


