### PR TITLE
fix(react-calendar-compat): Make header button in overlaid month picker match the other header button's styles

### DIFF
--- a/change/@fluentui-react-calendar-compat-f98806df-da6a-4f9b-a2ef-93fada7e15a0.json
+++ b/change/@fluentui-react-calendar-compat-f98806df-da6a-4f9b-a2ef-93fada7e15a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Make header button in overlaid month picker match the other header button's styles.",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/src/components/CalendarDay/useCalendarDayStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarDay/useCalendarDayStyles.styles.ts
@@ -70,12 +70,16 @@ const useMonthAndYearStyles = makeStyles({
   },
   headerIsClickable: {
     '&:hover': {
-      backgroundColor: tokens.colorBrandBackground2,
-      color: tokens.colorNeutralForeground1Hover,
+      backgroundColor: tokens.colorBrandBackgroundInvertedHover,
+      color: tokens.colorBrandForegroundOnLightHover,
       cursor: 'pointer',
+      ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
     '&:hover:active': {
-      backgroundColor: tokens.colorBrandBackground2,
+      backgroundColor: tokens.colorBrandBackgroundInvertedPressed,
+      color: tokens.colorBrandForegroundOnLightPressed,
+      cursor: 'pointer',
+      ...shorthands.outline('1px', 'solid', tokens.colorTransparentStroke),
     },
   },
 });

--- a/packages/react-components/react-calendar-compat/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
@@ -73,6 +73,7 @@ const useCurrentItemButtonStyles = makeStyles({
     animationTimingFunction: EASING_FUNCTION_2,
   },
   hasHeaderClickCallback: {
+    // If this is updated, make sure to update headerIsClickable in useCalendarDayStyles as well
     '&:hover': {
       backgroundColor: tokens.colorBrandBackgroundInvertedHover,
       color: tokens.colorBrandForegroundOnLightHover,

--- a/packages/react-components/react-calendar-compat/stories/Calendar/CalendarDateBoundaries.stories.tsx
+++ b/packages/react-components/react-calendar-compat/stories/Calendar/CalendarDateBoundaries.stories.tsx
@@ -37,7 +37,7 @@ CalendarDateBoundaries.parameters = {
   docs: {
     description: {
       story:
-        'A Calendar Compat can be modified to set a minDate and maxDate in order to restrict' +
+        'A Calendar Compat can be modified to set a minDate and maxDate in order to restrict ' +
         'the dates that can be selected.',
     },
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
(hovering the header as you can see it's not showing up due to hover style issues)
![image](https://github.com/microsoft/fluentui/assets/5953191/beb64454-75cd-438a-854e-ccaa43d2e896)


## New Behavior

![image](https://github.com/microsoft/fluentui/assets/5953191/7b7e9b88-5992-4608-8fe4-7ac5e1122173)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31375
