### PR TITLE
fix: SpinButton buttons now show correct visuals at bounds

### DIFF
--- a/change/@fluentui-react-spinbutton-9b1df688-9bc5-4b68-980b-a25a14e3c0d3.json
+++ b/change/@fluentui-react-spinbutton-9b1df688-9bc5-4b68-980b-a25a14e3c0d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: SpinButton buttons now display correct visuals at bounds",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/src/components/SpinButton/useSpinButton.tsx
@@ -245,6 +245,24 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
     setTextValue(undefined);
   };
 
+  let valueToDisplay;
+  if (textValue !== undefined) {
+    valueToDisplay = textValue;
+  } else if (value === null || currentValue === null) {
+    valueToDisplay = displayValue ?? '';
+    internalState.current.value = null;
+    internalState.current.atBound = 'none';
+  } else {
+    const roundedValue = precisionRound(currentValue, precision);
+    internalState.current.value = roundedValue;
+    internalState.current.atBound = getBound(roundedValue, min, max);
+    if (isControlled) {
+      valueToDisplay = displayValue ?? String(roundedValue);
+    } else {
+      valueToDisplay = String(roundedValue);
+    }
+  }
+
   const state: SpinButtonState = {
     size,
     appearance,
@@ -293,24 +311,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
       elementType: 'button',
     }),
   };
-
-  let valueToDisplay;
-  if (textValue !== undefined) {
-    valueToDisplay = textValue;
-  } else if (value === null || currentValue === null) {
-    valueToDisplay = displayValue ?? '';
-    internalState.current.value = null;
-    internalState.current.atBound = 'none';
-  } else {
-    const roundedValue = precisionRound(currentValue, precision);
-    internalState.current.value = roundedValue;
-    internalState.current.atBound = getBound(roundedValue, min, max);
-    if (isControlled) {
-      valueToDisplay = displayValue ?? String(roundedValue);
-    } else {
-      valueToDisplay = String(roundedValue);
-    }
-  }
 
   state.input.value = valueToDisplay;
   state.input['aria-valuemin'] = min;


### PR DESCRIPTION
## Previous Behavior

It was possible to get `SpinButton` buttons in the wrong visual state.

## New Behavior

`SpinButton` buttons now show the correct visual state.

## Related Issue(s)

- Fixes #30234
