### PR TITLE
deprecate(react-drawer): deprecate `defaultOpen` prop as it is not being used

### DIFF
--- a/change/@fluentui-react-drawer-833b3b3a-a24f-4bc8-8748-7e3584d7727a.json
+++ b/change/@fluentui-react-drawer-833b3b3a-a24f-4bc8-8748-7e3584d7727a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "deprecate defaultOpen as it is not being used",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-833b3b3a-a24f-4bc8-8748-7e3584d7727a.json
+++ b/change/@fluentui-react-drawer-833b3b3a-a24f-4bc8-8748-7e3584d7727a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "deprecate defaultOpen as it is not being used",
+  "comment": "deprecate: defaultOpen as it is not being used",
   "packageName": "@fluentui/react-drawer",
   "email": "marcosvmmoura@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-drawer/etc/react-drawer.api.md
+++ b/packages/react-components/react-drawer/etc/react-drawer.api.md
@@ -158,7 +158,9 @@ export const OverlayDrawer: ForwardRefComponent<OverlayDrawerProps>;
 export const overlayDrawerClassNames: SlotClassNames<OverlayDrawerSurfaceSlots>;
 
 // @public
-export type OverlayDrawerProps = ComponentProps<OverlayDrawerSlots> & Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus' | 'defaultOpen'> & DrawerBaseProps;
+export type OverlayDrawerProps = ComponentProps<OverlayDrawerSlots> & Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus'> & DrawerBaseProps & {
+    defaultOpen?: boolean;
+};
 
 // @public
 export type OverlayDrawerSlots = {

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.types.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/OverlayDrawer.types.ts
@@ -28,8 +28,14 @@ export type OverlayDrawerInternalSlots = OverlayDrawerSlots & {
  * OverlayDrawer Props
  */
 export type OverlayDrawerProps = ComponentProps<OverlayDrawerSlots> &
-  Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus' | 'defaultOpen'> &
-  DrawerBaseProps;
+  Pick<DialogProps, 'modalType' | 'onOpenChange' | 'inertTrapFocus'> &
+  DrawerBaseProps & {
+    /**
+     * @deprecated OverlayDrawer can work only as a controlled component
+     * and does not support uncontrolled mode i.e. defaultOpen prop
+     */
+    defaultOpen?: boolean;
+  };
 
 /**
  * State used in rendering OverlayDrawer

--- a/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawer.ts
+++ b/packages/react-components/react-drawer/src/components/OverlayDrawer/useOverlayDrawer.ts
@@ -21,7 +21,7 @@ export const useOverlayDrawer_unstable = (
   ref: React.Ref<HTMLDivElement>,
 ): OverlayDrawerState => {
   const { open, size, position } = useDrawerDefaultProps(props);
-  const { modalType = 'modal', inertTrapFocus, defaultOpen = false, onOpenChange } = props;
+  const { modalType = 'modal', inertTrapFocus, onOpenChange } = props;
 
   const motion = useMotion<HTMLDivElement>(open);
 
@@ -44,7 +44,6 @@ export const useOverlayDrawer_unstable = (
   const dialog = slot.always(
     {
       open,
-      defaultOpen,
       onOpenChange,
       inertTrapFocus,
       modalType,


### PR DESCRIPTION
## Context
This PR adds a deprecation notice for a prop that is not currently in use, but it was introduced when the component was first released.

## Related Issue(s)
- Fixes [#30451](https://github.com/microsoft/fluentui/issues/30451)
