### PR TITLE
fix: prevent pixel-fraction overflow from v8 TextField focus indicator

### DIFF
--- a/change/@fluentui-react-a80addea-99f6-4096-9383-b0b193004086.json
+++ b/change/@fluentui-react-a80addea-99f6-4096-9383-b0b193004086.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent pixel-fraction overflow from TextField focus indicator",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/TextField/TextField.styles.tsx
+++ b/packages/react/src/components/TextField/TextField.styles.tsx
@@ -200,6 +200,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         flexDirection: 'row',
         alignItems: 'stretch',
         position: 'relative',
+        overflow: 'hidden',
       },
       multiline && {
         minHeight: '60px',


### PR DESCRIPTION
## Previous Behavior

Sometimes at certain zoom levels, some browsers calculate the width of the `::after` focus indicator on TextField to be fractions of a pixel larger than the root node. That can result in conditional scroll overflow when the textfield gets focus.

## New Behavior

Adds `overflow: hidden` to the node that has the focus indicator `::after` style. That node only wraps the input element, so there shouldn't be any side effects to hiding overflow.

## Related Issue
- Fixes #31031
