### PR TITLE
chore(react-dialog): re-export DialogProvider

### DIFF
--- a/change/@fluentui-react-components-29682e95-1e8c-4688-9fee-0eada89b9b32.json
+++ b/change/@fluentui-react-components-29682e95-1e8c-4688-9fee-0eada89b9b32.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: re-exports DialogProvider",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -263,6 +263,7 @@ import { DialogContextValue } from '@fluentui/react-dialog';
 import { DialogOpenChangeData } from '@fluentui/react-dialog';
 import { DialogOpenChangeEvent } from '@fluentui/react-dialog';
 import { DialogProps } from '@fluentui/react-dialog';
+import { DialogProvider } from '@fluentui/react-dialog';
 import { DialogSlots } from '@fluentui/react-dialog';
 import { DialogState } from '@fluentui/react-dialog';
 import { DialogSurface } from '@fluentui/react-dialog';
@@ -2220,6 +2221,8 @@ export { DialogOpenChangeData }
 export { DialogOpenChangeEvent }
 
 export { DialogProps }
+
+export { DialogProvider }
 
 export { DialogSlots }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -860,6 +860,7 @@ export {
   useDialogContext_unstable,
   useDialogSurfaceContext_unstable,
   useDialogSurfaceContextValues_unstable,
+  DialogProvider,
 } from '@fluentui/react-dialog';
 
 export type {


### PR DESCRIPTION
## New Behavior

re-export `DialogProvider` into `@fluentui/react-components`
