### PR TITLE
feat: improve type-checking perf within  all apps

### DIFF
--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -9,7 +9,7 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "type-check": "tsc -p . --noEmit",
+    "type-check": "just-scripts type-check",
     "test:perf": "just-scripts perf-test"
   },
   "devDependencies": {

--- a/apps/perf-test-react-components/tsconfig.app.json
+++ b/apps/perf-test-react-components/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2019",
+    "outDir": "lib",
+    "jsx": "react",
+    "lib": ["ES2019", "DOM"],
+    "types": ["webpack-env"]
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"]
+}

--- a/apps/perf-test-react-components/tsconfig.json
+++ b/apps/perf-test-react-components/tsconfig.json
@@ -1,14 +1,21 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "outDir": "lib",
     "module": "commonjs",
+    "target": "ES2019",
+    "noEmit": true,
+    "isolatedModules": true,
+    "importHelpers": true,
     "jsx": "react",
-    "experimentalDecorators": true,
+    "noUnusedLocals": true,
     "preserveConstEnums": true,
-    "lib": ["ES2019", "DOM"],
-    "types": ["webpack-env"]
+    "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": [],
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
 }

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -9,7 +9,7 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "type-check": "tsc -p . --noEmit",
+    "type-check": "just-scripts type-check",
     "test:perf": "just-scripts perf-test"
   },
   "devDependencies": {

--- a/apps/perf-test/tsconfig.app.json
+++ b/apps/perf-test/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES5",
+    "outDir": "lib",
+    "jsx": "react",
+    "lib": ["ES2015", "DOM"],
+    "types": ["webpack-env", "node"]
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"]
+}

--- a/apps/perf-test/tsconfig.json
+++ b/apps/perf-test/tsconfig.json
@@ -2,13 +2,15 @@
   "extends": "../../tsconfig.base.v8.json",
   "compilerOptions": {
     "target": "es5",
-    "outDir": "lib",
     "module": "commonjs",
-    "jsx": "react",
     "experimentalDecorators": true,
-    "preserveConstEnums": true,
-    "lib": ["ES2015", "DOM"],
-    "types": ["webpack-env", "node"]
+    "preserveConstEnums": true
   },
-  "include": ["src"]
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
 }

--- a/apps/public-docsite-v9/.storybook/preview.js
+++ b/apps/public-docsite-v9/.storybook/preview.js
@@ -1,5 +1,6 @@
 import * as rootPreview from '../../../.storybook/preview';
 
+// TODO: These custom Docs implementations should be part of custom SB addon/storybook components package
 import { FluentDocsContainer } from '../src/DocsComponents/FluentDocsContainer.stories';
 import { FluentDocsPage } from '../src/DocsComponents/FluentDocsPage.stories';
 

--- a/apps/public-docsite-v9/.storybook/tsconfig.json
+++ b/apps/public-docsite-v9/.storybook/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
+    "jsx": "react",
     "types": ["node", "static-assets", "storybook__addons"]
   },
   "include": ["*.js"]

--- a/apps/public-docsite-v9/tsconfig.json
+++ b/apps/public-docsite-v9/tsconfig.json
@@ -7,8 +7,7 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,
-    "noImplicitAny": true,
-    "types": ["webpack-env"]
+    "noImplicitAny": true
   },
   "include": [],
   "files": [],

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -4,7 +4,7 @@
   "version": "8.0.0",
   "private": true,
   "scripts": {
-    "type-check": "tsc -p tsconfig.react-compat-check.json",
+    "type-check": "just-scripts type-check",
     "format": "prettier -w . --ignore-path ../.prettierignore",
     "format:check": "yarn format -c",
     "e2e": "cypress run --component",

--- a/apps/react-18-tests-v8/tsconfig.react-compat-check.json
+++ b/apps/react-18-tests-v8/tsconfig.react-compat-check.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.app.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "paths": {}
-  }
-}

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "type-check": "tsc -p tsconfig.react-compat-check.json",
+    "type-check": "just-scripts type-check",
     "lint": "eslint --ext .js,.ts,.tsx ./src",
     "test": "jest --passWithNoTests",
     "format": "prettier -w . --ignore-path ../.prettierignore",

