### PR TITLE
fix(PresenceGroup): cleanup children properly

### DIFF
--- a/change/@fluentui-react-motions-preview-d544a8a1-37e7-4f26-8891-8a5dc747582b.json
+++ b/change/@fluentui-react-motions-preview-d544a8a1-37e7-4f26-8891-8a5dc747582b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(PresenceGroup): cleanup children properly",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/config/tests.js
+++ b/packages/react-components/react-motions-preview/config/tests.js
@@ -1,1 +1,3 @@
 /** Jest test setup file. */
+
+require('@testing-library/jest-dom');

--- a/packages/react-components/react-motions-preview/src/components/PresenceGroup.tsx
+++ b/packages/react-components/react-motions-preview/src/components/PresenceGroup.tsx
@@ -41,7 +41,7 @@ export class PresenceGroup extends React.Component<PresenceGroupProps, PresenceG
     };
   }
 
-  #handleExit(childKey: string) {
+  #handleExit = (childKey: string) => {
     const currentChildMapping = getChildMapping(this.props.children);
 
     if (childKey in currentChildMapping) {
@@ -56,7 +56,7 @@ export class PresenceGroup extends React.Component<PresenceGroupProps, PresenceG
         return { childMapping };
       });
     }
-  }
+  };
 
   componentDidMount() {
     this.#mounted = true;

--- a/packages/react-components/react-motions-preview/src/components/PresenceGroupItemProvider.tsx
+++ b/packages/react-components/react-motions-preview/src/components/PresenceGroupItemProvider.tsx
@@ -3,9 +3,12 @@ import * as React from 'react';
 import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
 import type { PresenceGroupChildContextValue } from '../contexts/PresenceGroupChildContext';
 
-type PresenceGroupItemProviderProps = PresenceGroupChildContextValue & {
+type PresenceGroupItemProviderProps = Omit<PresenceGroupChildContextValue, 'onExit'> & {
   children: React.ReactElement;
   childKey: string;
+  // That's an internal callback, so we don't need to enforce the type here
+  // eslint-disable-next-line @nx/workspace-consistent-callback-type
+  onExit: (childKey: string) => void;
 };
 
 /**

--- a/packages/react-components/react-motions-preview/src/contexts/PresenceGroupChildContext.ts
+++ b/packages/react-components/react-motions-preview/src/contexts/PresenceGroupChildContext.ts
@@ -8,7 +8,7 @@ export type PresenceGroupChildContextValue = {
   visible: boolean;
   unmountOnExit: boolean;
 
-  onExit: (childKey: string) => void;
+  onExit: () => void;
 };
 
 /**

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import type { PresenceMotion } from '../types';
 import { createPresenceComponent } from './createPresenceComponent';
+import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
 
 const enterKeyframes = [{ opacity: 0 }, { opacity: 1 }];
 const exitKeyframes = [{ opacity: 1 }, { opacity: 0 }];
@@ -203,5 +204,43 @@ describe('createPresenceComponent', () => {
 
       expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
     });
+  });
+});
+
+describe('PresenceGroupChildContext', () => {
+  it('calls "onExit" when "visible" changes to "false"', () => {
+    const onExit = jest.fn();
+    const TestAtom = createPresenceComponent(motion);
+    const { ElementMock } = createElementMock();
+
+    const Wrapper: React.FC<{ visible: boolean }> = ({ children, visible }) => (
+      <PresenceGroupChildContext.Provider value={{ appear: false, onExit, visible, unmountOnExit: true }}>
+        {children}
+      </PresenceGroupChildContext.Provider>
+    );
+
+    const { queryByText, rerender } = render(
+      <Wrapper visible>
+        <TestAtom>
+          <ElementMock />
+        </TestAtom>
+      </Wrapper>,
+    );
+
+    expect(queryByText('ElementMock')).toBeTruthy();
+    expect(onExit).toHaveBeenCalledTimes(0);
+
+    // ---
+
+    rerender(
+      <Wrapper visible={false}>
+        <TestAtom>
+          <ElementMock />
+        </TestAtom>
+      </Wrapper>,
+    );
+
+    expect(queryByText('ElementMock')).toBe(null);
+    expect(onExit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
@@ -66,6 +66,7 @@ export function createPresenceComponent(motion: PresenceMotion | PresenceMotionF
 
       if (unmountOnExit) {
         setMounted(false);
+        itemContext?.onExit();
       }
     });
 

--- a/packages/react-components/react-motions-preview/tsconfig.spec.json
+++ b/packages/react-components/react-motions-preview/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "dist",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
## New Behavior

Calls `onExit()` from a parent context to properly unmounted and fix zombie children.

## Related Issue(s)

Fixes #31174.
