### PR TITLE
fix:(react-nav-preview) Addresses keyboarding and typing issue.

### DIFF
--- a/change/@fluentui-react-nav-preview-36abc784-bfcc-4828-9322-11f7f4c04b7c.json
+++ b/change/@fluentui-react-nav-preview-36abc784-bfcc-4828-9322-11f7f4c04b7c.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "fix: Updating types for NavItem and NavSubItem to better handle keyboarding.",
   "packageName": "@fluentui/react-nav-preview",
-  "email": "17346018+mltejera@users.noreply.github.com",
+  "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-nav-preview-36abc784-bfcc-4828-9322-11f7f4c04b7c.json
+++ b/change/@fluentui-react-nav-preview-36abc784-bfcc-4828-9322-11f7f4c04b7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Updating types for NavItem and NavSubItem to better handle keyboarding.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "17346018+mltejera@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/react-v9/contributing/command-cheat-sheet.md
+++ b/docs/react-v9/contributing/command-cheat-sheet.md
@@ -13,7 +13,6 @@ yarn update-snapshots # updates snapshot tests
 yarn run dedupe # dedupes dependencies - necessary to run after any kind of package bump/changes
 yarn nx run <package-name>:generate-api # updates API files
 yarn nx run <package-name>:<target-name> # runs tasks within a package. [More help here](https://nx.dev/features/run-tasks#running-tasks)
-yarn workspace @fluentui/<package-name> type-check # quickly runs type checks and associated linting
 yarn lage build --to react # build v8 so intellisense works.
 ```
 

--- a/docs/react-v9/contributing/command-cheat-sheet.md
+++ b/docs/react-v9/contributing/command-cheat-sheet.md
@@ -13,6 +13,7 @@ yarn update-snapshots # updates snapshot tests
 yarn run dedupe # dedupes dependencies - necessary to run after any kind of package bump/changes
 yarn nx run <package-name>:generate-api # updates API files
 yarn nx run <package-name>:<target-name> # runs tasks within a package. [More help here](https://nx.dev/features/run-tasks#running-tasks)
+yarn workspace @fluentui/<package-name> type-check # quickly runs type checks and associated linting
 yarn lage build --to react # build v8 so intellisense works.
 ```
 

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -204,7 +204,7 @@ export const NavItem: ForwardRefComponent<NavItemProps>;
 export const navItemClassNames: SlotClassNames<NavItemSlots>;
 
 // @public
-export type NavItemProps = ComponentProps<NavItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement> & {
+export type NavItemProps = ComponentProps<NavItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement> & React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
     value: NavItemValue;
 };
 
@@ -294,9 +294,9 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 };
 
 // @public
-export type NavSubItemProps = ComponentProps<NavSubItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement> & {
+export type NavSubItemProps = (ComponentProps<NavSubItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement>) & (React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
     value: NavItemValue;
-};
+});
 
 // @public (undocumented)
 export type NavSubItemSlots = {

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -204,7 +204,8 @@ export const NavItem: ForwardRefComponent<NavItemProps>;
 export const navItemClassNames: SlotClassNames<NavItemSlots>;
 
 // @public
-export type NavItemProps = ComponentProps<NavItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement> & React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
+export type NavItemProps = ComponentProps<NavItemSlots> & {
+    href?: string;
     value: NavItemValue;
 };
 
@@ -294,9 +295,10 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 };
 
 // @public
