### PR TITLE
feat(react-tag-picker): exports TagPicker event handlers types

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-f5058ed3-1d6b-48ce-add6-e1c8cd8945a8.json
+++ b/change/@fluentui-react-tag-picker-preview-f5058ed3-1d6b-48ce-add6-e1c8cd8945a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: exports TagPicker event handlers types",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
+++ b/packages/react-components/react-tag-picker-preview/etc/react-tag-picker-preview.api.md
@@ -32,15 +32,8 @@ import { TagGroupContextValues } from '@fluentui/react-tags';
 import type { TagGroupSlots } from '@fluentui/react-tags';
 import type { TagGroupState } from '@fluentui/react-tags';
 
-// @public (undocumented)
-export type PickerContextValues = {
-    picker: TagPickerContextValue;
-    activeDescendant: ActiveDescendantContextValue;
-    listbox: ListboxContextValue;
-};
-
 // @public
-export const renderTagPicker_unstable: (state: TagPickerState, contexts: PickerContextValues) => JSX.Element;
+export const renderTagPicker_unstable: (state: TagPickerState, contexts: TagPickerContextValues) => JSX.Element;
 
 // @public
 export const renderTagPickerButton_unstable: (state: TagPickerButtonState) => JSX.Element;
@@ -85,6 +78,13 @@ export type TagPickerButtonSlots = {
 // @public
 export type TagPickerButtonState = ComponentState<TagPickerButtonSlots> & Pick<TagPickerContextValue, 'size'> & {
     hasSelectedOption: boolean;
+};
+
+// @public (undocumented)
+export type TagPickerContextValues = {
+    picker: TagPickerContextValue;
+    activeDescendant: ActiveDescendantContextValue;
+    listbox: ListboxContextValue;
 };
 
 // @public
@@ -163,6 +163,17 @@ export type TagPickerListSlots = {
 // @public
 export type TagPickerListState = ComponentState<TagPickerListSlots> & Pick<TagPickerContextValue, 'open'>;
 
+// @public (undocumented)
+export type TagPickerOnOpenChangeData = {
+    open: boolean;
+} & (EventData<'click', React_2.MouseEvent<HTMLDivElement>> | EventData<'keydown', React_2.KeyboardEvent<HTMLDivElement>>);
+
+// @public
+export type TagPickerOnOptionSelectData = {
+    value: string;
+    selectedOptions: string[];
+} & (EventData<'click', React_2.MouseEvent<HTMLDivElement>> | EventData<'keydown', React_2.KeyboardEvent<HTMLDivElement>>);
+
 // @public
 export const TagPickerOption: ForwardRefComponent<TagPickerOptionProps>;
 
@@ -206,6 +217,9 @@ export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps
     children: [JSX.Element, JSX.Element] | JSX.Element;
     inline?: boolean;
 };
+
+// @public (undocumented)
+export type TagPickerSize = 'medium' | 'large' | 'extra-large';
 
 // @public (undocumented)
 export type TagPickerSlots = {};

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.types.ts
@@ -8,23 +8,19 @@ export type TagPickerSlots = {};
 
 export type TagPickerSize = 'medium' | 'large' | 'extra-large';
 
-/*
- * Data for the onOptionSelect callback.
- * `optionValue` and `optionText` will be undefined if multiple options are modified at once.
+/**
+ * Event data for the `onOptionSelect` event.
+ *
+ * * value - The value of the selected option that triggered the event
+ * * selectedOptions - The list of selected options
  */
 export type TagPickerOnOptionSelectData = {
-  optionValue: string | undefined;
-  optionText: string | undefined;
+  value: string;
   selectedOptions: string[];
-} & (
-  | EventData<'click', React.MouseEvent<HTMLDivElement>>
-  | EventData<'change', React.ChangeEvent<HTMLDivElement>>
-  | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>
-);
+} & (EventData<'click', React.MouseEvent<HTMLDivElement>> | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>);
 
 export type TagPickerOnOpenChangeData = { open: boolean } & (
   | EventData<'click', React.MouseEvent<HTMLDivElement>>
-  | EventData<'change', React.ChangeEvent<HTMLDivElement>>
   | EventData<'keydown', React.KeyboardEvent<HTMLDivElement>>
 );
 

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
@@ -50,7 +50,8 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     ...props,
     onOptionSelect: useEventCallback((event, data) =>
       props.onOptionSelect?.(event, {
-        ...data,
+        selectedOptions: data.selectedOptions,
+        value: data.optionValue,
         type: event.type,
         event,
       } as TagPickerOnOptionSelectData),

--- a/packages/react-components/react-tag-picker-preview/src/index.ts
+++ b/packages/react-components/react-tag-picker-preview/src/index.ts
@@ -1,9 +1,12 @@
 export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable } from './TagPicker';
 export type {
-  TagPickerContextValues as PickerContextValues,
+  TagPickerContextValues,
   TagPickerProps,
   TagPickerSlots,
   TagPickerState,
+  TagPickerOnOpenChangeData,
+  TagPickerOnOptionSelectData,
+  TagPickerSize,
 } from './TagPicker';
 export {
   TagPickerInput,

--- a/packages/react-components/react-tag-picker-preview/stories/TagPicker/TagPickerFiltering.stories.tsx
+++ b/packages/react-components/react-tag-picker-preview/stories/TagPicker/TagPickerFiltering.stories.tsx
@@ -26,7 +26,7 @@ export const Filtering = () => {
   const [query, setQuery] = React.useState<string>('');
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
-    if (data.optionValue === 'no-matches') {
+    if (data.value === 'no-matches') {
       return;
     }
     setSelectedOptions(data.selectedOptions);

--- a/packages/react-components/react-tag-picker-preview/stories/TagPicker/TagPickerSingleSelect.stories.tsx
+++ b/packages/react-components/react-tag-picker-preview/stories/TagPicker/TagPickerSingleSelect.stories.tsx
@@ -21,34 +21,34 @@ const options = [
   'Maria Rossi',
 ];
 
-export const Default = () => {
-  const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
+export const SingleSelect = () => {
+  const [selectedOption, setSelectedOption] = React.useState<string | undefined>();
+  const selectedOptions = React.useMemo(() => (selectedOption ? [selectedOption] : []), [selectedOption]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
-    console.log(data.type);
-    setSelectedOptions(data.selectedOptions);
+    setSelectedOption(selectedOption === data.value ? undefined : data.value);
   };
 
   return (
     <div style={{ maxWidth: 400 }}>
       <TagPicker onOptionSelect={onOptionSelect} selectedOptions={selectedOptions}>
         <TagPickerControl>
-          <TagPickerGroup>
-            {selectedOptions.map(option => (
+          {selectedOption && (
+            <TagPickerGroup>
               <Tag
-                key={option}
+                key={selectedOption}
                 shape="rounded"
-                media={<Avatar aria-hidden name={option} color="colorful" />}
-                value={option}
+                media={<Avatar aria-hidden name={selectedOption} color="colorful" />}
+                value={selectedOption}
               >
-                {option}
+                {selectedOption}
               </Tag>
-            ))}
-          </TagPickerGroup>
+            </TagPickerGroup>
+          )}
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
           {options
-            .filter(option => !selectedOptions.includes(option))
+            .filter(option => selectedOption !== option)
             .map(option => (
               <TagPickerOption
                 secondaryContent="Microsoft FTE"
@@ -63,4 +63,14 @@ export const Default = () => {
       </TagPicker>
     </div>
   );
+};
+
+SingleSelect.parameters = {
+  docs: {
+    description: {
+      story: `
+By default, the \`TagPicker\` allows multiple selections. To enable single selection, you can manage the selected options state yourself and pass only one selected option to the \`TagPicker\` component.
+      `,
+    },
+  },
 };

--- a/packages/react-components/react-tag-picker-preview/stories/TagPicker/index.stories.tsx
+++ b/packages/react-components/react-tag-picker-preview/stories/TagPicker/index.stories.tsx
@@ -22,6 +22,7 @@ export { SecondaryAction } from './TagPickerSecondaryAction.stories';
 export { Grouped } from './TagPickerGrouped.stories';
 export { Freeform } from './TagPickerFreeform.stories';
 export { TruncatedText } from './TagPickerTruncatedText.stories';
+export { SingleSelect } from './TagPickerSingleSelect.stories';
 
 export default {
   title: 'Preview Components/TagPicker',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds story for single select case
2. updates `onOptionSelect` types
3. exports `onOptionSelect` and `onOpenChange` types

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
