### PR TITLE
feat: use ariaNotify when available for AriaLiveAnnouncer

### DIFF
--- a/change/@fluentui-react-aria-7b56d0a2-0299-4c6c-94dc-07533c23d6d6.json
+++ b/change/@fluentui-react-aria-7b56d0a2-0299-4c6c-94dc-07533c23d6d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: use ariaNotify in AriaLiveAnnouncer when available",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.ts
@@ -11,9 +11,10 @@ export const useAriaLiveAnnouncer_unstable = (props: AriaLiveAnnouncerProps): Ar
   const ariaNotifyAnnounce = useAriaNotifyAnnounce_unstable();
 
   const announce = React.useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supportsAriaNotify = typeof (targetDocument as any)?.ariaNotify === 'function';
     return supportsAriaNotify ? ariaNotifyAnnounce : domAnnounce;
-  }, [targetDocument]);
+  }, [targetDocument, ariaNotifyAnnounce, domAnnounce]);
 
   return {
     announce,

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.ts
@@ -1,154 +1,18 @@
-import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import { createPriorityQueue, useTimeout } from '@fluentui/react-utilities';
 import * as React from 'react';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { useDomAnnounce_unstable } from './useDomAnnounce';
+import { useAriaNotifyAnnounce_unstable } from './useAriaNotifyAnnounce';
 
-import type {
-  AriaLiveAnnounceFn,
-  AriaLiveAnnouncerState,
-  AriaLiveAnnouncerProps,
-  AriaLiveMessage,
-} from './AriaLiveAnnouncer.types';
-
-/** The duration the message needs to be in present in DOM for screen readers to register a change and announce */
-const MESSAGE_DURATION = 500;
-
-const VISUALLY_HIDDEN_STYLES = {
-  clip: 'rect(0px, 0px, 0px, 0px)',
-  height: '1px',
-  margin: '-1px',
-  width: '1px',
-  position: 'absolute',
-  overflow: 'hidden',
-  textWrap: 'nowrap',
-};
+import type { AriaLiveAnnouncerState, AriaLiveAnnouncerProps } from './AriaLiveAnnouncer.types';
 
 export const useAriaLiveAnnouncer_unstable = (props: AriaLiveAnnouncerProps): AriaLiveAnnouncerState => {
   const { targetDocument } = useFluent();
+  const domAnnounce = useDomAnnounce_unstable();
+  const ariaNotifyAnnounce = useAriaNotifyAnnounce_unstable();
 
-  const timeoutRef = React.useRef<number | undefined>(undefined);
-  const [setAnnounceTimeout, clearAnnounceTimeout] = useTimeout();
-
-  const elementRef = React.useRef<HTMLDivElement | null>(null);
-
-  const order = React.useRef(0);
-
-  // investigate alert implementation later
-  // const [alertList, setAlertList] = React.useState<string[]>([]);
-
-  const batchMessages = React.useRef<{ batchId: string; message: AriaLiveMessage }[]>([]);
-
-  const [messageQueue] = React.useState(() =>
-    createPriorityQueue<AriaLiveMessage>((a, b) => {
-      if (a.priority !== b.priority) {
-        return b.priority - a.priority;
-      }
-
-      return a.createdAt - b.createdAt;
-    }),
-  );
-
-  const queueMessage = React.useCallback(() => {
-    if (timeoutRef.current || !elementRef.current) {
-      return;
-    }
-
-    const runCycle = () => {
-      if (!elementRef.current) {
-        return;
-      }
-
-      if (targetDocument && messageQueue.peek()) {
-        // need a wrapping element for Narrator/Edge, which currently does not pick up text-only live region changes
-        // consistently
-        // if this is fixed, we can set textContent to the string directly
-
-        const wrappingEl = targetDocument.createElement('span');
-
-        wrappingEl.innerText = messageQueue
-          .all()
-          .filter(msg => msg.message.trim().length > 0)
-          .reduce((prevText, currMsg) => prevText + currMsg.message + '. ', '');
-
-        elementRef.current.innerText = '';
-        elementRef.current.appendChild(wrappingEl);
-
-        messageQueue.clear();
-        batchMessages.current = [];
-
-        // begin new cycle to clear (or update) messages
-        timeoutRef.current = setAnnounceTimeout(() => {
-          runCycle();
-        }, MESSAGE_DURATION);
-      } else {
-        elementRef.current.textContent = '';
-        clearAnnounceTimeout();
-
-        timeoutRef.current = undefined;
-      }
-    };
-
-    runCycle();
-  }, [clearAnnounceTimeout, messageQueue, setAnnounceTimeout, targetDocument]);
-
-  const announce: AriaLiveAnnounceFn = React.useMemo(
-    () =>
-      (message, options = {}) => {
-        const { alert = false, priority = 0, batchId } = options;
-
-        // check if message is an alert
-        if (alert) {
-          // TODO: alert implementation
-          // setAlertList([...alertList, message]);
-        }
-
-        const liveMessage: AriaLiveMessage = {
-          message,
-          createdAt: order.current++,
-          priority,
-          batchId,
-        };
-
-        // check if batchId exists
-        if (batchId) {
-          // update associated msg if it does
-          const batchMessage = batchMessages.current.find(msg => msg.batchId === batchId);
-
-          if (batchMessage) {
-            // replace existing message in queue
-            messageQueue.remove(batchMessage.message);
-
-            // update list of existing batchIds w/ most recent message
-            batchMessage.message = liveMessage;
-          } else {
-            // update list of existing batchIds, add new if doesn't already exist
-            batchMessages.current = [...batchMessages.current, { batchId, message: liveMessage }];
-          }
-        }
-
-        // add new message
-        messageQueue.enqueue(liveMessage);
-        queueMessage();
-      },
-    [messageQueue, queueMessage],
-  );
-
-  React.useEffect(() => {
-    if (!targetDocument) {
-      return;
-    }
-
-    const element = targetDocument.createElement('div');
-    element.setAttribute('aria-live', 'assertive');
-
-    Object.assign(element.style, VISUALLY_HIDDEN_STYLES);
-    targetDocument.body.append(element);
-
-    elementRef.current = element;
-
-    return () => {
-      element.remove();
-      elementRef.current = null;
-    };
+  const announce = React.useMemo(() => {
+    const supportsAriaNotify = typeof (targetDocument as any)?.ariaNotify === 'function';
+    return supportsAriaNotify ? ariaNotifyAnnounce : domAnnounce;
   }, [targetDocument]);
 
   return {

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
@@ -1,4 +1,5 @@
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import type { AnnounceOptions } from '@fluentui/react-shared-contexts';
 import * as React from 'react';
 
 import type { AriaLiveAnnounceFn } from './AriaLiveAnnouncer.types';
@@ -17,18 +18,19 @@ type DocumentWithAriaNotify = Document & {
 export const useAriaNotifyAnnounce_unstable = (): AriaLiveAnnounceFn => {
   const { targetDocument } = useFluent();
 
-  const announce: AriaLiveAnnounceFn = React.useMemo(
+  const announce: AriaLiveAnnounceFn = React.useCallback(
     () =>
-      (message, options = {}) => {
-        if (!targetDocument) return;
+      (message: string, options: AnnounceOptions = {}) => {
+        if (!targetDocument) {
+          return;
+        }
 
-        let { alert = false, polite, priority, batchId } = options;
+        const { alert = false, polite, batchId } = options;
 
         // default priority to 0 if polite, 2 if alert, and 1 by default
         // used to set both ariaNotify's priority and interrupt
-        if (typeof priority !== 'number') {
-          priority = polite ? 0 : alert ? 2 : 1;
-        }
+        const defaultPriority = polite ? 0 : alert ? 2 : 1;
+        const priority = options.priority ?? defaultPriority;
 
         // map fluent announce options to ariaNotify options
         const ariaNotifyOptions: AriaNotifyOptions = {

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
@@ -1,0 +1,46 @@
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import * as React from 'react';
+
+import type { AriaLiveAnnounceFn } from './AriaLiveAnnouncer.types';
+
+type AriaNotifyOptions = {
+  notificationID?: string;
+  priority?: 'none' | 'important';
+  interrupt?: 'all' | 'pending' | 'none';
+};
+
+type DocumentWithAriaNotify = Document & {
+  ariaNotify: (message: string, options: AriaNotifyOptions) => void;
+};
+
+/* INTERNAL: implementation of the announcer using the ariaNotify API */
+export const useAriaNotifyAnnounce_unstable = (): AriaLiveAnnounceFn => {
+  const { targetDocument } = useFluent();
+
+  const announce: AriaLiveAnnounceFn = React.useMemo(
+    () =>
+      (message, options = {}) => {
+        if (!targetDocument) return;
+
+        let { alert = false, polite, priority, batchId } = options;
+
+        // default priority to 0 if polite, 2 if alert, and 1 by default
+        // used to set both ariaNotify's priority and interrupt
+        if (typeof priority !== 'number') {
+          priority = polite ? 0 : alert ? 2 : 1;
+        }
+
+        // map fluent announce options to ariaNotify options
+        const ariaNotifyOptions: AriaNotifyOptions = {
+          notificationID: batchId,
+          priority: priority > 1 ? 'important' : 'none',
+          interrupt: batchId ? (priority > 0 ? 'all' : 'pending') : 'none',
+        };
+
+        (targetDocument as DocumentWithAriaNotify).ariaNotify(message, ariaNotifyOptions);
+      },
+    [],
+  );
+
+  return announce;
+};

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
@@ -19,28 +19,27 @@ export const useAriaNotifyAnnounce_unstable = (): AriaLiveAnnounceFn => {
   const { targetDocument } = useFluent();
 
   const announce: AriaLiveAnnounceFn = React.useCallback(
-    () =>
-      (message: string, options: AnnounceOptions = {}) => {
-        if (!targetDocument) {
-          return;
-        }
+    (message: string, options: AnnounceOptions = {}) => {
+      if (!targetDocument) {
+        return;
+      }
 
-        const { alert = false, polite, batchId } = options;
+      const { alert = false, polite, batchId } = options;
 
-        // default priority to 0 if polite, 2 if alert, and 1 by default
-        // used to set both ariaNotify's priority and interrupt
-        const defaultPriority = polite ? 0 : alert ? 2 : 1;
-        const priority = options.priority ?? defaultPriority;
+      // default priority to 0 if polite, 2 if alert, and 1 by default
+      // used to set both ariaNotify's priority and interrupt
+      const defaultPriority = polite ? 0 : alert ? 2 : 1;
+      const priority = options.priority ?? defaultPriority;
 
-        // map fluent announce options to ariaNotify options
-        const ariaNotifyOptions: AriaNotifyOptions = {
-          notificationID: batchId,
-          priority: priority > 1 ? 'important' : 'none',
-          interrupt: batchId ? (priority > 0 ? 'all' : 'pending') : 'none',
-        };
+      // map fluent announce options to ariaNotify options
+      const ariaNotifyOptions: AriaNotifyOptions = {
+        notificationID: batchId,
+        priority: priority > 1 ? 'important' : 'none',
+        interrupt: batchId ? (priority > 0 ? 'all' : 'pending') : 'none',
+      };
 
-        (targetDocument as DocumentWithAriaNotify).ariaNotify(message, ariaNotifyOptions);
-      },
+      (targetDocument as DocumentWithAriaNotify).ariaNotify(message, ariaNotifyOptions);
+    },
     [targetDocument],
   );
 

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
@@ -39,7 +39,7 @@ export const useAriaNotifyAnnounce_unstable = (): AriaLiveAnnounceFn => {
 
         (targetDocument as DocumentWithAriaNotify).ariaNotify(message, ariaNotifyOptions);
       },
-    [],
+    [targetDocument],
   );
 
   return announce;

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -1,4 +1,5 @@
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import type { AnnounceOptions } from '@fluentui/react-shared-contexts';
 import { createPriorityQueue, useTimeout } from '@fluentui/react-utilities';
 import * as React from 'react';
 
@@ -86,9 +87,9 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
     runCycle();
   }, [clearAnnounceTimeout, messageQueue, setAnnounceTimeout, targetDocument]);
 
-  const announce: AriaLiveAnnounceFn = React.useMemo(
+  const announce: AriaLiveAnnounceFn = React.useCallback(
     () =>
-      (message, options = {}) => {
+      (message: string, options: AnnounceOptions = {}) => {
         const { alert = false, priority = 0, batchId } = options;
 
         // check if message is an alert

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -88,44 +88,43 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
   }, [clearAnnounceTimeout, messageQueue, setAnnounceTimeout, targetDocument]);
 
   const announce: AriaLiveAnnounceFn = React.useCallback(
-    () =>
-      (message: string, options: AnnounceOptions = {}) => {
-        const { alert = false, priority = 0, batchId } = options;
+    (message: string, options: AnnounceOptions = {}) => {
+      const { alert = false, priority = 0, batchId } = options;
 
-        // check if message is an alert
-        if (alert) {
-          // TODO: alert implementation
-          // setAlertList([...alertList, message]);
+      // check if message is an alert
+      if (alert) {
+        // TODO: alert implementation
+        // setAlertList([...alertList, message]);
+      }
+
+      const liveMessage: AriaLiveMessage = {
+        message,
+        createdAt: order.current++,
+        priority,
+        batchId,
+      };
+
+      // check if batchId exists
+      if (batchId) {
+        // update associated msg if it does
+        const batchMessage = batchMessages.current.find(msg => msg.batchId === batchId);
+
+        if (batchMessage) {
+          // replace existing message in queue
+          messageQueue.remove(batchMessage.message);
+
+          // update list of existing batchIds w/ most recent message
+          batchMessage.message = liveMessage;
+        } else {
+          // update list of existing batchIds, add new if doesn't already exist
+          batchMessages.current = [...batchMessages.current, { batchId, message: liveMessage }];
         }
+      }
 
-        const liveMessage: AriaLiveMessage = {
-          message,
-          createdAt: order.current++,
-          priority,
-          batchId,
-        };
-
-        // check if batchId exists
-        if (batchId) {
-          // update associated msg if it does
-          const batchMessage = batchMessages.current.find(msg => msg.batchId === batchId);
-
-          if (batchMessage) {
-            // replace existing message in queue
-            messageQueue.remove(batchMessage.message);
-
-            // update list of existing batchIds w/ most recent message
-            batchMessage.message = liveMessage;
-          } else {
-            // update list of existing batchIds, add new if doesn't already exist
-            batchMessages.current = [...batchMessages.current, { batchId, message: liveMessage }];
-          }
-        }
-
-        // add new message
-        messageQueue.enqueue(liveMessage);
-        queueMessage();
-      },
+      // add new message
+      messageQueue.enqueue(liveMessage);
+      queueMessage();
+    },
     [messageQueue, queueMessage],
   );
 

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -1,0 +1,151 @@
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { createPriorityQueue, useTimeout } from '@fluentui/react-utilities';
+import * as React from 'react';
+
+import type { AriaLiveAnnounceFn, AriaLiveMessage } from './AriaLiveAnnouncer.types';
+
+/** The duration the message needs to be in present in DOM for screen readers to register a change and announce */
+const MESSAGE_DURATION = 500;
+
+const VISUALLY_HIDDEN_STYLES = {
+  clip: 'rect(0px, 0px, 0px, 0px)',
+  height: '1px',
+  margin: '-1px',
+  width: '1px',
+  position: 'absolute',
+  overflow: 'hidden',
+  textWrap: 'nowrap',
+};
+
+/* INTERNAL: implementation of the announcer using a live region element */
+export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
+  const { targetDocument } = useFluent();
+
+  const timeoutRef = React.useRef<number | undefined>(undefined);
+  const [setAnnounceTimeout, clearAnnounceTimeout] = useTimeout();
+
+  const elementRef = React.useRef<HTMLDivElement | null>(null);
+
+  const order = React.useRef(0);
+
+  // investigate alert implementation later
+  // const [alertList, setAlertList] = React.useState<string[]>([]);
+
+  const batchMessages = React.useRef<{ batchId: string; message: AriaLiveMessage }[]>([]);
+
+  const [messageQueue] = React.useState(() =>
+    createPriorityQueue<AriaLiveMessage>((a, b) => {
+      if (a.priority !== b.priority) {
+        return b.priority - a.priority;
+      }
+
+      return a.createdAt - b.createdAt;
+    }),
+  );
+
+  const queueMessage = React.useCallback(() => {
+    if (timeoutRef.current || !elementRef.current) {
+      return;
+    }
+
+    const runCycle = () => {
+      if (!elementRef.current) {
+        return;
+      }
+
+      if (targetDocument && messageQueue.peek()) {
+        // need a wrapping element for Narrator/Edge, which currently does not pick up text-only live region changes
+        // consistently
+        // if this is fixed, we can set textContent to the string directly
+
+        const wrappingEl = targetDocument.createElement('span');
+
+        wrappingEl.innerText = messageQueue
+          .all()
+          .filter(msg => msg.message.trim().length > 0)
+          .reduce((prevText, currMsg) => prevText + currMsg.message + '. ', '');
+
+        elementRef.current.innerText = '';
+        elementRef.current.appendChild(wrappingEl);
+
+        messageQueue.clear();
+        batchMessages.current = [];
+
+        // begin new cycle to clear (or update) messages
+        timeoutRef.current = setAnnounceTimeout(() => {
+          runCycle();
+        }, MESSAGE_DURATION);
+      } else {
+        elementRef.current.textContent = '';
+        clearAnnounceTimeout();
+
+        timeoutRef.current = undefined;
+      }
+    };
+
+    runCycle();
+  }, [clearAnnounceTimeout, messageQueue, setAnnounceTimeout, targetDocument]);
+
+  const announce: AriaLiveAnnounceFn = React.useMemo(
+    () =>
+      (message, options = {}) => {
+        const { alert = false, priority = 0, batchId } = options;
+
+        // check if message is an alert
+        if (alert) {
+          // TODO: alert implementation
+          // setAlertList([...alertList, message]);
+        }
+
+        const liveMessage: AriaLiveMessage = {
+          message,
+          createdAt: order.current++,
+          priority,
+          batchId,
+        };
+
+        // check if batchId exists
+        if (batchId) {
+          // update associated msg if it does
+          const batchMessage = batchMessages.current.find(msg => msg.batchId === batchId);
+
+          if (batchMessage) {
+            // replace existing message in queue
+            messageQueue.remove(batchMessage.message);
+
+            // update list of existing batchIds w/ most recent message
+            batchMessage.message = liveMessage;
+          } else {
+            // update list of existing batchIds, add new if doesn't already exist
+            batchMessages.current = [...batchMessages.current, { batchId, message: liveMessage }];
+          }
+        }
+
+        // add new message
+        messageQueue.enqueue(liveMessage);
+        queueMessage();
+      },
+    [messageQueue, queueMessage],
+  );
+
+  React.useEffect(() => {
+    if (!targetDocument) {
+      return;
+    }
+
+    const element = targetDocument.createElement('div');
+    element.setAttribute('aria-live', 'assertive');
+
+    Object.assign(element.style, VISUALLY_HIDDEN_STYLES);
+    targetDocument.body.append(element);
+
+    elementRef.current = element;
+
+    return () => {
+      element.remove();
+      elementRef.current = null;
+    };
+  }, [targetDocument]);
+
+  return announce;
+};


### PR DESCRIPTION
`ariaNotify` is a new live notification API in ARIA (ref: https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md). The Edge team has implemented this in canary builds of Edge and Chrome, behind a flag. The next step towards getting `ariaNotify` into the spec is to have real-world implementations to test against, which is why we agreed to test this out in Fluent & Fluent AI.

This won't change the behavior for people who haven't turned on the flag (so in practice, all our real-world customers) until `ariaNotify` is shipped as a stable feature. But it should allow us, Edge, and screen reader vendors to test how well this works as an API in practice.