### PR TITLE
fix(motions): use useFirstMount() in createPresenceComponent()

### DIFF
--- a/change/@fluentui-react-motions-preview-39389bb9-22be-417f-87ef-3f8fc4e752e1.json
+++ b/change/@fluentui-react-motions-preview-39389bb9-22be-417f-87ef-3f8fc4e752e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(motions): use useFirstMount() in createPresenceComponent()",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Previous Behavior

`createPresenceComponent()` does not work with React Strict Mode.

## New Behavior

`createPresenceComponent()` works with React Strict Mode.

> Note: `useFirstMount()` is the single reliable way on how to implement this check for React Strict Mode. Other implementations (including previous) that are based on effects won't work. Because of that I had to exclude `isFirstMount` from dependencies.

## Related Issue(s)

Fixes #31368.
