### PR TITLE
chore: bump `react-strict-dom` to 0.0.8

### DIFF
--- a/.github/workflows/check-xplat.yml
+++ b/.github/workflows/check-xplat.yml
@@ -13,7 +13,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: '18'
+          # TODO: Temporarily downgrade until tooling correctly handles
+          # the security fixes in 18.20.2
+          node-version: '18.20.1'
           cache: yarn
       - name: Install npm dependencies
         run: yarn --frozen-lockfile --ignore-platform

--- a/apps/xplat-v9/package.json
+++ b/apps/xplat-v9/package.json
@@ -24,13 +24,13 @@
     "@fluentui/react-platform-adapter-preview": "*",
     "@fluentui/react-provider": "*",
     "@fluentui/react-theme": "*",
-    "@stylexjs/babel-plugin": "^0.5.1",
+    "@stylexjs/babel-plugin": "^0.6.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "^0.73.6",
     "react-native-macos": "^0.73.21",
     "react-native-windows": "^0.73.11",
-    "react-strict-dom": "0.0.3"
+    "react-strict-dom": "0.0.8"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/xplat-v9/stories/Button/ButtonStories.tsx
+++ b/apps/xplat-v9/stories/Button/ButtonStories.tsx
@@ -14,8 +14,8 @@ export const ButtonStories = () => (
   <div>
     <h1>Default</h1>
     <Default />
-    {/* <h1>Shape</h1>
-    <Shape /> */}
+    <h1>Shape</h1>
+    <Shape />
     <h1>Appearance</h1>
     <Appearance />
     <h1>Size</h1>

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "react-hot-loader": "4.13.0",
     "react-is": "17.0.2",
     "react-shadow": "20.3.0",
-    "react-strict-dom": "0.0.3",
+    "react-strict-dom": "0.0.8",
     "react-test-renderer": "17.0.2",
     "react-vis": "1.11.7",
     "read-pkg-up": "7.0.1",

--- a/packages/react-components/react-platform-adapter-preview/package.json
+++ b/packages/react-components/react-platform-adapter-preview/package.json
@@ -31,7 +31,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
     "@fluentui/scripts-tasks": "*",
-    "@stylexjs/stylex": "^0.5.1"
+    "@stylexjs/stylex": "^0.6.0"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.16.0",
@@ -39,7 +39,7 @@
     "@griffel/core": "^1.14.1",
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",
-    "react-strict-dom": "0.0.3"
+    "react-strict-dom": "0.0.8"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5264,34 +5264,33 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
-"@stylexjs/babel-plugin@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@stylexjs/babel-plugin/-/babel-plugin-0.5.1.tgz#adef04e823e9dbaba4c3ba467863f4c2cdb6c50c"
-  integrity sha512-Q5AaCyVZRC88QMF8sFHmFC3Rakm19t2jkwfaPImyoGjMyOPySCYVmF4NDffAIwIP+j8J/qn7T8njfKIhSpEftg==
+"@stylexjs/babel-plugin@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@stylexjs/babel-plugin/-/babel-plugin-0.6.0.tgz#b9d5e86877d3549d6d4b34f6df48cfeeeacf8f77"
+  integrity sha512-hCoXSppm4+sXqnSG+Ocro7pVG+4Ha+ztBzLR/draQmcPEi8QFhfry4PvnmFa8BvZWpQ0QgB4rrIe6OE3IKLKmA==
   dependencies:
     "@babel/core" "^7.23.6"
     "@babel/helper-module-imports" "^7.22.15"
     "@babel/traverse" "^7.23.6"
     "@babel/types" "^7.23.6"
-    "@stylexjs/shared" "0.5.1"
-    "@stylexjs/stylex" "0.5.1"
+    "@stylexjs/shared" "0.6.0"
+    "@stylexjs/stylex" "0.6.0"
 
-"@stylexjs/shared@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@stylexjs/shared/-/shared-0.5.1.tgz#c61393cd2f4b7fb19a4d9b636710f5a405c37479"
-  integrity sha512-3kuvLfPr1P5lbLjvtEjXmJxyBOygudhH93DA8OtNnb0H3bQjDZJQqaR/Pde67tlsdbqU5pFuaeueKkZhnuurzA==
+"@stylexjs/shared@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@stylexjs/shared/-/shared-0.6.0.tgz#05c52ae344e417382dd3e0281d9ac152dd200f3b"
+  integrity sha512-1j8PX03+rsgM+jhQHUvOM+J9JYbOAwu9dOBxp9Kls1ZKYBp58cAgvIucS0hQlye/IC+CvfraMvu/JQ+GHv248g==
   dependencies:
     postcss-value-parser "^4.1.0"
 
-"@stylexjs/stylex@0.5.1", "@stylexjs/stylex@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@stylexjs/stylex/-/stylex-0.5.1.tgz#e604908c4933d01474bff7c909cb9cef659bd56c"
-  integrity sha512-KO55dRB1+LhUo9OxfHqH5FwO2F0HdTe4g6fyRJb7JT5FiWEA/vYJ9MY7W8NdMSprW/7FeQKnSg6u5WlHU2ji2g==
+"@stylexjs/stylex@0.6.0", "@stylexjs/stylex@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@stylexjs/stylex/-/stylex-0.6.0.tgz#f71682c08ae812833cd870eeecc318f88a64fb8b"
+  integrity sha512-8PUoEKvalcm5eXEy7P1OEV3e9E39nguZgZQkjSLp6aMG9bDOuZ0cfdj09I6DQTyWA+Hk7r9sJd4Nk3iRCMdJaQ==
   dependencies:
     css-mediaquery "^0.1.2"
     invariant "^2.2.4"
     styleq "0.1.3"
-    utility-types "^3.10.0"
 
 "@swc/cli@0.1.62":
   version "0.1.62"
@@ -22159,12 +22158,12 @@ react-source-render@4.0.0-1:
     react-fast-compare "^2.0.4"
     react-is "^16.6.3"
 
-react-strict-dom@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/react-strict-dom/-/react-strict-dom-0.0.3.tgz#e6a131a16e4d8f1f5de6cf084db3d31532593b1a"
-  integrity sha512-dQDE2zTEQSRzLvxGuNRbYMRYZWu5tptBJnrMOt2m4GJa1AYcdTnahRRNUlRZV32VKPG+/GnLRXZK6gNqoiZN8Q==
+react-strict-dom@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/react-strict-dom/-/react-strict-dom-0.0.8.tgz#4a86332e6dad254a21a22b30ed29616a88be004e"
+  integrity sha512-9Z8raaqw1XeMNYHb0ZO/qxtk0DGSrimHqV8QTlVlaMBwpQ4aN0PNtM/ipLHKn2CABqOQo5m4RmPmxDvAYCkSRg==
   dependencies:
-    "@stylexjs/stylex" "0.5.1"
+    "@stylexjs/stylex" "0.6.0"
     css-mediaquery "0.1.2"
     postcss-value-parser "^4.1.0"
 
@@ -26161,11 +26160,6 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
-
-utility-types@^3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
-  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
> [!NOTE]
> This is being merged into the `xplat` branch, not `master`

## Previous Behavior

Android app crashes when trying to render `<Button shape="square">`

## New Behavior

Bump `react-strict-dom` to 0.0.8 to fix Android app crashing when trying to render `<Button shape="square">`

## Related Issue(s)

n/a

## Screenshot(s)

![Screenshot_1713443003](https://github.com/microsoft/fluentui/assets/4123478/0be3d94f-fb1c-4e20-bbe6-8933b8dafe20)
