### PR TITLE
feat(workspace-plugin): implement split-library-in-two migration generator

### DIFF
--- a/tools/workspace-plugin/src/generators/split-library-in-two/README.md
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/README.md
@@ -1,0 +1,61 @@
+# split-library-in-two
+
+Workspace Generator for splitting existing v9 web packages into `/library` and `/stories` packages under the same folder name.
+
+```sh
+|- react-components/
+|- |- react-text/
+```
+
+↓↓↓
+
+```
+|- react-components/
+|- |- react-text/
+|- |- |- library/
+|- |- |- stories/
+```
+
+Generator also parses source AST and adds ghost dependencies as `devDependencies` to `library` project for cypress/jest test files in order to create proper dependency graph ( without this `type-check` would fail )
+
+<!-- toc -->
+
+- [Usage](#usage)
+  - [Examples](#examples)
+- [Options](#options)
+  - [`project`](#project)
+  - [`all`](#all)
+
+<!-- tocstop -->
+
+## Usage
+
+```sh
+yarn nx g @fluentui/workspace-plugin:split-library-in-two --help
+```
+
+Show what will be generated without writing to disk:
+
+```sh
+yarn nx g @fluentui/workspace-plugin:split-library-in-two --dry-run
+```
+
+### Examples
+
+```sh
+yarn nx g @fluentui/workspace-plugin:split-library-in-two
+```
+
+## Options
+
+#### `project`
+
+Type: `string`
+
+project name
+
+#### `all`
+
+Type: `boolean`
+
+will execute generator on all applicable projects

--- a/tools/workspace-plugin/src/generators/split-library-in-two/files/src/index.ts.template
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/files/src/index.ts.template
@@ -1,1 +1,0 @@
-const variable = "<%= name %>";

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -1,20 +1,478 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import {
+  Tree,
+  readProjectConfiguration,
+  stripIndents,
+  addProjectConfiguration,
+  serializeJson,
+  readJson,
+  updateJson,
+  writeJson,
+} from '@nx/devkit';
 
 import { splitLibraryInTwoGenerator } from './generator';
 import { SplitLibraryInTwoGeneratorSchema } from './schema';
+import { setupCodeowners } from '../../utils-testing';
+import { TsConfig } from '../../types';
+import { addCodeowner } from '../add-codeowners';
+import { workspacePaths } from '../../utils';
 
 describe('split-library-in-two generator', () => {
   let tree: Tree;
-  const options: SplitLibraryInTwoGeneratorSchema = { name: 'test' };
+  const options: SplitLibraryInTwoGeneratorSchema = { project: '@proj/react-hello' };
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+    tree = setup(tree);
   });
 
-  it('should run successfully', async () => {
+  it('should split v9 project into 2', async () => {
+    const oldConfig = readProjectConfiguration(tree, options.project);
+
     await splitLibraryInTwoGenerator(tree, options);
-    const config = readProjectConfiguration(tree, 'test');
-    expect(config).toBeDefined();
+
+    const newConfig = readProjectConfiguration(tree, options.project);
+    const storiesConfig = readProjectConfiguration(tree, `${options.project}-stories`);
+
+    // new Shared
+    expect(tree.children(oldConfig.root)).toEqual(['stories', 'library']);
+
+    expect(readJson(tree, '/tsconfig.base.json').compilerOptions.paths).toEqual({
+      '@proj/react-hello': ['packages/react-components/react-hello/library/src/index.ts'],
+      '@proj/react-hello-stories': ['packages/react-components/react-hello/stories/src/index.ts'],
+    });
+
+    expect(tree.read(workspacePaths.github.codeowners, 'utf-8')).toMatchInlineSnapshot(`
+      "packages/react-components/react-hello/library Mr.Wick
+      packages/react-components/react-hello/stories Mr.Wick
+      # <%= NX-CODEOWNER-PLACEHOLDER %>"
+    `);
+
+    // new SRC
+    expect(tree.exists(`${newConfig.root}/.storybook/main.js`)).toBe(false);
+    expect(tree.exists(`${newConfig.root}/stories/index.stories.tsx`)).toBe(false);
+
+    expect(newConfig).toMatchInlineSnapshot(`
+      Object {
+        "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+        "name": "@proj/react-hello",
+        "projectType": "library",
+        "root": "packages/react-components/react-hello/library",
+        "sourceRoot": "packages/react-components/react-hello/library/src",
+        "tags": Array [
+          "vNext",
+          "platform:web",
+        ],
+      }
+    `);
+
+    expect(readJson(tree, `${newConfig.root}/tsconfig.json`)).toEqual(
+      expect.objectContaining({
+        extends: '../../../../tsconfig.base.json',
+        references: [
+          {
+            path: './tsconfig.lib.json',
+          },
+          {
+            path: './tsconfig.spec.json',
+          },
+        ],
+      }),
+    );
+
+    expect(readJson(tree, `${newConfig.root}/package.json`)).toEqual(
+      expect.objectContaining({
+        name: '@proj/react-hello',
+        scripts: expect.objectContaining({
+          'type-check': 'just-scripts type-check',
+          storybook: 'yarn --cwd ../stories storybook',
+        }),
+      }),
+    );
+
+    expect(tree.read(`${newConfig.root}/jest.config.js`, 'utf-8')).toMatchInlineSnapshot(`
+      "module.exports = {
+        displayName: 'react-text',
+        preset: '../../../../jest.preset.js',
+        transform: {
+          '^.+\\\\\\\\.tsx?$': [
+            'ts-jest',
+            {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+              isolatedModules: true,
+            },
+          ],
+        },
+        coverageDirectory: './coverage',
+        setupFilesAfterEnv: ['./config/tests.js'],
+        snapshotSerializers: ['@griffel/jest-serializer'],
+      };
+      "
+    `);
+
+    // new SB
+    expect(storiesConfig).toMatchInlineSnapshot(`
+      Object {
+        "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+        "name": "@proj/react-hello-stories",
+        "projectType": "library",
+        "root": "packages/react-components/react-hello/stories",
+        "sourceRoot": "packages/react-components/react-hello/stories/src",
+        "tags": Array [
+          "vNext",
+          "platform:web",
+          "type:stories",
+        ],
+      }
+    `);
+
+    expect(readJson(tree, `${storiesConfig.root}/package.json`)).toMatchInlineSnapshot(`
+      Object {
+        "devDependencies": Object {
+          "@fluentui/eslint-plugin": "*",
+          "@fluentui/react-components": "*",
+          "@fluentui/react-icons": "^2.0.224",
+          "@fluentui/react-storybook-addon": "*",
+          "@fluentui/react-storybook-addon-export-to-sandbox": "*",
+          "@fluentui/scripts-storybook": "*",
+          "@fluentui/scripts-tasks": "*",
+        },
+        "name": "@proj/react-hello-stories",
+        "private": true,
+        "scripts": Object {
+          "format": "just-scripts prettier",
+          "lint": "just-scripts lint",
+          "start": "yarn storybook",
+          "storybook": "start-storybook",
+          "test-ssr": "test-ssr \\"./src/**/*.stories.tsx\\"",
+          "type-check": "just-scripts type-check",
+        },
+        "version": "0.0.0",
+      }
+    `);
+
+    expect(readJson(tree, `${storiesConfig.root}/tsconfig.json`)).toMatchInlineSnapshot(`
+      Object {
+        "compilerOptions": Object {
+          "importHelpers": true,
+          "isolatedModules": true,
+          "jsx": "react",
+          "noEmit": true,
+          "noUnusedLocals": true,
+          "preserveConstEnums": true,
+          "target": "ES2019",
+        },
+        "extends": "../../../../tsconfig.base.json",
+        "files": Array [],
+        "include": Array [],
+        "references": Array [
+          Object {
+            "path": "./tsconfig.lib.json",
+          },
+          Object {
+            "path": "./.storybook/tsconfig.json",
+          },
+        ],
+      }
+    `);
+
+    expect(readJson(tree, `${storiesConfig.root}/tsconfig.lib.json`)).toMatchInlineSnapshot(`
+      Object {
+        "compilerOptions": Object {
+          "inlineSources": true,
+          "lib": Array [
+            "ES2019",
+            "dom",
+          ],
+          "outDir": "../../../../dist/out-tsc",
+          "types": Array [
+            "static-assets",
+            "environment",
+          ],
+        },
+        "extends": "./tsconfig.json",
+        "include": Array [
+          "./src/**/*.ts",
+          "./src/**/*.tsx",
+        ],
+      }
+    `);
+    expect(readJson(tree, `${storiesConfig.root}/.eslintrc.json`)).toMatchInlineSnapshot(`
+      Object {
+        "extends": Array [
+          "plugin:@fluentui/eslint-plugin/react",
+        ],
+        "root": true,
+      }
+    `);
+    expect(tree.read(`${storiesConfig.root}/README.md`, 'utf-8')).toMatchInlineSnapshot(`
+      "# @proj/react-hello-stories
+
+      Storybook stories for packages/react-components/react-hello
+
+      ## Usage
+
+      To include within storybook specify stories globs:
+
+      \\\\\`\\\\\`\\\\\`js
+      module.exports = {
+      stories: ['../packages/react-components/react-hello/stories/src/**/*.stories.mdx', '../packages/react-components/react-hello/stories/src/**/index.stories.@(ts|tsx)'],
+      }
+      \\\\\`\\\\\`\\\\\`
+
+      ## API
+
+      no public API available
+      "
+    `);
+
+    expect(readJson(tree, `${storiesConfig.root}/.storybook/tsconfig.json`)).toMatchInlineSnapshot(`
+      Object {
+        "compilerOptions": Object {
+          "allowJs": true,
+          "checkJs": true,
+          "outDir": "",
+          "types": Array [
+            "static-assets",
+            "environment",
+            "storybook__addons",
+          ],
+        },
+        "extends": "../tsconfig.json",
+        "include": Array [
+          "*.js",
+        ],
+      }
+    `);
+    expect(tree.read(`${storiesConfig.root}/.storybook/main.js`, 'utf-8')).toMatchInlineSnapshot(`
+      "const rootMain = require('../../../../../.storybook/main');
+
+      module.exports =
+        /** @type {Omit<import('../../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+          ...rootMain,
+          stories: [
+            ...rootMain.stories,
+            '../src/**/*.stories.mdx',
+            '../src/**/index.stories.@(ts|tsx)',
+          ],
+          addons: [...rootMain.addons],
+          webpackFinal: (config, options) => {
+            const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+            // add your own webpack tweaks if needed
+
+            return localConfig;
+          },
+        });
+      "
+    `);
+    expect(tree.read(`${storiesConfig.root}/.storybook/preview.js`, 'utf-8')).toMatchInlineSnapshot(`
+      "import * as rootPreview from '../../../../../.storybook/preview';
+
+      /** @type {typeof rootPreview.decorators} */
+      export const decorators = [...rootPreview.decorators];
+
+      /** @type {typeof rootPreview.parameters} */
+      export const parameters = { ...rootPreview.parameters };
+      "
+    `);
   });
 });
+
+function setup(tree: Tree) {
+  setupCodeowners(tree, { content: '' });
+  writeJson(tree, 'tsconfig.base.v0.json', { compilerOptions: { paths: {} } });
+  writeJson(tree, 'tsconfig.base.v8.json', { compilerOptions: { paths: {} } });
+  writeJson(tree, 'tsconfig.base.all.json', { compilerOptions: { paths: {} } });
+  tree = setupDummyPackage(tree, { projectName: 'react-hello' });
+
+  return tree;
+}
+
+function setupDummyPackage(tree: Tree, options: { projectName: string }) {
+  const npmScope = '@proj';
+  const npmProjectName = `${npmScope}/${options.projectName}`;
+  const rootPath = `packages/react-components/${options.projectName}`;
+
+  const templates = {
+    packageJson: {
+      name: npmProjectName,
+      version: '9.0.0',
+      typings: 'lib/index.d.ts',
+      main: 'lib-commonjs/index.js',
+      scripts: {
+        build: 'just-scripts build',
+        'bundle-size': 'monosize measure',
+        clean: 'just-scripts clean',
+        'code-style': 'just-scripts code-style',
+        just: 'just-scripts',
+        lint: 'just-scripts lint',
+        start: 'yarn storybook',
+        test: 'jest --passWithNoTests',
+        storybook: 'start-storybook',
+        'type-check': 'tsc -b tsconfig.json',
+        'generate-api': 'just-scripts generate-api',
+        'test-ssr': 'test-ssr "./stories/**/*.stories.tsx"',
+        'verify-packaging': 'just-scripts verify-packaging',
+      },
+      dependencies: {},
+    },
+    tsConfig: {
+      extends: '../../../tsconfig.base.json',
+      compilerOptions: {
+        target: 'ES2019',
+        noEmit: true,
+        isolatedModules: true,
+        importHelpers: true,
+        jsx: 'react',
+        noUnusedLocals: true,
+        preserveConstEnums: true,
+      },
+      include: [],
+      files: [],
+      references: [
+        {
+          path: './tsconfig.lib.json',
+        },
+        {
+          path: './tsconfig.spec.json',
+        },
+        {
+          path: './.storybook/tsconfig.json',
+        },
+      ],
+    },
+    jestConfig: stripIndents`
+      module.exports = {
+        displayName: 'react-text',
+        preset: '../../../jest.preset.js',
+        transform: {
+          '^.+\\.tsx?$': [
+            'ts-jest',
+            {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+              isolatedModules: true,
+            },
+          ],
+        },
+        coverageDirectory: './coverage',
+        setupFilesAfterEnv: ['./config/tests.js'],
+        snapshotSerializers: ['@griffel/jest-serializer'],
+      };
+      `,
+    babelConfig: {},
+    justConfig: `
+      import { preset, task } from '@fluentui/scripts-tasks';
+
+      preset();
+
+      task('build', 'build:react-components').cached?.();
+    `,
+    apiExtractorConfig: {
+      $schema: 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
+      extends: '@fluentui/scripts-api-extractor/api-extractor.common.v-next.json',
+    },
+    storybook: {
+      main: stripIndents`
+      const rootMain = require('../../../../.storybook/main');
+
+  module.exports = /** @type {Omit<import('../../../../.storybook/main'), 'typescript'|'babel'>} */ ({
+    ...rootMain,
+    stories: [...rootMain.stories, '../stories/**/*.stories.mdx', '../stories/**/index.stories.@(ts|tsx)'],
+    addons: [...rootMain.addons],
+    webpackFinal: (config, options) => {
+      const localConfig = { ...rootMain.webpackFinal(config, options) };
+
+      // add your own webpack tweaks if needed
+
+      return localConfig;
+    },
+});
+
+      `,
+      preview: stripIndents`
+      import * as rootPreview from '../../../../.storybook/preview';
+
+      /** @type {typeof rootPreview.decorators} */
+      export const decorators = [...rootPreview.decorators];
+
+      /** @type {typeof rootPreview.parameters} */
+      export const parameters = { ...rootPreview.parameters };
+      `,
+      tsConfig: {
+        extends: '../tsconfig.json',
+        compilerOptions: {
+          outDir: '',
+          allowJs: true,
+          checkJs: true,
+          types: ['static-assets', 'environment', 'storybook__addons'],
+        },
+        include: ['../stories/**/*.stories.ts', '../stories/**/*.stories.tsx', '*.js'],
+      },
+    },
+  };
+
+  tree.write(`${rootPath}/package.json`, serializeJson(templates.packageJson));
+  tree.write(`${rootPath}/tsconfig.json`, serializeJson(templates.tsConfig));
+  tree.write(`${rootPath}/.babelrc.json`, serializeJson(templates.babelConfig));
+  tree.write(`${rootPath}/jest.config.js`, templates.jestConfig);
+  tree.write(`${rootPath}/config/api-extractor.json`, serializeJson(templates.apiExtractorConfig));
+  tree.write(`${rootPath}/just.config.ts`, templates.justConfig);
+
+  tree.write(`${rootPath}/.storybook/main.js`, templates.storybook.main);
+  tree.write(`${rootPath}/.storybook/preview.js`, templates.storybook.preview);
+  tree.write(`${rootPath}/.storybook/tsconfig.json`, serializeJson(templates.storybook.tsConfig));
+
+  // src
+  tree.write(`${rootPath}/src/index.ts`, `export const greet = 'hello' `);
+  tree.write(
+    `${rootPath}/src/index.test.ts`,
+    `
+    import {greet} from './index';
+    describe('test me', () => {
+      it('should greet', () => {
+        expect(greet).toBe('hello');
+      });
+    });
+  `,
+  );
+
+  // stories
+
+  tree.write(
+    `${rootPath}/stories/index.stories.tsx`,
+    stripIndents`
+    import { Meta } from '@storybook/react';
+
+    export { Default } from './Default.stories';
+    export default {} as Meta
+  `,
+  );
+  tree.write(
+    `${rootPath}/stories/Default.stories.tsx`,
+    stripIndents`
+    import * as React from 'react';
+    import { Text } from '@fluentui/react-components';
+
+    export const Default = () => <Text>This is an example of the Text component's usage.</Text>;
+  `,
+  );
+  tree.write(`${rootPath}/stories/Hello.md`, stripIndents``);
+
+  addProjectConfiguration(tree, npmProjectName, {
+    root: rootPath,
+    sourceRoot: `${rootPath}/src`,
+    projectType: 'library',
+    tags: ['vNext', 'platform:web'],
+  });
+
+  addCodeowner(tree, { owner: 'Mr.Wick', packageName: npmProjectName });
+
+  updateJson(tree, '/tsconfig.base.json', (json: TsConfig) => {
+    json.compilerOptions.paths = json.compilerOptions.paths ?? {};
+    json.compilerOptions.paths[npmProjectName] = [`${rootPath}/src/index.ts`];
+    return json;
+  });
+
+  return tree;
+}

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -88,6 +88,7 @@ describe('split-library-in-two generator', () => {
       expect.objectContaining({
         name: '@proj/react-hello',
         scripts: expect.objectContaining({
+          'test-ssr': 'test-ssr \\"../stories/src/**/*.stories.tsx\\"',
           'type-check': 'just-scripts type-check',
           storybook: 'yarn --cwd ../stories storybook',
         }),
@@ -149,7 +150,6 @@ describe('split-library-in-two generator', () => {
           "lint": "eslint src/",
           "start": "yarn storybook",
           "storybook": "start-storybook",
-          "test-ssr": "test-ssr \\"./src/**/*.stories.tsx\\"",
           "type-check": "just-scripts type-check",
         },
         "version": "0.0.0",

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -146,7 +146,7 @@ describe('split-library-in-two generator', () => {
         "private": true,
         "scripts": Object {
           "format": "just-scripts prettier",
-          "lint": "just-scripts lint",
+          "lint": "eslint src/",
           "start": "yarn storybook",
           "storybook": "start-storybook",
           "test-ssr": "test-ssr \\"./src/**/*.stories.tsx\\"",
@@ -208,6 +208,17 @@ describe('split-library-in-two generator', () => {
           "plugin:@fluentui/eslint-plugin/react",
         ],
         "root": true,
+        "rules": Object {
+          "import/no-extraneous-dependencies": Array [
+            "error",
+            Object {
+              "packageDir": Array [
+                ".",
+                "../../../../",
+              ],
+            },
+          ],
+        },
       }
     `);
     expect(tree.read(`${storiesConfig.root}/README.md`, 'utf-8')).toMatchInlineSnapshot(`

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -8,6 +8,7 @@ import {
   readJson,
   updateJson,
   writeJson,
+  output,
 } from '@nx/devkit';
 
 import { splitLibraryInTwoGenerator } from './generator';
@@ -16,6 +17,10 @@ import { TsConfig } from '../../types';
 import { addCodeowner } from '../add-codeowners';
 import { workspacePaths } from '../../utils';
 
+const noop = () => {
+  return;
+};
+
 describe('split-library-in-two generator', () => {
   let tree: Tree;
   const options = { project: '@proj/react-hello' };
@@ -23,6 +28,10 @@ describe('split-library-in-two generator', () => {
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
     tree = setup(tree);
+
+    jest.spyOn(output, 'log').mockImplementation(noop);
+    jest.spyOn(output, 'warn').mockImplementation(noop);
+    jest.spyOn(output, 'error').mockImplementation(noop);
   });
 
   it('should split v9 project into 2', async () => {
@@ -85,7 +94,7 @@ describe('split-library-in-two generator', () => {
     expect(readJson(tree, `${newConfig.root}/config/api-extractor.json`)).toEqual(
       expect.objectContaining({
         mainEntryPointFilePath:
-          '<projectRoot>../../../../dist/out-tsc/types/packages/react-components/<unscopedPackageName>/library/src/index.d.ts',
+          '<projectRoot>/../../../../../../dist/out-tsc/types/packages/react-components/<unscopedPackageName>/library/src/index.d.ts',
       }),
     );
 

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -115,7 +115,9 @@ function makeSrcLibrary(tree: Tree, options: Options) {
     json.scripts ??= {};
     json.scripts.storybook = 'yarn --cwd ../stories storybook';
     json.scripts['type-check'] = 'just-scripts type-check';
-    json.scripts['test-ssr'] = 'test-ssr \\"../stories/src/**/*.stories.tsx\\"';
+    if (json.scripts['test-ssr']) {
+      json.scripts['test-ssr'] = 'test-ssr \\"../stories/src/**/*.stories.tsx\\"';
+    }
     return json;
   });
 

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -1,17 +1,289 @@
-import { addProjectConfiguration, formatFiles, generateFiles, Tree } from '@nx/devkit';
-import * as path from 'path';
+import {
+  moveFilesToNewDirectory,
+  formatFiles,
+  readProjectConfiguration,
+  Tree,
+  visitNotIgnoredFiles,
+  stripIndents,
+  writeJson,
+  addProjectConfiguration,
+  updateProjectConfiguration,
+  offsetFromRoot,
+  joinPathFragments,
+  updateJson,
+  readJson,
+} from '@nx/devkit';
+
+import tsConfigBaseAllGenerator from '../tsconfig-base-all/index';
+import { TsConfig } from '../../types';
+import { workspacePaths } from '../../utils';
 import { SplitLibraryInTwoGeneratorSchema } from './schema';
 
+interface Options extends SplitLibraryInTwoGeneratorSchema {
+  projectConfig: ReturnType<typeof readProjectConfiguration>;
+  projectOffsetFromRoot: { old: string; updated: string };
+  oldContent: {
+    tsConfig: Record<string, unknown>;
+    eslintrc: Record<string, unknown>;
+  };
+}
+
 export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibraryInTwoGeneratorSchema) {
-  const projectRoot = `libs/${options.name}`;
-  addProjectConfiguration(tree, options.name, {
-    root: projectRoot,
-    projectType: 'library',
-    sourceRoot: `${projectRoot}/src`,
-    targets: {},
-  });
-  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
+  const projectConfig = readProjectConfiguration(tree, options.project);
+
+  const eslintRcPath = joinPathFragments(projectConfig.root, '.eslintrc.json');
+
+  const normalizedOptions = {
+    ...options,
+    projectConfig,
+    projectOffsetFromRoot: {
+      old: offsetFromRoot(projectConfig.root),
+      updated: offsetFromRoot(projectConfig.root) + '../',
+    },
+    oldContent: {
+      eslintrc: tree.exists(eslintRcPath) ? readJson(tree, eslintRcPath) : {},
+      tsConfig: readJson(tree, joinPathFragments(projectConfig.root, 'tsconfig.json')),
+    },
+  };
+
+  cleanup(tree, normalizedOptions);
+
+  makeSrcLibrary(tree, normalizedOptions);
+  makeStoriesLibrary(tree, normalizedOptions);
+
+  await tsConfigBaseAllGenerator(tree, { verify: false });
+
   await formatFiles(tree);
 }
 
 export default splitLibraryInTwoGenerator;
+
+function cleanup(tree: Tree, options: Options) {
+  tree.delete(joinPathFragments(options.projectConfig.root, 'dist'));
+  tree.delete(joinPathFragments(options.projectConfig.root, 'lib'));
+  tree.delete(joinPathFragments(options.projectConfig.root, 'lib-commonjs'));
+  tree.delete(joinPathFragments(options.projectConfig.root, 'temp'));
+  tree.delete(joinPathFragments(options.projectConfig.root, '.eslintcache'));
+  tree.delete(joinPathFragments(options.projectConfig.root, '.swc'));
+  tree.delete(joinPathFragments(options.projectConfig.root, 'node_modules'));
+}
+
+function makeSrcLibrary(tree: Tree, options: Options) {
+  const newProjectRoot = joinPathFragments(options.projectConfig.root, 'library');
+  const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
+
+  visitNotIgnoredFiles(tree, options.projectConfig.root, file => {
+    if (file.includes('/stories/') || file.includes('/.storybook/')) {
+      return;
+    }
+
+    tree.rename(file, file.replace(options.projectConfig.root, newProjectRoot));
+  });
+
+  updateProjectConfiguration(tree, options.projectConfig.name!, {
+    ...options.projectConfig,
+    // @ts-expect-error - nx doesn't type $schema prop
+    $schema: joinPathFragments(options.projectOffsetFromRoot.updated, 'node_modules/nx/schemas/project-schema.json'),
+    root: newProjectRoot,
+    sourceRoot: newProjectSourceRoot,
+  });
+
+  updateJson(tree, joinPathFragments(newProjectRoot, 'package.json'), json => {
+    json.scripts ??= {};
+    json.scripts.storybook = 'yarn --cwd ../stories storybook';
+    json.scripts['type-check'] = 'just-scripts type-check';
+    return json;
+  });
+
+  updateJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.json'), (json: TsConfig) => {
+    json.extends = json.extends?.replace(options.projectOffsetFromRoot.old, options.projectOffsetFromRoot.updated);
+    json.references = json.references?.filter(ref => {
+      return !ref.path.startsWith('./.storybook');
+    });
+    return json;
+  });
+
+  updateFileContent(tree, joinPathFragments(newProjectRoot, 'jest.config.js'), content => {
+    const newContent = content.replace(options.projectOffsetFromRoot.old, options.projectOffsetFromRoot.updated);
+
+    return newContent;
+  });
+
+  updateJson(tree, '/tsconfig.base.json', (json: TsConfig) => {
+    json.compilerOptions.paths = json.compilerOptions.paths ?? {};
+    json.compilerOptions.paths[options.projectConfig.name!] = [`${newProjectSourceRoot}/index.ts`];
+    return json;
+  });
+
+  updateCodeowners(tree, options);
+}
+
+function makeStoriesLibrary(tree: Tree, options: Options) {
+  const newProjectRoot = joinPathFragments(options.projectConfig.root, 'stories');
+  const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
+  const newProjectName = `${options.projectConfig.name}-stories`;
+
+  // move stories/
+  moveFilesToNewDirectory(tree, joinPathFragments(options.projectConfig.root, 'stories'), newProjectSourceRoot);
+
+  // move .storybook/
+  moveFilesToNewDirectory(
+    tree,
+    joinPathFragments(options.projectConfig.root, '.storybook'),
+    joinPathFragments(newProjectRoot, '.storybook'),
+  );
+
+  // TODO = probably having a generator to invoke here would be more efficient
+  tree.write(joinPathFragments(newProjectSourceRoot, 'index.ts'), stripIndents`export {}`);
+  tree.write(
+    joinPathFragments(newProjectRoot, 'just.config.ts'),
+    stripIndents`
+      import { preset, task } from '@fluentui/scripts-tasks';
+
+      preset();
+  `,
+  );
+
+  const templates = {
+    readme: stripIndents`
+      # ${newProjectName}
+
+      Storybook stories for ${options.projectConfig.root}
+
+      ## Usage
+
+      To include within storybook specify stories globs:
+
+      \`\`\`js
+      module.exports = {
+        stories: ['../${newProjectSourceRoot}/**/*.stories.mdx', '../${newProjectSourceRoot}/**/index.stories.@(ts|tsx)'],
+      }
+      \`\`\`
+
+      ## API
+
+      no public API available
+    `,
+    packageJson: {
+      name: newProjectName,
+      version: '0.0.0',
+      private: true,
+      scripts: {
+        start: 'yarn storybook',
+        storybook: 'start-storybook',
+        'type-check': 'just-scripts type-check',
+        'test-ssr': 'test-ssr "./src/**/*.stories.tsx"',
+        lint: 'just-scripts lint',
+        format: 'just-scripts prettier',
+      },
+      devDependencies: {
+        // TODO: parse AST to get proper version of deps needed
+        '@fluentui/react-components': '*',
+        '@fluentui/react-icons': '^2.0.224',
+        // always added
+        '@fluentui/react-storybook-addon': '*',
+        '@fluentui/react-storybook-addon-export-to-sandbox': '*',
+        '@fluentui/scripts-storybook': '*',
+        '@fluentui/eslint-plugin': '*',
+        '@fluentui/scripts-tasks': '*',
+      },
+    },
+    eslintrc: {
+      extends: ['plugin:@fluentui/eslint-plugin/react'],
+      root: true,
+    },
+    tsconfig: {
+      root: {
+        ...options.oldContent.tsConfig,
+        extends: joinPathFragments(options.projectOffsetFromRoot.updated, 'tsconfig.base.json'),
+        references: [
+          {
+            path: './tsconfig.lib.json',
+          },
+          {
+            path: './.storybook/tsconfig.json',
+          },
+        ],
+      },
+      lib: {
+        extends: './tsconfig.json',
+        compilerOptions: {
+          lib: ['ES2019', 'dom'],
+          outDir: joinPathFragments(options.projectOffsetFromRoot.updated, 'dist/out-tsc'),
+          inlineSources: true,
+          types: ['static-assets', 'environment'],
+        },
+        include: ['./src/**/*.ts', './src/**/*.tsx'],
+      },
+    },
+  };
+
+  tree.write(joinPathFragments(newProjectRoot, 'README.md'), templates.readme);
+  writeJson(tree, joinPathFragments(newProjectRoot, '.eslintrc.json'), templates.eslintrc);
+  writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.json'), templates.tsconfig.root);
+  writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.lib.json'), templates.tsconfig.lib);
+  writeJson(tree, joinPathFragments(newProjectRoot, 'package.json'), templates.packageJson);
+  updateJson(tree, joinPathFragments(newProjectRoot, '.storybook/tsconfig.json'), (json: TsConfig) => {
+    json.include = ['*.js'];
+    return json;
+  });
+  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook/main.js'), content => {
+    content = content
+      .replace(new RegExp('../stories/', 'g'), '../src/')
+      .replace(new RegExp(options.projectOffsetFromRoot.old, 'g'), options.projectOffsetFromRoot.updated);
+
+    return content;
+  });
+  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook/preview.js'), content => {
+    content = content.replace(
+      new RegExp(options.projectOffsetFromRoot.old, 'g'),
+      options.projectOffsetFromRoot.updated,
+    );
+    return content;
+  });
+  addProjectConfiguration(tree, `${options.projectConfig.name}-stories`, {
+    ...options.projectConfig,
+    root: newProjectRoot,
+    sourceRoot: newProjectSourceRoot,
+    name: `${options.projectConfig.name}-stories`,
+    tags: ['vNext', 'platform:web', 'type:stories'],
+  });
+
+  updateJson(tree, '/tsconfig.base.json', (json: TsConfig) => {
+    json.compilerOptions.paths = json.compilerOptions.paths ?? {};
+    json.compilerOptions.paths[newProjectName] = [`${newProjectSourceRoot}/index.ts`];
+    return json;
+  });
+
+  // TODO - update all relative paths
+}
+
+function updateFileContent(tree: Tree, filePath: string, updater: (content: string) => string) {
+  if (!tree.exists(filePath)) {
+    return;
+  }
+
+  const content = tree.read(filePath, 'utf-8') ?? '';
+  tree.write(filePath, updater(content));
+}
+
+function updateCodeowners(tree: Tree, options: Options) {
+  const codeownersPath = workspacePaths.github.codeowners;
+
+  const content = tree.read(codeownersPath, 'utf-8') ?? '';
+
+  const lines = content.split('\n');
+  const lineIndex = lines.findIndex(line => line.includes(options.projectConfig.root));
+
+  if (lineIndex !== -1) {
+    const currentLine = lines[lineIndex];
+    const updatedLine = currentLine.replace(options.projectConfig.root, `${options.projectConfig.root}/library`);
+    const newLine = currentLine.replace(options.projectConfig.root, `${options.projectConfig.root}/stories`);
+
+    lines.splice(lineIndex, 1, updatedLine, newLine);
+
+    const newContent = lines.join('\n');
+
+    tree.write(codeownersPath, newContent);
+  }
+}

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -185,7 +185,7 @@ function makeStoriesLibrary(tree: Tree, options: Options) {
         storybook: 'start-storybook',
         'type-check': 'just-scripts type-check',
         'test-ssr': 'test-ssr "./src/**/*.stories.tsx"',
-        lint: 'just-scripts lint',
+        lint: 'eslint src/',
         format: 'just-scripts prettier',
       },
       devDependencies: {
@@ -207,6 +207,9 @@ function makeStoriesLibrary(tree: Tree, options: Options) {
     eslintrc: {
       extends: ['plugin:@fluentui/eslint-plugin/react'],
       root: true,
+      rules: {
+        'import/no-extraneous-dependencies': ['error', { packageDir: ['.', options.projectOffsetFromRoot.updated] }],
+      },
     },
     tsconfig: {
       root: {

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -176,7 +176,9 @@ function makeSrcLibrary(tree: Tree, options: Options) {
 
   if (tree.exists(filePaths.apiExtractorConfig)) {
     updateJson(tree, filePaths.apiExtractorConfig, json => {
-      json.mainEntryPointFilePath = `<projectRoot>${options.projectOffsetFromRoot.updated}dist/out-tsc/types/packages/react-components/<unscopedPackageName>/library/src/index.d.ts`;
+      json.mainEntryPointFilePath = `<projectRoot>/${offsetFromRoot(
+        filePaths.apiExtractorConfig,
+      )}dist/out-tsc/types/packages/react-components/<unscopedPackageName>/library/src/index.d.ts`;
 
       return json;
     });

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -110,6 +110,7 @@ function makeSrcLibrary(tree: Tree, options: Options) {
     json.scripts ??= {};
     json.scripts.storybook = 'yarn --cwd ../stories storybook';
     json.scripts['type-check'] = 'just-scripts type-check';
+    json.scripts['test-ssr'] = 'test-ssr \\"../stories/src/**/*.stories.tsx\\"';
     return json;
   });
 
@@ -184,7 +185,6 @@ function makeStoriesLibrary(tree: Tree, options: Options) {
         start: 'yarn storybook',
         storybook: 'start-storybook',
         'type-check': 'just-scripts type-check',
-        'test-ssr': 'test-ssr "./src/**/*.stories.tsx"',
         lint: 'eslint src/',
         format: 'just-scripts prettier',
       },

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
@@ -1,3 +1,3 @@
 export interface SplitLibraryInTwoGeneratorSchema {
-  name: string;
+  project: string;
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
@@ -1,3 +1,4 @@
 export interface SplitLibraryInTwoGeneratorSchema {
-  project: string;
+  project?: string;
+  all?: string;
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
@@ -4,15 +4,16 @@
   "title": "",
   "type": "object",
   "properties": {
-    "name": {
+    "project": {
       "type": "string",
       "description": "",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use?"
+      "x-prompt": "Which project would you like to split?",
+      "x-dropdown": "projects"
     }
   },
-  "required": ["name"]
+  "required": ["project"]
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
@@ -6,14 +6,17 @@
   "properties": {
     "project": {
       "type": "string",
-      "description": "",
+      "description": "Which project would you like to split?",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "Which project would you like to split?",
       "x-dropdown": "projects"
+    },
+    "all": {
+      "type": "boolean",
+      "description": "Run generator on all vNext packages"
     }
   },
-  "required": ["project"]
+  "required": []
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

> Based on RFC https://github.com/microsoft/fluentui/pull/30514/files#diff-fd1f65124cb8a5f905a337bf23e6dd67b607808793d84f21178c25c80b3a8028R283

nx generator which will split existing STABLE UI v9 web packages into `library` and `stories` packages under the same folder name.

```
|- react-components/
|- |- react-text/
```
↓↓↓
```
|- react-components/
|- |- react-text/
|- |- |- library/
|- |- |- stories/
```

- generator also parses source AST and adds ghost dependencies as `devDependencies` to `library` project for cypress/jest test files in order to create proper dependency graph ( without this `type-check` would fail )

- CLI options:
  - `project` (runs on specified  project)
  - `all` (runs on all applicable projects) 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
