### PR TITLE
docs: improve consistency in theming examples

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Theming.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Theming.stories.mdx
@@ -37,7 +37,7 @@ export const AppRoot = ({children}) => (
 Import `tokens` to style a component using `makeStyles`
 
 ```jsx
-import { tokens } from '@fluentui/react-theme';
+import { tokens } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: { display: 'flex' },


### PR DESCRIPTION
## Previous Behavior

One example imported code from `@fluentui/theme` instead of `@fluentui/react-components`. This caused some confusion with users.

## New Behavior

All examples import from `@fluentui/react-components`.

