### PR TITLE
Meaure "all up" bundle size for `@fluentui/react` and `@fluentui/react-components`

### DIFF
--- a/packages/react-components/react-components/bundle-size/ReactComponents.fixture.js
+++ b/packages/react-components/react-components/bundle-size/ReactComponents.fixture.js
@@ -1,0 +1,7 @@
+import * as rc from '@fluentui/react-components';
+
+console.log(rc);
+
+export default {
+  name: 'react-components: entire library',
+};

--- a/packages/react/bundle-size/React.fixture.js
+++ b/packages/react/bundle-size/React.fixture.js
@@ -1,0 +1,7 @@
+import * as r from '@fluentui/react';
+
+console.log(r);
+
+export default {
+  name: 'Fluent UI React (entire library)',
+};


### PR DESCRIPTION
## Previous Behavior

We measured bundle size for individual components but not for the entire library.

## New Behavior

We now measure the bundle size of the entire library. This will give us better insight into how changes affect bundle size in applications as most users a likely to use many components from the library rather than a single one.

## Related Issue(s)

This came out of #30689 as we want to understand the overall bundle size impact of the shadow DOM feature in Fluent v8.
