### PR TITLE
Tabster 7.1.1 and v8 v9 interop improvement

### DIFF
--- a/change/@fluentui-react-dbf5be0d-3f74-47d8-b010-40e86d3fee7e.json
+++ b/change/@fluentui-react-dbf5be0d-3f74-47d8-b010-40e86d3fee7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Making sure V9 dialog doesn't set aria-hidden on a host element that is used as a container for V8 popups, dropdowns and menus.",
+  "packageName": "@fluentui/react",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-e823c5ba-242f-49ee-a806-9b7e24b81921.json
+++ b/change/@fluentui-react-tabster-e823c5ba-242f-49ee-a806-9b7e24b81921.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pulling Tabster 7.1.1 that supports more granular configuration of the aria-hidden handling for modal dialogs.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -37,7 +37,7 @@
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",
     "keyborg": "^2.5.0",
-    "tabster": "^7.1.0"
+    "tabster": "^7.1.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22863,10 +22863,10 @@ table@^6.0.4, table@^6.0.7:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-7.1.0.tgz#30110aa56ed7d90db468577ab891a609c8c5db62"
-  integrity sha512-/saGl9AYqgjAe5yZWQsnbtBwXTK+tDXm93ipxAARxhX0jP2xiQbPgykybzU7li6H4mJtTw0GnK51w6A0mMvx3Q==
+tabster@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-7.1.1.tgz#8d1ed706a6af08c140c60127e29714b03a520331"
+  integrity sha512-3VsXUb0XxVcFq9NmzTieAJAlruMiaj/dvXIHm7RgjsUrMGkEcq9KbBdai05NAGp2D2d/CxHc6j1mbuUzGofWBA==
   dependencies:
     keyborg "2.5.0"
     tslib "^2.3.1"


### PR DESCRIPTION
Making sure V9 dialog doesn't set aria-hidden on a host element that is used as a container for V8 popups, dropdowns and menus. To address https://github.com/microsoft/fluentui/issues/30545.