### PR TITLE
fix: expand button should be disabled when Combobox is disabled

### DIFF
--- a/change/@fluentui-react-combobox-d398e5dd-1262-4606-887c-5bccc8842c7d.json
+++ b/change/@fluentui-react-combobox-d398e5dd-1262-4606-887c-5bccc8842c7d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: expand button should be disabled when Combobox is disabled",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/useCombobox.tsx
@@ -39,7 +39,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   });
   const baseState = useComboboxBaseState({ ...props, editable: true, activeDescendantController });
 
-  const { clearable, clearSelection, multiselect, open, selectedOptions, value, hasFocus } = baseState;
+  const { clearable, clearSelection, disabled, multiselect, open, selectedOptions, value, hasFocus } = baseState;
   const [comboboxPopupRef, comboboxTargetRef] = useComboboxPositioning(props);
   const { freeform, inlinePopup } = props;
   const comboId = useId('combobox-');
@@ -98,6 +98,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     expandIcon: slot.optional(props.expandIcon, {
       renderByDefault: true,
       defaultProps: {
+        'aria-disabled': disabled ? 'true' : undefined,
         'aria-expanded': open,
         children: <ChevronDownIcon />,
         role: 'button',


### PR DESCRIPTION
This is a small semantics-only fix; the functionality to disabled expand/collapse is already there.

## Previous Behavior

When the combobox is disabled, the expand/collapse button was not also semantically disabled.

## New Behavior

Adds `aria-disabled` to the button based on the `disabled` combobox state.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18707)
