### PR TITLE
chore(react-tag-picker): removes aria-checked from TagPickerOption

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-11ab6472-b215-4f46-8791-45430fdb2857.json
+++ b/change/@fluentui-react-tag-picker-preview-11ab6472-b215-4f46-8791-45430fdb2857.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: removes aria-checked from TagPickerOption",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerOption/useTagPickerOption.ts
@@ -30,7 +30,7 @@ export const useTagPickerOption_unstable = (
       elementType: 'span',
     }),
     root: slot.always(
-      { ...optionState.root, role: 'option' },
+      { ...optionState.root, role: 'option', 'aria-checked': props['aria-checked'] },
       {
         elementType: 'div',
       },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. removes  `aria-checked` property from `TagPickerOption`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
