### PR TITLE
chore: improve state handling in createPresenceComponent()

### DIFF
--- a/change/@fluentui-react-motions-preview-e2edd59f-e00a-4e90-b6a3-f2336231996e.json
+++ b/change/@fluentui-react-motions-preview-e2edd59f-e00a-4e90-b6a3-f2336231996e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: improve state handling in createPresenceComponent()",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
+import { useMountedState } from '../hooks/useMountedState';
 import { getChildElement } from '../utils/getChildElement';
 import type { PresenceMotion, MotionImperativeRef, PresenceMotionFn } from '../types';
 
@@ -12,7 +13,7 @@ type PresenceMotionEventData = EventData<'animation', AnimationPlaybackEvent> & 
   direction: 'enter' | 'exit';
 };
 
-type PresenceComponentProps = {
+export type PresenceComponentProps = {
   /**
    * By default, the child component won't execute the "enter" motion when it initially mounts, regardless of the value
    * of "visible". If you desire this behavior, ensure both "appear" and "visible" are set to "true".
@@ -37,19 +38,22 @@ type PresenceComponentProps = {
   unmountOnExit?: boolean;
 };
 
+function shouldSkipAnimation(appear: boolean | undefined, isFirstMount: boolean, visible: boolean | undefined) {
+  return !appear && isFirstMount && visible;
+}
+
 export function createPresenceComponent(motion: PresenceMotion | PresenceMotionFn) {
   const Presence: React.FC<PresenceComponentProps> = props => {
     const itemContext = React.useContext(PresenceGroupChildContext);
     const { appear, children, imperativeRef, onMotionFinish, visible, unmountOnExit } = { ...itemContext, ...props };
 
+    const [mounted, setMounted] = useMountedState(visible, unmountOnExit);
     const child = getChildElement(children);
 
     const animationRef = useMotionImperativeRef(imperativeRef);
     const elementRef = React.useRef<HTMLElement>();
     const ref = useMergedRefs(elementRef, child.ref);
-    const optionsRef = React.useRef<{ appear?: boolean }>();
-
-    const [mounted, setMounted] = React.useState(() => (unmountOnExit ? visible : true));
+    const optionsRef = React.useRef<{ appear?: boolean }>({});
 
     const isFirstMount = React.useRef<boolean>(true);
     const isReducedMotion = useIsReducedMotion();
@@ -70,65 +74,34 @@ export function createPresenceComponent(motion: PresenceMotion | PresenceMotionF
     });
 
     useIsomorphicLayoutEffect(() => {
-      if (visible) {
-        setMounted(true);
+      if (!elementRef.current || shouldSkipAnimation(optionsRef.current.appear, isFirstMount.current, visible)) {
         return;
       }
 
-      if (elementRef.current) {
-        const definition = typeof motion === 'function' ? motion(elementRef.current) : motion;
-        const { keyframes, ...options } = definition.exit;
+      const presenceDefinition = typeof motion === 'function' ? motion(elementRef.current) : motion;
+      const { keyframes, ...options } = visible ? presenceDefinition.enter : presenceDefinition.exit;
 
-        const animation = elementRef.current.animate(keyframes, {
-          fill: 'forwards',
+      const animation = elementRef.current.animate(keyframes, {
+        fill: 'forwards',
 
-          ...options,
-          ...(isReducedMotion() && { duration: 1 }),
-        });
+        ...options,
+        ...(isReducedMotion() && { duration: 1 }),
+      });
 
-        if (isFirstMount.current) {
-          // Heads up!
-          // .finish() is used there to skip animation on first mount, but apply animation styles
-          animation.finish();
-          return;
-        }
-
-        animationRef.current = animation;
-        animation.onfinish = onExitFinish;
-
-        return () => {
-          // TODO: should we set unmount there?
-          animation.cancel();
-        };
-      }
-    }, [animationRef, isReducedMotion, onExitFinish, visible]);
-
-    useIsomorphicLayoutEffect(() => {
-      if (!elementRef.current) {
+      if (!visible && isFirstMount.current) {
+        // Heads up!
+        // .finish() is used there to skip animation on first mount, but apply animation styles immediately
+        animation.finish();
         return;
       }
 
-      const shouldEnter = isFirstMount.current ? optionsRef.current?.appear && visible : mounted && visible;
+      animationRef.current = animation;
+      animation.onfinish = visible ? onEnterFinish : onExitFinish;
 
-      if (shouldEnter) {
-        const definition = typeof motion === 'function' ? motion(elementRef.current) : motion;
-        const { keyframes, ...options } = definition.enter;
-
-        const animation = elementRef.current.animate(keyframes, {
-          fill: 'forwards',
-
-          ...options,
-          ...(isReducedMotion() && { duration: 1 }),
-        });
-
-        animationRef.current = animation;
-        animation.onfinish = onEnterFinish;
-
-        return () => {
-          animation.cancel();
-        };
-      }
-    }, [animationRef, isReducedMotion, mounted, onEnterFinish, visible]);
+      return () => {
+        animation.cancel();
+      };
+    }, [animationRef, isReducedMotion, onEnterFinish, onExitFinish, visible]);
 
     useIsomorphicLayoutEffect(() => {
       isFirstMount.current = false;

--- a/packages/react-components/react-motions-preview/src/hooks/useMountedState.test.tsx
+++ b/packages/react-components/react-motions-preview/src/hooks/useMountedState.test.tsx
@@ -1,0 +1,22 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useMountedState } from './useMountedState';
+
+describe('useMountedState', () => {
+  it.each([
+    // "visible={true}" overrides any state updates
+    { visible: true, unmountOnExit: true, initialResult: true, afterUnmountResult: true },
+    { visible: true, unmountOnExit: false, initialResult: true, afterUnmountResult: true },
+
+    { visible: false, unmountOnExit: false, initialResult: true, afterUnmountResult: false },
+    { visible: false, unmountOnExit: true, initialResult: false, afterUnmountResult: false },
+  ])('handles state updates', ({ afterUnmountResult, initialResult, visible, unmountOnExit }) => {
+    const { result } = renderHook(() => useMountedState(visible, unmountOnExit));
+
+    expect(result.current[0]).toBe(initialResult);
+    act(() => {
+      result.current[1](false);
+    });
+
+    expect(result.current[0]).toBe(afterUnmountResult);
+  });
+});

--- a/packages/react-components/react-motions-preview/src/hooks/useMountedState.ts
+++ b/packages/react-components/react-motions-preview/src/hooks/useMountedState.ts
@@ -1,0 +1,32 @@
+import { useForceUpdate } from '@fluentui/react-utilities';
+import * as React from 'react';
+
+/**
+ * This hook manages the mounted state of a component, based on the "visible" and "unmountOnExit" props.
+ * It simulates the behavior of getDerivedStateFromProps(), which is not available in functional components.
+ */
+export function useMountedState(
+  visible: boolean = false,
+  unmountOnExit: boolean = false,
+): [boolean, (value: boolean) => void] {
+  const mountedRef = React.useRef<boolean>(unmountOnExit ? visible : true);
+  const forceUpdate = useForceUpdate();
+
+  const setMounted = React.useCallback(
+    (newValue: boolean) => {
+      if (mountedRef.current !== newValue) {
+        mountedRef.current = newValue;
+        forceUpdate();
+      }
+    },
+    [forceUpdate],
+  );
+
+  React.useEffect(() => {
+    if (visible) {
+      mountedRef.current = visible;
+    }
+  });
+
+  return [visible || mountedRef.current, setMounted];
+}


### PR DESCRIPTION
## Previous Behavior

Transition from `{ visible: false, unmountOnExit: false }` to `{ visible: true, unmountOnExit: false }` caused a re-render.

## New Behavior

Transition from `{ visible: false, unmountOnExit: false }` to `{ visible: true, unmountOnExit: false }` does not cause a re-render.

- `mounted` state is managed by `useMountedState()` hook (covered with tests)
- `createPresenceComponent()` logic was simplified from two `useLayoutEffect()` hooks to a single one
- Additional tests & assertions added

## Related Issue(s)

Fixes #31135
