### PR TITLE
feat: Add `caseSensitive` prop to `ComboBox`

### DIFF
--- a/change/@fluentui-react-5ecf88df-8c30-41f1-8a97-c0b86767af49.json
+++ b/change/@fluentui-react-5ecf88df-8c30-41f1-8a97-c0b86767af49.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add caseSensitive prop to Combobox.",
+  "packageName": "@fluentui/react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx
+++ b/packages/react-examples/src/react/ComboBox/ComboBox.FreeInput.Example.tsx
@@ -40,6 +40,15 @@ export const ComboBoxFreeInputExample: React.FunctionComponent = () => {
         allowFreeInput
         autoComplete="off"
       />
+      <ComboBox
+        defaultSelectedKey="C"
+        label="ComboBox with allowFreeInput and caseSensitive without autocomplete"
+        options={options}
+        styles={comboBoxStyles}
+        allowFreeInput
+        autoComplete="off"
+        caseSensitive
+      />
     </div>
   );
 };

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3933,6 +3933,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
     autofill?: IAutofillProps;
     buttonIconProps?: IIconProps;
     caretDownButtonStyles?: Partial<IButtonStyles>;
+    caseSensitive?: boolean;
     comboBoxOptionStyles?: Partial<IComboBoxOptionStyles>;
     componentRef?: IRefObject<IComboBox>;
     dropdownMaxWidth?: number;

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -898,9 +898,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
     // Remember the original value and then make the value lowercase for comparison
     const originalUpdatedValue: string = updatedValue;
     // Make the value lowercase for comparison if caseSensitive is false
-    if (!this.props.caseSensitive) {
-      updatedValue = updatedValue.toLocaleLowerCase();
-    }
+    updatedValue = this._adjustForCaseSensitivity(updatedValue);
 
     let newSuggestedDisplayValue = '';
 
@@ -913,17 +911,14 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           option =>
             isNormalOption(option) &&
             !option.disabled &&
-            (this.props.caseSensitive ? getPreviewText(option) : getPreviewText(option).toLocaleLowerCase()).indexOf(
-              updatedValue,
-            ) === 0,
+            this._adjustForCaseSensitivity(getPreviewText(option)).indexOf(updatedValue) === 0,
         );
       if (items.length > 0) {
         // use ariaLabel as the value when the option is set
         const text: string = getPreviewText(items[0]);
 
         // If the user typed out the complete option text, we don't need any suggested display text anymore
-        newSuggestedDisplayValue =
-          (this.props.caseSensitive ? text : text.toLocaleLowerCase()) !== updatedValue ? text : '';
+        newSuggestedDisplayValue = this._adjustForCaseSensitivity(text) !== updatedValue ? text : '';
 
         // remember the index of the match we found
         newCurrentPendingValueValidIndex = items[0].index;
@@ -936,8 +931,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
           option =>
             isNormalOption(option) &&
             !option.disabled &&
-            (this.props.caseSensitive ? getPreviewText(option) : getPreviewText(option).toLocaleLowerCase()) ===
-              updatedValue,
+            this._adjustForCaseSensitivity(getPreviewText(option)) === updatedValue,
         );
 
       // if we found a match remember the index
@@ -1003,9 +997,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
   private _updateAutocompleteIndexWithoutFreeform(updatedValue: string): number {
     const { currentOptions } = this.props.hoisted;
     const originalUpdatedValue: string = updatedValue;
-    if (!this.props.caseSensitive) {
-      updatedValue = updatedValue.toLocaleLowerCase();
-    }
+    updatedValue = this._adjustForCaseSensitivity(updatedValue);
 
     // If autoComplete is on, attempt to find a match where the text of an option starts with the updated value
     const items = currentOptions
@@ -1015,7 +1007,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         option =>
           isNormalOption(option) &&
           !option.disabled &&
-          (this.props.caseSensitive ? option.text : option.text.toLocaleLowerCase()).indexOf(updatedValue) === 0,
+          this._adjustForCaseSensitivity(option.text).indexOf(updatedValue) === 0,
       );
 
     // If we found a match, update the state
@@ -1313,19 +1305,17 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
       // Check to see if the user typed an exact match
       if (indexWithinBounds(currentOptions, currentPendingValueValidIndex)) {
-        let pendingOptionText = getPreviewText(currentOptions[currentPendingValueValidIndex]);
-        if (!this.props.caseSensitive) {
-          pendingOptionText = pendingOptionText.toLocaleLowerCase();
-        }
+        const pendingOptionText = this._adjustForCaseSensitivity(
+          getPreviewText(currentOptions[currentPendingValueValidIndex]),
+        );
+
         const autofill = this._autofill.current;
 
         // By exact match, that means: our pending value is the same as the pending option text OR
         // the pending option starts with the pending value and we have an "autoComplete" selection
         // where the total length is equal to pending option length OR
         // the live value in the underlying input matches the pending option; update the state
-        const adjustedCurrentPendingValue = this.props.caseSensitive
-          ? currentPendingValue
-          : currentPendingValue.toLocaleLowerCase();
+        const adjustedCurrentPendingValue = this._adjustForCaseSensitivity(currentPendingValue);
         if (
           adjustedCurrentPendingValue === pendingOptionText ||
           (autoComplete &&
@@ -1333,9 +1323,8 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
             autofill?.isValueSelected &&
             currentPendingValue.length + (autofill.selectionEnd! - autofill.selectionStart!) ===
               pendingOptionText.length) ||
-          (this.props.caseSensitive
-            ? autofill?.inputElement?.value
-            : autofill?.inputElement?.value.toLocaleLowerCase()) === pendingOptionText
+          (autofill?.inputElement?.value !== undefined &&
+            this._adjustForCaseSensitivity(autofill.inputElement.value) === pendingOptionText)
         ) {
           this._setSelectedIndex(currentPendingValueValidIndex, submitPendingValueEvent);
           if (multiSelect && this.state.isOpen) {
@@ -2511,6 +2500,10 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    */
   private _hasFocus() {
     return this.state.focusState !== 'none';
+  }
+
+  private _adjustForCaseSensitivity(text: string): string {
+    return this.props.caseSensitive ? text : text.toLowerCase();
   }
 }
 

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -284,6 +284,12 @@ export interface IComboBoxProps
    * Custom render function for the label text.
    */
   onRenderLabel?: IRenderFunction<IOnRenderComboBoxLabelProps>;
+
+  /**
+   * Whether matching the ComboBox options when writing in the ComboBox input should be case-sensitive or not.
+   * @defaultvalue false
+   */
+  caseSensitive?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Previous Behavior

`ComboBox` would always match input with the options in a case insensitive way without the possibility of modifying this behavior.

## New Behavior

A new `caseSensitive` prop is introduced to `ComboBox` in this PR, through which all internal comparisons in the logic of `ComboBox` are done in a case sensitive manner. A new example of what this behavior looks like is introduced in this PR as well.

## Related Issue(s)

- Fixes #30915.
