### PR TITLE
feat: unify v9 babel preset in all packages

### DIFF
--- a/change/@fluentui-react-provider-3d9b4f67-b650-4c9b-abbe-e3b734dd0f84.json
+++ b/change/@fluentui-react-provider-3d9b4f67-b650-4c9b-abbe-e3b734dd0f84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat: unify v9 babel preset in all packages",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-provider/.babelrc.json
+++ b/packages/react-components/react-provider/.babelrc.json
@@ -1,25 +1,4 @@
 {
-  "presets": [
-    [
-      "@griffel",
-      {
-        "babelOptions": {
-          "plugins": [
-            [
-              "babel-plugin-module-resolver",
-              {
-                "root": ["../../../"],
-                "alias": {
-                  "@fluentui/tokens": "packages/tokens/lib/index.js",
-                  "^@fluentui/(?!react-icons)(.+)": "packages/react-components/\\1/lib/index.js"
-                }
-              }
-            ]
-          ]
-        },
-        "modules": [{ "moduleSource": "@griffel/core", "importName": "makeStyles" }]
-      }
-    ]
-  ],
+  "extends": "../../../.babelrc-v9.json",
   "plugins": ["annotate-pure-calls", "@babel/transform-react-pure-annotations"]
 }

--- a/scripts/babel/preset-v9.js
+++ b/scripts/babel/preset-v9.js
@@ -56,7 +56,14 @@ const preset = (api, options) => {
             ],
           ],
         },
-        modules: [{ moduleSource: '@griffel/core', importName: 'makeStyles' }],
+        /**
+         * https://github.com/microsoft/griffel/tree/main/packages/babel-preset#importing-griffel-from-custom-packages
+         * "By default, preset handles imports from @griffel/react & @fluentui/react-components" - under the hood griffel preset wont merge rather override thus we need to provide the default modules explicitly
+         */
+        modules: [
+          { moduleSource: '@griffel/core', importName: 'makeStyles' },
+          { moduleSource: '@fluentui/react-components', importName: 'makeStyles' },
+        ],
       },
     ],
   ];

--- a/scripts/babel/preset-v9.js
+++ b/scripts/babel/preset-v9.js
@@ -56,6 +56,7 @@ const preset = (api, options) => {
             ],
           ],
         },
+        modules: [{ moduleSource: '@griffel/core', importName: 'makeStyles' }],
       },
     ],
   ];

--- a/scripts/babel/preset-v9.js
+++ b/scripts/babel/preset-v9.js
@@ -61,7 +61,13 @@ const preset = (api, options) => {
          * "By default, preset handles imports from @griffel/react & @fluentui/react-components" - under the hood griffel preset wont merge rather override thus we need to provide the default modules explicitly
          */
         modules: [
+          // Why is core needed ?
+          // - https://github.com/microsoft/fluentui/blob/8d4bd6428dc2f52948e668f1f1410972b6c5cf62/packages/react-components/react-provider/src/components/FluentProvider/useFluentProviderStyles.styles.ts#L1
+          // - https://github.com/microsoft/fluentui/pull/22936
           { moduleSource: '@griffel/core', importName: 'makeStyles' },
+          // these are defaults provided by griffel preset
+          // https://github.com/microsoft/griffel/blob/7d27e6075f2d0647256fcc489e1e369696347e05/packages/babel-preset/src/transformPlugin.ts#L207-L210
+          { moduleSource: '@griffel/react', importName: 'makeStyles' },
           { moduleSource: '@fluentui/react-components', importName: 'makeStyles' },
         ],
       },

--- a/scripts/babel/preset-v9.spec.ts
+++ b/scripts/babel/preset-v9.spec.ts
@@ -27,6 +27,7 @@ describe(`babel preset v9`, () => {
       },
       modules: [
         { moduleSource: '@griffel/core', importName: 'makeStyles' },
+        { moduleSource: '@griffel/react', importName: 'makeStyles' },
         { moduleSource: '@fluentui/react-components', importName: 'makeStyles' },
       ],
     });

--- a/scripts/babel/preset-v9.spec.ts
+++ b/scripts/babel/preset-v9.spec.ts
@@ -25,7 +25,10 @@ describe(`babel preset v9`, () => {
           ],
         ],
       },
-      modules: [{ moduleSource: '@griffel/core', importName: 'makeStyles' }],
+      modules: [
+        { moduleSource: '@griffel/core', importName: 'makeStyles' },
+        { moduleSource: '@fluentui/react-components', importName: 'makeStyles' },
+      ],
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/scripts/babel/preset-v9.spec.ts
+++ b/scripts/babel/preset-v9.spec.ts
@@ -25,6 +25,7 @@ describe(`babel preset v9`, () => {
           ],
         ],
       },
+      modules: [{ moduleSource: '@griffel/core', importName: 'makeStyles' }],
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

react-provider uses different babel setup for griffel processing

## New Behavior

react-provider uses same babel setup for griffel.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
