### PR TITLE
fix(web-components): ensure buttons with long text maintain center alignment

### DIFF
--- a/change/@fluentui-web-components-1441c105-086f-424c-a9f3-9fbc8c070e50.json
+++ b/change/@fluentui-web-components-1441c105-086f-424c-a9f3-9fbc8c070e50.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ensure buttons with long text maintain center alignment",
+  "packageName": "@fluentui/web-components",
+  "email": "=",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -72,6 +72,7 @@ export const styles = css`
     align-items: center;
     box-sizing: border-box;
     justify-content: center;
+    text-align: center;
     text-decoration-line: none;
     margin: 0;
     min-height: 32px;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Behavior regressed for buttons with long text.

## New Behavior
This PR ensures that buttons with long text have the text center aligned when wrapping.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
