### PR TITLE
Virtualizer: Update IO/Timer to use Fluent hooks

### DIFF
--- a/change/@fluentui-react-virtualizer-2b9d6cc8-1a23-4f0c-82c2-2c9814ffc2ab.json
+++ b/change/@fluentui-react-virtualizer-2b9d6cc8-1a23-4f0c-82c2-2c9814ffc2ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix: Use Fluent hooks for IO and timeout functionality",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -109,7 +109,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
   useEffect(() => {
     initializeScrollingTimer();
-  }, [actualIndex]);
+  }, [actualIndex, initializeScrollingTimer]);
 
   const batchUpdateNewIndex = (index: number) => {
     // Local updates

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -86,30 +86,30 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   const [setScrollTimer, clearScrollTimer] = useTimeout();
   const scrollCounter = useRef<number>(0);
 
+  const initializeScrollingTimer = useCallback(() => {
+    /*
+     * This can be considered the 'velocity' required to start 'isScrolling'
+     * INIT_SCROLL_FLAG_REQ: Number of renders required to activate isScrolling
+     * INIT_SCROLL_FLAG_DELAY: Amount of time (ms) before current number of renders is reset
+     *  - Maybe we should let users customize these in the future.
+     */
+    const INIT_SCROLL_FLAG_REQ = 10;
+    const INIT_SCROLL_FLAG_DELAY = 100;
+
+    scrollCounter.current++;
+    if (scrollCounter.current >= INIT_SCROLL_FLAG_REQ) {
+      setIsScrolling(true);
+    }
+    clearScrollTimer();
+    setScrollTimer(() => {
+      setIsScrolling(false);
+      scrollCounter.current = 0;
+    }, INIT_SCROLL_FLAG_DELAY);
+  }, [clearScrollTimer, setScrollTimer]);
+
   useEffect(() => {
-    const initializeScrollingTimer = () => {
-      /*
-       * This can be considered the 'velocity' required to start 'isScrolling'
-       * INIT_SCROLL_FLAG_REQ: Number of renders required to activate isScrolling
-       * INIT_SCROLL_FLAG_DELAY: Amount of time (ms) before current number of renders is reset
-       *  - Maybe we should let users customize these in the future.
-       */
-      const INIT_SCROLL_FLAG_REQ = 10;
-      const INIT_SCROLL_FLAG_DELAY = 100;
-
-      scrollCounter.current++;
-      if (scrollCounter.current >= INIT_SCROLL_FLAG_REQ) {
-        setIsScrolling(true);
-      }
-      clearScrollTimer();
-      setScrollTimer(() => {
-        setIsScrolling(false);
-        scrollCounter.current = 0;
-      }, INIT_SCROLL_FLAG_DELAY);
-    };
-
     initializeScrollingTimer();
-  }, [actualIndex]);
+  }, [actualIndex, initializeScrollingTimer]);
 
   const batchUpdateNewIndex = (index: number) => {
     // Local updates

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef, useCallback, useReducer, useImperativeHandle, useSta
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { flushSync } from 'react-dom';
 import { useVirtualizerContextState_unstable } from '../../Utilities';
-import { slot } from '@fluentui/react-utilities';
+import { slot, useTimeout } from '@fluentui/react-utilities';
 
 export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerState {
   const {
@@ -83,7 +83,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   };
 
   const [isScrolling, setIsScrolling] = useState<boolean>(false);
-  const scrollTimer = useRef<ReturnType<typeof setTimeout> | null>();
+  const [setScrollTimer, clearScrollTimer] = useTimeout();
   const scrollCounter = useRef<number>(0);
 
   const initializeScrollingTimer = () => {
@@ -100,10 +100,8 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
     if (scrollCounter.current >= INIT_SCROLL_FLAG_REQ) {
       setIsScrolling(true);
     }
-    if (scrollTimer.current) {
-      clearTimeout(scrollTimer.current);
-    }
-    scrollTimer.current = setTimeout(() => {
+    clearScrollTimer();
+    setScrollTimer(() => {
       setIsScrolling(false);
       scrollCounter.current = 0;
     }, INIT_SCROLL_FLAG_DELAY);

--- a/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -86,30 +86,30 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   const [setScrollTimer, clearScrollTimer] = useTimeout();
   const scrollCounter = useRef<number>(0);
 
-  const initializeScrollingTimer = () => {
-    /*
-     * This can be considered the 'velocity' required to start 'isScrolling'
-     * INIT_SCROLL_FLAG_REQ: Number of renders required to activate isScrolling
-     * INIT_SCROLL_FLAG_DELAY: Amount of time (ms) before current number of renders is reset
-     *  - Maybe we should let users customize these in the future.
-     */
-    const INIT_SCROLL_FLAG_REQ = 10;
-    const INIT_SCROLL_FLAG_DELAY = 100;
-
-    scrollCounter.current++;
-    if (scrollCounter.current >= INIT_SCROLL_FLAG_REQ) {
-      setIsScrolling(true);
-    }
-    clearScrollTimer();
-    setScrollTimer(() => {
-      setIsScrolling(false);
-      scrollCounter.current = 0;
-    }, INIT_SCROLL_FLAG_DELAY);
-  };
-
   useEffect(() => {
+    const initializeScrollingTimer = () => {
+      /*
+       * This can be considered the 'velocity' required to start 'isScrolling'
+       * INIT_SCROLL_FLAG_REQ: Number of renders required to activate isScrolling
+       * INIT_SCROLL_FLAG_DELAY: Amount of time (ms) before current number of renders is reset
+       *  - Maybe we should let users customize these in the future.
+       */
+      const INIT_SCROLL_FLAG_REQ = 10;
+      const INIT_SCROLL_FLAG_DELAY = 100;
+
+      scrollCounter.current++;
+      if (scrollCounter.current >= INIT_SCROLL_FLAG_REQ) {
+        setIsScrolling(true);
+      }
+      clearScrollTimer();
+      setScrollTimer(() => {
+        setIsScrolling(false);
+        scrollCounter.current = 0;
+      }, INIT_SCROLL_FLAG_DELAY);
+    };
+
     initializeScrollingTimer();
-  }, [actualIndex, initializeScrollingTimer]);
+  }, [actualIndex]);
 
   const batchUpdateNewIndex = (index: number) => {
     // Local updates

--- a/packages/react-components/react-virtualizer/src/hooks/useDynamicPagination.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useDynamicPagination.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerDynamicPaginationProps } from './hooks.types';
 import { useRef } from 'react';
+import { useTimeout } from '@fluentui/react-utilities';
 
 /**
  * Optional hook that will enable pagination on the virtualizer so that it 'autoscrolls' to an items exact position
@@ -14,7 +15,7 @@ export const useDynamicVirtualizerPagination = (
 ) => {
   const { axis = 'vertical', currentIndex, progressiveItemSizes, virtualizerLength } = virtualizerProps;
 
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [setScrollTimer, clearScrollTimer] = useTimeout();
   const lastScrollPos = useRef<number>(-1);
   const lastIndexScrolled = useRef<number>(-1);
 
@@ -24,9 +25,7 @@ export const useDynamicVirtualizerPagination = (
     if (scrollContainer.current) {
       scrollContainer.current.removeEventListener('scroll', onScroll);
       scrollContainer.current = null;
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      clearScrollTimer();
     }
   };
 
@@ -106,10 +105,8 @@ export const useDynamicVirtualizerPagination = (
    */
   const onScroll = React.useCallback(
     event => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      timeoutRef.current = setTimeout(onScrollEnd, 100);
+      clearScrollTimer();
+      setScrollTimer(onScrollEnd, 100);
     },
     [onScrollEnd],
   );

--- a/packages/react-components/react-virtualizer/src/hooks/useDynamicPagination.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useDynamicPagination.ts
@@ -108,7 +108,7 @@ export const useDynamicVirtualizerPagination = (
       clearScrollTimer();
       setScrollTimer(onScrollEnd, 100);
     },
-    [onScrollEnd],
+    [onScrollEnd, clearScrollTimer, setScrollTimer],
   );
 
   /**

--- a/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
@@ -123,7 +123,7 @@ export const useIntersectionObserver = (
         observer.current.disconnect();
       }
     };
-  }, [observerList, observerInit, callback]);
+  }, [observerList, observerInit, callback, targetDocument?.defaultView]);
 
   // Do not use internally, we need to track external settings only here
   const setObserverInitExternal = useCallback(

--- a/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useIntersectionObserver.ts
@@ -100,12 +100,15 @@ export const useIntersectionObserver = (
   // Observer elements in passed in list and clean up previous list
   // This effect is only triggered when observerList is updated
   useIsomorphicLayoutEffect(() => {
-    observer.current = new IntersectionObserver(callback, {
+    const win = targetDocument?.defaultView;
+    if (!win) {
+      return;
+    }
+
+    observer.current = new win.IntersectionObserver(callback, {
       ...observerInit,
       rootMargin: getRTLRootMargin(ltrRootMargin.current, observerInit?.root),
     });
-
-    observer.current = new IntersectionObserver(callback, observerInit);
 
     // If we have an instance of IO and a list with elements, observer the elements
     if (observer.current && observerList && observerList.length > 0) {

--- a/packages/react-components/react-virtualizer/src/hooks/useStaticPagination.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useStaticPagination.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { VirtualizerStaticPaginationProps } from './hooks.types';
 import { useRef } from 'react';
+import { useTimeout } from '@fluentui/react-utilities';
 
 /**
  * Optional hook that will enable pagination on the virtualizer so that it 'autoscrolls' to an items exact position
@@ -14,7 +15,7 @@ export const useStaticVirtualizerPagination = (
 ) => {
   const { itemSize, axis = 'vertical' } = virtualizerProps;
 
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [setScrollTimer, clearScrollTimer] = useTimeout();
   const lastScrollPos = useRef<number>(0);
   const lastIndexScrolled = useRef<number>(0);
 
@@ -25,9 +26,7 @@ export const useStaticVirtualizerPagination = (
       scrollContainer.current.removeEventListener('scroll', onScroll);
 
       scrollContainer.current = null;
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      clearScrollTimer();
     }
   };
 
@@ -83,10 +82,8 @@ export const useStaticVirtualizerPagination = (
    */
   const onScroll = React.useCallback(
     event => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      timeoutRef.current = setTimeout(onScrollEnd, 100);
+      clearScrollTimer();
+      setScrollTimer(onScrollEnd, 100);
     },
     [onScrollEnd],
   );

