### PR TITLE
fix: make type-check task run with --noEmit and return only void Promise on success and update recipes app tsconfig

### DIFF
--- a/apps/recipes-react-components/tsconfig.app.json
+++ b/apps/recipes-react-components/tsconfig.app.json
@@ -6,6 +6,5 @@
     "declaration": true,
     "inlineSources": true
   },
-  "exclude": [],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

master is failing on type-check error
<img width="868" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/de670c38-11c7-4b0b-bf31-ceb7001c6c1e">


## New Behavior

- `type-check` uses noEmit and returns only `Promise<void>` on success in order to follow just-scripts patterns
- removes `exclude` from tsconfig within recipes app which is probably main issue with failures

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31451
