### PR TITLE
chore: bump @griffel/eslint-plugin

### DIFF
--- a/change/@fluentui-eslint-plugin-e10d836e-a2c8-4990-8abc-afdece98a1d8.json
+++ b/change/@fluentui-eslint-plugin-e10d836e-a2c8-4990-8abc-afdece98a1d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump @griffel/eslint-plugin",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@cypress/webpack-dev-server": "1.8.3",
     "@fluentui/react-icons": "^2.0.239",
     "@griffel/babel-preset": "1.5.8",
-    "@griffel/eslint-plugin": "^1.6.2",
+    "@griffel/eslint-plugin": "^1.6.3",
     "@griffel/jest-serializer": "1.1.24",
     "@griffel/react": "^1.5.22",
     "@griffel/shadow-dom": "0.2.2",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -13,7 +13,7 @@
     "test": "yarn jest --passWithNoTests"
   },
   "dependencies": {
-    "@griffel/eslint-plugin": "^1.6.2",
+    "@griffel/eslint-plugin": "^1.6.3",
     "@rnx-kit/eslint-plugin": "^0.2.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/experimental-utils": "^4.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,10 +2022,10 @@
     stylis "^4.2.0"
     tslib "^2.1.0"
 
-"@griffel/eslint-plugin@^1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@griffel/eslint-plugin/-/eslint-plugin-1.6.2.tgz#346f4e0c50a2819e1d745ae095f52f26e35aee90"
-  integrity sha512-HYpGxBo5+U8MzQujA+Qp8cxL85961OeGfi521mFT10tv2JFGRuB2K8OvqOrLYcolUg13pz+WO+X9uqLLmNnucw==
+"@griffel/eslint-plugin@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@griffel/eslint-plugin/-/eslint-plugin-1.6.3.tgz#cb4e9b88e31bcaed5c16e13a6ec60882d49bd938"
+  integrity sha512-Lefrqz/JSZUheA4DeDNOnZtabfL9dyFBrOdIWrN6G7w/gQnPY62KuxvbRymZy4VcwnjAoFitLY5j9TtAHGyH0w==
   dependencies:
     "@typescript-eslint/utils" "^6.18.1"
     csstype "^3.1.3"


### PR DESCRIPTION
## New Behavior

Bumps `@griffel/eslint-plugin` to get https://github.com/microsoft/griffel/pull/562 so CSS shorthands could be actually used.
