### PR TITLE
Adding support for error handling

### DIFF
--- a/packages/react-charting/etc/react-charting.api.md
+++ b/packages/react-charting/etc/react-charting.api.md
@@ -678,6 +678,8 @@ export interface IHorizontalBarChartProps {
     className?: string;
     culture?: string;
     data?: IChartProps[];
+    handleEmptyState?: () => JSX.Element;
+    handleError?: () => JSX.Element;
     hideLabels?: boolean;
     hideRatio?: boolean[];
     hideTooltip?: boolean;
@@ -735,6 +737,8 @@ export interface IHorizontalBarChartWithAxisProps extends ICartesianChartProps {
     colors?: string[];
     culture?: string;
     data?: IHorizontalBarChartWithAxisDataPoint[];
+    handleEmptyState?: () => JSX.Element;
+    handleError?: () => JSX.Element;
     onRenderCalloutPerDataPoint?: IRenderFunction<IHorizontalBarChartWithAxisDataPoint>;
     showYAxisLables?: boolean;
     showYAxisLablesTooltip?: boolean;

--- a/packages/react-charting/src/components/CommonComponents/ErrorBoundary.tsx
+++ b/packages/react-charting/src/components/CommonComponents/ErrorBoundary.tsx
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as React from 'react';
+import { getId } from '@fluentui/react/lib/Utilities';
+import ErrorImage from '../assets/ErrorImage';
+import { ITheme } from '@fluentui/react/lib/Styling';
+import MissingDataImage from '../assets/MissingDataImage';
+
+export enum ErrorCodes {
+  NoData = 'No data',
+  GeneralError = 'General error',
+}
+
+export interface IErrorBoundaryProps {
+  hasErrorState?: boolean;
+  hasEmptyState?: boolean;
+  handleError?: () => JSX.Element;
+  handleEmptyState?: () => JSX.Element;
+  theme?: ITheme;
+  width?: number;
+  height?: number;
+}
+
+interface IErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<IErrorBoundaryProps, IErrorBoundaryState> {
+  static getDerivedStateFromError(_error: Error) {
+    return { hasError: true };
+  }
+
+  constructor(props: IErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  public componentDidCatch(_error: any, _errorInfo: any) {
+    this.setState({
+      hasError: true,
+    });
+  }
+
+  render() {
+    if (this.state.hasError || this.props.hasErrorState) {
+      if (this.props.handleError !== undefined) {
+        return this.props.handleError();
+      }
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            marginTop: '10px',
+          }}
+        >
+          <ErrorImage
+            theme={this.props.theme}
+            width={
+              this.props.width ? (this.props.width > 500 ? 500 : this.props.width < 350 ? 350 : this.props.width) : 350
+            }
+            height={
+              this.props.height
+                ? this.props.height > 500
+                  ? 500
+                  : this.props.height < 350
+                  ? 350
+                  : this.props.height
+                : 350
+            }
+          />
+          <div style={{ fontSize: '14px', fontWeight: 700, fontFamily: 'Segoe UI', textAlign: 'center' }}>
+            Couldn't load data
+          </div>
+          <div style={{ fontSize: '12px', fontFamily: 'Segoe UI', textAlign: 'center' }}>
+            Something went wrong and we couldn't get the page to display
+          </div>
+          <div style={{ fontSize: '12px', fontFamily: 'Segoe UI', textAlign: 'center' }}>
+            Error code: {ErrorCodes.GeneralError}
+          </div>
+        </div>
+      );
+    } else if (this.props.hasEmptyState) {
+      if (this.props.handleEmptyState) {
+        return this.props.handleEmptyState();
+      }
+      return (
+        <div
+          id={getId('_Chart_empty_')}
+          role={'alert'}
+          aria-label={'Graph has no data to display'}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            marginTop: '10px',
+          }}
+        >
+          <MissingDataImage
+            theme={this.props.theme}
+            width={
+              this.props.width ? (this.props.width > 500 ? 500 : this.props.width < 350 ? 350 : this.props.width) : 350
+            }
+            height={
+              this.props.height
+                ? this.props.height > 500
+                  ? 500
+                  : this.props.height < 350
+                  ? 350
+                  : this.props.height
+                : 350
+            }
+          />
+          <div style={{ fontSize: '14px', fontWeight: 700, fontFamily: 'Segoe UI', textAlign: 'center' }}>
+            Couldn't load data
+          </div>
+          <div style={{ fontSize: '12px', fontFamily: 'Segoe UI', textAlign: 'center' }}>
+            Something went wrong and we couldn't get the page to display
+          </div>
+          <div style={{ fontSize: '12px', fontFamily: 'Segoe UI', textAlign: 'center' }}>
+            Error code: {ErrorCodes.NoData}
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/packages/react-charting/src/components/CommonComponents/ErrorBoundaryRTL.tsx
+++ b/packages/react-charting/src/components/CommonComponents/ErrorBoundaryRTL.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import ErrorBoundary, { ErrorCodes, IErrorBoundaryProps } from './ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  const renderErrorBoundary = (props: IErrorBoundaryProps) => {
+    render(
+      <ErrorBoundary {...props}>
+        <div>Child component</div>
+      </ErrorBoundary>,
+    );
+  };
+
+  it('should render child component when there is no error', () => {
+    renderErrorBoundary({});
+
+    expect(screen.getByText('Child component')).toBeInTheDocument();
+  });
+
+  it('should render error state when hasErrorState prop is true', () => {
+    renderErrorBoundary({ hasErrorState: true });
+
+    expect(screen.getByText("Couldn't load data")).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong and we couldn't get the page to display")).toBeInTheDocument();
+    expect(screen.getByText(`Error code: ${ErrorCodes.GeneralError}`)).toBeInTheDocument();
+  });
+
+  it('should render empty state when hasEmptyState prop is true', () => {
+    renderErrorBoundary({ hasEmptyState: true });
+
+    expect(screen.getByText("Couldn't load data")).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong and we couldn't get the page to display")).toBeInTheDocument();
+    expect(screen.getByText(`Error code: ${ErrorCodes.NoData}`)).toBeInTheDocument();
+  });
+
+  it('should render custom error component when handleError prop is provided', () => {
+    const CustomErrorComponent = () => <div>Custom error component</div>;
+
+    renderErrorBoundary({ hasErrorState: true, handleError: CustomErrorComponent });
+
+    expect(screen.getByText('Custom error component')).toBeInTheDocument();
+  });
+
+  it('should render custom empty state component when handleEmptyState prop is provided', () => {
+    const CustomEmptyStateComponent = () => <div>Custom empty state component</div>;
+
+    renderErrorBoundary({ hasEmptyState: true, handleEmptyState: CustomEmptyStateComponent });
+
+    expect(screen.getByText('Custom empty state component')).toBeInTheDocument();
+  });
+});

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -16,6 +16,7 @@ import { convertToLocaleString } from '../../utilities/locale-util';
 import { ChartHoverCard, formatValueWithSIPrefix, getAccessibleDataObject } from '../../utilities/index';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 import { FocusableTooltipText } from '../../utilities/FocusableTooltipText';
