### PR TITLE
feat(test-ssr): add custom esbuild-plugin to properly resolve TS path aliases which stopped working starting esbuild 0.19

### DIFF
--- a/scripts/test-ssr/src/commands/main.ts
+++ b/scripts/test-ssr/src/commands/main.ts
@@ -141,6 +141,8 @@ export async function main(params: MainParams) {
   await buildAssets({
     chromeVersion: CHROME_VERSION,
 
+    distDirectory,
+
     esmEntryPoint,
     cjsEntryPoint,
 

--- a/scripts/test-ssr/src/esbuild-plugin.js
+++ b/scripts/test-ssr/src/esbuild-plugin.js
@@ -1,0 +1,47 @@
+// @ts-check
+const path = require('node:path');
+
+const { loadConfig } = require('tsconfig-paths');
+
+exports.tsConfigPathsPlugin = tsConfigPathsPlugin;
+
+/**
+ *
+ * @param {{cwd:string}} options
+ * @returns {import('esbuild').Plugin}
+ */
+function tsConfigPathsPlugin(options) {
+  const tsConfig = loadConfig(options.cwd);
+
+  if (tsConfig.resultType === 'failed') {
+    throw new Error(tsConfig.message);
+  }
+
+  const pathAliases = tsConfig.paths;
+
+  /** @type {import('esbuild').Plugin} */
+  const pluginConfig = {
+    name: 'tsconfig-paths',
+    setup({ onResolve }) {
+      onResolve({ filter: /.*/ }, args => {
+        const pathMapping = pathAliases[args.path];
+
+        if (!pathMapping) {
+          return null;
+        }
+
+        for (const dir of pathMapping) {
+          const absoluteImportPath = path.join(tsConfig.absoluteBaseUrl, dir);
+
+          if (absoluteImportPath) {
+            return { path: absoluteImportPath };
+          }
+        }
+
+        return { path: args.path };
+      });
+    },
+  };
+
+  return pluginConfig;
+}

--- a/scripts/test-ssr/src/utils/buildAssets.test.ts
+++ b/scripts/test-ssr/src/utils/buildAssets.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { stripIndents } from '@nx/devkit';
 import * as tmp from 'tmp';
 
 import { buildAssets } from './buildAssets';
@@ -9,71 +10,165 @@ function stripComments(content: string): string {
   return content.replace(/\/\/ .+/g, '');
 }
 
+async function setup(code: string) {
+  const filesDir = tmp.dirSync({ unsafeCleanup: true }).name;
+
+  const cjsEntryPoint = path.resolve(filesDir, 'cjs.js');
+  const esmEntryPoint = path.resolve(filesDir, 'esm.js');
+
+  const cjsOutfile = path.resolve(filesDir, 'cjs-out.js');
+  const esmOutfile = path.resolve(filesDir, 'esm-out.js');
+
+  await fs.promises.writeFile(cjsEntryPoint, code);
+  await fs.promises.writeFile(esmEntryPoint, code);
+
+  await fs.promises.mkdir(path.resolve(filesDir, 'packages/hello'), { recursive: true });
+  await fs.promises.writeFile(path.resolve(filesDir, 'packages/hello/index.ts'), `export const hello = 'hello';`);
+
+  const tsConfigPath = path.resolve(filesDir, 'tsconfig.json');
+  const tsConfigContent = {
+    compilerOptions: {
+      baseUrl: '.',
+      paths: {
+        '@proj/hello': ['packages/hello/index.ts'],
+      },
+    },
+  };
+
+  await fs.promises.writeFile(tsConfigPath, JSON.stringify(tsConfigContent, null, 2), { encoding: 'utf8' });
+
+  const getCjsContent = async () =>
+    stripIndents`${stripComments(await fs.promises.readFile(cjsOutfile, { encoding: 'utf8' }))}`;
+  const getEsmContent = async () =>
+    stripIndents`${stripComments(await fs.promises.readFile(esmOutfile, { encoding: 'utf8' }))}`;
+
+  const getCjsContentWithoutHelpers = (content: string) => content.split('\n').slice(-8).join('\n');
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateTsConfig = async (updater: (content: Record<string, any>) => typeof content) => {
+    const updatedContent = updater(tsConfigContent);
+    await fs.promises.writeFile(tsConfigPath, JSON.stringify(updatedContent, null, 2), { encoding: 'utf-8' });
+  };
+
+  return {
+    cjsOutfile,
+    esmOutfile,
+    cjsEntryPoint,
+    esmEntryPoint,
+    distDirectory: filesDir,
+    updateTsConfig,
+    getCjsContent,
+    getEsmContent,
+    getCjsContentWithoutHelpers,
+  };
+}
+
 describe('buildAssets', () => {
   it('compiles code to CJS & ESM', async () => {
-    const template = `
+    const template = stripIndents`
+      export const Foo = 'foo';
+    `;
+
+    const { getCjsContent, getEsmContent, getCjsContentWithoutHelpers, ...apiArgs } = await setup(template);
+
+    await buildAssets({
+      chromeVersion: 100,
+      ...apiArgs,
+    });
+
+    const cjsContent = await getCjsContent();
+    const esmContent = await getEsmContent();
+
+    const cjsContentWithoutHelpers = getCjsContentWithoutHelpers(cjsContent);
+
+    expect(cjsContentWithoutHelpers).toMatchInlineSnapshot(`
+      "
+
+      var cjs_exports = {};
+      __export(cjs_exports, {
+      Foo: () => Foo
+      });
+      module.exports = __toCommonJS(cjs_exports);
+      var Foo = \\"foo\\";"
+    `);
+    expect(esmContent).toMatchInlineSnapshot(`
+      "(() => {
+
+      var Foo = \\"foo\\";
+      })();"
+    `);
+  }, /* Sets 15s timeout to allow for the build to complete */ 15000);
+
+  it('resolves package imports via TS path aliases', async () => {
+    const template = stripIndents`
       import { hello } from '@proj/hello';
 
       export const Foo = 'foo' + hello
       `;
 
-    const filesDir = tmp.dirSync({ unsafeCleanup: true }).name;
-
-    const cjsEntryPoint = path.resolve(filesDir, 'cjs.js');
-    const esmEntryPoint = path.resolve(filesDir, 'esm.js');
-
-    const cjsOutfile = path.resolve(filesDir, 'cjs-out.js');
-    const esmOutfile = path.resolve(filesDir, 'esm-out.js');
-
-    await fs.promises.writeFile(
-      path.resolve(filesDir, 'tsconfig.json'),
-      JSON.stringify({
-        compilerOptions: {
-          baseUrl: '.',
-          paths: {
-            '@proj/hello': ['packages/hello/index.ts'],
-          },
-        },
-      }),
-    );
-    await fs.promises.mkdir(path.resolve(filesDir, 'packages/hello'), { recursive: true });
-    await fs.promises.writeFile(path.resolve(filesDir, 'packages/hello/index.ts'), `export const hello = 'hello';`);
-    await fs.promises.writeFile(cjsEntryPoint, template);
-    await fs.promises.writeFile(esmEntryPoint, template);
+    const {
+      getCjsContent,
+      getEsmContent,
+      getCjsContentWithoutHelpers,
+      updateTsConfig: _,
+      ...apiArgs
+    } = await setup(template);
 
     await buildAssets({
       chromeVersion: 100,
-      cjsEntryPoint,
-      cjsOutfile,
-      esmEntryPoint,
-      esmOutfile,
-      distDirectory: filesDir,
+      ...apiArgs,
     });
 
-    const cjsContent = stripComments(await fs.promises.readFile(cjsOutfile, { encoding: 'utf8' }));
-    const esmContent = stripComments(await fs.promises.readFile(esmOutfile, { encoding: 'utf8' }));
+    const cjsContent = await getCjsContent();
+    const esmContent = await getEsmContent();
 
-    const cjsContentWithoutHelpers = cjsContent.split('\n').slice(-8).join('\n');
+    const cjsContentWithoutHelpers = getCjsContentWithoutHelpers(cjsContent);
 
     expect(cjsContentWithoutHelpers).toMatchInlineSnapshot(`
-      "module.exports = __toCommonJS(cjs_exports);
+      "});
+      module.exports = __toCommonJS(cjs_exports);
 
 
       var hello = \\"hello\\";
 
 
-      var Foo = \\"foo\\" + hello;
-      "
+      var Foo = \\"foo\\" + hello;"
     `);
     expect(esmContent).toMatchInlineSnapshot(`
       "(() => {
-        
-        var hello = \\"hello\\";
 
-        
-        var Foo = \\"foo\\" + hello;
-      })();
-      "
+      var hello = \\"hello\\";
+
+
+      var Foo = \\"foo\\" + hello;
+      })();"
     `);
-  }, /* Sets 15s timeout to allow for the build to complete */ 15000);
+  });
+
+  it('fails if TS path aliases path mapping contains unsupported pattern', async () => {
+    const template = stripIndents`
+      import { hello } from '@proj/hello';
+
+      export const Foo = 'foo' + hello
+      `;
+
+    const { getCjsContent, getEsmContent, getCjsContentWithoutHelpers, updateTsConfig, ...apiArgs } = await setup(
+      template,
+    );
+
+    await updateTsConfig(content => {
+      const currentMapping = content.compilerOptions.paths['@proj/hello'];
+      content.compilerOptions.paths['@proj/hello'] = [...currentMapping, 'packages/hello/foo.ts'];
+      return content;
+    });
+
+    await expect(
+      buildAssets({
+        chromeVersion: 100,
+        ...apiArgs,
+      }),
+    ).rejects.toMatchInlineSnapshot(
+      `[Error: Multiple TS path mappings are not supported. Please adjust your config. "@proj/hello": [ packages/hello/index.ts,packages/hello/foo.ts ]"]`,
+    );
+  });
 });

