### PR TITLE
fix(web-components): add default Badge values and fix iconPosition story

### DIFF
--- a/packages/web-components/src/badge/badge.stories.ts
+++ b/packages/web-components/src/badge/badge.stories.ts
@@ -31,7 +31,7 @@ const storyTemplate = html<BadgeStoryArgs>`
     ${when(
       x => x.iconPosition === 'end',
       html<BadgeStoryArgs>`<svg
-        slot="start"
+        slot="end"
         aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -52,39 +52,65 @@ export default {
   title: 'Components/Badge/Badge',
   args: {
     content: null,
+    appearance: BadgeAppearance.filled,
+    color: BadgeColor.brand,
+    shape: BadgeShape.circular,
+    size: BadgeSize.medium,
+    iconPosition: 'none',
   },
   argTypes: {
     appearance: {
-      options: Object.values(BadgeAppearance),
+      description: 'Sets the appearance of the badge to one of the predefined styles',
+      table: {
+        defaultValue: { summary: BadgeAppearance.filled },
+      },
       control: {
         type: 'select',
+        options: Object.values(BadgeAppearance),
       },
     },
     color: {
-      options: Object.values(BadgeColor),
+      description: 'Sets the color of the badge to one of the predefined colors',
+      table: {
+        defaultValue: { summary: BadgeColor.brand },
+      },
       control: {
         type: 'select',
+        options: Object.values(BadgeColor),
       },
     },
     shape: {
-      options: Object.values(BadgeShape),
+      description: 'Sets the shape of the badge to one of the predefined shapes',
+      table: {
+        defaultValue: { summary: BadgeShape.circular },
+      },
       control: {
         type: 'select',
+        options: Object.values(BadgeShape),
       },
     },
     size: {
-      options: Object.values(BadgeSize),
+      description: 'Sets the size of the badge to one of the predefined sizes',
+      table: {
+        defaultValue: { summary: BadgeSize.medium },
+      },
       control: {
         type: 'select',
+        options: Object.values(BadgeSize),
       },
     },
     iconPosition: {
-      options: ['none', 'start', 'end'],
+      description: 'Sets the position of the icon to start or end of the badge content',
+      table: {
+        defaultValue: { summary: 'none' },
+      },
       control: {
         type: 'select',
+        options: ['none', 'start', 'end'],
       },
     },
     content: {
+      description: 'Sets the content of the badge',
       control: 'text',
     },
   },


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

I noticed there were no defaults args in the Badge documentation. There was also a broken story for `Badge.iconPosition` when setting it to `end` due to a `slot` attribute error (`slot="start"`).

## New Behavior

- Added defaults and descriptions to the argType options
- Updated slot attribute on SVG to put it in the correct position (`slot="end"`).  

![Screenshot of updated Badge args table in Storybook](https://github.com/microsoft/fluentui/assets/42218/b58aa5e3-0828-4a55-9278-2ecc5db3a145)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
