### PR TITLE
feat: modifies `useHeadlessFlatTree` return signature to include `getItem` method

### DIFF
--- a/change/@fluentui-react-tree-0aa4730f-3deb-451a-b469-e6a748f310d3.json
+++ b/change/@fluentui-react-tree-0aa4730f-3deb-451a-b469-e6a748f310d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: adds getItem to HeadlessFlatTree (breaking change)",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-0aa4730f-3deb-451a-b469-e6a748f310d3.json
+++ b/change/@fluentui-react-tree-0aa4730f-3deb-451a-b469-e6a748f310d3.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: adds getItem to HeadlessFlatTree (breaking change)",
+  "comment": "feat: exposes createHeadlessTree",
   "packageName": "@fluentui/react-tree",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -32,9 +32,6 @@ import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
-export function createHeadlessTree<Props extends HeadlessTreeItemProps>(initialProps?: Props[]): HeadlessTree<Props>;
-
-// @public
 export const flattenTree_unstable: <Props extends TreeItemProps>(items: FlattenTreeItem<Props>[]) => FlattenedTreeItem<Props>[];
 
 // @public (undocumented)
@@ -407,7 +404,7 @@ export const useFlatTreeContextValues_unstable: (state: FlatTreeState) => FlatTr
 export const useFlatTreeStyles_unstable: (state: FlatTreeState) => FlatTreeState;
 
 // @public
-export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps>(props: Props[] | HeadlessTree<Props>, options?: HeadlessFlatTreeOptions): HeadlessFlatTree<Props>;
+export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps>(props: Props[], options?: HeadlessFlatTreeOptions): HeadlessFlatTreeReturn<Props>;
 
 // @public (undocumented)
 export const useSubtreeContext_unstable: () => SubtreeContextValue;

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -86,6 +86,7 @@ export type HeadlessFlatTree<Props extends HeadlessFlatTreeItemProps> = {
     navigate(data: TreeNavigationData_unstable): void;
     getNextNavigableItem(visibleItems: HeadlessTreeItem<Props>[], data: TreeNavigationData_unstable): HeadlessTreeItem<Props> | undefined;
     getElementFromItem(item: HeadlessTreeItem<Props>): HTMLElement | null;
+    getItem(value: TreeItemValue): HeadlessTreeItem<Props> | undefined;
     items(): IterableIterator<HeadlessTreeItem<Props>>;
 };
 

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -32,6 +32,9 @@ import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
+export function createHeadlessTree<Props extends HeadlessTreeItemProps>(initialProps?: Props[]): HeadlessTree<Props>;
+
+// @public
 export const flattenTree_unstable: <Props extends TreeItemProps>(items: FlattenTreeItem<Props>[]) => FlattenedTreeItem<Props>[];
 
 // @public (undocumented)
@@ -86,7 +89,6 @@ export type HeadlessFlatTree<Props extends HeadlessFlatTreeItemProps> = {
     navigate(data: TreeNavigationData_unstable): void;
     getNextNavigableItem(visibleItems: HeadlessTreeItem<Props>[], data: TreeNavigationData_unstable): HeadlessTreeItem<Props> | undefined;
     getElementFromItem(item: HeadlessTreeItem<Props>): HTMLElement | null;
-    getItem(value: TreeItemValue): HeadlessTreeItem<Props> | undefined;
     items(): IterableIterator<HeadlessTreeItem<Props>>;
 };
 
@@ -405,7 +407,7 @@ export const useFlatTreeContextValues_unstable: (state: FlatTreeState) => FlatTr
 export const useFlatTreeStyles_unstable: (state: FlatTreeState) => FlatTreeState;
 
 // @public
-export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps>(props: Props[], options?: HeadlessFlatTreeOptions): HeadlessFlatTree<Props>;
+export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps>(props: Props[] | HeadlessTree<Props>, options?: HeadlessFlatTreeOptions): HeadlessFlatTree<Props>;
 
 // @public (undocumented)
 export const useSubtreeContext_unstable: () => SubtreeContextValue;

--- a/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
@@ -82,6 +82,7 @@ export type HeadlessFlatTree<Props extends HeadlessFlatTreeItemProps> = {
    * similar to getElementById but for FlatTreeItems
    */
   getElementFromItem(item: HeadlessTreeItem<Props>): HTMLElement | null;
+  getItem(value: TreeItemValue): HeadlessTreeItem<Props> | undefined;
   /**
    * an iterable containing all visually available flat tree items
    */
@@ -176,11 +177,14 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
       onCheckedChange: handleCheckedChange,
       onNavigation: options.onNavigation ?? noop,
     }),
