### PR TITLE
chore(react-tag-picker): follow up on #31165

### DIFF
--- a/change/@fluentui-react-tag-picker-preview-35e06389-b8ac-46fa-a9a9-c186c3c2941e.json
+++ b/change/@fluentui-react-tag-picker-preview-35e06389-b8ac-46fa-a9a9-c186c3c2941e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: follow up on #31165",
+  "packageName": "@fluentui/react-tag-picker-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-preview-35e06389-b8ac-46fa-a9a9-c186c3c2941e.json
+++ b/change/@fluentui-react-tag-picker-preview-35e06389-b8ac-46fa-a9a9-c186c3c2941e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: follow up on #31165",
+  "comment": "fix: move focus on backspace press; fix space key closing dropdown",
   "packageName": "@fluentui/react-tag-picker-preview",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPicker/TagPicker.cy.tsx
@@ -289,10 +289,10 @@ describe('TagPicker', () => {
         cy.get(`[data-testid="tag--${options[0]}"]`).focus().realPress('Backspace').should('not.exist');
         cy.get(`[data-testid="tag--${options[1]}"]`).should('be.focused');
       });
-      it('should remove last tag on Backspace key press on input', () => {
+      it('should move to last tag on Backspace key press on input', () => {
         mount(<TagPickerControlled defaultSelectedOptions={options} />);
         cy.get('[data-testid="tag-picker-input"]').focus().realPress('Backspace');
-        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('not.exist');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('be.focused');
       });
       it('should focus on input once all tags have been removed', () => {
         mount(<TagPickerControlled defaultSelectedOptions={[options[0]]} />);

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -9,7 +9,7 @@ import {
   useEventCallback,
   useIsomorphicLayoutEffect,
 } from '@fluentui/react-utilities';
-import { ArrowLeft, Backspace, Enter, Space } from '@fluentui/keyboard-keys';
+import { ArrowLeft, Backspace, Enter } from '@fluentui/keyboard-keys';
 import { useInputTriggerSlot } from '@fluentui/react-combobox';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { tagPickerInputCSSRules } from '../../utils/tokens';
@@ -76,12 +76,12 @@ export const useTagPickerInput_unstable = (
       ...getIntrinsicElementProps('input', props),
       onKeyDown: useEventCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
         props.onKeyDown?.(event);
-        if (event.key === ArrowLeft && event.currentTarget.selectionStart === 0 && tagPickerGroupRef.current) {
+        if (
+          (event.key === ArrowLeft || event.key === Backspace) &&
+          event.currentTarget.selectionStart === 0 &&
+          tagPickerGroupRef.current
+        ) {
           findLastFocusable(tagPickerGroupRef.current)?.focus();
-          return;
-        }
-        if (event.key === Space && open) {
-          setOpen(event, false);
           return;
         }
         if (event.key === Enter) {
@@ -93,17 +93,6 @@ export const useTagPickerInput_unstable = (
           } else {
             setOpen(event, true);
           }
-          return;
-        }
-        if (event.key === Backspace && value?.length === 0 && selectedOptions.length) {
-          const toDismiss = selectedOptions[selectedOptions.length - 1];
-          selectOption(event, {
-            value: toDismiss,
-            // These values no longer exist because the option has unregistered itself
-            // for the purposes of selection - these values aren't actually used
-            id: 'ERROR_DO_NOT_USE',
-            text: 'ERROR_DO_NOT_USE',
-          });
           return;
         }
       }),

--- a/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker-preview/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -9,7 +9,7 @@ import {
   useEventCallback,
   useIsomorphicLayoutEffect,
 } from '@fluentui/react-utilities';
-import { ArrowLeft, Backspace, Enter } from '@fluentui/keyboard-keys';
+import { ArrowLeft, Backspace, Enter, Space } from '@fluentui/keyboard-keys';
 import { useInputTriggerSlot } from '@fluentui/react-combobox';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { tagPickerInputCSSRules } from '../../utils/tokens';
@@ -67,6 +67,8 @@ export const useTagPickerInput_unstable = (
   const { value = contextValue, disabled = contextDisabled } = props;
   const { findLastFocusable } = useFocusFinders();
 
+  const isTypingRef = React.useRef(false);
+
   const root = useInputTriggerSlot(
     {
       type: 'text',
@@ -82,9 +84,11 @@ export const useTagPickerInput_unstable = (
           tagPickerGroupRef.current
         ) {
           findLastFocusable(tagPickerGroupRef.current)?.focus();
-          return;
-        }
-        if (event.key === Enter) {
+        } else if (event.key === Space) {
+          if (open && !isTypingRef.current) {
+            setOpen(event, false);
+          }
+        } else if (event.key === Enter) {
           if (open) {
             ReactDOM.unstable_batchedUpdates(() => {
               setValue(undefined);
@@ -93,8 +97,9 @@ export const useTagPickerInput_unstable = (
           } else {
             setOpen(event, true);
           }
-          return;
         }
+        isTypingRef.current =
+          event.key.length === 1 && event.code !== Space && !event.altKey && !event.ctrlKey && !event.metaKey;
       }),
     },
     useMergedRefs(triggerRef, ref),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. when backspacing on `TagPickerInput`, when the caret is on the beginning of the input, the focus will move to the last tag present in `TagPickerGroup`
2. fixes issue that pressing `Space` on `TagPickerInput` would close the dropdown and delete the input

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31165
