### PR TITLE
feat(workspace-plugin): make all react library generators work with both split project and old project setup

### DIFF
--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
@@ -3,13 +3,18 @@ import {
   generateFiles,
   joinPathFragments,
   offsetFromRoot,
+  ProjectConfiguration,
   readProjectConfiguration,
   Tree,
   updateJson,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
+
 import * as path from 'path';
+
 import { PackageJson } from '../../types';
+import { assertStoriesProject, isSplitProject } from '../split-library-in-two/shared';
+
 import { BundleSizeConfigurationGeneratorSchema } from './schema';
 
 export async function bundleSizeConfigurationGenerator(tree: Tree, schema: BundleSizeConfigurationGeneratorSchema) {
@@ -17,9 +22,7 @@ export async function bundleSizeConfigurationGenerator(tree: Tree, schema: Bundl
 
   const project = readProjectConfiguration(tree, options.name);
 
-  const isSplitProject = tree.exists(joinPathFragments(project.root, '../stories/project.json'));
-
-  assertOptions(tree, { isSplitProject, ...options });
+  assertOptions(tree, { isSplitProject: isSplitProject(tree, project), project });
 
   const configPaths = {
     bundleSizeRoot: joinPathFragments(project.root, 'bundle-size'),
@@ -62,15 +65,8 @@ function normalizeOptions(tree: Tree, schema: BundleSizeConfigurationGeneratorSc
   };
 }
 
-function assertOptions(tree: Tree, options: ReturnType<typeof normalizeOptions> & { isSplitProject: boolean }) {
-  if (options.isSplitProject && options.name.endsWith('-stories')) {
-    throw new Error(
-      `This generator can be invoked only against library project. Please run it against "${options.name.replace(
-        '-stories',
-        '',
-      )}" library project.`,
-    );
-  }
+function assertOptions(tree: Tree, options: { project: ProjectConfiguration; isSplitProject: boolean }) {
+  assertStoriesProject(tree, options);
 }
 
 export default bundleSizeConfigurationGenerator;

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/index.spec.ts
@@ -71,10 +71,17 @@ describe(`cypress-component-configuration`, () => {
       }
     `);
 
-    expect(readJson(tree, 'packages/one/package.json').scripts).toEqual(
+    const pkgJson = readJson(tree, 'packages/one/package.json');
+
+    expect(pkgJson.scripts).toEqual(
       expect.objectContaining({
         e2e: 'cypress run --component',
         'e2e:local': 'cypress open --component',
+      }),
+    );
+    expect(pkgJson.devDependencies).toEqual(
+      expect.objectContaining({
+        '@fluentui/scripts-cypress': '*',
       }),
     );
   });

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/index.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/index.ts
@@ -4,6 +4,8 @@ import { getProjectConfig, printUserLogs, UserLog } from '../../utils';
 
 import type { CypressComponentConfigurationGeneratorSchema } from './schema';
 
+import { assertStoriesProject } from '../split-library-in-two/shared';
+
 import { addFiles } from './lib/add-files';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -44,14 +46,7 @@ function assertOptions(tree: Tree, options: ReturnType<typeof normalizeOptions> 
     return false;
   }
 
-  if (options.isSplitProject && options.name.endsWith('-stories')) {
-    throw new Error(
-      `This generator can be invoked only against library project. Please run it against "${options.name.replace(
-        '-stories',
-        '',
-      )}" library project.`,
-    );
-  }
+  assertStoriesProject(tree, { isSplitProject: options.isSplitProject, project: options.projectConfig });
 
   return true;
 }

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -32,6 +32,9 @@ export function addFiles(tree: Tree, options: Options) {
     json.scripts.e2e = 'cypress run --component';
     json.scripts['e2e:local'] = 'cypress open --component';
 
+    json.devDependencies = json.devDependencies ?? {};
+    json.devDependencies['@fluentui/scripts-cypress'] = '*';
+
     return json;
   });
 

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.spec.ts
@@ -625,6 +625,18 @@ describe('prepare-initial-release generator', () => {
             library: [],
             stories: [
               {
+                filePath: 'packages/react-one-preview/library/bundle-size/index.fixture.js',
+                content: stripIndents`
+                import {One} from '@proj/react-one-preview';
+
+                console.log(One);
+
+                export default {
+                   name: '@proj/react-one-preview - package',
+                }
+          `,
+              },
+              {
                 filePath: 'packages/react-one-preview/stories/src/One.stories.tsx',
                 content: stripIndents`
             import { One } from '@proj/react-one-preview';
@@ -716,6 +728,18 @@ describe('prepare-initial-release generator', () => {
             sourceRoot: 'packages/react-one/stories/src',
           }),
         );
+
+        expect(utils.project.library.bundleSize()).toMatchInlineSnapshot(`
+          Object {
+            "packages/react-one/library/bundle-size/index.fixture.js": "import { One } from '@proj/react-one';
+
+          console.log(One);
+
+          export default {
+          name: '@proj/react-one - package',
+          };",
+          }
+        `);
 
         expect(utils.project.library.md.readme()).toMatchInlineSnapshot(`
           "# @proj/react-one

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -221,6 +221,26 @@ describe('react-library generator', () => {
       "
     `);
 
+    expect(readJson(tree, `${stories.root}/.eslintrc.json`)).toMatchInlineSnapshot(`
+      Object {
+        "extends": Array [
+          "plugin:@fluentui/eslint-plugin/react",
+        ],
+        "root": true,
+        "rules": Object {
+          "import/no-extraneous-dependencies": Array [
+            "error",
+            Object {
+              "packageDir": Array [
+                ".",
+                "../../../../",
+              ],
+            },
+          ],
+        },
+      }
+    `);
+
     // global updates
 
     const expectedPathAlias = {
@@ -246,9 +266,12 @@ describe('react-library generator', () => {
     setup(tree);
 
     await generator(tree, { name: 'react-one', owner: '@org/chosen-one', kind: 'compat' });
-    const config = readProjectConfiguration(tree, '@proj/react-one-compat');
+    const library = readProjectConfiguration(tree, '@proj/react-one-compat');
+    const stories = readProjectConfiguration(tree, '@proj/react-one-compat-stories');
 
-    expect(tree.children(config.root)).toMatchInlineSnapshot(`
+    // library
+
+    expect(tree.children(library.root)).toMatchInlineSnapshot(`
       Array [
         "project.json",
         ".babelrc.json",
@@ -268,11 +291,35 @@ describe('react-library generator', () => {
         "tsconfig.spec.json",
       ]
     `);
-    expect(config).toEqual(
+    expect(library).toEqual(
       expect.objectContaining({
         root: 'packages/react-components/react-one-compat/library',
         sourceRoot: 'packages/react-components/react-one-compat/library/src',
         tags: ['platform:web', 'vNext', 'compat'],
+      }),
+    );
+
+    // stories
+
+    expect(tree.children(stories.root)).toMatchInlineSnapshot(`
+      Array [
+        "src",
+        ".storybook",
+        "README.md",
+        "just.config.ts",
+        ".eslintrc.json",
+        "tsconfig.json",
+        "tsconfig.lib.json",
+        "package.json",
+        "project.json",
+      ]
+    `);
+
+    expect(stories).toEqual(
+      expect.objectContaining({
+        root: 'packages/react-components/react-one-compat/stories',
+        sourceRoot: 'packages/react-components/react-one-compat/stories/src',
+        tags: ['vNext', 'platform:web', 'compat', 'type:stories'],
       }),
     );
   });

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -98,7 +98,9 @@ describe('react-library generator', () => {
       mainEntryPointFilePath:
         '<projectRoot>/../../../../../../dist/out-tsc/types/packages/react-components/<unscopedPackageName>/library/src/index.d.ts',
     });
-    expect(readJson(tree, `${library.root}/package.json`)).toEqual(
+    const libPackageJson = readJson(tree, `${library.root}/package.json`);
+    expect(libPackageJson.scripts['test-ssr']).toEqual(undefined);
+    expect(libPackageJson).toEqual(
       expect.objectContaining({
         name: '@proj/react-one-preview',
         private: true,
@@ -197,6 +199,7 @@ describe('react-library generator', () => {
         start: 'yarn storybook',
         storybook: 'start-storybook',
         'type-check': 'just-scripts type-check',
+        'test-ssr': 'test-ssr "./src/**/*.stories.tsx"',
       },
     });
 

--- a/tools/workspace-plugin/src/generators/react-library/index.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.ts
@@ -12,6 +12,8 @@ import {
   readJson,
 } from '@nx/devkit';
 
+import { splitLibraryInTwoGenerator } from '../split-library-in-two/generator';
+
 import { getProjectConfig, getWorkspaceConfig } from '../../utils';
 
 import { ReactLibraryGeneratorSchema } from './schema';
@@ -31,6 +33,8 @@ export default async function (tree: Tree, schema: ReactLibraryGeneratorSchema) 
   await tsConfigBaseAllGenerator(tree, {});
 
   addCodeowner(tree, { packageName: options.projectConfig.name as string, owner: schema.owner });
+
+  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name });
 
   await formatFiles(tree);
 

--- a/tools/workspace-plugin/src/generators/react-library/index.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.ts
@@ -34,7 +34,7 @@ export default async function (tree: Tree, schema: ReactLibraryGeneratorSchema) 
 
   addCodeowner(tree, { packageName: options.projectConfig.name as string, owner: schema.owner });
 
-  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name });
+  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name, skipFormat: true });
 
   await formatFiles(tree);
 

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -23,7 +23,7 @@ const noop = () => {
 
 describe('split-library-in-two generator', () => {
   let tree: Tree;
-  const options = { project: '@proj/react-hello' };
+  const options = { project: '@proj/react-hello', logs: true };
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -119,11 +119,12 @@ describe('split-library-in-two generator', () => {
       }),
     );
 
-    expect(readJson(tree, `${newConfig.root}/package.json`)).toEqual(
+    const newConfigPackageJSON = readJson(tree, `${newConfig.root}/package.json`);
+    expect(newConfigPackageJSON.scripts['test-ssr']).toEqual(undefined);
+    expect(newConfigPackageJSON).toEqual(
       expect.objectContaining({
         name: '@proj/react-hello',
         scripts: expect.objectContaining({
-          'test-ssr': 'test-ssr "../stories/src/**/*.stories.tsx"',
           'type-check': 'just-scripts type-check',
           storybook: 'yarn --cwd ../stories storybook',
         }),
@@ -192,6 +193,7 @@ describe('split-library-in-two generator', () => {
           "lint": "eslint src/",
           "start": "yarn storybook",
           "storybook": "start-storybook",
+          "test-ssr": "test-ssr \\"./src/**/*.stories.tsx\\"",
           "type-check": "just-scripts type-check",
         },
         "version": "0.0.0",

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -395,7 +395,12 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: typeof output)
     root: newProjectRoot,
     sourceRoot: newProjectSourceRoot,
     name: `${options.projectConfig.name}-stories`,
-    tags: ['vNext', 'platform:web', 'type:stories'],
+    tags: [
+      'vNext',
+      'platform:web',
+      options.projectConfig.tags?.includes('compat') ? 'compat' : null,
+      'type:stories',
+    ].filter(Boolean) as string[],
   });
 
   updateJson(tree, '/tsconfig.base.json', (json: TsConfig) => {

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -25,6 +25,8 @@ import { TsConfig } from '../../types';
 import { workspacePaths } from '../../utils';
 import { SplitLibraryInTwoGeneratorSchema } from './schema';
 
+export { isSplitProject, assertStoriesProject } from './shared';
+
 interface Options extends SplitLibraryInTwoGeneratorSchema {
   projectConfig: ReturnType<typeof readProjectConfiguration>;
   projectOffsetFromRoot: { old: string; updated: string };

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -388,16 +388,6 @@ function assertProject(tree: Tree, projectConfig: ProjectConfiguration, logger: 
     return;
   }
 
-  if (projectConfig.name?.endsWith('-preview')) {
-    logger.warn({ title: 'preview projects are not supported YET, skipping...' });
-    return;
-  }
-
-  if (tags.includes('compat')) {
-    logger.warn({ title: 'compat projects are not supported YET, skipping...' });
-    return;
-  }
-
   if (projectConfig.root?.endsWith('/stories') || projectConfig.root?.endsWith('/library')) {
     logger.warn({ title: 'attempting to migrate already migrated projects, skipping...' });
     return;

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -87,7 +87,9 @@ export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibra
   // TODO: we don't wanna fail master build because formatting failed
   // - Nx is using await `prettier.format` under the hood which is for prettier v3, but we use prettier v2 ATM, while that unnecessary await should not cause harm it seems it does
   try {
-    await formatFiles(tree);
+    if (!options.skipFormat) {
+      await formatFiles(tree);
+    }
   } catch (err) {
     console.log(err);
   }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -37,6 +37,19 @@ const noop = () => {
   return;
 };
 
+function createOutputLogger(options: SplitLibraryInTwoGeneratorSchema) {
+  if (options.logs) {
+    return output;
+  }
+
+  return {
+    log: noop,
+    note: noop,
+    warn: noop,
+    error: noop,
+  } as unknown as typeof output;
+}
+
 export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibraryInTwoGeneratorSchema) {
   if (options.project && options.all) {
     throw new Error('Cannot specify both project and all');
@@ -45,24 +58,26 @@ export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibra
     throw new Error('missing `project` or `all` option');
   }
 
+  const cliOutput = createOutputLogger(options);
+
   if (options.all) {
     const projects = getProjects(tree);
     const projectsToSplit = Array.from(projects).filter(([_, project]) =>
       assertProject(tree, project, { warn: noop } as unknown as typeof output),
     );
 
-    output.log({
+    cliOutput.log({
       title: `Splitting ${projectsToSplit.length} libraries in two...`,
       bodyLines: projectsToSplit.map(([name]) => name),
     });
 
     for (const [projectName, project] of projectsToSplit) {
-      splitLibraryInTwoInternal(tree, { projectName, project });
+      splitLibraryInTwoInternal(tree, { projectName, project }, cliOutput);
     }
   }
 
   if (options.project) {
-    splitLibraryInTwoInternal(tree, { projectName: options.project });
+    splitLibraryInTwoInternal(tree, { projectName: options.project }, cliOutput);
   }
 
   await tsConfigBaseAllGenerator(tree, { verify: false, skipFormat: true });
@@ -80,11 +95,15 @@ export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibra
   };
 }
 
-function splitLibraryInTwoInternal(tree: Tree, options: { projectName: string; project?: ProjectConfiguration }) {
+function splitLibraryInTwoInternal(
+  tree: Tree,
+  options: { projectName: string; project?: ProjectConfiguration },
+  logger: typeof output,
+) {
   const { projectName, project } = options;
   const projectConfig = project ?? readProjectConfiguration(tree, options.projectName);
 
-  output.log({ title: `Splitting library in two: ${projectConfig.name}`, color: 'magenta' });
+  logger.log({ title: `Splitting library in two: ${projectConfig.name}`, color: 'magenta' });
 
   if (!assertProject(tree, projectConfig, output)) {
     return;
@@ -102,16 +121,16 @@ function splitLibraryInTwoInternal(tree: Tree, options: { projectName: string; p
     },
   };
 
-  cleanup(tree, normalizedOptions);
+  cleanup(tree, normalizedOptions, logger);
 
-  makeSrcLibrary(tree, normalizedOptions);
-  makeStoriesLibrary(tree, normalizedOptions);
+  makeSrcLibrary(tree, normalizedOptions, logger);
+  makeStoriesLibrary(tree, normalizedOptions, logger);
 }
 
 export default splitLibraryInTwoGenerator;
 
-function cleanup(tree: Tree, options: Options) {
-  output.log({ title: 'Cleaning up build assets...' });
+function cleanup(tree: Tree, options: Options, logger: typeof output) {
+  logger.log({ title: 'Cleaning up build assets...' });
   const oldProjectRoot = options.projectConfig.root;
   tree.delete(joinPathFragments(oldProjectRoot, 'dist'));
   tree.delete(joinPathFragments(oldProjectRoot, 'lib'));
@@ -122,8 +141,8 @@ function cleanup(tree: Tree, options: Options) {
   tree.delete(joinPathFragments(oldProjectRoot, 'node_modules'));
 }
 
-function makeSrcLibrary(tree: Tree, options: Options) {
-  output.log({ title: 'creating library/ project' });
+function makeSrcLibrary(tree: Tree, options: Options, logger: typeof output) {
+  logger.log({ title: 'creating library/ project' });
 
   const oldProjectRoot = options.projectConfig.root;
   const newProjectRoot = joinPathFragments(oldProjectRoot, 'library');
@@ -165,11 +184,15 @@ function makeSrcLibrary(tree: Tree, options: Options) {
       json.scripts['test-ssr'] = `test-ssr \"../stories/src/**/*.stories.tsx\"`;
     }
 
-    const deps = getMissingDevDependenciesFromCypressAndJestFiles(tree, {
-      sourceRoot: newProjectSourceRoot,
-      projectName: options.projectConfig.name!,
-      dependencies: json.dependencies,
-    });
+    const deps = getMissingDevDependenciesFromCypressAndJestFiles(
+      tree,
+      {
+        sourceRoot: newProjectSourceRoot,
+        projectName: options.projectConfig.name!,
+        dependencies: json.dependencies,
+      },
+      logger,
+    );
 
     json.devDependencies ??= {};
     json.devDependencies = { ...deps, ...json.devDependencies };
@@ -230,8 +253,8 @@ function makeSrcLibrary(tree: Tree, options: Options) {
   updateCodeowners(tree, options);
 }
 
-function makeStoriesLibrary(tree: Tree, options: Options) {
-  output.log({ title: 'creating stories/ project' });
+function makeStoriesLibrary(tree: Tree, options: Options, logger: typeof output) {
+  logger.log({ title: 'creating stories/ project' });
   const oldProjectRoot = options.projectConfig.root;
   const newProjectRoot = joinPathFragments(oldProjectRoot, 'stories');
   const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
@@ -487,6 +510,7 @@ function getWorkspaceDependencies(tree: Tree, imports: string[]) {
 function getMissingDevDependenciesFromCypressAndJestFiles(
   tree: Tree,
   options: { sourceRoot: string; projectName: string; dependencies: Record<string, string> },
+  logger: typeof output,
 ) {
   const { projectName, sourceRoot, dependencies } = options;
 
@@ -518,7 +542,7 @@ function getMissingDevDependenciesFromCypressAndJestFiles(
     // don't add self to deps
     delete deps[projectName];
 
-    output.warn({
+    logger.warn({
       title: 'Not adding self to dependencies',
       bodyLines: ['You should not import from you package absolute path within test files. Prefer relative imports.'],
     });
@@ -535,7 +559,7 @@ function getMissingDevDependenciesFromCypressAndJestFiles(
     });
 
     if (log.length > 0) {
-      output.warn({
+      logger.warn({
         title: 'Not adding dependencies that are already present in package.json',
         bodyLines: log,
       });
@@ -543,7 +567,7 @@ function getMissingDevDependenciesFromCypressAndJestFiles(
   }
 
   if (deps['@fluentui/react-components']) {
-    output.error({
+    logger.error({
       title: 'react-components cannot be used within cypress or jest test files as it creates circular dependency.',
       bodyLines: [
         'Please remove/replace problematic imports from the test files and remove the dependency from "package.json#devDependencies".',
@@ -551,7 +575,7 @@ function getMissingDevDependenciesFromCypressAndJestFiles(
     });
   }
 
-  output.log({ title: 'Adding missing dependencies', bodyLines: Object.keys(deps) });
+  logger.log({ title: 'Adding missing dependencies', bodyLines: Object.keys(deps) });
 
   return deps;
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
@@ -6,4 +6,9 @@ export interface SplitLibraryInTwoGeneratorSchema {
    * @internal
    */
   logs?: boolean;
+
+  /**
+   * @internal
+   */
+  skipFormat?: boolean;
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.d.ts
@@ -1,4 +1,9 @@
 export interface SplitLibraryInTwoGeneratorSchema {
   project?: string;
   all?: string;
+
+  /**
+   * @internal
+   */
+  logs?: boolean;
 }

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
@@ -16,6 +16,12 @@
     "all": {
       "type": "boolean",
       "description": "Run generator on all vNext packages"
+    },
+    "logs": {
+      "type": "boolean",
+      "default": true,
+      "visible": false,
+      "x-priority": "internal"
     }
   },
   "required": []

--- a/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/schema.json
@@ -22,6 +22,12 @@
       "default": true,
       "visible": false,
       "x-priority": "internal"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": []

--- a/tools/workspace-plugin/src/generators/split-library-in-two/shared.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/shared.ts
@@ -1,0 +1,15 @@
+import { joinPathFragments, type ProjectConfiguration, type Tree } from '@nx/devkit';
+
+export const isSplitProject = (tree: Tree, project: ProjectConfiguration) =>
+  tree.exists(joinPathFragments(project.root, '../stories/project.json'));
+
+export function assertStoriesProject(tree: Tree, options: { isSplitProject: boolean; project: ProjectConfiguration }) {
+  if (options.isSplitProject && options.project.name?.endsWith('-stories')) {
+    throw new Error(
+      `This generator can be invoked only against library project. Please run it against "${options.project.name.replace(
+        '-stories',
+        '',
+      )}" library project.`,
+    );
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

### Pre-requirements:

- [x] https://github.com/microsoft/monosize/issues/62
- [x] https://github.com/microsoft/fluentui/pull/31395

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

makes following generators work in both v9 package configuration ( old/current and new split library `root-folder/library root-folder/stories`:
- react-library
- react-component
- cypress-component-configuration
- bundle-size-configuration
- prepare-initial-release

**NOTE:** once we migrate all packages those conditional (old) behaviours implemented will be removed from all changed generators in this PR ( except  `split-library-in-two` generator )

**Additional features:**

- `react-library`
  - once this is merged any new react library will start from scratch in split projects mode 
- `cypress-component-configuration`
  - properly add devDependencies when invoking 
- `split-library-in-two`
  - make cli log output configurable for better composability
  - enable execution on preview and compat packages
  - based on offline convo, `test-ssr` task will be moved to `/stories` project instead staying within `/library` as it's the right thing to do from domain and dependency graph POV.



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
