### PR TITLE
fix: update hover active styles in Switch

### DIFF
--- a/change/@fluentui-react-switch-144fd00c-f01b-4d08-b082-e733be903d67.json
+++ b/change/@fluentui-react-switch-144fd00c-f01b-4d08-b082-e733be903d67.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add HC hover active styling to Switch.",
+  "packageName": "@fluentui/react-switch",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.styles.ts
+++ b/packages/react-components/react-switch/src/components/Switch/useSwitchStyles.styles.ts
@@ -194,8 +194,17 @@ const useInputBaseClassName = makeResetStyles({
     ':hover': {
       color: 'CanvasText',
     },
+    ':hover:active': {
+      color: 'CanvasText',
+    },
     ':enabled:checked': {
       ':hover': {
+        [`& ~ .${switchClassNames.indicator}`]: {
+          backgroundColor: 'Highlight',
+          color: 'Canvas',
+        },
+      },
+      ':hover:active': {
         [`& ~ .${switchClassNames.indicator}`]: {
           backgroundColor: 'Highlight',
           color: 'Canvas',


### PR DESCRIPTION
This fixes an issue in HC where the `Switch` indicator disappears when checked and hovered over. Fixes #31244 