### PR TITLE
docs: Surfacing `Dropdown` and `Combobox` prop comments to docsite

### DIFF
--- a/change/@fluentui-react-combobox-a54806f1-3231-45ec-b382-a32664cad6a0.json
+++ b/change/@fluentui-react-combobox-a54806f1-3231-45ec-b382-a32664cad6a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: Surfacing Dropdown and Combobox prop comments to docsite.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-combobox/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/etc/react-combobox.api.md
@@ -201,7 +201,7 @@ export type OptionGroupSlots = {
 // @public
 export type OptionGroupState = ComponentState<OptionGroupSlots>;
 
-// @public (undocumented)
+// @public
 export type OptionOnSelectData = {
     optionValue: string | undefined;
     optionText: string | undefined;
@@ -249,7 +249,7 @@ export const renderOption_unstable: (state: OptionState) => JSX.Element;
 // @public
 export const renderOptionGroup_unstable: (state: OptionGroupState) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type SelectionEvents = React_2.ChangeEvent<HTMLElement> | React_2.KeyboardEvent<HTMLElement> | React_2.MouseEvent<HTMLElement>;
 
 // @internal

--- a/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Combobox/Combobox.types.ts
@@ -12,19 +12,19 @@ import type {
 import { Listbox } from '../Listbox/Listbox';
 
 export type ComboboxSlots = {
-  /* The root combobox slot */
+  /** The root combobox slot */
   root: NonNullable<Slot<'div'>>;
 
-  /* The dropdown arrow icon */
+  /** The dropdown arrow icon */
   expandIcon?: Slot<'span'>;
 
-  /* The dropdown clear icon */
+  /** The dropdown clear icon */
   clearIcon?: Slot<'span'>;
 
-  /* The primary slot, an input with role="combobox" */
+  /** The primary slot, an input with role="combobox" */
   input: NonNullable<Slot<'input'>>;
 
-  /* The dropdown listbox slot */
+  /** The dropdown listbox slot */
   listbox?: Slot<typeof Listbox>;
 };
 
@@ -34,7 +34,7 @@ export type ComboboxSlots = {
 export type ComboboxProps = Omit<ComponentProps<Partial<ComboboxSlots>, 'input'>, 'children' | 'size'> &
   ComboboxBaseProps & {
     freeform?: boolean;
-    /*
+    /**
      * The primary slot, `<input>`, does not support children so we need to explicitly include it here.
      */
     children?: React.ReactNode;

--- a/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-components/react-combobox/src/components/Dropdown/Dropdown.types.ts
@@ -11,19 +11,19 @@ import type {
 import { Listbox } from '../Listbox/Listbox';
 
 export type DropdownSlots = {
-  /* The root dropdown slot */
+  /** The root dropdown slot */
   root: NonNullable<Slot<'div'>>;
 
-  /* The dropdown arrow icon */
+  /** The dropdown arrow icon */
   expandIcon?: Slot<'span'>;
 
-  /* The dropdown clear icon */
+  /** The dropdown clear icon */
   clearButton?: Slot<'button'>;
 
-  /* The primary slot, the element with role="combobox" */
+  /** The primary slot, the element with role="combobox" */
   button: NonNullable<Slot<'button'>>;
 
-  /* The dropdown listbox slot */
+  /** The dropdown listbox slot */
   listbox?: Slot<typeof Listbox>;
 };
 
@@ -37,7 +37,7 @@ export type DropdownProps = ComponentProps<Partial<DropdownSlots>, 'button'> & C
  */
 export type DropdownState = ComponentState<DropdownSlots> &
   Omit<ComboboxBaseState, 'freeform'> & {
-    /* Whether the placeholder is currently displayed */
+    /** Whether the placeholder is currently displayed */
     placeholderVisible: boolean;
 
     showClearButton?: boolean;

--- a/packages/react-components/react-combobox/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/src/components/Listbox/Listbox.types.ts
@@ -9,7 +9,7 @@ import { SelectionEvents, SelectionProps, SelectionState } from '../../utils/Sel
 import type { ListboxContextValue } from '../../contexts/ListboxContext';
 
 export type ListboxSlots = {
-  /* The root slot, a `<div>` with `role="listbox"` */
+  /** The root slot, a `<div>` with `role="listbox"` */
   root: Slot<'div'>;
 };
 

--- a/packages/react-components/react-combobox/src/components/Option/Option.types.ts
+++ b/packages/react-components/react-combobox/src/components/Option/Option.types.ts
@@ -2,10 +2,10 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import * as React from 'react';
 
 export type OptionSlots = {
-  /* The root option slot, with role="option" */
+  /** The root option slot, with role="option" */
   root: NonNullable<Slot<'div'>>;
 
-  /* The check icon that is visible for selected options */
+  /** The check icon that is visible for selected options */
   checkIcon: Slot<'span'>;
 };
 
@@ -19,7 +19,7 @@ export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
    */
   disabled?: boolean;
 
-  /*
+  /**
    * Defines a unique identifier for the option.
    * Use this to control selectedOptions, or to get the option value in the onOptionSelect callback.
    * Defaults to `text` if not provided.
@@ -62,9 +62,9 @@ export type OptionState = ComponentState<OptionSlots> &
      */
     focusVisible: boolean;
 
-    /* If true, the option is part of a multiselect combobox or listbox */
+    /** If true, the option is part of a multiselect combobox or listbox */
     multiselect?: boolean;
 
-    /* If true, the option is selected */
+    /** If true, the option is selected */
     selected: boolean;
   };

--- a/packages/react-components/react-combobox/src/components/OptionGroup/OptionGroup.types.ts
+++ b/packages/react-components/react-combobox/src/components/OptionGroup/OptionGroup.types.ts
@@ -1,10 +1,10 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type OptionGroupSlots = {
-  /* The root group wrapper */
+  /** The root group wrapper */
   root: NonNullable<Slot<'div'>>;
 
-  /*
+  /**
    * The option group label, displayed as static text before the child options.
    * If not using label, it's recommended to set `aria-label` directly on the OptionGroup instead.
    */

--- a/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/src/utils/ComboboxBase.types.ts
@@ -141,7 +141,7 @@ export type ComboboxBaseOpenChangeData = {
   open: boolean;
 };
 
-/* Possible event types for onOpen */
+/** Possible event types for onOpen */
 export type ComboboxBaseOpenEvents =
   | React.MouseEvent<HTMLElement>
   | React.KeyboardEvent<HTMLElement>

--- a/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/OptionCollection.types.ts
@@ -40,6 +40,6 @@ export type OptionCollectionState = {
   /** The unordered option data. */
   options: OptionValue[];
 
-  /* A function that child options call to register their values. Returns a function to unregister the option. */
+  /** A function that child options call to register their values. Returns a function to unregister the option. */
   registerOption: (option: OptionValue, element: HTMLElement) => () => void;
 };

--- a/packages/react-components/react-combobox/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/src/utils/Selection.types.ts
@@ -16,7 +16,7 @@ export type SelectionProps = {
    */
   multiselect?: boolean;
 
-  /* Callback when an option is selected */
+  /** Callback when an option is selected */
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- can't change type of existing callback
   onOptionSelect?: (event: SelectionEvents, data: OptionOnSelectData) => void;
 
@@ -28,14 +28,14 @@ export type SelectionProps = {
   selectedOptions?: string[];
 };
 
-/* Values returned by the useSelection hook */
+/** Values returned by the useSelection hook */
 export type SelectionState = {
   clearSelection: (event: SelectionEvents) => void;
   selectedOptions: string[];
   selectOption: (event: SelectionEvents, option: OptionValue) => void;
 };
 
-/*
+/**
  * Data for the onOptionSelect callback.
  * `optionValue` and `optionText` will be undefined if multiple options are modified at once.
  */
@@ -45,7 +45,7 @@ export type OptionOnSelectData = {
   selectedOptions: string[];
 };
 
-/* Possible event types for onOptionSelect */
+/** Possible event types for onOptionSelect */
 export type SelectionEvents =
   | React.ChangeEvent<HTMLElement>
   | React.KeyboardEvent<HTMLElement>


### PR DESCRIPTION
## Previous Behavior

The documentation comments of some props in `Dropdown` and `Combobox` were not being correctly surfaced to the docsite.

## New Behavior

This was happening because some of the comments had `/*` instead of `/**`, which is what indicates the docsite which comments to surface. This PR fixes this issue so that those comments are correctly surfaced now.

## Related Issue(s)

- Fixes #31252
