### PR TITLE
fix: Restore focus when the focused treeitem is unmounted

### DIFF
--- a/change/@fluentui-react-tree-35209cd8-df9b-4c21-bb0a-289e7b39c419.json
+++ b/change/@fluentui-react-tree-35209cd8-df9b-4c21-bb0a-289e7b39c419.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Restore focus when the focused treeitem is unmounted",
+  "packageName": "@fluentui/react-tree",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -38,7 +38,7 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
         }),
         onNavigation: useEventCallback((event, data) => {
           props.onNavigation?.(event, data);
-          if (!event.isDefaultPrevented()) {
+          if (!event.defaultPrevented) {
             navigation.navigate(data);
           }
         }),

--- a/packages/react-components/react-tree/src/utils/createSyntheticKeyboardEvent.ts
+++ b/packages/react-components/react-tree/src/utils/createSyntheticKeyboardEvent.ts
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { ArrowUp, ArrowDown } from '@fluentui/keyboard-keys';
+
+/**
+ * Tree navigation request is coupled to events. We can't remove the dependency on event since it would be a breaking
+ * change. So this utility creates a shim of a React keyboard event
+ * @param key - The keyboard key
+ * @param target - HTMLElement used as target
+ * @returns - shim of a React.KeyboardEvent
+ */
+export const createSyntheticKeyboardEvent = <TElement extends HTMLElement = HTMLDivElement>(
+  key: typeof ArrowDown | typeof ArrowUp,
+  target: TElement,
+): React.KeyboardEvent<TElement> => {
+  return {
+    altKey: false,
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: false,
+    currentTarget: target,
+    defaultPrevented: false,
+    code: '-1',
+    detail: -1,
+    eventPhase: -1,
+    isDefaultPrevented: () => false,
+    isPropagationStopped: () => false,
+    isTrusted: false,
+    key,
+    locale: 'en',
+    nativeEvent: new KeyboardEvent('keydown', { key }),
+    shiftKey: false,
+    metaKey: false,
+    location: -1,
+    repeat: false,
+    target,
+    type: 'keydown',
+    view: null as unknown as React.AbstractView,
+    timeStamp: -1,
+    stopPropagation: () => null,
+    persist: () => null,
+    preventDefault: () => null,
+    getModifierState: () => false,
+    charCode: -1,
+    keyCode: -1,
+    which: -1,
+  };
+};


### PR DESCRIPTION
Uses a shim React keyboard event to trigger navigation when the focused treeitem is unmonted in order not to lose focus.

The shim keyboard event is needed to prevent breaking changes since the navigation request is coupled to events - adding a new event or changing the signature of `onNavigation` would be a breaking change

fixes #30001