--- a/apps/react-18-tests-v9/tsconfig.react-compat-check.json
+++ b/apps/react-18-tests-v9/tsconfig.react-compat-check.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.app.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "paths": {}
-  }
-}

--- a/apps/recipes-react-components/package.json
+++ b/apps/recipes-react-components/package.json
@@ -9,7 +9,7 @@
     "format": "prettier . -w --ignore-path ../../.prettierignore",
     "lint": "just-scripts lint",
     "start": "start-storybook",
-    "type-check": "tsc"
+    "type-check": "just-scripts type-check"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/apps/ssr-tests-v9/package.json
+++ b/apps/ssr-tests-v9/package.json
@@ -14,7 +14,7 @@
     "lint": "just-scripts lint",
     "storybook": "start-storybook",
     "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
+    "type-check": "just-scripts type-check",
     "test-ssr": "test-ssr \"./src/stories/**/*.stories.tsx\""
   },
   "dependencies": {

--- a/apps/ssr-tests/package.json
+++ b/apps/ssr-tests/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@fluentui/react": "*",
-    "@microsoft/load-themed-styles": "^1.10.26",
     "@types/mocha": "7.0.2",
-    "@fluentui/public-docsite-resources": "*",
     "mocha": "7.2.0",
+    "@microsoft/load-themed-styles": "^1.10.26",
     "@fluentui/scripts-tasks": "*",
-    "@fluentui/scripts-webpack": "*"
+    "@fluentui/scripts-webpack": "*",
+    "@fluentui/react": "*",
+    "@fluentui/public-docsite-resources": "*"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/apps/ssr-tests/package.json
+++ b/apps/ssr-tests/package.json
@@ -4,6 +4,7 @@
   "description": "Server-side rendering tests for @fluentui/react.",
   "private": true,
   "scripts": {
+    "type-check": "tsc -p . --noEmit --baseUrl .",
     "build": "just-scripts build",
     "bundle": "just-scripts bundle",
     "test": "just-scripts test",

--- a/apps/ssr-tests/test/test.js
+++ b/apps/ssr-tests/test/test.js
@@ -32,6 +32,12 @@ describe('Fabric components', () => {
     let links = AppDefinition.examplePages[i].links;
     for (let j = 0; j < links.length; j++) {
       let { key, component } = links[j];
+      if (!key) {
+        throw new Error(`Component key (current value "${key}") is missing for ${component}`);
+      }
+      if (!component) {
+        throw new Error(`Component (current value "${component}") is missing for ${key}`);
+      }
 
       testRender(key, component);
     }
@@ -55,7 +61,7 @@ describe('Utilities', () => {
 /**
  *
  * @param {string} componentName
- * @param {React.FunctionComponent} component
+ * @param {React.ComponentClass | (() => JSX.Element)} component
  */
 function testRender(componentName, component) {
   it(`${componentName} can render in a server environment`, done => {

--- a/apps/ssr-tests/test/test.js
+++ b/apps/ssr-tests/test/test.js
@@ -52,6 +52,11 @@ describe('Utilities', () => {
   });
 });
 
+/**
+ *
+ * @param {string} componentName
+ * @param {React.FunctionComponent} component
+ */
 function testRender(componentName, component) {
   it(`${componentName} can render in a server environment`, done => {
     let elem = React.createElement(component);
@@ -59,7 +64,7 @@ function testRender(componentName, component) {
     try {
       ReactDOMServer.renderToString(elem);
       done();
-    } catch (e) {
+    } catch (/** @type {any} */ e) {
       done(new Error(e));
     }
   });

--- a/apps/ssr-tests/tsconfig.json
+++ b/apps/ssr-tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "preserveConstEnums": true,
+    "checkJs": true,
+    "allowJs": true,
+    "types": ["node", "mocha"]
+  },
+  "include": ["test/"]
+}

--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -10,7 +10,7 @@
     "lint": "just-scripts lint",
     "start": "start-storybook",
     "test": "just-scripts test",
-    "type-check": "tsc",
+    "type-check": "tsc -p . --noEmit --baseUrl .",
     "vr:build": "yarn build",
     "vr:test": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true"
   },

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -10,7 +10,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "start-storybook -p 3000",
-    "type-check": "tsc",
+    "type-check": "tsc -p . --noEmit --baseUrl .",
     "vr:build": "yarn build",
     "vr:test": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true"
   },

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -24,6 +24,6 @@
     "perf:test:debug": "cross-env PERF=true gulp perf:debug --debug",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
-    "type-check": "tsc -p ."
+    "type-check": "tsc -p . --noEmit --baseUrl ."
   }
 }

--- a/scripts/tasks/src/utils.ts
+++ b/scripts/tasks/src/utils.ts
@@ -30,20 +30,24 @@ export function getTsPathAliasesConfig() {
   const tsConfigFileNames = {
     root: 'tsconfig.json',
     lib: 'tsconfig.lib.json',
+    app: 'tsconfig.app.json',
   };
   const tsConfigFilePaths = {
     root: path.join(cwd, tsConfigFileNames.root),
     lib: path.join(cwd, tsConfigFileNames.lib),
+    app: path.join(cwd, tsConfigFileNames.app),
   };
   const tsConfigFileContents = {
     root: fs.existsSync(tsConfigFilePaths.root) ? fs.readFileSync(tsConfigFilePaths.root, 'utf-8') : null,
     lib: fs.existsSync(tsConfigFilePaths.lib) ? fs.readFileSync(tsConfigFilePaths.lib, 'utf-8') : null,
+    app: fs.existsSync(tsConfigFilePaths.app) ? fs.readFileSync(tsConfigFilePaths.app, 'utf-8') : null,
   };
   const tsConfigs = {
     root: tsConfigFileContents.root
       ? (parseJson(tsConfigFileContents.root, { expectComments: true }) as TsConfig)
       : null,
     lib: tsConfigFileContents.lib ? (parseJson(tsConfigFileContents.lib, { expectComments: true }) as TsConfig) : null,
+    app: tsConfigFileContents.app ? (parseJson(tsConfigFileContents.app, { expectComments: true }) as TsConfig) : null,
   };
   const packageJson: PackageJson = JSON.parse(fs.readFileSync(path.join(cwd, './package.json'), 'utf-8'));
 
@@ -51,7 +55,7 @@ export function getTsPathAliasesConfig() {
     tsConfigs.root &&
     tsConfigs.root.references &&
     tsConfigs.root.references.length > 0 &&
-    Boolean(tsConfigFileContents.lib);
+    (Boolean(tsConfigFileContents.lib) || Boolean(tsConfigFileContents.app));
 
   return {
     tsConfigFileNames,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- applies new performant `type-check` command to all apps applicable
- normalizes some apps tsconfig setup with ts solution config pattern
- adds TS setup and type checking for ssr-test v8 app

_Applications type-checking perf improvements:_

| app | Before | After / Delta |
|--------|--------|--------|
| vr-tests | 9.37s | 2.82s / 𝚫70% 🚅|
| vr-tests-react-components | 14s | 5s / 𝚫64% 🚅|
| ssr-tests-v9 | 27.8s | 3.41s / 𝚫88% 🚅|
| recipes-react-components | 12.44s | 2.17s / 𝚫83% 🚅| 
| perf-test-react-components |  12s  | 1.33s  / 𝚫89% 🚅 |
| perf-test |  7s  | 1.74s  /  𝚫75%  🚅 |
| perf | 10.26s |  1.73s / 𝚫83% 🚅 |

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30516
