### PR TITLE
fix(MenuList): Removing ignoreKeydown from MenuList.

### DIFF
--- a/change/@fluentui-react-menu-6f394e3c-789d-463b-9292-34fbdddb0970.json
+++ b/change/@fluentui-react-menu-6f394e3c-789d-463b-9292-34fbdddb0970.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removing ignoreKeydown on MenuList as it has side effect on submenus.",
+  "packageName": "@fluentui/react-menu",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-801c3f1f-2eb1-4c83-91fa-19a5893454ed.json
+++ b/change/@fluentui-react-tabster-801c3f1f-2eb1-4c83-91fa-19a5893454ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exposing TabsterMoveFocusEvent.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`MenuList renders a default state 1`] = `
 <div
   aria-labelledby=""
   className="fui-MenuList"
-  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1,\\"memorizeCurrent\\":true},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Tab\\":false}}}"
+  data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1,\\"memorizeCurrent\\":true}}"
   role="menu"
 >
   Default MenuList

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -39,16 +39,11 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
   React.useEffect(() => {
     const element = innerRef.current;
 
-    if (targetDocument && element) {
+    if (hasMenuContext && targetDocument && element) {
       const onTabsterMoveFocus = (e: TabsterMoveFocusEvent) => {
         const nextElement = e.detail.next;
 
-        if (
-          nextElement &&
-          hasMenuContext &&
-          element.contains(targetDocument.activeElement) &&
-          !element.contains(nextElement)
-        ) {
+        if (nextElement && element.contains(targetDocument.activeElement) && !element.contains(nextElement)) {
           e.preventDefault();
         }
       };

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -12,6 +12,7 @@ import {
   TabsterMoveFocusEventName,
   type TabsterMoveFocusEvent,
 } from '@fluentui/react-tabster';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
 import { MenuContext } from '../../contexts/menuContext';
@@ -22,6 +23,7 @@ import type { MenuListProps, MenuListState } from './MenuList.types';
  */
 export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLElement>): MenuListState => {
   const { findAllFocusable } = useFocusFinders();
+  const { targetDocument } = useFluent();
   const menuContext = useMenuContextSelectors();
   const hasMenuContext = useHasParentContext(MenuContext);
   const focusAttributes = useArrowNavigationGroup({ circular: true });
@@ -37,25 +39,24 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
   React.useEffect(() => {
     const element = innerRef.current;
 
-    if (element) {
-      const doc = element.ownerDocument;
+    if (targetDocument && element) {
       const onTabsterMoveFocus = (e: TabsterMoveFocusEvent) => {
         const nextElement = e.detail.next;
 
-        if (element.contains(doc.activeElement) && nextElement && !element.contains(nextElement)) {
+        if (nextElement && element.contains(targetDocument.activeElement) && !element.contains(nextElement)) {
           e.preventDefault();
 
           nextElement.focus();
         }
       };
 
-      doc.addEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
+      targetDocument.addEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
 
       return () => {
-        doc.removeEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
+        targetDocument.removeEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
       };
     }
-  }, [innerRef]);
+  }, [innerRef, targetDocument]);
 
   const setFocusByFirstCharacter = React.useCallback(
     (e: React.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => {

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -43,10 +43,13 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
       const onTabsterMoveFocus = (e: TabsterMoveFocusEvent) => {
         const nextElement = e.detail.next;
 
-        if (nextElement && element.contains(targetDocument.activeElement) && !element.contains(nextElement)) {
+        if (
+          nextElement &&
+          hasMenuContext &&
+          element.contains(targetDocument.activeElement) &&
+          !element.contains(nextElement)
+        ) {
           e.preventDefault();
-
-          nextElement.focus();
         }
       };
 
@@ -56,7 +59,7 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
         targetDocument.removeEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
       };
     }
-  }, [innerRef, targetDocument]);
+  }, [innerRef, targetDocument, hasMenuContext]);
 
   const setFocusByFirstCharacter = React.useCallback(
     (e: React.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => {

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -10,7 +10,7 @@ import {
   useArrowNavigationGroup,
   useFocusFinders,
   TabsterMoveFocusEventName,
-  TabsterMoveFocusEvent,
+  type TabsterMoveFocusEvent,
 } from '@fluentui/react-tabster';
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import { useMenuContext_unstable } from '../../contexts/menuContext';

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -44,6 +44,7 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
         const nextElement = e.detail.next;
 
         if (nextElement && element.contains(targetDocument.activeElement) && !element.contains(nextElement)) {
+          // Preventing Tabster from handling Tab press, useMenuPopover will handle it.
           e.preventDefault();
         }
       };

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -38,17 +38,16 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
     const element = innerRef.current;
 
     if (element) {
+      const doc = element.ownerDocument;
       const onTabsterMoveFocus = (e: TabsterMoveFocusEvent) => {
         const nextElement = e.detail.next;
 
-        if (nextElement && !element.contains(nextElement)) {
+        if (element.contains(doc.activeElement) && nextElement && !element.contains(nextElement)) {
           e.preventDefault();
 
           nextElement.focus();
         }
       };
-
-      const doc = element.ownerDocument;
 
       doc.addEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
 

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -574,6 +574,9 @@ const GroupperMoveFocusActions_2: GroupperMoveFocusActions_2;
 export { GroupperMoveFocusEvent }
 
 // @public (undocumented)
+export type GroupperMoveFocusEvent = Events.GroupperMoveFocusEvent;
+
+// @public (undocumented)
 type GroupperMoveFocusEvent_2 = CustomEvent<{
     action: GroupperMoveFocusAction;
 } | undefined>;
@@ -816,6 +819,9 @@ export type MoverMemorizedElementEventDetail = EventsTypes.MoverMemorizedElement
 export { MoverMemorizedElementEventName }
 
 export { MoverMoveFocusEvent }
+
+// @public (undocumented)
+export type MoverMoveFocusEvent = Events.MoverMoveFocusEvent;
 
 // @public (undocumented)
 type MoverMoveFocusEvent_2 = CustomEvent<{
@@ -1221,7 +1227,13 @@ interface TabsterElementStorageEntry {
 type TabsterEventWithDetails<D> = CustomEvent<D | undefined>;
 
 // @public (undocumented)
-type TabsterMoveFocusEvent = TabsterEventWithDetails<TabsterMoveFocusEventDetails>;
+export const TabsterMoveFocusEvent: typeof Events.TabsterMoveFocusEvent;
+
+// @public (undocumented)
+export type TabsterMoveFocusEvent = Events.TabsterMoveFocusEvent;
+
+// @public (undocumented)
+type TabsterMoveFocusEvent_2 = TabsterEventWithDetails<TabsterMoveFocusEventDetails>;
 
 // @public (undocumented)
 interface TabsterMoveFocusEventDetails {
@@ -1234,6 +1246,9 @@ interface TabsterMoveFocusEventDetails {
     // (undocumented)
     relatedEvent?: KeyboardEvent;
 }
+
+// @public (undocumented)
+export const TabsterMoveFocusEventName: "tabster:movefocus";
 
 // @public (undocumented)
 type TabsterOnElement = Partial<RootOnElement & DeloserOnElement & ModalizerOnElement & FocusableOnElement & MoverOnElement & GroupperOnElement & ObservedOnElement & OutlineOnElement & UncontrolledOnElement & SysOnElement & RestorerOnElement>;
@@ -1285,7 +1300,7 @@ declare namespace TabsterTypes {
         GroupperMoveFocusEvent_2 as GroupperMoveFocusEvent,
         TabsterEventWithDetails,
         TabsterMoveFocusEventDetails,
-        TabsterMoveFocusEvent,
+        TabsterMoveFocusEvent_2 as TabsterMoveFocusEvent,
         TabsterDOMAttribute_2 as TabsterDOMAttribute,
         TabsterCoreProps,
         DOMAPI,

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -21,6 +21,8 @@ import { MoverMoveFocusEvent } from 'tabster';
 import { MoverMoveFocusEventName } from 'tabster';
 import * as React_2 from 'react';
 import type { RefObject } from 'react';
+import { TabsterMoveFocusEvent } from 'tabster';
+import { TabsterMoveFocusEventName } from 'tabster';
 import { Types } from 'tabster';
 
 // @internal (undocumented)
@@ -574,9 +576,6 @@ const GroupperMoveFocusActions_2: GroupperMoveFocusActions_2;
 export { GroupperMoveFocusEvent }
 
 // @public (undocumented)
-export type GroupperMoveFocusEvent = Events.GroupperMoveFocusEvent;
-
-// @public (undocumented)
 type GroupperMoveFocusEvent_2 = CustomEvent<{
     action: GroupperMoveFocusAction;
 } | undefined>;
@@ -819,9 +818,6 @@ export type MoverMemorizedElementEventDetail = EventsTypes.MoverMemorizedElement
 export { MoverMemorizedElementEventName }
 
 export { MoverMoveFocusEvent }
-
-// @public (undocumented)
-export type MoverMoveFocusEvent = Events.MoverMoveFocusEvent;
 
 // @public (undocumented)
 type MoverMoveFocusEvent_2 = CustomEvent<{
@@ -1226,14 +1222,13 @@ interface TabsterElementStorageEntry {
 // @public (undocumented)
 type TabsterEventWithDetails<D> = CustomEvent<D | undefined>;
 
-// @public (undocumented)
-export const TabsterMoveFocusEvent: typeof Events.TabsterMoveFocusEvent;
-
-// @public (undocumented)
-export type TabsterMoveFocusEvent = Events.TabsterMoveFocusEvent;
+export { TabsterMoveFocusEvent }
 
 // @public (undocumented)
 type TabsterMoveFocusEvent_2 = TabsterEventWithDetails<TabsterMoveFocusEventDetails>;
+
+// @public (undocumented)
+export type TabsterMoveFocusEventDetail = EventsTypes.TabsterMoveFocusEventDetail;
 
 // @public (undocumented)
 interface TabsterMoveFocusEventDetails {
@@ -1247,8 +1242,7 @@ interface TabsterMoveFocusEventDetails {
     relatedEvent?: KeyboardEvent;
 }
 
-// @public (undocumented)
-export const TabsterMoveFocusEventName: "tabster:movefocus";
+export { TabsterMoveFocusEventName }
 
 // @public (undocumented)
 type TabsterOnElement = Partial<RootOnElement & DeloserOnElement & ModalizerOnElement & FocusableOnElement & MoverOnElement & GroupperOnElement & ObservedOnElement & OutlineOnElement & UncontrolledOnElement & SysOnElement & RestorerOnElement>;

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -46,6 +46,8 @@ import {
   GroupperMoveFocusActions,
   MoverMemorizedElementEventName,
   MoverMemorizedElementEvent,
+  TabsterMoveFocusEventName,
+  TabsterMoveFocusEvent,
 } from 'tabster';
 
 export type TabsterDOMAttribute = Types.TabsterDOMAttribute;
@@ -80,3 +82,6 @@ export type GroupperMoveFocusEventDetail = EventsTypes.GroupperMoveFocusEventDet
 
 export { MoverMemorizedElementEventName, MoverMemorizedElementEvent };
 export type MoverMemorizedElementEventDetail = EventsTypes.MoverMemorizedElementEventDetail;
+
+export { TabsterMoveFocusEventName, TabsterMoveFocusEvent };
+export type TabsterMoveFocusEventDetail = EventsTypes.TabsterMoveFocusEventDetail;


### PR DESCRIPTION
MenuList had ignoreKeydown for Tab to prevent Tabster from handling the Tab press. As a side effect this ignoreKeydown was affecting submenus too. This PR uses TabsterMoveFocusEvent to prevent Tabster from handling the Tab press in a particular case that doesn't affect submenus.