### PR TITLE
Fix focus trap issue in sankey chart

### DIFF
--- a/change/@fluentui-react-charting-4e7f95fa-3196-4b13-84bd-e646c674683c.json
+++ b/change/@fluentui-react-charting-4e7f95fa-3196-4b13-84bd-e646c674683c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix focus trap issue in sankey chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
@@ -792,11 +792,7 @@ export class SankeyChartBase extends React.Component<ISankeyChartProps, ISankeyC
           ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
           onMouseLeave={this._onCloseCallout}
         >
-          <FocusZone
-            direction={FocusZoneDirection.bidirectional}
-            isCircularNavigation={true}
-            handleTabKey={FocusZoneTabbableElements.all}
-          >
+          <FocusZone direction={FocusZoneDirection.bidirectional} handleTabKey={FocusZoneTabbableElements.all}>
             <svg width={width} height={height} id={this._chartId}>
               <g className={classNames.links} strokeOpacity={1}>
                 {linkData}

--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
@@ -792,7 +792,7 @@ export class SankeyChartBase extends React.Component<ISankeyChartProps, ISankeyC
           ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
           onMouseLeave={this._onCloseCallout}
         >
-          <FocusZone direction={FocusZoneDirection.bidirectional} handleTabKey={FocusZoneTabbableElements.all}>
+          <FocusZone direction={FocusZoneDirection.bidirectional}>
             <svg width={width} height={height} id={this._chartId}>
               <g className={classNames.links} strokeOpacity={1}>
                 {linkData}

--- a/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
+++ b/packages/react-charting/src/components/SankeyChart/SankeyChart.base.tsx
@@ -1,4 +1,4 @@
-import { FocusZone, FocusZoneDirection, FocusZoneTabbableElements } from '@fluentui/react-focus';
+import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { IProcessedStyleSet, ITheme } from '@fluentui/react/lib/Styling';
 import {


### PR DESCRIPTION
## Previous Behavior

Keyboard focus becomes trapped within the SankeyChart, preventing users from navigating out of the chart using the tab or escape keys.

## New Behavior

Users can navigate out of the chart using the tab key.