### PR TITLE
Sankey diagram bug fix - Use the formatted node value instead of the raw value, to calculate text measurement.

### DIFF
--- a/change/@fluentui-react-charting-fa376ca6-a8af-40af-b196-3960a2a15f77.json
+++ b/change/@fluentui-react-charting-fa376ca6-a8af-40af-b196-3960a2a15f77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Sankey diagram bug fix - Use the formatted node value instead of the raw value, to calculate text measurement.",
+  "packageName": "@fluentui/react-charting",
+  "email": "lamalkar@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
Sometimes, sankey shows node value text outside the node rectangle. 
For example, let say we have following link from source node 1 to target node 2 with value `0.0945945945945946` (16 fraction digits)

```
{
                "source": 1,
                "target": 2,
                "value": 0.0945945945945946
}
```
The 16+digit value is too long to display. So, if we want to round off to 2 digits, and set the `formatNumberOptions` prop as follows:
```
        <SankeyChart
          data={data}
          accessibility={accessibilityStrings}
          formatNumberOptions={{
            maximumFractionDigits: 2,
          }}
        />
```
For the above configuration, the issue is that sankey diagram renders the node with overlapping name and number values making it unable to read. This is due to current way of calculating the node's attributes such as the text's offset using the raw value length (which is 16 fraction digits) instead of the formatted value length (which is 2 fraction digits).
![image](https://github.com/microsoft/fluentui/assets/15314579/c97da7e7-e07b-430a-8a49-1aa6a2e45e07)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

In this PR, we are honoring the text length of the formatted node value, while calculating node width limitations. We converted `computeNodeAttributes` to a private method and made a one-line code change to call measureText() method with the formatted node value as follows.
Before:
`const measurement = measureText(weightSpan, nodeValue);`
After
`const measurement = measureText(weightSpan, this._formatNumber(nodeValue));`

![image](https://github.com/microsoft/fluentui/assets/15314579/b9847855-2503-4c0b-8eaf-108514ee06ce)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
