### PR TITLE
Add HC styling for Switch when using font icons

### DIFF
--- a/change/@fluentui-react-switch-ba7b05e3-f407-4157-b014-864a2ceafb0d.json
+++ b/change/@fluentui-react-switch-ba7b05e3-f407-4157-b014-864a2ceafb0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add HC styling for Switch font icon",
+  "packageName": "@fluentui/react-switch",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.styles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.styles.ts
@@ -57,6 +57,13 @@ const useIndicatorBaseClassName = makeResetStyles({
     transitionDuration: '0.01ms',
   },
 
+  '@media (forced-colors: active)': {
+    color: 'CanvasText',
+    '> i': {
+      forcedColorAdjust: 'none',
+    },
+  },
+
   '> *': {
     transitionDuration: tokens.durationNormal,
     transitionTimingFunction: tokens.curveEasyEase,
@@ -184,7 +191,9 @@ const useInputBaseClassName = makeResetStyles({
         color: 'GrayText',
       },
     },
-
+    ':hover': {
+      color: 'CanvasText',
+    },
     ':enabled:checked': {
       ':hover': {
         [`& ~ .${switchClassNames.indicator}`]: {


### PR DESCRIPTION
This PR fixes a visual issue with the `Switch` component in HC mode when the icon rendered is a font icon. The `<i>` tag has a black backplate in HC mode that doesn't get overridden by the color of its parent. 

Fixes #31192 