### PR TITLE
fix(workspace-plugin): update import within bundle-size fixtures within prepare-intial-release generator

### DIFF
--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
@@ -124,6 +124,16 @@ async function stableRelease(tree: Tree, options: NormalizedSchema) {
 
   updateFileContent(tree, { filePath: options.paths.jestConfig, updater: contentNameUpdater });
 
+  const bundleSizeFixturesRoot = joinPathFragments(options.projectConfig.root, 'bundle-size');
+  if (tree.exists(bundleSizeFixturesRoot)) {
+    visitNotIgnoredFiles(tree, bundleSizeFixturesRoot, filePath => {
+      updateFileContent(tree, {
+        filePath,
+        updater: contentNameUpdater,
+      });
+    });
+  }
+
   const mdFilePath = {
     readme: joinPathFragments(options.projectConfig.root, 'README.md'),
     api: joinPathFragments(options.projectConfig.root, 'etc', options.normalizedPkgName + '.api.md'),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

bundle-size fixture imports are not renamed when going to stable

## New Behavior

bundle-size fixtures imports are properly renamed

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
