### PR TITLE
docs: Fixing typo in Avatar.types.ts

### DIFF
--- a/change/@fluentui-react-avatar-8d124f45-a88f-4f4d-9a06-bb44b2bab292.json
+++ b/change/@fluentui-react-avatar-8d124f45-a88f-4f4d-9a06-bb44b2bab292.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Fixing typo in Avatar.types.ts.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/src/components/Avatar/Avatar.types.ts
@@ -144,7 +144,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
    *
    * Note: At size 16, if initials are displayed, only the first initial will be rendered.
    *
-   * If a non-supported size is neeeded, set `size` to the next-smaller supported size, and set `width` and `height`
+   * If a non-supported size is needed, set `size` to the next-smaller supported size, and set `width` and `height`
    * to override the rendered size.
    *
    * For example, to set the avatar to 45px in size:


### PR DESCRIPTION
## Previous Behavior

Avatar component JSDoc had an incorrect spelling of "needed" (was "neeeded"). 

## New Behavior

Avatar component JSDoc has correct spelling of "needed".

![image](https://github.com/microsoft/fluentui/assets/6444251/3b0769f2-ba1b-474d-b137-9bf15806dbeb)