### PR TITLE
feat(scripts-storybook): make getMetadata throwable via config to be able to process stories glob for packages no longer present in the repo

### DIFF
--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -243,7 +243,8 @@ function getPackageStoriesGlob(options) {
 
     const storiesGlob = '**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
 
-    // if defined package has stories project use that
+    // if defined package(project) has stories sibling project, that means we need to look for stories in sibling project as the original project doesn't have stories anymore
+    // @see https://github.com/microsoft/fluentui/issues/30516
     const pkgMetadataStories = projects.get(`${pkgName}-stories`);
     if (pkgMetadataStories) {
       acc.push(`${rootOffset}${pkgMetadataStories.root}/src/${storiesGlob}`);

--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -217,7 +217,9 @@ function getPackageStoriesGlob(options) {
   const projects = getAllProjects();
 
   const excludeStoriesInsertionFromPackages = options.excludeStoriesInsertionFromPackages ?? [];
-  const projectMetadata = getMetadata(options.packageName, projects);
+  const projectMetadata = /** @type {NonNullable<ReturnType<typeof getMetadata>>} */ (
+    getMetadata(options.packageName, projects)
+  );
 
   /** @type {{name:string;version:string;dependencies?:Record<string,string>}} */
   const packageJson = JSON.parse(
@@ -228,24 +230,37 @@ function getPackageStoriesGlob(options) {
   const rootOffset = offsetFromRoot(options.callerPath.replace(workspaceRoot, ''));
   const packages = Object.keys(dependencies);
 
-  const result = packages
-    .filter(pkgName => projects.has(pkgName) && !excludeStoriesInsertionFromPackages.includes(pkgName))
-    .map(pkgName => {
-      const storiesGlob = '**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
-      const pkgMetadata = getMetadata(pkgName, projects);
+  const result = packages.reduce((acc, pkgName) => {
+    if (!(pkgName.startsWith('@fluentui/') && !excludeStoriesInsertionFromPackages.includes(pkgName))) {
+      return acc;
+    }
 
-      if (fs.existsSync(path.resolve(workspaceRoot, pkgMetadata.root, 'stories'))) {
-        return `${rootOffset}${pkgMetadata.root}/stories/${storiesGlob}`;
-      }
+    const pkgMetadata = getMetadata(pkgName, projects, { throwIfNotFound: false });
 
-      // if defined package has stories project use that
-      const pkgMetadataStories = projects.get(`${pkgName}-stories`);
-      if (pkgMetadataStories) {
-        return `${rootOffset}${pkgMetadataStories.root}/src/${storiesGlob}`;
-      }
+    if (!pkgMetadata) {
+      return acc;
+    }
 
-      return `${rootOffset}${pkgMetadata.root}/src/${storiesGlob}`;
-    });
+    const storiesGlob = '**/@(index.stories.@(ts|tsx)|*.stories.mdx)';
+
+    // if defined package has stories project use that
+    const pkgMetadataStories = projects.get(`${pkgName}-stories`);
+    if (pkgMetadataStories) {
+      acc.push(`${rootOffset}${pkgMetadataStories.root}/src/${storiesGlob}`);
+      return acc;
+    }
+
+    const hasStoriesFolder = fs.existsSync(path.resolve(workspaceRoot, pkgMetadata.root, 'stories'));
+
+    if (hasStoriesFolder) {
+      acc.push(`${rootOffset}${pkgMetadata.root}/stories/${storiesGlob}`);
+      return acc;
+    }
+
+    acc.push(`${rootOffset}${pkgMetadata.root}/src/${storiesGlob}`);
+
+    return acc;
+  }, /** @type {string[]}*/ ([]));
 
   return result;
 
@@ -258,11 +273,20 @@ function getPackageStoriesGlob(options) {
     return getProjects(tree);
   }
 
-  function getMetadata(/** @type {string}*/ packageName, /** @type {ReturnType<typeof getAllProjects>}*/ allProjects) {
+  function getMetadata(
+    /** @type {string}*/ packageName,
+    /** @type {ReturnType<typeof getAllProjects>}*/ allProjects,
+    /** @type {Partial<{throwIfNotFound:boolean}>}*/ _options,
+  ) {
+    const { throwIfNotFound = true } = { ..._options };
     const metadata = allProjects.get(packageName);
 
     if (!metadata) {
-      throw new Error(`Project ${options.packageName} not found in workspace`);
+      if (throwIfNotFound) {
+        throw new Error(`Project "${packageName}" not found in workspace`);
+      }
+
+      return null;
     }
 
     return metadata;

--- a/scripts/storybook/src/utils.spec.js
+++ b/scripts/storybook/src/utils.spec.js
@@ -235,6 +235,11 @@ describe(`utils`, () => {
 
       expect(actual).not.toContain(expect.stringContaining('/react-text/stories/'));
     });
+
+    // @TODO: Once we will have at least 1 project migrated to the new structure we can enable/implement this test
+    it.todo(
+      `should generate storybook stories string array of glob based on package.json#dependencies field pointing to sibling /stories project if it exists`,
+    );
   });
 
   describe(`#processBabelLoaderOptions`, () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`getMetadata` will throw if dependency is not an workspace project

## New Behavior

- `getMetadata` will throw if dependency is not an workspace project only if explicitly set via new options API.
-  internal logic of `getPackageStoriesGlob` refactored to use Array.reduce for perf and simpler logic

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Unblocks https://github.com/microsoft/fluentui/pull/31007
