### PR TITLE
fix: TeachingPopover arrow off by a pixel

### DIFF
--- a/change/@fluentui-react-teaching-popover-b32cb5ff-1e29-4c94-bb2d-a5ad448d78f9.json
+++ b/change/@fluentui-react-teaching-popover-b32cb5ff-1e29-4c94-bb2d-a5ad448d78f9.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "visual bug fix",
+  "comment": "fix: Arrow was 1px offset and incorrect box-sizing",
   "packageName": "@fluentui/react-teaching-popover",
   "email": "edwardwang.94@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-teaching-popover-b32cb5ff-1e29-4c94-bb2d-a5ad448d78f9.json
+++ b/change/@fluentui-react-teaching-popover-b32cb5ff-1e29-4c94-bb2d-a5ad448d78f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "visual bug fix",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "edwardwang.94@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
@@ -7,32 +7,34 @@ export const teachingPopoverBodyClassNames: SlotClassNames<TeachingPopoverBodySl
   media: 'fui-TeachingPopoverBody__media',
 };
 
+const popoverBodyDimension = 288;
+
 export const useMediaStyles = makeStyles({
   base: {
     ...shorthands.gridArea('media'),
     ...shorthands.overflow('hidden'),
-    width: '288px',
+    width: `${popoverBodyDimension}px`,
     marginBottom: '12px',
     verticalAlign: 'middle',
     justifyContent: 'center',
     display: 'flex',
   },
   short: {
-    aspectRatio: 288 / 117,
+    aspectRatio: popoverBodyDimension / 117,
     '@supports not (aspect-ratio)': {
       height: '117px',
     },
   },
   medium: {
-    aspectRatio: 288 / 176,
+    aspectRatio: popoverBodyDimension / 176,
     '@supports not (aspect-ratio)': {
       height: '176px',
     },
   },
   tall: {
-    aspectRatio: 288 / 288,
+    aspectRatio: popoverBodyDimension / popoverBodyDimension,
     '@supports not (aspect-ratio)': {
-      height: '288px',
+      height: `${popoverBodyDimension}px`,
     },
   },
 });

--- a/packages/react-components/react-teaching-popover/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
@@ -12,9 +12,8 @@ const useStyles = makeStyles({
   root: {
     ...shorthands.padding(tokens.spacingVerticalL, tokens.spacingVerticalL),
     ...shorthands.borderRadius(tokens.borderRadiusXLarge),
-    ...shorthands.borderWidth('0px'),
-    width: '320px',
-    boxSizing: 'border-box',
+    width: '288px',
+    boxSizing: 'content-box',
   },
 });
 


### PR DESCRIPTION
## Previous Behavior

![react fluentui dev__path=_docs_components-teachingpopover--default (1)](https://github.com/microsoft/fluentui/assets/11350529/75fb4916-f5a2-46e0-9829-a9cb4d6d6737)

The arrow is off by 1px
![image](https://github.com/microsoft/fluentui/assets/11350529/8c34dfbc-bee1-4874-875f-b291d34495b8)


## New Behavior

![localhost_3000__path=_docs_components-teachingpopover--default](https://github.com/microsoft/fluentui/assets/11350529/690d8e2d-aabb-4f0f-9a94-bce87f836dbb)

The arrow is no longer off by 1px
![image](https://github.com/microsoft/fluentui/assets/11350529/9ef95521-76bb-4da3-9908-bf8c3a81b176)


## Related Issue(s)

Previously the `...shorthands.borderWidth('0px'),` was introduced here: https://github.com/microsoft/fluentui/pull/30270

It was done so because the items within the TeachingPopoverSurface did not align:
![Screenshot 2024-04-23 at 4 10 15 PM](https://github.com/microsoft/fluentui/assets/11350529/23ce56ea-6db9-4143-8536-3a0e86b82a6c)

By changing the `boxSizing` from `'border-box'` to `'content-box'`
![image](https://github.com/microsoft/fluentui/assets/11350529/34d47892-c055-4d28-bc1f-eceb45dddefa)


## open questions?
- Not sure if this is the right way to do things. Open to suggestions.