### PR TITLE
chore(react-tag-picker): remove _unstable notation

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-421a4d9a-8a7a-42de-9f63-94ce052288a8.json
+++ b/change/@fluentui-react-tag-picker-preview-421a4d9a-8a7a-42de-9f63-94ce052288a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: remove _unstable notation",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useTagPicker_unstable } from './useTagPicker';
-import { renderTagPicker_unstable } from './renderTagPicker';
+import { useTagPicker } from './useTagPicker';
+import { renderTagPicker } from './renderTagPicker';
 import type { TagPickerProps } from './TagPicker.types';
 import { useTagPickerContextValues } from './useTagPickerContextValues';
 
@@ -8,9 +8,9 @@ import { useTagPickerContextValues } from './useTagPickerContextValues';
  * TagPicker component - TODO: add more docs
  */
 export const TagPicker: React.FC<TagPickerProps> = React.memo(props => {
-  const state = useTagPicker_unstable(props);
+  const state = useTagPicker(props);
   const contextValues = useTagPickerContextValues(state);
-  return renderTagPicker_unstable(state, contextValues);
+  return renderTagPicker(state, contextValues);
 });
 
 TagPicker.displayName = 'TagPicker';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/renderTagPicker.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/renderTagPicker.tsx
@@ -9,7 +9,7 @@ import { assertSlots } from '@fluentui/react-utilities';
 /**
  * Render the final JSX of Picker
  */