--- a/packages/react-components/react-virtualizer/src/hooks/useStaticPagination.ts
+++ b/packages/react-components/react-virtualizer/src/hooks/useStaticPagination.ts
@@ -85,7 +85,7 @@ export const useStaticVirtualizerPagination = (
       clearScrollTimer();
       setScrollTimer(onScrollEnd, 100);
     },
-    [onScrollEnd],
+    [onScrollEnd, clearScrollTimer, setScrollTimer],
   );
 
   /**

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/Dynamic.stories.tsx
@@ -5,7 +5,8 @@ import {
   VirtualizerContextProvider,
 } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
+import { useTimeout } from '@fluentui/react-utilities';
 
 const smallSize = 100;
 const largeSize = 200;
@@ -37,7 +38,7 @@ export const Dynamic = () => {
   const [flag, toggleFlag] = React.useState(false);
   const styles = useStyles();
   const childLength = 1000;
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const [setScrollTimer, clearScrollTimer] = useTimeout();
 
   React.useEffect(() => {
     updateTimeout();
@@ -45,8 +46,8 @@ export const Dynamic = () => {
   }, []);
 
   const updateTimeout = () => {
-    clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => {
+    clearScrollTimer();
+    setScrollTimer(() => {
       toggleFlag(iFlag => !iFlag);
       updateTimeout();
     }, 2000);

--- a/packages/react-components/react-virtualizer/stories/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/Virtualizer/Dynamic.stories.tsx
@@ -5,8 +5,7 @@ import {
   VirtualizerContextProvider,
 } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
-import { useCallback } from 'react';
-import { useTimeout } from '@fluentui/react-utilities';
+import { useCallback, useRef } from 'react';
 
 const smallSize = 100;
 const largeSize = 200;
@@ -38,7 +37,7 @@ export const Dynamic = () => {
   const [flag, toggleFlag] = React.useState(false);
   const styles = useStyles();
   const childLength = 1000;
-  const [setScrollTimer, clearScrollTimer] = useTimeout();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   React.useEffect(() => {
     updateTimeout();
@@ -46,8 +45,8 @@ export const Dynamic = () => {
   }, []);
 
   const updateTimeout = () => {
-    clearScrollTimer();
-    setScrollTimer(() => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
       toggleFlag(iFlag => !iFlag);
       updateTimeout();
     }, 2000);


### PR DESCRIPTION
## Previous Behavior
Used native IO and timer functions

## New Behavior
Uses equivalent Fluent hooks.

## Related Issue(s)
- Fixes #31095 
- Fixes #31096 
