### PR TITLE
chore: register react-components nested folders to workspace and make storybook properly load split project stories 

### DIFF
--- a/package.json
+++ b/package.json
@@ -360,6 +360,7 @@
       "packages/*",
       "packages/fluentui/*",
       "packages/react-components/*",
+      "packages/react-components/*/*",
       "scripts/*",
       "tools/*",
       "typings"

--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -229,13 +229,19 @@ function getPackageStoriesGlob(options) {
   const packages = Object.keys(dependencies);
 
   const result = packages
-    .filter(pkgName => pkgName.startsWith('@fluentui/') && !excludeStoriesInsertionFromPackages.includes(pkgName))
+    .filter(pkgName => projects.has(pkgName) && !excludeStoriesInsertionFromPackages.includes(pkgName))
     .map(pkgName => {
       const storiesGlob = '**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
       const pkgMetadata = getMetadata(pkgName, projects);
 
       if (fs.existsSync(path.resolve(workspaceRoot, pkgMetadata.root, 'stories'))) {
         return `${rootOffset}${pkgMetadata.root}/stories/${storiesGlob}`;
+      }
+
+      // if defined package has stories project use that
+      const pkgMetadataStories = projects.get(`${pkgName}-stories`);
+      if (pkgMetadataStories) {
+        return `${rootOffset}${pkgMetadataStories.root}/src/${storiesGlob}`;
       }
 
       return `${rootOffset}${pkgMetadata.root}/src/${storiesGlob}`;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- adds new monorepo workspace glob ( this will trigger warnings on local machines for build react-components/unstable/package.json and react-jsx-runtime nested package.json files )
- loads stories properly from split projects

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
