### PR TITLE
chore(react-popover): modify arrow styles to create a proper triangle

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning.stories.tsx
@@ -55,8 +55,6 @@ const useStyles = makeStyles({
   arrow: {
     ...createArrowStyles({
       arrowHeight: 12,
-      borderStyle: 'solid',
-      borderColor: 'blue',
       borderWidth: '3px',
     }),
   },

--- a/change/@fluentui-react-popover-0f00224e-dd41-401d-b085-6c1f1700cb91.json
+++ b/change/@fluentui-react-popover-0f00224e-dd41-401d-b085-6c1f1700cb91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: modify arrow styles to create a proper triangle",
+  "packageName": "@fluentui/react-popover",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-01fcfed1-42a1-4bb2-81c3-60ea028c82b1.json
+++ b/change/@fluentui-react-positioning-01fcfed1-42a1-4bb2-81c3-60ea028c82b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: modify arrow styles to create a proper triangle",
+  "packageName": "@fluentui/react-positioning",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-popover/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
@@ -1,5 +1,5 @@
 import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
-import { createArrowHeightStyles, createArrowStyles, createSlideStyles } from '@fluentui/react-positioning';
+import { createArrowStyles, createSlideStyles } from '@fluentui/react-positioning';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import type { PopoverSize } from '../Popover/Popover.types';
 import type { PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.types';
@@ -57,9 +57,14 @@ const useStyles = makeStyles({
     ...shorthands.padding('20px'),
   },
 
-  smallArrow: createArrowHeightStyles(arrowHeights.small),
-  mediumLargeArrow: createArrowHeightStyles(arrowHeights.medium),
-  arrow: createArrowStyles({ arrowHeight: undefined }),
+  smallArrow: createArrowStyles({
+    arrowHeight: arrowHeights.small,
+    backgroundColor: tokens.colorNeutralBackground1,
+  }),
+  mediumLargeArrow: createArrowStyles({
+    arrowHeight: arrowHeights.medium,
+    backgroundColor: tokens.colorNeutralBackground1,
+  }),
 });
 
 /**
@@ -79,10 +84,7 @@ export const usePopoverSurfaceStyles_unstable = (state: PopoverSurfaceState): Po
     state.root.className,
   );
 
-  state.arrowClassName = mergeClasses(
-    styles.arrow,
-    state.size === 'small' ? styles.smallArrow : styles.mediumLargeArrow,
-  );
+  state.arrowClassName = mergeClasses(state.size === 'small' ? styles.smallArrow : styles.mediumLargeArrow);
 
   return state;
 };

--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -17,20 +17,13 @@ export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | '
 export type Boundary = HTMLElement | Array<HTMLElement> | 'clippingParents' | 'scrollParent' | 'window';
 
 // @internal
-export function createArrowHeightStyles(arrowHeight: number): {
-    width: string;
-    height: string;
-};
-
-// @internal
 export function createArrowStyles(options: CreateArrowStylesOptions): GriffelStyle;
 
 // @internal
 export type CreateArrowStylesOptions = {
     arrowHeight: number | undefined;
     borderWidth?: GriffelStyle['borderBottomWidth'];
-    borderStyle?: GriffelStyle['borderBottomStyle'];
-    borderColor?: GriffelStyle['borderBottomColor'];
+    backgroundColor?: React_2.CSSProperties['backgroundColor'];
 };
 
 // @public

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -1,6 +1,6 @@
 import { shorthands } from '@griffel/react';
-import { tokens } from '@fluentui/react-theme';
 import type { GriffelStyle } from '@griffel/react';
+import * as React from 'react';
 
 /**
  * @internal
@@ -9,9 +9,6 @@ import type { GriffelStyle } from '@griffel/react';
 export type CreateArrowStylesOptions = {
   /**
    * The height of the arrow from the base to the tip, in px. The base width of the arrow is always twice its height.
-   *
-   * This can be undefined to leave out the arrow size styles. You must then add styles created by
-   * createArrowHeightStyles to set the arrow's size correctly. This can be useful if the arrow can be different sizes.
    */
   arrowHeight: number | undefined;
 
@@ -21,20 +18,7 @@ export type CreateArrowStylesOptions = {
    * @defaultvalue 1px
    */
   borderWidth?: GriffelStyle['borderBottomWidth'];
-
-  /**
-   * The borderStyle for the arrow. Should be the same borderStyle as the parent element.
-   *
-   * @defaultvalue solid
-   */
-  borderStyle?: GriffelStyle['borderBottomStyle'];
-
-  /**
-   * The borderColor of the arrow. Should be the same borderColor as the parent element.
-   *
-   * @defaultvalue tokens.colorTransparentStroke
-   */
-  borderColor?: GriffelStyle['borderBottomColor'];
+  backgroundColor?: React.CSSProperties['backgroundColor'];
 };
 
 /**
@@ -44,86 +28,48 @@ export type CreateArrowStylesOptions = {
  *
  * ```ts
  *   makeStyles({
- *     arrowWithSize: createArrowStyles({ arrowHeight: 6 }),
- *
- *     arrowWithoutSize: createArrowStyles({ arrowHeight: undefined }),
- *     mediumArrow: createArrowHeightStyles(4),
- *     smallArrow: createArrowHeightStyles(2),
+ *     arrow: createArrowStyles({ arrowHeight: 6 }),
  *   })
- *   ...
- *
- *   state.arrowWithSize.className = styles.arrowWithSize;
- *   state.arrowWithoutSize.className = mergeClasses(
- *     styles.arrowWithoutSize,
- *     state.smallArrow && styles.smallArrow,
- *     state.mediumArrow && styles.mediumArrow,
- *   )
  * ```
  */
 export function createArrowStyles(options: CreateArrowStylesOptions): GriffelStyle {
-  const {
-    arrowHeight,
-    borderWidth = '1px',
-    borderStyle = 'solid',
-    borderColor = tokens.colorTransparentStroke,
-  } = options;
+  const { arrowHeight, borderWidth = '1px', backgroundColor = 'transparent' } = options;
 
   return {
     position: 'absolute',
-    backgroundColor: 'inherit',
-    visibility: 'hidden',
     zIndex: -1,
-
-    ...(arrowHeight && createArrowHeightStyles(arrowHeight)),
-
-    '::before': {
-      content: '""',
-      visibility: 'visible',
-      position: 'absolute',
-      boxSizing: 'border-box',
-      width: 'inherit',
-      height: 'inherit',
-      backgroundColor: 'inherit',
-      ...shorthands.borderRight(
-        `${borderWidth} /* @noflip */`,
-        `${borderStyle} /* @noflip */`,
-        `${borderColor} /* @noflip */`,
-      ),
-      ...shorthands.borderBottom(borderWidth, borderStyle, borderColor),
-      borderBottomRightRadius: tokens.borderRadiusSmall,
-      transform: 'rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(45deg) /* @noflip */',
-    },
-
+    width: 0,
+    height: 0,
+    boxSizing: 'border-box',
+    ...shorthands.borderColor(backgroundColor),
     // Popper sets data-popper-placement on the root element, which is used to align the arrow
     ':global([data-popper-placement^="top"])': {
       bottom: `-${borderWidth}`,
-      '--fui-positioning-angle': '0',
+      ...shorthands.borderLeft(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderRight(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderTop(`${arrowHeight}px`, 'solid'),
+      transform: 'translate(0, 100%)',
     },
     ':global([data-popper-placement^="right"])': {
       left: `-${borderWidth} /* @noflip */`,
-      '--fui-positioning-angle': '90deg',
+      ...shorthands.borderTop(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderBottom(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderRight(`${arrowHeight}px`, 'solid'),
+      transform: 'translate(-100%, 0)',
     },
     ':global([data-popper-placement^="bottom"])': {
       top: `-${borderWidth}`,
-      '--fui-positioning-angle': '180deg',
+      ...shorthands.borderLeft(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderRight(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderBottom(`${arrowHeight}px`, 'solid'),
+      transform: 'translate(0, -100%)',
     },
     ':global([data-popper-placement^="left"])': {
       right: `-${borderWidth} /* @noflip */`,
-      '--fui-positioning-angle': '270deg',
+      ...shorthands.borderTop(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderBottom(`${arrowHeight}px`, 'solid', 'transparent'),
+      ...shorthands.borderLeft(`${arrowHeight}px`, 'solid'),
+      transform: 'translate(100%, 0)',
     },
   };
-}
-
-/**
- * @internal
- * Creates CSS styles to size the arrow created by createArrowStyles to the given height.
- *
- * Use this when you need to create classes for several different arrow sizes. If you only need a
- * constant arrow size, you can pass the `arrowHeight` param to createArrowStyles instead.
- */
-export function createArrowHeightStyles(arrowHeight: number) {
-  // The arrow is a square rotated 45 degrees to have its bottom and right edges form a right triangle.
-  // Multiply the triangle's height by sqrt(2) to get length of its edges.
-  const edgeLength = `${1.414 * arrowHeight}px`;
-  return { width: edgeLength, height: edgeLength };
 }

--- a/packages/react-components/react-positioning/src/index.ts
+++ b/packages/react-components/react-positioning/src/index.ts
@@ -1,5 +1,5 @@
 export { createVirtualElementFromClick } from './createVirtualElementFromClick';
-export { createArrowHeightStyles, createArrowStyles } from './createArrowStyles';
+export { createArrowStyles } from './createArrowStyles';
 export { createSlideStyles } from './createSlideStyles';
 export type { CreateArrowStylesOptions } from './createArrowStyles';
 export { usePositioning } from './usePositioning';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

While investigating Semi-transparent support https://github.com/microsoft/fluentui/issues/29491, the `Popover` arrow style turned out to be a little problematic, as we're creating a square and rotating it:
![image](https://github.com/microsoft/fluentui/assets/5483269/b9381dd0-644f-4fa7-a284-b9618166d8a1)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. restyles the arrow creation to ensure a triangle is generated instead of a rotated square (https://css-tricks.com/snippets/css/css-triangle)

![image](https://github.com/microsoft/fluentui/assets/5483269/4b9adfff-29a6-4b24-8a20-c4ddeb3eb859)

