### PR TITLE
chore: deprecate width prop in Skeleton

### DIFF
--- a/change/@fluentui-react-skeleton-cbec776a-75c8-4212-8ea9-d9c565cf775e.json
+++ b/change/@fluentui-react-skeleton-cbec776a-75c8-4212-8ea9-d9c565cf775e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: deprecate the width prop.",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-skeleton/src/components/Skeleton/Skeleton.types.ts
+++ b/packages/react-components/react-skeleton/src/components/Skeleton/Skeleton.types.ts
@@ -28,6 +28,7 @@ export type SkeletonProps = Omit<ComponentProps<Partial<SkeletonSlots>>, 'width'
   /**
    * Sets the width value of the skeleton wrapper.
    * @defaultValue 100%
+   * @deprecated Use `className` prop to set width
    */
   width?: number | string;
 };


### PR DESCRIPTION
This PR deprecates the `width` prop in `Skeleton`. The recommended way to set the width is to use `className`. Fixes #30016 