### PR TITLE
fix(web-components): remove determinate from spinner implementation

### DIFF
--- a/change/@fluentui-web-components-82d13efa-8e97-478a-b1d9-d6b7c6f32868.json
+++ b/change/@fluentui-web-components-82d13efa-8e97-478a-b1d9-d6b7c6f32868.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(web-components): remove determinate from spinner implementation",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -2710,8 +2710,11 @@ export const spacingVerticalXXS = "var(--spacingVerticalXXS)";
 export const spacingVerticalXXXL = "var(--spacingVerticalXXXL)";
 
 // @public
-export class Spinner extends BaseProgress {
+export class Spinner extends FASTElement {
+    constructor();
     appearance?: SpinnerAppearance;
+    // @internal
+    protected elementInternals: ElementInternals;
     size?: SpinnerSize;
 }
 

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -17,6 +17,7 @@ import { HTMLDirective } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { SyntheticViewTemplate } from '@microsoft/fast-element';
 import type { Theme } from '@fluentui/tokens';
+import { ViewTemplate } from '@microsoft/fast-element';
 
 // @public
 export class Accordion extends FASTElement {
@@ -2727,11 +2728,6 @@ export type SpinnerAppearance = ValuesOf<typeof SpinnerAppearance>;
 export const SpinnerDefinition: FASTElementDefinition<typeof Spinner>;
 
 // @public
-export type SpinnerOptions = {
-    indeterminateIndicator?: StaticallyComposableHTML<Spinner>;
-};
-
-// @public
 export const SpinnerSize: {
     readonly tiny: "tiny";
     readonly extraSmall: "extra-small";
@@ -2749,7 +2745,7 @@ export type SpinnerSize = ValuesOf<typeof SpinnerSize>;
 export const SpinnerStyles: ElementStyles;
 
 // @public (undocumented)
-export const SpinnerTemplate: ElementViewTemplate<Spinner>;
+export const SpinnerTemplate: ViewTemplate<Spinner, any>;
 
 // @public (undocumented)
 export const strokeWidthThick = "var(--strokeWidthThick)";

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -155,7 +155,6 @@ export {
   Spinner,
   SpinnerAppearance,
   SpinnerSize,
-  SpinnerOptions,
   SpinnerTemplate,
   SpinnerStyles,
   SpinnerDefinition,

--- a/packages/web-components/src/spinner/index.ts
+++ b/packages/web-components/src/spinner/index.ts
@@ -1,4 +1,4 @@
-export { Spinner, SpinnerOptions } from './spinner.js';
+export { Spinner } from './spinner.js';
 export { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
 export { template as SpinnerTemplate } from './spinner.template.js';
 export { styles as SpinnerStyles } from './spinner.styles.js';

--- a/packages/web-components/src/spinner/spinner.spec.ts
+++ b/packages/web-components/src/spinner/spinner.spec.ts
@@ -22,17 +22,6 @@ test.describe('Spinner', () => {
     await page.close();
   });
 
-  // Foundation tests
-  test('should include a role of progressbar', async () => {
-    await root.evaluate(node => {
-      node.innerHTML = /* html */ `
-            <fluent-spinner></fluent-spinner>
-        `;
-    });
-
-    await expect(element).toHaveAttribute('role', 'progressbar');
-  });
-
   // Fluent Specific property tests
   test('should set and retrieve the `appearance` property correctly to primary', async () => {
     await element.evaluate((node: Spinner) => {

--- a/packages/web-components/src/spinner/spinner.stories.ts
+++ b/packages/web-components/src/spinner/spinner.stories.ts
@@ -79,5 +79,7 @@ export const Size = renderComponent(html<SpinnerStoryArgs>`
     <fluent-spinner size="large"></fluent-spinner>
     <code>extra-large</code>
     <fluent-spinner size="extra-large"></fluent-spinner>
+    <code>huge</code>
+    <fluent-spinner size="huge"></fluent-spinner>
   </div>
 `);

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -51,21 +51,7 @@ export const styles = css`
     stroke: rgba(255, 255, 255, 0.2);
   }
 
-  .determinate {
-    stroke: ${colorBrandStroke1};
-    fill: none;
-    stroke-width: 1.5px;
-    stroke-linecap: round;
-    transform-origin: 50% 50%;
-    transform: rotate(-90deg);
-    transition: all 0.2s ease-in-out;
-  }
-
-  :host([appearance='inverted']) .determinite {
-    stroke: ${colorNeutralStrokeOnBrand2};
-  }
-
-  .indeterminate-indicator-1 {
+  .indicator {
     stroke: ${colorBrandStroke1};
     fill: none;
     stroke-width: 1.5px;
@@ -76,7 +62,7 @@ export const styles = css`
     animation: spin-infinite 3s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
   }
 
-  :host([appearance='inverted']) .indeterminate-indicator-1 {
+  :host([appearance='inverted']) .indicator {
     stroke: ${colorNeutralStrokeOnBrand2};
   }
 

--- a/packages/web-components/src/spinner/spinner.template.ts
+++ b/packages/web-components/src/spinner/spinner.template.ts
@@ -2,16 +2,9 @@ import { html } from '@microsoft/fast-element';
 import { Spinner } from './spinner.js';
 
 export const template = html<Spinner>`
-  <template
-    role="progressbar"
-    aria-valuenow="${x => x.value}"
-    aria-valuemin="${x => x.min}"
-    aria-valuemax="${x => x.max}"
-  >
-    <slot name="indicator"
-      ><svg class="progress" part="progress" viewBox="0 0 16 16">
-        <circle class="background" cx="8px" cy="8px" r="7px"></circle>
-        <circle class="indicator" cx="8px" cy="8px" r="7px"></circle></svg
-    ></slot>
-  </template>
+  <slot name="indicator"
+    ><svg class="progress" part="progress" viewBox="0 0 16 16">
+      <circle class="background" cx="8px" cy="8px" r="7px"></circle>
+      <circle class="indicator" cx="8px" cy="8px" r="7px"></circle></svg
+  ></slot>
 `;

--- a/packages/web-components/src/spinner/spinner.template.ts
+++ b/packages/web-components/src/spinner/spinner.template.ts
@@ -1,56 +1,17 @@
-import { html, when } from '@microsoft/fast-element';
-import type { ElementViewTemplate } from '@microsoft/fast-element';
-import { staticallyCompose } from '../utils/index.js';
-import { Spinner, SpinnerOptions } from './spinner.js';
+import { html } from '@microsoft/fast-element';
+import { Spinner } from './spinner.js';
 
-const progressSegments: number = 44;
-
-export function progressRingTemplate<T extends Spinner>(options: SpinnerOptions = {}): ElementViewTemplate<T> {
-  return html<T>`
-    <template
-      role="progressbar"
-      aria-valuenow="${x => x.value}"
-      aria-valuemin="${x => x.min}"
-      aria-valuemax="${x => x.max}"
-    >
-      ${when(
-        x => typeof x.value === 'number',
-        html<T>`
-          <svg class="progress" part="progress" viewBox="0 0 16 16" slot="determinate">
-            <circle class="background" part="background" cx="8px" cy="8px" r="7px"></circle>
-            <circle
-              class="determinate"
-              part="determinate"
-              style="stroke-dasharray: ${x => (progressSegments * x.percentComplete) / 100}px ${progressSegments}px"
-              cx="8px"
-              cy="8px"
-              r="7px"
-            ></circle>
-          </svg>
-        `,
-        html<T>` <slot name="indeterminate"> ${staticallyCompose(options.indeterminateIndicator)} </slot> `,
-      )}
-    </template>
-  `;
-}
-
-export const template: ElementViewTemplate<Spinner> = progressRingTemplate({
-  indeterminateIndicator: `
-    <svg class="progress" part="progress" viewBox="0 0 16 16">
-        <circle
-            class="background"
-            part="background"
-            cx="8px"
-            cy="8px"
-            r="7px"
-        ></circle>
-        <circle
-            class="indeterminate-indicator-1"
-            part="indeterminate-indicator-1"
-            cx="8px"
-            cy="8px"
-            r="7px"
-        ></circle>
-    </svg>
-  `,
-});
+export const template = html<Spinner>`
+  <template
+    role="progressbar"
+    aria-valuenow="${x => x.value}"
+    aria-valuemin="${x => x.min}"
+    aria-valuemax="${x => x.max}"
+  >
+    <slot name="indicator"
+      ><svg class="progress" part="progress" viewBox="0 0 16 16">
+        <circle class="background" cx="8px" cy="8px" r="7px"></circle>
+        <circle class="indicator" cx="8px" cy="8px" r="7px"></circle></svg
+    ></slot>
+  </template>
+`;

--- a/packages/web-components/src/spinner/spinner.ts
+++ b/packages/web-components/src/spinner/spinner.ts
@@ -1,15 +1,6 @@
 import { attr } from '@microsoft/fast-element';
 import { BaseProgress } from '../progress-bar/base-progress.js';
-import { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import type { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
-
-/**
- * Progress configuration options
- * @public
- */
-export type SpinnerOptions = {
-  indeterminateIndicator?: StaticallyComposableHTML<Spinner>;
-};
 
 /**
  * The base class used for constructing a fluent-spinner custom element

--- a/packages/web-components/src/spinner/spinner.ts
+++ b/packages/web-components/src/spinner/spinner.ts
@@ -1,12 +1,18 @@
-import { attr } from '@microsoft/fast-element';
-import { BaseProgress } from '../progress-bar/base-progress.js';
+import { attr, FASTElement } from '@microsoft/fast-element';
 import type { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
 
 /**
  * The base class used for constructing a fluent-spinner custom element
  * @public
  */
-export class Spinner extends BaseProgress {
+export class Spinner extends FASTElement {
+  /**
+   * The internal {@link https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
+   */
+  protected elementInternals: ElementInternals = this.attachInternals();
+
   /**
    * The size of the spinner
    *
@@ -27,4 +33,9 @@ export class Spinner extends BaseProgress {
    */
   @attr
   public appearance?: SpinnerAppearance;
+
+  constructor() {
+    super();
+    this.elementInternals.role = 'progressbar';
+  }
 }


### PR DESCRIPTION
## Previous Behavior
Spinner optionally could be set as a determinate progress indicator.

## New Behavior
There is no construct for a determinate spinner, the behavior has been removed.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
