### PR TITLE
fix(scripts-tasks): don't run swc:compile task twice

### DIFF
--- a/scripts/tasks/src/api-extractor.ts
+++ b/scripts/tasks/src/api-extractor.ts
@@ -60,7 +60,7 @@ export function apiExtractor(): TaskFunction {
   const { isUsingTsSolutionConfigs, packageJson, tsConfigs } = getTsPathAliasesConfig();
 
   if (configsToExecute.length === 0) {
-    return noop;
+    return task('api-extractor-noop', noop);
   }
 
   /**

--- a/scripts/tasks/src/presets.ts
+++ b/scripts/tasks/src/presets.ts
@@ -151,7 +151,6 @@ export function preset() {
       'copy',
       condition('sass', () => metadata.hasSass()),
       parallel('swc:compile', 'generate-api'),
-      'swc:compile',
     );
   }).cached!();
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- `swc:compile` is being run twice  for every `react-components:build` task 
- `api-extractor` task ends up with failure if no config is present
  - <img width="505" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/39ee0faf-2f31-4e36-87e0-3472c2a809c8">


## New Behavior


- undo typo introduced https://github.com/microsoft/fluentui/pull/31008/files#diff-6b9fd8010d1649873a9056e36874ef5494545149935c80ed533ca7aed1f27837R154
- api-extractor ends with success if no configs are present
  - <img width="498" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/a6190c01-42f0-42f7-9454-81cd31a5482c">
 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
