### PR TITLE
Check empty string and 0 for combobox

### DIFF
--- a/change/@fluentui-react-combobox-0d7b531b-8a4d-40aa-9081-d164d87f2ba8.json
+++ b/change/@fluentui-react-combobox-0d7b531b-8a4d-40aa-9081-d164d87f2ba8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix combobox empty string and zero value",
+  "packageName": "@fluentui/react-combobox",
+  "email": "mingyuanyu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/src/components/Option/useOption.tsx
@@ -61,7 +61,7 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
   const selected = useListboxContext_unstable(ctx => {
     const selectedOptions = ctx.selectedOptions;
 
-    return !!optionValue && !!selectedOptions.find(o => o === optionValue);
+    return optionValue !== undefined && selectedOptions.find(o => o === optionValue) !== undefined;
   });
   const selectOption = useListboxContext_unstable(ctx => ctx.selectOption);
   const onOptionClick = useListboxContext_unstable(ctx => ctx.onOptionClick);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Selected Combobox and Dropdown option with "" or 0 value do not show CheckIcon.
<!-- This is the behavior we have today -->

## New Behavior
Selected Combobox and Dropdown option with "" or 0 value show CheckIcon.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/microsoft/fluentui/issues/30924

- Fixes #30924
