### PR TITLE
fix(react-motions-preview): fix easing token values; match original names & structure

### DIFF
--- a/change/@fluentui-react-motions-preview-45124139-6f6d-4192-a24b-02196c3a6c42.json
+++ b/change/@fluentui-react-motions-preview-45124139-6f6d-4192-a24b-02196c3a6c42.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING: fix motion token values and adjust structure to match original source",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "robert@robertpenner.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -23,52 +23,29 @@ export function createMotionComponent(motion: AtomMotion | AtomMotionFn): React_
 export function createPresenceComponent(motion: PresenceMotion | PresenceMotionFn): React_2.FC<PresenceComponentProps>;
 
 // @public (undocumented)
-const durationFast = 150;
+export const curves: {
+    readonly curveAccelerateMax: "cubic-bezier(0.9,0.1,1,0.2)";
+    readonly curveAccelerateMid: "cubic-bezier(1,0,1,1)";
+    readonly curveAccelerateMin: "cubic-bezier(0.8,0,0.78,1)";
+    readonly curveDecelerateMax: "cubic-bezier(0.1,0.9,0.2,1)";
+    readonly curveDecelerateMid: "cubic-bezier(0,0,0,1)";
+    readonly curveDecelerateMin: "cubic-bezier(0.33,0,0.1,1)";
+    readonly curveEasyEaseMax: "cubic-bezier(0.8,0,0.2,1)";
+    readonly curveEasyEase: "cubic-bezier(0.33,0,0.67,1)";
+    readonly curveLinear: "cubic-bezier(0,0,1,1)";
+};
 
 // @public (undocumented)
