### PR TITLE
chore: make expandIcon aria-hidden by default

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-8f841c14-fa16-4dad-9127-cf8f050b142f.json
+++ b/change/@fluentui-react-tag-picker-preview-8f841c14-fa16-4dad-9127-cf8f050b142f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: make expandIcon aria-hidden by default",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/__snapshots__/TagPickerControl.test.tsx.snap
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/__snapshots__/TagPickerControl.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`TagPickerControl renders a default state 1`] = `
       class="fui-TagPickerControl__aside"
     >
       <span
-        aria-expanded="false"
+        aria-hidden="true"
         class="fui-TagPickerControl__expandIcon"
         role="button"
       >

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -51,7 +51,7 @@ export const useTagPickerControl_unstable = (
   const expandIcon = slot.optional(props.expandIcon, {
     renderByDefault: true,
     defaultProps: {
-      'aria-expanded': open,
+      'aria-hidden': true,
       children: <ChevronDownRegular />,
       role: 'button',
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. makes `expandIcon` slot `aria-hidden` by default

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
