### PR TITLE
fix(scripts-cypress): mitigate esbuild-loader WARNING spam when running cypress tests

### DIFF
--- a/scripts/cypress/src/base.config.ts
+++ b/scripts/cypress/src/base.config.ts
@@ -33,6 +33,16 @@ const cypressWebpackConfig = (): Configuration => {
     });
   }
 
+  // TODO: remove this once esbuild-loader properly handles module loading https://github.com/privatenumber/esbuild-loader/issues/343#issuecomment-1845836603
+  baseWebpackConfig.ignoreWarnings = [
+    ...(baseWebpackConfig.ignoreWarnings ?? []),
+    {
+      module: /[esbuild-loader]/,
+      message:
+        /The specified tsconfig at\s+"[/a-z0-9-/.\s]+"\s+was applied to the file\s+"[/a-z0-9-.\s]+"\s+but does not match its "include" patterns/i,
+    },
+  ];
+
   baseWebpackConfig.resolve ??= {};
   baseWebpackConfig.resolve.plugins ??= [];
   baseWebpackConfig.resolve.plugins.push(


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

<img width="1012" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/c906f5a8-37b8-4040-b0f8-06dfbf2c8bc7">


## New Behavior

see PR title

<img width="2045" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/f7a5adc9-6963-4f35-8628-65f4da53290e">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31276
