### PR TITLE
fix(react-drawer): restore page scroll when Drawer closes

### DIFF
--- a/change/@fluentui-react-drawer-1cda71d6-0464-4bf9-8003-329089924620.json
+++ b/change/@fluentui-react-drawer-1cda71d6-0464-4bf9-8003-329089924620.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: restore scroll when Drawer closes",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.cy.tsx
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.cy.tsx
@@ -12,6 +12,23 @@ const mountFluent = (element: JSX.Element) => {
   mount(<FluentProvider theme={webLightTheme}>{element}</FluentProvider>);
 };
 
+const LongPageContent = ({ children }: React.PropsWithChildren<{}>) => (
+  <>
+    {Array.from({ length: 10 }).map((_, index) => (
+      <p key={index}>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Corrupti, animi? Quos, eum pariatur. Labore magni vel
+        doloremque reiciendis, consequatur porro explicabo similique harum illo, ad hic, earum nobis accusantium quasi?
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Provident eligendi impedit culpa ea ipsum voluptate
+        inventore labore, delectus nam veniam dolor debitis dolorem blanditiis in, natus deleniti illo. Asperiores,
+        porro. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat obcaecati aperiam recusandae. Pariatur
+        dolorem cumque odit delectus voluptates ea ipsam culpa voluptate? Praesentium beatae corrupti accusamus.
+        Suscipit voluptas natus illo?
+      </p>
+    ))}
+    {children}
+  </>
+);
+
 describe('OverlayDrawer', () => {
   testDrawerBaseScenarios(OverlayDrawer);
 
@@ -62,6 +79,30 @@ describe('OverlayDrawer', () => {
 
         cy.get(`.${overlayDrawerClassNames.backdrop}`).should('not.exist');
       });
+    });
+  });
+
+  describe('body scroll', () => {
+    it('should hide scroll when opened', () => {
+      const ExampleDrawer = (props: OverlayDrawerProps) => {
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <LongPageContent>
+            <OverlayDrawer id="drawer" open={open} onOpenChange={(_, { open: isOpen }) => setOpen(isOpen)} {...props} />
+            <button id="button" onClick={() => setOpen(!open)}>
+              Toggle Drawer
+            </button>
+          </LongPageContent>
+        );
+      };
+
+      mountFluent(<ExampleDrawer />);
+
+      cy.viewport(600, 300);
+      cy.get('html').should('have.css', 'overflow-y', 'clip');
+      cy.get('#button').click({ force: true });
+      cy.get('html').should('have.css', 'overflow-y', 'visible');
     });
   });
 });

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawer.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawer.ts
@@ -43,7 +43,7 @@ export const useOverlayDrawer_unstable = (
 
   const dialog = slot.always(
     {
-      open: true,
+      open,
       defaultOpen,
       onOpenChange,
       inertTrapFocus,


### PR DESCRIPTION
This fix is a regression after changes to the Dialog component that the Drawer uses under the hood. I added a test to prevent that in the future.

## Previous Behavior
The Drawer removes the page scroll when opening but it fails to restore it

## New Behavior
Restore the page scroll after closing.

## Related Issue(s)
- Fixes #31334
