### PR TITLE
fix(react-listbox): Fixing click/tap focus scroll bug introduced with recent Listbox standalone changes

### DIFF
--- a/change/@fluentui-react-combobox-7c2043a7-1e96-40fa-87a9-aff3adf28a3e.json
+++ b/change/@fluentui-react-combobox-7c2043a7-1e96-40fa-87a9-aff3adf28a3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing bug where click or tap focusing an item in an unfocused listbox would result in the listbox scrolling all the way to the top due to unrestrained initial focus logic",
+  "packageName": "@fluentui/react-combobox",
+  "email": "stevenco@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/useListbox.ts
@@ -18,6 +18,7 @@ import { useOptionCollection } from '../../utils/useOptionCollection';
 import { useSelection } from '../../utils/useSelection';
 import { optionClassNames } from '../Option/useOptionStyles.styles';
 import { ListboxContext, useListboxContext_unstable } from '../../contexts/ListboxContext';
+import { useOnKeyboardNavigationChange } from '@fluentui/react-tabster';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const UNSAFE_noLongerUsed = {
@@ -47,6 +48,11 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   } = useActiveDescendant<HTMLInputElement, HTMLDivElement>({
     matchOption: el => el.classList.contains(optionClassNames.root),
   });
+
+  const isNavigatingWithKeyboardRef = React.useRef(false);
+  useOnKeyboardNavigationChange(
+    _isNavigatingWithKeyboard => (isNavigatingWithKeyboardRef.current = _isNavigatingWithKeyboard),
+  );
 
   const activeDescendantContext = useActiveDescendantContext();
   const hasParentActiveDescendantContext = useHasParentActiveDescendantContext();
@@ -90,7 +96,11 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   };
 
   const onFocus = (_event: React.FocusEvent<HTMLElement>) => {
-    if (hasParentActiveDescendantContext || activeDescendantController.active()) {
+    if (
+      hasParentActiveDescendantContext ||
+      activeDescendantController.active() ||
+      !isNavigatingWithKeyboardRef.current
+    ) {
       return;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Initial focus logic added in a previous commit to help Listbox function better as a standalone component is triggered by any focus event, even if the focus event is from a mouse or touch. In a scrollable listbox (standalone), this means you can scroll down the list and then attempt to click and it will cause a focus event to trigger and scroll the listbox to the top and not select the list item.

## New Behavior

Ignores focus events if not navigating with a keyboard