### PR TITLE
bugfix(react-dialog): fix scroll locking issues introduced by a regression

### DIFF
--- a/change/@fluentui-react-dialog-f8bedb1e-8ca8-4bd7-86ed-0c7623fd0368.json
+++ b/change/@fluentui-react-dialog-f8bedb1e-8ca8-4bd7-86ed-0c7623fd0368.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: fix scroll locking issues introduced by a regression",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/src/components/Dialog/useDialog.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useControllableState, useEventCallback, useId, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useControllableState, useEventCallback, useId } from '@fluentui/react-utilities';
 import { useHasParentContext } from '@fluentui/react-context-selector';
-import { useDisableBodyScroll, useFocusFirstElement } from '../../utils';
+import { useFocusFirstElement } from '../../utils';
 import { DialogContext } from '../../contexts';
 
 import type { DialogOpenChangeData, DialogProps, DialogState } from './Dialog.types';
@@ -44,19 +44,6 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
   });
 
   const isNestedDialog = useHasParentContext(DialogContext);
-
-  const { disableBodyScroll, enableBodyScroll } = useDisableBodyScroll();
-  const isBodyScrollLocked = Boolean(open && modalType !== 'non-modal');
-  useIsomorphicLayoutEffect(() => {
-    if (isNestedDialog) {
-      return;
-    }
-    if (open && isBodyScrollLocked) {
-      disableBodyScroll();
-    } else {
-      enableBodyScroll();
-    }
-  }, [disableBodyScroll, enableBodyScroll, isBodyScrollLocked, isNestedDialog, open]);
 
   return {
     components: {

--- a/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.styles.ts
+++ b/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.styles.ts
@@ -5,3 +5,7 @@ export const useHTMLNoScrollStyles = makeResetStyles({
   overflowY: ['hidden', 'clip'],
   scrollbarGutter: 'stable',
 });
+
+export const useBodyNoScrollStyles = makeResetStyles({
+  overflowY: 'hidden',
+});

--- a/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.ts
+++ b/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.ts
@@ -1,37 +1,41 @@
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { useCallback } from 'react';
 
-import { useHTMLNoScrollStyles } from './useDisableBodyScroll.styles';
+import { useBodyNoScrollStyles, useHTMLNoScrollStyles } from './useDisableBodyScroll.styles';
 
 /**
- * hook that disables body scrolling through `overflowY: hidden` CSS property
+ * @internal
+ * A React *hook* that disables body scrolling through `overflowY: hidden` CSS property
  */
 export function useDisableBodyScroll(): {
   disableBodyScroll: () => void;
   enableBodyScroll: () => void;
 } {
-  const htmlNoScrollStyle = useHTMLNoScrollStyles();
+  const htmlNoScrollStyles = useHTMLNoScrollStyles();
+  const bodyNoScrollStyles = useBodyNoScrollStyles();
   const { targetDocument } = useFluent_unstable();
 
   const disableBodyScroll = useCallback(() => {
     if (!targetDocument) {
       return;
     }
-    const isScrollbarVisible =
-      (targetDocument.defaultView?.innerWidth ?? 0) > targetDocument.documentElement.clientWidth;
-    if (!isScrollbarVisible) {
+    const isHorizontalScrollbarVisible =
+      targetDocument.body.clientHeight > (targetDocument.defaultView?.innerHeight ?? 0);
+    if (!isHorizontalScrollbarVisible) {
       return;
     }
-    targetDocument.documentElement.classList.add(htmlNoScrollStyle);
+    targetDocument.documentElement.classList.add(htmlNoScrollStyles);
+    targetDocument.body.classList.add(bodyNoScrollStyles);
     return;
-  }, [targetDocument, htmlNoScrollStyle]);
+  }, [targetDocument, htmlNoScrollStyles, bodyNoScrollStyles]);
 
   const enableBodyScroll = useCallback(() => {
     if (!targetDocument) {
       return;
     }
-    targetDocument.documentElement.classList.remove(htmlNoScrollStyle);
-  }, [targetDocument, htmlNoScrollStyle]);
+    targetDocument.documentElement.classList.remove(htmlNoScrollStyles);
+    targetDocument.body.classList.remove(bodyNoScrollStyles);
+  }, [targetDocument, htmlNoScrollStyles, bodyNoScrollStyles]);
 
   return {
     disableBodyScroll,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

1. In chromium browsers the dialog seem to jump on entering animation
2. in firefox and safari the body lock mechanism is not working (there's a condition check if the scroll bar is present, that condition is returning false negatives) https://github.com/microsoft/fluentui/blob/3855dcb9c010e463ab2e0f2524da4f36a02eccbe/packages/react-components/react-dialog/src/utils/useDisableBodyScroll.ts#L20-L23

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. moves scroll body locking mechanism from `useDialog` to `useDialogSurface` to optain access to the animation `transitionStatus` (solves issue 1.)
2. adds `overflow-y: hidden` to body (seems like in `html` element is not enough
3. modifies the condition check if the scroll bar is present https://github.com/microsoft/fluentui/pull/31377/files#diff-8f2d1997fb63aa1fca8391cd2ab72b3f776d4d80b89cf2b331321bd11fa60de6R22-R26

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes regression from https://github.com/microsoft/fluentui/pull/31199
