### PR TITLE
chore: refactor tests for createPresenceComponent()

### DIFF
--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
@@ -4,19 +4,13 @@ import * as React from 'react';
 import type { PresenceMotion } from '../types';
 import { createPresenceComponent } from './createPresenceComponent';
 
+const enterKeyframes = [{ opacity: 0 }, { opacity: 1 }];
+const exitKeyframes = [{ opacity: 1 }, { opacity: 0 }];
+const options = { duration: 500 as const, fill: 'forwards' as const };
+
 const motion: PresenceMotion = {
-  enter: {
-    keyframes: [{ opacity: 0 }, { opacity: 1 }],
-
-    duration: 500,
-    fill: 'forwards',
-  },
-  exit: {
-    keyframes: [{ opacity: 0 }, { opacity: 1 }],
-
-    duration: 500,
-    fill: 'forwards',
-  },
+  enter: { keyframes: enterKeyframes, ...options },
+  exit: { keyframes: exitKeyframes, ...options },
 };
 
 function createElementMock() {
@@ -43,10 +37,84 @@ function createElementMock() {
 }
 
 describe('createPresenceComponent', () => {
+  describe('appear', () => {
+    it('does not animate by default', () => {
+      const TestAtom = createPresenceComponent(motion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      render(
+        <TestAtom visible>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(animateMock).not.toHaveBeenCalled();
+    });
+
+    it('animates when is "true"', () => {
+      const TestAtom = createPresenceComponent(motion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      render(
+        <TestAtom appear visible>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
+    });
+  });
+
+  describe('visible', () => {
+    it('animates when state changes', () => {
+      const TestAtom = createPresenceComponent(motion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      const { rerender } = render(
+        <TestAtom visible>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(animateMock).not.toHaveBeenCalled();
+
+      rerender(
+        <TestAtom visible={false}>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
+    });
+  });
+
+  describe('unmountOnExit', () => {
+    it('unmounts when state changes', () => {
+      const TestAtom = createPresenceComponent(motion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      const { rerender, queryByText } = render(
+        <TestAtom visible unmountOnExit>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(queryByText('ElementMock')).toBeTruthy();
+      expect(animateMock).not.toHaveBeenCalled();
+
+      rerender(
+        <TestAtom visible={false} unmountOnExit>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(queryByText('ElementMock')).toBe(null);
+      expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
+    });
+  });
+
   describe('definitions', () => {
     it('supports functions as motion definitions', () => {
-      const { keyframes, ...options } = motion.exit;
-
       const fnMotion = jest.fn().mockImplementation(() => motion);
       const TestAtom = createPresenceComponent(fnMotion);
       const { animateMock, ElementMock } = createElementMock();
@@ -67,89 +135,7 @@ describe('createPresenceComponent', () => {
       expect(fnMotion).toHaveBeenCalledTimes(1);
       expect(fnMotion).toHaveBeenCalledWith({ animate: animateMock } /* mock of html element */);
 
-      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
-    });
-  });
-
-  describe('appear', () => {
-    it('does not animate by default', () => {
-      const TestAtom = createPresenceComponent(motion);
-      const { animateMock, ElementMock } = createElementMock();
-
-      render(
-        <TestAtom visible>
-          <ElementMock />
-        </TestAtom>,
-      );
-
-      expect(animateMock).not.toHaveBeenCalled();
-    });
-
-    it('animates when is "true"', () => {
-      const { keyframes, ...options } = motion.enter;
-      const TestAtom = createPresenceComponent(motion);
-
-      const { animateMock, ElementMock } = createElementMock();
-
-      render(
-        <TestAtom appear visible>
-          <ElementMock />
-        </TestAtom>,
-      );
-
-      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
-    });
-  });
-
-  describe('visible', () => {
-    it('animates when state changes', () => {
-      const { keyframes, ...options } = motion.exit;
-      const TestAtom = createPresenceComponent(motion);
-
-      const { animateMock, ElementMock } = createElementMock();
-
-      const { rerender } = render(
-        <TestAtom visible>
-          <ElementMock />
-        </TestAtom>,
-      );
-
-      expect(animateMock).not.toHaveBeenCalled();
-
-      rerender(
-        <TestAtom visible={false}>
-          <ElementMock />
-        </TestAtom>,
-      );
-
-      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
-    });
-  });
-
-  describe('unmountOnExit', () => {
-    it('unmounts when state changes', () => {
-      const { keyframes, ...options } = motion.enter;
-      const TestAtom = createPresenceComponent(motion);
-
-      const { animateMock, ElementMock } = createElementMock();
-
-      const { rerender, queryByText } = render(
-        <TestAtom visible unmountOnExit>
-          <ElementMock />
-        </TestAtom>,
-      );
-
-      expect(queryByText('ElementMock')).toBeTruthy();
-      expect(animateMock).not.toHaveBeenCalled();
-
-      rerender(
-        <TestAtom visible={false} unmountOnExit>
-          <ElementMock />
-        </TestAtom>,
-      );
-
-      expect(queryByText('ElementMock')).toBe(null);
-      expect(animateMock).toHaveBeenCalledWith(keyframes, options);
+      expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
     });
   });
 });


### PR DESCRIPTION
## New Behavior

_Moved out from a larger PR_.

- Test for `unmountOnExit` was false positive as `motion` used the same keyframes set for "exit" & "enter"
- `motion` was split to smaller objects to simplify tests & assertions
