### PR TITLE
fix: Button stories shouldn't shrink past min-content

### DIFF
--- a/change/@fluentui-react-button-72d7280b-cfe5-4200-9763-ca081ecf50ce.json
+++ b/change/@fluentui-react-button-72d7280b-cfe5-4200-9763-ca081ecf50ce.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: Button doesn't shrink past min-content",
-  "packageName": "@fluentui/react-button",
-  "email": "sarah.higley@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-button-72d7280b-cfe5-4200-9763-ca081ecf50ce.json
+++ b/change/@fluentui-react-button-72d7280b-cfe5-4200-9763-ca081ecf50ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Button doesn't shrink past min-content",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -59,7 +59,7 @@ const useRootBaseClassName = makeResetStyles({
   },
 
   padding: `${buttonSpacingMedium} ${tokens.spacingHorizontalM}`,
-  minWidth: '96px',
+  minWidth: 'min-content',
   borderRadius: tokens.borderRadiusMedium,
 
   fontSize: tokens.fontSizeBase300,

--- a/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/src/components/Button/useButtonStyles.styles.ts
@@ -59,7 +59,7 @@ const useRootBaseClassName = makeResetStyles({
   },
 
   padding: `${buttonSpacingMedium} ${tokens.spacingHorizontalM}`,
-  minWidth: 'min-content',
+  minWidth: '96px',
   borderRadius: tokens.borderRadiusMedium,
 
   fontSize: tokens.fontSizeBase300,

--- a/packages/react-components/react-button/stories/Button/ButtonShape.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonShape.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/Button/ButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonSize.stories.tsx
@@ -12,6 +12,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     rowGap: '15px',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/Button/ButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/stories/Button/ButtonWithLongText.stories.tsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonAppearance.stories.tsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonDisabled.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   innerWrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
   outerWrapper: {
     display: 'flex',

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonIcon.stories.tsx
@@ -7,6 +7,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonShape.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonShape.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonSize.stories.tsx
@@ -7,6 +7,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/CompoundButton/CompoundButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/stories/CompoundButton/CompoundButtonWithLongText.stories.tsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonAppearance.stories.tsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonDisabled.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonIcon.stories.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonShape.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonShape.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSize.stories.tsx
@@ -6,6 +6,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeLarge.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeLarge.stories.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeMedium.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeMedium.stories.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonSizeSmall.stories.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/MenuButton/MenuButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/stories/MenuButton/MenuButtonWithLongText.stories.tsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonAppearance.stories.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonDisabled.stories.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonIcon.stories.tsx
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonShape.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonShape.stories.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSize.stories.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeLarge.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeLarge.stories.tsx
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeMedium.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeMedium.stories.tsx
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonSizeSmall.stories.tsx
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/SplitButton/SplitButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/stories/SplitButton/SplitButtonWithLongText.stories.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonAppearance.stories.tsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonChecked.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonChecked.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonDisabled.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonDisabled.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   innerWrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
   outerWrapper: {
     display: 'flex',

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonIcon.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonIcon.stories.tsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonShape.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonShape.stories.tsx
@@ -5,6 +5,7 @@ const useStyles = makeStyles({
   wrapper: {
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonSize.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonSize.stories.tsx
@@ -6,6 +6,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 

--- a/packages/react-components/react-button/stories/ToggleButton/ToggleButtonWithLongText.stories.tsx
+++ b/packages/react-components/react-button/stories/ToggleButton/ToggleButtonWithLongText.stories.tsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: '15px',
     display: 'flex',
+    minWidth: 'min-content',
   },
 });
 


### PR DESCRIPTION
Story-only styles, lots of adding `min-width: min-content` :D

Previously some text was getting clipped when there was a word that went longer than the `min-width: 96px` on Button.