### PR TITLE
chore(tact-picker): ensures cursor looks like a text on whole control

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-b2bc6960-e8e7-4c20-a833-8f458640442b.json
+++ b/change/@fluentui-react-tag-picker-preview-b2bc6960-e8e7-4c20-a833-8f458640442b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensures cursor looks like a text on whole control",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
@@ -13,6 +13,18 @@ import { TagPickerOption } from '../TagPickerOption/TagPickerOption';
 import { Avatar } from '@fluentui/react-avatar';
 import { Button } from '@fluentui/react-button';
 
+/**
+ * This error means that ResizeObserver
+ * was not able to deliver all observations within a single animation frame.
+ * https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+ */
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+Cypress.on('uncaught:exception', err => {
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false;
+  }
+});
+
 const mount = (element: JSX.Element) => {
   mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
 };

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -81,7 +81,15 @@ export const useTagPickerControl_unstable = (
   const aside = slot.optional<ExtractSlotProps<Slot<'span'>>>(undefined, {
     elementType: 'span',
     renderByDefault: Boolean(secondaryAction || expandIcon),
-    defaultProps: { ref: observerRef },
+    defaultProps: {
+      ref: observerRef,
+      onClick: useEventCallback(event => {
+        // if it's a click on the aside itself, we want to focus the trigger
+        if (event.target === event.currentTarget) {
+          triggerRef.current?.focus();
+        }
+      }),
+    },
   });
   return {
     components: {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -156,11 +156,15 @@ const useStyles = makeStyles({
 
 const useAsideStyles = makeStyles({
   root: {
-    display: 'flex',
+    display: 'grid',
     alignItems: 'center',
     position: 'absolute',
     top: '0',
     right: tokens.spacingHorizontalM,
+    gridTemplateColumns: 'repeat(2, auto)',
+    gridTemplateRows: 'minmax(32px, auto) 1fr',
+    height: '100%',
+    cursor: 'text',
   },
   // size variants
   medium: {

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -42,7 +42,15 @@ export const useTagPickerGroup_unstable = (
       size,
       appearance: tagPickerAppearanceToTagAppearance(appearance),
       dismissible: true,
+      onClick: useEventCallback(event => {
+        props.onClick?.(event);
+        // if it's a click on the group itself, we want to focus the trigger
+        if (event.target === event.currentTarget) {
+          triggerRef.current?.focus();
+        }
+      }),
       onKeyDown: useEventCallback(event => {
+        props.onKeyDown?.(event);
         if (isHTMLElement(event.target) && event.key === ArrowRight) {
           triggerRef.current?.focus();
         }

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
   root: {
     flexWrap: 'wrap',
     boxSizing: 'border-box',
+    cursor: 'text',
   },
   // size variants
   medium: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

<img width="483" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/d18cc39a-3247-4bfb-9afd-3dc93e51e7f3">


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. ensures cursor looks like a text on whole control, even on dead parts of it (everything bellow secondary action and expand icon is not used as input)
2. adds exception on cypress for false positive error about ResizeObserver (https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded , https://github.com/cypress-io/cypress/issues/20341)


<img width="492" alt="image" src="https://github.com/microsoft/fluentui/assets/5483269/2719503a-4a0a-485c-afe5-c85822ffbd52">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
