### PR TITLE
Fix Focus styling for AreaChart examples in public docsite

### DIFF
--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.CustomAccessibility.Example.tsx
@@ -18,7 +18,7 @@ export class AreaChartCustomAccessibilityExample extends React.Component<{}, IAr
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return <div className="containerDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.DataChange.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.DataChange.Example.tsx
@@ -51,7 +51,7 @@ export class AreaChartDataChangeExample extends React.Component<{}, IAreaChartBa
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return <div className="containerDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.LargeData.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.LargeData.Example.tsx
@@ -16,7 +16,7 @@ export class AreaChartLargeDataExample extends React.Component<{}, IACLargeDataE
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return <div className="containerDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Multiple.Example.tsx
@@ -18,7 +18,7 @@ export class AreaChartMultipleExample extends React.Component<{}, IAreaChartBasi
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return <div className="containerDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Styled.Example.tsx
@@ -17,7 +17,7 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return <div className="containerDiv">{this._basicExample()}</div>;
   }
 
   private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Focus styling for AreaChart examples was being overriden.

## New Behavior

Focus styling was fixed for AreaChart examples. Refer PR #30907 for more details.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
