### PR TITLE
fix: MessageBar without actions should not take up space

### DIFF
--- a/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
@@ -75,9 +75,7 @@ export const MultilineWithoutActions = () => (
           <MessageBarTitle>{intent}</MessageBarTitle>
           Message providing information to the user with actionable insights. <Link>Link</Link>
         </MessageBarBody>
-        <MessageBarActions
-          containerAction={<Button appearance="transparent" icon={<DismissRegular />} />}
-         />
+        <MessageBarActions containerAction={<Button appearance="transparent" icon={<DismissRegular />} />} />
       </MessageBar>
     ))}
   </div>

--- a/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/MessageBar/MessageBar.stories.tsx
@@ -64,6 +64,25 @@ export const Multiline = () => (
   </div>
 );
 
+export const MultilineWithoutActions = () => (
+  <div
+    style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 500, padding: 10 }}
+    className="testWrapper"
+  >
+    {intents.map(intent => (
+      <MessageBar layout="multiline" key={intent} intent={intent}>
+        <MessageBarBody>
+          <MessageBarTitle>{intent}</MessageBarTitle>
+          Message providing information to the user with actionable insights. <Link>Link</Link>
+        </MessageBarBody>
+        <MessageBarActions
+          containerAction={<Button appearance="transparent" icon={<DismissRegular />} />}
+         />
+      </MessageBar>
+    ))}
+  </div>
+);
+
 export const MultilineNoActions = () => (
   <div
     style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: 500, padding: 10 }}

--- a/change/@fluentui-react-message-bar-15a4f96c-8b0f-468e-a6cb-c2bd24943031.json
+++ b/change/@fluentui-react-message-bar-15a4f96c-8b0f-468e-a6cb-c2bd24943031.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MessageBar without actions should not take up space",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar/etc/react-message-bar.api.md
+++ b/packages/react-components/react-message-bar/etc/react-message-bar.api.md
@@ -33,7 +33,9 @@ export type MessageBarActionsSlots = {
 };
 
 // @public
-export type MessageBarActionsState = ComponentState<MessageBarActionsSlots> & Pick<Required<MessageBarContextValue>, 'layout'>;
+export type MessageBarActionsState = ComponentState<MessageBarActionsSlots> & Pick<Required<MessageBarContextValue>, 'layout'> & {
+    hasActions: boolean;
+};
 
 // @public
 export const MessageBarBody: ForwardRefComponent<MessageBarBodyProps>;

--- a/packages/react-components/react-message-bar/src/components/MessageBarActions/MessageBarActions.types.ts
+++ b/packages/react-components/react-message-bar/src/components/MessageBarActions/MessageBarActions.types.ts
@@ -23,4 +23,9 @@ export type MessageBarActionsProps = ComponentProps<MessageBarActionsSlots>;
  * State used in rendering MessageBarActions
  */
 export type MessageBarActionsState = ComponentState<MessageBarActionsSlots> &
-  Pick<Required<MessageBarContextValue>, 'layout'>;
+  Pick<Required<MessageBarContextValue>, 'layout'> & {
+    /**
+     * Whether there are actions as children of this component
+     */
+    hasActions: boolean;
+  };

--- a/packages/react-components/react-message-bar/src/components/MessageBarActions/useMessageBarActions.ts
+++ b/packages/react-components/react-message-bar/src/components/MessageBarActions/useMessageBarActions.ts
@@ -31,5 +31,6 @@ export const useMessageBarActions_unstable = (
       { elementType: 'div' },
     ),
     layout,
+    hasActions: !!props.children,
   };
 };

--- a/packages/react-components/react-message-bar/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
+++ b/packages/react-components/react-message-bar/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
@@ -31,6 +31,10 @@ const useMultilineStyles = makeStyles({
     marginRight: '0px',
     paddingRight: tokens.spacingVerticalM,
   },
+
+  noActions: {
+    display: 'none',
+  },
 });
 
 /**
@@ -44,6 +48,7 @@ export const useMessageBarActionsStyles_unstable = (state: MessageBarActionsStat
     messageBarActionsClassNames.root,
     rootBaseStyles,
     state.layout === 'multiline' && multilineStyles.root,
+    !state.hasActions && multilineStyles.noActions,
     state.root.className,
   );
 


### PR DESCRIPTION
Sets `display: none` to the MessageBarActions root slot if there are no children, so that the slot does not take up space

Fixes #30331

