### PR TITLE
RFC: Stop pre-processing styles with Griffel in `@fluentui/react-components`

### DIFF
--- a/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
+++ b/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
@@ -159,4 +159,5 @@ module.exports = {
 - 👍 Backward compatible
 - 👍 No changes required in consuming apps
 - 👎 Harder to maintain; adds complexity to the build system
+- 👎 Another public API that is tightly coupled only for limited set of files including Griffel
 - 👎 Increased install size (NPM package will be larger)

--- a/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
+++ b/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
@@ -131,7 +131,8 @@ This is the simplest option, albeit it necessitates adjustments in the consuming
 
 ## Pros and Cons
 
-- 👍 Simple & easy
+- 👍 (DX) drastically simplified Fluent build flow
+  👍 (DX/CI) significantly faster transpilation of Fluent libraries ([microsoft/griffel#534](https://github.com/microsoft/griffel/issues/534))
 - 👎 Not backward compatible
 
 ### Option B: Ship ESM output with unprocessed styles

--- a/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
+++ b/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
@@ -157,7 +157,23 @@ As a result, the CSS rules will have a higher specificity and will override any 
 
 A [StackBlitz example](https://stackblitz.com/edit/vitejs-vite-d11ccd) demonstrates this workaround.
 
-## Proposal
+## Accepted solution
+
+### Option A: Stop pre-processing styles
+
+> Note: Applications already undertake this responsibility, as first and third-party packages do not include pre-processed styles.
+
+This option involves eliminating the pre-processing step from `@fluentui/react-components`, shifting the responsibility to the consuming application.
+
+This is the simplest option, albeit it necessitates adjustments in the consuming app and is not backward compatible. Consequently, apps not utilizing [AOT in Griffel](https://griffel.js.org/react/ahead-of-time-compilation/introduction) will experience noticeable slowdowns during initial loading.
+
+## Pros and Cons
+
+- 👍 (DX) drastically simplified Fluent build flow
+  👍 (DX/CI) significantly faster transpilation of Fluent libraries ([microsoft/griffel#534](https://github.com/microsoft/griffel/issues/534))
+- 👎 Not backward compatible
+
+### Rejected solutions
 
 ### Option B: Ship ESM output with unprocessed styles
 
@@ -186,23 +202,3 @@ module.exports = {
 - 👎 Harder to maintain; adds complexity to the build system
 - 👎 Another public API that is tightly coupled only for limited set of files including Griffel
 - 👎 Increased install size (NPM package will be larger)
-
-## Rejected solutions
-
-### Option A: Stop pre-processing styles
-
-_Rejection reason:_
-
-_- This option is not backward compatible and will cause performance issues for apps not utilizing AOT_
-
-> Note: Applications already undertake this responsibility, as first and third-party packages do not include pre-processed styles.
-
-This option involves eliminating the pre-processing step from `@fluentui/react-components`, shifting the responsibility to the consuming application.
-
-This is the simplest option, albeit it necessitates adjustments in the consuming app and is not backward compatible. Consequently, apps not utilizing [AOT in Griffel](https://griffel.js.org/react/ahead-of-time-compilation/introduction) will experience noticeable slowdowns during initial loading.
-
-## Pros and Cons
-
-- 👍 (DX) drastically simplified Fluent build flow
-  👍 (DX/CI) significantly faster transpilation of Fluent libraries ([microsoft/griffel#534](https://github.com/microsoft/griffel/issues/534))
-- 👎 Not backward compatible

--- a/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
+++ b/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
@@ -132,7 +132,7 @@ This is the simplest option, albeit it necessitates adjustments in the consuming
 ## Pros and Cons
 
 - 👍 Simple & easy
-- 👍 Not backward compatible
+- 👎 Not backward compatible
 
 ### Option B: Ship ESM output with unprocessed styles
 

--- a/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
+++ b/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
@@ -117,6 +117,38 @@ const useStyles = /*#__PURE__*/ __styles(
 
 Addressing prefixing for pre-processed styles presents a challenge, as they have already been transformed into CSS rules and classes.
 
+## Current workaround
+
+We have proposed a temporary workaround in [microsoft/griffel#453](https://github.com/microsoft/griffel/issues/453#issuecomment-1850115159). The workaround involves increasing the specificity of the CSS rules in the consuming app. This is achieved by adding a unique class to the root element of the app, for example:
+
+```css
+.color-red {
+}
+/* becomes ⬇️ */
+.PREFIX .color-red {
+}
+```
+
+As a result, the CSS rules will have a higher specificity and will override any conflicting rules from the application. This approach is not ideal, as it affects performance (makes CSS rules less efficient).
+
+> Note: We cannot prefix classes as Fluent components have pre-processed styles:
+>
+> ```js
+> const useStyles = /*#__PURE__*/ __styles(
+>   // Part 1: CSS classes mapping
+>   { root: { B6of3ja: 'fvjh0tl' } },
+>   // Part 2: CSS rules
+>   { d: ['.fvjh0tl{margin-top:4px;}'] },
+> );
+> ```
+>
+> - We cannot prefix classes in the mapping with current APIs (part 1)
+> - We can prefix CSS classes (part 2)
+
+> Note: `__styles()` is a result of AOT compilation in Griffel, adding additional responsibilities to it makes the idea of AOT compilation obsolete.
+
+A [StackBlitz example](https://stackblitz.com/edit/vitejs-vite-d11ccd) demonstrates this workaround.
+
 ## Proposal
 
 The long-term solution is to discontinue the pre-processing of styles in `@fluentui/react-components` and transfer this responsibility to the consuming application.


### PR DESCRIPTION
## Description

The RFC proposes halting the pre-processing of styles in `@fluentui/react-components` to address CSS clashes observed when apps are bundled into multiple separate bundles.

Two options are presented:
- stopping pre-processing entirely, requiring consuming apps to handle it (breaking change) 
- shipping ESM output with unprocessed styles alongside pre-processed styles, maintaining backward compatibility, but increasing complexity and package size
