### PR TITLE
feat(workspace-plugin): catch potential issues with running formatFiles on CI and add skipFormat config for tsConfigBaseAllGenerator

### DIFF
--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -60,13 +60,20 @@ export async function splitLibraryInTwoGenerator(tree: Tree, options: SplitLibra
       splitLibraryInTwoInternal(tree, { projectName, project });
     }
   }
+
   if (options.project) {
     splitLibraryInTwoInternal(tree, { projectName: options.project });
   }
 
-  await tsConfigBaseAllGenerator(tree, { verify: false });
+  await tsConfigBaseAllGenerator(tree, { verify: false, skipFormat: true });
 
-  await formatFiles(tree);
+  // TODO: we don't wanna fail master build because formatting failed
+  // - Nx is using await `prettier.format` under the hood which is for prettier v3, but we use prettier v2 ATM, while that unnecessary await should not cause harm it seems it does
+  try {
+    await formatFiles(tree);
+  } catch (err) {
+    console.log(err);
+  }
 
   return () => {
     installPackagesTask(tree, true);

--- a/tools/workspace-plugin/src/generators/tsconfig-base-all/index.ts
+++ b/tools/workspace-plugin/src/generators/tsconfig-base-all/index.ts
@@ -14,7 +14,10 @@ export default async function (tree: Tree, schema: TsconfigBaseAllGeneratorSchem
 
   if (!normalizedOptions.verify) {
     writeJson(tree, tsConfigAllPath, mergedTsConfig);
-    await formatFiles(tree);
+
+    if (!normalizedOptions.skipFormat) {
+      await formatFiles(tree);
+    }
 
     return;
   }

--- a/tools/workspace-plugin/src/generators/tsconfig-base-all/schema.json
+++ b/tools/workspace-plugin/src/generators/tsconfig-base-all/schema.json
@@ -8,6 +8,12 @@
     "verify": {
       "type": "boolean",
       "description": "Verify integrity of tsconfig.base.all.json path aliases"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": []

--- a/tools/workspace-plugin/src/generators/tsconfig-base-all/schema.ts
+++ b/tools/workspace-plugin/src/generators/tsconfig-base-all/schema.ts
@@ -3,4 +3,8 @@ export interface TsconfigBaseAllGeneratorSchema {
    * Verify integrity of tsconfig.base.all.json path aliases
    */
   verify?: boolean;
+  /**
+   * @internal
+   */
+  skipFormat?: boolean;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- Intermittent issues are still occurring on CI https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=341231&view=logs&j=e51d397b-0a7b-5b89-4b48-0052e021371d&t=88c41216-94ff-5ca8-d686-48ce16c1eefc

## New Behavior

nx `formatFiles`  is using prettier v3 api (which is async) but we are on prettier v2 which is sync. 

While unnecessary await shouldn't  cause issues it seems it does.

This PR:
- mitigates `formatFiles` calls within split in two generator to 1
- extends `tsConfigBaseAllGenerator` api with `skipFormatting` config

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31217
