### PR TITLE
fix(Combobox): `expandIcon={null}` should not throw

### DIFF
--- a/change/@fluentui-react-combobox-70b71069-7838-4549-9c50-4ab77328e735.json
+++ b/change/@fluentui-react-combobox-70b71069-7838-4549-9c50-4ab77328e735.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Combobox): `expandIcon={null}` should not throw",
+  "packageName": "@fluentui/react-combobox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -91,7 +91,7 @@ export const ComboboxProvider: Provider<ComboboxContextValue> & FC<ProviderProps
 // @public (undocumented)
 export type ComboboxSlots = {
     root: NonNullable<Slot<'div'>>;
-    expandIcon: Slot<'span'>;
+    expandIcon?: Slot<'span'>;
     clearIcon?: Slot<'span'>;
     input: NonNullable<Slot<'input'>>;
     listbox?: Slot<typeof Listbox>;

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.test.tsx
@@ -147,31 +147,6 @@ describe('Combobox', () => {
     expect(chevronButton?.getAttribute('aria-labelledby')).toBeFalsy();
   });
 
-  it('Respects author-provided labels for the chevron button', () => {
-    const renderedCombobox = render(
-      <Combobox aria-label="not used" aria-labelledby="not-used" expandIcon={{ 'aria-label': 'test label' }}>
-        <Option>Red</Option>
-        <Option>Green</Option>
-        <Option>Blue</Option>
-      </Combobox>,
-    );
-
-    const chevronButton = renderedCombobox.container.querySelector('[role=button]');
-    expect(chevronButton?.getAttribute('aria-label')).toEqual('test label');
-    expect(chevronButton?.getAttribute('aria-labelledby')).toBeFalsy();
-
-    renderedCombobox.rerender(
-      <Combobox aria-label="not used" aria-labelledby="not-used" expandIcon={{ 'aria-labelledby': 'testId' }}>
-        <Option>Red</Option>
-        <Option>Green</Option>
-        <Option>Blue</Option>
-      </Combobox>,
-    );
-
-    expect(chevronButton?.getAttribute('aria-label')).toBeFalsy();
-    expect(chevronButton?.getAttribute('aria-labelledby')).toEqual('testId');
-  });
-
   it('adds aria-owns and aria-controls pointing to the popup', () => {
     const { getByRole, container } = render(
       <Combobox open className="root">
@@ -221,20 +196,6 @@ describe('Combobox', () => {
     expect(combobox.getAttribute('aria-expanded')).toEqual('false');
   });
 
-  it('opens the popup on expand icon click', () => {
-    const { getByRole, getByTestId } = render(
-      <Combobox expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
-        <Option>Red</Option>
-        <Option>Green</Option>
-        <Option>Blue</Option>
-      </Combobox>,
-    );
-
-    userEvent.click(getByTestId('icon'));
-
-    expect(getByRole('listbox')).not.toBeNull();
-  });
-
   it('opens the popup when typing', () => {
     const { getByRole } = render(
       <Combobox>
@@ -249,40 +210,6 @@ describe('Combobox', () => {
 
     expect(getByRole('listbox')).not.toBeNull();
     expect(getByRole('combobox').getAttribute('aria-expanded')).toEqual('true');
-  });
-
-  it('closes the popup on expand icon click', () => {
-    const { getByTestId, queryByRole } = render(
-      <Combobox defaultOpen expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
-        <Option>Red</Option>
-        <Option>Green</Option>
-        <Option>Blue</Option>
-      </Combobox>,
-    );
-
-    userEvent.tab();
-    userEvent.click(getByTestId('icon'));
-
-    expect(queryByRole('listbox')).toBeNull();
-  });
-
-  it('closes the popup on blur/outside click after clicking on the expand icon', () => {
-    const { getByTestId, queryByRole } = render(
-      <>
-        <Combobox expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
-          <Option>Red</Option>
-          <Option>Green</Option>
-          <Option>Blue</Option>
-        </Combobox>
-        <div data-testid="outside">outside</div>
-      </>,
-    );
-
-    userEvent.click(getByTestId('icon'));
-    expect(queryByRole('listbox')).not.toBeNull();
-
-    userEvent.click(getByTestId('outside'));
-    expect(queryByRole('listbox')).toBeNull();
   });
 
   it('does not close the combobox on click with controlled open', () => {
@@ -1142,6 +1069,90 @@ describe('Combobox', () => {
       expect(activeOptionText).toBe('Green');
       userEvent.keyboard('{ArrowUp}');
       expect(activeOptionText).toBe('Red');
+    });
+  });
+
+  describe('expandIcon', () => {
+    it('respects author-provided labels for the chevron button', () => {
+      const { container, rerender } = render(
+        <Combobox aria-label="not used" aria-labelledby="not-used" expandIcon={{ 'aria-label': 'test label' }}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+
+      const chevronButton = container.querySelector('[role=button]');
+      expect(chevronButton?.getAttribute('aria-label')).toEqual('test label');
+      expect(chevronButton?.getAttribute('aria-labelledby')).toBeFalsy();
+
+      rerender(
+        <Combobox aria-label="not used" aria-labelledby="not-used" expandIcon={{ 'aria-labelledby': 'testId' }}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+
+      expect(chevronButton?.getAttribute('aria-label')).toBeFalsy();
+      expect(chevronButton?.getAttribute('aria-labelledby')).toEqual('testId');
+    });
+
+    it('opens the popup on expand icon click', () => {
+      const { getByRole, getByTestId } = render(
+        <Combobox expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+
+      userEvent.click(getByTestId('icon'));
+      expect(getByRole('listbox')).not.toBeNull();
+    });
+
+    it('closes the popup on expand icon click', () => {
+      const { getByTestId, queryByRole } = render(
+        <Combobox defaultOpen expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+
+      userEvent.tab();
+      userEvent.click(getByTestId('icon'));
+
+      expect(queryByRole('listbox')).toBeNull();
+    });
+
+    it('closes the popup on blur/outside click after clicking on the expand icon', () => {
+      const { getByTestId, queryByRole } = render(
+        <>
+          <Combobox expandIcon={{ 'data-testid': 'icon' } as React.HTMLAttributes<HTMLSpanElement>}>
+            <Option>Red</Option>
+            <Option>Green</Option>
+            <Option>Blue</Option>
+          </Combobox>
+          <div data-testid="outside">outside</div>
+        </>,
+      );
+
+      userEvent.click(getByTestId('icon'));
+      expect(queryByRole('listbox')).not.toBeNull();
+
+      userEvent.click(getByTestId('outside'));
+      expect(queryByRole('listbox')).toBeNull();
+    });
+
+    it('allows to pass "null"', () => {
+      const { container } = render(
+        <Combobox expandIcon={null}>
+          <Option>Red</Option>
+        </Combobox>,
+      );
+
+      expect(container.querySelector(`.${comboboxClassNames.expandIcon}`)).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -16,7 +16,7 @@ export type ComboboxSlots = {
   root: NonNullable<Slot<'div'>>;
 
   /* The dropdown arrow icon */
-  expandIcon: Slot<'span'>;
+  expandIcon?: Slot<'span'>;
 
   /* The dropdown clear icon */
   clearIcon?: Slot<'span'>;

--- a/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-components/react-combobox/src/components/Combobox/renderCombobox.tsx
@@ -22,7 +22,7 @@ export const renderCombobox_unstable = (state: ComboboxState, contextValues: Com
           <ComboboxContext.Provider value={contextValues.combobox}>
             <state.input />
             {state.clearIcon && <state.clearIcon />}
-            <state.expandIcon />
+            {state.expandIcon && <state.expandIcon />}
             {state.listbox &&
               (state.inlinePopup ? (
                 <state.listbox />


### PR DESCRIPTION
## New Behavior

- Updated types to match implementation
- Re-arranged tests and added a new one

## Related Issue(s)

Fixes #31101
