### PR TITLE
feat(scripts-tasks): implement ~36% faster type-check task

### DIFF
--- a/scripts/tasks/src/type-check.ts
+++ b/scripts/tasks/src/type-check.ts
@@ -1,45 +1,52 @@
-import * as fs from 'fs';
-
 import { logger } from 'just-scripts';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { exec } from 'just-scripts-utils';
 
-import { getTsPathAliasesConfig } from './utils';
+import { type TsConfig, getTsPathAliasesConfig } from './utils';
 
-export function typeCheck() {
-  const { isUsingTsSolutionConfigs, tsConfigFileContents, tsConfigs, tsConfigFilePaths } = getTsPathAliasesConfig();
+export async function typeCheck() {
+  const { isUsingTsSolutionConfigs, tsConfigs } = getTsPathAliasesConfig();
 
   if (!isUsingTsSolutionConfigs) {
     logger.info('project is not using TS solution config. skipping...');
     return;
   }
 
-  const content = tsConfigFileContents.root;
   const config = tsConfigs.root;
-  const configPath = tsConfigFilePaths.root;
 
-  if (!(content && config)) {
+  if (!config) {
     return;
   }
 
-  // turn off path aliases.
-  // @ts-expect-error - bad just-scripts ts types
-  config.compilerOptions.paths = {};
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+  const tsConfigsRefs = getTsConfigs(config, { spec: false, e2e: false });
 
-  const cmd = 'tsc';
-  const args = ['-b', '--pretty', configPath];
-  const program = `${cmd} ${args.join(' ')}`;
+  const asyncQueue = [];
 
-  return exec(program)
-    .catch(err => {
-      console.error(err.stdout);
-      // restore original tsconfig.json
-      fs.writeFileSync(configPath, content, 'utf-8');
-      process.exit(1);
-    })
-    .finally(() => {
-      // restore original tsconfig.json
-      fs.writeFileSync(configPath, content, 'utf-8');
-    });
+  for (const ref of tsConfigsRefs) {
+    const program = `tsc -p ${ref} --pretty --baseUrl .`;
+    asyncQueue.push(exec(program));
+  }
+
+  return Promise.all(asyncQueue).catch(err => {
+    console.error(err.stdout);
+    process.exit(1);
+  });
+}
+
+function getTsConfigs(solutionConfig: TsConfig, exclude: { spec: boolean; e2e: boolean }) {
+  const refs = solutionConfig.references ?? [];
+  const refsPaths: string[] = [];
+
+  for (const ref of refs) {
+    if (exclude.spec && ref.path.includes('spec')) {
+      continue;
+    }
+    if (exclude.e2e && ref.path.includes('cy')) {
+      continue;
+    }
+
+    refsPaths.push(ref.path);
+  }
+
+  return refsPaths;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

TS build mode is significantly more expensive and makes sense only with composite projects ( reference linking across whole monorepo ).

This PR changes implementation to use simple `tsc -p` against all referenced projects within project root TS solution config. As a nice benefit we don't have to override tsconfigs in order to turn off path aliases as that is being handeld by `--baseUrl` CLI override on callsite.

> `@fluentui/react-migration-v8-v9 type-check`

| Command                                                                                 | Time                   | Delta |
| --------------------------------------------------------- | ---------------- | ------|
| `tsc -b`  (current)                                                                                   |  5s          | BASE          |
| `tsc -p N` (parallel execution - avoiding build mode)          | 3.2s    | 𝚫 -36%  |

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
