### PR TITLE
(web-components) call click in button keydownHandler

### DIFF
--- a/change/@fluentui-web-components-b3fafaa6-c49f-4778-872d-2bf39a9ecab2.json
+++ b/change/@fluentui-web-components-b3fafaa6-c49f-4778-872d-2bf39a9ecab2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use click() instead of press() in button keydownHandler",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.ts
+++ b/packages/web-components/src/button/button.ts
@@ -378,7 +378,7 @@ export class Button extends FASTElement {
     }
 
     if (e.key === keyEnter || e.key === keySpace) {
-      this.press();
+      this.click();
       return;
     }
 


### PR DESCRIPTION
## Previous Behavior

The `keydownHandler` function calls `this.press()`, which does the action but doesn't do it in the same way as described in the spec. Pressing `space` or `enter` on a button should call the `click` function.

## New Behavior

The `keydownHandler` calls `this.click()` when the space or enter key is pressed.
