### PR TITLE
fix: use "key" properly in ToastContainer

### DIFF
--- a/change/@fluentui-react-toast-65c1ffc6-4887-4c29-bb82-d66c58373dda.json
+++ b/change/@fluentui-react-toast-65c1ffc6-4887-4c29-bb82-d66c58373dda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use \"key\" properly in ToastContainer",
+  "packageName": "@fluentui/react-toast",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
+++ b/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
@@ -12,7 +12,7 @@ export const renderToastContainer_unstable = (
   state: ToastContainerState,
   contextValues: ToastContainerContextValues,
 ) => {
-  const { onTransitionEntering, visible, transitionTimeout, remove, nodeRef } = state;
+  const { onTransitionEntering, visible, transitionTimeout, remove, nodeRef, updateId } = state;
   assertSlots<ToastContainerSlots>(state);
 
   return (
@@ -27,7 +27,7 @@ export const renderToastContainer_unstable = (
     >
       <ToastContainerContextProvider value={contextValues.toast}>
         <state.root />
-        <state.timer />
+        <state.timer key={updateId} />
       </ToastContainerContextProvider>
     </Transition>
   );

--- a/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/useToastContainer.ts
@@ -214,10 +214,7 @@ export const useToastContainer_unstable = (
       timer: Timer,
       root: 'div',
     },
-    timer: slot.always<TimerProps>(
-      { key: updateId, onTimeout: close, running, timeout: timerTimeout ?? -1 },
-      { elementType: Timer },
-    ),
+    timer: slot.always<TimerProps>({ onTimeout: close, running, timeout: timerTimeout ?? -1 }, { elementType: Timer }),
     root: slot.always(
       getIntrinsicElementProps('div', {
         // FIXME:


### PR DESCRIPTION
## Previous Behavior

Warnings with canary versions of React.

## New Behavior

No warnings.

## Related Issue(s)

Fixes #30942.