### PR TITLE
bugfix: open/close animation jumps when body is scrollable

### DIFF
--- a/change/@fluentui-react-dialog-64487e2f-fbe5-47c6-9c00-05c8c37b74d7.json
+++ b/change/@fluentui-react-dialog-64487e2f-fbe5-47c6-9c00-05c8c37b74d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: open/close animation jumps when body is scrollable",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-dialog/src/components/Dialog/Dialog.cy.tsx
@@ -296,30 +296,33 @@ describe('Dialog', () => {
     });
     it('should lock body scroll when dialog open', () => {
       mount(
-        <Dialog modalType="modal">
-          <DialogTrigger disableButtonEnhancement>
-            <Button id={dialogTriggerOpenId}>Open dialog</Button>
-          </DialogTrigger>
-          <DialogSurface>
-            <DialogTitle>Dialog title</DialogTitle>
-            <DialogBody>
-              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque
-              est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure
-              cumque eaque?
-            </DialogBody>
-            <DialogActions>
-              <DialogTrigger disableButtonEnhancement>
-                <Button id={dialogTriggerCloseId} appearance="secondary">
-                  Close
-                </Button>
-              </DialogTrigger>
-              <Button appearance="primary">Do Something</Button>
-            </DialogActions>
-          </DialogSurface>
-        </Dialog>,
+        <>
+          <Dialog modalType="modal">
+            <DialogTrigger disableButtonEnhancement>
+              <Button id={dialogTriggerOpenId}>Open dialog</Button>
+            </DialogTrigger>
+            <DialogSurface>
+              <DialogTitle>Dialog title</DialogTitle>
+              <DialogBody>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus
+                eaque est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in
+                natus iure cumque eaque?
+              </DialogBody>
+              <DialogActions>
+                <DialogTrigger disableButtonEnhancement>
+                  <Button id={dialogTriggerCloseId} appearance="secondary">
+                    Close
+                  </Button>
+                </DialogTrigger>
+                <Button appearance="primary">Do Something</Button>
+              </DialogActions>
+            </DialogSurface>
+          </Dialog>
+          {lorem}
+        </>,
       );
       cy.get(dialogTriggerOpenSelector).realClick();
-      cy.get('body').should('have.css', 'overflow', 'hidden');
+      cy.get('html').should('have.css', 'overflow', 'visible clip');
     });
 
     it('should focus trap by default', () => {
@@ -418,32 +421,35 @@ describe('Dialog', () => {
     });
     it('should not lock body scroll when dialog open', () => {
       mount(
-        <Dialog modalType="non-modal">
-          <DialogTrigger disableButtonEnhancement>
-            <Button id={dialogTriggerOpenId}>Open dialog</Button>
-          </DialogTrigger>
-          <DialogSurface>
-            <DialogBody>
-              <DialogTitle>Dialog title</DialogTitle>
-              <DialogContent>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus
-                eaque est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in
-                natus iure cumque eaque?
-              </DialogContent>
-              <DialogActions>
-                <DialogTrigger disableButtonEnhancement>
-                  <Button id={dialogTriggerCloseId} appearance="secondary">
-                    Close
-                  </Button>
-                </DialogTrigger>
-                <Button appearance="primary">Do Something</Button>
-              </DialogActions>
-            </DialogBody>
-          </DialogSurface>
-        </Dialog>,
+        <>
+          <Dialog modalType="non-modal">
+            <DialogTrigger disableButtonEnhancement>
+              <Button id={dialogTriggerOpenId}>Open dialog</Button>
+            </DialogTrigger>
+            <DialogSurface>
+              <DialogBody>
+                <DialogTitle>Dialog title</DialogTitle>
+                <DialogContent>
+                  Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus
+                  eaque est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in
+                  natus iure cumque eaque?
+                </DialogContent>
+                <DialogActions>
+                  <DialogTrigger disableButtonEnhancement>
+                    <Button id={dialogTriggerCloseId} appearance="secondary">
+                      Close
+                    </Button>
+                  </DialogTrigger>
+                  <Button appearance="primary">Do Something</Button>
+                </DialogActions>
+              </DialogBody>
+            </DialogSurface>
+          </Dialog>
+          {lorem}
+        </>,
       );
       cy.get(dialogTriggerOpenSelector).realClick();
-      cy.get('body').should('not.have.css', 'overflow', 'hidden');
+      cy.get('html').should('not.have.css', 'overflow', 'visible clip');
     });
     it('should be able to focus inside non-modal dialog after navigating outside', () => {
       mount(
@@ -510,32 +516,35 @@ describe('Dialog', () => {
     });
     it('should lock body scroll when dialog open', () => {
       mount(
-        <Dialog modalType="alert">
-          <DialogTrigger disableButtonEnhancement>
-            <Button id={dialogTriggerOpenId}>Open dialog</Button>
-          </DialogTrigger>
-          <DialogSurface>
-            <DialogBody>
-              <DialogTitle>Dialog title</DialogTitle>
-              <DialogContent>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus
-                eaque est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in
-                natus iure cumque eaque?
-              </DialogContent>
-              <DialogActions>
-                <DialogTrigger disableButtonEnhancement>
-                  <Button id={dialogTriggerCloseId} appearance="secondary">
-                    Close
-                  </Button>
-                </DialogTrigger>
-                <Button appearance="primary">Do Something</Button>
-              </DialogActions>
-            </DialogBody>
-          </DialogSurface>
-        </Dialog>,
+        <>
+          <Dialog modalType="alert">
+            <DialogTrigger disableButtonEnhancement>
+              <Button id={dialogTriggerOpenId}>Open dialog</Button>
+            </DialogTrigger>
+            <DialogSurface>
+              <DialogBody>
+                <DialogTitle>Dialog title</DialogTitle>
+                <DialogContent>
+                  Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus
+                  eaque est dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in
+                  natus iure cumque eaque?
+                </DialogContent>
+                <DialogActions>
+                  <DialogTrigger disableButtonEnhancement>
+                    <Button id={dialogTriggerCloseId} appearance="secondary">
+                      Close
+                    </Button>
+                  </DialogTrigger>
+                  <Button appearance="primary">Do Something</Button>
+                </DialogActions>
+              </DialogBody>
+            </DialogSurface>
+          </Dialog>
+          {lorem}
+        </>,
       );
       cy.get(dialogTriggerOpenSelector).realClick();
-      cy.get('body').should('have.css', 'overflow', 'hidden');
+      cy.get('html').should('have.css', 'overflow', 'visible clip');
     });
     it('should focus trap by default', () => {
       mount(
@@ -654,3 +663,15 @@ describe('Dialog', () => {
     cy.get('#first-dialog').should('not.exist');
   });
 });
+
+const lorem = (
+  <>
+    {Array.from({ length: 10 }, (_, i) => (
+      <p key={i}>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam exercitationem cumque repellendus eaque est
+        dolor eius expedita nulla ullam? Tenetur reprehenderit aut voluptatum impedit voluptates in natus iure cumque
+        eaque?
+      </p>
+    ))}
+  </>
+);

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -37,19 +37,26 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
   });
 
   const focusRef = useFocusFirstElement(open, modalType);
-  const disableBodyScroll = useDisableBodyScroll();
-  const isBodyScrollLocked = Boolean(open && modalType !== 'non-modal');
-
-  useIsomorphicLayoutEffect(() => {
-    if (isBodyScrollLocked) {
-      return disableBodyScroll();
-    }
-  }, [disableBodyScroll, isBodyScrollLocked]);
 
   const { modalAttributes, triggerAttributes } = useModalAttributes({
     trapFocus: modalType !== 'non-modal',
     legacyTrapFocus: !inertTrapFocus,
   });
+
+  const isNestedDialog = useHasParentContext(DialogContext);
+
+  const { disableBodyScroll, enableBodyScroll } = useDisableBodyScroll();
+  const isBodyScrollLocked = Boolean(open && modalType !== 'non-modal');
+  useIsomorphicLayoutEffect(() => {
+    if (isNestedDialog) {
+      return;
+    }
+    if (open && isBodyScrollLocked) {
+      disableBodyScroll();
+    } else {
+      enableBodyScroll();
+    }
+  }, [disableBodyScroll, enableBodyScroll, isBodyScrollLocked, isNestedDialog, open]);
 
   return {
     components: {
@@ -62,7 +69,7 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
     trigger,
     requestOpenChange,
     dialogTitleId: useId('dialog-title-'),
-    isNestedDialog: useHasParentContext(DialogContext),
+    isNestedDialog,
     dialogRef: focusRef,
     modalAttributes: modalType !== 'non-modal' ? modalAttributes : undefined,
     triggerAttributes,

--- a/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.ts
+++ b/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.ts
@@ -1,55 +1,45 @@
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
+import { makeResetStyles } from '@griffel/react';
 import { useCallback } from 'react';
 
-const disableScrollElementProp = '__fluentDisableScrollElement' as const;
-
-type FluentDisableScrollElement = HTMLElement & {
-  [disableScrollElementProp]: {
-    count: number;
-    previousOverflowStyle: string;
-    previousPaddingRightStyle: string;
-  };
-};
+// this style must be applied to the html element to disable scrolling
+const useHTMLNoScrollStyles = makeResetStyles({
+  overflowY: ['hidden', 'clip'],
+  scrollbarGutter: 'stable',
+});
 
 /**
- * hook that disables body scrolling through `overflow: hidden` CSS property
+ * hook that disables body scrolling through `overflowY: hidden` CSS property
  */
-export function useDisableBodyScroll() {
+export function useDisableBodyScroll(): {
+  disableBodyScroll: () => void;
+  enableBodyScroll: () => void;
+} {
+  const htmlNoScrollStyle = useHTMLNoScrollStyles();
   const { targetDocument } = useFluent_unstable();
-  return useCallback(() => {
-    if (targetDocument) {
-      return disableScroll(targetDocument.body);
-    }
-  }, [targetDocument]);
-}
 
-/**
- * disables scrolling from a given element through `overflow: hidden` CSS property
- * @param target - element to disable scrolling from
- * @returns a method for enabling scrolling again
- */
-export function disableScroll(target: HTMLElement) {
-  const { clientWidth } = target.ownerDocument.documentElement;
-  const innerWidth = target.ownerDocument.defaultView?.innerWidth ?? 0;
-  assertIsDisableScrollElement(target);
-  if (target[disableScrollElementProp].count === 0) {
-    target.style.overflow = 'hidden';
-    target.style.paddingRight = `${innerWidth - clientWidth}px`;
-  }
-  target[disableScrollElementProp].count++;
-  return () => {
-    target[disableScrollElementProp].count--;
-    if (target[disableScrollElementProp].count === 0) {
-      target.style.overflow = target[disableScrollElementProp].previousOverflowStyle;
-      target.style.paddingRight = target[disableScrollElementProp].previousPaddingRightStyle;
+  const disableBodyScroll = useCallback(() => {
+    if (!targetDocument) {
+      return;
     }
-  };
-}
+    const isScrollbarVisible =
+      (targetDocument.defaultView?.innerWidth ?? 0) > targetDocument.documentElement.clientWidth;
+    if (!isScrollbarVisible) {
+      return;
+    }
+    targetDocument.documentElement.classList.add(htmlNoScrollStyle);
+    return;
+  }, [targetDocument, htmlNoScrollStyle]);
 
-function assertIsDisableScrollElement(element: HTMLElement): asserts element is FluentDisableScrollElement {
-  (element as FluentDisableScrollElement)[disableScrollElementProp] ??= {
-    count: 0,
-    previousOverflowStyle: element.style.overflow,
-    previousPaddingRightStyle: element.style.paddingRight,
+  const enableBodyScroll = useCallback(() => {
+    if (!targetDocument) {
+      return;
+    }
+    targetDocument.documentElement.classList.remove(htmlNoScrollStyle);
+  }, [targetDocument, htmlNoScrollStyle]);
+
+  return {
+    disableBodyScroll,
+    enableBodyScroll,
   };
 }


### PR DESCRIPTION
See https://github.com/microsoft/fluentui/pull/31180 for more details. This might be a regression that was introduced once animations were applied to the `DialogSurface` component

https://github.com/microsoft/fluentui/assets/5483269/33e2ba69-b322-438a-8a7a-31bcd383790c

1. moves `useDisableBodyScroll` invocation from `Dialog` to `DialogSurface` (with comments on why that is not ideal and that we should move it back to `Dialog` once animations are modified)
   * moving to `DialogSurface` now is required to have access to `transitionStatus` to ensure the scroll styles are properly controlled once the animations are concluded
2. modifies `useDisableBodyScroll`
    * uses `makeStyles` instead of modifying `element.style` (less code)
    * uses `overflow-y: clip` with fallback to `hidden` ([griffel's fallback properties](https://griffel.js.org/react/api/make-styles#css-fallback-properties))
    * uses [`scrollbar-gutter`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) to avoid shifting from the body content (this is not supported by Safari/IOS Safari