### PR TITLE
Tabster - update Keyborg to 2.6.0

### DIFF
--- a/change/@fluentui-react-tabster-0c3b52fd-dc29-4554-b0d3-09db567a106a.json
+++ b/change/@fluentui-react-tabster-0c3b52fd-dc29-4554-b0d3-09db567a106a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update version of keyborg to fix iOS touch bug",
+  "packageName": "@fluentui/react-tabster",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -36,7 +36,7 @@
     "@fluentui/react-utilities": "^9.18.7",
     "@griffel/react": "^1.5.14",
     "@swc/helpers": "^0.5.1",
-    "keyborg": "^2.5.0",
+    "keyborg": "^2.6.0",
     "tabster": "^7.1.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16333,10 +16333,15 @@ karma@6.4.0:
     ua-parser-js "^0.7.30"
     yargs "^16.1.1"
 
-keyborg@2.5.0, keyborg@^2.5.0:
+keyborg@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-2.5.0.tgz#0690136ecfa75e2f245b67f65bdb2be296f5735a"
   integrity sha512-nb4Ji1suqWqj6VXb61Jrs4ab/UWgtGph4wDch2NIZDfLBUObmLcZE0aiDjZY49ghtu03fvwxDNvS9ZB0XMz6/g==
+
+keyborg@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-2.6.0.tgz#ebfcaaed2f517f9295058ff5d57d14e71958ab5a"
+  integrity sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA==
 
 keygrip@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Update keyborg to 2.6.0 to fix iOS touch bug https://github.com/microsoft/keyborg/issues/79