### PR TITLE
chore(react-tag-picker): ensure clicking on surface will toggle open state

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-6f3fa670-6d8d-4dd6-8486-e007c82bf9f1.json
+++ b/change/@fluentui-react-tag-picker-preview-6f3fa670-6d8d-4dd6-8486-e007c82bf9f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure clicking on surface will toggle open state",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
@@ -74,7 +74,7 @@ const TagPickerControlled = ({ open, defaultOpen, defaultSelectedOptions = [] }:
             </Button>
           }
         >
-          <TagPickerGroup>
+          <TagPickerGroup data-testid="tag-picker-group">
             {selectedOptions.map(option => (
               <Tag
                 data-testid={`tag--${option}`}
@@ -139,6 +139,30 @@ describe('TagPicker', () => {
       cy.get('[data-testid="tag-picker-input"]').should('be.focused');
       cy.get('[data-testid="tag-picker-control__expandIcon"]').realClick();
       cy.get('[data-testid="tag-picker-list"]').should('not.be.visible');
+    });
+    it('should open/close a listbox once surface (control) is clicked', () => {
+      mount(<TagPickerControlled />);
+      cy.get('[data-testid="tag-picker-list"]').should('not.exist');
+      cy.get('[data-testid="tag-picker-control"]').realClick();
+      cy.get('[data-testid="tag-picker-list"]').should('be.visible');
+      cy.get('[data-testid="tag-picker-input"]').should('be.focused');
+      cy.get('[data-testid="tag-picker-control"]').realClick();
+      cy.get('[data-testid="tag-picker-list"]').should('not.be.visible');
+    });
+    it('should open/close a listbox once surface (tag group) is clicked', () => {
+      mount(<TagPickerControlled defaultSelectedOptions={options} />);
+      cy.get('[data-testid="tag-picker-list"]').should('not.exist');
+      cy.get('[data-testid="tag-picker-group"]').realClick();
+      cy.get('[data-testid="tag-picker-list"]').should('be.visible');
+      cy.get('[data-testid="tag-picker-input"]').should('be.focused');
+      cy.get('[data-testid="tag-picker-group"]').realClick();
+      cy.get('[data-testid="tag-picker-list"]').should('not.be.visible');
+    });
+    it('should not open/close a listbox once secondary action is clicked', () => {
+      mount(<TagPickerControlled />);
+      cy.get('[data-testid="tag-picker-list"]').should('not.exist');
+      cy.get('[data-testid="tag-picker-control__secondaryAction"]').realClick();
+      cy.get('[data-testid="tag-picker-list"]').should('not.exist');
     });
     it('should select a tag on option click', () => {
       mount(<TagPickerControlled defaultOpen />);

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/useTagPicker.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isHTMLElement, elementContains, useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
+import { useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
 import type {
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
@@ -9,7 +9,10 @@ import type {
 import { optionClassNames } from '@fluentui/react-combobox';
 import { PositioningShorthandValue, resolvePositioningShorthand, usePositioning } from '@fluentui/react-positioning';
 import { useActiveDescendant } from '@fluentui/react-aria';
-import { useComboboxBaseState, ComboboxBaseState } from '@fluentui/react-combobox';
+import { useComboboxBaseState } from '@fluentui/react-combobox';
+
+// Set a default set of fallback positions to try if the dropdown does not fit on screen
+const fallbackPositions: PositioningShorthandValue[] = ['above', 'after', 'after-top', 'before', 'before-top'];
 
 /**
  * Create the state required to render Picker.
@@ -25,9 +28,6 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
   const secondaryActionRef = React.useRef<HTMLSpanElement>(null);
   const tagPickerGroupRef = React.useRef<HTMLDivElement>(null);
   const { positioning, size = 'medium', inline = false } = props;
-
-  // Set a default set of fallback positions to try if the dropdown does not fit on screen
-  const fallbackPositions: PositioningShorthandValue[] = ['above', 'after', 'after-top', 'before', 'before-top'];
 
   const { targetRef, containerRef } = usePositioning({
     position: 'below' as const,
@@ -71,19 +71,6 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
 
   const { trigger, popover } = childrenToTriggerAndPopover(props.children);
 
-  const setOpen: ComboboxBaseState['setOpen'] = useEventCallback((event, newValue) => {
-    // if event comes from secondary action, ignore it
-    // if event comes from tags, ignore it
-    if (
-      isHTMLElement(event.target) &&
-      (elementContains(secondaryActionRef.current, event.target) ||
-        elementContains(tagPickerGroupRef.current, event.target))
-    ) {
-      return;
-    }
-    comboboxState.setOpen(event, newValue);
-  });
-
   return {
     activeDescendantController,
     components: {},
@@ -102,7 +89,7 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     mountNode: comboboxState.mountNode,
     onOptionClick: useEventCallback(event => {
       comboboxState.onOptionClick(event);
-      setOpen(event, false);
+      comboboxState.setOpen(event, false);
     }),
     appearance: comboboxState.appearance,
     clearSelection: comboboxState.clearSelection,
@@ -111,7 +98,7 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     selectedOptions: comboboxState.selectedOptions,
     selectOption: comboboxState.selectOption,
     setHasFocus: comboboxState.setHasFocus,
-    setOpen,
+    setOpen: comboboxState.setOpen,
     setValue: comboboxState.setValue,
     value: comboboxState.value,
     freeform: comboboxState.freeform,

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -42,13 +42,6 @@ export const useTagPickerGroup_unstable = (
       size,
       appearance: tagPickerAppearanceToTagAppearance(appearance),
       dismissible: true,
-      onClick: useEventCallback(event => {
-        props.onClick?.(event);
-        // if it's a click on the group itself, we want to focus the trigger
-        if (event.target === event.currentTarget) {
-          triggerRef.current?.focus();
-        }
-      }),
       onKeyDown: useEventCallback(event => {
         props.onKeyDown?.(event);
         if (isHTMLElement(event.target) && event.key === ArrowRight) {

--- a/packages/react-components/react-tag-picker-preview/stories/TagPicker/TagPickerDefault.stories.tsx
+++ b/packages/react-components/react-tag-picker-preview/stories/TagPicker/TagPickerDefault.stories.tsx
@@ -24,7 +24,6 @@ const options = [
 export const Default = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
-    console.log(data.type);
     setSelectedOptions(data.selectedOptions);
   };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. ensures clicks on the surface of the `TagPicker` will toggle the open state

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