+    // ref, handleOpenChange - useEventCallback, handleCheckedChange - useEventCallback
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [openItems, checkedItems, options.selectionMode, options.onNavigation],
   );
 
   const items = React.useCallback(() => headlessTree.visibleItems(openItems), [openItems, headlessTree]);
+
+  const getItem = React.useCallback((value: TreeItemValue) => headlessTree.get(value), [headlessTree]);
 
   return React.useMemo<HeadlessFlatTree<Props>>(
     () => ({
@@ -188,9 +192,10 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
       getTreeProps,
       getNextNavigableItem,
       getElementFromItem,
+      getItem,
       items,
     }),
-    [navigation.navigate, getTreeProps, getNextNavigableItem, getElementFromItem, items],
+    [navigation.navigate, getTreeProps, getNextNavigableItem, getElementFromItem, items, getItem],
   );
 }
 

--- a/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
@@ -1,11 +1,6 @@
 import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
-import {
-  HeadlessTree,
-  HeadlessTreeItem,
-  HeadlessTreeItemProps,
-  createHeadlessTree,
-} from '../../utils/createHeadlessTree';
+import { HeadlessTreeItem, HeadlessTreeItemProps, createHeadlessTree } from '../../utils/createHeadlessTree';
 import { treeDataTypes } from '../../utils/tokens';
 import { useFlatTreeNavigation } from '../../hooks/useFlatTreeNavigation';
 import { createNextOpenItems, useControllableOpenItems } from '../../hooks/useControllableOpenItems';
