### PR TITLE
(feat):react-nav-preview - Scaffolding a bunch of new components for re-composition

### DIFF
--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -19,6 +19,40 @@ import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
+export const Hamburger: ForwardRefComponent<HamburgerProps>;
+
+// @public (undocumented)
+export const hamburgerClassNames: SlotClassNames<HamburgerSlots>;
+
+// @public
+export const HamburgerInNav: ForwardRefComponent<HamburgerInNavProps>;
+
+// @public (undocumented)
+export const hamburgerInNavClassNames: SlotClassNames<HamburgerInNavSlots>;
+
+// @public
+export type HamburgerInNavProps = ComponentProps<HamburgerInNavSlots> & {};
+
+// @public (undocumented)
+export type HamburgerInNavSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type HamburgerInNavState = ComponentState<HamburgerInNavSlots>;
+
+// @public
+export type HamburgerProps = ComponentProps<HamburgerSlots> & {};
+
+// @public (undocumented)
+export type HamburgerSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type HamburgerState = ComponentState<HamburgerSlots>;
+
+// @public
 export const Nav: ForwardRefComponent<NavProps>;
 
 // @public
@@ -81,8 +115,76 @@ export type NavContextValues = {
 // @public
 export const NavDrawer: ForwardRefComponent<NavDrawerProps>;
 
+// @public
+export const NavDrawerBody: ForwardRefComponent<NavDrawerBodyProps>;
+
+// @public (undocumented)
+export const navDrawerBodyClassNames: SlotClassNames<NavDrawerBodySlots>;
+
+// @public
+export type NavDrawerBodyProps = ComponentProps<NavDrawerBodySlots> & {};
+
+// @public (undocumented)
+export type NavDrawerBodySlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavDrawerBodyState = ComponentState<NavDrawerBodySlots>;
+
 // @public (undocumented)
 export const navDrawerClassNames: SlotClassNames<InlineDrawerSlots>;
+
+// @public
+export const NavDrawerFooter: ForwardRefComponent<NavDrawerFooterProps>;
+
+// @public (undocumented)
+export const navDrawerFooterClassNames: SlotClassNames<NavDrawerFooterSlots>;
+
+// @public
+export type NavDrawerFooterProps = ComponentProps<NavDrawerFooterSlots> & {};
+
+// @public (undocumented)
+export type NavDrawerFooterSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavDrawerFooterState = ComponentState<NavDrawerFooterSlots>;
+
+// @public
+export const NavDrawerHeader: ForwardRefComponent<NavDrawerHeaderProps>;
+
+// @public (undocumented)
+export const navDrawerHeaderClassNames: SlotClassNames<NavDrawerHeaderSlots>;
+
+// @public
+export const NavDrawerHeaderNav: ForwardRefComponent<NavDrawerHeaderNavProps>;
+
+// @public (undocumented)
+export const navDrawerHeaderNavClassNames: SlotClassNames<NavDrawerHeaderNavSlots>;
+
+// @public
+export type NavDrawerHeaderNavProps = ComponentProps<NavDrawerHeaderNavSlots> & {};
+
+// @public (undocumented)
+export type NavDrawerHeaderNavSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavDrawerHeaderNavState = ComponentState<NavDrawerHeaderNavSlots>;
+
+// @public
+export type NavDrawerHeaderProps = ComponentProps<NavDrawerHeaderSlots> & {};
+
+// @public (undocumented)
+export type NavDrawerHeaderSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavDrawerHeaderState = ComponentState<NavDrawerHeaderSlots>;
 
 // @public
 export type NavDrawerProps = DrawerProps & NavProps;
@@ -136,6 +238,23 @@ export type NavProps = ComponentProps<NavSlots> & {
 // @public (undocumented)
 export const NavProvider: React_2.Provider<NavContextValue | undefined>;
 
+// @public
+export const NavSectionHeader: ForwardRefComponent<NavSectionHeaderProps>;
+
+// @public (undocumented)
+export const navSectionHeaderClassNames: SlotClassNames<NavSectionHeaderSlots>;
+
+// @public
+export type NavSectionHeaderProps = ComponentProps<NavSectionHeaderSlots> & {};
+
+// @public (undocumented)
+export type NavSectionHeaderSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavSectionHeaderState = ComponentState<NavSectionHeaderSlots>;
+
 // @public (undocumented)
 export type NavSlots = {
     root: NonNullable<Slot<'div'>>;
@@ -187,6 +306,12 @@ export type NavSubItemState = ComponentState<NavSubItemSlots> & Pick<NavSubItemP
 // @public (undocumented)
 export type RegisterNavItemEventHandler = (data: NavItemRegisterData) => void;
 
+// @public
+export const renderHamburger_unstable: (state: HamburgerState) => JSX.Element;
+
+// @public
+export const renderHamburgerInNav_unstable: (state: HamburgerInNavState) => JSX.Element;
+
 // @public (undocumented)
 export const renderNav_unstable: (state: NavState, contextValues: NavContextValues) => JSX.Element;
 
@@ -200,13 +325,40 @@ export const renderNavCategoryItem_unstable: (state: NavCategoryItemState, conte
 export const renderNavDrawer_unstable: (state: NavDrawerState, contextValues: NavContextValues) => JSX.Element;
 
 // @public
+export const renderNavDrawerBody_unstable: (state: NavDrawerBodyState) => JSX.Element;
+
+// @public
+export const renderNavDrawerFooter_unstable: (state: NavDrawerFooterState) => JSX.Element;
+
+// @public
+export const renderNavDrawerHeader_unstable: (state: NavDrawerHeaderState) => JSX.Element;
+
+// @public
+export const renderNavDrawerHeaderNav_unstable: (state: NavDrawerHeaderNavState) => JSX.Element;
+
+// @public
 export const renderNavItem_unstable: (state: NavItemState) => JSX.Element;
+
+// @public
+export const renderNavSectionHeader_unstable: (state: NavSectionHeaderState) => JSX.Element;
 
 // @public
 export const renderNavSubItem_unstable: (state: NavSubItemState) => JSX.Element;
 
 // @public
 export const renderNavSubItemGroup_unstable: (state: NavSubItemGroupState) => JSX.Element | null;
+
+// @public
+export const useHamburger_unstable: (props: HamburgerProps, ref: React_2.Ref<HTMLDivElement>) => HamburgerState;
+
+// @public
+export const useHamburgerInNav_unstable: (props: HamburgerInNavProps, ref: React_2.Ref<HTMLDivElement>) => HamburgerInNavState;
+
+// @public
+export const useHamburgerInNavStyles_unstable: (state: HamburgerInNavState) => HamburgerInNavState;
+
+// @public
+export const useHamburgerStyles_unstable: (state: HamburgerState) => HamburgerState;
 
 // @public
 export const useNav_unstable: (props: NavProps, ref: React_2.Ref<HTMLDivElement>) => NavState;
@@ -227,6 +379,30 @@ export const useNavContext_unstable: () => NavContextValue;
 export const useNavDrawer_unstable: (props: NavDrawerProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerState;
 
 // @public
+export const useNavDrawerBody_unstable: (props: NavDrawerBodyProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerBodyState;
+
+// @public
+export const useNavDrawerBodyStyles_unstable: (state: NavDrawerBodyState) => NavDrawerBodyState;
+
+// @public
+export const useNavDrawerFooter_unstable: (props: NavDrawerFooterProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerFooterState;
+
+// @public
+export const useNavDrawerFooterStyles_unstable: (state: NavDrawerFooterState) => NavDrawerFooterState;
+
+// @public
+export const useNavDrawerHeader_unstable: (props: NavDrawerHeaderProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerHeaderState;
+
+// @public
+export const useNavDrawerHeaderNav_unstable: (props: NavDrawerHeaderNavProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerHeaderNavState;
+
+// @public
+export const useNavDrawerHeaderNavStyles_unstable: (state: NavDrawerHeaderNavState) => NavDrawerHeaderNavState;
+
+// @public
+export const useNavDrawerHeaderStyles_unstable: (state: NavDrawerHeaderState) => NavDrawerHeaderState;
+
+// @public
 export const useNavDrawerStyles_unstable: (state: NavDrawerState) => NavDrawerState;
 
 // @public
@@ -234,6 +410,12 @@ export const useNavItem_unstable: (props: NavItemProps, ref: React_2.Ref<HTMLAnc
 
 // @public
 export const useNavItemStyles_unstable: (state: NavItemState) => NavItemState;
+
+// @public
+export const useNavSectionHeader_unstable: (props: NavSectionHeaderProps, ref: React_2.Ref<HTMLDivElement>) => NavSectionHeaderState;
+
+// @public
+export const useNavSectionHeaderStyles_unstable: (state: NavSectionHeaderState) => NavSectionHeaderState;
 
 // @public
 export const useNavStyles_unstable: (state: NavState) => NavState;

--- a/packages/react-components/react-nav-preview/src/Hamburger.ts
+++ b/packages/react-components/react-nav-preview/src/Hamburger.ts
@@ -1,0 +1,1 @@
+export * from './components/Hamburger/index';

--- a/packages/react-components/react-nav-preview/src/HamburgerInNav.ts
+++ b/packages/react-components/react-nav-preview/src/HamburgerInNav.ts
@@ -1,0 +1,1 @@
+export * from './components/HamburgerInNav/index';

--- a/packages/react-components/react-nav-preview/src/NavDrawerBody.ts
+++ b/packages/react-components/react-nav-preview/src/NavDrawerBody.ts
@@ -1,0 +1,1 @@
+export * from './components/NavDrawerBody/index';

--- a/packages/react-components/react-nav-preview/src/NavDrawerFooter.ts
+++ b/packages/react-components/react-nav-preview/src/NavDrawerFooter.ts
@@ -1,0 +1,1 @@
+export * from './components/NavDrawerFooter/index';

--- a/packages/react-components/react-nav-preview/src/NavDrawerHeader.ts
+++ b/packages/react-components/react-nav-preview/src/NavDrawerHeader.ts
@@ -1,0 +1,1 @@
+export * from './components/NavDrawerHeader/index';

--- a/packages/react-components/react-nav-preview/src/NavDrawerHeaderNav.ts
+++ b/packages/react-components/react-nav-preview/src/NavDrawerHeaderNav.ts
@@ -1,0 +1,1 @@
+export * from './components/NavDrawerHeaderNav/index';

--- a/packages/react-components/react-nav-preview/src/NavSectionHeader.ts
+++ b/packages/react-components/react-nav-preview/src/NavSectionHeader.ts
@@ -1,0 +1,1 @@
+export * from './components/NavSectionHeader/index';

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { Hamburger } from './Hamburger';
+
+describe('Hamburger', () => {
+  isConformant({
+    Component: Hamburger,
+    displayName: 'Hamburger',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<Hamburger>Default Hamburger</Hamburger>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { Hamburger } from './Hamburger';
 
@@ -7,12 +5,5 @@ describe('Hamburger', () => {
   isConformant({
     Component: Hamburger,
     displayName: 'Hamburger',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<Hamburger>Default Hamburger</Hamburger>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useHamburger_unstable } from './useHamburger';
+import { renderHamburger_unstable } from './renderHamburger';
+import { useHamburgerStyles_unstable } from './useHamburgerStyles.styles';
+import type { HamburgerProps } from './Hamburger.types';
+
+/**
+ * Hamburger component - TODO: add more docs
+ */
+export const Hamburger: ForwardRefComponent<HamburgerProps> = React.forwardRef((props, ref) => {
+  const state = useHamburger_unstable(props, ref);
+
+  useHamburgerStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useHamburgerStyles_unstable')(state);
+  return renderHamburger_unstable(state);
+});
+
+Hamburger.displayName = 'Hamburger';

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/Hamburger.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type HamburgerSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * Hamburger Props
+ */
+export type HamburgerProps = ComponentProps<HamburgerSlots> & {};
+
+/**
+ * State used in rendering Hamburger
+ */
+export type HamburgerState = ComponentState<HamburgerSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from HamburgerProps.
+// & Required<Pick<HamburgerProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/index.ts
@@ -1,0 +1,5 @@
+export * from './Hamburger';
+export * from './Hamburger.types';
+export * from './renderHamburger';
+export * from './useHamburger';
+export * from './useHamburgerStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/renderHamburger.tsx
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/renderHamburger.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { HamburgerState, HamburgerSlots } from './Hamburger.types';
+
+/**
+ * Render the final JSX of Hamburger
+ */
+export const renderHamburger_unstable = (state: HamburgerState) => {
+  assertSlots<HamburgerSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/useHamburger.ts
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/useHamburger.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { HamburgerProps, HamburgerState } from './Hamburger.types';
+
+/**
+ * Create the state required to render Hamburger.
+ *
+ * The returned state can be modified with hooks such as useHamburgerStyles_unstable,
+ * before being passed to renderHamburger_unstable.
+ *
+ * @param props - props from this instance of Hamburger
+ * @param ref - reference to root HTMLDivElement of Hamburger
+ */
+export const useHamburger_unstable = (props: HamburgerProps, ref: React.Ref<HTMLDivElement>): HamburgerState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/Hamburger/useHamburgerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/Hamburger/useHamburgerStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { HamburgerSlots, HamburgerState } from './Hamburger.types';
+
+export const hamburgerClassNames: SlotClassNames<HamburgerSlots> = {
+  root: 'fui-Hamburger',
+  // TODO: add class names for all slots on HamburgerSlots.
+  // Should be of the form `<slotName>: 'fui-Hamburger__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the Hamburger slots based on the state
+ */
+export const useHamburgerStyles_unstable = (state: HamburgerState): HamburgerState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(hamburgerClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { HamburgerInNav } from './HamburgerInNav';
+
+describe('HamburgerInNav', () => {
+  isConformant({
+    Component: HamburgerInNav,
+    displayName: 'HamburgerInNav',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<HamburgerInNav>Default HamburgerInNav</HamburgerInNav>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { HamburgerInNav } from './HamburgerInNav';
 
@@ -7,12 +5,5 @@ describe('HamburgerInNav', () => {
   isConformant({
     Component: HamburgerInNav,
     displayName: 'HamburgerInNav',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<HamburgerInNav>Default HamburgerInNav</HamburgerInNav>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useHamburgerInNav_unstable } from './useHamburgerInNav';
+import { renderHamburgerInNav_unstable } from './renderHamburgerInNav';
+import { useHamburgerInNavStyles_unstable } from './useHamburgerInNavStyles.styles';
+import type { HamburgerInNavProps } from './HamburgerInNav.types';
+
+/**
+ * HamburgerInNav component - TODO: add more docs
+ */
+export const HamburgerInNav: ForwardRefComponent<HamburgerInNavProps> = React.forwardRef((props, ref) => {
+  const state = useHamburgerInNav_unstable(props, ref);
+
+  useHamburgerInNavStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useHamburgerInNavStyles_unstable')(state);
+  return renderHamburgerInNav_unstable(state);
+});
+
+HamburgerInNav.displayName = 'HamburgerInNav';

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/HamburgerInNav.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type HamburgerInNavSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * HamburgerInNav Props
+ */
+export type HamburgerInNavProps = ComponentProps<HamburgerInNavSlots> & {};
+
+/**
+ * State used in rendering HamburgerInNav
+ */
+export type HamburgerInNavState = ComponentState<HamburgerInNavSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from HamburgerInNavProps.
+// & Required<Pick<HamburgerInNavProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/index.ts
@@ -1,0 +1,5 @@
+export * from './HamburgerInNav';
+export * from './HamburgerInNav.types';
+export * from './renderHamburgerInNav';
+export * from './useHamburgerInNav';
+export * from './useHamburgerInNavStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/renderHamburgerInNav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/renderHamburgerInNav.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { HamburgerInNavState, HamburgerInNavSlots } from './HamburgerInNav.types';
+
+/**
+ * Render the final JSX of HamburgerInNav
+ */
+export const renderHamburgerInNav_unstable = (state: HamburgerInNavState) => {
+  assertSlots<HamburgerInNavSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/useHamburgerInNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/useHamburgerInNav.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { HamburgerInNavProps, HamburgerInNavState } from './HamburgerInNav.types';
+
+/**
+ * Create the state required to render HamburgerInNav.
+ *
+ * The returned state can be modified with hooks such as useHamburgerInNavStyles_unstable,
+ * before being passed to renderHamburgerInNav_unstable.
+ *
+ * @param props - props from this instance of HamburgerInNav
+ * @param ref - reference to root HTMLDivElement of HamburgerInNav
+ */
+export const useHamburgerInNav_unstable = (
+  props: HamburgerInNavProps,
+  ref: React.Ref<HTMLDivElement>,
+): HamburgerInNavState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/HamburgerInNav/useHamburgerInNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/HamburgerInNav/useHamburgerInNavStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { HamburgerInNavSlots, HamburgerInNavState } from './HamburgerInNav.types';
+
+export const hamburgerInNavClassNames: SlotClassNames<HamburgerInNavSlots> = {
+  root: 'fui-HamburgerInNav',
+  // TODO: add class names for all slots on HamburgerInNavSlots.
+  // Should be of the form `<slotName>: 'fui-HamburgerInNav__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the HamburgerInNav slots based on the state
+ */
+export const useHamburgerInNavStyles_unstable = (state: HamburgerInNavState): HamburgerInNavState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(hamburgerInNavClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { NavDrawerBody } from './NavDrawerBody';
 
@@ -7,12 +5,5 @@ describe('NavDrawerBody', () => {
   isConformant({
     Component: NavDrawerBody,
     displayName: 'NavDrawerBody',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<NavDrawerBody>Default NavDrawerBody</NavDrawerBody>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavDrawerBody } from './NavDrawerBody';
+
+describe('NavDrawerBody', () => {
+  isConformant({
+    Component: NavDrawerBody,
+    displayName: 'NavDrawerBody',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavDrawerBody>Default NavDrawerBody</NavDrawerBody>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useNavDrawerBody_unstable } from './useNavDrawerBody';
+import { renderNavDrawerBody_unstable } from './renderNavDrawerBody';
+import { useNavDrawerBodyStyles_unstable } from './useNavDrawerBodyStyles.styles';
+import type { NavDrawerBodyProps } from './NavDrawerBody.types';
+
+/**
+ * NavDrawerBody component - TODO: add more docs
+ */
+export const NavDrawerBody: ForwardRefComponent<NavDrawerBodyProps> = React.forwardRef((props, ref) => {
+  const state = useNavDrawerBody_unstable(props, ref);
+
+  useNavDrawerBodyStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useNavDrawerBodyStyles_unstable')(state);
+  return renderNavDrawerBody_unstable(state);
+});
+
+NavDrawerBody.displayName = 'NavDrawerBody';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/NavDrawerBody.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavDrawerBodySlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavDrawerBody Props
+ */
+export type NavDrawerBodyProps = ComponentProps<NavDrawerBodySlots> & {};
+
+/**
+ * State used in rendering NavDrawerBody
+ */
+export type NavDrawerBodyState = ComponentState<NavDrawerBodySlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavDrawerBodyProps.
+// & Required<Pick<NavDrawerBodyProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/index.ts
@@ -1,0 +1,5 @@
+export * from './NavDrawerBody';
+export * from './NavDrawerBody.types';
+export * from './renderNavDrawerBody';
+export * from './useNavDrawerBody';
+export * from './useNavDrawerBodyStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/renderNavDrawerBody.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/renderNavDrawerBody.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavDrawerBodyState, NavDrawerBodySlots } from './NavDrawerBody.types';
+
+/**
+ * Render the final JSX of NavDrawerBody
+ */
+export const renderNavDrawerBody_unstable = (state: NavDrawerBodyState) => {
+  assertSlots<NavDrawerBodySlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/useNavDrawerBody.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/useNavDrawerBody.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavDrawerBodyProps, NavDrawerBodyState } from './NavDrawerBody.types';
+
+/**
+ * Create the state required to render NavDrawerBody.
+ *
+ * The returned state can be modified with hooks such as useNavDrawerBodyStyles_unstable,
+ * before being passed to renderNavDrawerBody_unstable.
+ *
+ * @param props - props from this instance of NavDrawerBody
+ * @param ref - reference to root HTMLDivElement of NavDrawerBody
+ */
+export const useNavDrawerBody_unstable = (
+  props: NavDrawerBodyProps,
+  ref: React.Ref<HTMLDivElement>,
+): NavDrawerBodyState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerBody/useNavDrawerBodyStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerBody/useNavDrawerBodyStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavDrawerBodySlots, NavDrawerBodyState } from './NavDrawerBody.types';
+
+export const navDrawerBodyClassNames: SlotClassNames<NavDrawerBodySlots> = {
+  root: 'fui-NavDrawerBody',
+  // TODO: add class names for all slots on NavDrawerBodySlots.
+  // Should be of the form `<slotName>: 'fui-NavDrawerBody__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavDrawerBody slots based on the state
+ */
+export const useNavDrawerBodyStyles_unstable = (state: NavDrawerBodyState): NavDrawerBodyState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(navDrawerBodyClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { NavDrawerFooter } from './NavDrawerFooter';
 
@@ -7,12 +5,5 @@ describe('NavDrawerFooter', () => {
   isConformant({
     Component: NavDrawerFooter,
     displayName: 'NavDrawerFooter',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<NavDrawerFooter>Default NavDrawerFooter</NavDrawerFooter>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavDrawerFooter } from './NavDrawerFooter';
+
+describe('NavDrawerFooter', () => {
+  isConformant({
+    Component: NavDrawerFooter,
+    displayName: 'NavDrawerFooter',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavDrawerFooter>Default NavDrawerFooter</NavDrawerFooter>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useNavDrawerFooter_unstable } from './useNavDrawerFooter';
+import { renderNavDrawerFooter_unstable } from './renderNavDrawerFooter';
+import { useNavDrawerFooterStyles_unstable } from './useNavDrawerFooterStyles.styles';
+import type { NavDrawerFooterProps } from './NavDrawerFooter.types';
+
+/**
+ * NavDrawerFooter component - TODO: add more docs
+ */
+export const NavDrawerFooter: ForwardRefComponent<NavDrawerFooterProps> = React.forwardRef((props, ref) => {
+  const state = useNavDrawerFooter_unstable(props, ref);
+
+  useNavDrawerFooterStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useNavDrawerFooterStyles_unstable')(state);
+  return renderNavDrawerFooter_unstable(state);
+});
+
+NavDrawerFooter.displayName = 'NavDrawerFooter';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/NavDrawerFooter.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavDrawerFooterSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavDrawerFooter Props
+ */
+export type NavDrawerFooterProps = ComponentProps<NavDrawerFooterSlots> & {};
+
+/**
+ * State used in rendering NavDrawerFooter
+ */
+export type NavDrawerFooterState = ComponentState<NavDrawerFooterSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavDrawerFooterProps.
+// & Required<Pick<NavDrawerFooterProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/index.ts
@@ -1,0 +1,5 @@
+export * from './NavDrawerFooter';
+export * from './NavDrawerFooter.types';
+export * from './renderNavDrawerFooter';
+export * from './useNavDrawerFooter';
+export * from './useNavDrawerFooterStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/renderNavDrawerFooter.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/renderNavDrawerFooter.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavDrawerFooterState, NavDrawerFooterSlots } from './NavDrawerFooter.types';
+
+/**
+ * Render the final JSX of NavDrawerFooter
+ */
+export const renderNavDrawerFooter_unstable = (state: NavDrawerFooterState) => {
+  assertSlots<NavDrawerFooterSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/useNavDrawerFooter.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/useNavDrawerFooter.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavDrawerFooterProps, NavDrawerFooterState } from './NavDrawerFooter.types';
+
+/**
+ * Create the state required to render NavDrawerFooter.
+ *
+ * The returned state can be modified with hooks such as useNavDrawerFooterStyles_unstable,
+ * before being passed to renderNavDrawerFooter_unstable.
+ *
+ * @param props - props from this instance of NavDrawerFooter
+ * @param ref - reference to root HTMLDivElement of NavDrawerFooter
+ */
+export const useNavDrawerFooter_unstable = (
+  props: NavDrawerFooterProps,
+  ref: React.Ref<HTMLDivElement>,
+): NavDrawerFooterState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/useNavDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerFooter/useNavDrawerFooterStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavDrawerFooterSlots, NavDrawerFooterState } from './NavDrawerFooter.types';
+
+export const navDrawerFooterClassNames: SlotClassNames<NavDrawerFooterSlots> = {
+  root: 'fui-NavDrawerFooter',
+  // TODO: add class names for all slots on NavDrawerFooterSlots.
+  // Should be of the form `<slotName>: 'fui-NavDrawerFooter__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavDrawerFooter slots based on the state
+ */
+export const useNavDrawerFooterStyles_unstable = (state: NavDrawerFooterState): NavDrawerFooterState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(navDrawerFooterClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { NavDrawerHeader } from './NavDrawerHeader';
 
@@ -7,12 +5,5 @@ describe('NavDrawerHeader', () => {
   isConformant({
     Component: NavDrawerHeader,
     displayName: 'NavDrawerHeader',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<NavDrawerHeader>Default NavDrawerHeader</NavDrawerHeader>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavDrawerHeader } from './NavDrawerHeader';
+
+describe('NavDrawerHeader', () => {
+  isConformant({
+    Component: NavDrawerHeader,
+    displayName: 'NavDrawerHeader',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavDrawerHeader>Default NavDrawerHeader</NavDrawerHeader>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useNavDrawerHeader_unstable } from './useNavDrawerHeader';
+import { renderNavDrawerHeader_unstable } from './renderNavDrawerHeader';
+import { useNavDrawerHeaderStyles_unstable } from './useNavDrawerHeaderStyles.styles';
+import type { NavDrawerHeaderProps } from './NavDrawerHeader.types';
+
+/**
+ * NavDrawerHeader component - TODO: add more docs
+ */
+export const NavDrawerHeader: ForwardRefComponent<NavDrawerHeaderProps> = React.forwardRef((props, ref) => {
+  const state = useNavDrawerHeader_unstable(props, ref);
+
+  useNavDrawerHeaderStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useNavDrawerHeaderStyles_unstable')(state);
+  return renderNavDrawerHeader_unstable(state);
+});
+
+NavDrawerHeader.displayName = 'NavDrawerHeader';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/NavDrawerHeader.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavDrawerHeaderSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavDrawerHeader Props
+ */
+export type NavDrawerHeaderProps = ComponentProps<NavDrawerHeaderSlots> & {};
+
+/**
+ * State used in rendering NavDrawerHeader
+ */
+export type NavDrawerHeaderState = ComponentState<NavDrawerHeaderSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavDrawerHeaderProps.
+// & Required<Pick<NavDrawerHeaderProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/index.ts
@@ -1,0 +1,5 @@
+export * from './NavDrawerHeader';
+export * from './NavDrawerHeader.types';
+export * from './renderNavDrawerHeader';
+export * from './useNavDrawerHeader';
+export * from './useNavDrawerHeaderStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/renderNavDrawerHeader.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/renderNavDrawerHeader.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavDrawerHeaderState, NavDrawerHeaderSlots } from './NavDrawerHeader.types';
+
+/**
+ * Render the final JSX of NavDrawerHeader
+ */
+export const renderNavDrawerHeader_unstable = (state: NavDrawerHeaderState) => {
+  assertSlots<NavDrawerHeaderSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/useNavDrawerHeader.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/useNavDrawerHeader.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavDrawerHeaderProps, NavDrawerHeaderState } from './NavDrawerHeader.types';
+
+/**
+ * Create the state required to render NavDrawerHeader.
+ *
+ * The returned state can be modified with hooks such as useNavDrawerHeaderStyles_unstable,
+ * before being passed to renderNavDrawerHeader_unstable.
+ *
+ * @param props - props from this instance of NavDrawerHeader
+ * @param ref - reference to root HTMLDivElement of NavDrawerHeader
+ */
+export const useNavDrawerHeader_unstable = (
+  props: NavDrawerHeaderProps,
+  ref: React.Ref<HTMLDivElement>,
+): NavDrawerHeaderState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavDrawerHeaderSlots, NavDrawerHeaderState } from './NavDrawerHeader.types';
+
+export const navDrawerHeaderClassNames: SlotClassNames<NavDrawerHeaderSlots> = {
+  root: 'fui-NavDrawerHeader',
+  // TODO: add class names for all slots on NavDrawerHeaderSlots.
+  // Should be of the form `<slotName>: 'fui-NavDrawerHeader__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavDrawerHeader slots based on the state
+ */
+export const useNavDrawerHeaderStyles_unstable = (state: NavDrawerHeaderState): NavDrawerHeaderState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(navDrawerHeaderClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { NavDrawerHeaderNav } from './NavDrawerHeaderNav';
 
@@ -7,12 +5,5 @@ describe('NavDrawerHeaderNav', () => {
   isConformant({
     Component: NavDrawerHeaderNav,
     displayName: 'NavDrawerHeaderNav',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<NavDrawerHeaderNav>Default NavDrawerHeaderNav</NavDrawerHeaderNav>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavDrawerHeaderNav } from './NavDrawerHeaderNav';
+
+describe('NavDrawerHeaderNav', () => {
+  isConformant({
+    Component: NavDrawerHeaderNav,
+    displayName: 'NavDrawerHeaderNav',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavDrawerHeaderNav>Default NavDrawerHeaderNav</NavDrawerHeaderNav>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useNavDrawerHeaderNav_unstable } from './useNavDrawerHeaderNav';
+import { renderNavDrawerHeaderNav_unstable } from './renderNavDrawerHeaderNav';
+import { useNavDrawerHeaderNavStyles_unstable } from './useNavDrawerHeaderNavStyles.styles';
+import type { NavDrawerHeaderNavProps } from './NavDrawerHeaderNav.types';
+
+/**
+ * NavDrawerHeaderNav component - TODO: add more docs
+ */
+export const NavDrawerHeaderNav: ForwardRefComponent<NavDrawerHeaderNavProps> = React.forwardRef((props, ref) => {
+  const state = useNavDrawerHeaderNav_unstable(props, ref);
+
+  useNavDrawerHeaderNavStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useNavDrawerHeaderNavStyles_unstable')(state);
+  return renderNavDrawerHeaderNav_unstable(state);
+});
+
+NavDrawerHeaderNav.displayName = 'NavDrawerHeaderNav';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/NavDrawerHeaderNav.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavDrawerHeaderNavSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavDrawerHeaderNav Props
+ */
+export type NavDrawerHeaderNavProps = ComponentProps<NavDrawerHeaderNavSlots> & {};
+
+/**
+ * State used in rendering NavDrawerHeaderNav
+ */
+export type NavDrawerHeaderNavState = ComponentState<NavDrawerHeaderNavSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavDrawerHeaderNavProps.
+// & Required<Pick<NavDrawerHeaderNavProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/index.ts
@@ -1,0 +1,5 @@
+export * from './NavDrawerHeaderNav';
+export * from './NavDrawerHeaderNav.types';
+export * from './renderNavDrawerHeaderNav';
+export * from './useNavDrawerHeaderNav';
+export * from './useNavDrawerHeaderNavStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/renderNavDrawerHeaderNav.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/renderNavDrawerHeaderNav.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavDrawerHeaderNavState, NavDrawerHeaderNavSlots } from './NavDrawerHeaderNav.types';
+
+/**
+ * Render the final JSX of NavDrawerHeaderNav
+ */
+export const renderNavDrawerHeaderNav_unstable = (state: NavDrawerHeaderNavState) => {
+  assertSlots<NavDrawerHeaderNavSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/useNavDrawerHeaderNav.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/useNavDrawerHeaderNav.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavDrawerHeaderNavProps, NavDrawerHeaderNavState } from './NavDrawerHeaderNav.types';
+
+/**
+ * Create the state required to render NavDrawerHeaderNav.
+ *
+ * The returned state can be modified with hooks such as useNavDrawerHeaderNavStyles_unstable,
+ * before being passed to renderNavDrawerHeaderNav_unstable.
+ *
+ * @param props - props from this instance of NavDrawerHeaderNav
+ * @param ref - reference to root HTMLDivElement of NavDrawerHeaderNav
+ */
+export const useNavDrawerHeaderNav_unstable = (
+  props: NavDrawerHeaderNavProps,
+  ref: React.Ref<HTMLDivElement>,
+): NavDrawerHeaderNavState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/useNavDrawerHeaderNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavDrawerHeaderNav/useNavDrawerHeaderNavStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavDrawerHeaderNavSlots, NavDrawerHeaderNavState } from './NavDrawerHeaderNav.types';
+
+export const navDrawerHeaderNavClassNames: SlotClassNames<NavDrawerHeaderNavSlots> = {
+  root: 'fui-NavDrawerHeaderNav',
+  // TODO: add class names for all slots on NavDrawerHeaderNavSlots.
+  // Should be of the form `<slotName>: 'fui-NavDrawerHeaderNav__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavDrawerHeaderNav slots based on the state
+ */
+export const useNavDrawerHeaderNavStyles_unstable = (state: NavDrawerHeaderNavState): NavDrawerHeaderNavState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(navDrawerHeaderNavClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavSectionHeader } from './NavSectionHeader';
+
+describe('NavSectionHeader', () => {
+  isConformant({
+    Component: NavSectionHeader,
+    displayName: 'NavSectionHeader',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavSectionHeader>Default NavSectionHeader</NavSectionHeader>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { NavSectionHeader } from './NavSectionHeader';
 
@@ -7,12 +5,5 @@ describe('NavSectionHeader', () => {
   isConformant({
     Component: NavSectionHeader,
     displayName: 'NavSectionHeader',
-  });
-
-  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
-
-  it('renders a default state', () => {
-    const result = render(<NavSectionHeader>Default NavSectionHeader</NavSectionHeader>);
-    expect(result.container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useNavSectionHeader_unstable } from './useNavSectionHeader';
+import { renderNavSectionHeader_unstable } from './renderNavSectionHeader';
+import { useNavSectionHeaderStyles_unstable } from './useNavSectionHeaderStyles.styles';
+import type { NavSectionHeaderProps } from './NavSectionHeader.types';
+
+/**
+ * NavSectionHeader component - TODO: add more docs
+ */
+export const NavSectionHeader: ForwardRefComponent<NavSectionHeaderProps> = React.forwardRef((props, ref) => {
+  const state = useNavSectionHeader_unstable(props, ref);
+
+  useNavSectionHeaderStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  // useCustomStyleHook_unstable('useNavSectionHeaderStyles_unstable')(state);
+  return renderNavSectionHeader_unstable(state);
+});
+
+NavSectionHeader.displayName = 'NavSectionHeader';

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/NavSectionHeader.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavSectionHeaderSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavSectionHeader Props
+ */
+export type NavSectionHeaderProps = ComponentProps<NavSectionHeaderSlots> & {};
+
+/**
+ * State used in rendering NavSectionHeader
+ */
+export type NavSectionHeaderState = ComponentState<NavSectionHeaderSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavSectionHeaderProps.
+// & Required<Pick<NavSectionHeaderProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/index.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/index.ts
@@ -1,0 +1,5 @@
+export * from './NavSectionHeader';
+export * from './NavSectionHeader.types';
+export * from './renderNavSectionHeader';
+export * from './useNavSectionHeader';
+export * from './useNavSectionHeaderStyles.styles';

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/renderNavSectionHeader.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/renderNavSectionHeader.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavSectionHeaderState, NavSectionHeaderSlots } from './NavSectionHeader.types';
+
+/**
+ * Render the final JSX of NavSectionHeader
+ */
+export const renderNavSectionHeader_unstable = (state: NavSectionHeaderState) => {
+  assertSlots<NavSectionHeaderSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/useNavSectionHeader.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/useNavSectionHeader.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavSectionHeaderProps, NavSectionHeaderState } from './NavSectionHeader.types';
+
+/**
+ * Create the state required to render NavSectionHeader.
+ *
+ * The returned state can be modified with hooks such as useNavSectionHeaderStyles_unstable,
+ * before being passed to renderNavSectionHeader_unstable.
+ *
+ * @param props - props from this instance of NavSectionHeader
+ * @param ref - reference to root HTMLDivElement of NavSectionHeader
+ */
+export const useNavSectionHeader_unstable = (
+  props: NavSectionHeaderProps,
+  ref: React.Ref<HTMLDivElement>,
+): NavSectionHeaderState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/src/components/NavSectionHeader/useNavSectionHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSectionHeader/useNavSectionHeaderStyles.styles.ts
@@ -1,0 +1,33 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavSectionHeaderSlots, NavSectionHeaderState } from './NavSectionHeader.types';
+
+export const navSectionHeaderClassNames: SlotClassNames<NavSectionHeaderSlots> = {
+  root: 'fui-NavSectionHeader',
+  // TODO: add class names for all slots on NavSectionHeaderSlots.
+  // Should be of the form `<slotName>: 'fui-NavSectionHeader__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavSectionHeader slots based on the state
+ */
+export const useNavSectionHeaderStyles_unstable = (state: NavSectionHeaderState): NavSectionHeaderState => {
+  const styles = useStyles();
+  state.root.className = mergeClasses(navSectionHeaderClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/src/index.ts
+++ b/packages/react-components/react-nav-preview/src/index.ts
@@ -57,3 +57,10 @@ export type {
   NavSubItemGroupState,
 } from './components/NavSubItemGroup/index';
 export * from './NavDrawer';
+export * from './NavDrawerFooter';
+export * from './NavDrawerHeader';
+export * from './NavDrawerHeaderNav';
+export * from './NavDrawerBody';
+export * from './HamburgerInNav';
+export * from './Hamburger';
+export * from './NavSectionHeader';

--- a/packages/react-components/react-nav-preview/stories/Hamburger/HamburgerBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/Hamburger/HamburgerBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/Hamburger/HamburgerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Hamburger/HamburgerDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { Hamburger, HamburgerProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<HamburgerProps>) => <Hamburger {...props} />;

--- a/packages/react-components/react-nav-preview/stories/Hamburger/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/Hamburger/index.stories.tsx
@@ -1,0 +1,18 @@
+import { Hamburger } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './HamburgerDescription.md';
+import bestPracticesMd from './HamburgerBestPractices.md';
+
+export { Default } from './HamburgerDefault.stories';
+
+export default {
+  title: 'Preview Components/Hamburger',
+  component: Hamburger,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/HamburgerInNav/HamburgerInNavBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/HamburgerInNav/HamburgerInNavBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/HamburgerInNav/HamburgerInNavDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/HamburgerInNav/HamburgerInNavDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { HamburgerInNav, HamburgerInNavProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<HamburgerInNavProps>) => <HamburgerInNav {...props} />;

--- a/packages/react-components/react-nav-preview/stories/HamburgerInNav/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/HamburgerInNav/index.stories.tsx
@@ -1,0 +1,18 @@
+import { HamburgerInNav } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './HamburgerInNavDescription.md';
+import bestPracticesMd from './HamburgerInNavBestPractices.md';
+
+export { Default } from './HamburgerInNavDefault.stories';
+
+export default {
+  title: 'Preview Components/HamburgerInNav',
+  component: HamburgerInNav,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/NavDrawerBody/NavDrawerBodyBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerBody/NavDrawerBodyBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/NavDrawerBody/NavDrawerBodyDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerBody/NavDrawerBodyDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavDrawerBody, NavDrawerBodyProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavDrawerBodyProps>) => <NavDrawerBody {...props} />;

--- a/packages/react-components/react-nav-preview/stories/NavDrawerBody/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerBody/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavDrawerBody } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavDrawerBodyDescription.md';
+import bestPracticesMd from './NavDrawerBodyBestPractices.md';
+
+export { Default } from './NavDrawerBodyDefault.stories';
+
+export default {
+  title: 'Preview Components/NavDrawerBody',
+  component: NavDrawerBody,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/NavDrawerFooter/NavDrawerFooterBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerFooter/NavDrawerFooterBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/NavDrawerFooter/NavDrawerFooterDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerFooter/NavDrawerFooterDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavDrawerFooter, NavDrawerFooterProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavDrawerFooterProps>) => <NavDrawerFooter {...props} />;

--- a/packages/react-components/react-nav-preview/stories/NavDrawerFooter/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerFooter/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavDrawerFooter } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavDrawerFooterDescription.md';
+import bestPracticesMd from './NavDrawerFooterBestPractices.md';
+
+export { Default } from './NavDrawerFooterDefault.stories';
+
+export default {
+  title: 'Preview Components/NavDrawerFooter',
+  component: NavDrawerFooter,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/NavDrawerHeader/NavDrawerHeaderBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerHeader/NavDrawerHeaderBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/NavDrawerHeader/NavDrawerHeaderDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerHeader/NavDrawerHeaderDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavDrawerHeader, NavDrawerHeaderProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavDrawerHeaderProps>) => <NavDrawerHeader {...props} />;

--- a/packages/react-components/react-nav-preview/stories/NavDrawerHeader/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerHeader/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavDrawerHeader } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavDrawerHeaderDescription.md';
+import bestPracticesMd from './NavDrawerHeaderBestPractices.md';
+
+export { Default } from './NavDrawerHeaderDefault.stories';
+
+export default {
+  title: 'Preview Components/NavDrawerHeader',
+  component: NavDrawerHeader,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/NavDrawerHeaderNav/NavDrawerHeaderNavBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerHeaderNav/NavDrawerHeaderNavBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/NavDrawerHeaderNav/NavDrawerHeaderNavDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerHeaderNav/NavDrawerHeaderNavDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavDrawerHeaderNav, NavDrawerHeaderNavProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavDrawerHeaderNavProps>) => <NavDrawerHeaderNav {...props} />;

--- a/packages/react-components/react-nav-preview/stories/NavDrawerHeaderNav/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawerHeaderNav/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavDrawerHeaderNav } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavDrawerHeaderNavDescription.md';
+import bestPracticesMd from './NavDrawerHeaderNavBestPractices.md';
+
+export { Default } from './NavDrawerHeaderNavDefault.stories';
+
+export default {
+  title: 'Preview Components/NavDrawerHeaderNav',
+  component: NavDrawerHeaderNav,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/NavSectionHeader/NavSectionHeaderBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/NavSectionHeader/NavSectionHeaderBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/NavSectionHeader/NavSectionHeaderDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavSectionHeader/NavSectionHeaderDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavSectionHeader, NavSectionHeaderProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavSectionHeaderProps>) => <NavSectionHeader {...props} />;

--- a/packages/react-components/react-nav-preview/stories/NavSectionHeader/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavSectionHeader/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavSectionHeader } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavSectionHeaderDescription.md';
+import bestPracticesMd from './NavSectionHeaderBestPractices.md';
+
+export { Default } from './NavSectionHeaderDefault.stories';
+
+export default {
+  title: 'Preview Components/NavSectionHeader',
+  component: NavSectionHeader,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};


### PR DESCRIPTION
This PR scaffolds out a lot of re-composed components necessary for the Nav component. We will add more styling and nav specific opinions to these down the road.

Result of running `yarn create-component` for several components.
Commenting out the custom style hook calls.
Removed snapshot tests.

Do the names make sense and follow paradigms?

Relates to #26649 