### PR TITLE
fix: standalone Listbox updates activedescendant correctly

### DIFF
--- a/change/@fluentui-react-aria-98a2ae86-abde-4e51-888a-d17e8e7badba.json
+++ b/change/@fluentui-react-aria-98a2ae86-abde-4e51-888a-d17e8e7badba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add options to manually show/hide focus visibility on active descendants, and scroll the active item into view",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-eda940fc-c0e1-4884-bfab-7b3a71b69269.json
+++ b/change/@fluentui-react-combobox-eda940fc-c0e1-4884-bfab-7b3a71b69269.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Listbox updates activedescendant correctly",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-938c2d34-5817-4f23-b592-0389cd9cd215.json
+++ b/change/@fluentui-react-tag-picker-938c2d34-5817-4f23-b592-0389cd9cd215.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update internal state to match Combobox and Listbox changes",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/library/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/library/etc/react-aria.api.md
@@ -37,17 +37,23 @@ export interface ActiveDescendantImperativeRef {
     first: (options?: IteratorOptions) => string | undefined;
     // (undocumented)
     focus: (id: string) => void;
-    focusLastActive: () => boolean | undefined;
+    // @deprecated (undocumented)
+    focusLastActive: () => void;
     // (undocumented)
     hideAttributes: () => void;
+    // (undocumented)
+    hideFocusVisibleAttributes: () => void;
     // (undocumented)
     last: (options?: IteratorOptions) => string | undefined;
     // (undocumented)
     next: (options?: IteratorOptions) => string | undefined;
     // (undocumented)
     prev: (options?: IteratorOptions) => string | undefined;
+    scrollActiveIntoView: () => void;
     // (undocumented)
     showAttributes: () => void;
+    // (undocumented)
+    showFocusVisibleAttributes: () => void;
 }
 
 // @public (undocumented)

--- a/packages/react-components/react-aria/library/src/activedescendant/ActiveDescendantContext.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/ActiveDescendantContext.ts
@@ -15,11 +15,14 @@ const activeDescendantContextDefaultValue: ActiveDescendantContextValue = {
     first: noop,
     focus: noop,
     focusLastActive: noop,
+    scrollActiveIntoView: noop,
     last: noop,
     next: noop,
     prev: noop,
     showAttributes: noop,
     hideAttributes: noop,
+    showFocusVisibleAttributes: noop,
+    hideFocusVisibleAttributes: noop,
   },
 };
 

--- a/packages/react-components/react-aria/library/src/activedescendant/types.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/types.ts
@@ -10,10 +10,9 @@ export interface ActiveDescendantImperativeRef {
   active: () => string | undefined;
   focus: (id: string) => void;
   /**
-   * Focuses the last active descendant, if it still exists
-   * @returns true if the last active descendant was focused
+   * Scrolls the active option into view, if it still exists
    */
-  focusLastActive: () => boolean | undefined;
+  scrollActiveIntoView: () => void;
   hideAttributes: () => void;
   showAttributes: () => void;
 }

--- a/packages/react-components/react-aria/library/src/activedescendant/types.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/types.ts
@@ -10,11 +10,17 @@ export interface ActiveDescendantImperativeRef {
   active: () => string | undefined;
   focus: (id: string) => void;
   /**
+   * @deprecated This function is not used internally anymore and will be removed in the future
+   */
+  focusLastActive: () => void;
+  /**
    * Scrolls the active option into view, if it still exists
    */
   scrollActiveIntoView: () => void;
   hideAttributes: () => void;
   showAttributes: () => void;
+  hideFocusVisibleAttributes: () => void;
+  showFocusVisibleAttributes: () => void;
 }
 
 export interface ActiveDescendantOptions {

--- a/packages/react-components/react-aria/library/src/activedescendant/useActiveDescendant.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/useActiveDescendant.ts
@@ -164,17 +164,6 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
           focusActiveDescendant(target);
         }
       },
