### PR TITLE
chore(react-tag-picker): ensure navigation between TagPickerGroup and TagPickerInput

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-f9dc682a-010e-41b3-b068-588232aa5abc.json
+++ b/change/@fluentui-react-tag-picker-preview-f9dc682a-010e-41b3-b068-588232aa5abc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure navigation between TagPickerGroup and TagPickerInput",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
@@ -219,14 +219,26 @@ describe('TagPicker', () => {
         cy.get('[data-testid="tag-picker-input"]').focus().realPress(['Shift', 'Tab']);
         cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('be.focused');
       });
-      it('should navigate circularly between tags with Arrow key press', () => {
+      it('should not navigate circularly between tags with Arrow key press', () => {
         mount(<TagPickerControlled defaultSelectedOptions={options} />);
         cy.get(`[data-testid="tag--${options[0]}"]`).focus().realPress('ArrowRight');
         cy.get(`[data-testid="tag--${options[1]}"]`).should('be.focused').realPress('ArrowDown');
         cy.get(`[data-testid="tag--${options[2]}"]`).should('be.focused').realPress('ArrowLeft');
         cy.get(`[data-testid="tag--${options[1]}"]`).should('be.focused').realPress('ArrowUp');
         cy.get(`[data-testid="tag--${options[0]}"]`).should('be.focused').realPress('ArrowUp');
-        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('be.focused');
+        cy.get(`[data-testid="tag--${options[0]}"]`).should('be.focused');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`)
+          .focus()
+          .realPress('ArrowRight');
+        cy.get(`[data-testid="tag--${options[0]}"]`).should('not.be.focused');
+      });
+      it('should navigate from tags to input and back with Arrow key press', () => {
+        mount(<TagPickerControlled defaultSelectedOptions={options} />);
+        cy.get(`[data-testid="tag-picker-input"]`).focus().realPress('ArrowLeft');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`)
+          .should('be.focused')
+          .realPress('ArrowRight');
+        cy.get(`[data-testid="tag-picker-input"]`).should('be.focused');
       });
       it('should memorize last focused tag while switching focus between tags and input', () => {
         mount(<TagPickerControlled defaultSelectedOptions={options} />);

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -2,8 +2,10 @@ import * as React from 'react';
 import type { TagPickerGroupProps, TagPickerGroupState } from './TagPickerGroup.types';
 import { useTagGroup_unstable } from '@fluentui/react-tags';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
-import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
+import { isHTMLElement, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { tagPickerAppearanceToTagAppearance, tagPickerSizeToTagSize } from '../../utils/tagPicker2Tag';
+import { useArrowNavigationGroup } from '@fluentui/react-tabster';
+import { ArrowRight } from '@fluentui/keyboard-keys';
 
 /**
  * Create the state required to render TagPickerGroup.
@@ -18,7 +20,7 @@ export const useTagPickerGroup_unstable = (
   props: TagPickerGroupProps,
   ref: React.Ref<HTMLDivElement>,
 ): TagPickerGroupState => {
-  const selectedOptions = useTagPickerContext_unstable(ctx => ctx.selectedOptions);
+  const hasSelectedOptions = useTagPickerContext_unstable(ctx => ctx.selectedOptions.length > 0);
   const hasOneSelectedOption = useTagPickerContext_unstable(ctx => ctx.selectedOptions.length === 1);
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
   const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
@@ -26,12 +28,25 @@ export const useTagPickerGroup_unstable = (
   const size = useTagPickerContext_unstable(ctx => tagPickerSizeToTagSize(ctx.size));
   const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
 
+  const arrowNavigationProps = useArrowNavigationGroup({
+    circular: false,
+    axis: 'both',
+    memorizeCurrent: true,
+  });
+
   const state = useTagGroup_unstable(
     {
+      role: 'listbox',
       ...props,
+      ...arrowNavigationProps,
       size,
       appearance: tagPickerAppearanceToTagAppearance(appearance),
       dismissible: true,
+      onKeyDown: useEventCallback(event => {
+        if (isHTMLElement(event.target) && event.key === ArrowRight) {
+          triggerRef.current?.focus();
+        }
+      }),
       onDismiss: useEventCallback((event, data) => {
         selectOption(event as React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>, {
           value: data.value,
@@ -50,6 +65,6 @@ export const useTagPickerGroup_unstable = (
 
   return {
     ...state,
-    hasSelectedOptions: !!selectedOptions.length,
+    hasSelectedOptions,
   };
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds role `listbox` to `TagPickerGroup`
2. LeftArrow on beginning of the `TagPickerInput` should focus on the last focusable element inside `TagPickerGroup`
3. RigthArrow on the last Tag of the `TagPickerGroup` should focus trigger
4. adds tests to ensure navigation behaviours

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
