### PR TITLE
chore(motions): don't throw in .animate() is not defined

### DIFF
--- a/change/@fluentui-react-motions-preview-5c42e067-2c80-4dbe-8f80-7f2ca4764b63.json
+++ b/change/@fluentui-react-motions-preview-5c42e067-2c80-4dbe-8f80-7f2ca4764b63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(motions): add mock for .animate() calls",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
+import { animate } from '../utils/animate';
 import { getChildElement } from '../utils/getChildElement';
 import type { AtomMotion, AtomMotionFn, MotionImperativeRef } from '../types';
 
@@ -38,7 +39,7 @@ export function createMotionComponent(motion: AtomMotion | AtomMotionFn) {
         const definition = typeof motion === 'function' ? motion(element) : motion;
         const { keyframes, ...options } = definition;
 
-        const animation = element.animate(keyframes, {
+        const animation = animate(element, keyframes, {
           fill: 'forwards',
 
           ...options,
@@ -46,6 +47,10 @@ export function createMotionComponent(motion: AtomMotion | AtomMotionFn) {
 
           ...(isReducedMotion() && { duration: 1 }),
         });
+
+        if (!animation) {
+          return;
+        }
 
         animationRef.current = animation;
 

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
@@ -6,6 +6,7 @@ import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
 import { useMountedState } from '../hooks/useMountedState';
+import { animate } from '../utils/animate';
 import { getChildElement } from '../utils/getChildElement';
 import type { PresenceMotion, MotionImperativeRef, PresenceMotionFn } from '../types';
 
@@ -83,12 +84,16 @@ export function createPresenceComponent(motion: PresenceMotion | PresenceMotionF
         const presenceDefinition = typeof motion === 'function' ? motion(elementRef.current) : motion;
         const { keyframes, ...options } = visible ? presenceDefinition.enter : presenceDefinition.exit;
 
-        const animation = elementRef.current.animate(keyframes, {
+        const animation = animate(elementRef.current, keyframes, {
           fill: 'forwards',
 
           ...options,
           ...(isReducedMotion() && { duration: 1 }),
         });
+
+        if (!animation) {
+          return;
+        }
 
         if (!visible && isFirstMount) {
           // Heads up!

--- a/packages/react-components/react-motions-preview/src/utils/animate.ts
+++ b/packages/react-components/react-motions-preview/src/utils/animate.ts
@@ -1,0 +1,17 @@
+/**
+ * Jest uses jsdom as the default environment, which doesn't support the Web Animations API. The same is true for
+ * older browsers that are out of browser support matrix.
+ *
+ * This function is a wrapper around the `Element.animate` that prevents errors to be thrown in such environments.
+ */
+export function animate(
+  element: HTMLElement,
+  keyframes: Keyframe[],
+  options: KeyframeAnimationOptions,
+): Animation | null {
+  if (typeof element.animate !== 'function') {
+    return null;
+  }
+
+  return element.animate(keyframes, options);
+}


### PR DESCRIPTION
## Previous Behavior

Components that use `createMotionComponent()` or `createPresenceComponent()` will throw as `.animate()` is not supported by jsdom (https://github.com/jsdom/jsdom/issues/3429).

## New Behavior

Components that use `createMotionComponent()` or `createPresenceComponent()` pass tests.
