### PR TITLE
feat:(react-nav-preview) Sets drawer width to 260px

### DIFF
--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
@@ -14,10 +14,8 @@ export const navDrawerClassNames: SlotClassNames<InlineDrawerSlots> = {
  */
 const useStyles = makeStyles({
   root: {
-    // TODO Add default styles for the root element
+    width: '260px', // per spec
   },
-
-  // TODO add additional classes for different states and/or slots
 });
 
 /**


### PR DESCRIPTION
Default width of the NavDrawer is 320px, spec calls for 260px. Extra pixel comes from the border.

Spec:
![image](https://github.com/microsoft/fluentui/assets/17346018/3b3e1f79-5bb6-4e11-b22f-cc628678f34c)

Before:
![320px](https://github.com/microsoft/fluentui/assets/17346018/d7e2f9e5-d1d6-47e2-bbe8-ba2ae2f7c7fc)

After:
![260px](https://github.com/microsoft/fluentui/assets/17346018/737c2625-96d9-49a6-9cb5-63f29bca1e6a)

Ladders up to #26649 
