### PR TITLE
docs(Avatar): fix spelling mistake in JSDoc

### DIFF
--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -144,7 +144,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
    *
    * Note: At size 16, if initials are displayed, only the first initial will be rendered.
    *
-   * If a non-supported size is neeeded, set `size` to the next-smaller supported size, and set `width` and `height`
+   * If a non-supported size is needed, set `size` to the next-smaller supported size, and set `width` and `height`
    * to override the rendered size.
    *
    * For example, to set the avatar to 45px in size:


### PR DESCRIPTION
Avatar JSDoc comment has mispelled word 'neeeded'. This commit fixes it to 'needed'.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x ] Code is up-to-date with the `master` branch
* [ x] Your changes are covered by tests (if possible)
* [ x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Avatar component JSDoc had an incorrect spelling of "needed" (was "neeeded"). 

## New Behavior

Avatar component JSDoc has correct spelling of "needed".

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
