### PR TITLE
Exposing MoverMemorizedElementEvent.

### DIFF
--- a/change/@fluentui-react-tabster-8b1e4e19-6b27-4d88-8afc-50de05d57187.json
+++ b/change/@fluentui-react-tabster-8b1e4e19-6b27-4d88-8afc-50de05d57187.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exposing MoverMemorizedElementEvent for the applications to be able to force forget or alter memorized elements.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -817,6 +817,15 @@ interface MoverKeys_2 {
 const MoverKeys_2: MoverKeys_2;
 
 // @public (undocumented)
+export const MoverMemorizedElementEvent: typeof Events.MoverMemorizedElementEvent;
+
+// @public (undocumented)
+export type MoverMemorizedElementEventDetail = Events.MoverMemorizedElementEventDetail;
+
+// @public (undocumented)
+export const MoverMemorizedElementEventName: "tabster:mover:memorized-element";
+
+// @public (undocumented)
 export const MoverMoveFocusEvent: typeof Events.MoverMoveFocusEvent;
 
 // @public (undocumented)

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -67,3 +67,7 @@ export const GroupperMoveFocusEventName = Events.GroupperMoveFocusEventName;
 export const GroupperMoveFocusEvent: typeof Events.GroupperMoveFocusEvent = Events.GroupperMoveFocusEvent;
 export type GroupperMoveFocusEventDetail = Events.GroupperMoveFocusEventDetail;
 export const GroupperMoveFocusActions = Types.GroupperMoveFocusActions;
+
+export const MoverMemorizedElementEventName = Events.MoverMemorizedElementEventName;
+export const MoverMemorizedElementEvent: typeof Events.MoverMemorizedElementEvent = Events.MoverMemorizedElementEvent;
+export type MoverMemorizedElementEventDetail = Events.MoverMemorizedElementEventDetail;


### PR DESCRIPTION
Exposing MoverMemorizedElementEvent for the applications to be able to force forget or alter memorized elements.