--- a/scripts/test-ssr/src/utils/buildAssets.ts
+++ b/scripts/test-ssr/src/utils/buildAssets.ts
@@ -1,7 +1,7 @@
 import { build } from 'esbuild';
 import type { BuildOptions } from 'esbuild';
 
-import { tsConfigPathsPlugin } from '../esbuild-plugin';
+import { tsConfigPathsPlugin } from './esbuild-plugin';
 
 const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
 

--- a/scripts/test-ssr/src/utils/buildAssets.ts
+++ b/scripts/test-ssr/src/utils/buildAssets.ts
@@ -1,6 +1,8 @@
 import { build } from 'esbuild';
 import type { BuildOptions } from 'esbuild';
 
+import { tsConfigPathsPlugin } from '../esbuild-plugin';
+
 const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
 
 const commonOptions: BuildOptions = {
@@ -21,10 +23,14 @@ type BuildConfig = {
   esmOutfile: string;
 
   chromeVersion: number;
+
+  distDirectory: string;
 };
 
 export async function buildAssets(config: BuildConfig): Promise<void> {
-  const { chromeVersion, cjsEntryPoint, cjsOutfile, esmEntryPoint, esmOutfile } = config;
+  const { chromeVersion, cjsEntryPoint, cjsOutfile, esmEntryPoint, esmOutfile, distDirectory } = config;
+
+  const pluginInstance = tsConfigPathsPlugin({ cwd: distDirectory });
 
   try {
     // Used for SSR rendering, see renderToHTML.js
@@ -38,6 +44,7 @@ export async function buildAssets(config: BuildConfig): Promise<void> {
       external: ['@griffel/core', '@griffel/react', 'react', 'react-dom', 'scheduler'],
       format: 'cjs',
       target: `node${NODE_MAJOR_VERSION}`,
+      plugins: [pluginInstance],
     });
 
     // Used in generated bundle that will be server by a browser
@@ -54,6 +61,7 @@ export async function buildAssets(config: BuildConfig): Promise<void> {
       ],
       format: 'iife',
       target: `chrome${chromeVersion}`,
+      plugins: [pluginInstance],
     });
   } catch (err) {
     throw new Error(

--- a/scripts/test-ssr/src/utils/esbuild-plugin.ts
+++ b/scripts/test-ssr/src/utils/esbuild-plugin.ts
@@ -1,16 +1,9 @@
-// @ts-check
-const path = require('node:path');
+import * as path from 'node:path';
 
-const { loadConfig } = require('tsconfig-paths');
+import type { Plugin } from 'esbuild';
+import { loadConfig } from 'tsconfig-paths';
 
-exports.tsConfigPathsPlugin = tsConfigPathsPlugin;
-
-/**
- *
- * @param {{cwd:string}} options
- * @returns {import('esbuild').Plugin}
- */
-function tsConfigPathsPlugin(options) {
+export function tsConfigPathsPlugin(options: { cwd: string }): Plugin {
   const tsConfig = loadConfig(options.cwd);
 
   if (tsConfig.resultType === 'failed') {
@@ -19,8 +12,7 @@ function tsConfigPathsPlugin(options) {
 
   const pathAliases = tsConfig.paths;
 
-  /** @type {import('esbuild').Plugin} */
-  const pluginConfig = {
+  const pluginConfig: Plugin = {
     name: 'tsconfig-paths',
     setup({ onResolve }) {
       onResolve({ filter: /.*/ }, args => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Esbuild stopped resolving TS path aliases since version 0.19 (BREAKING CHANGE)

https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0190 / 
<img width="690" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/849936a4-7a83-4ef7-b93d-3143cbca0428">


With this in place our SSR test are working by "accident" ( lage scheduling build task prior to executing test-ssr ),
and following pipeline issues might start happening at any time (https://github.com/microsoft/fluentui/pull/29327).

This issue started to appear in one of PR's that removes a deprecated package from the repo https://github.com/microsoft/fluentui/pull/31007


## New Behavior

- this PR implements a custom ESbuild plugin to resolve against path aliases mittigating all the possible issues described above.
- tested against whole repo https://github.com/microsoft/fluentui/pull/31220

### More context

Even if we added `build` task as pre-requirement for `test-ssr` pipeline issues would appear sooner than later.

**So we can either:**
- provide proper dependency declarations to all packages ( which would introduce circular dependencies - this will be mitigated after implementing https://github.com/microsoft/fluentui/issues/30516) + moving `test-ssr` to `*-stories` packages
- implement tsConfigPathAliases esbuild plugin


Ideal solution is to have both so until that type-checking epic is done

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Unblocks https://github.com/microsoft/fluentui/pull/31007
