### PR TITLE
docs: add `autoSize` example to positioning component page

### DIFF
--- a/packages/react-components/react-components/stories/Concepts/Positioning/PositioningAutoSize.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/PositioningAutoSize.stories.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import {
+  Button,
+  makeStyles,
+  shorthands,
+  Checkbox,
+  SpinButton,
+  Label,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItem,
+} from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  boundary: {
+    ...shorthands.border('2px', 'dashed', 'red'),
+    width: '300px',
+    height: '300px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  trigger: {
+    display: 'block',
+    width: '150px',
+  },
+});
+
+export const AutoSizeForSmallViewport = () => {
+  const styles = useStyles();
+  const [boundaryRef, setBoundaryRef] = React.useState<HTMLDivElement | null>(null);
+  const [open, setOpen] = React.useState(false);
+  const [menuItemCount, setMenuItemCount] = React.useState(10);
+
+  return (
+    <>
+      <div>
+        <Checkbox
+          labelPosition="before"
+          label="Open"
+          checked={open}
+          onChange={(e, data) => setOpen(data.checked as boolean)}
+        />
+      </div>
+      <div>
+        <Label style={{ marginRight: 4, marginLeft: 8 }} htmlFor="menu-item-count">
+          Menu Item Count
+        </Label>
+        <SpinButton
+          id="menu-item-count"
+          value={menuItemCount}
+          onChange={(e, { value }) => value && setMenuItemCount(value)}
+        />
+      </div>
+      <div ref={setBoundaryRef} className={styles.boundary}>
+        <Menu
+          open={open}
+          positioning={{
+            overflowBoundary: boundaryRef,
+            flipBoundary: boundaryRef,
+            autoSize: true,
+          }}
+        >
+          <MenuTrigger disableButtonEnhancement>
+            <Button className={styles.trigger}>AutoSized Menu</Button>
+          </MenuTrigger>
+          <MenuPopover>
+            <MenuList>
+              {Array.from({ length: menuItemCount }, (_, i) => (
+                <MenuItem>Item {i}</MenuItem>
+              ))}
+            </MenuList>
+          </MenuPopover>
+        </Menu>
+      </div>
+    </>
+  );
+};
+
+AutoSizeForSmallViewport.parameters = {
+  docs: {
+    description: {
+      story:
+        '`autoSize` sets inline max-width and max-height styles to the element to ensure it fits within the available space.',
+    },
+  },
+};

--- a/packages/react-components/react-components/stories/Concepts/Positioning/index.stories.tsx
+++ b/packages/react-components/react-components/stories/Concepts/Positioning/index.stories.tsx
@@ -16,6 +16,7 @@ export { FlipBoundary } from './PositioningFlipBoundary.stories';
 export { MatchTargetSize } from './MatchTargetSize.stories';
 export { DisableTransform } from './PositioningDisableTransform.stories';
 export { ListenToUpdates } from './PositioningListenToUpdates.stories';
+export { AutoSizeForSmallViewport } from './PositioningAutoSize.stories';
 
 export default {
   title: 'Concepts/Developer/Positioning Components',


### PR DESCRIPTION
<img width="903" alt="Screenshot 2024-04-23 at 13 19 35" src="https://github.com/microsoft/fluentui/assets/28751745/58630132-4d2f-4ed6-979e-5942aedb8bd5">
