### PR TITLE
feat: add motion slots to Dialog

### DIFF
--- a/change/@fluentui-react-dialog-a88dcd08-5fd2-41fa-94e6-c6175ae4980e.json
+++ b/change/@fluentui-react-dialog-a88dcd08-5fd2-41fa-94e6-c6175ae4980e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add motion slots (surfaceMotion to Dialog & backdropMotion to DialogSurface)",
+  "packageName": "@fluentui/react-dialog",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/library/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/library/etc/react-dialog.api.md
@@ -14,6 +14,7 @@ import { ContextSelector } from '@fluentui/react-context-selector';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElementConstructor } from 'react';
 import type { PortalProps } from '@fluentui/react-portal';
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import { Provider } from 'react';
 import * as React_2 from 'react';
 import { ReactElement } from 'react';
@@ -137,7 +138,9 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
 export const DialogProvider: React_2.Provider<DialogContextValue | undefined> & React_2.FC<React_2.ProviderProps<DialogContextValue | undefined>>;
 
 // @public (undocumented)
-export type DialogSlots = {};
+export type DialogSlots = {
+    surfaceMotion: Slot<PresenceMotionSlotProps>;
+};
 
 // @public (undocumented)
 export type DialogState = ComponentState<DialogSlots> & DialogContextValue & {
@@ -149,7 +152,7 @@ export type DialogState = ComponentState<DialogSlots> & DialogContextValue & {
 export const DialogSurface: ForwardRefComponent<DialogSurfaceProps>;
 
 // @public (undocumented)
-export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots>;
+export const dialogSurfaceClassNames: SlotClassNames<Omit<DialogSurfaceSlots, 'backdropMotion'>>;
 
 // @public (undocumented)
 export type DialogSurfaceContextValue = boolean;
@@ -163,7 +166,7 @@ export type DialogSurfaceContextValues = {
 export type DialogSurfaceElement = HTMLElement;
 
 // @public
-export type DialogSurfaceProps = ComponentProps<DialogSurfaceSlots> & Pick<PortalProps, 'mountNode'>;
+export type DialogSurfaceProps = ComponentProps<Partial<DialogSurfaceSlots>> & Pick<PortalProps, 'mountNode'>;
 
 // @public (undocumented)
 export const DialogSurfaceProvider: Provider<boolean | undefined>;
@@ -172,6 +175,7 @@ export const DialogSurfaceProvider: Provider<boolean | undefined>;
 export type DialogSurfaceSlots = {
     backdrop?: Slot<'div'>;
     root: Slot<'div'>;
+    backdropMotion: Slot<PresenceMotionSlotProps>;
 };
 
 // @public

--- a/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
@@ -1,9 +1,13 @@
 import type * as React from 'react';
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
 import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
 import type { DialogSurfaceElement } from '../DialogSurface/DialogSurface.types';
 
-export type DialogSlots = {};
+export type DialogSlots = {
+  surfaceMotion: Slot<PresenceMotionSlotProps>;
+};
 
 export type DialogOpenChangeEvent = DialogOpenChangeData['event'];
 

--- a/packages/react-components/react-dialog/library/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/renderDialog.tsx
@@ -1,28 +1,28 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
+import { assertSlots } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { DialogProvider, DialogSurfaceProvider } from '../../contexts';
-import { DialogSurfaceMotion } from '../DialogSurfaceMotion';
-import type { DialogState, DialogContextValues } from './Dialog.types';
+import type { DialogState, DialogContextValues, DialogSlots } from './Dialog.types';
 
 /**
  * Render the final JSX of Dialog
  */
 export const renderDialog_unstable = (state: DialogState, contextValues: DialogContextValues) => {
-  const { content, open, trigger } = state;
+  assertSlots<DialogSlots>(state);
 
   return (
     <DialogProvider value={contextValues.dialog}>
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
-        {trigger}
-        {content && (
-          <DialogSurfaceMotion appear visible={open} unmountOnExit>
+        {state.trigger}
+        {state.content && (
+          <state.surfaceMotion>
             {/* Casting here as content should be equivalent to <DialogSurface/> */}
             {/* FIXME: content should not be ReactNode it should be ReactElement instead. */}
-            {content as React.ReactElement}
-          </DialogSurfaceMotion>
+            {state.content as React.ReactElement}
+          </state.surfaceMotion>
         )}
       </DialogSurfaceProvider>
     </DialogProvider>

--- a/packages/react-components/react-dialog/library/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/useDialog.ts
@@ -1,11 +1,13 @@
-import * as React from 'react';
-import { useControllableState, useEventCallback, useId } from '@fluentui/react-utilities';
 import { useHasParentContext } from '@fluentui/react-context-selector';
+import { useModalAttributes } from '@fluentui/react-tabster';
+import { presenceMotionSlot, type PresenceMotionSlotProps } from '@fluentui/react-motion';
+import { useControllableState, useEventCallback, useId } from '@fluentui/react-utilities';
+import * as React from 'react';
+
 import { useFocusFirstElement } from '../../utils';
 import { DialogContext } from '../../contexts';
-
+import { DialogSurfaceMotion } from '../DialogSurfaceMotion';
 import type { DialogOpenChangeData, DialogProps, DialogState } from './Dialog.types';
-import { useModalAttributes } from '@fluentui/react-tabster';
 
 /**
  * Create the state required to render Dialog.
@@ -42,12 +44,15 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     trapFocus: modalType !== 'non-modal',
     legacyTrapFocus: !inertTrapFocus,
   });
-
   const isNestedDialog = useHasParentContext(DialogContext);
 
   return {
     components: {
-      backdrop: 'div',
+      // TODO: remove once React v18 slot API is modified
+      // This is a problem at the moment due to UnknownSlotProps assumption
+      // that `children` property is `ReactNode`, which in this case is not valid
+      // as PresenceComponentProps['children'] is `ReactElement`
+      surfaceMotion: DialogSurfaceMotion as React.FC<PresenceMotionSlotProps>,
     },
     inertTrapFocus,
     open,
@@ -60,6 +65,14 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     dialogRef: focusRef,
     modalAttributes,
     triggerAttributes,
+    surfaceMotion: presenceMotionSlot(props.surfaceMotion, {
+      elementType: DialogSurfaceMotion,
+      defaultProps: {
+        appear: true,
+        visible: open,
+        unmountOnExit: true,
+      },
+    }),
   };
 };
 

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/DialogSurface.types.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/DialogSurface.types.ts
@@ -1,3 +1,4 @@
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import type { PortalProps } from '@fluentui/react-portal';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
@@ -13,6 +14,8 @@ export type DialogSurfaceSlots = {
    */
   backdrop?: Slot<'div'>;
   root: Slot<'div'>;
+
+  backdropMotion: Slot<PresenceMotionSlotProps>;
 };
 
 /**
@@ -23,7 +26,7 @@ export type DialogSurfaceElement = HTMLElement;
 /**
  * DialogSurface Props
  */
-export type DialogSurfaceProps = ComponentProps<DialogSurfaceSlots> & Pick<PortalProps, 'mountNode'>;
+export type DialogSurfaceProps = ComponentProps<Partial<DialogSurfaceSlots>> & Pick<PortalProps, 'mountNode'>;
 
 export type DialogSurfaceContextValues = {
   dialogSurface: DialogSurfaceContextValue;

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/renderDialogSurface.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/renderDialogSurface.tsx
@@ -5,7 +5,6 @@ import { Portal } from '@fluentui/react-portal';
 import { assertSlots } from '@fluentui/react-utilities';
 
 import { DialogSurfaceProvider } from '../../contexts';
-import { DialogBackdropMotion } from '../DialogBackdropMotion';
 import type { DialogSurfaceState, DialogSurfaceSlots, DialogSurfaceContextValues } from './DialogSurface.types';
 
 /**
@@ -17,9 +16,9 @@ export const renderDialogSurface_unstable = (state: DialogSurfaceState, contextV
   return (
     <Portal mountNode={state.mountNode}>
       {state.backdrop && (
-        <DialogBackdropMotion appear visible={state.open}>
+        <state.backdropMotion>
           <state.backdrop />
-        </DialogBackdropMotion>
+        </state.backdropMotion>
       )}
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         <state.root />

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurface.ts
@@ -1,4 +1,5 @@
 import { Escape } from '@fluentui/keyboard-keys';
+import { presenceMotionSlot, type PresenceMotionSlotProps } from '@fluentui/react-motion';
 import {
   useEventCallback,
   useMergedRefs,
@@ -11,6 +12,7 @@ import * as React from 'react';
 
 import { useDialogContext_unstable } from '../../contexts';
 import { useDisableBodyScroll } from '../../utils/useDisableBodyScroll';
+import { DialogBackdropMotion } from '../DialogBackdropMotion';
 import type { DialogSurfaceElement, DialogSurfaceProps, DialogSurfaceState } from './DialogSurface.types';
 
 /**
@@ -89,7 +91,15 @@ export const useDialogSurface_unstable = (
   }, [enableBodyScroll, isNestedDialog, disableBodyScroll, modalType]);
 
   return {
-    components: { backdrop: 'div', root: 'div' },
+    components: {
+      backdrop: 'div',
+      root: 'div',
+      // TODO: remove once React v18 slot API is modified
+      // This is a problem at the moment due to UnknownSlotProps assumption
+      // that `children` property is `ReactNode`, which in this case is not valid
+      // as PresenceComponentProps['children'] is `ReactElement`
+      backdropMotion: DialogBackdropMotion as React.FC<PresenceMotionSlotProps>,
+    },
     open,
     backdrop,
     isNestedDialog,
@@ -110,6 +120,13 @@ export const useDialogSurface_unstable = (
       }),
       { elementType: 'div' },
     ),
+    backdropMotion: presenceMotionSlot(props.backdropMotion, {
+      elementType: DialogBackdropMotion,
+      defaultProps: {
+        appear: true,
+        visible: open,
+      },
+    }),
 
     // Deprecated properties
     transitionStatus: undefined,

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -11,7 +11,7 @@ import {
 } from '../../contexts';
 import type { DialogSurfaceSlots, DialogSurfaceState } from './DialogSurface.types';
 
-export const dialogSurfaceClassNames: SlotClassNames<DialogSurfaceSlots> = {
+export const dialogSurfaceClassNames: SlotClassNames<Omit<DialogSurfaceSlots, 'backdropMotion'>> = {
   root: 'fui-DialogSurface',
   backdrop: 'fui-DialogSurface__backdrop',
 };


### PR DESCRIPTION
## Previous Behavior

`Dialog` & `DialogSurface` have built-in motion, but it's impossible to customize it.

## New Behavior

- `Dialog` gets `surfaceMotion` slot
- `DialogSurface` gets `backdropMotion` slot

Motion slots allow to customize or replace built-in motion, see examples in #31984.

## Related issues

- Fixes #30603
- Fixes #31129