### PR TITLE
bugfix(react-tag-picker): fixes padding error introduced by PR 31272

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-4dc187e5-80b6-49e0-9937-0ab7ada11736.json
+++ b/change/@fluentui-react-tag-picker-preview-4dc187e5-80b6-49e0-9937-0ab7ada11736.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: fixes padding error introduced by PR 31272",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -22,12 +22,8 @@ export const tagPickerControlAsideWidthToken = '--fui-TagPickerControl-aside-wid
 const useStyles = makeStyles({
   root: {
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    ...shorthands.padding(
-      0,
-      tokens.spacingHorizontalM,
-      0,
-      `calc(${tokens.spacingHorizontalM} + var(${tagPickerControlAsideWidthToken}, 0px))`,
-    ),
+    paddingRight: `calc(${tokens.spacingHorizontalM} + var(${tagPickerControlAsideWidthToken}, 0px))`,
+    paddingLeft: tokens.spacingHorizontalM,
     alignItems: 'center',
     columnGap: tokens.spacingHorizontalXXS,
     boxSizing: 'border-box',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

While trying to solve the misuse of `paddingInline`, the padding values from right and left were inverted on https://github.com/microsoft/fluentui/pull/31272

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. reverts padding back to it's original value

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