+import ErrorBoundary from '../CommonComponents/ErrorBoundary';
 
 const getClassNames = classNamesFunction<IHorizontalBarChartStyleProps, IHorizontalBarChartStyles>();
 
@@ -42,7 +43,6 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
   private _calloutAnchorPoint: IChartDataPoint | null;
   private _isRTL: boolean = getRTL();
   private barChartSvgRef: React.RefObject<SVGSVGElement>;
-  private _emptyChartId: string;
 
   constructor(props: IHorizontalBarChartProps) {
     super(props);
@@ -62,7 +62,6 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     this._uniqLineText = '_HorizontalLine_' + Math.random().toString(36).substring(7);
     this._hoverOff = this._hoverOff.bind(this);
     this._calloutId = getId('callout');
-    this._emptyChartId = getId('_HBC_empty');
     this.barChartSvgRef = React.createRef<SVGSVGElement>();
   }
 
@@ -81,108 +80,112 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     const { palette } = theme!;
     let datapoint: number | undefined = 0;
     return !this._isChartEmpty() ? (
-      <div className={this._classNames.root} onMouseLeave={this._handleChartMouseLeave}>
-        {data!.map((points: IChartProps, index: number) => {
-          if (points.chartData && points.chartData![0] && points.chartData![0].horizontalBarChartdata!.x) {
-            datapoint = points.chartData![0].horizontalBarChartdata!.x;
-          } else {
-            datapoint = 0;
-          }
-          points.chartData![1] = {
-            legend: '',
-            horizontalBarChartdata: {
-              x: points.chartData![0].horizontalBarChartdata!.y - datapoint!,
-              y: points.chartData![0].horizontalBarChartdata!.y,
-            },
-            color: palette.neutralLight,
-          };
+      <ErrorBoundary handleError={this.props.handleError} theme={this.props.theme}>
+        <div className={this._classNames.root} onMouseLeave={this._handleChartMouseLeave}>
+          {data!.map((points: IChartProps, index: number) => {
+            if (points.chartData && points.chartData![0] && points.chartData![0].horizontalBarChartdata!.x) {
+              datapoint = points.chartData![0].horizontalBarChartdata!.x;
+            } else {
+              datapoint = 0;
+            }
+            points.chartData![1] = {
+              legend: '',
+              horizontalBarChartdata: {
+                x: points.chartData![0].horizontalBarChartdata!.y - datapoint!,
+                y: points.chartData![0].horizontalBarChartdata!.y,
+              },
+              color: palette.neutralLight,
+            };
 
-          // Hide right side text of chart title for absolute-scale variant
-          const chartDataText =
-            this.props.variant === HorizontalBarChartVariant.AbsoluteScale ? null : this._getChartDataText(points!);
-          const bars = this._createBars(points!, palette);
-          const keyVal = this._uniqLineText + '_' + index;
-          const classNames = getClassNames(this.props.styles!, {
-            theme: this.props.theme!,
-            width: this.props.width,
-            showTriangle: !!points!.chartData![0].data,
-            variant: this.props.variant,
-          });
+            // Hide right side text of chart title for absolute-scale variant
+            const chartDataText =
+              this.props.variant === HorizontalBarChartVariant.AbsoluteScale ? null : this._getChartDataText(points!);
+            const bars = this._createBars(points!, palette);
+            const keyVal = this._uniqLineText + '_' + index;
+            const classNames = getClassNames(this.props.styles!, {
+              theme: this.props.theme!,
+              width: this.props.width,
+              showTriangle: !!points!.chartData![0].data,
+              variant: this.props.variant,
+            });
 
-          return (
-            <div key={index}>
-              <div className={classNames.items}>
-                <FocusZone direction={FocusZoneDirection.horizontal}>
-                  <div className={this._classNames.chartTitle}>
-                    {points!.chartTitle && (
-                      <FocusableTooltipText
-                        className={this._classNames.chartTitleLeft}
-                        content={points!.chartTitle}
-                        accessibilityData={points!.chartTitleAccessibilityData}
-                      />
-                    )}
-                    {chartDataText}
-                  </div>
-                </FocusZone>
-                {points!.chartData![0].data && this._createBenchmark(points!)}
-                <FocusZone direction={FocusZoneDirection.horizontal} className={this._classNames.chartWrapper}>
-                  <svg ref={this.barChartSvgRef} className={this._classNames.chart} aria-label={points!.chartTitle}>
-                    <g
-                      id={keyVal}
-                      key={keyVal}
-                      ref={(e: SVGGElement) => {
-                        this._refCallback(e, points!.chartData![0].legend);
-                      }}
-                      // NOTE: points.chartData![0] contains current data value
-                      onClick={() => {
-                        const p = points!.chartData![0];
-                        if (p && p.onClick) {
-                          p.onClick();
-                        }
-                      }}
-                    >
-                      {bars}
-                    </g>
-                  </svg>
-                </FocusZone>
+            return (
+              <div key={index}>
+                <div className={classNames.items}>
+                  <FocusZone direction={FocusZoneDirection.horizontal}>
+                    <div className={this._classNames.chartTitle}>
+                      {points!.chartTitle && (
+                        <FocusableTooltipText
+                          className={this._classNames.chartTitleLeft}
+                          content={points!.chartTitle}
+                          accessibilityData={points!.chartTitleAccessibilityData}
+                        />
+                      )}
+                      {chartDataText}
+                    </div>
+                  </FocusZone>
+                  {points!.chartData![0].data && this._createBenchmark(points!)}
+                  <FocusZone direction={FocusZoneDirection.horizontal} className={this._classNames.chartWrapper}>
+                    <svg ref={this.barChartSvgRef} className={this._classNames.chart} aria-label={points!.chartTitle}>
+                      <g
+                        id={keyVal}
+                        key={keyVal}
+                        ref={(e: SVGGElement) => {
+                          this._refCallback(e, points!.chartData![0].legend);
+                        }}
+                        // NOTE: points.chartData![0] contains current data value
+                        onClick={() => {
+                          const p = points!.chartData![0];
+                          if (p && p.onClick) {
+                            p.onClick();
+                          }
+                        }}
+                      >
+                        {bars}
+                      </g>
+                    </svg>
+                  </FocusZone>
+                </div>
               </div>
-            </div>
-          );
-        })}
-        <Callout
-          target={this.state.refSelected}
-          coverTarget={true}
-          isBeakVisible={false}
-          gapSpace={30}
-          hidden={!(!this.props.hideTooltip && this.state.isCalloutVisible)}
-          directionalHint={DirectionalHint.topAutoEdge}
-          id={this._calloutId}
-          onDismiss={this._closeCallout}
-          preventDismissOnLostFocus={true}
-          {...this.props.calloutProps!}
-          {...getAccessibleDataObject(this.state.callOutAccessibilityData)}
-        >
-          <>
-            {this.props.onRenderCalloutPerHorizontalBar ? (
-              this.props.onRenderCalloutPerHorizontalBar(this.state.barCalloutProps)
-            ) : (
-              <ChartHoverCard
-                Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.legend!}
-                YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.hoverValue!}
-                color={this.state.lineColor}
-                culture={this.props.culture}
-              />
-            )}
-          </>
-        </Callout>
-      </div>
+            );
+          })}
+          <Callout
+            target={this.state.refSelected}
+            coverTarget={true}
+            isBeakVisible={false}
+            gapSpace={30}
+            hidden={!(!this.props.hideTooltip && this.state.isCalloutVisible)}
+            directionalHint={DirectionalHint.topAutoEdge}
+            id={this._calloutId}
+            onDismiss={this._closeCallout}
+            preventDismissOnLostFocus={true}
+            {...this.props.calloutProps!}
+            {...getAccessibleDataObject(this.state.callOutAccessibilityData)}
+          >
+            <>
+              {this.props.onRenderCalloutPerHorizontalBar ? (
+                this.props.onRenderCalloutPerHorizontalBar(this.state.barCalloutProps)
+              ) : (
+                <ChartHoverCard
+                  Legend={this.state.xCalloutValue ? this.state.xCalloutValue : this.state.legend!}
+                  YValue={this.state.yCalloutValue ? this.state.yCalloutValue : this.state.hoverValue!}
+                  color={this.state.lineColor}
+                  culture={this.props.culture}
+                />
+              )}
+            </>
+          </Callout>
+        </div>
+      </ErrorBoundary>
     ) : (
-      <div
-        id={this._emptyChartId}
-        role={'alert'}
-        style={{ opacity: '0' }}
-        aria-label={'Graph has no data to display'}
-      />
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        <ErrorBoundary
+          hasEmptyState={this._isChartEmpty()}
+          theme={this.props.theme}
+          width={this.props.width!}
+          handleEmptyState={this.props.handleEmptyState}
+        />
+      </div>
     );
   }
 

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -92,6 +92,16 @@ export interface IHorizontalBarChartProps {
    * @default false
    */
   hideLabels?: boolean;
+
+  /**
+   * Callback to handle error while chart is rendering.
+   */
+  handleError?: () => JSX.Element;
+
+  /**
+   * Callback to handle empty state while chart is rendering.
+   */
+  handleEmptyState?: () => JSX.Element;
 }
 
 /**

--- a/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChartRTL.test.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChart/HorizontalBarChartRTL.test.tsx
@@ -355,13 +355,13 @@ describe('Horizontal bar chart re-rendering', () => {
     const { container, rerender } = render(<HorizontalBarChart data={[]} />);
     // Assert
     expect(container).toMatchSnapshot();
-    expect(getById(container, /_HBC_empty/i)).toHaveLength(1);
+    expect(getById(container, /_Chart_empty_/i)).toHaveLength(1);
     // Act
     rerender(<HorizontalBarChart data={chartPoints} />);
     await waitFor(() => {
       // Assert
       expect(container).toMatchSnapshot();
-      expect(getById(container, /_HBC_empty/i)).toHaveLength(0);
+      expect(getById(container, /_Chart_empty_/i)).toHaveLength(0);
     });
   });
 });

--- a/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone1"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -72,7 +72,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             </span>
             <div
               hidden={true}
-              id="tooltip3"
+              id="tooltip2"
               style={
                 Object {
                   "border": 0,
@@ -113,7 +113,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             {
               padding-right: 0px;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone3"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -190,7 +190,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone5"
+        data-focuszone-id="FocusZone4"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -235,7 +235,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             </span>
             <div
               hidden={true}
-              id="tooltip6"
+              id="tooltip5"
               style={
                 Object {
                   "border": 0,
@@ -276,7 +276,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             {
               padding-right: 0px;
             }
-        data-focuszone-id="FocusZone7"
+        data-focuszone-id="FocusZone6"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -538,7 +538,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone1"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -583,7 +583,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             </span>
             <div
               hidden={true}
-              id="tooltip3"
+              id="tooltip2"
               style={
                 Object {
                   "border": 0,
@@ -624,7 +624,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             {
               padding-right: 0px;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone3"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -701,7 +701,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone5"
+        data-focuszone-id="FocusZone4"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -746,7 +746,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             </span>
             <div
               hidden={true}
-              id="tooltip6"
+              id="tooltip5"
               style={
                 Object {
                   "border": 0,
@@ -787,7 +787,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             {
               padding-right: 0px;
             }
-        data-focuszone-id="FocusZone7"
+        data-focuszone-id="FocusZone6"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -960,7 +960,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone1"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1005,7 +1005,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
             </span>
             <div
               hidden={true}
-              id="tooltip3"
+              id="tooltip2"
               style={
                 Object {
                   "border": 0,
@@ -1033,7 +1033,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
             {
               padding-right: 0px;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone3"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1091,7 +1091,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone5"
+        data-focuszone-id="FocusZone4"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1136,7 +1136,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
             </span>
             <div
               hidden={true}
-              id="tooltip6"
+              id="tooltip5"
               style={
                 Object {
                   "border": 0,
@@ -1164,7 +1164,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
             {
               padding-right: 0px;
             }
-        data-focuszone-id="FocusZone7"
+        data-focuszone-id="FocusZone6"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1239,7 +1239,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone2"
+        data-focuszone-id="FocusZone1"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1284,7 +1284,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
             </span>
             <div
               hidden={true}
-              id="tooltip3"
+              id="tooltip2"
               style={
                 Object {
                   "border": 0,
@@ -1312,7 +1312,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
             {
               padding-right: 40px;
             }
-        data-focuszone-id="FocusZone4"
+        data-focuszone-id="FocusZone3"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1388,7 +1388,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
             &:focus {
               outline: none;
             }
-        data-focuszone-id="FocusZone5"
+        data-focuszone-id="FocusZone4"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1433,7 +1433,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
             </span>
             <div
               hidden={true}
-              id="tooltip6"
+              id="tooltip5"
               style={
                 Object {
                   "border": 0,
@@ -1461,7 +1461,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
             {
               padding-right: 40px;
             }
-        data-focuszone-id="FocusZone7"
+        data-focuszone-id="FocusZone6"
         data-tabster="{\\"uncontrolled\\": {}}"
         onFocus={[Function]}
         onKeyDown={[Function]}

--- a/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChartRTL.test.tsx.snap
+++ b/packages/react-charting/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChartRTL.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone2"
+          data-focuszone-id="FocusZone1"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -63,7 +63,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               </span>
               <div
                 hidden=""
-                id="tooltip3"
+                id="tooltip2"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 one
@@ -94,7 +94,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone4"
+          data-focuszone-id="FocusZone3"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -159,7 +159,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone5"
+          data-focuszone-id="FocusZone4"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -197,7 +197,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               </span>
               <div
                 hidden=""
-                id="tooltip6"
+                id="tooltip5"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 two
@@ -228,7 +228,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone7"
+          data-focuszone-id="FocusZone6"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -293,7 +293,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone8"
+          data-focuszone-id="FocusZone7"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -331,7 +331,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               </span>
               <div
                 hidden=""
-                id="tooltip9"
+                id="tooltip8"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 three
@@ -362,7 +362,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone10"
+          data-focuszone-id="FocusZone9"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -445,7 +445,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone2"
+          data-focuszone-id="FocusZone1"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -483,7 +483,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               </span>
               <div
                 hidden=""
-                id="tooltip3"
+                id="tooltip2"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 one
@@ -514,7 +514,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone4"
+          data-focuszone-id="FocusZone3"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -579,7 +579,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone5"
+          data-focuszone-id="FocusZone4"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -617,7 +617,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               </span>
               <div
                 hidden=""
-                id="tooltip6"
+                id="tooltip5"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 two
@@ -648,7 +648,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone7"
+          data-focuszone-id="FocusZone6"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -713,7 +713,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone8"
+          data-focuszone-id="FocusZone7"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -751,7 +751,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               </span>
               <div
                 hidden=""
-                id="tooltip9"
+                id="tooltip8"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 three
@@ -782,7 +782,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone10"
+          data-focuszone-id="FocusZone9"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -878,7 +878,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone5"
+            data-focuszone-id="FocusZone4"
             data-tabster="{\\"uncontrolled\\": {}}"
           >
             <div
@@ -916,7 +916,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 </span>
                 <div
                   hidden=""
-                  id="tooltip6"
+                  id="tooltip5"
                   style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
                 >
                   one
@@ -947,7 +947,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 {
                   padding-right: 0px;
                 }
-            data-focuszone-id="FocusZone7"
+            data-focuszone-id="FocusZone6"
             data-tabster="{\\"uncontrolled\\": {}}"
           >
             <svg
@@ -1012,7 +1012,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone8"
+            data-focuszone-id="FocusZone7"
             data-tabster="{\\"uncontrolled\\": {}}"
           >
             <div
@@ -1050,7 +1050,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 </span>
                 <div
                   hidden=""
-                  id="tooltip9"
+                  id="tooltip8"
                   style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
                 >
                   two
@@ -1081,7 +1081,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 {
                   padding-right: 0px;
                 }
-            data-focuszone-id="FocusZone10"
+            data-focuszone-id="FocusZone9"
             data-tabster="{\\"uncontrolled\\": {}}"
           >
             <svg
@@ -1146,7 +1146,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone11"
+            data-focuszone-id="FocusZone10"
             data-tabster="{\\"uncontrolled\\": {}}"
           >
             <div
@@ -1184,7 +1184,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 </span>
                 <div
                   hidden=""
-                  id="tooltip12"
+                  id="tooltip11"
                   style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
                 >
                   three
@@ -1215,7 +1215,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
                 {
                   padding-right: 0px;
                 }
-            data-focuszone-id="FocusZone13"
+            data-focuszone-id="FocusZone12"
             data-tabster="{\\"uncontrolled\\": {}}"
           >
             <svg
@@ -1277,11 +1277,51 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
 exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar chart with data 1`] = `
 <div>
   <div
-    aria-label="Graph has no data to display"
-    id="_HBC_empty1"
-    role="alert"
-    style="opacity: 0;"
-  />
+    style="display: flex; justify-content: center; align-items: center; height: 100%;"
+  >
+    <div
+      aria-label="Graph has no data to display"
+      id="_Chart_empty_1"
+      role="alert"
+      style="display: flex; flex-direction: column; justify-content: center; align-items: center; margin-top: 10px;"
+    >
+      <div
+        style="display: flex; justify-content: center; align-items: center; height: 100%;"
+      >
+        <span
+          aria-hidden="true"
+          class=""
+          style="font-size: 175px; height: 175px;"
+        >
+          <svg
+            focusable="false"
+            viewBox="0 0 2048 2048"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M960 0q133 0 255 34t230 96 194 150 150 195 97 229 34 256q0 133-34 255t-96 230-150 194-195 150-229 97-256 34q-133 0-255-34t-230-96-194-150-150-195-97-229T0 960q0-133 34-255t96-230 150-194 195-150 229-97T960 0zm0 1792q114 0 220-30t199-84 169-130 130-168 84-199 30-221q0-114-30-220t-84-199-130-169-168-130-199-84-221-30q-115 0-221 30t-198 84-169 130-130 168-84 199-30 221q0 114 30 220t84 199 130 169 168 130 199 84 221 30zM896 512h128v640H896V512zm0 768h128v128H896v-128z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        style="font-size: 14px; font-weight: 700; font-family: Segoe UI; text-align: center;"
+      >
+        Couldn't load data
+      </div>
+      <div
+        style="font-size: 12px; font-family: Segoe UI; text-align: center;"
+      >
+        Something went wrong and we couldn't get the page to display
+      </div>
+      <div
+        style="font-size: 12px; font-family: Segoe UI; text-align: center;"
+      >
+        Error code: 
+        No data
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
@@ -1295,7 +1335,6 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
           flex-direction: column;
           width: 100%;
         }
-    style=""
   >
     <div>
       <div
@@ -1731,7 +1770,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone2"
+          data-focuszone-id="FocusZone1"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -1769,7 +1808,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               </span>
               <div
                 hidden=""
-                id="tooltip3"
+                id="tooltip2"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 one
@@ -1800,7 +1839,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone4"
+          data-focuszone-id="FocusZone3"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -1865,7 +1904,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone5"
+          data-focuszone-id="FocusZone4"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -1903,7 +1942,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               </span>
               <div
                 hidden=""
-                id="tooltip6"
+                id="tooltip5"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 two
@@ -1934,7 +1973,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone7"
+          data-focuszone-id="FocusZone6"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg
@@ -1999,7 +2038,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               &:focus {
                 outline: none;
               }
-          data-focuszone-id="FocusZone8"
+          data-focuszone-id="FocusZone7"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <div
@@ -2037,7 +2076,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               </span>
               <div
                 hidden=""
-                id="tooltip9"
+                id="tooltip8"
                 style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
               >
                 three
@@ -2068,7 +2107,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
               {
                 padding-right: 0px;
               }
-          data-focuszone-id="FocusZone10"
+          data-focuszone-id="FocusZone9"
           data-tabster="{\\"uncontrolled\\": {}}"
         >
           <svg

--- a/packages/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
+++ b/packages/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
@@ -34,6 +34,7 @@ import {
   getTypeOfAxis,
   getNextColor,
 } from '../../utilities/index';
+import ErrorBoundary from '../CommonComponents/ErrorBoundary';
 
 const getClassNames = classNamesFunction<IHorizontalBarChartWithAxisStyleProps, IHorizontalBarChartWithAxisStyles>();
 export interface IHorizontalBarChartWithAxisState extends IBasestate {
@@ -134,34 +135,45 @@ export class HorizontalBarChartWithAxisBase extends React.Component<
       tickValues: this.props.tickValues,
       tickFormat: this.props.tickFormat,
     };
-    return (
-      <CartesianChart
-        {...this.props}
-        points={this._points}
-        chartType={ChartTypes.HorizontalBarChartWithAxis}
-        xAxisType={this._xAxisType}
-        yAxisType={this._yAxisType}
-        stringDatasetForYAxisDomain={this._yAxisLabels}
-        calloutProps={calloutProps}
-        tickParams={tickParams}
-        legendBars={legendBars}
-        barwidth={this._barHeight}
-        focusZoneDirection={FocusZoneDirection.vertical}
-        customizedCallout={this._getCustomizedCallout()}
-        getmargins={this._getMargins}
-        getGraphData={this._getGraphData}
-        getAxisData={this._getAxisData}
-        onChartMouseLeave={this._handleChartMouseLeave}
-        /* eslint-disable react/jsx-no-bind */
-        // eslint-disable-next-line react/no-children-prop
-        children={(props: IChildProps) => {
-          return (
-            <>
-              <g>{this._bars}</g>
-            </>
-          );
-        }}
-      />
+    return !this._isChartEmpty() ? (
+      <ErrorBoundary handleError={this.props.handleError} theme={this.props.theme}>
+        <CartesianChart
+          {...this.props}
+          points={this._points}
+          chartType={ChartTypes.HorizontalBarChartWithAxis}
+          xAxisType={this._xAxisType}
+          yAxisType={this._yAxisType}
+          stringDatasetForYAxisDomain={this._yAxisLabels}
+          calloutProps={calloutProps}
+          tickParams={tickParams}
+          legendBars={legendBars}
+          barwidth={this._barHeight}
+          focusZoneDirection={FocusZoneDirection.vertical}
+          customizedCallout={this._getCustomizedCallout()}
+          getmargins={this._getMargins}
+          getGraphData={this._getGraphData}
+          getAxisData={this._getAxisData}
+          onChartMouseLeave={this._handleChartMouseLeave}
+          /* eslint-disable react/jsx-no-bind */
+          // eslint-disable-next-line react/no-children-prop
+          children={(props: IChildProps) => {
+            return (
+              <>
+                <g>{this._bars}</g>
+              </>
+            );
+          }}
+        />
+      </ErrorBoundary>
+    ) : (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        <ErrorBoundary
+          hasEmptyState={true}
+          theme={this.props.theme}
+          width={this.props.width!}
+          handleEmptyState={this.props.handleEmptyState}
+        />
+      </div>
     );
   }
 
