### PR TITLE
fix(Overflow): Update overflow menu when items are removed

### DIFF
--- a/change/@fluentui-priority-overflow-fa429c3d-9437-41f4-b893-33fafeb8b65b.json
+++ b/change/@fluentui-priority-overflow-fa429c3d-9437-41f4-b893-33fafeb8b65b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "force update the overflow when item is removed",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -256,6 +256,12 @@ export function createOverflowManager(): OverflowManager {
       return;
     }
 
+    if (observing) {
+      // We might be removing an item in an overflow which would not affect the tops,
+      // but we need to update anyway to update the overflow menu state
+      forceDispatch = true;
+    }
+
     const item = overflowItems[itemId];
     visibleItemQueue.remove(itemId);
     invisibleItemQueue.remove(itemId);

--- a/packages/react-components/react-overflow/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/src/Overflow.cy.tsx
@@ -608,6 +608,145 @@ describe('Overflow', () => {
     cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
   });
 
+  it('should update overflow menu when visible item is added/removed', () => {
+    const Example = () => {
+      const [mapHelper, setMapHelper] = React.useState<string[]>(new Array(10).fill(0).map((_, i) => i.toString()));
+      const addItem = React.useCallback((index: number, item: string) => {
+        setMapHelper(m => [...m.slice(0, index), item, ...m.slice(index)]);
+      }, []);
+      const deleteItem = React.useCallback((index, count) => {
+        setMapHelper(m => [...m.slice(0, index), ...m.slice(index + count)]);
+      }, []);
+
+      return (
+        <>
+          <Container>
+            {mapHelper.map(i => (
+              <Item key={i} id={i}>
+                {i}
+              </Item>
+            ))}
+            <Menu />
+          </Container>
+          <div>
+            <button id="add-3rd" onClick={() => addItem(3, '2b')}>
+              Add at index 3
+            </button>
+            <button id="delete-3rd" onClick={() => deleteItem(3, 1)}>
+              Delete at index 3
+            </button>
+          </div>
+        </>
+      );
+    };
+    mount(<Example />);
+    setContainerWidth(300);
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+5');
+
+    cy.get('#add-3rd').click();
+    cy.get(`[${selectors.item}="3"]`).should('be.visible');
+    cy.get(`[${selectors.item}="4"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+6');
+
+    cy.get('#delete-3rd').click();
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+5');
+  });
+
+  it('should update overflow menu when overflow item is added/removed', () => {
+    const Example = () => {
+      const [mapHelper, setMapHelper] = React.useState<string[]>(new Array(10).fill(0).map((_, i) => i.toString()));
+      const addItem = React.useCallback((index: number, item: string) => {
+        setMapHelper(m => [...m.slice(0, index), item, ...m.slice(index)]);
+      }, []);
+      const deleteItem = React.useCallback((index, count) => {
+        setMapHelper(m => [...m.slice(0, index), ...m.slice(index + count)]);
+      }, []);
+
+      return (
+        <>
+          <Container>
+            {mapHelper.map(i => (
+              <Item key={i} id={i}>
+                {i}
+              </Item>
+            ))}
+            <Menu />
+          </Container>
+          <div>
+            <button id="add-8th" onClick={() => addItem(8, '7b')}>
+              Add at index 8
+            </button>
+            <button id="delete-8th" onClick={() => deleteItem(8, 1)}>
+              Delete at index 8
+            </button>
+          </div>
+        </>
+      );
+    };
+    mount(<Example />);
+    setContainerWidth(300);
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+5');
+
+    cy.get('#add-8th').click();
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+6');
+
+    cy.get('#delete-8th').click();
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+5');
+  });
+
+  it('should remove overflow menu when all overflow items are removed', () => {
+    const Example = () => {
+      const [mapHelper, setMapHelper] = React.useState<string[]>(new Array(10).fill(0).map((_, i) => i.toString()));
+      const deleteItem = React.useCallback((index, count) => {
+        setMapHelper(m => [...m.slice(0, index), ...m.slice(index + count)]);
+      }, []);
+
+      return (
+        <>
+          <Container>
+            {mapHelper.map(i => (
+              <Item key={i} id={i}>
+                {i}
+              </Item>
+            ))}
+            <Menu />
+          </Container>
+          <div>
+            <button id="delete-5plus" onClick={() => deleteItem(5, 10)}>
+              Delete all from index 5
+            </button>
+          </div>
+        </>
+      );
+    };
+    mount(<Example />);
+    setContainerWidth(300);
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.item}="5"]`).should('not.be.visible');
+    cy.get(`[${selectors.menu}]`).should('exist');
+    cy.get(`[${selectors.menu}]`).should('have.text', '+5');
+
+    cy.get('#delete-5plus').click();
+    cy.get(`[${selectors.item}="4"]`).should('be.visible');
+    cy.get(`[${selectors.menu}]`).should('not.exist');
+  });
+
   it('should be no flickering with larger divider', () => {
     mount(
       <Container>


### PR DESCRIPTION
## Previous Behavior

In `Overflow`, when an `OverflowItem` was removed from the container, the overflow was updated only when the queue of visible items was changed by the removal.
As a result, when an overflowing item was removed, the overflow menu was not updated. Similarly, when all overflow items were removed, the overflow menu was not removed.

## New Behavior

Whenever `OverflowItem` is removed while the `Overflow` is in `observing` state, force dispatch is triggered to update the overflow menu. This behavior matches the add logic.

## Related Issue(s)

- Fixes #29509
