### PR TITLE
fix(web-components): add `--noEmit` for type-checking task

### DIFF
--- a/change/@fluentui-web-components-c8b47bb9-83cd-4bcc-92f6-c3fe1851402b.json
+++ b/change/@fluentui-web-components-c8b47bb9-83cd-4bcc-92f6-c3fe1851402b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: add --noEmit for type-checking task",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/scripts/type-check.js
+++ b/packages/web-components/scripts/type-check.js
@@ -27,7 +27,7 @@ async function main() {
   const asyncQueue = [];
 
   for (const ref of tsConfigsRefs) {
-    const program = `tsc -p ${ref} --pretty --baseUrl .`;
+    const program = `tsc -p ${ref} --pretty --noEmit --baseUrl .`;
     asyncQueue.push(asyncExec(program));
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

type check emits declarations

## New Behavior

type check wont emit anything

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31423
