### PR TITLE
bugfix: Space and Enter should close TagPicker when selecting

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-7b1dad06-5aa8-4d2e-a155-f58b710e3b8e.json
+++ b/change/@fluentui-react-tag-picker-preview-7b1dad06-5aa8-4d2e-a155-f58b710e3b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Space and Enter should close TagPicker when selecting",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
@@ -196,31 +196,21 @@ describe('TagPicker', () => {
         );
       }),
     );
-    it('should close listbox and select activedescendant on Enter key press', () => {
-      mount(<TagPickerControlled />);
-      cy.get('[data-testid="tag-picker-list"]').should('not.exist');
-      cy.get(`[data-testid="tag--${options[0]}]"`).should('not.exist');
-      cy.get('[data-testid="tag-picker-input"]').focus().realPress('Enter');
-      cy.get('[data-testid="tag-picker-list"]').should('exist').should('be.visible');
-      cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-activedescendant', `tag-picker-option--0`);
-      cy.get('[data-testid="tag-picker-input"]').focus().realPress('Enter');
-      cy.get('[data-testid="tag-picker-list"]').should('exist').should('not.be.visible');
-      cy.get(`[data-testid="tag-picker-input"]`).should('not.have.attr', 'aria-activedescendant');
-      cy.get(`[data-testid="tag-picker-option--0"]`).should('not.exist');
-      cy.get(`[data-testid="tag--${options[0]}"]`).should('exist');
-    });
-    it('should select activedescendant on Space key press', () => {
-      mount(<TagPickerControlled />);
-      cy.get('[data-testid="tag-picker-list"]').should('not.exist');
-      cy.get(`[data-testid="tag--${options[0]}]"`).should('not.exist');
-      cy.get('[data-testid="tag-picker-input"]').focus().realPress('Enter');
-      cy.get('[data-testid="tag-picker-list"]').should('exist').should('be.visible');
-      cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-activedescendant', `tag-picker-option--0`);
-      cy.get('[data-testid="tag-picker-input"]').realPress('Space');
-      cy.get('[data-testid="tag-picker-list"]').should('be.visible');
-      cy.get(`[data-testid="tag-picker-option--0"]`).should('not.exist');
-      cy.get(`[data-testid="tag--${options[0]}"]`).should('exist');
-    });
+    (['Enter', 'Space'] as const).forEach(keypress =>
+      it(`should close listbox and select activedescendant on ${keypress} key press`, () => {
+        mount(<TagPickerControlled />);
+        cy.get('[data-testid="tag-picker-list"]').should('not.exist');
+        cy.get(`[data-testid="tag--${options[0]}]"`).should('not.exist');
+        cy.get('[data-testid="tag-picker-input"]').focus().realPress('Enter');
+        cy.get('[data-testid="tag-picker-list"]').should('exist').should('be.visible');
+        cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-activedescendant', `tag-picker-option--0`);
+        cy.get('[data-testid="tag-picker-input"]').focus().realPress(keypress);
+        cy.get('[data-testid="tag-picker-list"]').should('exist').should('not.be.visible');
+        cy.get(`[data-testid="tag-picker-input"]`).should('not.have.attr', 'aria-activedescendant');
+        cy.get(`[data-testid="tag-picker-option--0"]`).should('not.exist');
+        cy.get(`[data-testid="tag--${options[0]}"]`).should('exist');
+      }),
+    );
     describe('Tags', () => {
       it('should focus on last tag on Shift + Tab', () => {
         mount(<TagPickerControlled defaultSelectedOptions={options} />);

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -9,7 +9,7 @@ import {
   useEventCallback,
   useIsomorphicLayoutEffect,
 } from '@fluentui/react-utilities';
-import { Backspace, Enter } from '@fluentui/keyboard-keys';
+import { Backspace, Enter, Space } from '@fluentui/keyboard-keys';
 import { useInputTriggerSlot } from '@fluentui/react-combobox';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { tagPickerInputCSSRules } from '../../utils/tokens';
@@ -78,6 +78,10 @@ export const useTagPickerInput_unstable = (
       ...getIntrinsicElementProps('input', props),
       onKeyDown: useEventCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
         props.onKeyDown?.(event);
+        if (event.key === Space && open) {
+          setOpen(event, false);
+          return;
+        }
         if (event.key === Enter) {
           if (open) {
             ReactDOM.unstable_batchedUpdates(() => {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerList.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerList/useTagPickerList.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { TagPickerListProps, TagPickerListState } from './TagPickerList.types';
 import { Listbox } from '@fluentui/react-combobox';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
-import { useMergedRefs } from '@fluentui/react-utilities';
+import { slot, useMergedRefs } from '@fluentui/react-utilities';
 import { useListboxSlot } from '@fluentui/react-combobox';
 
 /**
@@ -31,11 +31,16 @@ export const useTagPickerList_unstable = (
     components: {
       root: Listbox,
     },
-    root: useListboxSlot(props, useMergedRefs(popoverRef, ref), {
-      state: { multiselect },
-      triggerRef,
-      defaultProps: { id: popoverId },
-      // FIXME: This is a workaround for the fact that useListboxSlot is not properly typed
-    })!,
+    root: slot.always(
+      {
+        ...useListboxSlot(props, useMergedRefs(popoverRef, ref), {
+          state: { multiselect },
+          triggerRef,
+          defaultProps: { id: popoverId },
+        }),
+        role: 'listbox',
+      },
+      { elementType: Listbox },
+    ),
   };
 };

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
@@ -29,7 +29,12 @@ export const useTagPickerOption_unstable = (
     secondaryContent: slot.optional(props.secondaryContent, {
       elementType: 'span',
     }),
-    root: optionState.root,
+    root: slot.always(
+      { ...optionState.root, role: 'option' },
+      {
+        elementType: 'div',
+      },
+    ),
   };
 
   return state;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds proper role to `TagPickerList` and `TagPickerOption` (listbox and option)
2. ensures `Space` and `Enter` close the tag picker when selecting a tag

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
