### PR TITLE
fix: add cleanup for timeout in announce

### DIFF
--- a/change/@fluentui-react-aria-9f8b5d1f-9449-49c0-b310-7cdc43927f88.json
+++ b/change/@fluentui-react-aria-9f8b5d1f-9449-49c0-b310-7cdc43927f88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add cleanup for timeout in announce",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -147,7 +147,7 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
       clearAnnounceTimeout();
       timeoutRef.current = undefined;
     };
-  }, [targetDocument]);
+  }, [clearAnnounceTimeout, targetDocument]);
 
   return announce;
 };

--- a/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -144,6 +144,8 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
     return () => {
       element.remove();
       elementRef.current = null;
+      clearAnnounceTimeout();
+      timeoutRef.current = undefined;
     };
   }, [targetDocument]);
 


### PR DESCRIPTION
Adds cleanup for the timeout set up for `announce()`, for if the announcer is unmounted while there's an existing timeout.

Ref: https://github.com/microsoft/fluentui/pull/31251#discussion_r1586814428