### PR TITLE
Fixed checkbox not shrinking even if option text is very long

### DIFF
--- a/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/src/components/Option/useOptionStyles.styles.ts
@@ -103,6 +103,7 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
 
     display: 'flex',
+    flexShrink: 0,
     alignItems: 'center',
     justifyContent: 'center',
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
As shown in the screenshot below, the ComboBox option's checkbox shrinks for long text.

![スクリーンショット 2024-05-19 10 52 16](https://github.com/microsoft/fluentui/assets/291184/4c700dd2-19b6-4282-ab8d-8eada5d9fdef)


## New Behavior
Checkbox does not shrink even if option text is very long.

| Previous Behavior | New Behavior |
|--------|--------|
| <video src="https://github.com/microsoft/fluentui/assets/291184/54bb0c81-de9d-4830-b610-1e0a4ba87290"> | <video src="https://github.com/microsoft/fluentui/assets/291184/013c6037-2b43-41bc-b075-cccce80189e8"> |

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
