### PR TITLE
Fix focus order issue in legends overflow callout

### DIFF
--- a/change/@fluentui-react-charting-e105accc-fa3e-466e-8341-eca4d3a8ff6f.json
+++ b/change/@fluentui-react-charting-e105accc-fa3e-466e-8341-eca4d3a8ff6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix focus order issue in legends overflow callout",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -6,7 +6,7 @@ import { classNamesFunction, find, getNativeProps, buttonProperties } from '@flu
 import { ResizeGroup } from '@fluentui/react/lib/ResizeGroup';
 import { IProcessedStyleSet } from '@fluentui/react/lib/Styling';
 import { OverflowSet, IOverflowSetItemProps } from '@fluentui/react/lib/OverflowSet';
-import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
+import { FocusZone, FocusZoneDirection, FocusZoneTabbableElements } from '@fluentui/react-focus';
 import {
   ILegend,
   ILegendsProps,
@@ -234,6 +234,8 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
           'aria-multiselectable': canSelectMultipleLegends,
         })}
         direction={FocusZoneDirection.vertical}
+        handleTabKey={FocusZoneTabbableElements.all}
+        isCircularNavigation={true}
         {...this.props.focusZonePropsInHoverCard}
         className={classNames.hoverCardRoot}
       >


### PR DESCRIPTION
## Previous Behavior

- Pressing the up or down arrow keys while at the first or last legend button in the legends overflow callout causes the page to scroll and collapses the list.
- Pressing the tab or shift-tab keys in the callout doesn't move focus to next or previous interactive element.

## New Behavior

- Navigating with the up or down arrow keys, or using the tab or shift-tab keys in the legends overflow callout, cycles focus through legend buttons.

When the legend overflow button is focused, pressing the enter key opens the callout, and pressing the escape key closes it.