### PR TITLE
feat(react-tag): adds role to TagGroupContextValue

### DIFF
--- a/change/@fluentui-react-tags-899b8dcb-621f-4601-8b1d-d2e432278f59.json
+++ b/change/@fluentui-react-tags-899b8dcb-621f-4601-8b1d-d2e432278f59.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds isInsideTagPicker exception case to TagGroupContextValue",
+  "packageName": "@fluentui/react-tags",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags/etc/react-tags.api.md
+++ b/packages/react-components/react-tags/etc/react-tags.api.md
@@ -146,7 +146,7 @@ export type TagGroupSlots = {
 // @public
 export type TagGroupState<Value = TagValue> = ComponentState<TagGroupSlots> & Required<Pick<TagGroupProps, 'size' | 'appearance' | 'dismissible'>> & {
     handleTagDismiss: TagDismissHandler<Value>;
-    isInsideTagPicker?: boolean;
+    role?: React_2.AriaRole;
 };
 
 // @public

--- a/packages/react-components/react-tags/etc/react-tags.api.md
+++ b/packages/react-components/react-tags/etc/react-tags.api.md
@@ -146,6 +146,7 @@ export type TagGroupSlots = {
 // @public
 export type TagGroupState<Value = TagValue> = ComponentState<TagGroupSlots> & Required<Pick<TagGroupProps, 'size' | 'appearance' | 'dismissible'>> & {
     handleTagDismiss: TagDismissHandler<Value>;
+    isInsideTagPicker?: boolean;
 };
 
 // @public

--- a/packages/react-components/react-tags/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/src/components/Tag/useTag.tsx
@@ -31,7 +31,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
     size: contextSize,
     appearance: contextAppearance,
     dismissible: contextDismissible,
-    isInsideTagPicker = false,
+    role: tagGroupRole,
   } = useTagGroupContext_unstable();
 
   const id = useId('fui-Tag', props.id);
@@ -82,7 +82,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
     root: slot.always(
       getIntrinsicElementProps(elementType, {
         ref,
-        role: isInsideTagPicker ? 'option' : undefined,
+        role: tagGroupRole === 'listbox' ? 'option' : undefined,
         ...props,
         id,
         ...(dismissible && { onClick: dismissOnClick, onKeyDown: dismissOnKeyDown }),

--- a/packages/react-components/react-tags/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/src/components/Tag/useTag.tsx
@@ -31,6 +31,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
     size: contextSize,
     appearance: contextAppearance,
     dismissible: contextDismissible,
+    isInsideTagPicker = false,
   } = useTagGroupContext_unstable();
 
   const id = useId('fui-Tag', props.id);
@@ -81,6 +82,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
     root: slot.always(
       getIntrinsicElementProps(elementType, {
         ref,
+        role: isInsideTagPicker ? 'option' : undefined,
         ...props,
         id,
         ...(dismissible && { onClick: dismissOnClick, onKeyDown: dismissOnKeyDown }),

--- a/packages/react-components/react-tags/src/components/TagGroup/TagGroup.types.ts
+++ b/packages/react-components/react-tags/src/components/TagGroup/TagGroup.types.ts
@@ -1,6 +1,7 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { TagSize, TagValue, TagDismissHandler, TagAppearance } from '../../utils/types';
 import { TagGroupContextValue } from '../../contexts/tagGroupContext';
+import * as React from 'react';
 
 export type TagGroupContextValues = {
   tagGroup: TagGroupContextValue;
@@ -31,5 +32,5 @@ export type TagGroupProps<Value = TagValue> = ComponentProps<TagGroupSlots> & {
 export type TagGroupState<Value = TagValue> = ComponentState<TagGroupSlots> &
   Required<Pick<TagGroupProps, 'size' | 'appearance' | 'dismissible'>> & {
     handleTagDismiss: TagDismissHandler<Value>;
-    isInsideTagPicker?: boolean;
+    role?: React.AriaRole;
   };

--- a/packages/react-components/react-tags/src/components/TagGroup/TagGroup.types.ts
+++ b/packages/react-components/react-tags/src/components/TagGroup/TagGroup.types.ts
@@ -31,4 +31,5 @@ export type TagGroupProps<Value = TagValue> = ComponentProps<TagGroupSlots> & {
 export type TagGroupState<Value = TagValue> = ComponentState<TagGroupSlots> &
   Required<Pick<TagGroupProps, 'size' | 'appearance' | 'dismissible'>> & {
     handleTagDismiss: TagDismissHandler<Value>;
+    isInsideTagPicker?: boolean;
   };

--- a/packages/react-components/react-tags/src/components/TagGroup/useTagGroup.ts
+++ b/packages/react-components/react-tags/src/components/TagGroup/useTagGroup.ts
@@ -53,6 +53,7 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDi
 
   return {
     handleTagDismiss,
+    isInsideTagPicker: false,
     size,
     appearance,
     dismissible,

--- a/packages/react-components/react-tags/src/components/TagGroup/useTagGroup.ts
+++ b/packages/react-components/react-tags/src/components/TagGroup/useTagGroup.ts
@@ -15,7 +15,7 @@ import { interactionTagSecondaryClassNames } from '../InteractionTagSecondary/us
  * @param ref - reference to root HTMLDivElement of TagGroup
  */
 export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDivElement>): TagGroupState => {
-  const { onDismiss, size = 'medium', appearance = 'filled', dismissible = false } = props;
+  const { onDismiss, size = 'medium', appearance = 'filled', dismissible = false, role = 'toolbar' } = props;
 
   const innerRef = React.useRef<HTMLElement>();
   const { targetDocument } = useFluent();
@@ -53,7 +53,7 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDi
 
   return {
     handleTagDismiss,
-    isInsideTagPicker: false,
+    role,
     size,
     appearance,
     dismissible,
@@ -67,7 +67,7 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDi
         // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
         // but since it would be a breaking change to fix it, we are casting ref to it's proper type
         ref: useMergedRefs(ref, innerRef) as React.Ref<HTMLDivElement>,
-        role: 'toolbar',
+        role,
         ...arrowNavigationProps,
         ...props,
       }),

--- a/packages/react-components/react-tags/src/components/TagGroup/useTagGroupContextValues.ts
+++ b/packages/react-components/react-tags/src/components/TagGroup/useTagGroupContextValues.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import type { TagGroupContextValues, TagGroupState } from './TagGroup.types';
 
 export function useTagGroupContextValues_unstable(state: TagGroupState): TagGroupContextValues {
-  const { handleTagDismiss, size, appearance, dismissible } = state;
+  const { handleTagDismiss, size, appearance, dismissible, isInsideTagPicker } = state;
   return {
     tagGroup: React.useMemo(
-      () => ({ handleTagDismiss, size, appearance, dismissible }),
-      [handleTagDismiss, size, appearance, dismissible],
+      () => ({ handleTagDismiss, size, appearance, dismissible, isInsideTagPicker }),
+      [handleTagDismiss, size, appearance, dismissible, isInsideTagPicker],
     ),
   };
 }

--- a/packages/react-components/react-tags/src/components/TagGroup/useTagGroupContextValues.ts
+++ b/packages/react-components/react-tags/src/components/TagGroup/useTagGroupContextValues.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import type { TagGroupContextValues, TagGroupState } from './TagGroup.types';
 
 export function useTagGroupContextValues_unstable(state: TagGroupState): TagGroupContextValues {
-  const { handleTagDismiss, size, appearance, dismissible, isInsideTagPicker } = state;
+  const { handleTagDismiss, size, appearance, dismissible, role } = state;
   return {
     tagGroup: React.useMemo(
-      () => ({ handleTagDismiss, size, appearance, dismissible, isInsideTagPicker }),
-      [handleTagDismiss, size, appearance, dismissible, isInsideTagPicker],
+      () => ({ handleTagDismiss, size, appearance, dismissible, role }),
+      [handleTagDismiss, size, appearance, dismissible, role],
     ),
   };
 }

--- a/packages/react-components/react-tags/src/contexts/tagGroupContext.tsx
+++ b/packages/react-components/react-tags/src/contexts/tagGroupContext.tsx
@@ -12,7 +12,14 @@ const tagGroupContextDefaultValue: TagGroupContextValue = {
  * Context shared between TagGroup and its children components
  */
 export type TagGroupContextValue = Required<Pick<TagGroupState, 'handleTagDismiss' | 'size'>> &
-  Partial<Pick<TagGroupState, 'appearance' | 'dismissible'>>;
+  Partial<Pick<TagGroupState, 'appearance' | 'dismissible'>> & {
+    /**
+     * Boolean that indicates that the tag is being render inside of a
+     * TagPicker element.
+     * When rendered inside of a TagPicker a tag should have role="option"
+     */
+    isInsideTagPicker?: boolean;
+  };
 
 export const TagGroupContextProvider = TagGroupContext.Provider;
 

--- a/packages/react-components/react-tags/src/contexts/tagGroupContext.tsx
+++ b/packages/react-components/react-tags/src/contexts/tagGroupContext.tsx
@@ -6,20 +6,14 @@ export const TagGroupContext = React.createContext<TagGroupContextValue | undefi
 const tagGroupContextDefaultValue: TagGroupContextValue = {
   handleTagDismiss: () => ({}),
   size: 'medium',
+  role: 'toolbar',
 };
 
 /**
  * Context shared between TagGroup and its children components
  */
 export type TagGroupContextValue = Required<Pick<TagGroupState, 'handleTagDismiss' | 'size'>> &
-  Partial<Pick<TagGroupState, 'appearance' | 'dismissible'>> & {
-    /**
-     * Boolean that indicates that the tag is being render inside of a
-     * TagPicker element.
-     * When rendered inside of a TagPicker a tag should have role="option"
-     */
-    isInsideTagPicker?: boolean;
-  };
+  Partial<Pick<TagGroupState, 'appearance' | 'dismissible' | 'role'>>;
 
 export const TagGroupContextProvider = TagGroupContext.Provider;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

There's a requirement that Tags should have `role="option"` when used in the `TagPicker`

1. adds `role` property to `TagGroupContextValue` and ensures that TagGroup provides its role
2. `Tag` component will opt into the `option` role in the case of a tag group with the role `listbox` is present

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