@@ -102,6 +97,13 @@ export type HeadlessFlatTreeOptions = Pick<
   };
 
 /**
+ * @internal
+ */
+type HeadlessFlatTreeReturn<Props extends HeadlessFlatTreeItemProps> = HeadlessFlatTree<Props> & {
+  getItem(value: TreeItemValue): HeadlessTreeItem<Props> | undefined;
+};
+
+/**
  * this hook provides FlatTree API to manage all required mechanisms to convert a list of items into renderable TreeItems
  * in multiple scenarios including virtualization.
  *
@@ -114,10 +116,10 @@ export type HeadlessFlatTreeOptions = Pick<
  * @param options - in case control over the internal openItems is required
  */
 export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps>(
-  props: Props[] | HeadlessTree<Props>,
+  props: Props[],
   options: HeadlessFlatTreeOptions = {},
-): HeadlessFlatTree<Props> {
-  const headlessTree = React.useMemo(() => (Array.isArray(props) ? createHeadlessTree(props) : props), [props]);
+): HeadlessFlatTreeReturn<Props> {
+  const headlessTree = React.useMemo(() => createHeadlessTree(props), [props]);
   const [openItems, setOpenItems] = useControllableOpenItems(options);
   const [checkedItems, setCheckedItems] = useFlatControllableCheckedItems(options, headlessTree);
   const navigation = useFlatTreeNavigation();
@@ -188,15 +190,18 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
 
   const items = React.useCallback(() => headlessTree.visibleItems(openItems), [openItems, headlessTree]);
 
-  return React.useMemo<HeadlessFlatTree<Props>>(
+  const getItem = React.useCallback((value: TreeItemValue) => headlessTree.get(value), [headlessTree]);
+
+  return React.useMemo<HeadlessFlatTreeReturn<Props>>(
     () => ({
       navigate: navigation.navigate,
       getTreeProps,
       getNextNavigableItem,
       getElementFromItem,
       items,
+      getItem,
     }),
-    [navigation.navigate, getTreeProps, getNextNavigableItem, getElementFromItem, items],
+    [navigation.navigate, getTreeProps, getNextNavigableItem, getElementFromItem, items, getItem],
   );
 }
 

--- a/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
+++ b/packages/react-components/react-tree/src/components/FlatTree/useHeadlessFlatTree.ts
@@ -1,6 +1,11 @@
 import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import * as React from 'react';
-import { HeadlessTreeItem, HeadlessTreeItemProps, createHeadlessTree } from '../../utils/createHeadlessTree';
+import {
+  HeadlessTree,
+  HeadlessTreeItem,
+  HeadlessTreeItemProps,
+  createHeadlessTree,
+} from '../../utils/createHeadlessTree';
 import { treeDataTypes } from '../../utils/tokens';
 import { useFlatTreeNavigation } from '../../hooks/useFlatTreeNavigation';
 import { createNextOpenItems, useControllableOpenItems } from '../../hooks/useControllableOpenItems';
@@ -82,7 +87,6 @@ export type HeadlessFlatTree<Props extends HeadlessFlatTreeItemProps> = {
    * similar to getElementById but for FlatTreeItems
    */
   getElementFromItem(item: HeadlessTreeItem<Props>): HTMLElement | null;
-  getItem(value: TreeItemValue): HeadlessTreeItem<Props> | undefined;
   /**
    * an iterable containing all visually available flat tree items
    */
@@ -110,10 +114,10 @@ export type HeadlessFlatTreeOptions = Pick<
  * @param options - in case control over the internal openItems is required
  */
 export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps>(
-  props: Props[],
+  props: Props[] | HeadlessTree<Props>,
   options: HeadlessFlatTreeOptions = {},
 ): HeadlessFlatTree<Props> {
-  const headlessTree = React.useMemo(() => createHeadlessTree(props), [props]);
+  const headlessTree = React.useMemo(() => (Array.isArray(props) ? createHeadlessTree(props) : props), [props]);
   const [openItems, setOpenItems] = useControllableOpenItems(options);
   const [checkedItems, setCheckedItems] = useFlatControllableCheckedItems(options, headlessTree);
   const navigation = useFlatTreeNavigation();
@@ -184,21 +188,19 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
 
   const items = React.useCallback(() => headlessTree.visibleItems(openItems), [openItems, headlessTree]);
 
-  const getItem = React.useCallback((value: TreeItemValue) => headlessTree.get(value), [headlessTree]);
-
   return React.useMemo<HeadlessFlatTree<Props>>(
     () => ({
       navigate: navigation.navigate,
       getTreeProps,
       getNextNavigableItem,
       getElementFromItem,
-      getItem,
       items,
     }),
-    [navigation.navigate, getTreeProps, getNextNavigableItem, getElementFromItem, items, getItem],
+    [navigation.navigate, getTreeProps, getNextNavigableItem, getElementFromItem, items],
   );
 }
 
+/** @internal */
 function noop() {
   /* noop */
 }

--- a/packages/react-components/react-tree/src/index.ts
+++ b/packages/react-components/react-tree/src/index.ts
@@ -97,3 +97,4 @@ export type {
 
 export { flattenTree_unstable } from './utils/flattenTree';
 export type { FlattenTreeItem } from './utils/flattenTree';
+export { createHeadlessTree } from './utils/createHeadlessTree';

--- a/packages/react-components/react-tree/src/index.ts
+++ b/packages/react-components/react-tree/src/index.ts
@@ -97,4 +97,3 @@ export type {
 
 export { flattenTree_unstable } from './utils/flattenTree';
 export type { FlattenTreeItem } from './utils/flattenTree';
-export { createHeadlessTree } from './utils/createHeadlessTree';

--- a/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
+++ b/packages/react-components/react-tree/src/utils/createHeadlessTree.ts
@@ -37,17 +37,17 @@ export type HeadlessTree<Props extends HeadlessTreeItemProps> = {
   root: HeadlessTreeItem<HeadlessTreeItemProps>;
   /**
    * method to get a virtual tree item by its value
-   * @param key the key of the item to get
+   * @param key - the key of the item to get
    */
   get(value: TreeItemValue): HeadlessTreeItem<Props> | undefined;
   /**
    * method to check if a virtual tree item exists by its value
-   * @param value the value of the item to check if exists
+   * @param value - the value of the item to check if exists
    */
   has(value: TreeItemValue): boolean;
   /**
    * method to add a new virtual tree item to the virtual tree
-   * @param props the props of the item to add
+   * @param props - the props of the item to add
    */
   add(props: Props): void;
   /**
@@ -55,32 +55,32 @@ export type HeadlessTree<Props extends HeadlessTreeItemProps> = {
    * When an item is removed:
    * 1. all its children are also removed
    * 2. all its siblings are repositioned
-   * @param value the value of the item to remove
+   * @param value - the value of the item to remove
    */
   // remove(value: TreeItemValue): void;
   /**
    * method to get the parent of a virtual tree item by its value
-   * @param value the value of the item to get the parent from
+   * @param value - the value of the item to get the parent from
    */
   getParent(value: TreeItemValue): HeadlessTreeItem<Props>;
   /**
    * method to get the subtree of a virtual tree item by its value
-   * @param value the value of the item to get the subtree from
+   * @param value - the value of the item to get the subtree from
    */
   subtree(value: TreeItemValue): IterableIterator<HeadlessTreeItem<Props>>;
   /**
    * method to get the children of a virtual tree item by its value
-   * @param value the value of the item to get the children from
+   * @param value - the value of the item to get the children from
    */
   children(value: TreeItemValue): IterableIterator<HeadlessTreeItem<Props>>;
   /**
    * method to get the visible items of a virtual tree
-   * @param openItems the open items of the tree
+   * @param openItems - the open items of the tree
    */
   visibleItems(openItems: ImmutableSet<TreeItemValue>): IterableIterator<HeadlessTreeItem<Props>>;
   /**
    * method to get the ancestors of a virtual tree item by its value
-   * @param value the value of the item to get the ancestors from
+   * @param value - the value of the item to get the ancestors from
    */
   ancestors(value: TreeItemValue): IterableIterator<HeadlessTreeItem<Props>>;
 };
@@ -137,29 +137,6 @@ export function createHeadlessTree<Props extends HeadlessTreeItemProps>(
       };
       itemsPerValue.set(item.value, item);
     },
-    // TODO: eventually it would be nice to have this method exported for the user to modify
-    // the internal state of the virtual tree
-    // remove(value) {
-    //   const itemToBeRemoved = itemsPerValue.get(value);
-    //   if (!itemToBeRemoved) {
-    //     return;
-    //   }
-    //   const parentItem = headlessTree.getParent(value);
-    //   parentItem.childrenValues.splice(itemToBeRemoved.position, 1);
-    //   itemsPerValue.delete(value);
-    //   if (parentItem.childrenValues.length === 0) {
-    //     parentItem.itemType = 'leaf';
-    //   }
-    //   for (let index = itemToBeRemoved.position; index < parentItem.childrenValues.length; index++) {
-    //     const child = itemsPerValue.get(parentItem.childrenValues[index]);
-    //     if (child) {
-    //       child.position = index + 1;
-    //     }
-    //   }
-    //   for (const descendant of HeadlessTreeSubtreeGenerator(value, headlessTree)) {
-    //     itemsPerValue.delete(descendant.value);
-    //   }
-    // },
     subtree: key => HeadlessTreeSubtreeGenerator(key, headlessTree),
     children: key => HeadlessTreeChildrenGenerator(key, headlessTree),
     ancestors: key => HeadlessTreeAncestorsGenerator(key, headlessTree),
@@ -223,7 +200,7 @@ function createHeadlessTreeRootItem(): HeadlessTreeItem<HeadlessTreeItemProps> {
 
 /**
  * Generator that returns all subtree of a given virtual tree item
- * @param key the key of the item to get the subtree from
+ * @param key - the key of the item to get the subtree from
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function* HeadlessTreeSubtreeGenerator<Props extends HeadlessTreeItemProps>(
@@ -242,7 +219,7 @@ function* HeadlessTreeSubtreeGenerator<Props extends HeadlessTreeItemProps>(
 
 /**
  * Generator that returns all children of a given virtual tree item
- * @param key the key of the item to get the children from
+ * @param key - the key of the item to get the children from
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function* HeadlessTreeChildrenGenerator<Props extends HeadlessTreeItemProps>(
@@ -260,7 +237,7 @@ function* HeadlessTreeChildrenGenerator<Props extends HeadlessTreeItemProps>(
 
 /**
  * Generator that returns all ancestors of a given virtual tree item
- * @param key the key of the item to get the children from
+ * @param key - the key of the item to get the children from
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function* HeadlessTreeAncestorsGenerator<Props extends HeadlessTreeItemProps>(
@@ -276,7 +253,7 @@ function* HeadlessTreeAncestorsGenerator<Props extends HeadlessTreeItemProps>(
 
 /**
  * Generator that returns all visible items of a given virtual tree
- * @param openItems the open items of the tree
+ * @param openItems - the open items of the tree
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function* HeadlessTreeVisibleItemsGenerator<Props extends HeadlessTreeItemProps>(


### PR DESCRIPTION
## Previous Behavior

Currently the only ways to get a headless tree item from the headless tree are:

1. by generating all the items with `.items()` method
2. by simulating a navigation and then using `.getNextNavigableItem()` method
 
## New Behavior

1. modifies the return signature of `useHeadlessFlatTree` to include  `.getItem` method that allow trying to locate the headless tree item

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/30985
