### PR TITLE
Ensure specified trigger id is used for menu aria-labelledby

### DIFF
--- a/packages/react-components/react-menu/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/Menu.test.tsx
@@ -397,4 +397,23 @@ describe('Menu', () => {
     expect(container.querySelector('#second')?.getAttribute('aria-checked')).toBe('true');
     expect(container.querySelector('#third')?.getAttribute('aria-checked')).toBe('false');
   });
+
+  it('should render correct aria-labelledby attribute from corresponding trigger id', () => {
+    const customId = 'myTrigger';
+    const { getByRole } = render(
+      <Menu open>
+        <MenuTrigger disableButtonEnhancement>
+          <button id={customId}>Menu trigger</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    // Assert
+    expect(getByRole('menu')).toHaveAttribute('aria-labelledby', customId);
+  });
 });

--- a/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/src/components/Menu/useMenu.tsx
@@ -54,7 +54,6 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     defaultCheckedValues,
     mountNode = null,
   } = props;
-  const triggerId = useId('menu');
   const [contextTarget, setContextTarget] = usePositioningMouseTarget();
 
   const positioningState = {
@@ -87,6 +86,8 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
   } else if (children.length === 1) {
     menuPopover = children[0];
   }
+
+  const triggerId = menuTrigger?.props?.children?.props?.id ?? useId('menu');
 
   const { targetRef: triggerRef, containerRef: menuPopoverRef } = usePositioning(positioningState);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Currently the aria-labelledby relationship in Menu is automatic. The useId hook is used to generate the id. If a users uses their own id prop they must also set their own aria relationship with that id manually.

## New Behavior

If the user manually sets id prop on the trigger then the aria-labelledby relationship that depends on it will be reflected.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #18318
