### PR TITLE
feat: add accessibility docs to Link about color/underlines

### DIFF
--- a/.storybook/docs-root.css
+++ b/.storybook/docs-root.css
@@ -181,6 +181,7 @@
 
 #docs-root a.sbdocs-a {
   color: #0078d4;
+  text-decoration: underline;
 }
 
 /*  */

--- a/packages/react-components/react-link/stories/Link/LinkAccessibility.md
+++ b/packages/react-components/react-link/stories/Link/LinkAccessibility.md
@@ -1,6 +1,6 @@
 ## Accessibility
 
-A Link can be rendered with or without an underline, controlled by the `inline` prop. This has notable accessibility implications since without an underline, Link is relying on contextual clues to differentiate itself from static text. This is because the color of the link does not have 3:1 contrast against the color of static text, so some other visual indicator is necessary to mark it as a link. It is the responsibility of the authoring team to choose the underline or no-underline variant based on their use case.
+A Link can be rendered with or without an underline, controlled by the `inline` prop. This has notable [accessibility implications](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html), since Link relies on either an underline or contextual clues to differentiate itself from static text. It is the responsibility of the authoring team to choose the underline or no-underline variant based on their use case.
 
 Links _must_ use underlines to be accessible except for the following use cases:
 

--- a/packages/react-components/react-link/stories/Link/LinkAccessibility.md
+++ b/packages/react-components/react-link/stories/Link/LinkAccessibility.md
@@ -1,0 +1,12 @@
+## Accessibility
+
+A Link can be rendered with or without an underline, controlled by the `inline` prop. This has notable accessibility implications since without an underline, Link is relying on contextual clues to differentiate itself from static text. This is because the color of the link does not have 3:1 contrast against the color of static text, so some other visual indicator is necessary to mark it as a link. It is the responsibility of the authoring team to choose the underline or no-underline variant based on their use case.
+
+Links _must_ use underlines to be accessible except for the following use cases:
+
+- The link exists in a visually discrete area with only other links (e.g. a navigation region, a drop-down nav menu, a footer nav section, etc.)
+- The link exists in a visually discrete area with only other interactive elements (e.g. a toolbar, the footer of a dialog that contains only other buttons and links, etc.)
+- All links have an icon to indicate that they are links (such as a caret, or the open-in-new-window icon)
+- There is some other part of the surrounding visual context that makes it clear the link is an interactive control
+
+Note: links do not need to be visually differentiated from buttons and other interactive controls to meet accessibility requirements.

--- a/packages/react-components/react-link/stories/Link/LinkAsSpan.stories.tsx
+++ b/packages/react-components/react-link/stories/Link/LinkAsSpan.stories.tsx
@@ -8,8 +8,10 @@ const useDivWithWidthClassName = makeResetStyles({
 export const AsSpan = () => (
   <div className={useDivWithWidthClassName()}>
     The following link renders as a span.{' '}
-    <Link as="span">Links that render as a span wrap correctly between lines when their content is very long</Link>.{' '}
-    This is because they behave as regular inline elements.
+    <Link as="span" inline>
+      Links that render as a span wrap correctly between lines when their content is very long
+    </Link>
+    . This is because they behave as regular inline elements.
   </div>
 );
 

--- a/packages/react-components/react-link/stories/Link/index.stories.tsx
+++ b/packages/react-components/react-link/stories/Link/index.stories.tsx
@@ -2,6 +2,7 @@ import { Link } from '@fluentui/react-components';
 
 import descriptionMd from './LinkDescription.md';
 import bestPracticesMd from './LinkBestPractices.md';
+import accessibilityMd from './LinkAccessibility.md';
 
 export { Default } from './LinkDefault.stories';
 export { Appearance } from './LinkAppearance.stories';
@@ -24,7 +25,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: [descriptionMd, bestPracticesMd].join('\n'),
+        component: [descriptionMd, bestPracticesMd, accessibilityMd].join('\n'),
       },
     },
   },


### PR DESCRIPTION
Docs-only PR, no package changes.

## Previous Behavior

We provided an underline variant, but not guidance on why it might be needed. This PR makes 3 changes:
1. adds docs wording in an a11y section
2. adds an underline to the inline span story, since it would otherwise fail the WCAG criterion & not meet our guidance 😅
3. adds underline styles to storybook links, since it seems a little too on the nose to have a failing link style in the paragraph about not making failing link styles

## New Behavior

has guidance!