### PR TITLE
fix(vr-tests-web-component): explicitly add @types/web and specify those within types globals in order to pass tsc

### DIFF
--- a/apps/vr-tests-web-components/package.json
+++ b/apps/vr-tests-web-components/package.json
@@ -13,7 +13,9 @@
     "vr:build": "yarn build",
     "vr:test": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/web": "^0.0.142"
+  },
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/vr-tests-web-components/tsconfig.json
+++ b/apps/vr-tests-web-components/tsconfig.json
@@ -7,7 +7,8 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "allowJs": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["jest", "node", "web"]
   },
   "include": ["./src", "./.storybook/*"]
 }


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Master pipeline fails because type issues with `vr-tests-web-components`

<img width="878" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/e0abb34f-b47a-44ff-bece-b98ed4a0ef27">


## New Behavior

Because web-components use https://www.npmjs.com/package/@types/web package in order to override DOM lib types every app and library within monorepo that uses wc as dependency needs to specify `web` within tsconfig types global

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31423