-export type NavSubItemProps = (ComponentProps<NavSubItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement>) & (React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
+export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {
+    href?: string;
     value: NavItemValue;
-});
+};
 
 // @public (undocumented)
 export type NavSubItemSlots = {

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -6,7 +6,7 @@
 
 /// <reference types="react" />
 
-import { ARIAButtonSlotProps } from '@fluentui/react-aria';
+import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { DrawerBodyProps } from '@fluentui/react-drawer';

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -204,7 +204,7 @@ export const NavItem: ForwardRefComponent<NavItemProps>;
 export const navItemClassNames: SlotClassNames<NavItemSlots>;
 
 // @public
-export type NavItemProps = ComponentProps<NavItemSlots> & {
+export type NavItemProps = ComponentProps<NavItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement> & {
     value: NavItemValue;
 };
 
@@ -294,7 +294,7 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 };
 
 // @public
-export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {
+export type NavSubItemProps = ComponentProps<NavSubItemSlots> & React_2.AnchorHTMLAttributes<HTMLAnchorElement> & {
     value: NavItemValue;
 };
 

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -6,6 +6,7 @@
 
 /// <reference types="react" />
 
+import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { DrawerBodyProps } from '@fluentui/react-drawer';
@@ -215,7 +216,7 @@ export type NavItemRegisterData = {
 
 // @public (undocumented)
 export type NavItemSlots = {
-    root: NonNullable<Slot<'a'>>;
+    root: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
     icon?: Slot<'span'>;
 };
 
@@ -299,7 +300,7 @@ export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
 
 // @public (undocumented)
 export type NavSubItemSlots = {
-    root: Slot<'a'>;
+    root: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
 };
 
 // @public
@@ -398,7 +399,7 @@ export const useNavDrawerHeaderStyles_unstable: (state: NavDrawerHeaderState) =>
 export const useNavDrawerStyles_unstable: (state: NavDrawerState) => NavDrawerState;
 
 // @public
-export const useNavItem_unstable: (props: NavItemProps, ref: React_2.Ref<HTMLAnchorElement>) => NavItemState;
+export const useNavItem_unstable: (props: NavItemProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => NavItemState;
 
 // @public
 export const useNavItemStyles_unstable: (state: NavItemState) => NavItemState;
@@ -413,7 +414,7 @@ export const useNavSectionHeaderStyles_unstable: (state: NavSectionHeaderState) 
 export const useNavStyles_unstable: (state: NavState) => NavState;
 
 // @public
-export const useNavSubItem_unstable: (props: NavSubItemProps, ref: React_2.Ref<HTMLAnchorElement>) => NavSubItemState;
+export const useNavSubItem_unstable: (props: NavSubItemProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => NavSubItemState;
 
 // @public
 export const useNavSubItemGroup_unstable: (props: NavSubItemGroupProps, ref: React_2.Ref<HTMLDivElement>) => NavSubItemGroupState;

--- a/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/etc/react-nav-preview.api.md
@@ -204,7 +204,7 @@ export const NavItem: ForwardRefComponent<NavItemProps>;
 export const navItemClassNames: SlotClassNames<NavItemSlots>;
 
 // @public
-export type NavItemProps = ComponentProps<Partial<NavItemSlots>> & {
+export type NavItemProps = ComponentProps<NavItemSlots> & {
     value: NavItemValue;
 };
 
@@ -294,7 +294,7 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
 };
 
 // @public
-export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
+export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {
     value: NavItemValue;
 };
 

--- a/packages/react-components/react-nav-preview/package.json
+++ b/packages/react-components/react-nav-preview/package.json
@@ -30,6 +30,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
+    "@fluentui/react-aria": "^9.11.2",
     "@fluentui/react-context-selector": "^9.1.59",
     "@fluentui/react-shared-contexts": "^9.18.0",
     "@fluentui/react-tabster": "^9.21.2",

--- a/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavCategoryItem/useNavCategoryItem.tsx
@@ -42,8 +42,6 @@ export const useNavCategoryItem_unstable = (
     root: slot.always(
       getIntrinsicElementProps('button', {
         ref,
-        role: 'nav',
-        type: 'navigation',
         ...props,
         onClick: onNavCategoryItemClick,
       }),

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.test.tsx
@@ -1,10 +1,12 @@
+import * as React from 'react';
 import { isConformant } from '../../testing/isConformant';
 import { NavItem } from './NavItem';
 import { navItemClassNames } from './useNavItemStyles.styles';
+import type { NavItemProps } from './NavItem.types';
 
 describe('NavItem', () => {
   isConformant({
-    Component: NavItem,
+    Component: NavItem as React.FunctionComponent<NavItemProps>,
     displayName: 'NavItem',
     testOptions: {
       'has-static-classnames': [

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
@@ -15,14 +14,13 @@ export type NavItemSlots = {
 /**
  * NavItem Props
  */
-export type NavItemProps = ComponentProps<NavItemSlots> &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> &
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
-    /**
-     * The value that identifies this navCategoryItem when selected.
-     */
-    value: NavItemValue;
-  };
+export type NavItemProps = ComponentProps<NavItemSlots> & {
+  href?: string;
+  /**
+   * The value that identifies this navCategoryItem when selected.
+   */
+  value: NavItemValue;
+};
 
 /**
  * State used in rendering NavItem

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
@@ -14,12 +15,13 @@ export type NavItemSlots = {
 /**
  * NavItem Props
  */
-export type NavItemProps = ComponentProps<NavItemSlots> & {
-  /**
-   * The value that identifies this navCategoryItem when selected.
-   */
-  value: NavItemValue;
-};
+export type NavItemProps = ComponentProps<NavItemSlots> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    /**
+     * The value that identifies this navCategoryItem when selected.
+     */
+    value: NavItemValue;
+  };
 
 /**
  * State used in rendering NavItem

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -15,13 +15,14 @@ export type NavItemSlots = {
 /**
  * NavItem Props
  */
-export type NavItemProps = ComponentProps<NavItemSlots> &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-    /**
-     * The value that identifies this navCategoryItem when selected.
-     */
-    value: NavItemValue;
-  };
+export type NavItemProps =
+  | (ComponentProps<NavItemSlots> & React.AnchorHTMLAttributes<HTMLAnchorElement>)
+  | (React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      /**
+       * The value that identifies this navCategoryItem when selected.
+       */
+      value: NavItemValue;
+    });
 
 /**
  * State used in rendering NavItem

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -1,8 +1,9 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavItemSlots = {
-  root: NonNullable<Slot<'a'>>;
+  root: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
 
   /**
    * Icon that renders before the content.

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -15,14 +15,14 @@ export type NavItemSlots = {
 /**
  * NavItem Props
  */
-export type NavItemProps =
-  | (ComponentProps<NavItemSlots> & React.AnchorHTMLAttributes<HTMLAnchorElement>)
-  | (React.ButtonHTMLAttributes<HTMLButtonElement> & {
-      /**
-       * The value that identifies this navCategoryItem when selected.
-       */
-      value: NavItemValue;
-    });
+export type NavItemProps = ComponentProps<NavItemSlots> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    /**
+     * The value that identifies this navCategoryItem when selected.
+     */
+    value: NavItemValue;
+  };
 
 /**
  * State used in rendering NavItem

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -14,7 +14,7 @@ export type NavItemSlots = {
 /**
  * NavItem Props
  */
-export type NavItemProps = ComponentProps<Partial<NavItemSlots>> & {
+export type NavItemProps = ComponentProps<NavItemSlots> & {
   /**
    * The value that identifies this navCategoryItem when selected.
    */

--- a/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/NavItem.types.ts
@@ -1,5 +1,5 @@
-import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
+import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavItemSlots = {

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -3,7 +3,7 @@ import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from
 import { useNavContext_unstable } from '../NavContext';
 
 import type { NavItemProps, NavItemState } from './NavItem.types';
-import { ARIAButtonSlotProps } from '@fluentui/react-aria';
+import { ARIAButtonSlotProps, useARIAButtonProps } from '@fluentui/react-aria';
 
 /**
  * Create the state required to render NavItem.
@@ -18,7 +18,7 @@ export const useNavItem_unstable = (
   props: NavItemProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): NavItemState => {
-  const { onClick, value, icon } = props;
+  const { onClick, value, icon, as = 'button' } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
 
@@ -45,14 +45,21 @@ export const useNavItem_unstable = (
   return {
     components: { root: 'button', icon: 'span' },
     root: slot.always<ARIAButtonSlotProps<'a'>>(
-      getIntrinsicElementProps('a', {
-        ref,
-        role: 'nav',
-        type: 'navigation',
-        ...props,
-        onClick: onNavItemClick,
-      }),
-      { elementType: 'a' },
+      getIntrinsicElementProps(
+        as,
+        useARIAButtonProps(props.as, {
+          ...props,
+          onClick: onNavItemClick,
+        }),
+      ),
+      {
+        elementType: 'button',
+        defaultProps: {
+          ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+          type: 'button',
+          role: 'nav',
+        },
+      },
     ),
     icon: slot.optional(icon, {
       elementType: 'span',

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -57,7 +57,6 @@ export const useNavItem_unstable = (
         defaultProps: {
           ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
           type: 'button',
-          role: 'nav',
         },
       },
     ),

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, isHTMLElement } from '@fluentui/react-utilities';
+import { useARIAButtonProps } from '@fluentui/react-aria';
 import { useNavContext_unstable } from '../NavContext';
 
+import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { NavItemProps, NavItemState } from './NavItem.types';
-import { ARIAButtonSlotProps, useARIAButtonProps } from '@fluentui/react-aria';
 
 /**
  * Create the state required to render NavItem.
@@ -36,7 +37,7 @@ export const useNavItem_unstable = (
     }
   });
 
-  const _navItem = slot.always<ARIAButtonSlotProps<'a'>>(
+  const root = slot.always<ARIAButtonSlotProps<'a'>>(
     getIntrinsicElementProps(rootElementType, useARIAButtonProps(rootElementType, props)),
     {
       elementType: rootElementType,
@@ -47,7 +48,7 @@ export const useNavItem_unstable = (
     },
   );
 
-  _navItem.onClick = onNavItemClick;
+  root.onClick = onNavItemClick;
 
   React.useEffect(() => {
     onRegister({
@@ -62,7 +63,7 @@ export const useNavItem_unstable = (
 
   return {
     components: { root: rootElementType, icon: 'span' },
-    root: _navItem,
+    root: root,
     icon: slot.optional(icon, {
       elementType: 'span',
     }),

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -3,6 +3,7 @@ import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from
 import { useNavContext_unstable } from '../NavContext';
 
 import type { NavItemProps, NavItemState } from './NavItem.types';
+import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 
 /**
  * Create the state required to render NavItem.
@@ -13,7 +14,10 @@ import type { NavItemProps, NavItemState } from './NavItem.types';
  * @param props - props from this instance of NavItem
  * @param ref - reference to root HTMLAnchorElement of NavItem
  */
-export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnchorElement>): NavItemState => {
+export const useNavItem_unstable = (
+  props: NavItemProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): NavItemState => {
   const { onClick, value, icon } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
@@ -22,7 +26,9 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
 
   const innerRef = React.useRef<HTMLElement>(null);
   const onNavItemClick = useEventCallback(
-    mergeCallbacks(onClick, event => onSelect(event, { type: 'click', event, value })),
+    mergeCallbacks(onClick as React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>, event =>
+      onSelect(event, { type: 'click', event, value }),
+    ),
   );
 
   React.useEffect(() => {
@@ -38,7 +44,7 @@ export const useNavItem_unstable = (props: NavItemProps, ref: React.Ref<HTMLAnch
 
   return {
     components: { root: 'a', icon: 'span' },
-    root: slot.always(
+    root: slot.always<ARIAButtonSlotProps<'a'>>(
       getIntrinsicElementProps('a', {
         ref,
         role: 'nav',

--- a/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavItem/useNavItem.ts
@@ -43,7 +43,7 @@ export const useNavItem_unstable = (
   }, [onRegister, onUnregister, innerRef, value]);
 
   return {
-    components: { root: 'a', icon: 'span' },
+    components: { root: 'button', icon: 'span' },
     root: slot.always<ARIAButtonSlotProps<'a'>>(
       getIntrinsicElementProps('a', {
         ref,

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.test.tsx
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.test.tsx
@@ -1,9 +1,11 @@
+import * as React from 'react';
 import { isConformant } from '../../testing/isConformant';
 import { NavSubItem } from './NavSubItem';
+import type { NavSubItemProps } from './NavSubItem.types';
 
 describe('NavSubItem', () => {
   isConformant({
-    Component: NavSubItem,
+    Component: NavSubItem as React.FunctionComponent<NavSubItemProps>,
     displayName: 'NavSubItem',
   });
 });

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -12,13 +12,13 @@ export type NavSubItemSlots = {
  * NavSubItem Props
  */
 export type NavSubItemProps =
-  | (ComponentProps<NavSubItemSlots> & React.AnchorHTMLAttributes<HTMLAnchorElement>)
-  | (React.ButtonHTMLAttributes<HTMLButtonElement> & {
-      /**
-       * The value that identifies this NavSubItem when selected.
-       */
-      value: NavItemValue;
-    });
+  | (ComponentProps<NavSubItemSlots> & React.AnchorHTMLAttributes<HTMLAnchorElement>) &
+      (React.ButtonHTMLAttributes<HTMLButtonElement> & {
+        /**
+         * The value that identifies this NavSubItem when selected.
+         */
+        value: NavItemValue;
+      });
 
 /**
  * State used in rendering NavSubItem

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -1,6 +1,6 @@
-import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
 
+import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavSubItemSlots = {

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
 
@@ -10,12 +11,13 @@ export type NavSubItemSlots = {
 /**
  * NavSubItem Props
  */
-export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {
-  /**
-   * The value that identifies this NavSubItem when selected.
-   */
-  value: NavItemValue;
-};
+export type NavSubItemProps = ComponentProps<NavSubItemSlots> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    /**
+     * The value that identifies this NavSubItem when selected.
+     */
+    value: NavItemValue;
+  };
 
 /**
  * State used in rendering NavSubItem

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -10,7 +10,7 @@ export type NavSubItemSlots = {
 /**
  * NavSubItem Props
  */
-export type NavSubItemProps = ComponentProps<Partial<NavSubItemSlots>> & {
+export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {
   /**
    * The value that identifies this NavSubItem when selected.
    */

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
 
@@ -11,14 +10,13 @@ export type NavSubItemSlots = {
 /**
  * NavSubItem Props
  */
-export type NavSubItemProps =
-  | (ComponentProps<NavSubItemSlots> & React.AnchorHTMLAttributes<HTMLAnchorElement>) &
-      (React.ButtonHTMLAttributes<HTMLButtonElement> & {
-        /**
-         * The value that identifies this NavSubItem when selected.
-         */
-        value: NavItemValue;
-      });
+export type NavSubItemProps = ComponentProps<NavSubItemSlots> & {
+  href?: string;
+  /**
+   * The value that identifies this NavSubItem when selected.
+   */
+  value: NavItemValue;
+};
 
 /**
  * State used in rendering NavSubItem

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -1,9 +1,10 @@
+import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { NavItemValue } from '../NavContext.types';
 
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type NavSubItemSlots = {
-  root: Slot<'a'>;
+  root: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
 };
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/NavSubItem.types.ts
@@ -11,13 +11,14 @@ export type NavSubItemSlots = {
 /**
  * NavSubItem Props
  */
-export type NavSubItemProps = ComponentProps<NavSubItemSlots> &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-    /**
-     * The value that identifies this NavSubItem when selected.
-     */
-    value: NavItemValue;
-  };
+export type NavSubItemProps =
+  | (ComponentProps<NavSubItemSlots> & React.AnchorHTMLAttributes<HTMLAnchorElement>)
+  | (React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      /**
+       * The value that identifies this NavSubItem when selected.
+       */
+      value: NavItemValue;
+    });
 
 /**
  * State used in rendering NavSubItem

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -48,7 +48,7 @@ export const useNavSubItem_unstable = (
 
   return {
     components: {
-      root: 'a',
+      root: 'button',
     },
     root: slot.always<ARIAButtonSlotProps<'a'>>(
       getIntrinsicElementProps('a', {

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from '@fluentui/react-utilities';
+import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { useNavContext_unstable } from '../NavContext';
 import { useNavCategoryContext_unstable } from '../NavCategoryContext';
 
@@ -14,7 +15,10 @@ import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
  * @param props - props from this instance of NavSubItem
  * @param ref - reference to root HTMLButtonElement of NavSubItem
  */
-export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HTMLAnchorElement>): NavSubItemState => {
+export const useNavSubItem_unstable = (
+  props: NavSubItemProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): NavSubItemState => {
   const { onClick, value: subItemValue } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
@@ -26,7 +30,7 @@ export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HT
   const innerRef = React.useRef<HTMLElement>(null);
 
   const onNavSubItemClick = useEventCallback(
-    mergeCallbacks(onClick, event =>
+    mergeCallbacks(onClick as React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>, event =>
       onSelect(event, { type: 'click', event, value: subItemValue, categoryValue: parentCategoryValue }),
     ),
   );
@@ -46,7 +50,7 @@ export const useNavSubItem_unstable = (props: NavSubItemProps, ref: React.Ref<HT
     components: {
       root: 'a',
     },
-    root: slot.always(
+    root: slot.always<ARIAButtonSlotProps<'a'>>(
       getIntrinsicElementProps('a', {
         ref,
         role: 'nav',

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  getIntrinsicElementProps,
-  slot,
-  useEventCallback,
-  mergeCallbacks,
-  isHTMLElement,
-} from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, slot, useEventCallback, isHTMLElement } from '@fluentui/react-utilities';
 import { ARIAButtonSlotProps, useARIAButtonProps } from '@fluentui/react-aria';
 import { useNavContext_unstable } from '../NavContext';
 import { useNavCategoryContext_unstable } from '../NavCategoryContext';

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, isHTMLElement } from '@fluentui/react-utilities';
-import { ARIAButtonSlotProps, useARIAButtonProps } from '@fluentui/react-aria';
+import { useARIAButtonProps } from '@fluentui/react-aria';
 import { useNavContext_unstable } from '../NavContext';
 import { useNavCategoryContext_unstable } from '../NavCategoryContext';
 
+import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
 
 /**

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -57,7 +57,6 @@ export const useNavSubItem_unstable = (
         defaultProps: {
           ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
           type: 'button',
-          role: 'nav',
         },
       },
     ),

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -40,7 +40,7 @@ export const useNavSubItem_unstable = (
     }
   });
 
-  const _navSubItem = slot.always<ARIAButtonSlotProps<'a'>>(
+  const root = slot.always<ARIAButtonSlotProps<'a'>>(
     getIntrinsicElementProps(rootElementType, useARIAButtonProps(rootElementType, props)),
     {
       elementType: rootElementType,
@@ -51,7 +51,7 @@ export const useNavSubItem_unstable = (
     },
   );
 
-  _navSubItem.onClick = onNavSubItemClick;
+  root.onClick = onNavSubItemClick;
 
   React.useEffect(() => {
     onRegister({
@@ -68,7 +68,7 @@ export const useNavSubItem_unstable = (
     components: {
       root: rootElementType,
     },
-    root: _navSubItem,
+    root: root,
     selected,
     value: subItemValue,
   };

--- a/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/src/components/NavSubItem/useNavSubItem.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, mergeCallbacks } from '@fluentui/react-utilities';
-import { ARIAButtonSlotProps } from '@fluentui/react-aria';
+import { ARIAButtonSlotProps, useARIAButtonProps } from '@fluentui/react-aria';
 import { useNavContext_unstable } from '../NavContext';
 import { useNavCategoryContext_unstable } from '../NavCategoryContext';
 
@@ -19,7 +19,7 @@ export const useNavSubItem_unstable = (
   props: NavSubItemProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): NavSubItemState => {
-  const { onClick, value: subItemValue } = props;
+  const { onClick, value: subItemValue, as = 'button' } = props;
 
   const { selectedValue, onRegister, onUnregister, onSelect } = useNavContext_unstable();
 
@@ -51,14 +51,15 @@ export const useNavSubItem_unstable = (
       root: 'button',
     },
     root: slot.always<ARIAButtonSlotProps<'a'>>(
-      getIntrinsicElementProps('a', {
-        ref,
-        role: 'nav',
-        type: 'navigation',
-        ...props,
-        onClick: onNavSubItemClick,
-      }),
-      { elementType: 'a' },
+      getIntrinsicElementProps(as, useARIAButtonProps(props.as, { ...props, onClick: onNavSubItemClick })),
+      {
+        elementType: 'button',
+        defaultProps: {
+          ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+          type: 'button',
+          role: 'nav',
+        },
+      },
     ),
     selected,
     value: subItemValue,

--- a/packages/react-components/react-nav-preview/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/sharedNavStyles.styles.ts
@@ -29,6 +29,9 @@ export const useRootDefaultClassName = makeResetStyles({
   color: tokens.colorNeutralForeground2,
   textDecorationLine: 'none',
   border: 'none',
+  // this element can change between a button and an anchor
+  // so we need to reset box sizing to prevent horizontal overflow
+  boxSizing: 'border-box',
   width: '100%',
   ...typographyStyles.body1,
   ':hover': {

--- a/packages/react-components/react-nav-preview/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/src/components/sharedNavStyles.styles.ts
@@ -29,6 +29,7 @@ export const useRootDefaultClassName = makeResetStyles({
   color: tokens.colorNeutralForeground2,
   textDecorationLine: 'none',
   border: 'none',
+  width: '100%',
   ...typographyStyles.body1,
   ':hover': {
     backgroundColor: navItemTokens.backgroundColorHover,

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -143,29 +143,29 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
         </NavDrawerHeader>
         <NavDrawerBody>
           <Caption1Strong className={styles.headingContent}>Home</Caption1Strong>
-          <NavItem as="a" href="https://www.bing.com" icon={<Dashboard />} value="1">
+          <NavItem icon={<Dashboard />} value="1">
             Dashboard
           </NavItem>
-          <NavItem as="button" icon={<Announcements />} onClick={someClickHandler} value="2">
+          <NavItem href="https://www.bing.com" icon={<Announcements />} value="2">
             Announcements
           </NavItem>
-          <NavItem as="button" icon={<EmployeeSpotlight />} onClick={someClickHandler} value="3">
+          <NavItem href="https://www.bing.com" icon={<EmployeeSpotlight />} value="3">
             Employee Spotlight
           </NavItem>
           <Caption1Strong className={styles.headingContent}>Employee Management</Caption1Strong>
-          <NavItem as="button" icon={<Search />} onClick={someClickHandler} value="4">
+          <NavItem icon={<Search />} href="https://www.bing.com" value="4">
             Profile Search
           </NavItem>
-          <NavItem as="button" icon={<PerformanceReviews />} onClick={someClickHandler} value="5">
+          <NavItem icon={<PerformanceReviews />} href="https://www.bing.com" value="5">
             Performance Reviews
           </NavItem>
           <NavCategory value="6">
             <NavCategoryItem icon={<JobPostings />}>Job Postings</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem as="button" onClick={someClickHandler} value="7">
+              <NavSubItem href="https://www.bing.com" value="7">
                 Openings
               </NavSubItem>
-              <NavSubItem as="button" onClick={someClickHandler} value="8">
+              <NavSubItem href="https://www.bing.com" value="8">
                 Submissions
               </NavSubItem>
             </NavSubItemGroup>
@@ -174,7 +174,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
             Interviews
           </NavItem>
           <Caption1Strong className={styles.headingContent}>Benefits</Caption1Strong>
-          <NavItem icon={<HealthPlans />} value="10">
+          <NavItem href="https://www.bing.com" onClick={someClickHandler} icon={<HealthPlans />} value="10">
             Health Plans
           </NavItem>
           <NavCategory value="11">
@@ -182,44 +182,44 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
               Retirement
             </NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem as="button" onClick={someClickHandler} value="13">
+              <NavSubItem href="https://www.bing.com" value="13">
                 Plan Information
               </NavSubItem>
-              <NavSubItem as="button" onClick={someClickHandler} value="14">
+              <NavSubItem href="https://www.bing.com" value="14">
                 Fund Performance
               </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>
 
           <Caption1Strong className={styles.headingContent}>Learning</Caption1Strong>
-          <NavItem icon={<TrainingPrograms />} value="15">
+          <NavItem icon={<TrainingPrograms />} onClick={someClickHandler} value="15">
             Training Programs
           </NavItem>
           <NavCategory value="16">
             <NavCategoryItem icon={<CareerDevelopment />}>Career Development</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem as="button" onClick={someClickHandler} value="17">
+              <NavSubItem href="https://www.bing.com" onClick={someClickHandler} value="17">
                 Career Paths
               </NavSubItem>
-              <NavSubItem as="button" onClick={someClickHandler} value="18">
+              <NavSubItem onClick={someClickHandler} value="18">
                 Planning
               </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>
 
           <Caption1Strong className={styles.headingContent}>Analytics</Caption1Strong>
-          <NavItem as="button" onClick={someClickHandler} icon={<Analytics />} value="19">
+          <NavItem href="https://www.bing.com" icon={<Analytics />} value="19">
             Workforce Data
           </NavItem>
-          <NavItem as="button" onClick={someClickHandler} icon={<Reports />} value="20">
+          <NavItem href="https://www.bing.com" icon={<Reports />} value="20">
             Reports
           </NavItem>
         </NavDrawerBody>
         <NavDrawerFooter>
-          <NavItem value="21" as="button" onClick={someClickHandler} icon={<Person />}>
+          <NavItem value="21" href="https://www.bing.com" icon={<Person />}>
             Profile
           </NavItem>
-          <NavItem icon={<Settings />} as="button" onClick={someClickHandler} value="24">
+          <NavItem icon={<Settings />} href="https://www.bing.com" value="24">
             App Settings
           </NavItem>
         </NavDrawerFooter>

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -192,7 +192,8 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           </NavCategory>
 
           <Caption1Strong className={styles.headingContent}>Learning</Caption1Strong>
-          <NavItem icon={<TrainingPrograms />} onClick={someClickHandler} value="15">
+          {/* As button, since no href is present */}
+          <NavItem icon={<TrainingPrograms />} as="button" onClick={someClickHandler} value="15">
             Training Programs
           </NavItem>
           <NavCategory value="16">
@@ -201,7 +202,8 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
               <NavSubItem href="https://www.bing.com" onClick={someClickHandler} value="17">
                 Career Paths
               </NavSubItem>
-              <NavSubItem onClick={someClickHandler} value="18">
+              {/* As button, since no href is present */}
+              <NavSubItem as="a" onClick={someClickHandler} value="18">
                 Planning
               </NavSubItem>
             </NavSubItemGroup>

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -143,7 +143,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
         </NavDrawerHeader>
         <NavDrawerBody>
           <Caption1Strong className={styles.headingContent}>Home</Caption1Strong>
-          <NavItem icon={<Dashboard />} value="1">
+          <NavItem onClick={someClickHandler} icon={<Dashboard />} value="1">
             Dashboard
           </NavItem>
           <NavItem href="https://www.bing.com" icon={<Announcements />} value="2">
@@ -192,8 +192,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           </NavCategory>
 
           <Caption1Strong className={styles.headingContent}>Learning</Caption1Strong>
-          {/* As button, since no href is present */}
-          <NavItem icon={<TrainingPrograms />} as="button" onClick={someClickHandler} value="15">
+          <NavItem icon={<TrainingPrograms />} onClick={someClickHandler} value="15">
             Training Programs
           </NavItem>
           <NavCategory value="16">
@@ -202,8 +201,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
               <NavSubItem href="https://www.bing.com" onClick={someClickHandler} value="17">
                 Career Paths
               </NavSubItem>
-              {/* As button, since no href is present */}
-              <NavSubItem as="a" onClick={someClickHandler} value="18">
+              <NavSubItem onClick={someClickHandler} value="18">
                 Planning
               </NavSubItem>
             </NavSubItemGroup>

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -143,7 +143,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
         </NavDrawerHeader>
         <NavDrawerBody>
           <Caption1Strong className={styles.headingContent}>Home</Caption1Strong>
-          <NavItem as="button" icon={<Dashboard />} onClick={someClickHandler} value="1">
+          <NavItem as="a" href="https://www.bing.com" icon={<Dashboard />} value="1">
             Dashboard
           </NavItem>
           <NavItem as="button" icon={<Announcements />} onClick={someClickHandler} value="2">

--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -143,29 +143,29 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
         </NavDrawerHeader>
         <NavDrawerBody>
           <Caption1Strong className={styles.headingContent}>Home</Caption1Strong>
-          <NavItem target="_blank" icon={<Dashboard />} onClick={someClickHandler} value="1">
+          <NavItem as="button" icon={<Dashboard />} onClick={someClickHandler} value="1">
             Dashboard
           </NavItem>
-          <NavItem target="_blank" icon={<Announcements />} onClick={someClickHandler} value="2">
+          <NavItem as="button" icon={<Announcements />} onClick={someClickHandler} value="2">
             Announcements
           </NavItem>
-          <NavItem target="_blank" icon={<EmployeeSpotlight />} onClick={someClickHandler} value="3">
+          <NavItem as="button" icon={<EmployeeSpotlight />} onClick={someClickHandler} value="3">
             Employee Spotlight
           </NavItem>
           <Caption1Strong className={styles.headingContent}>Employee Management</Caption1Strong>
-          <NavItem target="_blank" icon={<Search />} onClick={someClickHandler} value="4">
+          <NavItem as="button" icon={<Search />} onClick={someClickHandler} value="4">
             Profile Search
           </NavItem>
-          <NavItem target="_blank" icon={<PerformanceReviews />} onClick={someClickHandler} value="5">
+          <NavItem as="button" icon={<PerformanceReviews />} onClick={someClickHandler} value="5">
             Performance Reviews
           </NavItem>
           <NavCategory value="6">
             <NavCategoryItem icon={<JobPostings />}>Job Postings</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem target="_blank" onClick={someClickHandler} value="7">
+              <NavSubItem as="button" onClick={someClickHandler} value="7">
                 Openings
               </NavSubItem>
-              <NavSubItem target="_blank" onClick={someClickHandler} value="8">
+              <NavSubItem as="button" onClick={someClickHandler} value="8">
                 Submissions
               </NavSubItem>
             </NavSubItemGroup>
@@ -182,10 +182,10 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
               Retirement
             </NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem target="_blank" onClick={someClickHandler} value="13">
+              <NavSubItem as="button" onClick={someClickHandler} value="13">
                 Plan Information
               </NavSubItem>
-              <NavSubItem target="_blank" onClick={someClickHandler} value="14">
+              <NavSubItem as="button" onClick={someClickHandler} value="14">
                 Fund Performance
               </NavSubItem>
             </NavSubItemGroup>
@@ -198,28 +198,28 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           <NavCategory value="16">
             <NavCategoryItem icon={<CareerDevelopment />}>Career Development</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem target="_blank" onClick={someClickHandler} value="17">
+              <NavSubItem as="button" onClick={someClickHandler} value="17">
                 Career Paths
               </NavSubItem>
-              <NavSubItem target="_blank" onClick={someClickHandler} value="18">
+              <NavSubItem as="button" onClick={someClickHandler} value="18">
                 Planning
               </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>
 
           <Caption1Strong className={styles.headingContent}>Analytics</Caption1Strong>
-          <NavItem target="_blank" onClick={someClickHandler} icon={<Analytics />} value="19">
+          <NavItem as="button" onClick={someClickHandler} icon={<Analytics />} value="19">
             Workforce Data
           </NavItem>
-          <NavItem target="_blank" onClick={someClickHandler} icon={<Reports />} value="20">
+          <NavItem as="button" onClick={someClickHandler} icon={<Reports />} value="20">
             Reports
           </NavItem>
         </NavDrawerBody>
         <NavDrawerFooter>
-          <NavItem value="21" target="_blank" onClick={someClickHandler} icon={<Person />}>
+          <NavItem value="21" as="button" onClick={someClickHandler} icon={<Person />}>
             Profile
           </NavItem>
-          <NavItem icon={<Settings />} target="_blank" onClick={someClickHandler} value="24">
+          <NavItem icon={<Settings />} as="button" onClick={someClickHandler} value="24">
             App Settings
           </NavItem>
         </NavDrawerFooter>

--- a/packages/react-components/react-nav-preview/stories/NavSubItem/NavSubItemDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavSubItem/NavSubItemDefault.stories.tsx
@@ -2,4 +2,4 @@ import * as React from 'react';
 import { NavSubItem } from '@fluentui/react-nav-preview';
 import type { NavSubItemProps } from '@fluentui/react-nav-preview';
 
-export const Default = (props: Partial<NavSubItemProps>) => <NavSubItem value={'0'} {...props} />;
+export const Default = (props: NavSubItemProps) => <NavSubItem {...props} value={'0'} />;


### PR DESCRIPTION
Keyboarding broke on nav. This PR addresses the issue.

Drafted off carouselNavButton for patterns.

Changed the types of the root slot.

This also effects the semantic output of the components. If no href is present, it should be a button, otherwise it should be an anchor.

Before - notice Items with click handlers are no longer keyboard navigable.

https://github.com/microsoft/fluentui/assets/17346018/e946147e-1bed-4469-9a7f-70f38ec4a969

After - notice all items are keyboard navigable.

https://github.com/microsoft/fluentui/assets/17346018/98c44091-123a-440e-9f58-3e604651765b

Ladders to #26649 and addresses #31190 directly.
