### PR TITLE
Cleanup/teaching popover

### DIFF
--- a/change/@fluentui-react-teaching-popover-e15e7050-bc2b-4db9-b444-cc75cee031a3.json
+++ b/change/@fluentui-react-teaching-popover-e15e7050-bc2b-4db9-b444-cc75cee031a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix TeachingPopover package name in LICENSE file and import path in bundle size",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/LICENSE
+++ b/packages/react-components/react-teaching-popover/LICENSE
@@ -1,4 +1,4 @@
-@fluentui/react-teaching-popover-preview
+@fluentui/react-teaching-popover
 
 Copyright (c) Microsoft Corporation
 

--- a/packages/react-components/react-teaching-popover/bundle-size/TeachingPopover.fixture.js
+++ b/packages/react-components/react-teaching-popover/bundle-size/TeachingPopover.fixture.js
@@ -1,4 +1,4 @@
-import { TeachingPopover } from '@fluentui/react-teaching-popover-preview';
+import { TeachingPopover } from '@fluentui/react-teaching-popover';
 
 console.log(TeachingPopover);
 


### PR DESCRIPTION
## Previous Behavior

1. Had the wrong package name in the LICENSE file
2. Imported from the `-preview` version of the package for bundle size tests.

## New Behavior

Use the correct package name in both instances.