### PR TITLE
docs: update popover custom target story

### DIFF
--- a/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -32,14 +32,13 @@ const ExampleContent = () => {
 };
 
 export const AnchorToCustomTarget = () => {
-  const updateTarget = React.useCallback(() => {
-    if (buttonRef.current) {
-      positioningRef.current?.setTarget(buttonRef.current);
-    }
-  }, [buttonRef, positioningRef]);
-
-  const buttonRef = useMergedRefs<HTMLButtonElement>(updateTarget);
-  const positioningRef = useMergedRefs<PositioningImperativeRef>(updateTarget);
+  const positioningRef = React.useRef<PositioningImperativeRef>(null);
+  const buttonRef = React.useCallback(
+    (el: HTMLButtonElement | null) => {
+      positioningRef.current?.setTarget(el);
+    },
+    [positioningRef],
+  );
 
   const styles = useStyles();
 

--- a/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -36,7 +36,7 @@ export const AnchorToCustomTarget = () => {
     if (buttonRef.current) {
       positioningRef.current?.setTarget(buttonRef.current);
     }
-  }, []);
+  }, [buttonRef, positioningRef]);
 
   const buttonRef = useMergedRefs<HTMLButtonElement>(updateTarget);
   const positioningRef = useMergedRefs<PositioningImperativeRef>(updateTarget);

--- a/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
-import {
-  makeStyles,
-  shorthands,
-  Button,
-  Popover,
-  PopoverSurface,
-  PopoverTrigger,
-  useMergedRefs,
-} from '@fluentui/react-components';
+import { makeStyles, shorthands, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 import type { PositioningImperativeRef } from '@fluentui/react-components';
 const useStyles = makeStyles({
   container: {

--- a/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
+++ b/packages/react-components/react-popover/stories/Popover/PopoverAnchorToCustomTarget.stories.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import {
+  makeStyles,
+  shorthands,
+  Button,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+  useMergedRefs,
+} from '@fluentui/react-components';
 import type { PositioningImperativeRef } from '@fluentui/react-components';
 const useStyles = makeStyles({
   container: {
@@ -24,15 +32,16 @@ const ExampleContent = () => {
 };
 
 export const AnchorToCustomTarget = () => {
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const positioningRef = React.useRef<PositioningImperativeRef>(null);
-  const styles = useStyles();
-
-  React.useEffect(() => {
+  const updateTarget = React.useCallback(() => {
     if (buttonRef.current) {
       positioningRef.current?.setTarget(buttonRef.current);
     }
-  }, [buttonRef, positioningRef]);
+  }, []);
+
+  const buttonRef = useMergedRefs<HTMLButtonElement>(updateTarget);
+  const positioningRef = useMergedRefs<PositioningImperativeRef>(updateTarget);
+
+  const styles = useStyles();
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## Previous Behavior

Previously the example relied on React refs as dependencies to a `useEffect()` call but these will never trigger the effect. The example still works but when trying to extrapolate from it and target elements that appear after the first render, the example breaks down because the effect will not be triggered.

## New Behavior

This example takes advantage of the fact that [useMergedRefs()](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts) supports functions as refs so we can trigger the effect when the refs are set.

Using `setState()` was also considered but this will always trigger a re-render, negatively affecting performance so this pattern, while perhaps useful in some cases, is not a good example for best practices documentation. `setState()` is the approach demonstrated in the positioning docs ([link](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--default#anchor-to-target))

The `useEffect()` could have its dependencies removed so it would be called every render which should allow it to function as needed with less of a performance overhead than the `setState()` approach. This may be a better approach for documentation.

## Related Issue(s)

This PR is motivated by user feedback.
