### PR TITLE
feat(react-nav-preview): Set Nav drawer background color

### DIFF
--- a/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawer/useNavDrawerStyles.styles.ts
@@ -2,6 +2,7 @@ import { makeStyles, mergeClasses } from '@griffel/react';
 import type { InlineDrawerSlots } from '@fluentui/react-drawer';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { NavDrawerState } from './NavDrawer.types';
+import { navItemTokens } from '../sharedNavStyles.styles';
 
 export const navDrawerClassNames: SlotClassNames<InlineDrawerSlots> = {
   root: 'fui-NavDrawer',
@@ -13,6 +14,7 @@ export const navDrawerClassNames: SlotClassNames<InlineDrawerSlots> = {
 const useStyles = makeStyles({
   root: {
     width: '260px', // per spec
+    backgroundColor: navItemTokens.backgroundColor,
   },
 });
 

--- a/packages/react-components/react-nav-preview/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/sharedNavStyles.styles.ts
@@ -8,6 +8,9 @@ export const navItemTokens = {
   indicatorOffset: 18,
   indicatorWidth: 4,
   indicatorHeight: 20,
+  backgroundColor: tokens.colorNeutralBackground4,
+  backgroundColorHover: tokens.colorNeutralBackground4Hover,
+  backgroundColorPressed: tokens.colorNeutralBackground4Pressed,
 };
 
 /**
@@ -21,17 +24,17 @@ export const useRootDefaultClassName = makeResetStyles({
   justifyContent: 'start',
   gap: tokens.spacingVerticalL,
   padding: tokens.spacingVerticalMNudge,
-  backgroundColor: tokens.colorNeutralBackground4,
+  backgroundColor: navItemTokens.backgroundColor,
   borderRadius: tokens.borderRadiusMedium,
   color: tokens.colorNeutralForeground2,
   textDecorationLine: 'none',
   border: 'none',
   ...typographyStyles.body1,
   ':hover': {
-    backgroundColor: tokens.colorNeutralBackground4Hover,
+    backgroundColor: navItemTokens.backgroundColorHover,
   },
   ':active': {
-    backgroundColor: tokens.colorNeutralBackground4Pressed,
+    backgroundColor: navItemTokens.backgroundColorPressed,
   },
 });
 


### PR DESCRIPTION
Taking advantage of Marco's recent work on Drawer.

Creating a few nav specific color tokens. Applying the background color to the Drawer.

Before:
![image](https://github.com/microsoft/fluentui/assets/17346018/04ad4d22-da0f-4b59-a61b-c81a3ae93779)



After:
![image](https://github.com/microsoft/fluentui/assets/17346018/70b5aeed-c298-418f-948a-b5bbf9e5d257)

Ladders up to #26649 