-export const renderTagPicker_unstable = (state: TagPickerState, contexts: TagPickerContextValues) => {
+export const renderTagPicker = (state: TagPickerState, contexts: TagPickerContextValues) => {
   assertSlots<TagPickerSlots>(state);
   return (
     <TagPickerContextProvider value={contexts.picker}>

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
@@ -14,12 +14,12 @@ import { useComboboxBaseState, ComboboxBaseState } from '@fluentui/react-combobo
 /**
  * Create the state required to render Picker.
  *
- * The returned state can be modified with hooks such as usePickerStyles_unstable,
- * before being passed to renderPicker_unstable.
+ * The returned state can be modified with hooks such as usePickerStyles,
+ * before being passed to renderPicker.
  *
  * @param props - props from this instance of Picker
  */
-export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => {
+export const useTagPicker = (props: TagPickerProps): TagPickerState => {
   const popoverId = useId('picker-listbox');
   const triggerInnerRef = React.useRef<HTMLInputElement | HTMLButtonElement>(null);
   const secondaryActionRef = React.useRef<HTMLSpanElement>(null);

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/TagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/TagPickerButton.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useTagPickerButton_unstable } from './useTagPickerButton';
-import { renderTagPickerButton_unstable } from './renderTagPickerButton';
-import { useTagPickerButtonStyles_unstable } from './useTagPickerButtonStyles.styles';
+import { useTagPickerButton } from './useTagPickerButton';
+import { renderTagPickerButton } from './renderTagPickerButton';
+import { useTagPickerButtonStyles } from './useTagPickerButtonStyles.styles';
 import type { TagPickerButtonProps } from './TagPickerButton.types';
 
 /**
  * PickerButton component - TODO: add more docs
  */
 export const TagPickerButton: ForwardRefComponent<TagPickerButtonProps> = React.forwardRef((props, ref) => {
-  const state = useTagPickerButton_unstable(props, ref);
+  const state = useTagPickerButton(props, ref);
 
-  useTagPickerButtonStyles_unstable(state);
-  return renderTagPickerButton_unstable(state);
+  useTagPickerButtonStyles(state);
+  return renderTagPickerButton(state);
 });
 
 TagPickerButton.displayName = 'TagPickerButton';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/renderTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/renderTagPickerButton.tsx
@@ -7,7 +7,7 @@ import type { TagPickerButtonState, TagPickerButtonSlots } from './TagPickerButt
 /**
  * Render the final JSX of PickerButton
  */
-export const renderTagPickerButton_unstable = (state: TagPickerButtonState) => {
+export const renderTagPickerButton = (state: TagPickerButtonState) => {
   assertSlots<TagPickerButtonSlots>(state);
 
   return <state.root />;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
 import type { TagPickerButtonProps, TagPickerButtonState } from './TagPickerButton.types';
-import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
+import { useTagPickerContext } from '../../contexts/TagPickerContext';
 import { useButtonTriggerSlot } from '@fluentui/react-combobox';
 
 /**
  * Create the state required to render PickerButton.
  *
- * The returned state can be modified with hooks such as usePickerButtonStyles_unstable,
- * before being passed to renderPickerButton_unstable.
+ * The returned state can be modified with hooks such as usePickerButtonStyles,
+ * before being passed to renderPickerButton.
  *
  * @param props - props from this instance of PickerButton
  * @param ref - reference to root HTMLDivElement of PickerButton
  */
-export const useTagPickerButton_unstable = (
+export const useTagPickerButton = (
   props: TagPickerButtonProps,
   ref: React.Ref<HTMLButtonElement>,
 ): TagPickerButtonState => {
@@ -51,7 +51,7 @@ export const useTagPickerButton_unstable = (
     },
   });
 
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
+  const size = useTagPickerContext(ctx => ctx.size);
 
   const state: TagPickerButtonState = {
     components: {
@@ -67,18 +67,18 @@ export const useTagPickerButton_unstable = (
 
 function usePickerContext() {
   return {
-    triggerRef: useTagPickerContext_unstable(ctx => ctx.triggerRef),
-    clearSelection: useTagPickerContext_unstable(ctx => ctx.clearSelection),
-    getOptionById: useTagPickerContext_unstable(ctx => ctx.getOptionById),
-    open: useTagPickerContext_unstable(ctx => ctx.open),
-    selectOption: useTagPickerContext_unstable(ctx => ctx.selectOption),
-    selectedOptions: useTagPickerContext_unstable(ctx => ctx.selectedOptions),
-    setHasFocus: useTagPickerContext_unstable(ctx => ctx.setHasFocus),
-    setOpen: useTagPickerContext_unstable(ctx => ctx.setOpen),
-    setValue: useTagPickerContext_unstable(ctx => ctx.setValue),
-    multiselect: useTagPickerContext_unstable(ctx => ctx.multiselect),
-    value: useTagPickerContext_unstable(ctx => ctx.value),
-    popoverId: useTagPickerContext_unstable(ctx => ctx.popoverId),
-    hasSelectedOption: useTagPickerContext_unstable(ctx => ctx.selectedOptions.length > 0),
+    triggerRef: useTagPickerContext(ctx => ctx.triggerRef),
+    clearSelection: useTagPickerContext(ctx => ctx.clearSelection),
+    getOptionById: useTagPickerContext(ctx => ctx.getOptionById),
+    open: useTagPickerContext(ctx => ctx.open),
+    selectOption: useTagPickerContext(ctx => ctx.selectOption),
+    selectedOptions: useTagPickerContext(ctx => ctx.selectedOptions),
+    setHasFocus: useTagPickerContext(ctx => ctx.setHasFocus),
+    setOpen: useTagPickerContext(ctx => ctx.setOpen),
+    setValue: useTagPickerContext(ctx => ctx.setValue),
+    multiselect: useTagPickerContext(ctx => ctx.multiselect),
+    value: useTagPickerContext(ctx => ctx.value),
+    popoverId: useTagPickerContext(ctx => ctx.popoverId),
+    hasSelectedOption: useTagPickerContext(ctx => ctx.selectedOptions.length > 0),
   };
 }

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/useTagPickerButtonStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerButton/useTagPickerButtonStyles.styles.ts
@@ -134,7 +134,7 @@ const useStyles = makeStyles({
 /**
  * Apply styling to the PickerButton slots based on the state
  */
-export const useTagPickerButtonStyles_unstable = (state: TagPickerButtonState): TagPickerButtonState => {
+export const useTagPickerButtonStyles = (state: TagPickerButtonState): TagPickerButtonState => {
   const styles = useStyles();
   state.root.className = mergeClasses(
     tagPickerButtonClassNames.root,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/TagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/TagPickerControl.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useTagPickerControl_unstable } from './useTagPickerControl';
-import { renderTagPickerControl_unstable } from './renderTagPickerControl';
-import { useTagPickerControlStyles_unstable } from './useTagPickerControlStyles.styles';
+import { useTagPickerControl } from './useTagPickerControl';
+import { renderTagPickerControl } from './renderTagPickerControl';
+import { useTagPickerControlStyles } from './useTagPickerControlStyles.styles';
 import type { TagPickerControlProps } from './TagPickerControl.types';
 
 /**
  * PickerControl component - TODO: add more docs
  */
 export const TagPickerControl: ForwardRefComponent<TagPickerControlProps> = React.forwardRef((props, ref) => {
-  const state = useTagPickerControl_unstable(props, ref);
+  const state = useTagPickerControl(props, ref);
 
-  useTagPickerControlStyles_unstable(state);
-  return renderTagPickerControl_unstable(state);
+  useTagPickerControlStyles(state);
+  return renderTagPickerControl(state);
 });
 
 TagPickerControl.displayName = 'TagPickerControl';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/renderTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/renderTagPickerControl.tsx
@@ -11,7 +11,7 @@ import type {
 /**
  * Render the final JSX of PickerControl
  */
-export const renderTagPickerControl_unstable = (state: TagPickerControlState) => {
+export const renderTagPickerControl = (state: TagPickerControlState) => {
   assertSlots<TagPickerControlSlots & TagPickerControlInternalSlots>(state);
 
   return (

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -9,34 +9,34 @@ import {
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import type { TagPickerControlProps, TagPickerControlState } from './TagPickerControl.types';
-import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
+import { useTagPickerContext } from '../../contexts/TagPickerContext';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import { useResizeObserverRef } from '../../utils/useResizeObserverRef';
 import { tagPickerControlAsideWidthToken } from './useTagPickerControlStyles.styles';
-import { useFieldContext_unstable } from '@fluentui/react-field';
+import { useFieldContext } from '@fluentui/react-field';
 
 /**
  * Create the state required to render PickerControl.
  *
- * The returned state can be modified with hooks such as usePickerControlStyles_unstable,
- * before being passed to renderPickerControl_unstable.
+ * The returned state can be modified with hooks such as usePickerControlStyles,
+ * before being passed to renderPickerControl.
  *
  * @param props - props from this instance of PickerControl
  * @param ref - reference to root HTMLDivElement of PickerControl
  */
-export const useTagPickerControl_unstable = (
+export const useTagPickerControl = (
   props: TagPickerControlProps,
   ref: React.Ref<HTMLDivElement>,
 ): TagPickerControlState => {
-  const targetRef = useTagPickerContext_unstable(ctx => ctx.targetRef);
-  const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
-  const open = useTagPickerContext_unstable(ctx => ctx.open);
-  const setOpen = useTagPickerContext_unstable(ctx => ctx.setOpen);
-  const secondaryInnerActionRef = useTagPickerContext_unstable(ctx => ctx.secondaryActionRef);
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
-  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
-  const disabled = useTagPickerContext_unstable(ctx => ctx.disabled);
-  const invalid = useFieldContext_unstable()?.validationState === 'error';
+  const targetRef = useTagPickerContext(ctx => ctx.targetRef);
+  const triggerRef = useTagPickerContext(ctx => ctx.triggerRef);
+  const open = useTagPickerContext(ctx => ctx.open);
+  const setOpen = useTagPickerContext(ctx => ctx.setOpen);
+  const secondaryInnerActionRef = useTagPickerContext(ctx => ctx.secondaryActionRef);
+  const size = useTagPickerContext(ctx => ctx.size);
+  const appearance = useTagPickerContext(ctx => ctx.appearance);
+  const disabled = useTagPickerContext(ctx => ctx.disabled);
+  const invalid = useFieldContext()?.validationState === 'error';
 
   const innerRef = React.useRef<HTMLDivElement>(null);
 

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -215,7 +215,7 @@ const useIconStyles = makeStyles({
 /**
  * Apply styling to the PickerControl slots based on the state
  */
-export const useTagPickerControlStyles_unstable = (state: TagPickerControlState): TagPickerControlState => {
+export const useTagPickerControlStyles = (state: TagPickerControlState): TagPickerControlState => {
   const styles = useStyles();
   const iconStyles = useIconStyles();
   const asideStyles = useAsideStyles();

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/TagPickerGroup.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/TagPickerGroup.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useTagPickerGroup_unstable } from './useTagPickerGroup';
+import { useTagPickerGroup } from './useTagPickerGroup';
 import type { TagPickerGroupProps } from './TagPickerGroup.types';
-import { useTagGroupContextValues_unstable } from '@fluentui/react-tags';
-import { renderTagPickerGroup_unstable } from './renderTagPickerGroup';
-import { useTagPickerGroupStyles_unstable } from './useTagPickerGroupStyles.styles';
+import { useTagGroupContextValues } from '@fluentui/react-tags';
+import { renderTagPickerGroup } from './renderTagPickerGroup';
+import { useTagPickerGroupStyles } from './useTagPickerGroupStyles.styles';
 
 /**
  * TagPickerGroup component - TODO: add more docs
  */
 export const TagPickerGroup: ForwardRefComponent<TagPickerGroupProps> = React.forwardRef((props, ref) => {
-  const state = useTagPickerGroup_unstable(props, ref);
+  const state = useTagPickerGroup(props, ref);
 
-  useTagPickerGroupStyles_unstable(state);
-  return renderTagPickerGroup_unstable(state, useTagGroupContextValues_unstable(state));
+  useTagPickerGroupStyles(state);
+  return renderTagPickerGroup(state, useTagGroupContextValues(state));
 });
 
 TagPickerGroup.displayName = 'TagPickerGroup';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/renderTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/renderTagPickerGroup.ts
@@ -1,10 +1,10 @@
 import { TagPickerGroupState } from './TagPickerGroup.types';
-import { renderTagGroup_unstable, type TagGroupContextValues } from '@fluentui/react-tags';
+import { renderTagGroup, type TagGroupContextValues } from '@fluentui/react-tags';
 
-export function renderTagPickerGroup_unstable(state: TagPickerGroupState, contexts: TagGroupContextValues) {
+export function renderTagPickerGroup(state: TagPickerGroupState, contexts: TagGroupContextValues) {
   if (!state.hasSelectedOptions) {
     return null;
   }
 
-  return renderTagGroup_unstable(state, contexts);
+  return renderTagGroup(state, contexts);
 }

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -1,32 +1,29 @@
 import * as React from 'react';
 import type { TagPickerGroupProps, TagPickerGroupState } from './TagPickerGroup.types';
-import { useTagGroup_unstable } from '@fluentui/react-tags';
-import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
+import { useTagGroup } from '@fluentui/react-tags';
+import { useTagPickerContext } from '../../contexts/TagPickerContext';
 import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { tagPickerAppearanceToTagAppearance, tagPickerSizeToTagSize } from '../../utils/tagPicker2Tag';
 
 /**
  * Create the state required to render TagPickerGroup.
  *
- * The returned state can be modified with hooks such as usePickerTagGroupStyles_unstable,
- * before being passed to renderPickerTagGroup_unstable.
+ * The returned state can be modified with hooks such as usePickerTagGroupStyles,
+ * before being passed to renderPickerTagGroup.
  *
  * @param props - props from this instance of TagPickerGroup
  * @param ref - reference to root HTMLDivElement of TagPickerGroup
  */
-export const useTagPickerGroup_unstable = (
-  props: TagPickerGroupProps,
-  ref: React.Ref<HTMLDivElement>,
-): TagPickerGroupState => {
-  const selectedOptions = useTagPickerContext_unstable(ctx => ctx.selectedOptions);
-  const hasOneSelectedOption = useTagPickerContext_unstable(ctx => ctx.selectedOptions.length === 1);
-  const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
-  const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
-  const selectOption = useTagPickerContext_unstable(ctx => ctx.selectOption);
-  const size = useTagPickerContext_unstable(ctx => tagPickerSizeToTagSize(ctx.size));
-  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
+export const useTagPickerGroup = (props: TagPickerGroupProps, ref: React.Ref<HTMLDivElement>): TagPickerGroupState => {
+  const selectedOptions = useTagPickerContext(ctx => ctx.selectedOptions);
+  const hasOneSelectedOption = useTagPickerContext(ctx => ctx.selectedOptions.length === 1);
+  const triggerRef = useTagPickerContext(ctx => ctx.triggerRef);
+  const tagPickerGroupRef = useTagPickerContext(ctx => ctx.tagPickerGroupRef);
+  const selectOption = useTagPickerContext(ctx => ctx.selectOption);
+  const size = useTagPickerContext(ctx => tagPickerSizeToTagSize(ctx.size));
+  const appearance = useTagPickerContext(ctx => ctx.appearance);
 
-  const state = useTagGroup_unstable(
+  const state = useTagGroup(
     {
       ...props,
       size,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
@@ -1,7 +1,7 @@
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TagPickerGroupSlots, TagPickerGroupState } from './TagPickerGroup.types';
-import { useTagGroupStyles_unstable } from '@fluentui/react-tags';
+import { useTagGroupStyles } from '@fluentui/react-tags';
 import { tokens } from '@fluentui/react-theme';
 import { tagSizeToTagPickerSize } from '../../utils/tagPicker2Tag';
 
@@ -35,8 +35,8 @@ const useStyles = makeStyles({
 /**
  * Apply styling to the TagPickerGroup slots based on the state
  */
-export const useTagPickerGroupStyles_unstable = (state: TagPickerGroupState): TagPickerGroupState => {
-  useTagGroupStyles_unstable(state);
+export const useTagPickerGroupStyles = (state: TagPickerGroupState): TagPickerGroupState => {
+  useTagGroupStyles(state);
   const styles = useStyles();
   state.root.className = mergeClasses(
     tagPickerGroupClassNames.root,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/TagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/TagPickerInput.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useTagPickerInput_unstable } from './useTagPickerInput';
-import { renderTagPickerInput_unstable } from './renderTagPickerInput';
-import { useTagPickerInputStyles_unstable } from './useTagPickerInputStyles.styles';
+import { useTagPickerInput } from './useTagPickerInput';
+import { renderTagPickerInput } from './renderTagPickerInput';
+import { useTagPickerInputStyles } from './useTagPickerInputStyles.styles';
 import type { TagPickerInputProps } from './TagPickerInput.types';
 
 /**
  * TagPickerInput component - TODO: add more docs
  */
 export const TagPickerInput: ForwardRefComponent<TagPickerInputProps> = React.forwardRef((props, ref) => {
-  const state = useTagPickerInput_unstable(props, ref);
+  const state = useTagPickerInput(props, ref);
 
-  useTagPickerInputStyles_unstable(state);
-  return renderTagPickerInput_unstable(state);
+  useTagPickerInputStyles(state);
+  return renderTagPickerInput(state);
 });
 
 TagPickerInput.displayName = 'TagPickerInput';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/renderTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/renderTagPickerInput.tsx
@@ -7,7 +7,7 @@ import type { TagPickerInputState, TagPickerInputSlots } from './TagPickerInput.
 /**
  * Render the final JSX of TagPickerInput
  */
-export const renderTagPickerInput_unstable = (state: TagPickerInputState) => {
+export const renderTagPickerInput = (state: TagPickerInputState) => {
   assertSlots<TagPickerInputSlots>(state);
 
   return <state.root />;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import type { TagPickerInputProps, TagPickerInputState } from './TagPickerInput.types';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
-import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
+import { useTagPickerContext } from '../../contexts/TagPickerContext';
 import {
   useMergedRefs,
   getIntrinsicElementProps,
@@ -11,27 +11,27 @@ import {
 } from '@fluentui/react-utilities';
 import { Backspace, Enter } from '@fluentui/keyboard-keys';
 import { useInputTriggerSlot } from '@fluentui/react-combobox';
-import { useFieldControlProps_unstable } from '@fluentui/react-field';
+import { useFieldControlProps } from '@fluentui/react-field';
 import { tagPickerInputCSSRules } from '../../utils/tokens';
 
 /**
  * Create the state required to render TagPickerInput.
  *
- * The returned state can be modified with hooks such as useTagPickerInputStyles_unstable,
- * before being passed to renderTagPickerInput_unstable.
+ * The returned state can be modified with hooks such as useTagPickerInputStyles,
+ * before being passed to renderTagPickerInput.
  *
  * @param props - props from this instance of TagPickerInput
  * @param ref - reference to root HTMLDivElement of TagPickerInput
  */
-export const useTagPickerInput_unstable = (
+export const useTagPickerInput = (
   props: TagPickerInputProps,
   ref: React.Ref<HTMLInputElement>,
 ): TagPickerInputState => {
-  props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
+  props = useFieldControlProps(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
   const { controller: activeDescendantController } = useActiveDescendantContext();
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
-  const freeform = useTagPickerContext_unstable(ctx => ctx.freeform);
-  const contextDisabled = useTagPickerContext_unstable(ctx => ctx.disabled);
+  const size = useTagPickerContext(ctx => ctx.size);
+  const freeform = useTagPickerContext(ctx => ctx.freeform);
+  const contextDisabled = useTagPickerContext(ctx => ctx.disabled);
   const {
     triggerRef,
     clearSelection,
@@ -134,18 +134,18 @@ export const useTagPickerInput_unstable = (
 
 function useTagPickerContexts() {
   return {
-    triggerRef: useTagPickerContext_unstable(ctx => ctx.triggerRef) as React.RefObject<HTMLInputElement>,
-    clearSelection: useTagPickerContext_unstable(ctx => ctx.clearSelection),
-    getOptionById: useTagPickerContext_unstable(ctx => ctx.getOptionById),
-    open: useTagPickerContext_unstable(ctx => ctx.open),
-    selectOption: useTagPickerContext_unstable(ctx => ctx.selectOption),
-    selectedOptions: useTagPickerContext_unstable(ctx => ctx.selectedOptions),
-    setHasFocus: useTagPickerContext_unstable(ctx => ctx.setHasFocus),
-    setOpen: useTagPickerContext_unstable(ctx => ctx.setOpen),
-    setValue: useTagPickerContext_unstable(ctx => ctx.setValue),
-    multiselect: useTagPickerContext_unstable(ctx => ctx.multiselect),
-    value: useTagPickerContext_unstable(ctx => ctx.value),
-    popoverId: useTagPickerContext_unstable(ctx => ctx.popoverId),
+    triggerRef: useTagPickerContext(ctx => ctx.triggerRef) as React.RefObject<HTMLInputElement>,
+    clearSelection: useTagPickerContext(ctx => ctx.clearSelection),
+    getOptionById: useTagPickerContext(ctx => ctx.getOptionById),
+    open: useTagPickerContext(ctx => ctx.open),
+    selectOption: useTagPickerContext(ctx => ctx.selectOption),
+    selectedOptions: useTagPickerContext(ctx => ctx.selectedOptions),
+    setHasFocus: useTagPickerContext(ctx => ctx.setHasFocus),
+    setOpen: useTagPickerContext(ctx => ctx.setOpen),
+    setValue: useTagPickerContext(ctx => ctx.setValue),
+    multiselect: useTagPickerContext(ctx => ctx.multiselect),
+    value: useTagPickerContext(ctx => ctx.value),
+    popoverId: useTagPickerContext(ctx => ctx.popoverId),
   };
 }
 

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
@@ -65,7 +65,7 @@ const useStyles = makeStyles({
 /**
  * Apply styling to the TagPickerInput slots based on the state
  */
-export const useTagPickerInputStyles_unstable = (state: TagPickerInputState): TagPickerInputState => {
+export const useTagPickerInputStyles = (state: TagPickerInputState): TagPickerInputState => {
   const baseStyle = useBaseStyle();
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/TagPickerList.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/TagPickerList.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useTagPickerList_unstable } from './useTagPickerList';
-import { renderTagPickerList_unstable } from './renderTagPickerList';
-import { useTagPickerListStyles_unstable } from './useTagPickerListStyles.styles';
+import { useTagPickerList } from './useTagPickerList';
+import { renderTagPickerList } from './renderTagPickerList';
+import { useTagPickerListStyles } from './useTagPickerListStyles.styles';
 import type { TagPickerListProps } from './TagPickerList.types';
 
 /**
  * TagPickerList component - TODO: add more docs
  */
 export const TagPickerList: ForwardRefComponent<TagPickerListProps> = React.forwardRef((props, ref) => {
-  const state = useTagPickerList_unstable(props, ref);
+  const state = useTagPickerList(props, ref);
 
-  useTagPickerListStyles_unstable(state);
-  return renderTagPickerList_unstable(state);
+  useTagPickerListStyles(state);
+  return renderTagPickerList(state);
 });
 
 TagPickerList.displayName = 'TagPickerList';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/renderTagPickerList.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/renderTagPickerList.tsx
@@ -7,7 +7,7 @@ import type { TagPickerListState, TagPickerListSlots } from './TagPickerList.typ
 /**
  * Render the final JSX of TagPickerList
  */
-export const renderTagPickerList_unstable = (state: TagPickerListState) => {
+export const renderTagPickerList = (state: TagPickerListState) => {
   assertSlots<TagPickerListSlots>(state);
   return <state.root />;
 };

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerList.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerList.ts
@@ -1,30 +1,27 @@
 import * as React from 'react';
 import type { TagPickerListProps, TagPickerListState } from './TagPickerList.types';
 import { Listbox } from '@fluentui/react-combobox';
-import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
+import { useTagPickerContext } from '../../contexts/TagPickerContext';
 import { useMergedRefs } from '@fluentui/react-utilities';
 import { useListboxSlot } from '@fluentui/react-combobox';
 
 /**
  * Create the state required to render TagPickerList.
  *
- * The returned state can be modified with hooks such as useTagPickerListStyles_unstable,
- * before being passed to renderTagPickerList_unstable.
+ * The returned state can be modified with hooks such as useTagPickerListStyles,
+ * before being passed to renderTagPickerList.
  *
  * @param props - props from this instance of TagPickerList
  * @param ref - reference to root HTMLDivElement of TagPickerList
  */
-export const useTagPickerList_unstable = (
-  props: TagPickerListProps,
-  ref: React.Ref<HTMLDivElement>,
-): TagPickerListState => {
-  const multiselect = useTagPickerContext_unstable(ctx => ctx.multiselect);
-  const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef) as
+export const useTagPickerList = (props: TagPickerListProps, ref: React.Ref<HTMLDivElement>): TagPickerListState => {
+  const multiselect = useTagPickerContext(ctx => ctx.multiselect);
+  const triggerRef = useTagPickerContext(ctx => ctx.triggerRef) as
     | React.RefObject<HTMLInputElement>
     | React.RefObject<HTMLButtonElement>;
-  const popoverRef = useTagPickerContext_unstable(ctx => ctx.popoverRef);
-  const popoverId = useTagPickerContext_unstable(ctx => ctx.popoverId);
-  const open = useTagPickerContext_unstable(ctx => ctx.open);
+  const popoverRef = useTagPickerContext(ctx => ctx.popoverRef);
+  const popoverId = useTagPickerContext(ctx => ctx.popoverId);
+  const open = useTagPickerContext(ctx => ctx.open);
 
   return {
     open,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerListStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerListStyles.styles.ts
@@ -26,7 +26,7 @@ const useStyles = makeStyles({
 /**
  * Apply styling to the TagPickerList slots based on the state
  */
-export const useTagPickerListStyles_unstable = (state: TagPickerListState): TagPickerListState => {
+export const useTagPickerListStyles = (state: TagPickerListState): TagPickerListState => {
   const styles = useStyles();
   state.root.className = mergeClasses(
     tagPickerListClassNames.root,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/TagPickerOption.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/TagPickerOption.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useTagPickerOption_unstable } from './useTagPickerOption';
-import { renderTagPickerOption_unstable } from './renderTagPickerOption';
-import { useTagPickerOptionStyles_unstable } from './useTagPickerOptionStyles.styles';
+import { useTagPickerOption } from './useTagPickerOption';
+import { renderTagPickerOption } from './renderTagPickerOption';
+import { useTagPickerOptionStyles } from './useTagPickerOptionStyles.styles';
 import type { TagPickerOptionProps } from './TagPickerOption.types';
 
 /**
  * TagPickerOption component - TODO: add more docs
  */
 export const TagPickerOption: ForwardRefComponent<TagPickerOptionProps> = React.forwardRef((props, ref) => {
-  const state = useTagPickerOption_unstable(props, ref);
+  const state = useTagPickerOption(props, ref);
 
-  useTagPickerOptionStyles_unstable(state);
-  return renderTagPickerOption_unstable(state);
+  useTagPickerOptionStyles(state);
+  return renderTagPickerOption(state);
 });
 
 TagPickerOption.displayName = 'TagPickerOption';

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/renderTagPickerOption.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/renderTagPickerOption.tsx
@@ -7,7 +7,7 @@ import type { TagPickerOptionState, TagPickerOptionSlots } from './TagPickerOpti
 /**
  * Render the final JSX of TagPickerOption
  */
-export const renderTagPickerOption_unstable = (state: TagPickerOptionState) => {
+export const renderTagPickerOption = (state: TagPickerOptionState) => {
   assertSlots<TagPickerOptionSlots>(state);
 
   return (

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
@@ -1,22 +1,22 @@
 import * as React from 'react';
 import { slot } from '@fluentui/react-utilities';
-import { OptionProps, useOption_unstable } from '@fluentui/react-combobox';
+import { OptionProps, useOption } from '@fluentui/react-combobox';
 import type { TagPickerOptionProps, TagPickerOptionState } from './TagPickerOption.types';
 
 /**
  * Create the state required to render TagPickerOption.
  *
- * The returned state can be modified with hooks such as useTagPickerOptionStyles_unstable,
- * before being passed to renderTagPickerOption_unstable.
+ * The returned state can be modified with hooks such as useTagPickerOptionStyles,
+ * before being passed to renderTagPickerOption.
  *
  * @param props - props from this instance of TagPickerOption
  * @param ref - reference to root HTMLDivElement of TagPickerOption
  */
-export const useTagPickerOption_unstable = (
+export const useTagPickerOption = (
   props: TagPickerOptionProps,
   ref: React.Ref<HTMLDivElement>,
 ): TagPickerOptionState => {
-  const optionState = useOption_unstable(props as OptionProps, ref);
+  const optionState = useOption(props as OptionProps, ref);
   const state: TagPickerOptionState = {
     components: {
       ...optionState.components,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -1,7 +1,7 @@
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TagPickerOptionSlots, TagPickerOptionState } from './TagPickerOption.types';
-import { useOptionStyles_unstable } from '@fluentui/react-combobox';
+import { useOptionStyles } from '@fluentui/react-combobox';
 
 export const tagPickerOptionClassNames: SlotClassNames<TagPickerOptionSlots> = {
   root: 'fui-TagPickerOption',
@@ -32,8 +32,8 @@ const useStyles = makeStyles({
 /**
  * Apply styling to the TagPickerOption slots based on the state
  */
-export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): TagPickerOptionState => {
-  useOptionStyles_unstable({
+export const useTagPickerOptionStyles = (state: TagPickerOptionState): TagPickerOptionState => {
+  useOptionStyles({
     ...state,
     active: false,
     disabled: false,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOptionGroup/renderTagPickerOptionGroup.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOptionGroup/renderTagPickerOptionGroup.tsx
@@ -2,9 +2,9 @@
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
 import type { TagPickerOptionGroupState } from './TagPickerOptionGroup.types';
-import { renderOptionGroup_unstable } from '@fluentui/react-combobox';
+import { renderOptionGroup } from '@fluentui/react-combobox';
 
 /**
  * Render the final JSX of TagPickerOptionGroup
  */
-export const renderTagPickerOptionGroup: (state: TagPickerOptionGroupState) => JSX.Element = renderOptionGroup_unstable;
+export const renderTagPickerOptionGroup: (state: TagPickerOptionGroupState) => JSX.Element = renderOptionGroup;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOptionGroup/useTagPickerOptionGroup.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOptionGroup/useTagPickerOptionGroup.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import type { TagPickerOptionGroupProps, TagPickerOptionGroupState } from './TagPickerOptionGroup.types';
-import { useOptionGroup_unstable } from '@fluentui/react-combobox';
+import { useOptionGroup } from '@fluentui/react-combobox';
 
 /**
  * Create the state required to render TagPickerOptionGroup.
  *
- * The returned state can be modified with hooks such as useTagPickerOptionGroupStyles_unstable,
- * before being passed to renderTagPickerOptionGroup_unstable.
+ * The returned state can be modified with hooks such as useTagPickerOptionGroupStyles,
+ * before being passed to renderTagPickerOptionGroup.
  *
  * @param props - props from this instance of TagPickerOptionGroup
  * @param ref - reference to root HTMLDivElement of TagPickerOptionGroup
@@ -14,4 +14,4 @@ import { useOptionGroup_unstable } from '@fluentui/react-combobox';
 export const useTagPickerOptionGroup: (
   props: TagPickerOptionGroupProps,
   ref: React.Ref<HTMLDivElement>,
-) => TagPickerOptionGroupState = useOptionGroup_unstable;
+) => TagPickerOptionGroupState = useOptionGroup;

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOptionGroup/useTagPickerOptionGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOptionGroup/useTagPickerOptionGroupStyles.styles.ts
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TagPickerOptionGroupSlots, TagPickerOptionGroupState } from './TagPickerOptionGroup.types';
-import { useOptionGroupStyles_unstable } from '@fluentui/react-combobox';
+import { useOptionGroupStyles } from '@fluentui/react-combobox';
 
 export const tagPickerOptionGroupClassNames: SlotClassNames<TagPickerOptionGroupSlots> = {
   root: 'fui-TagPickerOptionGroup',
@@ -12,7 +12,7 @@ export const tagPickerOptionGroupClassNames: SlotClassNames<TagPickerOptionGroup
  * Apply styling to the TagPickerOptionGroup slots based on the state
  */
 export const useTagPickerOptionGroupStyles = (state: TagPickerOptionGroupState): TagPickerOptionGroupState => {
-  useOptionGroupStyles_unstable(state);
+  useOptionGroupStyles(state);
   state.root.className = mergeClasses(tagPickerOptionGroupClassNames.root, state.root.className);
 
   if (state.label) {

--- a/packages/react-components/react-tag-picker-preview/src/contexts/TagPickerContext.ts
+++ b/packages/react-components/react-tag-picker-preview/src/contexts/TagPickerContext.ts
@@ -59,5 +59,5 @@ export const tagPickerContextDefaultValue: TagPickerContextValue = {
 const TagPickerContext = createContext<TagPickerContextValue | undefined>(undefined);
 
 export const TagPickerContextProvider = TagPickerContext.Provider;
-export const useTagPickerContext_unstable = <T>(selector: ContextSelector<TagPickerContextValue, T>) =>
+export const useTagPickerContext = <T>(selector: ContextSelector<TagPickerContextValue, T>) =>
   useContextSelector(TagPickerContext, (ctx = tagPickerContextDefaultValue) => selector(ctx));

--- a/packages/react-components/react-tag-picker-preview/src/index.ts
+++ b/packages/react-components/react-tag-picker-preview/src/index.ts
@@ -1,4 +1,4 @@
-export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable } from './TagPicker';
+export { TagPicker, renderTagPicker, useTagPicker } from './TagPicker';
 export type {
   TagPickerContextValues as PickerContextValues,
   TagPickerProps,
@@ -8,49 +8,49 @@ export type {
 export {
   TagPickerInput,
   tagPickerInputClassNames,
-  renderTagPickerInput_unstable,
-  useTagPickerInputStyles_unstable,
-  useTagPickerInput_unstable,
+  renderTagPickerInput,
+  useTagPickerInputStyles,
+  useTagPickerInput,
 } from './TagPickerInput';
 export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './TagPickerInput';
 export {
   TagPickerList,
   tagPickerListClassNames,
-  renderTagPickerList_unstable,
-  useTagPickerListStyles_unstable,
-  useTagPickerList_unstable,
+  renderTagPickerList,
+  useTagPickerListStyles,
+  useTagPickerList,
 } from './TagPickerList';
 export type { TagPickerListProps, TagPickerListSlots, TagPickerListState } from './TagPickerList';
 export {
   TagPickerButton,
   tagPickerButtonClassNames,
-  renderTagPickerButton_unstable,
-  useTagPickerButtonStyles_unstable,
-  useTagPickerButton_unstable,
+  renderTagPickerButton,
+  useTagPickerButtonStyles,
+  useTagPickerButton,
 } from './TagPickerButton';
 export type { TagPickerButtonProps, TagPickerButtonSlots, TagPickerButtonState } from './TagPickerButton';
 export {
   TagPickerControl,
   tagPickerControlClassNames,
-  renderTagPickerControl_unstable,
-  useTagPickerControlStyles_unstable,
-  useTagPickerControl_unstable,
+  renderTagPickerControl,
+  useTagPickerControlStyles,
+  useTagPickerControl,
 } from './TagPickerControl';
 export type { TagPickerControlProps, TagPickerControlSlots, TagPickerControlState } from './TagPickerControl';
 export {
   TagPickerOption,
   tagPickerOptionClassNames,
-  renderTagPickerOption_unstable,
-  useTagPickerOptionStyles_unstable,
-  useTagPickerOption_unstable,
+  renderTagPickerOption,
+  useTagPickerOptionStyles,
+  useTagPickerOption,
 } from './TagPickerOption';
 export type { TagPickerOptionProps, TagPickerOptionSlots, TagPickerOptionState } from './TagPickerOption';
 export {
   TagPickerGroup,
   tagPickerGroupClassNames,
-  renderTagPickerGroup_unstable,
-  useTagPickerGroupStyles_unstable,
-  useTagPickerGroup_unstable,
+  renderTagPickerGroup,
+  useTagPickerGroupStyles,
+  useTagPickerGroup,
 } from './TagPickerGroup';
 export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './TagPickerGroup';
 

--- a/packages/react-components/react-tag-picker-preview/src/utils/useResizeObserverRef.ts
+++ b/packages/react-components/react-tag-picker-preview/src/utils/useResizeObserverRef.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { useFluent as useFluent } from '@fluentui/react-shared-contexts';
 
 export const useResizeObserverRef = <E extends HTMLElement>(callback: ResizeObserverCallback): React.Ref<E> => {
   const { targetDocument } = useFluent();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Removes `_unstable` indicator on all methods and variables exported

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
