### PR TITLE
(web-components) Export component definitions from rollup bundle

### DIFF
--- a/change/@fluentui-web-components-4d0a93e1-80de-43da-be84-d6231d7f5699.json
+++ b/change/@fluentui-web-components-4d0a93e1-80de-43da-be84-d6231d7f5699.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: Export component definitions from rollup bundle",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -142,7 +142,8 @@
     "./theme.js": {
       "types": "./dist/dts/theme/index.d.ts",
       "default": "./dist/esm/theme/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": [
     "./dist/esm/accordion/define.js",
@@ -173,7 +174,9 @@
     "./dist/esm/tab-panel/define.js",
     "./dist/esm/text/define.js",
     "./dist/esm/text-input/define.js",
-    "./dist/esm/toggle-button/define.js"
+    "./dist/esm/toggle-button/define.js",
+    "./dist/web-components.js",
+    "./dist/web-components.min.js"
   ],
   "scripts": {
     "type-check": "node ./scripts/type-check",

--- a/packages/web-components/src/index-rollup.ts
+++ b/packages/web-components/src/index-rollup.ts
@@ -1,203 +1,29 @@
-export {
-  Accordion,
-  AccordionExpandMode,
-  accordionTemplate,
-  accordionStyles,
-  accordionDefinition,
-} from './accordion/index.js';
-export {
-  AccordionItem,
-  AccordionItemSize,
-  AccordionItemExpandIconPosition,
-  accordionItemTemplate,
-  accordionItemStyles,
-  accordionItemDefinition,
-} from './accordion-item/index.js';
-export {
-  AnchorButton,
-  AnchorButtonAppearance,
-  AnchorButtonShape,
-  AnchorButtonSize,
-  AnchorTarget,
-  AnchorButtonTemplate,
-  AnchorButtonDefinition,
-} from './anchor-button/index.js';
-export {
-  Avatar,
-  AvatarActive,
-  AvatarAppearance,
-  AvatarColor,
-  AvatarNamedColor,
-  AvatarShape,
-  AvatarSize,
-  AvatarTemplate,
-  AvatarStyles,
-  AvatarDefinition,
-} from './avatar/index.js';
-export {
-  Badge,
-  BadgeAppearance,
-  BadgeColor,
-  BadgeShape,
-  BadgeSize,
-  BadgeTemplate,
-  BadgeStyles,
-  BadgeDefinition,
-} from './badge/index.js';
-export {
-  Button,
-  ButtonAppearance,
-  ButtonShape,
-  ButtonSize,
-  ButtonType,
-  ButtonTemplate,
-  ButtonStyles,
-  ButtonDefinition,
-} from './button/index.js';
-export {
-  Checkbox,
-  CheckboxLabelPosition,
-  CheckboxShape,
-  CheckboxSize,
-  CheckboxDefinition,
-  CheckboxTemplate,
-  CheckboxStyles,
-} from './checkbox/index.js';
-export {
-  CompoundButton,
-  CompoundButtonAppearance,
-  CompoundButtonShape,
-  CompoundButtonSize,
-  CompoundButtonTemplate,
-  CompoundButtonStyles,
-  CompoundButtonDefinition,
-} from './compound-button/index.js';
-export {
-  CounterBadge,
-  CounterBadgeAppearance,
-  CounterBadgeColor,
-  CounterBadgeShape,
-  CounterBadgeSize,
-  CounterBadgeTemplate,
-  CounterBadgeStyles,
-  CounterBadgeDefinition,
-} from './counter-badge/index.js';
-export { Dialog, DialogModalType, DialogDefinition, DialogTemplate, DialogStyles } from './dialog/index.js';
-export {
-  Divider,
-  DividerAlignContent,
-  DividerAppearance,
-  DividerOrientation,
-  DividerRole,
-  DividerDefinition,
-  DividerTemplate,
-  DividerStyles,
-} from './divider/index.js';
-export { Image, ImageFit, ImageShape, ImageDefinition, ImageTemplate, ImageStyles } from './image/index.js';
-export { Label, LabelSize, LabelWeight, LabelDefinition, LabelStyles, LabelTemplate } from './label/index.js';
-export { Menu, MenuTemplate, MenuStyles, MenuDefinition } from './menu/index.js';
-export {
-  MenuButton,
-  MenuButtonAppearance,
-  MenuButtonShape,
-  MenuButtonSize,
-  MenuButtonTemplate,
-  MenuButtonStyles,
-  MenuButtonDefinition,
-} from './menu-button/index.js';
-export {
-  MenuItem,
-  MenuItemRole,
-  roleForMenuItem,
-  MenuItemTemplate,
-  MenuItemStyles,
-  MenuItemDefinition,
-} from './menu-item/index.js';
-export { MenuList, MenuListTemplate, MenuListStyles, MenuListDefinition } from './menu-list/index.js';
-export {
-  ProgressBar,
-  ProgressBarShape,
-  ProgressBarThickness,
-  ProgressBarValidationState,
-  ProgressBarDefinition,
-  ProgressBarStyles,
-  ProgressBarTemplate,
-} from './progress-bar/index.js';
-export { Radio, RadioDefinition, RadioStyles, RadioTemplate } from './radio/index.js';
-export {
-  RadioGroup,
-  RadioGroupOrientation,
-  RadioGroupDefinition,
-  RadioGroupStyles,
-  RadioGroupTemplate,
-} from './radio-group/index.js';
-export {
-  Slider,
-  SliderMode,
-  SliderOrientation,
-  SliderSize,
-  SliderDefinition,
-  SliderStyles,
-  SliderTemplate,
-} from './slider/index.js';
-export {
-  Spinner,
-  SpinnerAppearance,
-  SpinnerSize,
-  SpinnerTemplate,
-  SpinnerStyles,
-  SpinnerDefinition,
-} from './spinner/index.js';
-export { Switch, SwitchLabelPosition, SwitchDefinition, SwitchStyles, SwitchTemplate } from './switch/index.js';
-export { Tab, TabTemplate, TabStyles, TabDefinition } from './tab/index.js';
-export { TabPanel, TabPanelTemplate, TabPanelStyles, TabPanelDefinition } from './tab-panel/index.js';
-export {
-  Tabs,
-  TabsAppearance,
-  TabsOrientation,
-  TabsSize,
-  TabsTemplate,
-  TabsStyles,
-  TabsDefinition,
-} from './tabs/index.js';
-export {
-  Text,
-  TextAlign,
-  TextFont,
-  TextSize,
-  TextWeight,
-  TextTemplate,
-  TextStyles,
-  TextDefinition,
-} from './text/index.js';
-export {
-  TextInput,
-  TextInputType,
-  TextInputAppearance,
-  TextInputControlSize,
-  TextInputTemplate,
-  TextInputStyles,
-  TextInputDefinition,
-} from './text-input/index.js';
-export {
-  ToggleButton,
-  ToggleButtonAppearance,
-  ToggleButtonShape,
-  ToggleButtonSize,
-  ToggleButtonTemplate,
-  ToggleButtonStyles,
-  ToggleButtonDefinition,
-} from './toggle-button/index.js';
-
-export { getDirection } from './utils/direction.js';
-export { display } from './utils/display.js';
-export {
-  forcedColorsStylesheetBehavior,
-  darkModeStylesheetBehavior,
-  lightModeStylesheetBehavior,
-} from './utils/behaviors/match-media-stylesheet-behavior.js';
-
-export { FluentDesignSystem } from './fluent-design-system.js';
-export { setTheme, setThemeFor } from './theme/index.js';
-
-export * from './theme/design-tokens.js';
+import './accordion-item/define.js';
+import './accordion/define.js';
+import './anchor-button/define.js';
+import './avatar/define.js';
+import './badge/define.js';
+import './button/define.js';
+import './checkbox/define.js';
+import './compound-button/define.js';
+import './counter-badge/define.js';
+import './dialog/define.js';
+import './divider/define.js';
+import './image/define.js';
+import './label/define.js';
+import './menu-button/define.js';
+import './menu-item/define.js';
+import './menu-list/define.js';
+import './menu/define.js';
+import './progress-bar/define.js';
+import './radio-group/define.js';
+import './radio/define.js';
+import './slider/define.js';
+import './spinner/define.js';
+import './switch/define.js';
+import './tab-panel/define.js';
+import './tab/define.js';
+import './tabs/define.js';
+import './text-input/define.js';
+import './text/define.js';
+import './toggle-button/define.js';


### PR DESCRIPTION
## Previous Behavior

The `index-rollup` bundle generated didn't include the component definitions.

## New Behavior

The generated `dist/web-components.js` and `dist/web-components.min.js` now focus on defining the components in the browser.