-const durationFaster = 100;
-
-// @public (undocumented)
-const durationNormal = 200;
-
-// @public (undocumented)
-const durationSlow = 300;
-
-// @public (undocumented)
-const durationSlower = 400;
-
-// @public (undocumented)
-const durationUltraFast = 50;
-
-// @public (undocumented)
-const durationUltraSlow = 500;
-
-// @public (undocumented)
-const easingAccelerateMax = "cubic-bezier(1,0,1,1)";
-
-// @public (undocumented)
-const easingAccelerateMid = "cubic-bezier(0.7,0,1,0.5)";
-
-// @public (undocumented)
-const easingAccelerateMin = "cubic-bezier(0.8,0,1,1)";
-
-// @public (undocumented)
-const easingDecelerateMax = "cubic-bezier(0,0,0,1)";
-
-// @public (undocumented)
-const easingDecelerateMid = "cubic-bezier(0.1,0.9,0.2,1)";
-
-// @public (undocumented)
-const easingDecelerateMin = "cubic-bezier(0.33,0,0.1,1)";
-
-// @public (undocumented)
-const easingEasyEase = "cubic-bezier(0.33,0,0.67,1)";
-
-// @public (undocumented)
-const easingLinear = "cubic-bezier(0,0,1,1)";
-
-// @public (undocumented)
-const easingMaxEasyEase = "cubic-bezier(0.8,0,0.1,1)";
+export const durations: {
+    readonly durationUltraFast: 50;
+    readonly durationFaster: 100;
+    readonly durationFast: 150;
+    readonly durationNormal: 200;
+    readonly durationGentle: 250;
+    readonly durationSlow: 300;
+    readonly durationSlower: 400;
+    readonly durationUltraSlow: 500;
+};
 
 // @public (undocumented)
 export type MotionImperativeRef = {
@@ -76,27 +53,26 @@ export type MotionImperativeRef = {
     setPlayState: (state: 'running' | 'paused') => void;
 };
 
-declare namespace motionTokens {
-    export {
-        durationUltraFast,
-        durationFaster,
-        durationFast,
-        durationNormal,
-        durationSlow,
-        durationSlower,
-        durationUltraSlow,
-        easingAccelerateMax,
-        easingAccelerateMid,
-        easingAccelerateMin,
-        easingDecelerateMax,
-        easingDecelerateMid,
-        easingDecelerateMin,
-        easingMaxEasyEase,
-        easingEasyEase,
-        easingLinear
-    }
-}
-export { motionTokens }
+// @public (undocumented)
+export const motionTokens: {
+    curveAccelerateMax: "cubic-bezier(0.9,0.1,1,0.2)";
+    curveAccelerateMid: "cubic-bezier(1,0,1,1)";
+    curveAccelerateMin: "cubic-bezier(0.8,0,0.78,1)";
+    curveDecelerateMax: "cubic-bezier(0.1,0.9,0.2,1)";
+    curveDecelerateMid: "cubic-bezier(0,0,0,1)";
+    curveDecelerateMin: "cubic-bezier(0.33,0,0.1,1)";
+    curveEasyEaseMax: "cubic-bezier(0.8,0,0.2,1)";
+    curveEasyEase: "cubic-bezier(0.33,0,0.67,1)";
+    curveLinear: "cubic-bezier(0,0,1,1)";
+    durationUltraFast: 50;
+    durationFaster: 100;
+    durationFast: 150;
+    durationNormal: 200;
+    durationGentle: 250;
+    durationSlow: 300;
+    durationSlower: 400;
+    durationUltraSlow: 500;
+};
 
 // @public (undocumented)
 export class PresenceGroup extends React_2.Component<PresenceGroupProps, PresenceGroupState> {

--- a/packages/react-components/react-motions-preview/src/index.ts
+++ b/packages/react-components/react-motions-preview/src/index.ts
@@ -1,10 +1,8 @@
-import * as motionTokens from './motions/motionTokens';
+export { motionTokens, durations, curves } from './motions/motionTokens';
 
 export { createMotionComponent } from './factories/createMotionComponent';
 export { createPresenceComponent } from './factories/createPresenceComponent';
 
 export { PresenceGroup } from './components/PresenceGroup';
-
-export { motionTokens };
 
 export type { AtomMotion, AtomMotionFn, PresenceMotion, PresenceMotionFn, MotionImperativeRef } from './types';

--- a/packages/react-components/react-motions-preview/src/motions/motionTokens.ts
+++ b/packages/react-components/react-motions-preview/src/motions/motionTokens.ts
@@ -1,17 +1,44 @@
-export const durationUltraFast = 50;
-export const durationFaster = 100;
-export const durationFast = 150;
-export const durationNormal = 200;
-export const durationSlow = 300;
-export const durationSlower = 400;
-export const durationUltraSlow = 500;
+// Copied from packages/tokens/src/global/durations.ts
+// Values are numeric in milliseconds for ease of use in Web Animations API
+// (rather than parsing '__ms')
+export const durations = {
+  durationUltraFast: 50,
+  durationFaster: 100,
+  durationFast: 150,
+  durationNormal: 200,
+  durationGentle: 250,
+  durationSlow: 300,
+  durationSlower: 400,
+  durationUltraSlow: 500,
+} as const;
 
-export const easingAccelerateMax = 'cubic-bezier(1,0,1,1)';
-export const easingAccelerateMid = 'cubic-bezier(0.7,0,1,0.5)';
-export const easingAccelerateMin = 'cubic-bezier(0.8,0,1,1)';
-export const easingDecelerateMax = 'cubic-bezier(0,0,0,1)';
-export const easingDecelerateMid = 'cubic-bezier(0.1,0.9,0.2,1)';
-export const easingDecelerateMin = 'cubic-bezier(0.33,0,0.1,1)';
-export const easingMaxEasyEase = 'cubic-bezier(0.8,0,0.1,1)';
-export const easingEasyEase = 'cubic-bezier(0.33,0,0.67,1)';
-export const easingLinear = 'cubic-bezier(0,0,1,1)';
+// Copied from packages/tokens/src/global/curves.ts
+// Names and values are preserved exactly
+export const curves = {
+  curveAccelerateMax: 'cubic-bezier(0.9,0.1,1,0.2)',
+  curveAccelerateMid: 'cubic-bezier(1,0,1,1)',
+  curveAccelerateMin: 'cubic-bezier(0.8,0,0.78,1)',
+  curveDecelerateMax: 'cubic-bezier(0.1,0.9,0.2,1)',
+  curveDecelerateMid: 'cubic-bezier(0,0,0,1)',
+  curveDecelerateMin: 'cubic-bezier(0.33,0,0.1,1)',
+  curveEasyEaseMax: 'cubic-bezier(0.8,0,0.2,1)',
+  curveEasyEase: 'cubic-bezier(0.33,0,0.67,1)',
+  curveLinear: 'cubic-bezier(0,0,1,1)',
+} as const;
+
+// A merged flat lookup for convenience
+export const motionTokens = {
+  ...durations,
+  ...curves,
+};
+
+/*
+TODO: enforce naming conventions when TypeScript 4.4 features are supported in Fluent:
+
+type DurationKey = `duration${Capitalize<string>}`;
+type CurveKey = `curve${Capitalize<string>}`;
+type CurveValue = `cubic-bezier(${number},${number},${number},${number})`;
+
+type DurationTokens = Record<DurationKey, number>;
+type CurveTokens = Record<CurveKey, CurveValue>;
+*/

--- a/packages/react-components/react-motions-preview/stories/PresenceGroup/PresenceGroupDefault.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/PresenceGroup/PresenceGroupDefault.stories.tsx
@@ -168,7 +168,7 @@ const ItemMotion = createPresenceComponent({
       { opacity: 0, transform: 'scaleY(0) translateX(-30px)', height: 0 },
       { opacity: 1, transform: 'scaleY(1) translateX(0)', height: '40px' },
     ],
-    easing: motionTokens.easingEasyEase,
+    easing: motionTokens.curveEasyEase,
     duration: motionTokens.durationUltraSlow,
   },
   exit: {
@@ -176,7 +176,7 @@ const ItemMotion = createPresenceComponent({
       { opacity: 1, transform: 'scaleY(1) translateX(0)', height: '40px' },
       { opacity: 0, transform: 'scaleY(0) translateX(-30px)', height: 0 },
     ],
-    easing: motionTokens.easingEasyEase,
+    easing: motionTokens.curveEasyEase,
     duration: motionTokens.durationUltraSlow,
   },
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
## Context

- Motion tokens (duration and easing) are defined in `@fluentui/tokens`, but are not exported there for direct consumption in JavaScript. Only the CSS variable names are exported.
- The motion tokens were copied into `@fluentui/react-motions-preview` to allow JavaScript consumption. This was deemed the least intrusive solution after a discussion of other possible approaches.
- The copied motion tokens deviated from the original in terms of some numerical values, names and structure.

## Previous Behavior

- Easing curve token values in `@fluentui/react-motions-preview` are incorrect (same errors as in #29546)
- Easing curve token names do not match those in `@fluentui/tokens` (`easing___` vs. `curve___`)
- Duration and easing tokens are combined in one flat set, whereas the original has them grouped in `durations` and `curves` objects

## New Behavior

- Easing curve token values are in sync with `packages/tokens/src/global/curves.ts`
- Easing curve tokens are named `curve___` as in the original
- The original's `durations` and `curves` objects are restored. This supports use cases like motion configurators where the durations and curves options are listed in dropdowns.
- The combined `motionTokens` object is kept as an combined, flat lookup. This can be more convenient for some use cases.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31191
