### PR TITLE
chore: migrate .shorthands() [cxe-prg]

### DIFF
--- a/change/@fluentui-react-breadcrumb-4eeaf59f-ddc5-4f05-b5cc-2e1845be5e71.json
+++ b/change/@fluentui-react-breadcrumb-4eeaf59f-ddc5-4f05-b5cc-2e1845be5e71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace usage of .shorthands() in styles",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-93553551-d4d5-43d4-a160-4d1e57257eb4.json
+++ b/change/@fluentui-react-card-93553551-d4d5-43d4-a160-4d1e57257eb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace usage of .shorthands() in styles",
+  "packageName": "@fluentui/react-card",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-5e548d8f-ec9a-4119-8488-2685a7f5ea81.json
+++ b/change/@fluentui-react-drawer-5e548d8f-ec9a-4119-8488-2685a7f5ea81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace usage of .shorthands() in styles",
+  "packageName": "@fluentui/react-drawer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-6ccaeb33-e45a-4131-b76b-3d53288e8991.json
+++ b/change/@fluentui-react-image-6ccaeb33-e45a-4131-b76b-3d53288e8991.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace usage of .shorthands() in styles",
+  "packageName": "@fluentui/react-image",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-bb8b313d-b279-4223-a608-8a9cb30f0825.json
+++ b/change/@fluentui-react-swatch-picker-bb8b313d-b279-4223-a608-8a9cb30f0825.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace usage of .shorthands() in styles",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-db6ed1d6-801e-4e99-b5d7-a29619796883.json
+++ b/change/@fluentui-react-text-db6ed1d6-801e-4e99-b5d7-a29619796883.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace usage of .shorthands() in styles",
+  "packageName": "@fluentui/react-text",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { BreadcrumbButtonSlots, BreadcrumbButtonState } from './BreadcrumbButton.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { useButtonStyles_unstable, buttonClassNames } from '@fluentui/react-button';
@@ -70,17 +70,17 @@ const useStyles = makeStyles({
   small: {
     height: '24px',
     ...typographyStyles.caption1,
-    ...shorthands.padding(tokens.spacingHorizontalSNudge),
+    padding: tokens.spacingHorizontalSNudge,
   },
   medium: {
     height: '32px',
     ...typographyStyles.body1,
-    ...shorthands.padding(tokens.spacingHorizontalSNudge),
+    padding: tokens.spacingHorizontalSNudge,
   },
   large: {
     height: '40px',
     ...typographyStyles.body2,
-    ...shorthands.padding(tokens.spacingHorizontalS),
+    padding: tokens.spacingHorizontalS,
   },
   current: {
     ':hover': {

--- a/packages/react-components/react-breadcrumb/stories/Breadcrumb/BreadcrumbWithOverflow.stories.tsx
+++ b/packages/react-components/react-breadcrumb/stories/Breadcrumb/BreadcrumbWithOverflow.stories.tsx
@@ -7,7 +7,6 @@ import {
   partitionBreadcrumbItems,
   ButtonProps,
   makeStyles,
-  shorthands,
   tokens,
   Button,
   Menu,
@@ -109,8 +108,8 @@ const items: Item[] = [
 const useExampleStyles = makeStyles({
   example: {
     backgroundColor: tokens.colorNeutralBackground2,
-    ...shorthands.overflow('hidden'),
-    ...shorthands.padding('5px'),
+    overflow: 'hidden',
+    padding: '5px',
     zIndex: 0, //stop the browser resize handle from piercing the overflow menu
     height: 'fit-content',
     minWidth: '200px',
@@ -122,7 +121,7 @@ const useExampleStyles = makeStyles({
 const useTooltipStyles = makeStyles({
   tooltip: {
     whiteSpace: 'nowrap',
-    ...shorthands.overflow('hidden'),
+    overflow: 'hidden',
     textOverflow: 'ellipsis',
   },
 });

--- a/packages/react-components/react-breadcrumb/stories/Breadcrumb/BreadcrumbWithTooltip.stories.tsx
+++ b/packages/react-components/react-breadcrumb/stories/Breadcrumb/BreadcrumbWithTooltip.stories.tsx
@@ -8,7 +8,6 @@ import {
   truncateBreadcrumbLongName,
   isTruncatableBreadcrumbContent,
   makeStyles,
-  shorthands,
   Tooltip,
   useIsOverflowItemVisible,
   Menu,
@@ -90,7 +89,7 @@ const itemsWithLongNames: Item[] = [
 const useTooltipStyles = makeStyles({
   tooltip: {
     whiteSpace: 'nowrap',
-    ...shorthands.overflow('hidden'),
+    overflow: 'hidden',
     textOverflow: 'ellipsis',
   },
 });

--- a/packages/react-components/react-card/src/components/Card/useCardStyles.styles.ts
+++ b/packages/react-components/react-card/src/components/Card/useCardStyles.styles.ts
@@ -34,10 +34,10 @@ const focusOutlineStyle: Partial<FocusOutlineStyleOptions> = {
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.overflow('hidden'),
-    ...shorthands.borderRadius(`var(${cardCSSVars.cardBorderRadiusVar})`),
-    ...shorthands.padding(`var(${cardCSSVars.cardSizeVar})`),
-    ...shorthands.gap(`var(${cardCSSVars.cardSizeVar})`),
+    overflow: 'hidden',
+    borderRadius: `var(${cardCSSVars.cardBorderRadiusVar})`,
+    padding: `var(${cardCSSVars.cardSizeVar})`,
+    gap: `var(${cardCSSVars.cardSizeVar})`,
 
     display: 'flex',
     position: 'relative',
@@ -56,7 +56,7 @@ const useStyles = makeStyles({
 
       ...shorthands.borderStyle('solid'),
       ...shorthands.borderWidth(tokens.strokeWidthThin),
-      ...shorthands.borderRadius(`var(${cardCSSVars.cardBorderRadiusVar})`),
+      borderRadius: `var(${cardCSSVars.cardBorderRadiusVar})`,
     },
 
     // Prevents CardHeader and CardFooter from shrinking.
@@ -340,7 +340,7 @@ const useStyles = makeStyles({
   },
 
   hiddenCheckbox: {
-    ...shorthands.overflow('hidden'),
+    overflow: 'hidden',
     width: '1px',
     height: '1px',
     position: 'absolute',

--- a/packages/react-components/react-card/src/components/CardFooter/useCardFooterStyles.styles.ts
+++ b/packages/react-components/react-card/src/components/CardFooter/useCardFooterStyles.styles.ts
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'row',
-    ...shorthands.gap('12px'),
+    gap: '12px',
   },
   action: {
     marginLeft: 'auto',

--- a/packages/react-components/react-card/stories/Card/CardAppearance.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardAppearance.stories.tsx
@@ -1,15 +1,5 @@
 import * as React from 'react';
-import {
-  makeStyles,
-  shorthands,
-  tokens,
-  Button,
-  Text,
-  Caption1,
-  Subtitle1,
-  Body1,
-  mergeClasses,
-} from '@fluentui/react-components';
+import { makeStyles, tokens, Button, Text, Caption1, Subtitle1, Body1, mergeClasses } from '@fluentui/react-components';
 import { MoreHorizontal20Regular } from '@fluentui/react-icons';
 import { Card, CardHeader, CardProps } from '@fluentui/react-components';
 
@@ -22,19 +12,15 @@ const resolveAsset = (asset: string) => {
 
 const useStyles = makeStyles({
   main: {
-    ...shorthands.gap('36px'),
+    gap: '36px',
     display: 'flex',
     flexDirection: 'column',
     flexWrap: 'wrap',
   },
 
-  title: {
-    ...shorthands.margin(0, 0, '12px'),
-  },
+  title: { margin: '0 0 12px' },
 
-  description: {
-    ...shorthands.margin(0, 0, '12px'),
-  },
+  description: { margin: '0 0 12px' },
 
   card: {
     width: '480px',
@@ -47,14 +33,12 @@ const useStyles = makeStyles({
   },
 
   logo: {
-    ...shorthands.borderRadius('4px'),
+    borderRadius: '4px',
     width: '48px',
     height: '48px',
   },
 
-  text: {
-    ...shorthands.margin(0),
-  },
+  text: { margin: '0' },
 });
 
 const ExampleHeader = ({ title, description }: Record<string, string>) => {

--- a/packages/react-components/react-card/stories/Card/CardDefault.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { makeStyles, Body1, Caption1, Button, shorthands } from '@fluentui/react-components';
+import { makeStyles, Body1, Caption1, Button } from '@fluentui/react-components';
 import { ArrowReplyRegular, ShareRegular } from '@fluentui/react-icons';
 import { Card, CardFooter, CardHeader, CardPreview } from '@fluentui/react-components';
 
@@ -13,7 +13,7 @@ const resolveAsset = (asset: string) => {
 
 const useStyles = makeStyles({
   card: {
-    ...shorthands.margin('auto'),
+    margin: 'auto',
     width: '720px',
     maxWidth: '100%',
   },

--- a/packages/react-components/react-card/stories/Card/CardFocusMode.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardFocusMode.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Caption1, Body1, Subtitle1 } from '@fluentui/react-components';
+import { makeStyles, Button, Caption1, Body1, Subtitle1 } from '@fluentui/react-components';
 import { MoreHorizontal20Regular, Open16Regular, Share16Regular } from '@fluentui/react-icons';
 import { Card, CardHeader, CardFooter, CardPreview, CardProps } from '@fluentui/react-components';
 
@@ -19,13 +19,9 @@ const useStyles = makeStyles({
     rowGap: '36px',
   },
 
-  title: {
-    ...shorthands.margin(0, 0, '12px'),
-  },
+  title: { margin: '0 0 12px' },
 
-  description: {
-    ...shorthands.margin(0, 0, '12px'),
-  },
+  description: { margin: '0 0 12px' },
 
   card: {
     width: '400px',
@@ -33,9 +29,7 @@ const useStyles = makeStyles({
     height: 'fit-content',
   },
 
-  text: {
-    ...shorthands.margin(0),
-  },
+  text: { margin: '0' },
 });
 
 const Header = ({ title, description }: Record<string, string>) => {

--- a/packages/react-components/react-card/stories/Card/CardOrientation.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardOrientation.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Caption1, Text, tokens, Subtitle1 } from '@fluentui/react-components';
+import { makeStyles, Button, Caption1, Text, tokens, Subtitle1 } from '@fluentui/react-components';
 import { MoreHorizontal20Regular } from '@fluentui/react-icons';
 import { Card, CardHeader, CardPreview } from '@fluentui/react-components';
 
@@ -12,7 +12,7 @@ const resolveAsset = (asset: string) => {
 
 const useStyles = makeStyles({
   main: {
-    ...shorthands.gap('36px'),
+    gap: '36px',
     display: 'flex',
     flexDirection: 'column',
     flexWrap: 'wrap',
@@ -28,9 +28,7 @@ const useStyles = makeStyles({
     width: 'fit-content',
   },
 
-  title: {
-    ...shorthands.margin(0, 0, '12px'),
-  },
+  title: { margin: '0 0 12px' },
 
   horizontalCardImage: {
     width: '64px',
@@ -38,7 +36,7 @@ const useStyles = makeStyles({
   },
 
   headerImage: {
-    ...shorthands.borderRadius('4px'),
+    borderRadius: '4px',
     maxWidth: '44px',
     maxHeight: '44px',
   },
@@ -47,9 +45,7 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
   },
 
-  text: {
-    ...shorthands.margin(0),
-  },
+  text: { margin: '0' },
 });
 
 const Title = ({ children }: React.PropsWithChildren<{}>) => {

--- a/packages/react-components/react-card/stories/Card/CardSelectable.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardSelectable.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Caption1, tokens, Text } from '@fluentui/react-components';
+import { makeStyles, Button, Caption1, tokens, Text } from '@fluentui/react-components';
 import { MoreHorizontal20Regular } from '@fluentui/react-icons';
 import { Card, CardHeader, CardPreview, CardProps } from '@fluentui/react-components';
 
@@ -12,7 +12,7 @@ const resolveAsset = (asset: string) => {
 
 const useStyles = makeStyles({
   main: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexWrap: 'wrap',
   },
@@ -27,17 +27,15 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
   },
 
-  smallRadius: {
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
-  },
+  smallRadius: { borderRadius: tokens.borderRadiusSmall },
 
   grayBackground: {
     backgroundColor: tokens.colorNeutralBackground3,
   },
 
   logoBadge: {
-    ...shorthands.padding('5px'),
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    padding: '5px',
+    borderRadius: tokens.borderRadiusSmall,
     backgroundColor: '#FFF',
     boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
   },

--- a/packages/react-components/react-card/stories/Card/CardSelectableIndicator.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardSelectableIndicator.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Caption1, tokens, Checkbox, Text } from '@fluentui/react-components';
+import { makeStyles, Button, Caption1, tokens, Checkbox, Text } from '@fluentui/react-components';
 import { MoreHorizontal20Regular } from '@fluentui/react-icons';
 import { Card, CardHeader, CardPreview } from '@fluentui/react-components';
 
@@ -11,7 +11,7 @@ const resolveAsset = (asset: string) => {
 };
 
 const flex = {
-  ...shorthands.gap('16px'),
+  gap: '16px',
   display: 'flex',
 };
 
@@ -36,17 +36,15 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground3,
   },
 
-  smallRadius: {
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
-  },
+  smallRadius: { borderRadius: tokens.borderRadiusSmall },
 
   grayBackground: {
     backgroundColor: tokens.colorNeutralBackground3,
   },
 
   logoBadge: {
-    ...shorthands.padding('5px'),
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    padding: '5px',
+    borderRadius: tokens.borderRadiusSmall,
     backgroundColor: '#FFF',
     boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
   },

--- a/packages/react-components/react-card/stories/Card/CardSize.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardSize.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, tokens, shorthands, Caption1, Subtitle1, mergeClasses, Text } from '@fluentui/react-components';
+import { makeStyles, tokens, Caption1, Subtitle1, mergeClasses, Text } from '@fluentui/react-components';
 import { Card, CardHeader, CardProps } from '@fluentui/react-components';
 
 const resolveAsset = (asset: string) => {
@@ -18,9 +18,7 @@ const useStyles = makeStyles({
     rowGap: '36px',
   },
 
-  title: {
-    ...shorthands.margin(0, 0, '12px'),
-  },
+  title: { margin: '0 0 12px' },
 
   card: {
     width: '300px',
@@ -29,14 +27,14 @@ const useStyles = makeStyles({
   },
 
   flex: {
-    ...shorthands.gap('4px'),
+    gap: '4px',
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
   },
 
   appIcon: {
-    ...shorthands.borderRadius('4px'),
+    borderRadius: '4px',
     height: '32px',
   },
 

--- a/packages/react-components/react-card/stories/Card/CardTemplates.stories.tsx
+++ b/packages/react-components/react-card/stories/Card/CardTemplates.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   makeStyles,
-  shorthands,
   tokens,
   Button,
   Text,
@@ -23,7 +22,7 @@ import { Card, CardHeader, CardPreview } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexWrap: 'wrap',
   },
@@ -34,19 +33,15 @@ const useStyles = makeStyles({
   },
 
   flex: {
-    ...shorthands.gap('4px'),
+    gap: '4px',
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
   },
 
-  labels: {
-    ...shorthands.gap('6px'),
-  },
+  labels: { gap: '6px' },
 
-  footer: {
-    ...shorthands.gap('12px'),
-  },
+  footer: { gap: '12px' },
 
   caption: {
     color: tokens.colorNeutralForeground3,
@@ -58,7 +53,7 @@ const useStyles = makeStyles({
   },
 
   grid: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexDirection: 'column',
   },

--- a/packages/react-components/react-card/stories/CardHeader/CardHeaderDefault.stories.tsx
+++ b/packages/react-components/react-card/stories/CardHeader/CardHeaderDefault.stories.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { CardHeader } from '@fluentui/react-components';
-import { makeStyles, shorthands, Button, Body1, Caption1 } from '@fluentui/react-components';
+import { makeStyles, Button, Body1, Caption1 } from '@fluentui/react-components';
 import { MoreHorizontal20Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   container: {
     display: 'flex',
     flexDirection: 'column',
-    ...shorthands.padding('16px'),
-    ...shorthands.gap('16px'),
+    padding: '16px',
+    gap: '16px',
   },
   header: {
     width: '300px',

--- a/packages/react-components/react-drawer/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
 
@@ -18,18 +18,12 @@ const useDrawerResetStyles = makeResetStyles({
 /**
  * Styles for the root slot
  */
-const separatorValues = ['1px', 'solid', tokens.colorNeutralBackground3] as const;
+const borderValue = `1px solid ${tokens.colorNeutralBackground3}`;
 const useDrawerRootStyles = makeStyles({
   /* Separator */
-  separatorStart: {
-    ...shorthands.borderRight(...separatorValues),
-  },
-  separatorEnd: {
-    ...shorthands.borderLeft(...separatorValues),
-  },
-  separatorBottom: {
-    ...shorthands.borderTop(...separatorValues),
-  },
+  separatorStart: { borderRight: borderValue },
+  separatorEnd: { borderLeft: borderValue },
+  separatorBottom: { borderTop: borderValue },
 
   /* Positioning */
   start: {

--- a/packages/react-components/react-drawer/src/shared/useDrawerBaseStyles.styles.ts
+++ b/packages/react-components/react-drawer/src/shared/useDrawerBaseStyles.styles.ts
@@ -1,4 +1,4 @@
-import { type GriffelResetStyle, makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { type GriffelResetStyle, makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 
 import { DrawerBaseState } from './DrawerBase.types';
@@ -48,13 +48,13 @@ const useDrawerStyles = makeStyles({
 
   /* Positioning */
   start: {
-    ...shorthands.borderRight(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+    borderRight: `${tokens.strokeWidthThin} solid ${tokens.colorTransparentStroke}`,
 
     left: 0,
     right: 'auto',
   },
   end: {
-    ...shorthands.borderLeft(tokens.strokeWidthThin, 'solid', tokens.colorTransparentStroke),
+    borderLeft: `${tokens.strokeWidthThin} solid ${tokens.colorTransparentStroke}`,
 
     right: 0,
     left: 'auto',

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerAlwaysOpen.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerAlwaysOpen.stories.tsx
@@ -1,25 +1,18 @@
 import * as React from 'react';
-import {
-  DrawerBody,
-  DrawerHeader,
-  DrawerHeaderTitle,
-  InlineDrawer,
-  makeStyles,
-  shorthands,
-} from '@fluentui/react-components';
+import { DrawerBody, DrawerHeader, DrawerHeaderTitle, InlineDrawer, makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
     display: 'flex',
     height: '480px',
     backgroundColor: '#fff',
   },
 
   content: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
+    flex: '1',
+    padding: '16px',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'flex-start',

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerDefault.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerDefault.stories.tsx
@@ -10,7 +10,6 @@ import {
   Radio,
   RadioGroup,
   makeStyles,
-  shorthands,
   tokens,
   useId,
 } from '@fluentui/react-components';
@@ -18,8 +17,8 @@ import { Dismiss24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
 
     display: 'flex',
     height: '480px',
@@ -27,8 +26,8 @@ const useStyles = makeStyles({
   },
 
   content: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
+    flex: '1',
+    padding: '16px',
 
     display: 'grid',
     justifyContent: 'flex-start',

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerMotionCustom.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerMotionCustom.stories.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   makeStyles,
   mergeClasses,
-  shorthands,
   // tokens,
   DrawerBody,
   DrawerHeader,
@@ -32,8 +31,8 @@ import { Dismiss24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
     display: 'flex',
     height: '480px',
     position: 'relative',
@@ -42,9 +41,8 @@ const useStyles = makeStyles({
   },
 
   content: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
-
+    flex: '1',
+    padding: '16px',
     boxSizing: 'border-box',
     overflowY: 'auto',
     position: 'absolute',

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerMotionDisabled.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerMotionDisabled.stories.tsx
@@ -10,7 +10,6 @@ import {
   Radio,
   RadioGroup,
   makeStyles,
-  shorthands,
   tokens,
   useId,
 } from '@fluentui/react-components';
@@ -18,8 +17,8 @@ import { Dismiss24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
 
     display: 'flex',
     height: '480px',
@@ -31,8 +30,8 @@ const useStyles = makeStyles({
   },
 
   content: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
+    flex: '1',
+    padding: '16px',
 
     display: 'grid',
     justifyContent: 'flex-start',

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerMultipleLevels.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerMultipleLevels.stories.tsx
@@ -11,7 +11,6 @@ import {
   ToolbarGroup,
   ToolbarButton,
   makeStyles,
-  shorthands,
   tokens,
   mergeClasses,
 } from '@fluentui/react-components';
@@ -24,8 +23,7 @@ const useStyles = makeStyles({
   },
 
   body: {
-    ...shorthands.flex(1),
-
+    flex: '1',
     width: '100%',
     maxWidth: '100%',
     position: 'relative',

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerResizable.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerResizable.stories.tsx
@@ -6,14 +6,13 @@ import {
   InlineDrawer,
   makeStyles,
   mergeClasses,
-  shorthands,
   tokens,
 } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
 
     display: 'flex',
     height: '480px',
@@ -36,7 +35,7 @@ const useStyles = makeStyles({
   },
 
   resizer: {
-    ...shorthands.borderRight('1px', 'solid', tokens.colorNeutralBackground5),
+    borderRight: `1px solid ${tokens.colorNeutralBackground5}`,
 
     width: '8px',
     position: 'absolute',
@@ -57,8 +56,8 @@ const useStyles = makeStyles({
   },
 
   content: {
-    ...shorthands.margin(tokens.spacingVerticalXL, tokens.spacingHorizontalXL),
-    ...shorthands.flex(1),
+    margin: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalXL}`,
+    flex: '1',
   },
 });
 

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerResponsive.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerResponsive.stories.tsx
@@ -7,15 +7,14 @@ import {
   DrawerProps,
   Button,
   makeStyles,
-  shorthands,
   tokens,
 } from '@fluentui/react-components';
 import { Dismiss24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
 
     display: 'flex',
     height: '480px',
@@ -23,8 +22,8 @@ const useStyles = makeStyles({
   },
 
   content: {
-    ...shorthands.margin(tokens.spacingVerticalXL, tokens.spacingHorizontalXL),
-    ...shorthands.flex(1),
+    margin: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalXL}`,
+    flex: '1',
 
     gridRowGap: tokens.spacingVerticalXXL,
   },

--- a/packages/react-components/react-drawer/stories/Drawer/DrawerSeparator.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/DrawerSeparator.stories.tsx
@@ -6,7 +6,6 @@ import {
   InlineDrawer,
   Button,
   makeStyles,
-  shorthands,
   tokens,
   DrawerProps,
   mergeClasses,
@@ -15,16 +14,16 @@ import { Dismiss24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
     display: 'flex',
     height: '480px',
     backgroundColor: '#fff',
   },
 
   content: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
+    flex: '1',
+    padding: '16px',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'flex-start',

--- a/packages/react-components/react-drawer/stories/Drawer/InlineDrawer.stories.tsx
+++ b/packages/react-components/react-drawer/stories/Drawer/InlineDrawer.stories.tsx
@@ -6,7 +6,6 @@ import {
   InlineDrawer,
   Button,
   makeStyles,
-  shorthands,
   tokens,
   DrawerProps,
   mergeClasses,
@@ -15,8 +14,8 @@ import { Dismiss24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   root: {
-    ...shorthands.border('2px', 'solid', '#ccc'),
-    ...shorthands.overflow('hidden'),
+    border: '2px solid #ccc',
+    overflow: 'hidden',
 
     display: 'flex',
     height: '480px',
@@ -24,9 +23,9 @@ const useStyles = makeStyles({
   },
 
   content: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
-    ...shorthands.overflow('auto'),
+    flex: '1',
+    padding: '16px',
+    overflow: 'auto',
 
     position: 'relative',
   },
@@ -36,8 +35,8 @@ const useStyles = makeStyles({
   },
 
   buttons: {
-    ...shorthands.flex(1),
-    ...shorthands.padding('16px'),
+    flex: '1',
+    padding: '16px',
 
     position: 'sticky',
     top: '-16px',

--- a/packages/react-components/react-image/src/components/Image/useImageStyles.styles.ts
+++ b/packages/react-components/react-image/src/components/Image/useImageStyles.styles.ts
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
   // Base styles
   base: {
     ...shorthands.borderColor(tokens.colorNeutralStroke1),
-    ...shorthands.borderRadius(tokens.borderRadiusNone),
+    borderRadius: tokens.borderRadiusNone,
 
     boxSizing: 'border-box',
     display: 'inline-block',
@@ -24,12 +24,8 @@ const useStyles = makeStyles({
   },
 
   // Shape variations
-  circular: {
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-  },
-  rounded: {
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-  },
+  circular: { borderRadius: tokens.borderRadiusCircular },
+  rounded: { borderRadius: tokens.borderRadiusMedium },
   square: {
     /* The square styles are exactly the same as the base styles. */
   },

--- a/packages/react-components/react-motion-preview/stories/UseMotion/UseMotion.stories.tsx
+++ b/packages/react-components/react-motion-preview/stories/UseMotion/UseMotion.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useMotion } from '@fluentui/react-motion-preview';
-import { Button, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
+import { Button, makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
   },
 
   rectangle: {
-    ...shorthands.borderRadius('8px'),
+    borderRadius: '8px',
 
     width: '150px',
     height: '100px',

--- a/packages/react-components/react-motion-preview/stories/UseMotion/UseMotionClassNames.stories.tsx
+++ b/packages/react-components/react-motion-preview/stories/UseMotion/UseMotionClassNames.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useMotion, useMotionClassNames } from '@fluentui/react-motion-preview';
-import { Button, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Button, makeStyles, tokens } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
   },
 
   rectangle: {
-    ...shorthands.borderRadius('8px'),
+    borderRadius: '8px',
 
     width: '150px',
     height: '100px',

--- a/packages/react-components/react-motion-preview/stories/UseMotion/UseMotionWithDuration.stories.tsx
+++ b/packages/react-components/react-motion-preview/stories/UseMotion/UseMotionWithDuration.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useMotion } from '@fluentui/react-motion-preview';
-import { Button, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
+import { Button, makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
 
 const DURATION = 500;
 const useStyles = makeStyles({
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   },
 
   rectangle: {
-    ...shorthands.borderRadius('8px'),
+    borderRadius: '8px',
 
     width: '150px',
     height: '100px',

--- a/packages/react-components/react-swatch-picker/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { ColorSwatchSlots, ColorSwatchState } from './ColorSwatch.types';
 import { tokens } from '@fluentui/react-theme';
@@ -72,7 +72,7 @@ const useStyles = makeStyles({
     },
   },
   selected: {
-    ...shorthands.border('none'),
+    border: 'none',
     boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
     ':hover': {
       boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
@@ -110,22 +110,16 @@ const useSizeStyles = makeStyles({
 
 const useShapeStyles = makeStyles({
   rounded: {
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    }),
+    borderRadius: tokens.borderRadiusMedium,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusMedium }),
   },
   circular: {
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    }),
+    borderRadius: tokens.borderRadiusCircular,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusCircular }),
   },
   square: {
-    ...shorthands.borderRadius(tokens.borderRadiusNone),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusNone),
-    }),
+    borderRadius: tokens.borderRadiusNone,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusNone }),
   },
 });
 

--- a/packages/react-components/react-swatch-picker/src/components/EmptySwatch/useEmptySwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/src/components/EmptySwatch/useEmptySwatchStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { EmptySwatchSlots, EmptySwatchState } from './EmptySwatch.types';
 import { tokens } from '@fluentui/react-theme';
@@ -37,22 +37,16 @@ const useSizeStyles = makeStyles({
 
 const useShapeStyles = makeStyles({
   rounded: {
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    }),
+    borderRadius: tokens.borderRadiusMedium,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusMedium }),
   },
   circular: {
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    }),
+    borderRadius: tokens.borderRadiusCircular,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusCircular }),
   },
   square: {
-    ...shorthands.borderRadius(tokens.borderRadiusNone),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusNone),
-    }),
+    borderRadius: tokens.borderRadiusNone,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusNone }),
   },
 });
 

--- a/packages/react-components/react-swatch-picker/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, makeResetStyles, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses, makeResetStyles } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { ImageSwatchSlots, ImageSwatchState } from './ImageSwatch.types';
 import { tokens } from '@fluentui/react-theme';
@@ -54,7 +54,7 @@ const useStyles = makeResetStyles({
 
 const useStylesSelected = makeStyles({
   selected: {
-    ...shorthands.border('none'),
+    border: 'none',
     boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
     ':hover': {
       boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
@@ -92,22 +92,16 @@ const useSizeStyles = makeStyles({
 
 const useShapeStyles = makeStyles({
   rounded: {
-    ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    }),
+    borderRadius: tokens.borderRadiusMedium,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusMedium }),
   },
   circular: {
-    ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusCircular),
-    }),
+    borderRadius: tokens.borderRadiusCircular,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusCircular }),
   },
   square: {
-    ...shorthands.borderRadius(tokens.borderRadiusNone),
-    ...createCustomFocusIndicatorStyle({
-      ...shorthands.borderRadius(tokens.borderRadiusNone),
-    }),
+    borderRadius: tokens.borderRadiusNone,
+    ...createCustomFocusIndicatorStyle({ borderRadius: tokens.borderRadiusNone }),
   },
 });
 

--- a/packages/react-components/react-swatch-picker/src/components/SwatchPicker/useSwatchPickerStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/src/components/SwatchPicker/useSwatchPickerStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { SwatchPickerSlots, SwatchPickerState } from './SwatchPicker.types';
 import { tokens } from '@fluentui/react-theme';
@@ -11,7 +11,7 @@ export const swatchPickerClassNames: SlotClassNames<SwatchPickerSlots> = {
  */
 const useStyles = makeStyles({
   root: {
-    ...shorthands.padding(tokens.spacingHorizontalNone, tokens.spacingVerticalNone),
+    padding: `${tokens.spacingHorizontalNone} ${tokens.spacingVerticalNone}`,
     display: 'flex',
   },
   row: {
@@ -20,12 +20,8 @@ const useStyles = makeStyles({
   grid: {
     flexDirection: 'column',
   },
-  spacingSmall: {
-    ...shorthands.gap('2px'),
-  },
-  spacingMedium: {
-    ...shorthands.gap('4px'),
-  },
+  spacingSmall: { gap: '2px' },
+  spacingMedium: { gap: '4px' },
 });
 
 /**

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/ColorSwatchVariants.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/ColorSwatchVariants.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { HeartFilled } from '@fluentui/react-icons';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { ColorSwatch } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {
     display: 'flex',
-    ...shorthands.gap('8px'),
+    gap: '8px',
   },
 });
 

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/EmptySwatch.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/EmptySwatch.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Label } from '@fluentui/react-components';
+import { makeStyles, Button, Label } from '@fluentui/react-components';
 import { SwatchPicker, EmptySwatch, ColorSwatch, SwatchPickerOnSelectEventHandler } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {
     width: '100px',
     height: '100px',
-    ...shorthands.border('1px', 'solid', '#ccc'),
-    ...shorthands.margin('20px', '0'),
+    border: '1px solid #ccc',
+    margin: '20px 0',
     '@media (forced-colors: active)': {
       forcedColorAdjust: 'none',
     },
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
   },
   input: {
     display: 'block',
-    ...shorthands.margin('10px', '0'),
+    margin: '10px 0',
   },
 });
 

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerDefault.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerDefault.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SwatchPicker, ColorSwatch, SwatchPickerOnSelectEventHandler } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {
     width: '100px',
     height: '100px',
-    ...shorthands.border('1px', 'solid', '#ccc'),
-    ...shorthands.margin('20px', '0'),
+    border: '1px solid #ccc',
+    margin: '20px 0',
     '@media (forced-colors: active)': {
       forcedColorAdjust: 'none',
     },

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerImage.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerImage.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SwatchPicker, SwatchPickerOnSelectEventHandler, ImageSwatch } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -7,7 +7,7 @@ const useStyles = makeStyles({
     width: '700px',
     height: '466px',
     backgroundSize: 'cover',
-    ...shorthands.margin('20px', '0'),
+    margin: '20px 0',
   },
   swatch: {
     width: '100px',

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerLayout.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerLayout.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import {
   SwatchPicker,
   SwatchPickerOnSelectEventHandler,
@@ -11,8 +11,8 @@ const useStyles = makeStyles({
   example: {
     width: '100px',
     height: '100px',
-    ...shorthands.border('1px', 'solid', '#ccc'),
-    ...shorthands.margin('20px', '0'),
+    border: '1px solid #ccc',
+    margin: '20px 0',
     '@media (forced-colors: active)': {
       forcedColorAdjust: 'none',
     },

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerMixedSwatches.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerMixedSwatches.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SwatchPicker, SwatchPickerOnSelectEventHandler, renderSwatchPickerGrid } from '@fluentui/react-components';
 import type { ColorSwatchProps, ImageSwatchProps, SwatchProps } from '@fluentui/react-components';
 
@@ -7,8 +7,8 @@ const useStyles = makeStyles({
   example: {
     width: '100px',
     height: '100px',
-    ...shorthands.border('1px', 'solid', '#ccc'),
-    ...shorthands.margin('20px', '0'),
+    border: '1px solid #ccc',
+    margin: '20px 0',
     '@media (forced-colors: active)': {
       forcedColorAdjust: 'none',
     },

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerPopup.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerPopup.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
+import { makeStyles, Button, Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-components';
 import { SwatchPicker, ColorSwatch } from '@fluentui/react-components';
 import type { SwatchPickerOnSelectEventHandler } from '@fluentui/react-components';
 
@@ -7,8 +7,8 @@ const useStyles = makeStyles({
   example: {
     width: '100px',
     height: '100px',
-    ...shorthands.border('1px', 'solid', '#ccc'),
-    ...shorthands.margin('20px', '0'),
+    border: '1px solid #ccc',
+    margin: '20px 0',
     '@media (forced-colors: active)': {
       forcedColorAdjust: 'none',
     },

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerShape.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerShape.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SwatchPicker, ColorSwatch } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {
     display: 'flex',
     flexDirection: 'column',
-    ...shorthands.gap('10px'),
+    gap: '10px',
   },
 });
 

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerSize.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerSize.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SwatchPicker, ColorSwatch } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {
     display: 'flex',
     flexDirection: 'column',
-    ...shorthands.gap('10px'),
+    gap: '10px',
   },
 });
 

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerSpacing.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerSpacing.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { makeStyles, shorthands } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { SwatchPicker, renderSwatchPickerGrid } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   example: {
     display: 'flex',
     flexDirection: 'column',
-    ...shorthands.gap('10px'),
+    gap: '10px',
   },
 });
 

--- a/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerWithTooltip.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/SwatchPicker/SwatchPickerWithTooltip.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Tooltip } from '@fluentui/react-components';
+import { makeStyles, Tooltip } from '@fluentui/react-components';
 import {
   SwatchPicker,
   ColorSwatch,
@@ -13,8 +13,8 @@ const useStyles = makeStyles({
   example: {
     width: '100px',
     height: '100px',
-    ...shorthands.border('1px', 'solid', '#ccc'),
-    ...shorthands.margin('20px', '0'),
+    border: '1px solid #ccc',
+    margin: '20px 0',
     '@media (forced-colors: active)': {
       forcedColorAdjust: 'none',
     },

--- a/packages/react-components/react-text/src/components/Text/Text.test.tsx
+++ b/packages/react-components/react-text/src/components/Text/Text.test.tsx
@@ -40,8 +40,7 @@ describe('Text', () => {
       display: inline;
       text-align: start;
       white-space: normal;
-      overflow-x: visible;
-      overflow-y: visible;
+      overflow: visible;
       text-overflow: clip;
     `);
   });
@@ -52,8 +51,7 @@ describe('Text', () => {
     const textElement = getByText('Test');
     expect(textElement).toHaveStyle(`
       white-space: nowrap;
-      overflow-x: hidden;
-      overflow-y: hidden;
+      overflow: hidden;
     `);
   });
 

--- a/packages/react-components/react-text/src/components/Text/useTextStyles.styles.ts
+++ b/packages/react-components/react-text/src/components/Text/useTextStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { TextSlots, TextState } from './Text.types';
 import { SlotClassNames } from '@fluentui/react-utilities';
@@ -19,12 +19,12 @@ const useStyles = makeStyles({
     textAlign: 'start',
     display: 'inline',
     whiteSpace: 'normal',
-    ...shorthands.overflow('visible'),
+    overflow: 'visible',
     textOverflow: 'clip',
   },
   nowrap: {
     whiteSpace: 'nowrap',
-    ...shorthands.overflow('hidden'),
+    overflow: 'hidden',
   },
   truncate: {
     textOverflow: 'ellipsis',

--- a/packages/react-components/react-text/stories/Text/TextAlignment.stories.tsx
+++ b/packages/react-components/react-text/stories/Text/TextAlignment.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Text } from '@fluentui/react-components';
+import { makeStyles, Text } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'stretch',

--- a/packages/react-components/react-text/stories/Text/TextFont.stories.tsx
+++ b/packages/react-components/react-text/stories/Text/TextFont.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Text } from '@fluentui/react-components';
+import { makeStyles, Text } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexDirection: 'column',
   },

--- a/packages/react-components/react-text/stories/Text/TextPresets.stories.tsx
+++ b/packages/react-components/react-text/stories/Text/TextPresets.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   makeStyles,
-  shorthands,
   Body1,
   Body1Strong,
   Body1Stronger,
@@ -24,7 +23,7 @@ import textPresetsMd from './TextPresets.md';
 
 const useStyles = makeStyles({
   container: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'baseline',

--- a/packages/react-components/react-text/stories/Text/TextSize.stories.tsx
+++ b/packages/react-components/react-text/stories/Text/TextSize.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Text } from '@fluentui/react-components';
+import { makeStyles, Text } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'baseline',

--- a/packages/react-components/react-text/stories/Text/TextTruncate.stories.tsx
+++ b/packages/react-components/react-text/stories/Text/TextTruncate.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Text } from '@fluentui/react-components';
+import { makeStyles, Text } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   text: {
-    ...shorthands.overflow('hidden'),
+    overflow: 'hidden',
     width: '240px',
     display: 'block',
   },

--- a/packages/react-components/react-text/stories/Text/TextWeight.stories.tsx
+++ b/packages/react-components/react-text/stories/Text/TextWeight.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { makeStyles, shorthands, Text } from '@fluentui/react-components';
+import { makeStyles, Text } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
-    ...shorthands.gap('16px'),
+    gap: '16px',
     display: 'flex',
     flexDirection: 'column',
   },


### PR DESCRIPTION
## Previous Behavior

Components owned by `cxe-prg` use `shorthands.*()`.

## New Behavior

Components owned by `cxe-prg` do use `shorthands.*()`, bundle size is decreased 👍 

## Related Issue(s)

Related to #31318.