-      focusLastActive: () => {
-        if (!listboxRef.current || !lastActiveIdRef.current) {
-          return;
-        }
-
-        const target = listboxRef.current.querySelector<HTMLElement>(`#${lastActiveIdRef.current}`);
-        if (target) {
-          focusActiveDescendant(target);
-          return true;
-        }
-      },
       find(predicate, { passive, startFrom } = {}) {
         const target = optionWalker.find(predicate, startFrom);
         if (!passive) {
@@ -182,6 +171,18 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
         }
 
         return target?.id;
+      },
+      scrollActiveIntoView: () => {
+        if (!listboxRef.current) {
+          return;
+        }
+
+        const active = getActiveDescendant();
+        if (!active) {
+          return;
+        }
+
+        scrollIntoView(active);
       },
       showAttributes() {
         attributeVisibilityRef.current = true;

--- a/packages/react-components/react-aria/library/src/activedescendant/useActiveDescendant.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/useActiveDescendant.ts
@@ -28,6 +28,7 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
 ): UseActiveDescendantReturn<TActiveParentElement, TListboxElement> {
   const { imperativeRef, matchOption: matchOptionUnstable } = options;
   const focusVisibleRef = React.useRef(false);
+  const shouldShowFocusVisibleAttrRef = React.useRef(true);
   const activeIdRef = React.useRef<string | null>(null);
   const lastActiveIdRef = React.useRef<string | null>(null);
   const activeParentRef = React.useRef<TActiveParentElement>(null);
@@ -36,6 +37,7 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
   const removeAttribute = React.useCallback(() => {
     activeParentRef.current?.removeAttribute('aria-activedescendant');
   }, []);
+
   const setAttribute = React.useCallback((id?: string) => {
     if (id) {
       activeIdRef.current = id;
@@ -47,12 +49,13 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
 
   useOnKeyboardNavigationChange(isNavigatingWithKeyboard => {
     focusVisibleRef.current = isNavigatingWithKeyboard;
+
     const active = getActiveDescendant();
     if (!active) {
       return;
     }
 
-    if (isNavigatingWithKeyboard) {
+    if (isNavigatingWithKeyboard && shouldShowFocusVisibleAttrRef.current) {
       active.setAttribute(ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE, '');
     } else {
       active.removeAttribute(ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE);
@@ -62,9 +65,28 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
   const matchOption = useEventCallback(matchOptionUnstable);
   const listboxRef = React.useRef<TListboxElement>(null);
   const { optionWalker, listboxCallbackRef } = useOptionWalker<TListboxElement>({ matchOption });
+
   const getActiveDescendant = React.useCallback(() => {
     return listboxRef.current?.querySelector<HTMLElement>(`#${activeIdRef.current}`);
   }, [listboxRef]);
+
+  const setShouldShowFocusVisibleAttribute = React.useCallback(
+    (shouldShow: boolean) => {
+      shouldShowFocusVisibleAttrRef.current = shouldShow;
+
+      const active = getActiveDescendant();
+      if (!active) {
+        return;
+      }
+
+      if (shouldShow && focusVisibleRef.current) {
+        active.setAttribute(ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE, '');
+      } else {
+        active.removeAttribute(ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE);
+      }
+    },
+    [getActiveDescendant],
+  );
 
   const blurActiveDescendant = React.useCallback(() => {
     const active = getActiveDescendant();
@@ -91,7 +113,7 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
       setAttribute(nextActive.id);
       nextActive.setAttribute(ACTIVEDESCENDANT_ATTRIBUTE, '');
 
-      if (focusVisibleRef.current) {
+      if (focusVisibleRef.current && shouldShowFocusVisibleAttrRef.current) {
         nextActive.setAttribute(ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE, '');
       }
 
@@ -164,6 +186,17 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
           focusActiveDescendant(target);
         }
       },
+      focusLastActive: () => {
+        if (!listboxRef.current || !lastActiveIdRef.current) {
+          return;
+        }
+
+        const target = listboxRef.current.querySelector<HTMLElement>(`#${lastActiveIdRef.current}`);
+        if (target) {
+          focusActiveDescendant(target);
+          return true;
+        }
+      },
       find(predicate, { passive, startFrom } = {}) {
         const target = optionWalker.find(predicate, startFrom);
         if (!passive) {
@@ -192,6 +225,12 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
         attributeVisibilityRef.current = false;
         removeAttribute();
       },
+      showFocusVisibleAttributes() {
+        setShouldShowFocusVisibleAttribute(true);
+      },
+      hideFocusVisibleAttributes() {
+        setShouldShowFocusVisibleAttribute(false);
+      },
     }),
     [
       optionWalker,
@@ -201,6 +240,7 @@ export function useActiveDescendant<TActiveParentElement extends HTMLElement, TL
       focusActiveDescendant,
       blurActiveDescendant,
       getActiveDescendant,
+      setShouldShowFocusVisibleAttribute,
     ],
   );
 

--- a/packages/react-components/react-aria/library/src/activedescendant/useActivedescendant.test.tsx
+++ b/packages/react-components/react-aria/library/src/activedescendant/useActivedescendant.test.tsx
@@ -272,6 +272,7 @@ describe('useActivedescendant', () => {
       const { getByRole } = render(<Test imperativeRef={imperativeRef} />);
 
       // there should not be a last active descendant yet
+      // eslint-disable-next-line deprecation/deprecation
       expect(imperativeRef.current?.focusLastActive()).toBeFalsy();
 
       imperativeRef.current?.focus('option-3');
@@ -280,6 +281,7 @@ describe('useActivedescendant', () => {
       imperativeRef.current?.blur();
       expect(imperativeRef.current?.active()).toBeUndefined();
 
+      // eslint-disable-next-line deprecation/deprecation
       expect(imperativeRef.current?.focusLastActive()).toBeTruthy();
       expect(imperativeRef.current?.active()).toBe('option-3');
 

--- a/packages/react-components/react-combobox/library/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/library/etc/react-combobox.api.md
@@ -144,7 +144,7 @@ export const Listbox: ForwardRefComponent<ListboxProps>;
 export const listboxClassNames: SlotClassNames<ListboxSlots>;
 
 // @public
-export type ListboxContextValue = Pick<ListboxState, 'activeOption' | 'focusVisible' | 'multiselect' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption'> & {
+export type ListboxContextValue = Pick<ListboxState, 'activeOption' | 'focusVisible' | 'getOptionById' | 'getOptionsMatchingValue' | 'multiselect' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'setActiveOption'> & {
     onOptionClick: (e: React_2.MouseEvent<HTMLElement>) => void;
     onActiveDescendantChange?: (e: ActiveDescendantChangeEvent) => void;
 };

--- a/packages/react-components/react-combobox/library/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/library/etc/react-combobox.api.md
@@ -171,6 +171,7 @@ export type ListboxState = ComponentState<ListboxSlots> & OptionCollectionState 
     activeOption?: OptionValue;
     focusVisible: boolean;
     setActiveOption(option?: OptionValue): void;
+    standalone: boolean;
     selectOption(event: SelectionEvents, option: OptionValue): void;
     activeDescendantController: ActiveDescendantImperativeRef;
     onActiveDescendantChange?: (event: ActiveDescendantChangeEvent) => void;

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useButtonTriggerSlot.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useButtonTriggerSlot.ts
@@ -104,9 +104,12 @@ export function useButtonTriggerSlot(
         searchString.current = '';
       }, 500);
 
+      if (open) {
+        moveToNextMatchingOptionWithSameCharacterHandling();
+      }
+
       // update state
       !open && setOpen(ev, true);
-      moveToNextMatchingOptionWithSameCharacterHandling();
     }
   };
 

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.test.tsx
@@ -77,7 +77,7 @@ describe('Listbox', () => {
     expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(option.id);
   });
 
-  it('should set active option to first option on focus if nothing is selected', () => {
+  it('should set active option to first option if nothing is selected', () => {
     const { getByTestId } = render(
       <Listbox data-testid="listbox">
         <Option data-testid="firstOption">Red</Option>
@@ -87,16 +87,12 @@ describe('Listbox', () => {
     );
 
     const firstOption = getByTestId('firstOption');
-    expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toBeNull();
-
-    fireEvent.focus(getByTestId('listbox'));
-
     expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(firstOption.id);
   });
 
-  it('should set active option to first selected option on focus', () => {
+  it('should set active option to first selected option if one is selected', () => {
     const { getByTestId } = render(
-      <Listbox data-testid="listbox" selectedOptions={['Blue', 'Green']}>
+      <Listbox data-testid="listbox" selectedOptions={['Green']}>
         <Option>Red</Option>
         <Option data-testid="firstSelectedOption">Green</Option>
         <Option>Blue</Option>
@@ -104,14 +100,23 @@ describe('Listbox', () => {
     );
 
     const selectedOption = getByTestId('firstSelectedOption');
-    expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toBeNull();
-
-    fireEvent.focus(getByTestId('listbox'));
-
     expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(selectedOption.id);
   });
 
-  it('should set active option to last active option on focus', () => {
+  it('should set active option to first option, not selected options if multiselect', () => {
+    const { getByTestId } = render(
+      <Listbox data-testid="listbox" multiselect={true} selectedOptions={['Green', 'Blue']}>
+        <Option data-testid="firstOption">Red</Option>
+        <Option>Green</Option>
+        <Option>Blue</Option>
+      </Listbox>,
+    );
+
+    const firstOption = getByTestId('firstOption');
+    expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(firstOption.id);
+  });
+
+  it('should preserve active option on last active option on blur and focus', () => {
     const { getByTestId } = render(
       <Listbox data-testid="listbox" selectedOptions={[]}>
         <Option data-testid="redOption">Red</Option>
@@ -120,10 +125,6 @@ describe('Listbox', () => {
       </Listbox>,
     );
 
-    expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toBeNull();
-
-    fireEvent.focus(getByTestId('listbox'));
-
     expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(getByTestId('redOption').id);
 
     fireEvent.keyDown(getByTestId('listbox'), { key: 'ArrowDown' });
@@ -131,9 +132,6 @@ describe('Listbox', () => {
     expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(getByTestId('greenOption').id);
 
     fireEvent.blur(getByTestId('listbox'));
-
-    expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toBeNull();
-
     fireEvent.focus(getByTestId('listbox'));
 
     expect(getByTestId('listbox').getAttribute('aria-activedescendant')).toEqual(getByTestId('greenOption').id);
@@ -150,11 +148,13 @@ describe('Listbox', () => {
 
     const listbox = getByTestId('listbox');
 
-    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     expect(listbox.getAttribute('aria-activedescendant')).toEqual(getByText('Red').id);
 
     fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     expect(listbox.getAttribute('aria-activedescendant')).toEqual(getByText('Green').id);
+
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    expect(listbox.getAttribute('aria-activedescendant')).toEqual(getByText('Blue').id);
   });
 
   it('should move active option with arrow up', () => {
@@ -353,7 +353,6 @@ describe('Listbox', () => {
     );
 
     const listbox = getByTestId('listbox');
-    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     fireEvent.keyDown(listbox, { key: 'Enter' });
 
     expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
@@ -372,7 +371,6 @@ describe('Listbox', () => {
     );
 
     const listbox = getByTestId('listbox');
-    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     fireEvent.keyDown(listbox, { key: ' ' });
 
     expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
@@ -42,6 +42,9 @@ export type ListboxState = ComponentState<ListboxSlots> &
      */
     setActiveOption(option?: OptionValue): void;
 
+    // Whether the Listbox renders within a Combobox, Dropdown, or picker, or as a standalone widget
+    standalone: boolean;
+
     selectOption(event: SelectionEvents, option: OptionValue): void;
 
     activeDescendantController: ActiveDescendantImperativeRef;

--- a/packages/react-components/react-combobox/library/src/components/Listbox/__snapshots__/Listbox.test.tsx.snap
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/__snapshots__/Listbox.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Listbox renders a default state 1`] = `
 <div>
   <div
+    aria-activedescendant="fluent-option1"
     class="fui-Listbox"
     role="listbox"
     tabindex="0"
@@ -10,6 +11,7 @@ exports[`Listbox renders a default state 1`] = `
     <div
       aria-selected="false"
       class="fui-Option"
+      data-activedescendant=""
       id="fluent-option1"
       role="option"
     >
@@ -95,6 +97,7 @@ exports[`Listbox renders a default state 1`] = `
 exports[`Listbox renders with a selected option 1`] = `
 <div>
   <div
+    aria-activedescendant="fluent-option4"
     class="fui-Listbox"
     role="listbox"
     tabindex="0"
@@ -102,6 +105,7 @@ exports[`Listbox renders with a selected option 1`] = `
     <div
       aria-selected="true"
       class="fui-Option"
+      data-activedescendant=""
       id="fluent-option4"
       role="option"
     >

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -187,6 +187,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
       }),
       { elementType: 'div' },
     ),
+    standalone: !hasListboxContext,
     multiselect,
     clearSelection,
     activeDescendantController,

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -19,6 +19,7 @@ import { useOptionCollection } from '../../utils/useOptionCollection';
 import { useSelection } from '../../utils/useSelection';
 import { optionClassNames } from '../Option/useOptionStyles.styles';
 import { ListboxContext, useListboxContext_unstable } from '../../contexts/ListboxContext';
+import { useOnKeyboardNavigationChange } from '@fluentui/react-tabster';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const UNSAFE_noLongerUsed = {
@@ -77,6 +78,9 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
       element.addEventListener('activedescendantchange', listener);
     };
   }, [onActiveDescendantChange]);
+
+  const [isNavigatingWithKeyboard, setIsNavigatingWithKeyboard] = React.useState(false);
+  useOnKeyboardNavigationChange(setIsNavigatingWithKeyboard);
 
   const activeDescendantContext = useActiveDescendantContext();
   const hasParentActiveDescendantContext = useHasParentActiveDescendantContext();
@@ -171,6 +175,12 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeDescendantController]);
 
+  const onFocus = React.useCallback(() => {
+    if (isNavigatingWithKeyboard && !hasParentActiveDescendantContext) {
+      activeDescendantController.scrollActiveIntoView();
+    }
+  }, [activeDescendantController, hasParentActiveDescendantContext, isNavigatingWithKeyboard]);
+
   const state: ListboxState = {
     components: {
       root: 'div',
@@ -197,6 +207,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   };
 
   state.root.onKeyDown = useEventCallback(mergeCallbacks(state.root.onKeyDown, onKeyDown));
+  state.root.onFocus = useEventCallback(mergeCallbacks(state.root.onFocus, onFocus));
 
   return state;
 };

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -39,7 +39,6 @@ const UNSAFE_noLongerUsed = {
 export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
   const { multiselect } = props;
   const optionCollection = useOptionCollection();
-  const { getOptionById } = optionCollection;
 
   const {
     listboxRef: activeDescendantListboxRef,
@@ -49,7 +48,15 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     matchOption: el => el.classList.contains(optionClassNames.root),
   });
 
+  const hasListboxContext = useHasParentContext(ListboxContext);
   const onActiveDescendantChange = useListboxContext_unstable(ctx => ctx.onActiveDescendantChange);
+  const contextGetOptionById = useListboxContext_unstable(ctx => ctx.getOptionById);
+  const contextGetOptionsMatchingValue = useListboxContext_unstable(ctx => ctx.getOptionsMatchingValue);
+
+  const getOptionById = hasListboxContext ? contextGetOptionById : optionCollection.getOptionById;
+  const getOptionsMatchingValue = hasListboxContext
+    ? contextGetOptionsMatchingValue
+    : optionCollection.getOptionsMatchingValue;
 
   const listenerRef = React.useMemo(() => {
     let element: HTMLDivElement | null = null;
@@ -126,7 +133,6 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   };
 
   // get state from parent combobox, if it exists
-  const hasListboxContext = useHasParentContext(ListboxContext);
   const contextSelectedOptions = useListboxContext_unstable(ctx => ctx.selectedOptions);
   const contextSelectOption = useListboxContext_unstable(ctx => ctx.selectOption);
 
@@ -146,9 +152,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
   React.useEffect(() => {
     // if it is single-select and there is a selected option, start at the selected option
     if (!multiselect && optionContextValues.selectedOptions.length > 0) {
-      const selectedOption = optionCollection
-        .getOptionsMatchingValue(v => v === optionContextValues.selectedOptions[0])
-        .pop();
+      const selectedOption = getOptionsMatchingValue(v => v === optionContextValues.selectedOptions[0]).pop();
 
       if (selectedOption?.id) {
         activeDescendantController.focus(selectedOption.id);

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
@@ -1,5 +1,6 @@
 import { tokens } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
+import { ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE } from '@fluentui/react-aria';
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { ListboxSlots, ListboxState } from './Listbox.types';
 
@@ -22,6 +23,12 @@ const useStyles = makeStyles({
     padding: tokens.spacingHorizontalXS,
     rowGap: tokens.spacingHorizontalXXS,
   },
+
+  standaloneRoot: {
+    [`&:not(:focus) [${ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE}]::after`]: {
+      display: 'none',
+    },
+  },
 });
 
 /**
@@ -29,7 +36,12 @@ const useStyles = makeStyles({
  */
 export const useListboxStyles_unstable = (state: ListboxState): ListboxState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(listboxClassNames.root, styles.root, state.root.className);
+  state.root.className = mergeClasses(
+    listboxClassNames.root,
+    styles.root,
+    state.standalone && styles.standaloneRoot,
+    state.root.className,
+  );
 
   return state;
 };

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
@@ -1,6 +1,5 @@
 import { tokens } from '@fluentui/react-theme';
 import { SlotClassNames } from '@fluentui/react-utilities';
-import { ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE } from '@fluentui/react-aria';
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { ListboxSlots, ListboxState } from './Listbox.types';
 
@@ -23,12 +22,6 @@ const useStyles = makeStyles({
     padding: tokens.spacingHorizontalXS,
     rowGap: tokens.spacingHorizontalXXS,
   },
-
-  standaloneRoot: {
-    [`&:not(:focus) [${ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE}]::after`]: {
-      display: 'none',
-    },
-  },
 });
 
 /**
@@ -36,12 +29,7 @@ const useStyles = makeStyles({
  */
 export const useListboxStyles_unstable = (state: ListboxState): ListboxState => {
   const styles = useStyles();
-  state.root.className = mergeClasses(
-    listboxClassNames.root,
-    styles.root,
-    state.standalone && styles.standaloneRoot,
-    state.root.className,
-  );
+  state.root.className = mergeClasses(listboxClassNames.root, styles.root, state.root.className);
 
   return state;
 };

--- a/packages/react-components/react-combobox/library/src/components/Option/Option.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Option/Option.test.tsx
@@ -22,6 +22,12 @@ describe('Option', () => {
   const defaultContextValues = {
     activeOption: undefined,
     focusVisible: false,
+    getOptionById() {
+      return undefined;
+    },
+    getOptionsMatchingValue() {
+      return [];
+    },
     multiselect: false,
     registerOption() {
       return () => undefined;

--- a/packages/react-components/react-combobox/library/src/contexts/ListboxContext.ts
+++ b/packages/react-components/react-combobox/library/src/contexts/ListboxContext.ts
@@ -10,6 +10,8 @@ export type ListboxContextValue = Pick<
   ListboxState,
   | 'activeOption'
   | 'focusVisible'
+  | 'getOptionById'
+  | 'getOptionsMatchingValue'
   | 'multiselect'
   | 'registerOption'
   | 'selectedOptions'
@@ -24,6 +26,12 @@ const listboxContextDefaultValue = {
   activeOption: undefined,
   focusVisible: false,
   multiselect: false,
+  getOptionById() {
+    return undefined;
+  },
+  getOptionsMatchingValue() {
+    return [];
+  },
   registerOption() {
     return () => undefined;
   },

--- a/packages/react-components/react-combobox/library/src/contexts/useComboboxContextValues.ts
+++ b/packages/react-components/react-combobox/library/src/contexts/useComboboxContextValues.ts
@@ -8,6 +8,8 @@ export function useComboboxContextValues(
   const {
     appearance,
     open,
+    getOptionById,
+    getOptionsMatchingValue,
     registerOption,
     selectedOptions,
     selectOption,
@@ -34,6 +36,8 @@ export function useComboboxContextValues(
   const listbox = {
     activeOption: undefined,
     focusVisible: false,
+    getOptionById,
+    getOptionsMatchingValue,
     registerOption,
     selectedOptions,
     selectOption,

--- a/packages/react-components/react-combobox/library/src/contexts/useListboxContextValues.ts
+++ b/packages/react-components/react-combobox/library/src/contexts/useListboxContextValues.ts
@@ -5,7 +5,15 @@ import { ListboxContext, useListboxContext_unstable } from './ListboxContext';
 
 export function useListboxContextValues(state: ListboxState): ListboxContextValues {
   const hasListboxContext = useHasParentContext(ListboxContext);
-  const { multiselect, registerOption, selectedOptions, selectOption, activeDescendantController } = state;
+  const {
+    getOptionById,
+    getOptionsMatchingValue,
+    multiselect,
+    registerOption,
+    selectedOptions,
+    selectOption,
+    activeDescendantController,
+  } = state;
 
   // get register/unregister functions from parent combobox context
   const parentRegisterOption = useListboxContext_unstable(ctx => ctx.registerOption);
@@ -17,6 +25,8 @@ export function useListboxContextValues(state: ListboxState): ListboxContextValu
   const listbox = {
     activeOption: undefined,
     focusVisible: false,
+    getOptionById,
+    getOptionsMatchingValue,
     multiselect,
     registerOption: registerOptionValue,
     selectedOptions,

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
@@ -148,23 +148,6 @@ export const useComboboxBaseState = (
     [onOpenChange, setOpenState, setValue, freeform, disabled],
   );
 
-  // update active option based on change in open state
-  React.useEffect(() => {
-    if (open) {
-      // if it is single-select and there is a selected option, start at the selected option
-      if (!multiselect && selectedOptions.length > 0) {
-        const selectedOption = getOptionsMatchingValue(v => v === selectedOptions[0]).pop();
-        if (selectedOption?.id) {
-          activeDescendantController.focus(selectedOption.id);
-        }
-      }
-    } else {
-      activeDescendantController.blur();
-    }
-    // this should only be run in response to changes in the open state or children
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, activeDescendantController]);
-
   // Fallback focus when children are updated in an open popover results in no item being focused
   React.useEffect(() => {
     if (open) {

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -230,7 +230,7 @@ export type TagPickerSize = 'medium' | 'large' | 'extra-large';
 export type TagPickerSlots = {};
 
 // @public
-export type TagPickerState = ComponentState<TagPickerSlots> & Pick<ComboboxState, 'open' | 'activeDescendantController' | 'mountNode' | 'onOptionClick' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'value' | 'setValue' | 'setOpen' | 'setHasFocus' | 'appearance' | 'clearSelection' | 'getOptionById' | 'disabled'> & Pick<TagPickerContextValue, 'triggerRef' | 'secondaryActionRef' | 'popoverId' | 'popoverRef' | 'targetRef' | 'tagPickerGroupRef' | 'size'> & {
+export type TagPickerState = ComponentState<TagPickerSlots> & Pick<ComboboxState, 'open' | 'activeDescendantController' | 'mountNode' | 'onOptionClick' | 'registerOption' | 'selectedOptions' | 'selectOption' | 'value' | 'setValue' | 'setOpen' | 'setHasFocus' | 'appearance' | 'clearSelection' | 'getOptionById' | 'getOptionsMatchingValue' | 'disabled'> & Pick<TagPickerContextValue, 'triggerRef' | 'secondaryActionRef' | 'popoverId' | 'popoverRef' | 'targetRef' | 'tagPickerGroupRef' | 'size'> & {
     trigger: React_2.ReactNode;
     popover?: React_2.ReactNode;
     inline: boolean;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
@@ -214,9 +214,10 @@ describe('TagPicker', () => {
       mount(<TagPickerControlled defaultOpen />);
       cy.get('[data-testid="tag-picker-list"]').should('be.visible');
       cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-activedescendant', `tag-picker-option--0`);
+      cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-expanded', 'true');
       cy.get('[data-testid="tag-picker-input"]').focus().realPress('Escape');
       cy.get('[data-testid="tag-picker-list"]').should('exist').should('not.be.visible');
-      cy.get(`[data-testid="tag-picker-input"]`).should('not.have.attr', 'aria-activedescendant');
+      cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-expanded', 'false');
     });
     (['ArrowDown', 'ArrowUp'] as const).forEach(keypress =>
       it(`should move aria-activedescendant on ${keypress}`, () => {
@@ -240,9 +241,12 @@ describe('TagPicker', () => {
         cy.get(`[data-testid="tag--${options[0]}]"`).should('not.exist');
         cy.get('[data-testid="tag-picker-input"]').focus().realPress('Enter');
         cy.get('[data-testid="tag-picker-list"]').should('exist').should('be.visible');
+        cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-expanded', 'true');
         cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-activedescendant', `tag-picker-option--0`);
         cy.get('[data-testid="tag-picker-input"]').focus().realPress(keypress);
         cy.get('[data-testid="tag-picker-list"]').should('exist').should('not.be.visible');
+        cy.get(`[data-testid="tag-picker-input"]`).should('have.attr', 'aria-expanded', 'false');
+        cy.get('[data-testid="tag-picker-input"]').focus().realPress(['Tab']);
         cy.get(`[data-testid="tag-picker-input"]`).should('not.have.attr', 'aria-activedescendant');
         cy.get(`[data-testid="tag-picker-option--0"]`).should('not.exist');
         cy.get(`[data-testid="tag--${options[0]}"]`).should('exist');

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
@@ -69,6 +69,7 @@ export type TagPickerState = ComponentState<TagPickerSlots> &
     | 'appearance'
     | 'clearSelection'
     | 'getOptionById'
+    | 'getOptionsMatchingValue'
     | 'disabled'
   > &
   Pick<

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
@@ -94,6 +94,7 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     appearance: comboboxState.appearance,
     clearSelection: comboboxState.clearSelection,
     getOptionById: comboboxState.getOptionById,
+    getOptionsMatchingValue: comboboxState.getOptionsMatchingValue,
     registerOption: comboboxState.registerOption,
     selectedOptions: comboboxState.selectedOptions,
     selectOption: comboboxState.selectOption,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPickerContextValues.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPickerContextValues.ts
@@ -20,6 +20,7 @@ export function useTagPickerContextValues(state: TagPickerState): TagPickerConte
     appearance,
     clearSelection,
     getOptionById,
+    getOptionsMatchingValue,
     open,
     popoverId,
     disabled,
@@ -32,6 +33,8 @@ export function useTagPickerContextValues(state: TagPickerState): TagPickerConte
     listbox: {
       onOptionClick,
       registerOption,
+      getOptionById,
+      getOptionsMatchingValue,
       selectedOptions,
       selectOption,
       focusVisible: false,


### PR DESCRIPTION
Related to #31140 and #31235

Essentially this moves the initial `activeDescendantController` setting logic from `useComboboxBaseState` to `useListbox`, so it runs when the listbox is first renders instead of based on the change in `open` state.

That both makes combobox/dropdown `aria-activedescendant` logic a bit more straightforward (the attribute is set if the referenced option exists), and also makes a standalone listbox work.

It also moves a couple option lookup functions to the context, so that Listbox can access them (previously the `getOptionById` logic in `onFocus` wasn't working when not a standalone widget, since it didn't have access to the parent combobox's option collection).

## Previous Behavior

The original issue was that listbox did not set the initial activedescendant. The first fix to that issue did so on focus, but that caused issues when clicking also set focus (and reset the activedescendant, potentially causing scroll & jumping).

## New Behavior

There's no reason Listbox should not always have `aria-activedescendant` set while it's present on the page, so this change moves the initial activedescendant logic from the combobox (which handled it when opened) to the listbox (which handles it when initially rendered).

There is a very subtle difference between the two, since the Listbox is rendered when the Combobox/Dropdown trigger gains focus, but before it is opened. This causes a minor difference in when `aria-activedescendant` is set, but does not cause any practical drawbacks to screen reader users. Some early ARIA combobox pattern work was based around the idea that `aria-activedescendant` would always be set, so screen readers already handle logic on whether to read the activedescendant based on `aria-expanded`.