@@ -685,4 +697,8 @@ export class HorizontalBarChartWithAxisBase extends React.Component<
     const yValue = point.yAxisCalloutData || point.y;
     return point.callOutAccessibilityData?.ariaLabel || `${xValue}. ` + `${yValue}.`;
   };
+
+  private _isChartEmpty(): boolean {
+    return !(this.props.data && this.props.data.length > 0);
+  }
 }

--- a/packages/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.types.ts
+++ b/packages/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.types.ts
@@ -70,6 +70,16 @@ export interface IHorizontalBarChartWithAxisProps extends ICartesianChartProps {
    *@default false
    *Used for showing complete y axis lables   */
   showYAxisLables?: boolean;
+
+  /**
+   * Callback to handle error while chart is rendering.
+   */
+  handleError?: () => JSX.Element;
+
+  /**
+   * Callback to handle empty state while chart is rendering.
+   */
+  handleEmptyState?: () => JSX.Element;
 }
 
 /**

--- a/packages/react-charting/src/components/assets/ErrorImage.tsx
+++ b/packages/react-charting/src/components/assets/ErrorImage.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+import { ITheme } from '@fluentui/react/lib/Styling';
+import * as React from 'react';
+import { ErrorBadgeIcon, StatusErrorFullIcon } from '@fluentui/react-icons-mdl2';
+
+export interface IErrorImageProps {
+  theme?: ITheme;
+  width: number;
+  height: number;
+}
+class ErrorImage extends React.Component<IErrorImageProps, {}> {
+  constructor(props: IErrorImageProps) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        {this.props.theme && !this.props.theme!.isInverted ? (
+          <ErrorBadgeIcon style={{ fontSize: this.props.width * 0.5, height: this.props.width * 0.5 }} />
+        ) : (
+          <StatusErrorFullIcon
+            style={{ fontSize: this.props.width * 0.5, height: this.props.width * 0.5, color: 'white' }}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+export default ErrorImage;

--- a/packages/react-charting/src/components/assets/MissingDataImage.tsx
+++ b/packages/react-charting/src/components/assets/MissingDataImage.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+import { ITheme } from '@fluentui/react/lib/Styling';
+import * as React from 'react';
+import { ErrorIcon } from '@fluentui/react-icons-mdl2';
+
+interface IMissingDataImageProps {
+  theme?: ITheme;
+  width: number;
+  height: number;
+}
+class MissingDataImage extends React.Component<IMissingDataImageProps, {}> {
+  constructor(props: IMissingDataImageProps) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        {this.props.theme && !this.props.theme!.isInverted ? (
+          <ErrorIcon style={{ fontSize: this.props.width * 0.5, height: this.props.width * 0.5 }} />
+        ) : (
+          <ErrorIcon style={{ fontSize: this.props.width * 0.5, height: this.props.width * 0.5, color: 'white' }} />
+        )}
+      </div>
+    );
+  }
+}
+
+export default MissingDataImage;

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Error.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Error.Example.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { ChartDataMode, HorizontalBarChart, IHorizontalBarChartProps } from '@fluentui/react-charting';
+
+interface IHorizontalBarChartState {
+  chartMode: ChartDataMode;
+}
+
+export class HorizontalBarChartErrorExample extends React.Component<
+  IHorizontalBarChartProps,
+  IHorizontalBarChartState
+> {
+  constructor(props: IHorizontalBarChartProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    return <div>{this._basicExample()}</div>;
+  }
+
+  private _basicExample() {
+    return (
+      <>
+        <div style={{ maxWidth: 600 }}>
+          <HorizontalBarChart culture={window.navigator.language} data={[]} />
+        </div>
+      </>
+    );
+  }
+}

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.doc.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.doc.tsx
@@ -7,6 +7,7 @@ import { HorizontalBarChartCustomCalloutExample } from './HorizontalBarChart.Cus
 import { HorizontalBarChartBenchmarkExample } from './HorizontalBarChart.Benchmark.Example';
 import { HorizontalBarChartCustomAccessibilityExample } from './HorizontalBarChart.CustomAccessibility.Example';
 import { HorizontalBarChartVariantExample } from './HorizontalBarChart.Variant.Example';
+import { HorizontalBarChartErrorExample } from './HorizontalBarChart.Error.Example';
 
 const HorizontalBarChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx') as string;
@@ -18,6 +19,8 @@ const HorizontalBarChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx') as string;
 const HorizontalBarChartVariantExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Variant.Example.tsx') as string;
+const HorizontalBarChartErrorExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Error.Example.tsx') as string;
 
 export const HorizontalBarChartPageProps: IDocPageProps = {
   title: 'HorizontalBarChart',
@@ -49,6 +52,11 @@ export const HorizontalBarChartPageProps: IDocPageProps = {
       title: 'HorizontalBarChart custom callout',
       code: HorizontalBarChartCustomCalloutExampleCode,
       view: <HorizontalBarChartCustomCalloutExample />,
+    },
+    {
+      title: 'HorizontalBarChart error scenario',
+      code: HorizontalBarChartErrorExampleCode,
+      view: <HorizontalBarChartErrorExample />,
     },
   ],
   overview: require<string>('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/docs/HorizontalBarChartOverview.md'),

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChartPage.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChartPage.tsx
@@ -13,6 +13,7 @@ import { HorizontalBarChartCustomCalloutExample } from './HorizontalBarChart.Cus
 import { HorizontalBarChartBenchmarkExample } from './HorizontalBarChart.Benchmark.Example';
 import { HorizontalBarChartCustomAccessibilityExample } from './HorizontalBarChart.CustomAccessibility.Example';
 import { HorizontalBarChartVariantExample } from './HorizontalBarChart.Variant.Example';
+import { HorizontalBarChartErrorExample } from './HorizontalBarChart.Error.Example';
 
 const HorizontalBarChartBasicExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx') as string;
@@ -24,6 +25,8 @@ const HorizontalBarChartCustomAccessibilityExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.CustomAccessibility.Example.tsx') as string;
 const HorizontalBarChartVariantExampleCode =
   require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Variant.Example.tsx') as string;
+const HorizontalBarChartErrorExampleCode =
+  require('!raw-loader?esModule=false!@fluentui/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Error.Example.tsx') as string;
 
 export class HorizontalBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -50,6 +53,9 @@ export class HorizontalBarChartPage extends React.Component<IComponentDemoPagePr
             </ExampleCard>
             <ExampleCard title="HorizontalBarChart Variant" code={HorizontalBarChartVariantExampleCode}>
               <HorizontalBarChartVariantExample />
+            </ExampleCard>
+            <ExampleCard title="HorizontalBarChart Error" code={HorizontalBarChartErrorExampleCode}>
+              <HorizontalBarChartErrorExample />
             </ExampleCard>
           </div>
         }


### PR DESCRIPTION
The following changes have been added:
1. Created a common control that can show error and empty states.
2. Used the common control to show already implemented empty messages.
3. Use the common control to show type errors (eg: when string data is used on x axis for Line chart or area chart which is not supported)
4. Added Error Codes to indicate Generic Error or No Data Error.
5. Kept provision for customizing the error handling while rendering if required.
6. Added support for light/dark theme.

Examples:
1. Generic Types Error 
![image](https://github.com/microsoft/fluentui/assets/120183316/85e2fe5a-d425-4d02-bc6b-5a426edbb6eb)

3. Missing Data
![image](https://github.com/microsoft/fluentui/assets/120183316/acd549fe-3e7c-4feb-a4f0-023fe9af771a)

Monosizes after adding error handling for horizontal bar chart variants:

![image](https://github.com/microsoft/fluentui/assets/120183316/f804aa0f-97a5-4abc-a062-d7c7b2b843dc)

Monosize in master:

<img width="408" alt="image" src="https://github.com/microsoft/fluentui/assets/120183316/029fd0d6-662d-4367-8ed6-b596a1c5d732">

Bundle size after adding error handling:
![image](https://github.com/microsoft/fluentui/assets/120183316/ce6ab3fb-926f-4871-9cc2-b04f0075167d)

Bundle size in master:
![image](https://github.com/microsoft/fluentui/assets/120183316/45695c7b-4ddd-4ce4-8bf9-7e50c8cdbe6b)
